### PR TITLE
feat(WebUI): design vs runtime ACL permission model depth (CD-19) (#2283)

### DIFF
--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -780,6 +780,7 @@ export function ContentTypeDetailPanel({
 
           <ObjectAclSection
             objectGuid={detail.guid?.stringValue}
+            objectKind="content-type"
             testIdPrefix="developer-ct-acl"
           />
 

--- a/WebUI/src/main/ts/developer/ObjectAclSection.tsx
+++ b/WebUI/src/main/ts/developer/ObjectAclSection.tsx
@@ -37,6 +37,15 @@ import {
 } from "./defaultAclTemplate";
 import { DEV_MSG } from "./messages";
 import {
+  DESIGN_ACCESS_PERMISSIONS,
+  RUNTIME_ACCESS_PERMISSIONS,
+  hasRuntimeAccessPermission,
+  shouldShowRuntimeAccessColumns,
+  type AclDesignObjectKind,
+  type AclPermissionLayer,
+  visibleAclPermissionsForObject,
+} from "./objectAclPermissionModel";
+import {
   canRemoveAclEntry,
   createSpecialAclEntryTemplate,
   isDuplicateAclEntry,
@@ -182,15 +191,41 @@ function structureEqual(a: DraftEntry[], b: DraftEntry[]): boolean {
   return true;
 }
 
+/** i18n label for a known REST permission column (Workbench wording). */
+function permissionColumnLabel(perm: AclPermissionName): string {
+  switch (perm) {
+    case "READ":
+      return DEV_MSG.ACL_PERM_READ;
+    case "UPDATE":
+      return DEV_MSG.ACL_PERM_UPDATE;
+    case "DELETE":
+      return DEV_MSG.ACL_PERM_DELETE;
+    case "OWNER":
+      return DEV_MSG.ACL_PERM_OWNER;
+    case "RUNTIME_VISIBLE":
+      return DEV_MSG.ACL_PERM_RUNTIME_VISIBLE;
+    default:
+      return String(perm).replace(/_/g, " ");
+  }
+}
+
 /**
- * Object ACL viewer/editor for Developer detail panels (SE-04).
- * Toggle permissions, add/remove entries, save via PUT /acls/bulk.
+ * Object ACL viewer/editor for Developer detail panels (SE-04 / CD-19).
+ * Design vs runtime permission columns (Workbench parity), toggle permissions,
+ * add/remove entries, save via PUT /acls/bulk.
  */
 export function ObjectAclSection({
   objectGuid,
+  objectKind = null,
   testIdPrefix = "developer-acl",
 }: {
   objectGuid: string | null | undefined;
+  /**
+   * Design-object kind for runtime-visibility column gating (CD-19).
+   * Content types / templates / etc. show Runtime visibility; others hide it
+   * unless an entry already carries RUNTIME_VISIBLE.
+   */
+  objectKind?: AclDesignObjectKind | null;
   testIdPrefix?: string;
 }): React.ReactElement {
   const [acl, setAcl] = useState<ObjectAcl | null>(null);
@@ -272,6 +307,31 @@ export function ObjectAclSection({
     () => missingSpecialAclKinds(draftEntries),
     [draftEntries],
   );
+
+  /** Force-show runtime columns when any draft entry already has runtime bits. */
+  const forceShowRuntime = useMemo(() => {
+    for (const e of draftEntries) {
+      const chosen = selected[e.clientKey];
+      if (chosen && hasRuntimeAccessPermission(chosen)) return true;
+      if (hasRuntimeAccessPermission(asPermissions(e))) return true;
+    }
+    return false;
+  }, [draftEntries, selected]);
+
+  const showRuntimeColumns = shouldShowRuntimeAccessColumns(objectKind, {
+    forceShow: forceShowRuntime,
+  });
+
+  const visiblePermissions = useMemo(
+    () =>
+      visibleAclPermissionsForObject(objectKind, {
+        forceShowRuntime: forceShowRuntime,
+      }),
+    [objectKind, forceShowRuntime],
+  );
+
+  const designPerms = DESIGN_ACCESS_PERMISSIONS;
+  const runtimePerms = showRuntimeColumns ? RUNTIME_ACCESS_PERMISSIONS : [];
 
   function togglePerm(key: string, perm: AclPermissionName) {
     setSelected((prev) => {
@@ -651,6 +711,8 @@ export function ObjectAclSection({
             <div style={{ overflowX: "auto", marginTop: "8px" }}>
               <table
                 data-testid={`${testIdPrefix}-table`}
+                data-acl-show-runtime={showRuntimeColumns ? "true" : "false"}
+                data-acl-object-kind={objectKind ?? "unknown"}
                 style={{
                   width: "100%",
                   borderCollapse: "collapse",
@@ -658,18 +720,73 @@ export function ObjectAclSection({
                 }}
               >
                 <thead>
-                  <tr style={tableHeaderRow}>
-                    <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_ENTRY}</th>
-                    <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_TYPE}</th>
-                    {ACL_PERMISSIONS.map((p) => (
+                  {/* Layer group headers — Design access | Runtime visibility (CD-19) */}
+                  <tr
+                    style={tableHeaderRow}
+                    data-testid={`${testIdPrefix}-layer-headers`}
+                  >
+                    <th style={{ padding: "8px" }} rowSpan={2}>
+                      {DEV_MSG.ACL_COL_ENTRY}
+                    </th>
+                    <th style={{ padding: "8px" }} rowSpan={2}>
+                      {DEV_MSG.ACL_COL_TYPE}
+                    </th>
+                    <th
+                      colSpan={designPerms.length}
+                      style={{
+                        padding: "6px 8px",
+                        textAlign: "center",
+                        fontSize: "0.8rem",
+                        borderBottom: `1px solid ${catalogColors.softBorder}`,
+                        background: "rgba(0,0,0,0.02)",
+                      }}
+                      title={DEV_MSG.ACL_LAYER_DESIGN_HINT}
+                      data-testid={`${testIdPrefix}-layer-design`}
+                      data-acl-layer={"design" satisfies AclPermissionLayer}
+                    >
+                      {DEV_MSG.ACL_LAYER_DESIGN}
+                    </th>
+                    {showRuntimeColumns ? (
+                      <th
+                        colSpan={runtimePerms.length}
+                        style={{
+                          padding: "6px 8px",
+                          textAlign: "center",
+                          fontSize: "0.8rem",
+                          borderBottom: `1px solid ${catalogColors.softBorder}`,
+                          background: "rgba(0,0,0,0.02)",
+                        }}
+                        title={DEV_MSG.ACL_LAYER_RUNTIME_HINT}
+                        data-testid={`${testIdPrefix}-layer-runtime`}
+                        data-acl-layer={"runtime" satisfies AclPermissionLayer}
+                      >
+                        {DEV_MSG.ACL_LAYER_RUNTIME}
+                      </th>
+                    ) : null}
+                    <th style={{ padding: "8px" }} rowSpan={2}>
+                      {DEV_MSG.ACL_COL_ACTIONS}
+                    </th>
+                  </tr>
+                  <tr
+                    style={tableHeaderRow}
+                    data-testid={`${testIdPrefix}-perm-headers`}
+                  >
+                    {visiblePermissions.map((p) => (
                       <th
                         key={p}
-                        style={{ padding: "8px", textAlign: "center", fontSize: "0.8rem" }}
+                        style={{
+                          padding: "8px",
+                          textAlign: "center",
+                          fontSize: "0.8rem",
+                          fontWeight: 500,
+                        }}
+                        data-testid={`${testIdPrefix}-perm-header-${p}`}
+                        data-acl-permission={p}
+                        title={p}
                       >
-                        {p.replace("_", " ")}
+                        {permissionColumnLabel(p)}
                       </th>
                     ))}
-                    <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_ACTIONS}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -707,7 +824,7 @@ export function ObjectAclSection({
                         >
                           {entryTypeLabel(e)}
                         </td>
-                        {ACL_PERMISSIONS.map((p) => (
+                        {visiblePermissions.map((p) => (
                           <td key={p} style={{ padding: "8px", textAlign: "center" }}>
                             <input
                               type="checkbox"
@@ -715,7 +832,7 @@ export function ObjectAclSection({
                               checked={chosen.has(p)}
                               disabled={busy}
                               onChange={() => togglePerm(key, p)}
-                              aria-label={`${p} for ${label}`}
+                              aria-label={`${permissionColumnLabel(p)} (${p}) for ${label}`}
                             />
                           </td>
                         ))}

--- a/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
@@ -722,6 +722,7 @@ export function TemplateDetailPanel({
 
           <ObjectAclSection
             objectGuid={detail.guid?.stringValue}
+            objectKind="template"
             testIdPrefix="developer-tpl-acl"
           />
 

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -29,7 +29,8 @@ export const DEV_MSG_KEYS = {
   INTRO: "perc.ui.developer@Design-time tools for content types, assembly, and related CMS objects. Replaces the classic Workbench / Design surfaces.",
   SESSION_REDIRECT: "perc.ui.developer@Session expired - redirecting to login...",
   ACL_TITLE: "perc.ui.developer@Object ACL",
-  ACL_HINT: "perc.ui.developer@Design-time access control for this object. Toggle permissions, add or remove entries, then save (full entry list replace via bulk ACL API).",
+  ACL_HINT:
+    "perc.ui.developer@Design-time and runtime access control for this object. Toggle Design access (Read, Update, Delete, Modify ACL) and Runtime visibility where applicable, add or remove entries, then save (full entry list replace via bulk ACL API).",
   ACL_LOADING: "perc.ui.developer@Loading ACL...",
   ACL_ERROR: "perc.ui.developer@Could not load object ACL.",
   ACL_EMPTY: "perc.ui.developer@No ACL defined for this object.",
@@ -45,6 +46,17 @@ export const DEV_MSG_KEYS = {
   ACL_COL_TYPE: "perc.ui.developer@Type",
   ACL_COL_PERMS: "perc.ui.developer@Permissions",
   ACL_COL_ACTIONS: "perc.ui.developer@Actions",
+  ACL_LAYER_DESIGN: "perc.ui.developer@Design access",
+  ACL_LAYER_RUNTIME: "perc.ui.developer@Runtime visibility",
+  ACL_LAYER_DESIGN_HINT:
+    "perc.ui.developer@Design access controls who can read, update, delete, or modify the ACL for this design object in Workbench / Developer tools.",
+  ACL_LAYER_RUNTIME_HINT:
+    "perc.ui.developer@Runtime visibility (RUNTIME_VISIBLE) controls Content Explorer / community visibility for this object at runtime.",
+  ACL_PERM_READ: "perc.ui.developer@Read",
+  ACL_PERM_UPDATE: "perc.ui.developer@Update",
+  ACL_PERM_DELETE: "perc.ui.developer@Delete",
+  ACL_PERM_OWNER: "perc.ui.developer@Modify ACL",
+  ACL_PERM_RUNTIME_VISIBLE: "perc.ui.developer@Visible",
   ACL_ENTRY_ADD: "perc.ui.developer@Add entry",
   ACL_ENTRY_REMOVE: "perc.ui.developer@Remove",
   ACL_ENTRY_NAME: "perc.ui.developer@Principal name",

--- a/WebUI/src/main/ts/developer/objectAclPermissionModel.ts
+++ b/WebUI/src/main/ts/developer/objectAclPermissionModel.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ACL_PERMISSIONS,
+  type AclPermissionName,
+} from "../api/developer/aclApi";
+
+/**
+ * Workbench Object ACL permission layers (CD-19 / FR inventory §5.4):
+ * <ul>
+ *   <li><b>Design access</b> — Read, Update, Delete, Modify ACL (OWNER)</li>
+ *   <li><b>Runtime access</b> — Content Explorer / community visibility
+ *       ({@code RUNTIME_VISIBLE})</li>
+ * </ul>
+ * Matches REST {@code Permissions} and server {@code PSPermissions}.
+ */
+export type AclPermissionLayer = "design" | "runtime";
+
+/**
+ * Stable design-object kind keys for ACL editor mounts.
+ * Runtime-relevant kinds are those Workbench shows runtime visibility for.
+ */
+export type AclDesignObjectKind =
+  | "content-type"
+  | "display-format"
+  | "action-menu"
+  | "menu-entry"
+  | "search"
+  | "site"
+  | "template"
+  | "variant"
+  | "view"
+  | "workflow"
+  | "slot"
+  | "keyword"
+  | "locale"
+  | "shared-field"
+  | "item-filter"
+  | "extension"
+  | "relationship-type"
+  | "pipeline"
+  | "community"
+  | "unknown";
+
+/**
+ * Design-time access flags (Workbench: Read, Update, Delete, Modify ACL).
+ * OWNER is design-layer "Modify ACL", not runtime — ordered after DELETE.
+ */
+export const DESIGN_ACCESS_PERMISSIONS: readonly AclPermissionName[] = [
+  "READ",
+  "UPDATE",
+  "DELETE",
+  "OWNER",
+] as const;
+
+/**
+ * Runtime access flag (Workbench: runtime Read / Content Explorer visibility).
+ */
+export const RUNTIME_ACCESS_PERMISSIONS: readonly AclPermissionName[] = [
+  "RUNTIME_VISIBLE",
+] as const;
+
+/**
+ * Column order for the ACL editor when both layers are shown:
+ * design block, then runtime (Workbench dialog layout).
+ */
+export const LAYERED_ACL_PERMISSIONS: readonly AclPermissionName[] = [
+  ...DESIGN_ACCESS_PERMISSIONS,
+  ...RUNTIME_ACCESS_PERMISSIONS,
+] as const;
+
+/**
+ * Design-object kinds where Workbench shows Runtime access (FR §5.4 item 5):
+ * Content Types, Display Formats, Menus, Menu Entries, Searches, Sites,
+ * Templates, Variants, Views, Workflows.
+ */
+export const RUNTIME_RELEVANT_OBJECT_KINDS: ReadonlySet<AclDesignObjectKind> =
+  new Set<AclDesignObjectKind>([
+    "content-type",
+    "display-format",
+    "action-menu",
+    "menu-entry",
+    "search",
+    "site",
+    "template",
+    "variant",
+    "view",
+    "workflow",
+  ]);
+
+/** Classify a REST permission name into design vs runtime layer. */
+export function aclPermissionLayer(
+  permission: string | null | undefined,
+): AclPermissionLayer | null {
+  const p = (permission ?? "").trim().toUpperCase();
+  if (!p) return null;
+  if ((RUNTIME_ACCESS_PERMISSIONS as readonly string[]).includes(p)) {
+    return "runtime";
+  }
+  if ((DESIGN_ACCESS_PERMISSIONS as readonly string[]).includes(p)) {
+    return "design";
+  }
+  // Unknown / future flags: treat as design so they stay editable if present
+  if ((ACL_PERMISSIONS as readonly string[]).includes(p)) {
+    return "design";
+  }
+  return null;
+}
+
+export function isDesignAccessPermission(permission: string): boolean {
+  return aclPermissionLayer(permission) === "design";
+}
+
+export function isRuntimeAccessPermission(permission: string): boolean {
+  return aclPermissionLayer(permission) === "runtime";
+}
+
+export function isRuntimeRelevantObjectKind(
+  kind: AclDesignObjectKind | null | undefined,
+): boolean {
+  if (kind == null || kind === "unknown") {
+    // Unknown mounts: show runtime columns so RUNTIME_VISIBLE stays editable.
+    return true;
+  }
+  return RUNTIME_RELEVANT_OBJECT_KINDS.has(kind);
+}
+
+/**
+ * Whether the ACL editor should render the Runtime visibility column group.
+ * Runtime-relevant kinds always show it; non-runtime kinds hide it unless the
+ * caller forces via {@code forceShow} (e.g. existing runtime bits on load).
+ */
+export function shouldShowRuntimeAccessColumns(
+  kind: AclDesignObjectKind | null | undefined,
+  options?: { forceShow?: boolean },
+): boolean {
+  if (options?.forceShow) return true;
+  return isRuntimeRelevantObjectKind(kind);
+}
+
+/**
+ * Permissions to expose as toggle columns for the given object kind.
+ * Design flags always included; runtime flags only when runtime columns show.
+ */
+export function visibleAclPermissionsForObject(
+  kind: AclDesignObjectKind | null | undefined,
+  options?: { forceShowRuntime?: boolean },
+): readonly AclPermissionName[] {
+  if (
+    shouldShowRuntimeAccessColumns(kind, {
+      forceShow: options?.forceShowRuntime,
+    })
+  ) {
+    return LAYERED_ACL_PERMISSIONS;
+  }
+  return DESIGN_ACCESS_PERMISSIONS;
+}
+
+/**
+ * Short English labels aligned with Workbench ACL dialog wording.
+ * UI may prefer i18n via {@code DEV_MSG}; these are pure-helper fallbacks.
+ */
+export const ACL_PERMISSION_SHORT_LABEL: Readonly<
+  Record<AclPermissionName, string>
+> = {
+  READ: "Read",
+  UPDATE: "Update",
+  DELETE: "Delete",
+  OWNER: "Modify ACL",
+  RUNTIME_VISIBLE: "Visible",
+};
+
+export function aclPermissionShortLabel(permission: string): string {
+  const p = permission.trim().toUpperCase() as AclPermissionName;
+  if (p in ACL_PERMISSION_SHORT_LABEL) {
+    return ACL_PERMISSION_SHORT_LABEL[p];
+  }
+  return permission.replace(/_/g, " ");
+}
+
+/**
+ * Partition chosen permission names into design vs runtime sets (for tests /
+ * summary chips). Unknown names land in {@code other}.
+ */
+export function partitionAclPermissions(permissions: readonly string[]): {
+  design: string[];
+  runtime: string[];
+  other: string[];
+} {
+  const design: string[] = [];
+  const runtime: string[] = [];
+  const other: string[] = [];
+  for (const raw of permissions) {
+    const p = String(raw ?? "").trim();
+    if (!p) continue;
+    const layer = aclPermissionLayer(p);
+    if (layer === "design") design.push(p.toUpperCase());
+    else if (layer === "runtime") runtime.push(p.toUpperCase());
+    else other.push(p);
+  }
+  return { design, runtime, other };
+}
+
+/**
+ * True when any of the given permission names is a runtime-layer flag.
+ * Useful to force-show runtime columns when editing a non-runtime kind that
+ * already has RUNTIME_VISIBLE (preserve/edit path).
+ */
+export function hasRuntimeAccessPermission(
+  permissions: Iterable<string>,
+): boolean {
+  for (const p of permissions) {
+    if (isRuntimeAccessPermission(p)) return true;
+  }
+  return false;
+}

--- a/WebUI/src/test/ts/developer/ObjectAclSection.createTemplate.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.createTemplate.test.tsx
@@ -141,8 +141,15 @@ describe("ObjectAclSection create + default template apply", () => {
         /template applied/i,
       );
     });
-    expect(screen.getByText("Default")).toBeTruthy();
-    expect(screen.getByText("AnyCommunity")).toBeTruthy();
+    // Specials render via DEV_MSG labels (i18n fallback includes key@English).
+    expect(screen.getByTestId("developer-acl-special-badge-default")).toBeTruthy();
+    expect(screen.getByTestId("developer-acl-special-badge-any-community")).toBeTruthy();
+    expect(screen.getByTestId("developer-acl-label-id:501").textContent).toMatch(
+      /Default/i,
+    );
+    expect(screen.getByTestId("developer-acl-label-id:502").textContent).toMatch(
+      /Any community/i,
+    );
   });
 
   it("still creates ACL when template load fails (best-effort)", async () => {

--- a/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
@@ -80,7 +80,13 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
 
   it("labels Default as protected and hides remove; offers Add AnyCommunity when missing", async () => {
     getAclForObject.mockResolvedValue(aclWithDefaultOnly);
-    render(<ObjectAclSection objectGuid="0-2-301" testIdPrefix="t-acl" />);
+    render(
+      <ObjectAclSection
+        objectGuid="0-2-301"
+        objectKind="content-type"
+        testIdPrefix="t-acl"
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("t-acl-table")).toBeTruthy();
@@ -102,9 +108,77 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(screen.queryByTestId("t-acl-add-default")).toBeNull();
   });
 
+  it("groups permission columns under Design access and Runtime visibility (CD-19)", async () => {
+    getAclForObject.mockResolvedValue(aclWithBothSpecials);
+    render(
+      <ObjectAclSection
+        objectGuid="0-2-301"
+        objectKind="content-type"
+        testIdPrefix="t-acl"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("t-acl-table")).toBeTruthy();
+    });
+
+    const table = screen.getByTestId("t-acl-table");
+    expect(table.getAttribute("data-acl-show-runtime")).toBe("true");
+    expect(table.getAttribute("data-acl-object-kind")).toBe("content-type");
+
+    expect(screen.getByTestId("t-acl-layer-headers")).toBeTruthy();
+    expect(screen.getByTestId("t-acl-layer-design").textContent).toMatch(/Design access/i);
+    expect(screen.getByTestId("t-acl-layer-runtime").textContent).toMatch(
+      /Runtime visibility/i,
+    );
+
+    // Design: Read, Update, Delete, Modify ACL; Runtime: Visible
+    expect(screen.getByTestId("t-acl-perm-header-READ").textContent).toMatch(/Read/i);
+    expect(screen.getByTestId("t-acl-perm-header-OWNER").textContent).toMatch(/Modify ACL/i);
+    expect(screen.getByTestId("t-acl-perm-header-RUNTIME_VISIBLE").textContent).toMatch(
+      /Visible/i,
+    );
+
+    // Runtime checkbox still toggles for AnyCommunity
+    const rt = screen.getByTestId("t-acl-perm-id:21-RUNTIME_VISIBLE") as HTMLInputElement;
+    expect(rt.checked).toBe(true);
+    fireEvent.click(rt);
+    expect(rt.checked).toBe(false);
+  });
+
+  it("hides Runtime visibility columns for non-runtime-relevant object kinds", async () => {
+    getAclForObject.mockResolvedValue(aclWithDefaultOnly);
+    render(
+      <ObjectAclSection
+        objectGuid="0-2-301"
+        objectKind="keyword"
+        testIdPrefix="t-acl"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("t-acl-table")).toBeTruthy();
+    });
+
+    expect(screen.getByTestId("t-acl-table").getAttribute("data-acl-show-runtime")).toBe(
+      "false",
+    );
+    expect(screen.getByTestId("t-acl-layer-design")).toBeTruthy();
+    expect(screen.queryByTestId("t-acl-layer-runtime")).toBeNull();
+    expect(screen.queryByTestId("t-acl-perm-header-RUNTIME_VISIBLE")).toBeNull();
+    expect(screen.getByTestId("t-acl-perm-header-READ")).toBeTruthy();
+    expect(screen.getByTestId("t-acl-perm-header-OWNER")).toBeTruthy();
+  });
+
   it("orders Default and AnyCommunity first and blocks remove on both", async () => {
     getAclForObject.mockResolvedValue(aclWithBothSpecials);
-    render(<ObjectAclSection objectGuid="0-2-301" testIdPrefix="t-acl" />);
+    render(
+      <ObjectAclSection
+        objectGuid="0-2-301"
+        objectKind="content-type"
+        testIdPrefix="t-acl"
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("t-acl-table")).toBeTruthy();
@@ -125,7 +199,13 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
 
   it("adds missing AnyCommunity via special action with correct REST shape on save", async () => {
     getAclForObject.mockResolvedValue(aclWithDefaultOnly);
-    render(<ObjectAclSection objectGuid="0-2-301" testIdPrefix="t-acl" />);
+    render(
+      <ObjectAclSection
+        objectGuid="0-2-301"
+        objectKind="content-type"
+        testIdPrefix="t-acl"
+      />,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("t-acl-add-any-community")).toBeTruthy();

--- a/WebUI/src/test/ts/developer/objectAclPermissionModel.test.ts
+++ b/WebUI/src/test/ts/developer/objectAclPermissionModel.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ACL_PERMISSIONS } from "../../../main/ts/api/developer/aclApi";
+import {
+  DESIGN_ACCESS_PERMISSIONS,
+  LAYERED_ACL_PERMISSIONS,
+  RUNTIME_ACCESS_PERMISSIONS,
+  RUNTIME_RELEVANT_OBJECT_KINDS,
+  aclPermissionLayer,
+  aclPermissionShortLabel,
+  hasRuntimeAccessPermission,
+  isDesignAccessPermission,
+  isRuntimeAccessPermission,
+  isRuntimeRelevantObjectKind,
+  partitionAclPermissions,
+  shouldShowRuntimeAccessColumns,
+  visibleAclPermissionsForObject,
+} from "../../../main/ts/developer/objectAclPermissionModel";
+
+describe("objectAclPermissionModel (CD-19 design vs runtime)", () => {
+  it("splits REST Permissions into design and runtime layers", () => {
+    expect(DESIGN_ACCESS_PERMISSIONS).toEqual([
+      "READ",
+      "UPDATE",
+      "DELETE",
+      "OWNER",
+    ]);
+    expect(RUNTIME_ACCESS_PERMISSIONS).toEqual(["RUNTIME_VISIBLE"]);
+    expect(LAYERED_ACL_PERMISSIONS).toEqual([
+      "READ",
+      "UPDATE",
+      "DELETE",
+      "OWNER",
+      "RUNTIME_VISIBLE",
+    ]);
+    // All known REST flags covered exactly once
+    expect(new Set(LAYERED_ACL_PERMISSIONS).size).toBe(ACL_PERMISSIONS.length);
+    for (const p of ACL_PERMISSIONS) {
+      expect(LAYERED_ACL_PERMISSIONS).toContain(p);
+    }
+  });
+
+  it("classifies each permission name", () => {
+    expect(aclPermissionLayer("READ")).toBe("design");
+    expect(aclPermissionLayer("UPDATE")).toBe("design");
+    expect(aclPermissionLayer("DELETE")).toBe("design");
+    expect(aclPermissionLayer("OWNER")).toBe("design");
+    expect(aclPermissionLayer("RUNTIME_VISIBLE")).toBe("runtime");
+    expect(aclPermissionLayer("runtime_visible")).toBe("runtime");
+    expect(aclPermissionLayer("")).toBeNull();
+    expect(aclPermissionLayer(null)).toBeNull();
+    expect(isDesignAccessPermission("OWNER")).toBe(true);
+    expect(isRuntimeAccessPermission("RUNTIME_VISIBLE")).toBe(true);
+    expect(isDesignAccessPermission("RUNTIME_VISIBLE")).toBe(false);
+  });
+
+  it("marks Workbench §5.4 runtime-relevant object kinds", () => {
+    const expected = [
+      "content-type",
+      "display-format",
+      "action-menu",
+      "menu-entry",
+      "search",
+      "site",
+      "template",
+      "variant",
+      "view",
+      "workflow",
+    ];
+    for (const k of expected) {
+      expect(RUNTIME_RELEVANT_OBJECT_KINDS.has(k as never)).toBe(true);
+      expect(isRuntimeRelevantObjectKind(k as never)).toBe(true);
+    }
+    expect(isRuntimeRelevantObjectKind("keyword")).toBe(false);
+    expect(isRuntimeRelevantObjectKind("slot")).toBe(false);
+    expect(isRuntimeRelevantObjectKind("pipeline")).toBe(false);
+    // Unknown / null → show runtime (safe default for mounts without kind)
+    expect(isRuntimeRelevantObjectKind(null)).toBe(true);
+    expect(isRuntimeRelevantObjectKind(undefined)).toBe(true);
+    expect(isRuntimeRelevantObjectKind("unknown")).toBe(true);
+  });
+
+  it("controls runtime column visibility", () => {
+    expect(shouldShowRuntimeAccessColumns("content-type")).toBe(true);
+    expect(shouldShowRuntimeAccessColumns("template")).toBe(true);
+    expect(shouldShowRuntimeAccessColumns("keyword")).toBe(false);
+    expect(shouldShowRuntimeAccessColumns("keyword", { forceShow: true })).toBe(
+      true,
+    );
+    expect(shouldShowRuntimeAccessColumns(null)).toBe(true);
+  });
+
+  it("returns visible permission columns for object kind", () => {
+    expect(visibleAclPermissionsForObject("content-type")).toEqual(
+      LAYERED_ACL_PERMISSIONS,
+    );
+    expect(visibleAclPermissionsForObject("keyword")).toEqual(
+      DESIGN_ACCESS_PERMISSIONS,
+    );
+    expect(
+      visibleAclPermissionsForObject("keyword", { forceShowRuntime: true }),
+    ).toEqual(LAYERED_ACL_PERMISSIONS);
+  });
+
+  it("provides Workbench-aligned short labels", () => {
+    expect(aclPermissionShortLabel("READ")).toBe("Read");
+    expect(aclPermissionShortLabel("OWNER")).toBe("Modify ACL");
+    expect(aclPermissionShortLabel("RUNTIME_VISIBLE")).toBe("Visible");
+    expect(aclPermissionShortLabel("CUSTOM_FLAG")).toBe("CUSTOM FLAG");
+  });
+
+  it("partitions permission lists and detects runtime bits", () => {
+    const parts = partitionAclPermissions([
+      "READ",
+      "RUNTIME_VISIBLE",
+      "OWNER",
+      "mystery",
+    ]);
+    expect(parts.design).toEqual(["READ", "OWNER"]);
+    expect(parts.runtime).toEqual(["RUNTIME_VISIBLE"]);
+    expect(parts.other).toEqual(["mystery"]);
+    expect(hasRuntimeAccessPermission(["READ", "OWNER"])).toBe(false);
+    expect(hasRuntimeAccessPermission(["READ", "RUNTIME_VISIBLE"])).toBe(true);
+  });
+});

--- a/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
@@ -2096,6 +2096,10 @@
       <tuv xml:lang="te"><seg>ఈ వస్తువు కోసం డిజైన్-సమయ యాక్సెస్ నియంత్రణ. అనుమతులను టోగుల్ చేయండి, ఎంట్రీలను జోడించండి లేదా తీసివేయండి, ఆపై సేవ్ చేయండి (పూర్తి ఎంట్రీ జాబితాను బల్క్ ACL API ద్వారా భర్తీ చేయండి).</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>该对象的设计时访问控制。切换权限、添加或删除条目，然后保存（通过批量 ACL API 替换完整条目列表）。</seg></tuv>
     <tuv xml:lang="ru"><seg>Управление доступом во время разработки для этого объекта. Переключайте разрешения, добавляйте или удаляйте записи, затем сохраняйте (полная замена списка записей через API-интерфейс ACL).</seg></tuv><tuv xml:lang="he"><seg>בקרת גישה בזמן עיצוב עבור אובייקט זה. החלף הרשאות, הוסף או הסר ערכים ולאחר מכן שמור (החלפה של רשימת ערכים מלאה באמצעות ACL API בכמות גדולה).</seg></tuv><tuv xml:lang="uk"><seg>Контроль доступу до цього об’єкта під час розробки. Перемкніть дозволи, додайте або видаліть записи, а потім збережіть (повний список записів замінено за допомогою групового API ACL).</seg></tuv></tu>
+    <!-- CD-19 / #2283: new English source for ACL_HINT (tuid includes English; prior tu above is orphaned for retranslation history). Non-en locales fall back to English until retranslated. -->
+    <tu tuid="perc.ui.developer@Design-time and runtime access control for this object. Toggle Design access (Read, Update, Delete, Modify ACL) and Runtime visibility where applicable, add or remove entries, then save (full entry list replace via bulk ACL API).">
+      <tuv xml:lang="en-us"><seg>Design-time and runtime access control for this object. Toggle Design access (Read, Update, Delete, Modify ACL) and Runtime visibility where applicable, add or remove entries, then save (full entry list replace via bulk ACL API).</seg></tuv>
+    </tu>
     <tu tuid="perc.ui.developer@An entry with that name and type already exists.">
       <tuv xml:lang="en-us"><seg>An entry with that name and type already exists.</seg></tuv>
       <tuv xml:lang="ar"><seg>هناك إدخال بهذا الاسم والنوع موجود بالفعل.</seg></tuv>

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Object ACL — design vs runtime permission model depth (#2283 / #2274 CD-19).
+ *
+ * Opens a content-type detail panel and asserts ObjectAclSection exposes
+ * Workbench-parity Design access vs Runtime visibility column groups and
+ * layered permission toggles (Read / Update / Delete / Modify ACL / Visible).
+ *
+ * Surface filter (H2 QA / agent path):
+ *   cd modules/perc-qa-automation/frontend
+ *   npx playwright test tests/developer-object-acl-design-runtime.spec.js
+ *
+ * Entry: spa.jsp?entry=developer&section=content-types
+ * Refs #2283, #2274, #2262, #1690.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  catalogRowSelector,
+} = require("./helpers/developer-catalog-selectors");
+
+function developerContentTypesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "content-types",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Developer Object ACL design vs runtime permissions (#2283)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("content type ACL shows Design access and Runtime visibility columns", async ({
+    page,
+  }) => {
+    await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+
+    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-content-types"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const error = page.locator('[data-testid="developer-ct-error"]');
+    const panel = page.locator('[data-testid="developer-ct-panel"]');
+    const empty = page.locator('[data-testid="developer-ct-empty"]');
+
+    await expect(panel.or(empty).or(error).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await error.isVisible()) {
+      const msg = (await error.innerText()).trim();
+      throw new Error(`Content types catalog error: ${msg}`);
+    }
+
+    if (await empty.isVisible()) {
+      test.skip(true, "No content types in CMS — cannot open Object ACL");
+      return;
+    }
+
+    const firstRow = page.locator(catalogRowSelector("developer-ct-row", 0));
+    await expect(firstRow).toBeVisible({ timeout: 15_000 });
+    const openBtn = firstRow.locator("button");
+    await expect(
+      openBtn,
+      "first content-type row should expose Open when selectionKey is set",
+    ).toBeVisible({ timeout: 5_000 });
+    await openBtn.click();
+
+    await expect(page.locator('[data-testid="developer-ct-detail"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const aclSection = page.locator('[data-testid="developer-ct-acl-section"]');
+    await expect(aclSection).toBeVisible({ timeout: 15_000 });
+
+    // Hint mentions design + runtime model
+    await expect(aclSection).toContainText(/Design-time and runtime|Design access|Runtime/i);
+
+    const aclError = page.locator('[data-testid="developer-ct-acl-error"]');
+    const aclEmpty = page.locator('[data-testid="developer-ct-acl-empty"]');
+    const aclTable = page.locator('[data-testid="developer-ct-acl-table"]');
+    const aclLoading = page.locator('[data-testid="developer-ct-acl-loading"]');
+
+    await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+    await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await aclError.isVisible()) {
+      const msg = (await aclError.innerText()).trim();
+      throw new Error(`Object ACL load error: ${msg}`);
+    }
+
+    if (await aclEmpty.isVisible()) {
+      test.skip(
+        true,
+        "Object has no ACL — create-first path not required for #2283 design/runtime columns",
+      );
+      return;
+    }
+
+    await expect(aclTable).toBeVisible();
+    await expect(aclTable).toHaveAttribute("data-acl-show-runtime", "true");
+    await expect(aclTable).toHaveAttribute("data-acl-object-kind", "content-type");
+
+    // Layer group headers
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-layer-design"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-layer-design"]'),
+    ).toContainText(/Design access/i);
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-layer-runtime"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-layer-runtime"]'),
+    ).toContainText(/Runtime visibility/i);
+
+    // Permission column headers (Workbench labels)
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-perm-header-READ"]'),
+    ).toContainText(/Read/i);
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-perm-header-UPDATE"]'),
+    ).toContainText(/Update/i);
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-perm-header-DELETE"]'),
+    ).toContainText(/Delete/i);
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-perm-header-OWNER"]'),
+    ).toContainText(/Modify ACL/i);
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-perm-header-RUNTIME_VISIBLE"]'),
+    ).toContainText(/Visible/i);
+
+    // At least one permission checkbox exists for design + runtime
+    const designRead = page.locator(
+      '[data-testid^="developer-ct-acl-perm-"][data-testid$="-READ"]',
+    );
+    const runtimeVis = page.locator(
+      '[data-testid^="developer-ct-acl-perm-"][data-testid$="-RUNTIME_VISIBLE"]',
+    );
+    await expect(designRead.first()).toBeVisible();
+    await expect(runtimeVis.first()).toBeVisible();
+
+    // Toggle a design permission (non-destructive if we don't save)
+    const firstRead = designRead.first();
+    const wasChecked = await firstRead.isChecked();
+    await firstRead.click();
+    await expect(firstRead).toBeChecked({ checked: !wasChecked });
+    // Restore so we leave UI clean if user has dirty state visible
+    await firstRead.click();
+    await expect(firstRead).toBeChecked({ checked: wasChecked });
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
@@ -157,12 +157,13 @@ test.describe("Developer Object ACL design vs runtime permissions (#2283)", () =
       page.locator('[data-testid="developer-ct-acl-perm-header-RUNTIME_VISIBLE"]'),
     ).toContainText(/Visible/i);
 
-    // At least one permission checkbox exists for design + runtime
+    // Checkbox-only locators: prefix also matches perm-header-<PERM> <th> cells;
+    // scope to input so .first() is never the header (see ObjectAclSection.tsx).
     const designRead = page.locator(
-      '[data-testid^="developer-ct-acl-perm-"][data-testid$="-READ"]',
+      'input[type="checkbox"][data-testid^="developer-ct-acl-perm-"][data-testid$="-READ"]',
     );
     const runtimeVis = page.locator(
-      '[data-testid^="developer-ct-acl-perm-"][data-testid$="-RUNTIME_VISIBLE"]',
+      'input[type="checkbox"][data-testid^="developer-ct-acl-perm-"][data-testid$="-RUNTIME_VISIBLE"]',
     );
     await expect(designRead.first()).toBeVisible();
     await expect(runtimeVis.first()).toBeVisible();


### PR DESCRIPTION
## Summary

Implements **B3 / CD-19 design vs runtime permission model depth** on Developer `ObjectAclSection` (slice of #2274 / residual #2262 / epic #1690).

### Inventory (posted on #2274 before coding)
- REST `Permissions` already exposes all five flags: `READ`, `UPDATE`, `DELETE`, `OWNER`, `RUNTIME_VISIBLE` — **no REST invent**.
- Workbench §5.4: **Design access** = Read/Update/Delete/Modify ACL (`OWNER`); **Runtime** = `RUNTIME_VISIBLE` for content types, templates, display formats, menus, searches, sites, variants, views, workflows.
- Pre-B3 UI showed a flat permission checkbox row (OWNER after RUNTIME_VISIBLE).

### Changes
- New pure helpers: `WebUI/src/main/ts/developer/objectAclPermissionModel.ts`
  - Design vs runtime layers, layered column order (OWNER with design), runtime-relevant object kinds, column visibility gating
- `ObjectAclSection`: two-row header — **Design access** | **Runtime visibility**; Workbench labels (Read, Update, Delete, Modify ACL, Visible); `objectKind` prop
- Mounts: content-type + template pass `objectKind`
- Vitest: helpers + section (design/runtime group, hide runtime for non-relevant kinds)
- Playwright HARD GATE surface: `developer-object-acl-design-runtime.spec.js`

### Out of scope (as required)
- B1 specials / B2 prefs rework, #2273 navigator, REST invent, new object-type ACL mounts

## Test plan
- [x] Vitest: `objectAclPermissionModel` + `ObjectAclSection` (17 tests green)
- [x] `WebUI` standalone `mvnw clean install` green
- [x] Playwright surface spec added (filter path below)
- [ ] Live CMS surface run — `perc-devctl qa-up` started H2 container but CMS returned **503** (Spring circular dependency `folderHelper`/`contentItemDao` during boot). Spec is ready for H2 QA once stack is healthy:

```bash
python docker/scripts/perc-devctl.py qa-up
cd modules/perc-qa-automation/frontend
# use TEST_CMS_URL + admin creds from qa-up
npm run test:surface -- --path tests/developer-object-acl-design-runtime.spec.js
python docker/scripts/perc-devctl.py qa-down
```

## Gates evidence
- Module install: WebUI `clean install` EXIT=0
- Unit: 17/17 Vitest pass for ACL model + section
- Playwright: companion surface filter present (live run blocked by QA CMS boot 503 this session)
- Erlang self-review: portable paths; no rest/sitemanage change (API gap not proven); no mega-PR with navigator/B1/B2

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

## Parent trackers
- Fixes #2283
- Refs #2274 #2262 #1690

> Co-Authored by Grok Build using grok-4.5 with agent main.