### PR TITLE
test(deployer): residual Package Installer NULL_INPUT_DOC smoke (#2266)

### DIFF
--- a/deployer/src/test/java/com/percussion/deployer/client/PSPackageInstallerNullInputDocResidualSmokeTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/client/PSPackageInstallerNullInputDocResidualSmokeTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.HTTPClient.NVPair;
+import com.percussion.deployer.catalog.server.PSCatalogHandler;
+import com.percussion.deployer.server.PSDeploymentHandler;
+import com.percussion.error.IPSDeploymentErrors;
+import com.percussion.error.PSDeployException;
+import com.percussion.server.PSRequest;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Locale;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Agent-safe residual smoke for Package Installer {@code NULL_INPUT_DOC} after the Slice 2
+ * multipart Content-Type fix (#2271 / #2265).
+ *
+ * <p>Parent epic: #955. This slice (#2266) does <strong>not</strong> run a live CMS Package
+ * Installer install; it locks the encode → MIME-gate contract for install-critical request types
+ * and verifies handlers do not report error 8 when an input document is present.
+ *
+ * <p>Live residual steps (when a CMS + sample {@code .ppkg} are available) are documented on #2266
+ * / #955 and in {@code docs/ai-generated/tasks/955-package-installer-null-input-doc/2266-residual-smoke.md}.
+ */
+@DisplayName("Package Installer NULL_INPUT_DOC residual smoke (#2266)")
+public class PSPackageInstallerNullInputDocResidualSmokeTest {
+
+  /**
+   * Install-critical deploy request roots that Package Installer exercises over HTTP multipart
+   * before / during package install (connect, catalog, validate).
+   */
+  static Stream<Arguments> installCriticalRequestDocs() {
+    return Stream.of(
+        Arguments.of("deploy-connect", "PSXDeployConnectRequest"),
+        Arguments.of("deploy-validateArchive", "PSXDeployValidateArchiveRequest"),
+        Arguments.of("deploy-getDeployableElements", "PSXDeployGetDeployableElementsRequest"),
+        Arguments.of("catalog-types", "PSXDeployCatalogTypesRequest"));
+  }
+
+  @ParameterizedTest(name = "{0} multipart forces application/xml")
+  @MethodSource("installCriticalRequestDocs")
+  public void residualSmoke_installRequestTypes_encodeWithApplicationXml(
+      String requestType, String rootElement) throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, rootElement);
+    // Placeholder only — not a real credential (no secrets in fixtures)
+    if ("PSXDeployConnectRequest".equals(rootElement)) {
+      root.setAttribute("userId", "smoke-user");
+      root.setAttribute("password", "smoke-password");
+      root.setAttribute("overrideLock", "no");
+      root.setAttribute("enforceLicense", "no");
+    } else if ("PSXDeployValidateArchiveRequest".equals(rootElement)) {
+      root.setAttribute("checkArchiveRef", "yes");
+    } else if ("PSXDeployGetDeployableElementsRequest".equals(rootElement)) {
+      root.setAttribute("type", "Package");
+    }
+
+    NVPair[] opts = new NVPair[] {new NVPair("sessionProbe", "1")};
+    NVPair[] hdrs = new NVPair[2];
+    hdrs[1] = new NVPair("PS-Request-Type", requestType);
+
+    byte[] body = PSDeploymentServerConnection.encodeXmlDocumentMultipart(opts, doc, hdrs);
+
+    assertTrue(
+        PSDeploymentServerConnection.multipartContainsXmlContentType(body),
+        () -> "missing XML Content-Type for " + requestType);
+    String asText = new String(body, StandardCharsets.ISO_8859_1);
+    assertTrue(
+        asText.toLowerCase(Locale.ROOT).contains("content-type: application/xml"),
+        () -> "expected application/xml for " + requestType + ", headers:\n" + extractHeaders(asText));
+    assertTrue(asText.contains(rootElement), () -> "XML body must include " + rootElement);
+    assertEquals("Content-Type", hdrs[0].getName());
+    assertTrue(
+        hdrs[0].getValue().toLowerCase(Locale.ROOT).startsWith("multipart/form-data"),
+        hdrs[0].getValue());
+  }
+
+  @Test
+  @DisplayName("production File encode path (execute) forces application/xml")
+  public void residualSmoke_fileBasedEncodeMatchesProductionExecutePath() throws Exception {
+    // Production execute() writes the request Document to a temp .xml file then encodes it.
+    java.nio.file.Path tmp = Files.createTempFile("dpl_smoke_", ".xml");
+    try {
+      String xml =
+          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+              + "<PSXDeployValidateArchiveRequest checkArchiveRef=\"yes\"/>";
+      Files.writeString(tmp, xml, StandardCharsets.UTF_8);
+
+      NVPair[] opts = null;
+      NVPair[] hdrs = new NVPair[2];
+      hdrs[1] = new NVPair("PS-Request-Type", "deploy-validateArchive");
+
+      byte[] body =
+          PSDeploymentServerConnection.encodeXmlDocumentMultipart(opts, tmp.toFile(), hdrs);
+
+      assertTrue(PSDeploymentServerConnection.multipartContainsXmlContentType(body));
+      String asText = new String(body, StandardCharsets.ISO_8859_1);
+      assertTrue(asText.toLowerCase(Locale.ROOT).contains("content-type: application/xml"));
+      assertTrue(asText.contains("PSXDeployValidateArchiveRequest"));
+    } finally {
+      Files.deleteIfExists(tmp);
+    }
+  }
+
+  @Test
+  @DisplayName("server MIME gate: application/xml and text/xml are XML; other types are not")
+  public void residualSmoke_serverMimeGateMatchesFormParserXmlClassification() {
+    // Mirrors PSFormContentParser: only text/xml and application/xml set isXml → setInputDocument.
+    assertTrue(isXmlMimeType("application/xml"));
+    assertTrue(isXmlMimeType("application/xml; charset=utf-8"));
+    assertTrue(isXmlMimeType("text/xml"));
+    assertTrue(isXmlMimeType("text/xml; charset=utf-8"));
+    assertFalse(isXmlMimeType("application/octet-stream"));
+    assertFalse(isXmlMimeType("text/plain"));
+    assertFalse(isXmlMimeType(""));
+    assertFalse(isXmlMimeType(null));
+  }
+
+  @Test
+  @DisplayName("handlers skip NULL_INPUT_DOC when input document is present")
+  public void residualSmoke_handlersDoNotThrowNullInputDocWhenDocumentPresent() throws Exception {
+    // Catalog: intentional non-catalog root → INVALID_REQUEST_TYPE, not error 8.
+    Document catalogDoc = PSXmlDocumentBuilder.createXmlDocument();
+    PSXmlDocumentBuilder.createRoot(catalogDoc, "PSXDeployConnectRequest");
+    PSRequest catalogReq = mock(PSRequest.class);
+    when(catalogReq.getInputDocument()).thenReturn(catalogDoc);
+
+    PSDeployException catalogEx =
+        assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(catalogReq));
+    assertNotEquals(
+        IPSDeploymentErrors.NULL_INPUT_DOC,
+        catalogEx.getErrorCode(),
+        "present document must not surface as NULL_INPUT_DOC");
+    assertEquals(IPSDeploymentErrors.INVALID_REQUEST_TYPE, catalogEx.getErrorCode());
+
+    // validateArchive: null-doc guard must not fire when document is present.
+    // Missing archive child fails later — residual gate is only error 8.
+    Document valDoc = PSXmlDocumentBuilder.createXmlDocument();
+    Element valRoot =
+        PSXmlDocumentBuilder.createRoot(valDoc, "PSXDeployValidateArchiveRequest");
+    valRoot.setAttribute("checkArchiveRef", "yes");
+    valRoot.setAttribute("warnOnBuidMismatch", "no");
+    valRoot.setAttribute("warnMissingPackageDep", "no");
+    PSRequest valReq = mock(PSRequest.class);
+    when(valReq.getInputDocument()).thenReturn(valDoc);
+
+    PSDeploymentHandler handler = new PSDeploymentHandler();
+    PSDeployException valEx =
+        assertThrows(PSDeployException.class, () -> handler.validateArchive(valReq));
+    assertNotEquals(
+        IPSDeploymentErrors.NULL_INPUT_DOC,
+        valEx.getErrorCode(),
+        "present document must not surface as NULL_INPUT_DOC from validateArchive: "
+            + valEx.getLocalizedMessage());
+  }
+
+  @Test
+  @DisplayName("null document still maps to NULL_INPUT_DOC (guards retained)")
+  public void residualSmoke_nullDocumentStillMapsToError8() {
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(null);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
+    assertEquals(IPSDeploymentErrors.NULL_INPUT_DOC, ex.getErrorCode());
+  }
+
+  /**
+   * Same classification rule as {@code PSFormContentParser} for multipart parts (startsWith
+   * text/xml or application/xml). Kept local so residual smoke does not require spinning the full
+   * request parser.
+   */
+  private static boolean isXmlMimeType(String mimeType) {
+    if (mimeType == null || mimeType.isEmpty()) {
+      return false;
+    }
+    String lower = mimeType.toLowerCase(Locale.ROOT).trim();
+    return lower.startsWith("text/xml") || lower.startsWith("application/xml");
+  }
+
+  private static String extractHeaders(String multipartBody) {
+    StringBuilder sb = new StringBuilder();
+    for (String line : multipartBody.split("\r\n")) {
+      if (line.toLowerCase(Locale.ROOT).startsWith("content-")) {
+        sb.append(line).append('\n');
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/docs/ai-generated/tasks/955-package-installer-null-input-doc/2266-residual-smoke.md
+++ b/docs/ai-generated/tasks/955-package-installer-null-input-doc/2266-residual-smoke.md
@@ -1,0 +1,84 @@
+# Residual smoke: Package Installer `NULL_INPUT_DOC` (Slice 3 / #2266)
+
+Parent epic: [#955](https://github.com/intersoftdatalabs-in/percussioncms/issues/955)  
+Depends on Slice 2 fix: [#2265](https://github.com/intersoftdatalabs-in/percussioncms/issues/2265) / [PR #2271](https://github.com/intersoftdatalabs-in/percussioncms/pull/2271) (merged)  
+Inventory: [2264-inventory.md](./2264-inventory.md)
+
+## Agent-safe automated residual (required overnight)
+
+Live Package Installer + CMS was **not** assumed available for overnight agents. Residual automation lives in the `deployer` module:
+
+| Test | Role |
+|------|------|
+| `PSDeploymentServerConnectionXmlMultipartTest` | Slice 2 encode + explicit `application/xml` |
+| `PSNullInputDocHandlerTest` | Slice 2 null-doc → error 8 throw sites |
+| `PSPackageInstallerNullInputDocResidualSmokeTest` | Slice 3 residual: install-critical request types, File encode path, MIME gate, handlers with present doc |
+
+### Run
+
+From repo root (or `deployer/`):
+
+```bash
+cd deployer
+../mvnw clean install
+# or focused:
+../mvnw -Dtest=PSPackageInstallerNullInputDocResidualSmokeTest,PSDeploymentServerConnectionXmlMultipartTest,PSNullInputDocHandlerTest test
+```
+
+Windows (PowerShell), same module:
+
+```powershell
+cd deployer
+..\mvnw.cmd clean install
+```
+
+**Pass criteria:** all three test classes green; multipart bodies for connect / validateArchive / catalog-style roots declare `Content-Type: application/xml`; null input doc still maps to `IPSDeploymentErrors.NULL_INPUT_DOC` (8); present document does **not** surface as error 8 from catalog / validateArchive entry.
+
+## Live residual (optional — human / env with CMS)
+
+Do **not** invent pass results. Run only when a running CMS, Package Installer client, and a sample package are available. **No secrets in logs or issue comments.**
+
+### Prerequisites
+
+1. CMS instance running (e.g. local qa-up / installed server) with deployer servlet reachable.
+2. Package Installer launchable from the install tree (`system/installResources` / product docs for `PackageInstaller` / `pspackagerui` as shipped).
+3. Sample package under the install tree, typically:
+   - `<CMSinstall>/Packages/Percussion/*.ppkg`
+   - or repo-sourced packages under `modules/perc-packages/src/main/resources` when packaged into a build.
+4. Deployer/admin credentials available **only** in the operator environment (do not commit or paste passwords).
+
+### Steps
+
+1. Launch **Package Installer**.
+2. Select any package from `<CMSinstall>/Packages/Percussion/` (or another known-good `.ppkg`).
+3. Provide server host, port, protocol, and deployer-capable credentials.
+4. Click **Install** (or the product’s validate-then-install flow).
+5. Observe result:
+   - **Pass:** install proceeds past connection/catalog/validate without  
+     `PSDeployException: Input document expected by server, none found`  
+     (`NULL_INPUT_DOC` / error 8).
+   - **Fail:** capture exact exception text, request type if logged, CMS build/version, and JRE version; comment on #955 and re-open residual if needed.
+
+### What this does *not* prove
+
+- Full package matrix / all content types.
+- In-process install via `PSLocalDeployerClient` (that path never uses HTTP multipart).
+- Opaque Swing orchestration inside `pspackagerui.jar` beyond the HTTP document APIs.
+
+## Env gap (overnight default)
+
+| Item | Overnight agent |
+|------|-----------------|
+| Live CMS | Not available / not assumed |
+| Package Installer UI | Not driven |
+| Agent-safe multipart + handler smoke | **Run** (see above) |
+| Live pass/fail | Document steps only; do not claim live pass |
+
+## Slice closure criteria
+
+- [x] Agent-safe residual smoke automated and green in `deployer`
+- [x] Live residual steps documented (this file + issue comments)
+- [ ] Live install executed (optional; human when env exists)
+- [x] Results recorded on #2266 and parent #955 agent progress
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.


### PR DESCRIPTION
## Summary

Slice **3 of 3** residual install smoke for Package Installer `NULL_INPUT_DOC` (parent **#955**), after Slice 2 multipart Content-Type fix merged in **#2271** / **#2265**.

### Agent-safe residual (this PR)

- New `PSPackageInstallerNullInputDocResidualSmokeTest`:
  - Install-critical request types (`deploy-connect`, `deploy-validateArchive`, `deploy-getDeployableElements`, catalog-style) encode multipart with explicit `Content-Type: application/xml`
  - Production **File** encode path (same as `execute()` temp attachment) forces `application/xml`
  - Server MIME-gate smoke aligned with `PSFormContentParser` (`application/xml` / `text/xml` → XML input doc; other types do not)
  - Handlers with a present input document do **not** report `IPSDeploymentErrors.NULL_INPUT_DOC` (8); null doc still maps to error 8
- Live residual procedure documented (no live CMS assumed overnight):
  - `docs/ai-generated/tasks/955-package-installer-null-input-doc/2266-residual-smoke.md`

### Live residual (env gap)

No live Package Installer + CMS was available for this overnight run. **Live pass is not claimed.** Steps for human/qa-up residual are in the doc and on #2266 / #955 comments.

## Parent / slices

| Slice | Issue | PR | Status |
|-------|-------|-----|--------|
| 1 Inventory | #2264 | #2267 | merged |
| 2 Minimal fix + unit tests | #2265 | #2271 | merged |
| 3 Residual install smoke | #2266 | **this PR** | agent-safe complete; live optional |

## Test plan

- [x] `cd deployer && ../mvnw clean install` — BUILD SUCCESS (174 tests, 0 failures; residual smoke green)
- [x] Focused: `-Dtest=PSPackageInstallerNullInputDocResidualSmokeTest,PSDeploymentServerConnectionXmlMultipartTest,PSNullInputDocHandlerTest`
- [ ] Live Package Installer install against CMS + sample `.ppkg` under Packages/Percussion (optional; document only — human when env exists)

## Gates evidence

- **Change class:** residual smoke tests + live residual procedure for installer/deployer multipart path
- **Module `mvnw clean install`:** `deployer` standalone — SUCCESS
- **Erlang:** portable temp files (`Files.createTempFile`); no secrets in fixtures; behavioral residual coverage; no product fix churn beyond smoke/docs
- **Live E2E:** env gap documented; no invented live pass

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2266  
Partial for #955 (slice 3/3 agent-safe; optional live residual remaining for human)  
Parent tracker: #955  
Depends on: #2265 / #2271  

> Co-Authored by Grok Build using grok-4.5 with agent main.