### PR TITLE
docs(release): hash final JAR after upload (#2212)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -627,6 +627,16 @@ Those types of errors will get written to SDTERR or STDOUT and will either only 
 
 If you see code like above, it should be refactored to use a Log4j2 logger.
 
+## Publishing a GitHub Release (installers + checksums)
+
+When attaching CMS / DTS installer JARs to a GitHub Release:
+
+1. Upload the **final** `perc-distribution-tree.jar` and `delivery-tier-distribution.jar`.
+2. Compute SHA-256 **after** that final upload (or of the exact bytes you uploaded). Never reuse an interim package-build checksum.
+3. Publish matching `*.jar.sha256` sidecars and confirm `hash(JAR) == sidecar` before calling the release complete.
+
+Full operator checklist (including how to correct a wrong published sidecar): [docs/release/github-release-assets-checklist.md](docs/release/github-release-assets-checklist.md). This process was tightened after issue [#2212](https://github.com/intersoftdatalabs-in/percussioncms/issues/2212) (v8.1.7 interim checksum).
+
 ### Pull Request Review / Approval
 
 All pull requests are subject to a number of automated checks, as well as manual review by at least one core maintainer. The check / review process is intended to ensure quality of changes and consistency of the system.

--- a/docs/release/github-release-assets-checklist.md
+++ b/docs/release/github-release-assets-checklist.md
@@ -1,0 +1,66 @@
+# GitHub Release Assets Checklist
+
+Operator checklist for publishing (or correcting) installer JARs and integrity sidecars on a GitHub Release. Applies to both CMS (`perc-distribution-tree`) and DTS (`delivery-tier-distribution`).
+
+## Why this exists
+
+On **v8.1.7**, the published SHA-256 for `perc-distribution-tree.jar` did not match the final release-attached JAR (an interim package hash was left on the release). Download verification failed for operators who checked the sidecar. See issue [#2212](https://github.com/intersoftdatalabs-in/percussioncms/issues/2212).
+
+**Hard rule:** Hash the **final** JAR **after** it is the asset that will remain on the release. Never reuse interim / pre-rebuild checksums.
+
+## Assets to publish
+
+| Artifact | Typical release asset name | Sidecar name(s) |
+|----------|----------------------------|-----------------|
+| CMS installer JAR | `perc-distribution-tree.jar` | Prefer `perc-distribution-tree.jar.sha256` (aligned with JAR). Versioned name `perc-distribution-tree-<version>.jar.sha256` is optional for history. |
+| DTS installer JAR | `delivery-tier-distribution.jar` | `delivery-tier-distribution.jar.sha256` |
+
+Sidecar content format used historically on releases: a single line of **64 lowercase hex characters** (SHA-256 of the file bytes), no `hash  filename` prefix required. Keep format consistent with sibling assets on the same release.
+
+## Pre-publish steps
+
+1. Build the final installers (module clean package / full release pipeline as usual).
+2. Confirm the JAR bytes you will upload are the **final** build (no further rebuilds planned).
+3. Upload the JAR(s) to the draft or published GitHub Release.
+4. **Only after** the final JAR is on the release (or you are hashing the exact file you just uploaded):
+   - Linux / macOS: `sha256sum perc-distribution-tree.jar` (or `shasum -a 256 …`)
+   - Windows PowerShell: `Get-FileHash -Algorithm SHA256 .\perc-distribution-tree.jar`
+5. Write the hash into the `.sha256` sidecar file(s).
+6. Upload the sidecar asset(s). Prefer names that match the JAR asset (`*.jar.sha256`).
+7. **Verify before calling the release done:**
+   ```text
+   hash(release JAR) == contents of published .sha256 sidecar
+   ```
+   Re-download both assets from the release (or hash the local file you uploaded) and compare. Do not skip this step.
+
+## Correcting a wrong published checksum
+
+1. Download the **release-attached** JAR (do not rebuild unless the JAR itself is wrong).
+2. Recompute SHA-256 of that JAR.
+3. Replace / re-upload only the `.sha256` sidecar(s).
+4. Confirm `hash(JAR) == sidecar`.
+5. Document the correction on the release notes (date; **checksum-only**, JAR unchanged) so operators who cached the bad hash re-download the sidecar only.
+
+Example (GitHub CLI):
+
+```bash
+# After computing $CORRECT_HEX for the final JAR on the release:
+printf '%s' "$CORRECT_HEX" > perc-distribution-tree.jar.sha256
+gh release delete-asset vX.Y.Z perc-distribution-tree-X.Y.Z.jar.sha256 --yes
+gh release upload vX.Y.Z perc-distribution-tree.jar.sha256 perc-distribution-tree-X.Y.Z.jar.sha256 --clobber
+```
+
+## Do / Don't
+
+| Do | Don't |
+|----|--------|
+| Hash **after** final JAR upload (or of the exact bytes you upload) | Hash an intermediate package build and leave that sidecar after rebuilding the JAR |
+| Verify hash(JAR) == sidecar on the live release | Trust a checksum file produced earlier in the pipeline without a final check |
+| Prefer sidecar names that match the JAR asset name | Leave only a mismatched or version-only sidecar that operators cannot map to the JAR |
+| Note checksum-only corrections on the release | Silently replace sidecars without a short release note |
+
+## Related modules
+
+- CMS packaging: `modules/perc-distribution-tree`
+- DTS packaging: `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution`
+- Contributing / local install pointers: [CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/modules/perc-distribution-tree/README.md
+++ b/modules/perc-distribution-tree/README.md
@@ -69,6 +69,10 @@ cd modules/perc-distribution-tree
 ../../mvnw clean install
 ```
 
+### GitHub Release checksums
+
+When publishing `perc-distribution-tree.jar` on a GitHub Release, hash the **final** JAR after upload and attach a matching `perc-distribution-tree.jar.sha256` (never reuse an interim build checksum). Operator checklist: [docs/release/github-release-assets-checklist.md](../../docs/release/github-release-assets-checklist.md).
+
 ## Key Files
 
 - **`src/main/resources/installDistributionFiles.xml`**: ANT build script that assembles the distribution


### PR DESCRIPTION
## Summary

Codifies the release-ops fix for **#2212** (v8.1.7 wrong SHA-256 for `perc-distribution-tree.jar`).

**Release asset correction (already applied on tag `v8.1.7`, not in this PR):**
- Recomputed SHA-256 of the published `perc-distribution-tree.jar`: `72838223b2f327b8c6243dc7c4341ef3d6b995fc499875a97da3eb51a707479f`
- Replaced `perc-distribution-tree-8.1.7.jar.sha256` (was interim `a7c49dee…`)
- Added aligned `perc-distribution-tree.jar.sha256` with the same hash
- Verified `delivery-tier-distribution.jar.sha256` already matched (`96f5ed22…`); left unchanged
- Documented checksum-only correction in release notes + issue comment (JAR unchanged)

**This PR (docs only):**
- New operator checklist: [docs/release/github-release-assets-checklist.md](docs/release/github-release-assets-checklist.md)
- Pointers from `CONTRIBUTING.md` and `modules/perc-distribution-tree/README.md`
- Rule: hash **after** final JAR upload; never reuse interim package checksums

## Test plan

- [x] Fresh SHA-256 of release `perc-distribution-tree.jar` == both published sidecars
- [x] DTS sidecar matches release JAR
- [x] Release notes include checksum correction (2026-08-07)
- [x] Human review of docs checklist wording

## Gates evidence

- No product code / Maven modules changed — no module `mvnw clean install` required
- Erlang-style review: docs-only; portable paths (relative markdown links); no path I/O
- Ops verification performed with `Get-FileHash -Algorithm SHA256` against release-downloaded JAR

## Parent / tracking

- Parent tracker: #2212 (self)
- Fixes #2212

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
