### PR TITLE
feat(rest,sitemanage): thin POST pipeline resource execute (#2269)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PipelinesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PipelinesAdaptor.java
@@ -31,24 +31,33 @@ import com.percussion.rest.pipelines.IPipelinesAdaptor;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.PSSecurityToken;
 import com.percussion.server.PSRequest;
+import com.percussion.services.pipeline.IPSPipelineRuntimeService;
+import com.percussion.services.pipeline.PSPipelineIrException;
+import com.percussion.services.pipeline.PSPipelineRuntimeServiceLocator;
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
 import com.percussion.servlets.PSSecurityFilter;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.util.PSCollection;
+import jakarta.ws.rs.WebApplicationException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Lists classic XML Applications (pipeline packages) visible to the current security token.
+ * Lists classic XML Applications (pipeline packages) visible to the current security token, and
+ * thin IR execute via {@link IPSPipelineRuntimeService}.
  *
  * <p>Uses {@link PSServerXmlObjectStore} for summaries; mapping/filter/limit are pure helpers so
- * they can be unit-tested without the object-store singleton.
+ * they can be unit-tested without the object-store singleton. Execute never calls classic {@code
+ * PSQueryHandler}.
  */
 @PSSiteManageBean
 public class PipelinesAdaptor implements IPipelinesAdaptor {
@@ -62,14 +71,31 @@ public class PipelinesAdaptor implements IPipelinesAdaptor {
   public static final int MAX_LIMIT = 1000;
 
   private final Function<PSSecurityToken, PSApplicationSummary[]> summaryLoader;
+  private final Supplier<IPSPipelineRuntimeService> runtimeSupplier;
 
   public PipelinesAdaptor() {
-    this(tok -> PSServerXmlObjectStore.getInstance().getApplicationSummaryObjects(tok, false));
+    this(
+        tok -> PSServerXmlObjectStore.getInstance().getApplicationSummaryObjects(tok, false),
+        PSPipelineRuntimeServiceLocator::getPipelineRuntimeService);
   }
 
   /** Package-visible for unit tests that inject a fake summary source. */
   PipelinesAdaptor(Function<PSSecurityToken, PSApplicationSummary[]> summaryLoader) {
+    this(summaryLoader, PSPipelineRuntimeServiceLocator::getPipelineRuntimeService);
+  }
+
+  /**
+   * Package-visible for unit tests that inject summary source and/or runtime service without the
+   * static locator.
+   */
+  PipelinesAdaptor(
+      Function<PSSecurityToken, PSApplicationSummary[]> summaryLoader,
+      Supplier<IPSPipelineRuntimeService> runtimeSupplier) {
     this.summaryLoader = summaryLoader;
+    this.runtimeSupplier =
+        runtimeSupplier != null
+            ? runtimeSupplier
+            : PSPipelineRuntimeServiceLocator::getPipelineRuntimeService;
   }
 
   @Override
@@ -123,6 +149,41 @@ public class PipelinesAdaptor implements IPipelinesAdaptor {
     }
   }
 
+  @Override
+  public PipelineExecuteResult execute(
+      URI baseUri, String appName, String resourceName, PipelineExecuteRequest request) {
+    // baseUri reserved for HATEOAS link building (interface contract)
+    if (StringUtils.isBlank(appName) || !isSafeApplicationName(appName.trim())) {
+      throw new WebApplicationException("Invalid pipeline application name", 400);
+    }
+    if (StringUtils.isBlank(resourceName) || !isSafeResourceName(resourceName.trim())) {
+      throw new WebApplicationException("Invalid pipeline resource name", 400);
+    }
+    String safeApp = appName.trim();
+    String safeResource = resourceName.trim();
+    PipelineExecuteRequest req = request != null ? request : PipelineExecuteRequest.empty();
+    try {
+      return runtimeSupplier.get().execute(safeApp, safeResource, req);
+    } catch (PSPipelineIrException e) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Pipeline execute failed";
+      // Generic 404 bodies: do not echo raw path params (name probing).
+      if (isNotFoundMessage(msg)) {
+        throw new WebApplicationException("Pipeline application or resource not found", 404);
+      }
+      // Planner/validation failures are client errors; keep message (no path echo).
+      throw new WebApplicationException(msg, 400);
+    }
+  }
+
+  /** True when the runtime reports missing IR app or resource (not validation failures). */
+  static boolean isNotFoundMessage(String message) {
+    if (message == null) {
+      return false;
+    }
+    String m = message.toLowerCase(Locale.ROOT);
+    return m.contains("pipeline ir not found") || m.contains("resource not found in ir");
+  }
+
   /**
    * Application names become object-store directory names. Reject path traversal and separators so
    * a user-supplied {@code idOrName} cannot escape the apps root ({@code java/path-injection}).
@@ -136,6 +197,14 @@ public class PipelinesAdaptor implements IPipelinesAdaptor {
         && name.indexOf('/') < 0
         && name.indexOf('\\') < 0
         && name.indexOf('\0') < 0;
+  }
+
+  /**
+   * Resource names are IR identifiers (not filesystem paths). Same single-segment rules as
+   * application names to reject traversal / separators in the path param.
+   */
+  static boolean isSafeResourceName(String name) {
+    return isSafeApplicationName(name);
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/PipelinesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/PipelinesAdaptorTest.java
@@ -21,8 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.design.objectstore.PSApplication;
@@ -32,8 +37,15 @@ import com.percussion.design.objectstore.PSRequestor;
 import com.percussion.design.objectstore.server.PSApplicationSummary;
 import com.percussion.rest.pipelines.ApplicationDetail;
 import com.percussion.rest.pipelines.ApplicationSummary;
+import com.percussion.services.pipeline.IPSPipelineRuntimeService;
+import com.percussion.services.pipeline.PSPipelineIrException;
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
 import com.percussion.util.PSCollection;
+import jakarta.ws.rs.WebApplicationException;
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -235,6 +247,116 @@ class PipelinesAdaptorTest {
     assertNull(PipelinesAdaptor.resolveApplicationName("../sys_cmpDocuments", sums));
     assertNull(PipelinesAdaptor.resolveApplicationName("sys_cmpDocuments/../other", sums));
     assertNull(PipelinesAdaptor.resolveApplicationName("99", sums));
+  }
+
+  @Test
+  void execute_delegatesToRuntimeService() throws Exception {
+    IPSPipelineRuntimeService runtime = mock(IPSPipelineRuntimeService.class);
+    PipelineExecuteResult expected = new PipelineExecuteResult();
+    expected.setAppName("lookupApp");
+    expected.setResourceName("DatasetQ");
+    expected.setOperation("query");
+    expected.setRows(List.of(Map.of("TYPE", "workflow")));
+    PipelineExecuteRequest req = PipelineExecuteRequest.ofParams(Map.of("TYPE", "workflow"));
+    when(runtime.execute(eq("lookupApp"), eq("DatasetQ"), eq(req))).thenReturn(expected);
+
+    PipelinesAdaptor adaptor = new PipelinesAdaptor(tok -> new PSApplicationSummary[0], () -> runtime);
+    PipelineExecuteResult out =
+        adaptor.execute(URI.create("http://localhost/services/"), "lookupApp", "DatasetQ", req);
+
+    assertEquals("query", out.getOperation());
+    assertEquals(1, out.getRowCount());
+    verify(runtime).execute(eq("lookupApp"), eq("DatasetQ"), eq(req));
+  }
+
+  @Test
+  void execute_nullBodyBecomesEmptyRequest() throws Exception {
+    IPSPipelineRuntimeService runtime = mock(IPSPipelineRuntimeService.class);
+    PipelineExecuteResult expected = new PipelineExecuteResult();
+    expected.setOperation("query");
+    when(runtime.execute(eq("app"), eq("res"), any(PipelineExecuteRequest.class)))
+        .thenReturn(expected);
+
+    PipelinesAdaptor adaptor = new PipelinesAdaptor(tok -> new PSApplicationSummary[0], () -> runtime);
+    assertEquals(
+        "query",
+        adaptor.execute(URI.create("http://localhost/"), "app", "res", null).getOperation());
+  }
+
+  @Test
+  void execute_rejectsUnsafeAppOrResourceNames() {
+    IPSPipelineRuntimeService runtime = mock(IPSPipelineRuntimeService.class);
+    PipelinesAdaptor adaptor = new PipelinesAdaptor(tok -> new PSApplicationSummary[0], () -> runtime);
+
+    WebApplicationException badApp =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                adaptor.execute(
+                    URI.create("http://localhost/"),
+                    "../evil",
+                    "res",
+                    PipelineExecuteRequest.empty()));
+    assertEquals(400, badApp.getResponse().getStatus());
+
+    WebApplicationException badRes =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                adaptor.execute(
+                    URI.create("http://localhost/"),
+                    "app",
+                    "foo/bar",
+                    PipelineExecuteRequest.empty()));
+    assertEquals(400, badRes.getResponse().getStatus());
+  }
+
+  @Test
+  void execute_mapsNotFoundIrTo404() throws Exception {
+    IPSPipelineRuntimeService runtime = mock(IPSPipelineRuntimeService.class);
+    when(runtime.execute(anyString(), anyString(), any(PipelineExecuteRequest.class)))
+        .thenThrow(new PSPipelineIrException("Pipeline IR not found: missing"));
+    PipelinesAdaptor adaptor = new PipelinesAdaptor(tok -> new PSApplicationSummary[0], () -> runtime);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                adaptor.execute(
+                    URI.create("http://localhost/"),
+                    "missing",
+                    "res",
+                    PipelineExecuteRequest.empty()));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertEquals("Pipeline application or resource not found", ex.getMessage());
+  }
+
+  @Test
+  void execute_mapsPlannerFailureTo400() throws Exception {
+    IPSPipelineRuntimeService runtime = mock(IPSPipelineRuntimeService.class);
+    when(runtime.execute(anyString(), anyString(), any(PipelineExecuteRequest.class)))
+        .thenThrow(new PSPipelineIrException("Insert requires request.rows or request.params"));
+    PipelinesAdaptor adaptor = new PipelinesAdaptor(tok -> new PSApplicationSummary[0], () -> runtime);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                adaptor.execute(
+                    URI.create("http://localhost/"),
+                    "updApp",
+                    "Ins",
+                    PipelineExecuteRequest.empty()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("Insert requires"));
+  }
+
+  @Test
+  void isNotFoundMessage_detectsRuntimeNotFoundWording() {
+    assertTrue(PipelinesAdaptor.isNotFoundMessage("Pipeline IR not found: x"));
+    assertTrue(PipelinesAdaptor.isNotFoundMessage("Resource not found in IR x: y"));
+    assertFalse(PipelinesAdaptor.isNotFoundMessage("Insert requires request.rows"));
+    assertFalse(PipelinesAdaptor.isNotFoundMessage(null));
   }
 
   private static PSApplicationSummary summary(

--- a/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
@@ -17,6 +17,8 @@
 
 package com.percussion.rest.pipelines;
 
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
 import java.net.URI;
 import java.util.List;
 
@@ -39,4 +41,20 @@ public interface IPipelinesAdaptor {
    * @return detail, or {@code null} when not found / not visible
    */
   ApplicationDetail getApplication(URI baseUri, String idOrName);
+
+  /**
+   * Execute a native pipeline IR resource via {@code IPSPipelineRuntimeService}.
+   *
+   * <p>Developer smoke / Slice A residual — does <strong>not</strong> call classic {@code
+   * PSQueryHandler} / {@code PSUpdateHandler}. JSON request/result shapes match the system model
+   * types used by the runtime codec.
+   *
+   * @param baseUri request base URI (reserved for HATEOAS)
+   * @param appName native IR application name
+   * @param resourceName resource within the IR document
+   * @param request params/rows body; {@code null} treated as empty by implementations
+   * @return execute result, never {@code null}
+   */
+  PipelineExecuteResult execute(
+      URI baseUri, String appName, String resourceName, PipelineExecuteRequest request);
 }

--- a/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
@@ -17,6 +17,8 @@
 
 package com.percussion.rest.pipelines;
 
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
 import com.percussion.system.utils.PSSiteManageBean;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -24,8 +26,10 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -39,15 +43,18 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only catalog of classic XML Applications (pipeline packages) for the Developer module.
+ * Catalog of classic XML Applications (pipeline packages) plus thin IR execute for Developer smoke.
  *
  * <p>Registered via {@link PSSiteManageBean} like sibling catalog resources ({@code Keywords},
- * {@code Slots}).
+ * {@code Slots}). Execute delegates to {@code IPSPipelineRuntimeService} only (never classic {@code
+ * PSQueryHandler} as the public path).
  */
 @PSSiteManageBean(value = "restPipelinesResource")
 @Path("/pipelines")
 @XmlRootElement
-@Tag(name = "Pipelines", description = "Data pipeline / XML application design catalog (read-only)")
+@Tag(
+    name = "Pipelines",
+    description = "Data pipeline / XML application design catalog and thin IR execute")
 public class PipelinesResource {
 
   private final IPipelinesAdaptor adaptor;
@@ -127,6 +134,46 @@ public class PipelinesResource {
       return detail;
     } catch (WebApplicationException e) {
       throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Thin Developer smoke invoke: POST JSON params/rows → pipeline runtime → {@link
+   * PipelineExecuteResult} JSON.
+   *
+   * <p>Path is multi-segment so it does not collide with {@code GET /{idOrName}} catalog detail.
+   */
+  @POST
+  @Path("/{app}/resources/{resource}/execute")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Execute a pipeline IR resource",
+      description =
+          "Runs a native pipeline IR resource via IPSPipelineRuntimeService (SQL adapter +"
+              + " parameterized plans). Body is PipelineExecuteRequest ({params}, {rows}). Does not"
+              + " call classic PSQueryHandler/PSUpdateHandler. Designer UI is out of scope.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = PipelineExecuteResult.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input or unsupported resource"),
+        @ApiResponse(responseCode = "404", description = "Application or resource not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public PipelineExecuteResult execute(
+      @PathParam("app") String app,
+      @PathParam("resource") String resource,
+      PipelineExecuteRequest body) {
+    try {
+      return requireAdaptor().execute(uriInfo.getBaseUri(), app, resource, body);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }

--- a/rest/src/test/java/com/percussion/rest/pipelines/PipelinesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/pipelines/PipelinesResourceTest.java
@@ -29,11 +29,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.UriInfo;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -130,5 +133,84 @@ public class PipelinesResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getApplication("sys_foo"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause(), "cause chain must preserve the original failure");
+  }
+
+  @Test
+  public void executeDelegatesToAdaptor() {
+    PipelineExecuteRequest req = PipelineExecuteRequest.ofParams(Map.of("TYPE", "workflow"));
+    PipelineExecuteResult expected = new PipelineExecuteResult();
+    expected.setAppName("lookupApp");
+    expected.setResourceName("DatasetQ");
+    expected.setOperation("query");
+    expected.setRows(List.of(Map.of("TYPE", "workflow", "NAME", "wf1")));
+    when(adaptor.execute(any(), eq("lookupApp"), eq("DatasetQ"), eq(req))).thenReturn(expected);
+
+    PipelineExecuteResult out = resource.execute("lookupApp", "DatasetQ", req);
+
+    assertEquals("lookupApp", out.getAppName());
+    assertEquals("DatasetQ", out.getResourceName());
+    assertEquals("query", out.getOperation());
+    assertEquals(1, out.getRowCount());
+    verify(adaptor).execute(any(), eq("lookupApp"), eq("DatasetQ"), eq(req));
+  }
+
+  @Test
+  public void executePassesNullBodyThrough() {
+    PipelineExecuteResult expected = new PipelineExecuteResult();
+    expected.setOperation("query");
+    when(adaptor.execute(any(), eq("app"), eq("res"), isNull())).thenReturn(expected);
+
+    assertEquals("query", resource.execute("app", "res", null).getOperation());
+    verify(adaptor).execute(any(), eq("app"), eq("res"), isNull());
+  }
+
+  @Test
+  public void executeRethrowsWebApplicationException() {
+    when(adaptor.execute(any(), eq("missing"), eq("r"), any()))
+        .thenThrow(new WebApplicationException("Pipeline application or resource not found", 404));
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.execute("missing", "r", PipelineExecuteRequest.empty()));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertEquals("Pipeline application or resource not found", ex.getMessage());
+  }
+
+  @Test
+  public void executeMapsIllegalArgumentTo400() {
+    when(adaptor.execute(any(), eq("app"), eq("res"), any()))
+        .thenThrow(new IllegalArgumentException("bad params"));
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.execute("app", "res", PipelineExecuteRequest.empty()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertEquals("bad params", ex.getMessage());
+  }
+
+  @Test
+  public void executeWrapsUnexpectedFailuresAs500() {
+    IllegalStateException boom = new IllegalStateException("runtime not configured");
+    when(adaptor.execute(any(), eq("app"), eq("res"), any())).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.execute("app", "res", PipelineExecuteRequest.empty()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void executeWithoutInjectionFailsWithDiagnostic() {
+    PipelinesResource bare = new PipelinesResource();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> bare.execute("app", "res", PipelineExecuteRequest.empty()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertInstanceOf(IllegalStateException.class, ex.getCause());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestPipelinesAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestPipelinesAdaptor.java
@@ -20,6 +20,8 @@ package com.percussion.rest.test.apibridge;
 import com.percussion.rest.pipelines.ApplicationDetail;
 import com.percussion.rest.pipelines.ApplicationSummary;
 import com.percussion.rest.pipelines.IPipelinesAdaptor;
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
 import java.net.URI;
 import java.util.List;
 import org.springframework.context.annotation.Lazy;
@@ -42,5 +44,17 @@ public class TestPipelinesAdaptor implements IPipelinesAdaptor {
   @Override
   public ApplicationDetail getApplication(URI baseUri, String idOrName) {
     return null;
+  }
+
+  @Override
+  public PipelineExecuteResult execute(
+      URI baseUri, String appName, String resourceName, PipelineExecuteRequest request) {
+    PipelineExecuteResult result = new PipelineExecuteResult();
+    result.setAppName(appName);
+    result.setResourceName(resourceName);
+    result.setOperation("stub");
+    result.setRowCount(0);
+    result.setAffectedRows(0);
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
Thin Developer smoke REST execute for pipeline IR resources (Slice A residual of #2248).

- `POST /services/pipelines/{app}/resources/{resource}/execute` with JSON `PipelineExecuteRequest` body
- Returns `PipelineExecuteResult` (same system model JSON shape used by runtime codec)
- Wires `PipelinesResource` → `IPipelinesAdaptor` → sitemanage `PipelinesAdaptor` → `IPSPipelineRuntimeService` via `PSPipelineRuntimeServiceLocator`
- **Never** calls classic `PSQueryHandler` / `PSUpdateHandler` as the public path
- Safe app/resource path params (reject traversal/separators); generic 404 bodies (no path echo)

### Change-class companions
| Layer | Artifact |
|-------|----------|
| rest resource | `PipelinesResource.execute` |
| rest interface | `IPipelinesAdaptor.execute` |
| sitemanage apibridge | `PipelinesAdaptor.execute` (+ injectible runtime supplier for tests) |
| Spring test stub | `TestPipelinesAdaptor.execute` |
| tests | `PipelinesResourceTest` (6 new), `PipelinesAdaptorTest` (6 new) |

### Residual (out of this PR)
Richer UPDATE/DELETE + multi-row txn + joins/where IR → **#2340**

## Test plan
- [x] `cd rest && ../mvnw clean install` — BUILD SUCCESS; `PipelinesResourceTest` 13/13
- [x] `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS; `PipelinesAdaptorTest` 18/18
- [x] Erlang-style self-review: path sanitization, no classic handler public path, cause-preserving 500s, Spring stub present
- [ ] Human: optional smoke against live CMS once runtime locator is production-wired

## Gates evidence
- Module clean install: rest + sitemanage green (root Maven wrapper 3.9.x; module-local 3.5 wrapper is too old for clean plugin)
- Operator: Grok: night-issue-prs (model grok-4.5)

## Links
- Partial for #2269 (thin REST execute done; richer UPDATE residual #2340)
- Parent slice #2248 / epic #1690
- Residual: #2340

Refs #2269 #2248 #1690

> Co-Authored by Grok Build using grok-4.5 with agent main.