### PR TITLE
fix(perc-ant): javac warnings batch 1 — raw types/casts (~50 diags) (#2023)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md
@@ -1,0 +1,36 @@
+# Erlang self-review — issue #2023 perc-ant javac batch 1
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2023-perc-ant-javac-warnings-batch1`  
+**Module:** `modules/perc-ant`  
+**Verdict:** **Approve** (commit-ready)
+
+## Scope
+
+PR-sized batch 1: real-fix raw types, redundant casts, and unchecked calls under project `-Xlint` / `-Xlint:-deprecation` (~50 diagnostics). No behavior change intended beyond type parameters and removal of redundant casts.
+
+**In batch:** top-level ant helpers, help-hint / helptopic mapping tasks, install tasks (copy, extract jar, war update, table/data/rxfix/secure property/page tags/derby, etc.).
+
+**Out of batch (residual on #2023):** `PSJunitFileSelector` (~15), `PSRxBuildInput` (~19), constructor `this-escape` sites (~6).
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in typed refactors | None found — collections already held the typed elements; only declarations/casts updated |
+| Portable paths / file I/O | N/A for this batch (no path-string changes) |
+| Behavioral unit tests | Existing module suite green (39 tests); no new non-trivial logic |
+| Prefer real fix over suppress | Yes — no new `@SuppressWarnings` |
+| Standalone `mvnw clean install` | BUILD SUCCESS |
+| Scope confined to perc-ant | Yes |
+
+## Notes
+
+- Jericho HTML 2.1 APIs return raw `List` / `Iterator`; callers use enhanced-for + local cast to `StartTag`/`Tag` (no unchecked conversion to `List<StartTag>`).
+- `PSProperties.getProperty` already returns `String` — redundant casts removed.
+- `PSJdbcTableSchema.getKeyColumns()` / `PSJdbcTableData.getRows()` / `PSRxFixCmd.getResults()` already parameterized upstream.
+- Residual `this-escape` and large GUI/JUnit selector files deferred deliberately for PR size.
+
+## Residual issue
+
+Follow-up residual issue to be filed for remaining ~40 main-source diagnostics (batch 2+).

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSCheckTmxFile.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSCheckTmxFile.java
@@ -206,7 +206,7 @@ public class PSCheckTmxFile extends Task {
 
     while (it.hasNext()) {
       boolean firstError = true;
-      file = new File((String) it.next());
+      file = new File(it.next());
       if (!file.exists())
         throw new BuildException("Property file does not exist: " + file.getAbsolutePath());
       try {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSCreateSharedClassList.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSCreateSharedClassList.java
@@ -103,9 +103,9 @@ public class PSCreateSharedClassList extends Task {
    *
    * @param macros the makefile interpreter macros, should not be <code>null</code>.
    */
-  private void createEntries(Map macros) {
-    String thePackage = ((String) macros.get(PACKAGE_MACRO)).trim().replace('.', '/');
-    String shared = (String) macros.get(SHARED_CLASSES_MACRO);
+  private void createEntries(Map<String, String> macros) {
+    String thePackage = macros.get(PACKAGE_MACRO).trim().replace('.', '/');
+    String shared = macros.get(SHARED_CLASSES_MACRO);
     StringTokenizer st = new StringTokenizer(shared, " \t\r\n");
     if (st.hasMoreTokens()) {
       addBreak();

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSDelete.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSDelete.java
@@ -142,9 +142,9 @@ public class PSDelete extends Delete {
         dirs.add(dir);
       }
 
-      Iterator it = dirs.iterator();
+      Iterator<File> it = dirs.iterator();
       while (it.hasNext()) {
-        File f = (File) it.next();
+        File f = it.next();
         if (isUsingMapping && !f.exists()) {
           if (m_verbosity == Project.MSG_VERBOSE) {
             log("Skipping non-existant directory " + f.getAbsolutePath());

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSHelpHintFileCreator.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSHelpHintFileCreator.java
@@ -102,7 +102,7 @@ public class PSHelpHintFileCreator {
    *
    * @return iterator of all unique parsed images. Never <code>null</code>, may be empty.
    */
-  public Iterator getImages() {
+  public Iterator<String> getImages() {
     return m_images.keySet().iterator();
   }
 
@@ -112,9 +112,7 @@ public class PSHelpHintFileCreator {
    * @param out assumed not <code>null</code>.
    */
   private void createFileBody(PrintStream out, Map<String, String> mappings) throws IOException {
-    Iterator it = mappings.keySet().iterator();
-    while (it.hasNext()) {
-      String key = (String) it.next();
+    for (String key : mappings.keySet()) {
       if (key.startsWith(EDITOR_PKG) || key.startsWith(WIZARD_PKG)) {
         final String filename = mappings.get(key);
         if (filename != null && filename.trim().length() > 0) {
@@ -139,11 +137,11 @@ public class PSHelpHintFileCreator {
   private void parseAndWriteHints(PrintStream out, File helpFile, String key) throws IOException {
     String text = getHelpFileText(helpFile);
     Source source = new Source(text);
-    List descTags = getAllFieldDescStartTags(source);
+    List<StartTag> descTags = getAllFieldDescStartTags(source);
     if (descTags.isEmpty()) return;
     for (int i = 0; i < descTags.size(); i++) {
       String content = null;
-      StartTag tagA = (StartTag) descTags.get(i);
+      StartTag tagA = descTags.get(i);
       if (i == descTags.size() - 1) {
         Tag lastTag = tagA.findEndTag();
         while (true) {
@@ -159,7 +157,7 @@ public class PSHelpHintFileCreator {
         content = text.substring(tagA.getBegin(), lastTag.getBegin());
 
       } else {
-        StartTag tagB = (StartTag) descTags.get(i + 1);
+        StartTag tagB = descTags.get(i + 1);
         content = text.substring(tagA.getBegin(), tagB.getBegin());
       }
 
@@ -200,8 +198,8 @@ public class PSHelpHintFileCreator {
   private String handleImages(String content) {
     Source source = new Source(content);
     OutputDocument outputDoc = new OutputDocument(content);
-    for (Iterator it = source.findAllStartTags(ELEM_IMAGE).iterator(); it.hasNext(); ) {
-      StartTag sTag = (StartTag) it.next();
+    for (Object tagObj : source.findAllStartTags(ELEM_IMAGE)) {
+      StartTag sTag = (StartTag) tagObj;
       Attributes attrs = sTag.getAttributes();
       Attribute attr = attrs.get(ATTR_SOURCE);
       String value = attr.getValue();
@@ -229,8 +227,8 @@ public class PSHelpHintFileCreator {
   private String handleAnchors(String content) {
     Source source = new Source(content);
     OutputDocument outputDoc = new OutputDocument(content);
-    for (Iterator it = source.findAllStartTags(ELEM_ANCHOR).iterator(); it.hasNext(); ) {
-      StartTag sTag = (StartTag) it.next();
+    for (Object tagObj : source.findAllStartTags(ELEM_ANCHOR)) {
+      StartTag sTag = (StartTag) tagObj;
       Attributes attrs = sTag.getAttributes();
       Attribute attr = attrs.get(ATTR_HREF);
       String value = attr.getValue();
@@ -257,7 +255,7 @@ public class PSHelpHintFileCreator {
   private String stripTags(String content) {
     Source source = new Source(content);
     OutputDocument outputDoc = new OutputDocument(content);
-    for (Iterator it = source.getNextTagIterator(0); it.hasNext(); ) {
+    for (Iterator<?> it = source.getNextTagIterator(0); it.hasNext(); ) {
       Tag tag = (Tag) it.next();
       outputDoc.add(new StringOutputSegment(tag.getBegin(), tag.getEnd(), ""));
     }
@@ -275,8 +273,8 @@ public class PSHelpHintFileCreator {
     if (!tag.getName().equals(ELEM_TABLE)) return false;
     EndTag eTag = tag.findEndTag();
     Source source = new Source(text.substring(tag.getBegin(), eTag.getEnd()));
-    for (Iterator it = source.findAllStartTags(ELEM_P).iterator(); it.hasNext(); ) {
-      StartTag sTag = (StartTag) it.next();
+    for (Object tagObj : source.findAllStartTags(ELEM_P)) {
+      StartTag sTag = (StartTag) tagObj;
       Attributes attrs = sTag.getAttributes();
       Attribute attr = attrs.get(ATTR_CLASS);
       if (attr != null && attr.getValue().equals(RELATEDHEADING)) return true;
@@ -292,8 +290,8 @@ public class PSHelpHintFileCreator {
    */
   private List<StartTag> getAllFieldDescStartTags(Source source) {
     List<StartTag> tags = new ArrayList<>();
-    for (Iterator<StartTag> it = source.findAllStartTags(ELEM_P).iterator(); it.hasNext(); ) {
-      StartTag sTag = it.next();
+    for (Object tagObj : source.findAllStartTags(ELEM_P)) {
+      StartTag sTag = (StartTag) tagObj;
       if (isFieldDescription(sTag)) {
         tags.add(sTag);
       }
@@ -309,8 +307,8 @@ public class PSHelpHintFileCreator {
    */
   private String getFieldName(String content) {
     Source source = new Source(content);
-    for (Iterator it = source.findAllStartTags(ELEM_STRONG).iterator(); it.hasNext(); ) {
-      StartTag sTag = (StartTag) it.next();
+    for (Object tagObj : source.findAllStartTags(ELEM_STRONG)) {
+      StartTag sTag = (StartTag) tagObj;
       Attributes attrs = sTag.getAttributes();
       Attribute attr = attrs.get(ATTR_CLASS);
       if (attr != null && attr.getValue().equals(FIELDNAME)) {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSPropagateFile.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSPropagateFile.java
@@ -65,22 +65,22 @@ public class PSPropagateFile extends Task {
 
     try {
       List<String> directories = new ArrayList<String>();
-      Iterator it = m_fileSets.iterator();
+      Iterator<DirSet> it = m_fileSets.iterator();
       FileUtils utils = FileUtils.newFileUtils();
       File baseDir = null;
       int count = 0;
       while (it.hasNext()) {
-        DirSet fs = (DirSet) it.next();
+        DirSet fs = it.next();
         DirectoryScanner ds = fs.getDirectoryScanner(getProject());
         baseDir = ds.getBasedir();
         String[] dirs = ds.getIncludedDirectories();
         directories.addAll(Arrays.asList(dirs));
       }
-      it = directories.iterator();
+      Iterator<String> dirIt = directories.iterator();
 
-      while (it.hasNext()) {
+      while (dirIt.hasNext()) {
 
-        File df = new File(baseDir + "/" + (String) it.next() + "/" + m_srcFile.getName());
+        File df = new File(baseDir + "/" + dirIt.next() + "/" + m_srcFile.getName());
 
         utils.copyFile(m_srcFile, df);
         count++;

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSSyncFiles.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSSyncFiles.java
@@ -79,27 +79,27 @@ public class PSSyncFiles extends Task {
     setCopies(m_fromDir);
 
     // process deletes
-    Iterator it = null;
+    Iterator<File> it = null;
     File current = null;
     log("Removing " + m_fileDeletes.size() + " files from destination");
     it = m_fileDeletes.iterator();
     while (it.hasNext()) {
-      current = (File) it.next();
+      current = it.next();
       deleteFile(current);
     }
     log("Removing " + m_dirDeletes.size() + " directories from destination");
     it = m_dirDeletes.iterator();
     while (it.hasNext()) {
-      current = (File) it.next();
+      current = it.next();
       deleteFile(current);
     }
 
     // process copies
-    Set keys = m_dirCopies.keySet();
+    Set<File> keys = m_dirCopies.keySet();
     log("Copying " + m_dirCopies.size() + " directories to" + " destination");
     it = keys.iterator();
     while (it.hasNext()) {
-      current = (File) it.next();
+      current = it.next();
       m_dirCopies.get(current).mkdirs();
     }
     keys = m_fileCopies.keySet();
@@ -107,7 +107,7 @@ public class PSSyncFiles extends Task {
     it = keys.iterator();
     try {
       while (it.hasNext()) {
-        current = (File) it.next();
+        current = it.next();
 
         try {
           copyFile(current, m_fileCopies.get(current));

--- a/modules/perc-ant/src/main/java/com/percussion/ant/doc/PSGenerateHelptopicMappingsTask.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/doc/PSGenerateHelptopicMappingsTask.java
@@ -25,7 +25,6 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
@@ -128,13 +127,11 @@ public class PSGenerateHelptopicMappingsTask extends Task {
                 new PSXmlSecurityOptions(true, true, true, false, true, false));
         DocumentBuilder builder = fact.newDocumentBuilder();
 
-        Map topics = readKeys(builder, keyFile);
-        Map mappings = readMappings(builder, mapFile);
+        Map<String, String> topics = readKeys(builder, keyFile);
+        Map<String, String> mappings = readMappings(builder, mapFile);
 
-        Iterator kiter = topics.keySet().iterator();
-        while (kiter.hasNext()) {
-          String key = (String) kiter.next();
-          String desturl = (String) topics.get(key);
+        for (String key : topics.keySet()) {
+          String desturl = topics.get(key);
 
           if (desturl.trim().length() == 0) {
             if (m_suppressError) {
@@ -143,7 +140,7 @@ public class PSGenerateHelptopicMappingsTask extends Task {
               throw new BuildException("Error, " + key + " is missing a destination url");
             }
           } else {
-            String index = (String) mappings.get(desturl);
+            String index = mappings.get(desturl);
             if (index != null) {
               out.println(key + "=" + index);
             } else {
@@ -174,7 +171,8 @@ public class PSGenerateHelptopicMappingsTask extends Task {
    * @throws IOException
    * @throws SAXException
    */
-  private Map readMappings(DocumentBuilder builder, File mapFile) throws SAXException, IOException {
+  private Map<String, String> readMappings(DocumentBuilder builder, File mapFile)
+      throws SAXException, IOException {
     return readKeyValueData(builder, mapFile, "mapID", "url", "target");
   }
 
@@ -188,7 +186,7 @@ public class PSGenerateHelptopicMappingsTask extends Task {
    * @throws IOException
    */
   // TODO: Remove me @SuppressFBWarnings("XXE_DOCUMENT")  // False positive - see PSSecureXMLUtils
-  private Map readKeyValueData(
+  private Map<String, String> readKeyValueData(
       DocumentBuilder builder, File mapFile, String nodeName, String keyName, String valName)
       throws SAXException, IOException {
     Document d = builder.parse(mapFile);
@@ -210,7 +208,8 @@ public class PSGenerateHelptopicMappingsTask extends Task {
    * @throws IOException
    * @throws SAXException
    */
-  private Map readKeys(DocumentBuilder builder, File keyFile) throws SAXException, IOException {
+  private Map<String, String> readKeys(DocumentBuilder builder, File keyFile)
+      throws SAXException, IOException {
     return readKeyValueData(builder, keyFile, "mapping", "key", "url");
   }
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSCopy.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSCopy.java
@@ -77,10 +77,10 @@ public class PSCopy extends Copy {
    */
   private void modifyFileMap() {
     if (fileCopyMap.size() > 0) {
-      Enumeration e = fileCopyMap.keys();
+      Enumeration<String> e = fileCopyMap.keys();
       while (e.hasMoreElements()) {
-        String fromFile = (String) e.nextElement();
-        String[] toFiles = (String[]) fileCopyMap.get(fromFile);
+        String fromFile = e.nextElement();
+        String[] toFiles = fileCopyMap.get(fromFile);
         ArrayList<String> toFilesList = new ArrayList<String>();
 
         for (int i = 0; i < toFiles.length; i++) {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSDBXMLDataUpdate.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSDBXMLDataUpdate.java
@@ -127,7 +127,7 @@ public class PSDBXMLDataUpdate extends PSXMLFileUpdate {
       // catalog table data
       // we will catalog the update key columns and the column whose
       // data we need to update
-      List keyColumns = tableSchema.getKeyColumns();
+      List<String> keyColumns = tableSchema.getKeyColumns();
       if (keyColumns.isEmpty()) {
         PSLogger.logInfo("ERROR : No key columns defined for table - " + tableName);
         PSLogger.logInfo("Data cannot be updated in table - " + tableName);
@@ -135,10 +135,10 @@ public class PSDBXMLDataUpdate extends PSXMLFileUpdate {
       }
 
       String[] columns = new String[keyColumns.size() + 1];
-      Iterator it = keyColumns.iterator();
+      Iterator<String> it = keyColumns.iterator();
       int index = 0;
       while (it.hasNext()) {
-        columns[index] = (String) it.next();
+        columns[index] = it.next();
         index++;
       }
       columns[index] = columnName;
@@ -159,9 +159,9 @@ public class PSDBXMLDataUpdate extends PSXMLFileUpdate {
       // create a plan containing all the update statements
       PSJdbcExecutionPlan plan = new PSJdbcExecutionPlan();
       PSJdbcExecutionStep step = null;
-      Iterator rowIt = tableData.getRows();
+      Iterator<PSJdbcRowData> rowIt = tableData.getRows();
       while (rowIt.hasNext()) {
-        PSJdbcRowData row = (PSJdbcRowData) rowIt.next();
+        PSJdbcRowData row = rowIt.next();
         PSJdbcColumnData colData = row.getColumn(columnName);
         if (colData != null) {
           String colValue = colData.getValue();

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSExtractJarFiles.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSExtractJarFiles.java
@@ -69,12 +69,12 @@ public class PSExtractJarFiles extends PSAction {
 
       PSLogger.logInfo("Extracting jar file : " + jarFile + " to :" + destinationDir);
 
-      List fileList = new ArrayList();
+      List<String> fileList = new ArrayList<>();
       try (JarFile jar = new JarFile(jarFile)) {
         if ((filesToExtract == null) || (filesToExtract.length == 0)) {
-          for (Enumeration entries = jar.entries(); entries.hasMoreElements(); ) {
+          for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements(); ) {
             // Get the next entry.
-            JarEntry entry = (JarEntry) entries.nextElement();
+            JarEntry entry = entries.nextElement();
             String entryName = entry.getName();
             if (!((entryName.endsWith(File.separator)) || (entryName.endsWith("/"))))
               fileList.add(entryName);
@@ -88,7 +88,7 @@ public class PSExtractJarFiles extends PSAction {
       int bytesRead;
 
       for (int k = 0; k < fileList.size(); k++) {
-        String entryName = (String) fileList.get(k);
+        String entryName = fileList.get(k);
         // CWE-22 / java/zipslip #720: never concatenate destinationDir with a raw jar entry
         // name. PathValidation.constructSafePath rejects absolute paths and .. traversal.
         final File fJarFile;

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSInstallLogTablesAction.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSInstallLogTablesAction.java
@@ -83,13 +83,13 @@ public class PSInstallLogTablesAction extends PSAction {
 
         PSProperties repProp = new PSProperties(repPropFile.getPath());
 
-        String strDriver = (String) repProp.getProperty(REP_DRIVER);
-        String strClass = (String) repProp.getProperty(REP_CLASS);
-        String strServer = (String) repProp.getProperty(REP_SERVER);
-        String strId = (String) repProp.getProperty(REP_ID);
-        String strPw = (String) repProp.getProperty(REP_PW);
-        String strDb = (String) repProp.getProperty(REP_DATABASE);
-        String strSchema = (String) repProp.getProperty(REP_SCHEMA);
+        String strDriver = repProp.getProperty(REP_DRIVER);
+        String strClass = repProp.getProperty(REP_CLASS);
+        String strServer = repProp.getProperty(REP_SERVER);
+        String strId = repProp.getProperty(REP_ID);
+        String strPw = repProp.getProperty(REP_PW);
+        String strDb = repProp.getProperty(REP_DATABASE);
+        String strSchema = repProp.getProperty(REP_SCHEMA);
 
         PSProperties serverProp = new PSProperties(serverPropFile.getAbsolutePath());
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSRenameDeprecatedApps.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSRenameDeprecatedApps.java
@@ -24,7 +24,7 @@ import com.percussion.util.PSProperties;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -98,7 +98,7 @@ public class PSRenameDeprecatedApps extends PSAction {
     String appName = null;
     File appFile = null;
     String[] apps = objDir.list();
-    HashSet depApps = (HashSet) PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps();
+    Set<?> depApps = PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps();
     int renamedApps = 0;
 
     for (int i = 0; i < apps.length; i++) {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSRxFix.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSRxFix.java
@@ -89,12 +89,12 @@ public class PSRxFix extends PSAction {
         cmd.execute();
 
         // Log the results
-        List results = cmd.getResults();
+        List<String> results = cmd.getResults();
 
         if (results.size() == 0) PSLogger.logInfo("No modifications were required");
         else {
           for (int i = 0; i < results.size(); i++) {
-            String result = (String) results.get(i);
+            String result = results.get(i);
             PSLogger.logInfo(result);
           }
         }

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSSecureProperty.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSSecureProperty.java
@@ -156,7 +156,7 @@ public class PSSecureProperty {
         log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       }
 
-      for (Map.Entry entry : props.entrySet()) {
+      for (Map.Entry<Object, Object> entry : props.entrySet()) {
         String value = (String) entry.getValue();
         if (isValueClouded(value)) {
           props.put(entry.getKey(), getValue(value, null));

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSTableAction.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSTableAction.java
@@ -150,12 +150,12 @@ public class PSTableAction extends PSAction {
           else dataColl.addAll(new PSJdbcTableDataCollection(doc));
         }
 
-        Iterator it = schemaColl.iterator();
+        Iterator<PSJdbcTableSchema> it = schemaColl.iterator();
 
         int index = 0;
 
         while (it.hasNext()) {
-          schema = (PSJdbcTableSchema) it.next();
+          schema = it.next();
           String tblName = schema.getName();
           data = dataColl.getTableData(tblName);
           // getTableData may return null if this table has no data associated

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpdateWarFiles.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpdateWarFiles.java
@@ -103,7 +103,7 @@ public class PSUpdateWarFiles extends PSAction {
     JarFile srcJarFile = null;
 
     try {
-      Set setJarFiles = new HashSet();
+      Set<String> setJarFiles = new HashSet<>();
       for (int k = 0; k < m_jarFiles.length; k++) {
         String jarFileName = jarFilesPath + new File(m_jarFiles[k]).getName();
 
@@ -156,9 +156,10 @@ public class PSUpdateWarFiles extends PSAction {
 
         // Loop through the jar entries and add/remove them to/from the temp jar,
         // skipping the entry that was added/(to be removed) to/from the temp jar already.
-        for (Enumeration srcJarEntries = srcJarFile.entries(); srcJarEntries.hasMoreElements(); ) {
+        for (Enumeration<JarEntry> srcJarEntries = srcJarFile.entries();
+            srcJarEntries.hasMoreElements(); ) {
           // Get the next entry.
-          JarEntry srcJarEntry = (JarEntry) srcJarEntries.nextElement();
+          JarEntry srcJarEntry = srcJarEntries.nextElement();
 
           String entryName = srcJarEntry.getName();
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeDerby.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeDerby.java
@@ -264,7 +264,8 @@ public class PSUpgradeDerby extends PSAction {
     PSLogger.logInfo("Loading DerbyDriver File " + derbyJDBCDriver.toString());
     java.net.URL url = derbyJDBCDriver.toURI().toURL();
     java.lang.reflect.Method method =
-        java.net.URLClassLoader.class.getDeclaredMethod("addURL", new Class[] {java.net.URL.class});
+        java.net.URLClassLoader.class.getDeclaredMethod(
+            "addURL", new Class<?>[] {java.net.URL.class});
     method.setAccessible(true); /*promote the method to public access*/
     method.invoke(Thread.currentThread().getContextClassLoader(), new Object[] {url});
   }

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeServerPageTags.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeServerPageTags.java
@@ -106,7 +106,7 @@ public class PSUpgradeServerPageTags extends PSAction {
 
         // list of "tag" elements whose attribute "isXslTag" has the
         // value "yes"
-        List processTagNodes = new ArrayList();
+        List<Element> processTagNodes = new ArrayList<>();
 
         NodeList resNl = resDoc.getElementsByTagName("tag");
         for (int i = 0; i < resNl.getLength(); i++) {
@@ -128,7 +128,7 @@ public class PSUpgradeServerPageTags extends PSAction {
           boolean processedOne = false;
 
           for (int i = 0; i < processTagNodes.size(); i++) {
-            PSXmlTreeWalker resWalker = new PSXmlTreeWalker((Element) processTagNodes.get(i));
+            PSXmlTreeWalker resWalker = new PSXmlTreeWalker(processTagNodes.get(i));
             String resOpening = resWalker.getElementData("opening", true);
             String resClosing = resWalker.getElementData("closing", true);
 


### PR DESCRIPTION
## Summary

PR-sized **batch 1** real-fix of javac diagnostics in `modules/perc-ant` (issue #2023).

Under project `-Xlint` / `-Xlint:-deprecation`, main-source diagnostics were **~90** before this PR (issue analysis originally reported 200 under a broader scan). This batch clears **~50** via real generics and redundant-cast removal (no new `@SuppressWarnings`).

### Fixed in this PR (~50 diagnostics)

- **Top-level helpers**: `PSCheckTmxFile`, `PSCreateSharedClassList`, `PSDelete`, `PSPropagateFile`, `PSSyncFiles`, `PSHelpHintFileCreator`
- **Doc**: `PSGenerateHelptopicMappingsTask` (`Map<String,String>` key/value readers)
- **Install**: `PSCopy`, `PSExtractJarFiles`, `PSUpdateWarFiles`, `PSDBXMLDataUpdate`, `PSInstallLogTablesAction`, `PSUpgradeServerPageTags`, `PSRenameDeprecatedApps` (Set<?>), `PSRxFix`, `PSSecureProperty`, `PSTableAction` (typed schema iterator), `PSUpgradeDerby` (`Class<?>[]`)

### Residual (not module-zero yet)

~**40** remaining main-source warnings, primarily:

- `PSJunitFileSelector` (~15 raw `Class` / unchecked)
- `gui/PSRxBuildInput` (~19 raw collections)
- Constructor `this-escape` (~6) in install actions

Residual issue: https://github.com/intersoftdatalabs-in/percussioncms/issues/2331

Parent tracker: #2200

## Test plan

- [x] `cd modules/perc-ant` → `../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **39**, Failures: **0**, Errors: **0**, Skipped: **0**
- [x] Main javac `warning:` lines: **~90 → ~40** under project `-Xlint`
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Standalone module clean install | BUILD SUCCESS |
| Prefer real fixes over blanket suppress | yes for batch 1 |
| Scope confined to perc-ant (+ review note) | yes |
| Portable path changes | N/A |

Partial for #2023 (residual batch 2+). Refs #2200

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.