### PR TITLE
fix(perc-ant): javac warnings batch 2 — residual Xlint zero (#2331)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2331-perc-ant-javac-batch2-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2331-perc-ant-javac-batch2-erlang.md
@@ -1,0 +1,40 @@
+# Erlang self-review — issue #2331 perc-ant javac batch 2
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2331-perc-ant-javac-batch2`  
+**Module:** `modules/perc-ant`  
+**Verdict:** **Approve** (commit-ready)
+
+## Scope
+
+Residual batch 2 of parent #2023 / tracker #2200 (after merged batch 1 PR #2330). Clear remaining **~40** project-`-Xlint` main-source diagnostics:
+
+| Area | Fix |
+|------|-----|
+| `PSJunitFileSelector` | `Class<?>` / `Iterator<String>` / typed `loadClass` / `ms_testAnnotation` |
+| `gui/PSRxBuildInput` | `List<String>` / `Set<String>` / `Enumeration<? extends ZipEntry>` |
+| Install this-escape | `final class` on `PSModifyProviders`, `PSRenameDeprecatedApps`, `PSTableAction`, `PSUpdateWebApps` (field inits call `getRootDir()`) |
+
+Did **not** re-touch batch 1 files from PR #2330 except the intentional residual this-escape files named in #2331 (`PSRenameDeprecatedApps`, `PSTableAction`).
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in typed refactors | None — collections already held strings / ZipEntry elements; only declarations and casts updated |
+| this-escape | Real fix via `final class` (peer pattern #2286 / #2016); no class-level `@SuppressWarnings` |
+| Portable paths / file I/O | N/A — no path-string or I/O behavior changes |
+| Behavioral unit tests | No new non-trivial logic; existing module suite green (**43** tests) |
+| Prefer real fix over suppress | Yes — no new `@SuppressWarnings` |
+| Standalone `mvnw clean install` | BUILD SUCCESS |
+| Scope confined to perc-ant + review doc | Yes |
+
+## Verification
+
+- `cd modules/perc-ant && ../../mvnw clean install` → BUILD SUCCESS
+- Main-source project-`-Xlint` javac warnings: **0** (was ~40 residual after batch 1)
+- Tests: 43 run, 0 fail, 0 skip
+
+## Residual
+
+Main-source project Xlint for `perc-ant` is zero after this batch. Optional later work (not filed unless needed): javadoc "no main description" noise on unrelated install tasks; test-source Xlint if ever enabled module-wide.

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSJunitFileSelector.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSJunitFileSelector.java
@@ -63,7 +63,7 @@ public class PSJunitFileSelector extends BaseExtendSelector {
 
     try {
       // try to load it
-      Class theClass = loadClass(className);
+      Class<?> theClass = loadClass(className);
 
       // load JUnit4 test annotation class
       loadTestAnnotation();
@@ -73,7 +73,7 @@ public class PSJunitFileSelector extends BaseExtendSelector {
       if (!Modifier.isPublic(mods) || Modifier.isInterface(mods) || Modifier.isAbstract(mods))
         return false;
 
-      final Class clazzTestCase = loadClass("junit.framework.TestCase");
+      final Class<?> clazzTestCase = loadClass("junit.framework.TestCase");
       // automatically exclude all non JUnit/JUnit4 TestCase classes.
       if (!clazzTestCase.isAssignableFrom(theClass) && !isJUnit4(theClass)) return false;
 
@@ -121,7 +121,7 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    *     <code>className</code>.
    * @return <code>true</code> if it should be excluded, <code>false</code> if not.
    */
-  private boolean isClassExcluded(String className, Class theClass) {
+  private boolean isClassExcluded(String className, Class<?> theClass) {
     boolean isExcluded = false;
 
     // see if name is excluded
@@ -141,7 +141,7 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    *     <code>className</code>.
    * @return <code>true</code> if it should be included, <code>false</code> if not.
    */
-  private boolean isClassIncluded(String className, Class theClass) {
+  private boolean isClassIncluded(String className, Class<?> theClass) {
     // default to true is no filters provided
     boolean isIncluded = m_classNameIncludes.isEmpty() && m_classImplIncludes.isEmpty();
 
@@ -186,11 +186,11 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    * @return <code>true</code> if the name matches any patterns, or if <code>patterns</code> is
    *     empty and <code>matchEmpty</code> is <code>true</code>, <code>false</code> otherwise.
    */
-  private boolean hasMatch(String name, Iterator patterns, boolean matchEmpty) {
+  private boolean hasMatch(String name, Iterator<String> patterns, boolean matchEmpty) {
     boolean hasMatch = (matchEmpty && !patterns.hasNext());
 
     while (patterns.hasNext() && !hasMatch) {
-      hasMatch = SelectorUtils.match((String) patterns.next(), name);
+      hasMatch = SelectorUtils.match(patterns.next(), name);
     }
 
     return hasMatch;
@@ -209,12 +209,12 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    *     classNames</code> is empty and <code>matchEmpty</code> is <code>true</code>, <code>false
    *     </code> otherwise.
    */
-  private boolean hasMatch(Class theClass, Iterator classNames, boolean matchEmpty) {
+  private boolean hasMatch(Class<?> theClass, Iterator<String> classNames, boolean matchEmpty) {
     boolean hasMatch = (matchEmpty && !classNames.hasNext());
 
     while (classNames.hasNext() && !hasMatch) {
-      Class testClass;
-      String testName = (String) classNames.next();
+      Class<?> testClass;
+      String testName = classNames.next();
       try {
         testClass = loadClass(testName);
         hasMatch = testClass.isAssignableFrom(theClass);
@@ -374,8 +374,8 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    * @return The class, never <code>null</code>.
    * @throws ClassNotFoundException If the class cannot be loaded.
    */
-  private Class loadClass(String className) throws ClassNotFoundException {
-    Class theClass = null;
+  private Class<?> loadClass(String className) throws ClassNotFoundException {
+    Class<?> theClass;
     if (ms_classLoader == null) theClass = Class.forName(className);
     else theClass = ms_classLoader.loadClass(className);
 
@@ -389,7 +389,7 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    * @param theClass The test class to inspect, assumed not <code>null</code>.
    * @return <code>true</code> if the test class is JUnit4, <code>false</code> otherwise.
    */
-  private boolean isJUnit4(Class theClass) {
+  private boolean isJUnit4(Class<?> theClass) {
     Method[] methods = theClass.getMethods();
     for (Method m : methods) {
       Annotation[] annotations = m.getDeclaredAnnotations();
@@ -487,5 +487,5 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    * Stores the test annotation class used by JUnit4-style test classes. Initialized in {@link
    * #loadTestAnnotation()}.
    */
-  private static Class ms_testAnnotation = null;
+  private static Class<?> ms_testAnnotation = null;
 }

--- a/modules/perc-ant/src/main/java/com/percussion/ant/gui/PSRxBuildInput.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/gui/PSRxBuildInput.java
@@ -29,6 +29,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -277,10 +278,10 @@ public class PSRxBuildInput {
     String mkdirContents = "";
     String copyContents = "";
     String cfgContents = "";
-    Set mkdirs = new HashSet();
+    Set<String> mkdirs = new HashSet<>();
 
     // Build jar copy tasks
-    ArrayList jarNames = new ArrayList();
+    List<String> jarNames = new ArrayList<>();
 
     cfgContents += BUILD_DATE_BEGIN_TAG + "\n";
     cfgContents += m_dateText + "\n";
@@ -297,7 +298,7 @@ public class PSRxBuildInput {
     cfgContents += ADDITIONAL_JARS_BEGIN_TAG + "\n";
 
     for (int i = 0; i < m_additionalJarsArrList.size(); i++) {
-      String jarName = (String) m_additionalJarsArrList.get(i);
+      String jarName = m_additionalJarsArrList.get(i);
 
       jarNames.add(jarName);
       cfgContents += jarName + "\n";
@@ -307,7 +308,7 @@ public class PSRxBuildInput {
     for (int i = 0; i < ms_requiredJars.length; i++) jarNames.add(ms_requiredJars[i]);
 
     for (int i = 0; i < jarNames.size(); i++) {
-      String name = (String) jarNames.get(i);
+      String name = jarNames.get(i);
       if (name.trim().length() == 0) continue;
 
       if (ms_jarMap.get(name) == null)
@@ -336,9 +337,9 @@ public class PSRxBuildInput {
     }
 
     // Build mkdir tasks
-    Iterator iter = mkdirs.iterator();
+    Iterator<String> iter = mkdirs.iterator();
     while (iter.hasNext()) {
-      String dir = "${outputdir}/patch/" + (String) iter.next();
+      String dir = "${outputdir}/patch/" + iter.next();
       String mkdirTask = "<mkdir dir=\"" + dir + "\"/>";
       mkdirContents += mkdirTask + "\n";
     }
@@ -357,7 +358,7 @@ public class PSRxBuildInput {
     // Build file copy tasks
     cfgContents += ADDITIONAL_FILES_BEGIN_TAG + "\n";
     for (int i = 0; i < m_addPatchFilesArrList.size(); i++) {
-      String[] mapping = ((String) m_addPatchFilesArrList.get(i)).split("->");
+      String[] mapping = m_addPatchFilesArrList.get(i).split("->");
       String src =
           FilenameUtils.separatorsToUnix(new File(m_rootDir, mapping[0]).getAbsolutePath());
 
@@ -390,7 +391,7 @@ public class PSRxBuildInput {
     // Build remove file tasks
     cfgContents += REMOVE_FILES_BEGIN_TAG + "\n";
     for (int i = 0; i < m_remPatchFilesArrList.size(); i++) {
-      String fileLoc = (String) m_remPatchFilesArrList.get(i);
+      String fileLoc = m_remPatchFilesArrList.get(i);
       File file = new File(fileLoc);
       String name = file.getName();
       File parent = file.getParentFile();
@@ -731,10 +732,10 @@ public class PSRxBuildInput {
     String backupTask = "";
 
     ZipFile zip = new ZipFile(src);
-    Enumeration entries = zip.entries();
-    Set<String> dirs = new HashSet<String>();
+    Enumeration<? extends ZipEntry> entries = zip.entries();
+    Set<String> dirs = new HashSet<>();
     while (entries.hasMoreElements()) {
-      ZipEntry entry = (ZipEntry) entries.nextElement();
+      ZipEntry entry = entries.nextElement();
       String entryName = entry.getName();
       try {
         // CWE-22: Validate zip entry path to prevent ZipSlip attacks
@@ -811,10 +812,10 @@ public class PSRxBuildInput {
     String uninstallTask = "";
 
     ZipFile zip = new ZipFile(src);
-    Enumeration entries = zip.entries();
-    Set<String> dirs = new HashSet<String>();
+    Enumeration<? extends ZipEntry> entries = zip.entries();
+    Set<String> dirs = new HashSet<>();
     while (entries.hasMoreElements()) {
-      ZipEntry entry = (ZipEntry) entries.nextElement();
+      ZipEntry entry = entries.nextElement();
       String entryName = entry.getName();
       try {
         // CWE-22: Validate zip entry path to prevent ZipSlip attacks
@@ -1354,11 +1355,11 @@ public class PSRxBuildInput {
 
   private String m_readme;
 
-  private ArrayList m_addPatchFilesArrList = new ArrayList();
+  private List<String> m_addPatchFilesArrList = new ArrayList<>();
 
-  private ArrayList m_remPatchFilesArrList = new ArrayList();
+  private List<String> m_remPatchFilesArrList = new ArrayList<>();
 
-  private ArrayList m_additionalJarsArrList = new ArrayList();
+  private List<String> m_additionalJarsArrList = new ArrayList<>();
 
   private static final String ms_action = "Build All";
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSModifyProviders.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSModifyProviders.java
@@ -75,7 +75,7 @@ import org.w3c.dom.Document;
  *
  * </pre>
  */
-public class PSModifyProviders extends PSAction {
+public final class PSModifyProviders extends PSAction {
   /** Creates a new modify providers task. */
   public PSModifyProviders() {}
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSRenameDeprecatedApps.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSRenameDeprecatedApps.java
@@ -50,7 +50,7 @@ import org.apache.logging.log4j.Logger;
  *
  * </pre>
  */
-public class PSRenameDeprecatedApps extends PSAction {
+public final class PSRenameDeprecatedApps extends PSAction {
   /** Creates a new deprecated apps rename task. */
   public PSRenameDeprecatedApps() {}
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSTableAction.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSTableAction.java
@@ -68,7 +68,7 @@ import org.w3c.dom.Document;
  *
  * </pre>
  */
-public class PSTableAction extends PSAction {
+public final class PSTableAction extends PSAction {
   /** Creates a new table action task. */
   public PSTableAction() {}
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpdateWebApps.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpdateWebApps.java
@@ -46,7 +46,7 @@ import java.io.IOException;
  *
  * </pre>
  */
-public class PSUpdateWebApps extends PSAction {
+public final class PSUpdateWebApps extends PSAction {
   /** Creates a new web apps update task. */
   public PSUpdateWebApps() {}
 


### PR DESCRIPTION
## Summary

Clears the remaining **~40** project-`-Xlint` main-source javac diagnostics in `modules/perc-ant` after merged batch 1 [PR #2330](https://github.com/intersoftdatalabs-in/percussioncms/pull/2330).

| Area | Change |
|------|--------|
| `PSJunitFileSelector` | `Class<?>`, `Iterator<String>`, typed `loadClass` / `ms_testAnnotation` |
| `gui/PSRxBuildInput` | `List<String>` / `Set<String>` / `Enumeration<? extends ZipEntry>` for patch builder collections |
| Install constructor this-escape | `final class` on `PSModifyProviders`, `PSRenameDeprecatedApps`, `PSTableAction`, `PSUpdateWebApps` (field inits call overridable `getRootDir()`) |

Prefer real generics / `final` this-escape patterns over class-level `@SuppressWarnings`. Does **not** rework batch-1-only files from #2330 except the residual this-escape sites listed in #2331.

**Parent / tracker:** module cleanup #2023 · monorepo tracker #2200

## Test plan

- [x] `cd modules/perc-ant && ../../mvnw clean install` — BUILD SUCCESS (43 tests, 0 failures)
- [x] Main-source project-`-Xlint` javac warnings: **0** (was ~40 residual after batch 1)
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-2331-perc-ant-javac-batch2-erlang.md` (approve)

## Gates evidence

- Standalone module clean install green
- No new `@SuppressWarnings`
- Typing / finality only — no intentional behavior change
- Erlang approve; portable path N/A for this batch

## Links

- Fixes #2331
- Refs #2023
- Refs #2200
- Batch 1: #2330

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.