### PR TITLE
fix(perc-taxonomy): clear module javac warnings (#2031)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2031-perc-taxonomy-javac-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2031-perc-taxonomy-javac-batch1-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — issue #2031 perc-taxonomy javac warnings
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2031-perc-taxonomy-javac-warnings-batch1`  
+**Scope:** `modules/perc-taxonomy` (javac warning cleanup)
+
+## Summary
+
+Real-fix cleanup of **~99 project-default javac diagnostics** in `perc-taxonomy` to **0**. Changes are generics typing, Hibernate 6 typed queries / `Session.find`, `final` for this-escape, serial fields, and removal of redundant casts. New unit tests cover JEXL helpers, validators, and `collection_to_hashmap`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none found |
+| Behavioral unit tests for new/changed non-trivial logic | **pass** (12 tests) |
+| Portable paths / file I/O | N/A (no path I/O in diff) |
+| May commit/push | **yes** |
+
+## Issues
+
+None (blocking).
+
+### Notes / low
+
+- Maven javadoc plugin still emits incomplete-Javadoc noise during `clean install`; original issue analysis reported **0** javadoc diagnostics and **100** javac. Out of scope for this javac-zero PR.
+- `executeUpdate` still uses untyped `createQuery(String)`; no current `-Xlint` warning under project defaults.
+- Making `TaxAttMap` / `TaxValues` `final` is safe (no subclasses in tree).
+
+## Verification
+
+- `cd modules/perc-taxonomy` → `../../mvnw.cmd clean install` → **BUILD SUCCESS**
+- Tests: **12** run, **0** fail, **0** error
+- Javac `[WARNING] *.java:[line,col]` under project `-Xlint`: **0**
+
+## Memory patterns hit
+
+- Prefer real generics / typed Hibernate `Query` over blanket `@SuppressWarnings`
+- `final` classes for this-escape when ctor calls overridable methods (`put`/`add` on Map/List subclasses)
+- `Session.find` replaces deprecated `Session.get`
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/perc-taxonomy/pom.xml
+++ b/modules/perc-taxonomy/pom.xml
@@ -108,6 +108,16 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/TaxonomyJexl.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/TaxonomyJexl.java
@@ -96,14 +96,14 @@ public class TaxonomyJexl extends PSJexlUtilBase implements IPSJexlExpression {
       }
       queryString += "and l.id = ? order by a.id";
 
-      Query q = session.createQuery(queryString);
+      Query<Attribute_lang> q = session.createQuery(queryString, Attribute_lang.class);
       if (taxID > 0) {
         q.setParameter(0, taxID);
       } else {
         q.setParameter(0, taxName);
       }
       q.setParameter(1, langID);
-      attLang = (List<Attribute_lang>) q.list();
+      attLang = q.list();
       ret = new TaxAttMap(attLang);
       tx.commit();
     } catch (HibernateException e) {
@@ -168,10 +168,10 @@ public class TaxonomyJexl extends PSJexlUtilBase implements IPSJexlExpression {
       queryString += "inner join  rn.relationship as rt ";
       queryString += "where rn.node.id = ? and rt.Relationship_type = ?";
 
-      Query q = session.createQuery(queryString);
+      Query<Node> q = session.createQuery(queryString, Node.class);
       q.setParameter(0, nodeID);
       q.setParameter(1, relationship_type_name);
-      nodes = (List<Node>) q.list();
+      nodes = q.list();
       for (Node node : nodes) {
         TaxNode taxNode = new TaxNode(node);
         ret.add(taxNode);
@@ -247,10 +247,10 @@ public class TaxonomyJexl extends PSJexlUtilBase implements IPSJexlExpression {
       queryString += "and al.language.id = ? ";
       queryString += "and v.lang.id = ? order by n.id";
 
-      Query q = session.createQuery(queryString);
+      Query<Node> q = session.createQuery(queryString, Node.class);
       q.setParameter(0, langID);
       q.setParameter(1, langID);
-      nodes = (List<Node>) q.list();
+      nodes = q.list();
 
       for (Node node : nodes) {
         TaxNode taxNode = new TaxNode(node);
@@ -327,7 +327,7 @@ public class TaxonomyJexl extends PSJexlUtilBase implements IPSJexlExpression {
       queryString += "and al.language.id = ? ";
       queryString += "and v.lang.id = ? order by n.id";
 
-      Query q = session.createQuery(queryString);
+      Query<Node> q = session.createQuery(queryString, Node.class);
       if (taxID > 0) {
         q.setParameter(0, taxID);
       } else {
@@ -335,7 +335,7 @@ public class TaxonomyJexl extends PSJexlUtilBase implements IPSJexlExpression {
       }
       q.setParameter(1, langID);
       q.setParameter(2, langID);
-      nodes = (List<Node>) q.list();
+      nodes = q.list();
       for (Node node : nodes) {
         TaxNode taxNode = new TaxNode(node);
         ret.add(taxNode);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/TaxonomySecurityHelper.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/TaxonomySecurityHelper.java
@@ -47,7 +47,7 @@ public class TaxonomySecurityHelper {
 
   public static List<String> getAllRoles() {
     List<String> ret;
-    ret = new ArrayList(PSRoleMgrLocator.getRoleManager().getDefinedRoles());
+    ret = new ArrayList<>(PSRoleMgrLocator.getRoleManager().getDefinedRoles());
     ret.remove(TAXONOMY_ADMIN_GROUP);
     Collections.sort(ret);
     return ret;

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/TaxonomyTextConverter.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/TaxonomyTextConverter.java
@@ -74,18 +74,18 @@ public class TaxonomyTextConverter implements IPSLuceneTextConverter {
       }
 
       // get similar ID for our main query
-      Query query = session.createQuery(SQL_SIMILAR);
-      query.setParameterList("nodes", ids);
-      query.setParameter("relationship_type_id", Relationship_type.SIMILAR);
+      Query<Integer> similarQuery = session.createQuery(SQL_SIMILAR, Integer.class);
+      similarQuery.setParameterList("nodes", ids);
+      similarQuery.setParameter("relationship_type_id", Relationship_type.SIMILAR);
 
       // add them
-      ids.addAll((Collection<Integer>) query.list());
+      ids.addAll(similarQuery.list());
 
       // run our main query
-      query = session.createQuery(SQL_GET_VALUES);
-      query.setParameter("language_id", langID);
-      query.setParameterList("ids", ids);
-      Collection<String> values = (Collection<String>) query.list();
+      Query<String> valuesQuery = session.createQuery(SQL_GET_VALUES, String.class);
+      valuesQuery.setParameter("language_id", langID);
+      valuesQuery.setParameterList("ids", ids);
+      Collection<String> values = valuesQuery.list();
 
       // add values to our search string to return
       for (String v : values) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/jexl/TaxAttMap.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/jexl/TaxAttMap.java
@@ -26,7 +26,7 @@ import java.util.List;
  *
  * @author stephenbolton
  */
-public class TaxAttMap extends HashMap<String, TaxAttribute> {
+public final class TaxAttMap extends HashMap<String, TaxAttribute> {
 
   private static final long serialVersionUID = 1L;
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/jexl/TaxValues.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/jexl/TaxValues.java
@@ -19,7 +19,7 @@ package com.percussion.taxonomy.jexl;
 import java.util.ArrayList;
 import org.apache.commons.lang3.StringUtils;
 
-public class TaxValues extends ArrayList<String> {
+public final class TaxValues extends ArrayList<String> {
   /**
    * An object that can handle both single and multiple taxonomy attribute values It can be treated
    * like a regular List for multiple values or toString will output a comma separated list for

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Attribute_langDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Attribute_langDAO.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public interface Attribute_langDAO {
 
-  public Collection getAllAttribute_langs();
+  public Collection<Attribute_lang> getAllAttribute_langs();
 
   public Attribute_lang getAttribute_lang(int id);
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Attribute_langServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Attribute_langServiceInf.java
@@ -31,7 +31,7 @@ public interface Attribute_langServiceInf {
    *
    * @return a collection of all Attribute_lang entities, or an empty collection
    */
-  public Collection getAllAttribute_langs();
+  public Collection<Attribute_lang> getAllAttribute_langs();
 
   /**
    * Retrieves a specific attribute language by its unique identifier.

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateAttribute_langDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateAttribute_langDAO.java
@@ -33,13 +33,12 @@ public class HibernateAttribute_langDAO implements Attribute_langDAO {
 
   public Attribute_lang getAttribute_lang(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Attribute_lang.class, id);
+    return session.find(Attribute_lang.class, id);
   }
 
-  public Collection getAllAttribute_langs() {
+  public Collection<Attribute_lang> getAllAttribute_langs() {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection)
-        (Collection<?>) session.createQuery("from Attribute_lang att", Attribute_lang.class).list();
+    return session.createQuery("from Attribute_lang att", Attribute_lang.class).list();
   }
 
   public void saveAttribute_lang(Attribute_lang attribute_lang) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateLanguageDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateLanguageDAO.java
@@ -33,13 +33,12 @@ public class HibernateLanguageDAO implements LanguageDAO {
 
   public Language getLanguage(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Language.class, id);
+    return session.find(Language.class, id);
   }
 
   public Collection<Language> getAllLanguages() {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection<Language>)
-        (Collection<?>) session.createQuery("from Language lan", Language.class).list();
+    return session.createQuery("from Language lan", Language.class).list();
   }
 
   public void saveLanguage(Language language) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateNodeDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateNodeDAO.java
@@ -47,17 +47,17 @@ public class HibernateNodeDAO implements NodeDAO {
 
   @Autowired private SessionFactory sessionFactory;
 
-  private Object executeQuery(String queryString) {
+  private <T> List<T> executeQuery(String queryString, Class<T> resultClass) {
     Session session = sessionFactory.getCurrentSession();
-    Query<?> query = session.createQuery(queryString, Object.class);
-    return query.list();
+    return session.createQuery(queryString, resultClass).list();
   }
 
-  private Object executeQuery(String queryString, Map<String, String> substitutions) {
+  private <T> List<T> executeQuery(
+      String queryString, Class<T> resultClass, Map<String, ?> substitutions) {
     Session session = sessionFactory.getCurrentSession();
-    Query<?> query = session.createQuery(queryString, Object.class);
+    Query<T> query = session.createQuery(queryString, resultClass);
     if (substitutions != null) {
-      for (Map.Entry<String, String> entry : substitutions.entrySet()) {
+      for (Map.Entry<String, ?> entry : substitutions.entrySet()) {
         query.setParameter(entry.getKey(), entry.getValue());
       }
     }
@@ -89,7 +89,7 @@ public class HibernateNodeDAO implements NodeDAO {
     queryString += "and al.language.id = " + langID + " ";
     queryString += "and v.lang.id = " + langID + "order by n.id";
 
-    return ((Collection<Node>) executeQuery(queryString)).iterator().next();
+    return executeQuery(queryString, Node.class).iterator().next();
   }
 
   public Collection<Node> getAllNodes(int taxID, int langID) {
@@ -108,7 +108,7 @@ public class HibernateNodeDAO implements NodeDAO {
     queryString += "and al.language.id = " + langID + " ";
     queryString += "and v.lang.id = " + langID + "order by n.id";
 
-    return (Collection<Node>) executeQuery(queryString);
+    return executeQuery(queryString, Node.class);
   }
 
   public Collection<Node> getNodesFromSearch(
@@ -136,7 +136,7 @@ public class HibernateNodeDAO implements NodeDAO {
     queryString += "and v.lang.id = " + langID + " ";
     queryString += "and lower(v.Name)  like ? order by n.id";
 
-    Query query = session.createQuery(queryString);
+    Query<Node> query = session.createQuery(queryString, Node.class);
     int paramIndex = 0;
 
     if (exclude_disabled) {
@@ -244,7 +244,7 @@ public class HibernateNodeDAO implements NodeDAO {
             + langID
             + " order by v.node.id, v.attribute.Is_node_name";
 
-    return concatNames(((Collection<Object[]>) executeQuery(queryString)));
+    return concatNames(executeQuery(queryString, Object[].class));
   }
 
   /** Return nodeID, parentID, and name of all nodes for a given taxonomy */
@@ -258,7 +258,7 @@ public class HibernateNodeDAO implements NodeDAO {
             + langID
             + " order by v.node.id, v.attribute.Is_node_name";
 
-    return concatNames(((Collection<Object[]>) executeQuery(queryString)));
+    return concatNames(executeQuery(queryString, Object[].class));
   }
 
   /** Return nodes for ides */
@@ -266,7 +266,7 @@ public class HibernateNodeDAO implements NodeDAO {
     String queryString =
         "select n from Node n where n.id in(" + StringUtils.join(ids.toArray(), ',') + ")";
 
-    return ((Collection<Node>) executeQuery(queryString));
+    return executeQuery(queryString, Node.class);
   }
 
   /** Return all values associated with a given node */
@@ -276,7 +276,7 @@ public class HibernateNodeDAO implements NodeDAO {
             + nodeID
             + " and v.lang.id = "
             + langID;
-    return (Collection<Value>) executeQuery(queryString);
+    return executeQuery(queryString, Value.class);
   }
 
   /** Return all values associated with a given node and attribute combo */
@@ -289,7 +289,7 @@ public class HibernateNodeDAO implements NodeDAO {
             + " and v.attribute.id = "
             + attrID;
 
-    return (Collection<Value>) executeQuery(queryString);
+    return executeQuery(queryString, Value.class);
   }
 
   /** Return all nodes 'related to' the given node */
@@ -325,7 +325,7 @@ public class HibernateNodeDAO implements NodeDAO {
     String queryString =
         "select n from Node n left join fetch n.nodeEditors ne where n.parent.id = " + nodeID;
 
-    return (Collection<Node>) executeQuery(queryString);
+    return executeQuery(queryString, Node.class);
   }
 
   /** Return all NodeEditors for the given node */
@@ -333,7 +333,7 @@ public class HibernateNodeDAO implements NodeDAO {
 
     String queryString = "select ne from Node_editor ne where ne.node.id = " + nodeID;
 
-    return (Collection<Node_editor>) executeQuery(queryString);
+    return executeQuery(queryString, Node_editor.class);
   }
 
   /** Return a nodeName for the given node */
@@ -346,7 +346,7 @@ public class HibernateNodeDAO implements NodeDAO {
             + langID
             + " order by v.node.id, v.attribute.Is_node_name";
 
-    return (Collection<String>) executeQuery(queryString);
+    return executeQuery(queryString, String.class);
   }
 
   public Map<String, String> deleteNodeAndFriends(int nodeID, int taxonomyID) {
@@ -354,7 +354,7 @@ public class HibernateNodeDAO implements NodeDAO {
     String queryString = "select n.id from Node n where n.parent.id = " + nodeID;
 
     Map<String, String> errors = null;
-    List<?> result = (List<?>) executeQuery(queryString);
+    List<Integer> result = executeQuery(queryString, Integer.class);
 
     if (result.size() == 0) {
 
@@ -397,9 +397,7 @@ public class HibernateNodeDAO implements NodeDAO {
             + languageID
             + " order by v.node.id";
 
-    Object raw = executeQuery(queryString);
-
-    return (Collection<Object[]>) raw;
+    return executeQuery(queryString, Object[].class);
   }
 
   /** Change the parent of a node */
@@ -445,8 +443,10 @@ public class HibernateNodeDAO implements NodeDAO {
   public Collection<Node> findNodesByAttribute(Attribute attribute) {
     Session session = sessionFactory.getCurrentSession();
     Collection<Node> nodes = null;
-    Query query =
-        session.createNamedQuery("findNodesByAttribute").setParameter("attribute", attribute);
+    Query<Node> query =
+        session
+            .createNamedQuery("findNodesByAttribute", Node.class)
+            .setParameter("attribute", attribute);
     nodes = query.list();
 
     return nodes;

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateNode_editorDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateNode_editorDAO.java
@@ -33,13 +33,12 @@ public class HibernateNode_editorDAO implements Node_editorDAO {
 
   public Node_editor getNode_editor(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Node_editor.class, id);
+    return session.find(Node_editor.class, id);
   }
 
   public Collection<Node_editor> getAllNode_editors() {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection<Node_editor>)
-        (Collection<?>) session.createQuery("from Node_editor nod", Node_editor.class).list();
+    return session.createQuery("from Node_editor nod", Node_editor.class).list();
   }
 
   public void saveNode_editor(Node_editor node_editor) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateNode_statusDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateNode_statusDAO.java
@@ -33,13 +33,12 @@ public class HibernateNode_statusDAO implements Node_statusDAO {
 
   public Node_status getNode_status(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Node_status.class, id);
+    return session.find(Node_status.class, id);
   }
 
   public Collection<Node_status> getAllNode_statuss() {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection<Node_status>)
-        (Collection<?>) session.createQuery("from Node_status nod", Node_status.class).list();
+    return session.createQuery("from Node_status nod", Node_status.class).list();
   }
 
   public void saveNode_status(Node_status node_status) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateRelated_nodeDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateRelated_nodeDAO.java
@@ -33,13 +33,13 @@ public class HibernateRelated_nodeDAO implements Related_nodeDAO {
 
   public Related_node getRelated_node(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Related_node.class, id);
+    return session.find(Related_node.class, id);
   }
 
-  public Collection getAllRelated_nodes() {
+  public Collection<Related_node> getAllRelated_nodes() {
     String queryString = "from Related_node rn left join fetch rn.relationship";
     Session session = sessionFactory.getCurrentSession();
-    return (Collection) (Collection<?>) session.createQuery(queryString, Related_node.class).list();
+    return session.createQuery(queryString, Related_node.class).list();
   }
 
   public void saveRelated_node(Related_node related_node) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateRelationship_typeDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateRelationship_typeDAO.java
@@ -32,14 +32,12 @@ public class HibernateRelationship_typeDAO implements Relationship_typeDAO {
 
   public Relationship_type getRelationship_type(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Relationship_type.class, id);
+    return session.find(Relationship_type.class, id);
   }
 
-  public Collection getAllRelationship_types() {
+  public Collection<Relationship_type> getAllRelationship_types() {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection)
-        (Collection<?>)
-            session.createQuery("from Relationship_type rel", Relationship_type.class).list();
+    return session.createQuery("from Relationship_type rel", Relationship_type.class).list();
   }
 
   public void saveRelationship_type(Relationship_type relationship_type) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateTaxonomyDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateTaxonomyDAO.java
@@ -34,7 +34,7 @@ public class HibernateTaxonomyDAO implements TaxonomyDAO {
 
   public Taxonomy getTaxonomy(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Taxonomy.class, id);
+    return session.find(Taxonomy.class, id);
   }
 
   public List<Taxonomy> getTaxonomy(String name) {
@@ -55,11 +55,11 @@ public class HibernateTaxonomyDAO implements TaxonomyDAO {
     return query.list();
   }
 
-  public Collection getAllTaxonomys() {
+  public Collection<Taxonomy> getAllTaxonomys() {
     Session session = sessionFactory.getCurrentSession();
     Query<Taxonomy> query =
         session.createQuery("from Taxonomy tax order by lower(name) asc", Taxonomy.class);
-    return (Collection) (Collection<?>) query.list();
+    return query.list();
   }
 
   public void saveTaxonomy(Taxonomy taxonomy) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateValueDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateValueDAO.java
@@ -48,13 +48,12 @@ public class HibernateValueDAO implements ValueDAO {
 
   public Value getValue(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Value.class, id);
+    return session.find(Value.class, id);
   }
 
   public Collection<Value> getAllValues() {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection<Value>)
-        (Collection<?>) session.createQuery("from Value val", Value.class).list();
+    return session.createQuery("from Value val", Value.class).list();
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -75,7 +74,7 @@ public class HibernateValueDAO implements ValueDAO {
       Session session = sessionFactory.getCurrentSession();
       HibernateValueCallback valueSetter =
           new HibernateValueCallback(params, attributes, node, langID, user_name);
-      values = (Map<String, String>) valueSetter.doInHibernate(session);
+      values = valueSetter.doInHibernate(session);
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -175,7 +174,7 @@ public class HibernateValueDAO implements ValueDAO {
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    public Object doInHibernate(Session session) throws HibernateException {
+    public Map<String, String> doInHibernate(Session session) throws HibernateException {
 
       Map<String, String> errors = null;
       Collection<Value> forGarbage = new HashSet<Value>();
@@ -280,7 +279,7 @@ public class HibernateValueDAO implements ValueDAO {
                 nodeInfo.isNew(),
                 username,
                 attribute,
-                StringUtils.trimToNull((String) params.get(getParamNameFor(attribute))[0]),
+                StringUtils.trimToNull(params.get(getParamNameFor(attribute))[0]),
                 currentValues.values(),
                 forGarbage));
       }
@@ -321,11 +320,10 @@ public class HibernateValueDAO implements ValueDAO {
           value.setAttribute(attribute);
           value.setNode(node);
           value.setLang(
-              (Language)
-                  session
-                      .createQuery("select l from Language l where l.id = :langId", Language.class)
-                      .setParameter("langId", langID)
-                      .uniqueResult());
+              session
+                  .createQuery("select l from Language l where l.id = :langId", Language.class)
+                  .setParameter("langId", langID)
+                  .uniqueResult());
           value.setCreated_by_id(userName);
           value.setCreated_at(new Timestamp(System.currentTimeMillis()));
           value.setName(s);
@@ -374,11 +372,10 @@ public class HibernateValueDAO implements ValueDAO {
           value.setAttribute(attribute);
           value.setNode(node);
           value.setLang(
-              (Language)
-                  session
-                      .createQuery("select l from Language l where l.id = :langId", Language.class)
-                      .setParameter("langId", langID)
-                      .uniqueResult());
+              session
+                  .createQuery("select l from Language l where l.id = :langId", Language.class)
+                  .setParameter("langId", langID)
+                  .uniqueResult());
           value.setCreated_by_id(userName);
           value.setCreated_at(new Timestamp(System.currentTimeMillis()));
         }

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateVisibilityDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateVisibilityDAO.java
@@ -33,24 +33,20 @@ public class HibernateVisibilityDAO implements VisibilityDAO {
 
   public Visibility getVisibility(int id) {
     Session session = sessionFactory.getCurrentSession();
-    return session.get(Visibility.class, id);
+    return session.find(Visibility.class, id);
   }
 
   public Collection<Visibility> getAllVisibilities() {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection<Visibility>)
-        (Collection<?>) session.createQuery("from Visibility v", Visibility.class).list();
+    return session.createQuery("from Visibility v", Visibility.class).list();
   }
 
   public Collection<Visibility> getAllVisibilitiesForTaxonomyId(int taxonomy_id) {
     Session session = sessionFactory.getCurrentSession();
-    return (Collection<Visibility>)
-        (Collection<?>)
-            session
-                .createQuery(
-                    "from Visibility v where v.taxonomy.id = :taxonomy_id", Visibility.class)
-                .setParameter("taxonomy_id", taxonomy_id)
-                .list();
+    return session
+        .createQuery("from Visibility v where v.taxonomy.id = :taxonomy_id", Visibility.class)
+        .setParameter("taxonomy_id", taxonomy_id)
+        .list();
   }
 
   public void saveVisibility(Visibility Visibility) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/LanguageDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/LanguageDAO.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public interface LanguageDAO {
 
-  public Collection getAllLanguages();
+  public Collection<Language> getAllLanguages();
 
   public Language getLanguage(int id);
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/LanguageServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/LanguageServiceInf.java
@@ -31,7 +31,7 @@ public interface LanguageServiceInf {
    *
    * @return a collection of all Language entities, or an empty collection if none exist
    */
-  public Collection getAllLanguages();
+  public Collection<Language> getAllLanguages();
 
   /**
    * Retrieves a specific language by its unique identifier.

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_editorDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_editorDAO.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public interface Node_editorDAO {
 
-  public Collection getAllNode_editors();
+  public Collection<Node_editor> getAllNode_editors();
 
   public Node_editor getNode_editor(int id);
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_editorServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_editorServiceInf.java
@@ -31,7 +31,7 @@ public interface Node_editorServiceInf {
    *
    * @return a collection of all Node_editor entities, or an empty collection
    */
-  public Collection getAllNode_editors();
+  public Collection<Node_editor> getAllNode_editors();
 
   /**
    * Retrieves a specific node editor by its unique identifier.

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_statusDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_statusDAO.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public interface Node_statusDAO {
 
-  public Collection getAllNode_statuss();
+  public Collection<Node_status> getAllNode_statuss();
 
   public Node_status getNode_status(int id);
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_statusServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Node_statusServiceInf.java
@@ -31,7 +31,7 @@ public interface Node_statusServiceInf {
    *
    * @return a collection of all Node_status entities, or an empty collection
    */
-  public Collection getAllNode_statuss();
+  public Collection<Node_status> getAllNode_statuss();
 
   /**
    * Retrieves a specific node status by its unique identifier.

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Related_nodeDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Related_nodeDAO.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public interface Related_nodeDAO {
 
-  public Collection getAllRelated_nodes();
+  public Collection<Related_node> getAllRelated_nodes();
 
   public Related_node getRelated_node(int id);
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Related_nodeServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Related_nodeServiceInf.java
@@ -31,7 +31,7 @@ public interface Related_nodeServiceInf {
    *
    * @return a collection of all Related_node entities, or an empty collection
    */
-  public Collection getAllRelated_nodes();
+  public Collection<Related_node> getAllRelated_nodes();
 
   /**
    * Retrieves a specific related node by its unique identifier.

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Relationship_typeDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Relationship_typeDAO.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public interface Relationship_typeDAO {
 
-  public Collection getAllRelationship_types();
+  public Collection<Relationship_type> getAllRelationship_types();
 
   public Relationship_type getRelationship_type(int id);
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Relationship_typeServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/Relationship_typeServiceInf.java
@@ -31,7 +31,7 @@ public interface Relationship_typeServiceInf {
    *
    * @return a collection of all Relationship_type entities, or an empty collection
    */
-  public Collection getAllRelationship_types();
+  public Collection<Relationship_type> getAllRelationship_types();
 
   /**
    * Retrieves a specific relationship type by its unique identifier.

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/VisibilityDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/VisibilityDAO.java
@@ -22,9 +22,9 @@ import java.util.Collection;
 
 public interface VisibilityDAO {
 
-  public Collection getAllVisibilities();
+  public Collection<Visibility> getAllVisibilities();
 
-  public Collection getAllVisibilitiesForTaxonomyId(int taxonomy_id);
+  public Collection<Visibility> getAllVisibilitiesForTaxonomyId(int taxonomy_id);
 
   public Visibility getVisibility(int id);
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/VisibilityServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/VisibilityServiceInf.java
@@ -31,7 +31,7 @@ public interface VisibilityServiceInf {
    *
    * @return a collection of all Visibility entities, or an empty collection
    */
-  public Collection getAllVisibilities();
+  public Collection<Visibility> getAllVisibilities();
 
   /**
    * Retrieves all visibility options for a specific taxonomy.
@@ -39,7 +39,7 @@ public interface VisibilityServiceInf {
    * @param taxonomy_id the unique identifier of the taxonomy
    * @return a collection of Visibility entities associated with the taxonomy
    */
-  public Collection getAllVisibilitiesForTaxonomyId(int taxonomy_id);
+  public Collection<Visibility> getAllVisibilitiesForTaxonomyId(int taxonomy_id);
 
   /**
    * Retrieves a specific visibility by its unique identifier.

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Attribute_langService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Attribute_langService.java
@@ -27,7 +27,7 @@ public class Attribute_langService implements Attribute_langServiceInf {
 
   public Attribute_langDAO attribute_langDAO;
 
-  public Collection getAllAttribute_langs() {
+  public Collection<Attribute_lang> getAllAttribute_langs() {
     try {
       return attribute_langDAO.getAllAttribute_langs();
     } catch (HibernateException e) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/LanguageService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/LanguageService.java
@@ -44,7 +44,7 @@ public class LanguageService implements LanguageServiceInf {
    *
    * @return a collection of all Language entities, or an empty collection if none exist
    */
-  public Collection getAllLanguages() {
+  public Collection<Language> getAllLanguages() {
     try {
       return languageDAO.getAllLanguages();
     } catch (HibernateException e) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/NodeService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/NodeService.java
@@ -78,7 +78,7 @@ public class NodeService implements NodeServiceInf {
   public Collection<Node> getAllNodes(int taxID, int langID) {
     Collection<Node> nodes = null;
     try {
-      nodes = (Collection<Node>) this.nodeDAO.getAllNodes(taxID, langID);
+      nodes = this.nodeDAO.getAllNodes(taxID, langID);
     } catch (HibernateException e) {
       throw new HibernateException(e);
     }
@@ -133,9 +133,7 @@ public class NodeService implements NodeServiceInf {
       int taxID, int langID, String search_string, boolean exclude_disabled) {
     Collection<Node> nodes = null;
     try {
-      nodes =
-          (Collection<Node>)
-              this.nodeDAO.getNodesFromSearch(taxID, langID, search_string, exclude_disabled);
+      nodes = this.nodeDAO.getNodesFromSearch(taxID, langID, search_string, exclude_disabled);
     } catch (HibernateException e) {
       throw new HibernateException(e);
     }
@@ -217,7 +215,7 @@ public class NodeService implements NodeServiceInf {
   public Collection<Object[]> getAllNodeNames(int taxonomyID, int langID) {
     Collection<Object[]> names = null;
     try {
-      names = (Collection<Object[]>) nodeDAO.getAllNodeNames(taxonomyID, langID);
+      names = nodeDAO.getAllNodeNames(taxonomyID, langID);
     } catch (HibernateException e) {
       throw new HibernateException(e);
     }
@@ -234,7 +232,7 @@ public class NodeService implements NodeServiceInf {
   public Collection<Object[]> getSomeNodeNames(Collection<Integer> ids, int langID) {
     Collection<Object[]> names = null;
     try {
-      names = (Collection<Object[]>) this.nodeDAO.getSomeNodeNames(ids, langID);
+      names = this.nodeDAO.getSomeNodeNames(ids, langID);
     } catch (HibernateException e) {
       throw new HibernateException(e);
     }
@@ -251,7 +249,7 @@ public class NodeService implements NodeServiceInf {
   public Collection<String> getNodeName(int nodeID, int langID) {
     Collection<String> names = null;
     try {
-      names = (Collection<String>) this.nodeDAO.getNodeName(nodeID, langID);
+      names = this.nodeDAO.getNodeName(nodeID, langID);
     } catch (HibernateException e) {
       throw new HibernateException(e);
     }
@@ -494,7 +492,7 @@ public class NodeService implements NodeServiceInf {
     // PSContentEditorSystemDef m_systemDef = PSServer.getContentEditorSystemDef();
     PSContentEditorSharedDef m_sharedDef = PSServer.getContentEditorSharedDef();
 
-    Iterator groupsItt = m_sharedDef.getFieldGroups();
+    Iterator<?> groupsItt = m_sharedDef.getFieldGroups();
 
     while (groupsItt.hasNext()) {
       PSSharedFieldGroup group = (PSSharedFieldGroup) groupsItt.next();
@@ -546,7 +544,7 @@ public class NodeService implements NodeServiceInf {
   private List<PSField> getControlFields(
       PSFieldSet fieldSet, PSDisplayMapper mapper, List<String> controlNames) {
     List<PSField> fields = new ArrayList<PSField>();
-    Iterator mappings = mapper.iterator();
+    Iterator<?> mappings = mapper.iterator();
     while (mappings.hasNext()) {
       PSDisplayMapping mapping = (PSDisplayMapping) mappings.next();
 
@@ -576,7 +574,7 @@ public class NodeService implements NodeServiceInf {
             PSFieldSet childFs = (PSFieldSet) o;
             if (childFs.getType() == PSFieldSet.TYPE_SIMPLE_CHILD) {
               PSDisplayMapper childMapper = mapping.getDisplayMapper();
-              Iterator childMappings = childMapper.iterator();
+              Iterator<?> childMappings = childMapper.iterator();
               while (childMappings.hasNext()) {
                 PSDisplayMapping childMapping = (PSDisplayMapping) childMappings.next();
                 fieldName = childMapping.getFieldRef();

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Node_editorService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Node_editorService.java
@@ -27,7 +27,7 @@ public class Node_editorService implements Node_editorServiceInf {
 
   public Node_editorDAO node_editorDAO;
 
-  public Collection getAllNode_editors() {
+  public Collection<Node_editor> getAllNode_editors() {
     try {
       return node_editorDAO.getAllNode_editors();
     } catch (HibernateException e) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Node_statusService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Node_statusService.java
@@ -27,7 +27,7 @@ public class Node_statusService implements Node_statusServiceInf {
 
   public Node_statusDAO node_statusDAO;
 
-  public Collection getAllNode_statuss() {
+  public Collection<Node_status> getAllNode_statuss() {
     try {
       return node_statusDAO.getAllNode_statuss();
     } catch (HibernateException e) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Related_nodeService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Related_nodeService.java
@@ -27,7 +27,7 @@ public class Related_nodeService implements Related_nodeServiceInf {
 
   public Related_nodeDAO related_nodeDAO;
 
-  public Collection getAllRelated_nodes() {
+  public Collection<Related_node> getAllRelated_nodes() {
     try {
       return related_nodeDAO.getAllRelated_nodes();
     } catch (HibernateException e) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Relationship_typeService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/Relationship_typeService.java
@@ -27,7 +27,7 @@ public class Relationship_typeService implements Relationship_typeServiceInf {
 
   public Relationship_typeDAO relationship_typeDAO;
 
-  public Collection getAllRelationship_types() {
+  public Collection<Relationship_type> getAllRelationship_types() {
     try {
       return relationship_typeDAO.getAllRelationship_types();
     } catch (HibernateException e) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/VisibilityService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/VisibilityService.java
@@ -27,7 +27,7 @@ public class VisibilityService implements VisibilityServiceInf {
 
   public VisibilityDAO VisibilityDAO;
 
-  public Collection getAllVisibilities() {
+  public Collection<Visibility> getAllVisibilities() {
     try {
       return VisibilityDAO.getAllVisibilities();
     } catch (HibernateException e) {
@@ -35,7 +35,7 @@ public class VisibilityService implements VisibilityServiceInf {
     }
   }
 
-  public Collection getAllVisibilitiesForTaxonomyId(int taxonomy_id) {
+  public Collection<Visibility> getAllVisibilitiesForTaxonomyId(int taxonomy_id) {
     try {
       return VisibilityDAO.getAllVisibilitiesForTaxonomyId(taxonomy_id);
     } catch (HibernateException e) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/validation/GenericValidator.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/validation/GenericValidator.java
@@ -25,6 +25,8 @@ import java.io.Serializable;
  */
 public class GenericValidator implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   public static boolean isBlankOrNull(String value) {
     return ((value == null) || (value.trim().length() == 0));
   }

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/validation/UrlValidator.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/validation/UrlValidator.java
@@ -70,6 +70,8 @@ import org.apache.oro.text.perl.Perl5Util;
  */
 public class UrlValidator implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   /**
    * Allows all validly formatted schemes to pass validation instead of supplying a set of valid
    * schemes.
@@ -151,7 +153,7 @@ public class UrlValidator implements Serializable {
   private Flags options;
 
   /** The set of schemes that are allowed to be in a URL. */
-  private Set allowedSchemes = new HashSet();
+  private final HashSet<String> allowedSchemes = new HashSet<>();
 
   /** If no schemes are provided, default to this set. */
   protected String[] defaultSchemes = {"http", "https", "ftp"};

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/visibility/TaxonomyFieldVisibility.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/visibility/TaxonomyFieldVisibility.java
@@ -69,11 +69,11 @@ public class TaxonomyFieldVisibility implements IPSFieldVisibilityRule {
     Transaction tx = session.beginTransaction();
 
     // get similar ID for our main query
-    Query query = session.createQuery(SQL_STRING);
+    Query<Long> query = session.createQuery(SQL_STRING, Long.class);
     query.setParameter("taxonomy_id", taxonomy_id);
 
     // add them
-    Collection<Long> visible_to_community_ids = (Collection<Long>) query.list();
+    Collection<Long> visible_to_community_ids = query.list();
 
     log.debug("visible_to_community_ids.size:" + visible_to_community_ids.size());
 

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/AbstractTaxonEditorController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/AbstractTaxonEditorController.java
@@ -65,9 +65,9 @@ public abstract class AbstractTaxonEditorController extends AbstractControllerWi
 
   public static final String ACTION_ERROR = "action_error";
 
-  protected static HashMap collection_to_hashmap(Collection c) {
-    HashMap ret = new HashMap();
-    for (Object o : c) {
+  protected static <T> HashMap<T, T> collection_to_hashmap(Collection<T> c) {
+    HashMap<T, T> ret = new HashMap<>();
+    for (T o : c) {
       ret.put(o, o);
     }
     return ret;
@@ -124,10 +124,10 @@ public abstract class AbstractTaxonEditorController extends AbstractControllerWi
 
   protected ArrayList<Pair> getAttributeNames(int taxonomy_id, int language_id) {
     ArrayList<Pair> attributeNames = new ArrayList<Pair>();
-    Collection all = attributeService.getAttributeNames(taxonomy_id, language_id);
-    Iterator pairs = all.iterator();
+    Collection<Object[]> all = attributeService.getAttributeNames(taxonomy_id, language_id);
+    Iterator<Object[]> pairs = all.iterator();
     while (pairs.hasNext()) {
-      Object[] pair = (Object[]) pairs.next();
+      Object[] pair = pairs.next();
       attributeNames.add(new Pair((String) pair[0], (Integer) pair[1]));
     }
     Collections.sort(attributeNames);
@@ -137,10 +137,10 @@ public abstract class AbstractTaxonEditorController extends AbstractControllerWi
   protected HashMap<String, Integer> getNodeNames(int taxID, int langID) {
     // TODO need to change this from a hard coding to an ajax based one
     HashMap<String, Integer> nodeNames = new HashMap<String, Integer>();
-    Collection all = nodeService.getAllNodeNames(taxID, langID);
-    Iterator pairs = all.iterator();
+    Collection<Object[]> all = nodeService.getAllNodeNames(taxID, langID);
+    Iterator<Object[]> pairs = all.iterator();
     while (pairs.hasNext()) {
-      Object[] pair = (Object[]) pairs.next();
+      Object[] pair = pairs.next();
       nodeNames.put((String) pair[2], (Integer) pair[0]);
     }
     return nodeNames;
@@ -207,7 +207,7 @@ public abstract class AbstractTaxonEditorController extends AbstractControllerWi
     }
 
     if (do_children) {
-      for (Node child_node : (Collection<Node>) nodeService.getChildNodes(this_node.getId())) {
+      for (Node child_node : nodeService.getChildNodes(this_node.getId())) {
         set_new_permissions_for_role(roleNames, child_node, do_children);
       }
     }

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/AbstractXMLProviderController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/AbstractXMLProviderController.java
@@ -93,13 +93,12 @@ public class AbstractXMLProviderController extends AbstractControllerWithSecurit
         titles_ConcurrentHashMap = buildTitlesConcurrentHashMap(tp.getTaxID(), langID);
 
     List<Object[]> the_nodes = null;
-    Collection<Object[]> unfilted_nodes =
-        (Collection<Object[]>) nodeService.getAllNodeNames(tp.getTaxID(), langID);
+    Collection<Object[]> unfilted_nodes = nodeService.getAllNodeNames(tp.getTaxID(), langID);
 
     // create helper objects
     ArrayList<Integer> nodes_with_children = new ArrayList<Integer>();
     ArrayList<Integer> root_nodes = new ArrayList<Integer>();
-    for (Node node : (Collection<Node>) nodeService.getAllNodes(tp.getTaxID(), langID)) {
+    for (Node node : nodeService.getAllNodes(tp.getTaxID(), langID)) {
       if (node.getParent() != null) {
         nodes_with_children.add(node.getParent().getId());
       } else {
@@ -163,7 +162,7 @@ public class AbstractXMLProviderController extends AbstractControllerWithSecurit
       ArrayList<Attr> attributes = null;
 
       if (tp.getForJEXL()) {
-        attributes = new ArrayList();
+        attributes = new ArrayList<>();
       }
 
       String title =
@@ -257,8 +256,7 @@ public class AbstractXMLProviderController extends AbstractControllerWithSecurit
     Collection<Integer> ret = new ArrayList<Integer>();
     Node bottom_node = nodeService.getNode(nodeID, langID);
     if (bottom_node.getParent() != null) {
-      for (Node sibling :
-          (Collection<Node>) nodeService.getChildNodes(bottom_node.getParent().getId())) {
+      for (Node sibling : nodeService.getChildNodes(bottom_node.getParent().getId())) {
         ret.add(Integer.valueOf(sibling.getId()));
       }
       ret.addAll(getSelfAndElders(bottom_node.getParent().getId(), langID));
@@ -271,7 +269,7 @@ public class AbstractXMLProviderController extends AbstractControllerWithSecurit
 
   protected Collection<Integer> children_and_sub_ids(int nodeID, boolean first_level_only) {
     Collection<Integer> ret = new ArrayList<Integer>();
-    for (Node node : (Collection<Node>) nodeService.getChildNodes(nodeID)) {
+    for (Node node : nodeService.getChildNodes(nodeID)) {
       ret.add(Integer.valueOf(node.getId()));
       if (!first_level_only) {
         ret.addAll(children_and_sub_ids(node.getId(), first_level_only));
@@ -284,7 +282,7 @@ public class AbstractXMLProviderController extends AbstractControllerWithSecurit
   protected ConcurrentHashMap<Integer, ConcurrentHashMap<String, Collection<String>>>
       buildTitlesConcurrentHashMap(int taxID, int langID) {
     // build titles
-    ArrayList<Object[]> raw_titles = new ArrayList(nodeService.getTitlesForNodes(taxID, langID));
+    ArrayList<Object[]> raw_titles = new ArrayList<>(nodeService.getTitlesForNodes(taxID, langID));
     ConcurrentHashMap<Integer, ConcurrentHashMap<String, Collection<String>>>
         titles_ConcurrentHashMap =
             new ConcurrentHashMap<Integer, ConcurrentHashMap<String, Collection<String>>>();

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/AttributeController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/AttributeController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Attribute;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.AttributeService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -53,7 +54,7 @@ public class AttributeController {
     // --------------------------- Templated - Modify or replace -----------------------------
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
     //      Collection all = attributeService.getAttribute(1);
-    Collection all = attributeService.getAllAttributes(2, 1);
+    Collection<Attribute> all = attributeService.getAllAttributes(2, 1);
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     return new ModelAndView("attribute", "model", myModel);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Attribute_langController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Attribute_langController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Attribute_lang;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.Attribute_langService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -52,7 +53,7 @@ public class Attribute_langController {
       throws Exception {
     // --------------------------- Templated - Modify or replace -----------------------------
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
-    Collection all = attribute_langService.getAllAttribute_langs();
+    Collection<Attribute_lang> all = attribute_langService.getAllAttribute_langs();
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     return new ModelAndView("attribute_lang", "model", myModel);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/LanguageController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/LanguageController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Language;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.LanguageService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,7 +52,7 @@ public class LanguageController {
       throws Exception {
     // --------------------------- Templated - Modify or replace -----------------------------
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
-    Collection all = languageService.getAllLanguages();
+    Collection<Language> all = languageService.getAllLanguages();
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     return new ModelAndView("language", "model", myModel);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/NodeController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/NodeController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Node;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.NodeService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,7 +52,7 @@ public class NodeController {
       throws Exception {
 
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
-    Collection all = nodeService.getAllNodes(1, 1);
+    Collection<Node> all = nodeService.getAllNodes(1, 1);
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     myModel.put("node", nodeService.getNode(1, 1));

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Node_editorController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Node_editorController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Node_editor;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.Node_editorService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,7 +52,7 @@ public class Node_editorController {
       throws Exception {
     // --------------------------- Templated - Modify or replace -----------------------------
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
-    Collection all = node_editorService.getAllNode_editors();
+    Collection<Node_editor> all = node_editorService.getAllNode_editors();
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     return new ModelAndView("node_editor", "model", myModel);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Related_nodeController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Related_nodeController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Related_node;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.Related_nodeService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -52,7 +53,7 @@ public class Related_nodeController {
       throws Exception {
     // --------------------------- Templated - Modify or replace -----------------------------
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
-    Collection all = related_nodeService.getAllRelated_nodes();
+    Collection<Related_node> all = related_nodeService.getAllRelated_nodes();
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     return new ModelAndView("related_node", "model", myModel);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Relationship_typeController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/Relationship_typeController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Relationship_type;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.Relationship_typeService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,7 +52,7 @@ public class Relationship_typeController {
       throws Exception {
     // --------------------------- Templated - Modify or replace -----------------------------
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
-    Collection all = relationship_typeService.getAllRelationship_types();
+    Collection<Relationship_type> all = relationship_typeService.getAllRelationship_types();
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     return new ModelAndView("relationship_type", "model", myModel);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/TaxonEditorController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/TaxonEditorController.java
@@ -44,8 +44,8 @@ public class TaxonEditorController extends AbstractTaxonEditorController {
   public ModelAndView index(HttpServletRequest request, HttpServletResponse response)
       throws Exception {
 
-    Collection taxonomys = taxonomyService.getAllTaxonomys();
-    Collection languages = languageService.getAllLanguages();
+    Collection<Taxonomy> taxonomys = taxonomyService.getAllTaxonomys();
+    Collection<Language> languages = languageService.getAllLanguages();
 
     TaxonParams tp =
         new TaxonParams(
@@ -106,7 +106,7 @@ public class TaxonEditorController extends AbstractTaxonEditorController {
     errors = nodeService.deleteNodeAndFriends(tp.getNodeID(), Language.DEFAUL_LANG);
     if (node.getParent() != null) {
       node_parent = nodeService.getNode(node.getParent().getId(), Language.DEFAUL_LANG);
-      Collection childNodes = nodeService.getChildNodes(node_parent.getId());
+      Collection<Node> childNodes = nodeService.getChildNodes(node_parent.getId());
       if (childNodes.size() == 0 && node_parent.getNot_leaf()) {
         node_parent.setNot_leaf(false);
         nodeService.saveNode(node_parent);
@@ -145,8 +145,8 @@ public class TaxonEditorController extends AbstractTaxonEditorController {
       HttpServletRequest request, HttpServletResponse response, Map<String, String> errors)
       throws Exception {
     HashMap<String, Object> myModel = new HashMap<String, Object>();
-    Collection taxonomys = taxonomyService.getAllTaxonomys();
-    Collection languages = languageService.getAllLanguages();
+    Collection<Taxonomy> taxonomys = taxonomyService.getAllTaxonomys();
+    Collection<Language> languages = languageService.getAllLanguages();
 
     TaxonParams tp = new TaxonParams(request, taxonomyService);
 
@@ -238,8 +238,7 @@ public class TaxonEditorController extends AbstractTaxonEditorController {
     if (referenced_by_ids.size() > 0) {
       Collection<String> referenced_by_node_names = new ArrayList<String>();
       for (Object[] obj :
-          (Collection<Object[]>)
-              nodeService.getSomeNodeNames(referenced_by_ids, Language.DEFAUL_LANG)) {
+          nodeService.getSomeNodeNames(referenced_by_ids, Language.DEFAUL_LANG)) {
         referenced_by_node_names.add(obj[2].toString());
       }
       myModel.put("referenced_by_node_names", StringUtils.join(referenced_by_node_names, ","));
@@ -444,7 +443,7 @@ public class TaxonEditorController extends AbstractTaxonEditorController {
       // a leaf node.
       if (node.getParent() != null) {
         orig_node_parent = nodeService.getNode(node.getParent().getId(), Language.DEFAUL_LANG);
-        Collection childNodes = nodeService.getChildNodes(orig_node_parent.getId());
+        Collection<Node> childNodes = nodeService.getChildNodes(orig_node_parent.getId());
         if (childNodes.size() == 1 && orig_node_parent.getNot_leaf()) {
           orig_node_parent.setNot_leaf(false);
           nodeService.saveNode(orig_node_parent);
@@ -466,7 +465,7 @@ public class TaxonEditorController extends AbstractTaxonEditorController {
       if (node.getParent() != null) {
         orig_node_parent = nodeService.getNode(node.getParent().getId(), Language.DEFAUL_LANG);
 
-        Collection children = nodeService.getChildNodes(orig_node_parent.getId());
+        Collection<Node> children = nodeService.getChildNodes(orig_node_parent.getId());
 
         if (children.size() == 0 && orig_node_parent.getNot_leaf()) {
           // save_values_from_params(request, orig_node_parent, tp.getLangID(), true);

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/TaxonomyController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/TaxonomyController.java
@@ -216,17 +216,17 @@ public class TaxonomyController extends AbstractControllerWithSecurityChecks {
     // save attr
     Attribute attr = new Attribute();
     attr.setTaxonomy(tax);
-    if (((String) request.getParameter("attr_is_multiple")).equalsIgnoreCase("yes")) {
+    if (request.getParameter("attr_is_multiple").equalsIgnoreCase("yes")) {
       attr.setIs_multiple(true);
     } else {
       attr.setIs_multiple(false);
     }
-    if (((String) request.getParameter("attr_is_percussion_item")).equalsIgnoreCase("yes")) {
+    if (request.getParameter("attr_is_percussion_item").equalsIgnoreCase("yes")) {
       attr.setIs_percussion_item(true);
     } else {
       attr.setIs_percussion_item(false);
     }
-    if (((String) request.getParameter("attr_is_node_name")).equalsIgnoreCase("yes")) {
+    if (request.getParameter("attr_is_node_name").equalsIgnoreCase("yes")) {
       attr.setIs_node_name(1);
       // override these options if needed
       attr.setIs_percussion_item(false);
@@ -234,7 +234,7 @@ public class TaxonomyController extends AbstractControllerWithSecurityChecks {
     } else {
       attr.setIs_node_name(0);
     }
-    if (((String) request.getParameter("attr_is_required")).equalsIgnoreCase("yes")) {
+    if (request.getParameter("attr_is_required").equalsIgnoreCase("yes")) {
       attr.setIs_required(true);
     } else {
       attr.setIs_required(false);
@@ -336,12 +336,12 @@ public class TaxonomyController extends AbstractControllerWithSecurityChecks {
   public ModelAndView delete_attribute(HttpServletRequest request, HttpServletResponse response)
       throws Exception {
     TaxonParams tp = new TaxonParams(request, taxonomyService);
-    String attributeId = ((String) request.getParameter("attrID"));
+    String attributeId = request.getParameter("attrID");
     notEmpty(attributeId);
 
-    Collection attributes = attributeService.getAttribute(Integer.valueOf(attributeId));
+    Collection<Attribute> attributes = attributeService.getAttribute(Integer.valueOf(attributeId));
     if (!attributes.isEmpty()) {
-      Attribute attribute = (Attribute) attributes.iterator().next();
+      Attribute attribute = attributes.iterator().next();
       attributeService.removeAttribute(attribute);
     }
     return new ModelAndView(

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/ValueController.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/web/ValueController.java
@@ -17,6 +17,7 @@
 
 package com.percussion.taxonomy.web;
 
+import com.percussion.taxonomy.domain.Value;
 import com.percussion.taxonomy.TaxonomySecurityHelper;
 import com.percussion.taxonomy.service.ValueService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,7 +52,7 @@ public class ValueController {
       throws Exception {
     // --------------------------- Templated - Modify or replace -----------------------------
     TaxonomySecurityHelper.raise_error_if_cannot_admin();
-    Collection all = valueService.getAllValues();
+    Collection<Value> all = valueService.getAllValues();
     Map<String, Object> myModel = new HashMap<String, Object>();
     myModel.put("all", all);
     return new ModelAndView("value", "model", myModel);

--- a/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/jexl/TaxAttMapTest.java
+++ b/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/jexl/TaxAttMapTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.taxonomy.jexl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.taxonomy.domain.Attribute;
+import com.percussion.taxonomy.domain.Attribute_lang;
+import com.percussion.taxonomy.domain.Language;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for {@link TaxAttMap} construction from Hibernate attribute langs. */
+public class TaxAttMapTest {
+
+  @Test
+  public void emptyConstructor_createsEmptyMap() {
+    TaxAttMap map = new TaxAttMap();
+    assertTrue(map.isEmpty());
+  }
+
+  @Test
+  public void constructorFromAttributeLangs_indexesByName() {
+    Attribute attribute = new Attribute();
+    attribute.setId(42);
+    attribute.setIs_multiple(true);
+    attribute.setIs_required(false);
+    attribute.setAttribute_langs(new ArrayList<>());
+
+    Language language = new Language();
+    language.setName("English");
+
+    Attribute_lang attLang = new Attribute_lang();
+    attLang.setName("Color");
+    attLang.setAttribute(attribute);
+    attLang.setLanguage(language);
+    attribute.addAttribute_lang(attLang);
+
+    List<Attribute_lang> langs = new ArrayList<>();
+    langs.add(attLang);
+
+    TaxAttMap map = new TaxAttMap(langs);
+    assertEquals(1, map.size());
+    TaxAttribute taxAttribute = map.get("Color");
+    assertNotNull(taxAttribute);
+    assertEquals(42, taxAttribute.getId());
+    assertEquals("Color", taxAttribute.getName());
+    assertTrue(taxAttribute.isMultiple());
+  }
+}

--- a/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/jexl/TaxValuesTest.java
+++ b/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/jexl/TaxValuesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.taxonomy.jexl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for {@link TaxValues} (single vs multi-value JEXL helper). */
+public class TaxValuesTest {
+
+  @Test
+  public void emptyConstructor_isNotMultiValued() {
+    TaxValues values = new TaxValues();
+    assertFalse(values.isMultiValued());
+    assertEquals("", values.toString());
+  }
+
+  @Test
+  public void singleValueConstructor_isNotMultiValued() {
+    TaxValues values = new TaxValues("alpha");
+    assertFalse(values.isMultiValued());
+    assertEquals("alpha", values.toString());
+    assertEquals(1, values.size());
+  }
+
+  @Test
+  public void multipleValues_joinAndToString() {
+    TaxValues values = new TaxValues();
+    values.add("one");
+    values.add("two");
+    values.add("three");
+    assertTrue(values.isMultiValued());
+    assertEquals("one|two|three", values.join("|"));
+    assertEquals("one,two,three", values.toString());
+  }
+}

--- a/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/validation/GenericValidatorTest.java
+++ b/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/validation/GenericValidatorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.taxonomy.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for {@link GenericValidator}. */
+public class GenericValidatorTest {
+
+  @Test
+  public void isBlankOrNull_nullAndBlank() {
+    assertTrue(GenericValidator.isBlankOrNull(null));
+    assertTrue(GenericValidator.isBlankOrNull(""));
+    assertTrue(GenericValidator.isBlankOrNull("   "));
+  }
+
+  @Test
+  public void isBlankOrNull_nonBlank() {
+    assertFalse(GenericValidator.isBlankOrNull("x"));
+    assertFalse(GenericValidator.isBlankOrNull(" value "));
+  }
+}

--- a/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/validation/UrlValidatorTest.java
+++ b/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/validation/UrlValidatorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.taxonomy.validation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for {@link UrlValidator} scheme allow-list and validity. */
+public class UrlValidatorTest {
+
+  @Test
+  public void defaultSchemes_acceptsHttp() {
+    UrlValidator validator = new UrlValidator();
+    assertTrue(validator.isValid("http://example.com/path"));
+  }
+
+  @Test
+  public void nullValue_isInvalid() {
+    UrlValidator validator = new UrlValidator();
+    assertFalse(validator.isValid(null));
+  }
+
+  @Test
+  public void customSchemes_rejectUnknownScheme() {
+    UrlValidator validator = new UrlValidator(new String[] {"https"});
+    assertFalse(validator.isValid("http://example.com/"));
+    assertTrue(validator.isValid("https://example.com/"));
+  }
+}

--- a/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/web/AbstractTaxonEditorControllerTest.java
+++ b/modules/perc-taxonomy/src/test/java/com/percussion/taxonomy/web/AbstractTaxonEditorControllerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.taxonomy.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for typed helpers on {@link AbstractTaxonEditorController}. */
+public class AbstractTaxonEditorControllerTest {
+
+  @Test
+  public void collectionToHashmap_identityKeys() {
+    HashMap<String, String> map =
+        AbstractTaxonEditorController.collection_to_hashmap(Arrays.asList("a", "b", "c"));
+    assertEquals(3, map.size());
+    assertEquals("a", map.get("a"));
+    assertEquals("b", map.get("b"));
+    assertEquals("c", map.get("c"));
+  }
+
+  @Test
+  public void collectionToHashmap_empty() {
+    HashMap<Integer, Integer> map =
+        AbstractTaxonEditorController.collection_to_hashmap(Arrays.asList());
+    assertTrue(map.isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

Clears **all remaining javac diagnostics** in `modules/perc-taxonomy` (issue #2031) with **real fixes** (no blanket rawtypes/unchecked suppressions).

Parent tracker: #2200

### Before / after (standalone compile under project `-Xlint`)

| Metric | Before | After |
|--------|--------|-------|
| Javac warning lines (main) | **99** | **0** |
| Categories | rawtypes, unchecked, this-escape, serial, redundant cast, Session.get removal | — |

### What changed

- **Typed Collection APIs** across small DAO / ServiceInf / service stacks (Language, Attribute_lang, Node_editor, Node_status, Related_node, Relationship_type, Visibility, Taxonomy)
- **Hibernate typed queries** — `createQuery(hql, Class)` / `Query<T>`; generic `executeQuery(hql, Class)` helper in `HibernateNodeDAO`; named query typed for `findNodesByAttribute`
- **Session.find** replaces deprecated `Session.get` in Hibernate DAOs
- **this-escape** — `final` on `TaxAttMap`, `TaxValues`
- **serial** — `serialVersionUID` on validators; `HashSet<String>` for allowed schemes
- **Web layer** — typed Collections / remove redundant casts in controllers
- **tests** — 12 behavioral unit tests (TaxValues, TaxAttMap, validators, collection_to_hashmap)

### Residual

**None for javac in this module** (module zero under project `-Xlint`). Optional later: maven-javadoc-plugin incomplete-Javadoc noise if a dedicated javadoc-zero gate is required.

## Test plan

- [x] `cd modules/perc-taxonomy` → `../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **12**, Failures: **0**, Errors: **0**, Skipped: **0**
- [x] Javac `[WARNING] *.java:[line,col]` lines: **0**
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2031-perc-taxonomy-javac-batch1-erlang.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Standalone module clean install | BUILD SUCCESS |
| Behavioral unit tests | 12 new green |
| Scope confined to perc-taxonomy (+ erlang report) | yes |
| Prefer real fixes over blanket suppress | yes |
| Erlang pre-commit | approve |

Fixes #2031  
Refs #2200

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
