### PR TITLE
fix(perc-system): cms.objectstore rawtypes batch 2b — RemoteAgent/Relationship/Search (#2311)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2311-cms-objectstore-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2311-cms-objectstore-rawtypes-erlang.md
@@ -1,0 +1,52 @@
+# Erlang code review — issue #2311 cms.objectstore rawtypes batch 2b
+
+**Branch:** `fix/issue-2311-objectstore-rawtypes-batch`  
+**Base:** `origin/main`  
+**Reviewer persona:** Erlang (strict independent)  
+**Date:** 2026-08-07  
+**Recommendation:** **approve**  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Continues #2022 / #2296 rawtypes/unchecked cleanup in `com.percussion.cms.objectstore` with the next hottest residual cluster: `PSRemoteAgent`, client/server `PSRelationshipProcessor` (+ proxy), `PSActiveAssemblerProcessor`, and selected `PSSearch` APIs. Real generics preferred (`List<PSEntry>`, `List<PSLocator>`, `Map<String,String>`, `List<?>`, etc.); interface alignment with existing `List<?>` on `IPSRelationshipProcessor`. Behavioral JUnit 5 tests cover `PSSearch.parseParameters`. Module `system` `mvnw clean install` green (1180 tests, 0 failures; 5 new tests green).
+
+Companion compile fix: `PSNavonNodeInvocationHandler` copy from `Map<?,?>` (utils `PSItemIterator.getMap` already returns wildcards) — unblocks perc-system compile after utils generics change.
+
+## Scope
+
+| Area | Change |
+| --- | --- |
+| Production | `client/PSRemoteAgent`, `client/PSRelationshipProcessor`, `server/PSRelationshipProcessor`, `server/PSActiveAssemblerProcessor`, `PSRelationshipProcessorProxy`, `PSSearch` (partial), `PSNavonNodeInvocationHandler` (compile companion) |
+| Tests | `PSSearchParseParametersTest` (5) |
+| Out of scope | design.objectstore (#2295/#2309), this-escape/serial (#2297/#2313/#2319), data.jdbc (#2298/#2315), remaining `PSSearch` Iterator fields/APIs, `PSServerFolderProcessor` raw List overrides |
+
+Cross-platform path review: **N/A** — no file I/O or path handling in this diff.
+
+## Issues
+
+None at severity `bug`.
+
+### suggestion (non-blocking)
+
+1. **`PSSearch` residual** — public/private `Iterator`/`setFields`/`getProperties` and property loops remain raw; leave for next #2022 residual slice.
+2. **`PSServerFolderProcessor`** still implements relationship methods with raw `List` parameters; compile-compatible with `List<?>` interface but residual rawtypes remain outside this batch.
+3. **Runtime casts** on relationship children (`(PSKey)`, `(PSLocator)`) are unchanged pre-existing contracts (callers pass locator/key lists).
+
+### nit
+
+- Approximate raw declaration sites cleared on touched production files: **~45–55** (within overnight ≤~40–50 target band plus proxy/companion).
+
+## Gate checklist
+
+| Check | Result |
+| --- | --- |
+| Bugs | none found |
+| Behavioral tests for changed logic | yes (5 new tests on pure `parseParameters`) |
+| Portable paths | N/A |
+| Module clean install | BUILD SUCCESS |
+| Scope confinement | cms.objectstore batch + one compile companion in services assembly nav |
+
+## Recommendation
+
+**approve** — ready to commit and open PR (Fixes #2311, Refs #2022 #2200).

--- a/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
+++ b/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
@@ -209,8 +209,12 @@ public class PSNavonNodeInvocationHandler implements InvocationHandler
             PSPropertyIterator iter =
                (PSPropertyIterator) method.invoke(m_containedNode, args);
 
-            // Add nav properties
-            Map<String,Property> map = new HashMap<>(iter.getMap());
+            // Add nav properties (copy from Map<?,?> returned by getMap)
+            Map<String, Property> map = new HashMap<>();
+            for (Map.Entry<?, ?> e : iter.getMap().entrySet())
+            {
+               map.put((String) e.getKey(), (Property) e.getValue());
+            }
             for(String prop : NAV_PROPERTIES)
             {
                Property p = getNavProperty((Node) proxy, prop);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipProcessorProxy.java
@@ -99,19 +99,21 @@ public class PSRelationshipProcessorProxy extends PSProcessorProxy
   }
 
   // see interface for description
-  public void add(String componentType, String relationshipType, List children, PSKey targetParent)
+  public void add(
+      String componentType, String relationshipType, List<?> children, PSKey targetParent)
       throws PSCmsException {
     getProcessor(componentType).add(componentType, relationshipType, children, targetParent);
   }
 
   // see interface for description
-  public void add(String relationshipType, List children, PSLocator targetParent)
+  public void add(String relationshipType, List<?> children, PSLocator targetParent)
       throws PSCmsException {
     getProcessor(m_componentType).add(relationshipType, children, targetParent);
   }
 
   // see interface for description
-  public void move(String relationshipType, PSKey sourceParent, List children, PSKey targetParent)
+  public void move(
+      String relationshipType, PSKey sourceParent, List<?> children, PSKey targetParent)
       throws PSCmsException {
     getProcessor(m_componentType).move(relationshipType, sourceParent, children, targetParent);
   }
@@ -120,13 +122,13 @@ public class PSRelationshipProcessorProxy extends PSProcessorProxy
    * @see com.percussion.cms.objectstore.IPSRelationshipProcessor#copy(
    * java.lang.String, java.util.List, com.percussion.cms.objectstore.PSKey)
    */
-  public void copy(String relationshipType, List children, PSKey targetParent)
+  public void copy(String relationshipType, List<?> children, PSKey targetParent)
       throws PSCmsException {
     getProcessor(m_componentType).copy(relationshipType, children, targetParent);
   }
 
   // see interface for description
-  public void delete(String relationshipType, PSKey sourceParent, List children)
+  public void delete(String relationshipType, PSKey sourceParent, List<?> children)
       throws PSCmsException {
     getProcessor(m_componentType).delete(relationshipType, sourceParent, children);
   }
@@ -185,7 +187,7 @@ public class PSRelationshipProcessorProxy extends PSProcessorProxy
    * @see com.percussion.cms.objectstore.IPSRelationshipProcessor#delete(
    * com.percussion.cms.objectstore.PSKey, java.util.List)
    */
-  public void delete(PSKey sourceParent, List children) throws PSCmsException {
+  public void delete(PSKey sourceParent, List<?> children) throws PSCmsException {
     getProcessor(m_componentType).delete(null, sourceParent, children);
   }
 
@@ -205,7 +207,7 @@ public class PSRelationshipProcessorProxy extends PSProcessorProxy
    * design.objectstore.PSLocator)
    */
   public void move(
-      String relationshipType, PSLocator sourceParent, List children, PSLocator targetParent)
+      String relationshipType, PSLocator sourceParent, List<?> children, PSLocator targetParent)
       throws PSCmsException {
     getProcessor(m_componentType).move(relationshipType, sourceParent, children, targetParent);
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
@@ -868,11 +868,9 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
    * @param communities list of communities this search is visible to. Must not be <code>null</code>
    *     or empty.
    */
-  public void setShowTo(Collection communities) {
-    Iterator iter = communities.iterator();
-    while (iter.hasNext()) {
-      String element = (String) iter.next();
-      setShowTo(SHOW_TO_COMMUNITY, element);
+  public void setShowTo(Collection<?> communities) {
+    for (Object community : communities) {
+      setShowTo(SHOW_TO_COMMUNITY, (String) community);
     }
   }
 
@@ -1053,7 +1051,7 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
       throw new IllegalArgumentException("communityIds cannot be null or empty");
     }
 
-    Collection currentIds = new ArrayList();
+    Collection<String> currentIds = new ArrayList<>();
     String[] vals = getPropertyValues(type);
     if (null != vals) currentIds.addAll(Arrays.asList(vals));
 
@@ -1281,22 +1279,21 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
   public String[] getPropertyValues(String strName) {
     if (strName == null || strName.trim().length() == 0) return null;
 
-    Iterator iter = m_properties.iterator();
-    Collection results = null;
+    Iterator<?> iter = m_properties.iterator();
+    Collection<String> results = null;
     while (iter.hasNext()) {
       PSSearchMultiProperty prop = (PSSearchMultiProperty) iter.next();
       if (prop.getName().equalsIgnoreCase(strName)) {
-        Iterator propIter = prop.iterator();
-        results = new ArrayList();
+        Iterator<?> propIter = prop.iterator();
+        results = new ArrayList<>();
         while (propIter.hasNext()) {
-          results.add(propIter.next());
+          results.add((String) propIter.next());
         }
       }
     }
     String[] retVal = null;
     if (null != results) {
-      retVal = new String[results.size()];
-      results.toArray(retVal);
+      retVal = results.toArray(new String[0]);
     }
     return retVal;
   }
@@ -1483,8 +1480,8 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
    * @return the map that was supplied or a new <code>HashMap</code> if <code>null</code> was
    *     supplied with all query parameters filled in, never <code>null</code>, may be empty.
    */
-  public static Map parseParameters(String url, Map params) {
-    if (params == null) params = new HashMap();
+  public static Map<String, String> parseParameters(String url, Map<String, String> params) {
+    if (params == null) params = new HashMap<>();
 
     if (url == null) return params;
 
@@ -1685,7 +1682,7 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
    *
    * @return A read-only collection of property names, never <code>null</code> or empty.
    */
-  public Collection getInternalPropertyNames() {
+  public Collection<String> getInternalPropertyNames() {
     return Collections.unmodifiableCollection(ms_internalSearchProps);
   }
 
@@ -2134,7 +2131,7 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
    * List of properties that cannot be modifed over the life cycle of this object. Initialized in
    * definition, setup with elements in ctor, never <code>null</code>.
    */
-  private List m_nonEditableProps = new ArrayList();
+  private List<String> m_nonEditableProps = new ArrayList<>();
 
   /**
    * A flag to indicate whether this search of type custom view that should contain a url that is

--- a/system/src/main/java/com/percussion/cms/objectstore/client/PSRelationshipProcessor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/client/PSRelationshipProcessor.java
@@ -48,7 +48,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *     <code>null</code>.
    * @param procConfig The parameters from the config file. This is not needed.
    */
-  public PSRelationshipProcessor(IPSRemoteRequester conn, Map procConfig) {
+  public PSRelationshipProcessor(IPSRemoteRequester conn, Map<?, ?> procConfig) {
     if (null == conn) {
       throw new IllegalArgumentException("Connection information must be supplied.");
     }
@@ -65,7 +65,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *
    * @throws UnsupportedOperationException Always.
    */
-  public void add(String componentType, String relationshipType, List children, PSKey targetParent)
+  public void add(
+      String componentType, String relationshipType, List<?> children, PSKey targetParent)
       throws PSCmsException {
     throw new UnsupportedOperationException("Not supported by this processor.");
   }
@@ -106,7 +107,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
     PSLocator pslocator = (PSLocator) locator;
     PSComponentSummaries summaries = null;
 
-    Map params = new HashMap();
+    Map<String, String> params = new HashMap<>();
     params.put(PARAM_ID, Integer.toString(pslocator.getId()));
     params.put(PARAM_REVISION, Integer.toString(pslocator.getRevision()));
     params.put(PARAM_METHOD, method);
@@ -141,7 +142,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *
    * @throws UnsupportedOperationException Always.
    */
-  public void move(String relationshipType, PSKey sourceParent, List children, PSKey targetParent)
+  public void move(
+      String relationshipType, PSKey sourceParent, List<?> children, PSKey targetParent)
       throws PSCmsException {
     throw new UnsupportedOperationException("Not supported by this processor.");
   }
@@ -151,7 +153,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *
    * @throws UnsupportedOperationException Always.
    */
-  public void copy(String relationshipType, List children, PSKey parent) throws PSCmsException {
+  public void copy(String relationshipType, List<?> children, PSKey parent) throws PSCmsException {
     throw new UnsupportedOperationException("Not supported by this processor.");
   }
 
@@ -160,7 +162,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *
    * @throws UnsupportedOperationException Always.
    */
-  public void delete(String type, PSKey parent, List children) throws PSCmsException {
+  public void delete(String type, PSKey parent, List<?> children) throws PSCmsException {
     throw new UnsupportedOperationException("Not supported by this processor.");
   }
 
@@ -193,7 +195,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *
    * @throws UnsupportedOperationException Always.
    */
-  public void add(String relationshipType, List children, PSLocator targetParent)
+  public void add(String relationshipType, List<?> children, PSLocator targetParent)
       throws PSCmsException {
     throw new UnsupportedOperationException(
         "getRelationships() is not implemented in : " + this.getClass().getName());
@@ -217,7 +219,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * @throws UnsupportedOperationException Always.
    */
   public void move(
-      String relationshipType, PSLocator sourceParent, List children, PSLocator targetParent)
+      String relationshipType, PSLocator sourceParent, List<?> children, PSLocator targetParent)
       throws PSCmsException {
     throw new UnsupportedOperationException(
         "move() is not implemented in : " + this.getClass().getName());
@@ -244,7 +246,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
 
     PSComponentSummaries summaries = null;
 
-    Map params = new HashMap();
+    Map<String, String> params = new HashMap<>();
     Document inputDoc = PSXmlDocumentBuilder.createXmlDocument();
     String rFilter = PSXmlDocumentBuilder.toString(filter.toXml(inputDoc));
     params.put(PARAM_OWNER, Boolean.toString(owner));

--- a/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteAgent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteAgent.java
@@ -192,8 +192,8 @@ public class PSRemoteAgent {
    *     but may be empty.
    * @throws PSRemoteException if an error occurs.
    */
-  public List getCommunities() throws PSRemoteException {
-    List communities = new ArrayList();
+  public List<PSEntry> getCommunities() throws PSRemoteException {
+    List<PSEntry> communities = new ArrayList<>();
     try {
       Document doc =
           m_requester.getRemoteRequester().getDocument("sys_cmpCommunities/communities.xml", null);
@@ -235,7 +235,7 @@ public class PSRemoteAgent {
    *     but may be empty.
    * @throws PSRemoteException if an error occurs.
    */
-  public List getContentTypes(PSEntry community) throws PSRemoteException {
+  public List<PSEntry> getContentTypes(PSEntry community) throws PSRemoteException {
     if (community == null) throw new IllegalArgumentException("community may not be null");
 
     return getCTypesOrWorkflows(community, "contenttypelookup.xml");
@@ -250,7 +250,7 @@ public class PSRemoteAgent {
    *     but may be empty.
    * @throws PSRemoteException if an error occurs.
    */
-  public List getWorkflows(PSEntry community) throws PSRemoteException {
+  public List<PSEntry> getWorkflows(PSEntry community) throws PSRemoteException {
     if (community == null) throw new IllegalArgumentException("community may not be null");
 
     return getCTypesOrWorkflows(community, "workflowlookup.xml");
@@ -267,11 +267,12 @@ public class PSRemoteAgent {
    *     but may be empty.
    * @throws PSRemoteException if an error occurs.
    */
-  private List getCTypesOrWorkflows(PSEntry community, String resource) throws PSRemoteException {
-    List entries = new ArrayList();
+  private List<PSEntry> getCTypesOrWorkflows(PSEntry community, String resource)
+      throws PSRemoteException {
+    List<PSEntry> entries = new ArrayList<>();
 
     try {
-      Map params = new HashMap();
+      Map<String, String> params = new HashMap<>();
       params.put("communityid", community.getValue());
       Document doc =
           m_requester.getRemoteRequester().getDocument("sys_commSupport/" + resource, params);
@@ -318,13 +319,13 @@ public class PSRemoteAgent {
    *     name.
    * @throws PSRemoteException if an error occurs.
    */
-  public List getTransitions(PSEntry workflow) throws PSRemoteException {
+  public List<PSEntry> getTransitions(PSEntry workflow) throws PSRemoteException {
     if (workflow == null) throw new IllegalArgumentException("workflow may not be null");
 
-    List entries = new ArrayList();
+    List<PSEntry> entries = new ArrayList<>();
 
     try {
-      Map params = new HashMap();
+      Map<String, String> params = new HashMap<>();
       params.put(IPSHtmlParameters.SYS_WORKFLOWID, workflow.getValue());
       Document doc =
           m_requester
@@ -378,7 +379,7 @@ public class PSRemoteAgent {
    */
   public String getLastTransitionComment(int contentId) throws PSRemoteException {
     try {
-      Map params = new HashMap();
+      Map<String, String> params = new HashMap<>();
       params.put(IPSHtmlParameters.SYS_CONTENTID, Integer.toString(contentId));
 
       Document doc =
@@ -404,8 +405,8 @@ public class PSRemoteAgent {
    *     but may be empty.
    * @throws PSRemoteException if an error occurs.
    */
-  public List getContextVariables() throws PSRemoteException {
-    List entries = new ArrayList();
+  public List<PSEntry> getContextVariables() throws PSRemoteException {
+    List<PSEntry> entries = new ArrayList<>();
 
     try {
       Document doc =
@@ -542,10 +543,10 @@ public class PSRemoteAgent {
    * @return List of <code>String</code> objects, never <code>null</code>, may be empty.
    * @throws PSRemoteException if content type not exist or any other error occurs.
    */
-  public List getFieldNames(String contentTypeId) throws PSRemoteException {
+  public List<String> getFieldNames(String contentTypeId) throws PSRemoteException {
     PSClientItem clientItem = newItem(contentTypeId);
-    Iterator itor = clientItem.getAllFieldNames();
-    List list = new ArrayList();
+    Iterator<String> itor = clientItem.getAllFieldNames();
+    List<String> list = new ArrayList<>();
     while (itor.hasNext()) list.add(itor.next());
     return list;
   }
@@ -596,9 +597,9 @@ public class PSRemoteAgent {
     // binary data
     Map<String, Object> params = new HashMap<>();
     List<PSBinaryFileData> files = new ArrayList<>();
-    Iterator it = item.getAllFields();
+    Iterator<PSItemField> it = item.getAllFields();
     while (it.hasNext()) {
-      PSItemField field = (PSItemField) it.next();
+      PSItemField field = it.next();
       PSItemFieldMeta meta = field.getItemFieldMeta();
 
       try {
@@ -750,7 +751,7 @@ public class PSRemoteAgent {
    *     </code>.
    * @throws PSRemoteException if an error occurs.
    */
-  public void removeComponentsFromFolder(PSKey parent, List children) throws PSRemoteException {
+  public void removeComponentsFromFolder(PSKey parent, List<?> children) throws PSRemoteException {
     if (parent == null) throw new IllegalArgumentException("parent may not be null");
 
     if (children == null) throw new IllegalArgumentException("children may not be null");
@@ -954,15 +955,15 @@ public class PSRemoteAgent {
 
     IPSRemoteRequesterEx requester = (IPSRemoteRequesterEx) m_requester.getRemoteRequester();
     String app_resource = getAppResource(item);
-    Iterator it = item.getAllFields();
+    Iterator<PSItemField> it = item.getAllFields();
     // Set up common params
-    Map params = new HashMap(4);
+    Map<String, Object> params = new HashMap<>(4);
     params.put(IPSHtmlParameters.SYS_COMMAND, "binary");
     params.put(IPSHtmlParameters.SYS_CONTENTID, Integer.toString(item.getContentId()));
     params.put(IPSHtmlParameters.SYS_REVISION, Integer.toString(item.getRevision()));
 
     while (it.hasNext()) {
-      PSItemField field = (PSItemField) it.next();
+      PSItemField field = it.next();
       PSItemFieldMeta meta = field.getItemFieldMeta();
 
       if (meta.isBinary()) {
@@ -1052,10 +1053,8 @@ public class PSRemoteAgent {
   private Element sendRequest(String action, String wsdlPort, Element params, String respElement)
       throws PSRemoteException {
     // set community and locale if available
-    Map extraParams = null;
-    extraParams = new HashMap();
+    Map<String, String> extraParams = new HashMap<>();
     if (m_community != null || m_locale != null) {
-      extraParams = new HashMap();
       if (m_community != null) extraParams.put(IPSHtmlParameters.SYS_COMMUNITY, m_community);
       if (m_locale != null) extraParams.put(IPSHtmlParameters.SYS_LANG, m_locale);
     }

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSActiveAssemblerProcessor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSActiveAssemblerProcessor.java
@@ -99,7 +99,7 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
 
     // build the insert set starting the sortrank at the supplied index
     PSRelationshipSet inserts = new PSRelationshipSet();
-    Iterator dependentKeys = dependents.iterator();
+    Iterator<?> dependentKeys = dependents.iterator();
     while (dependentKeys.hasNext()) {
       PSDependent dependent = (PSDependent) dependentKeys.next();
       PSRelationship relationship = new PSRelationship(-1, owner, dependent.getLocator(), config);
@@ -150,7 +150,7 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
       String resource =
           PSRelationshipUtils.SYS_PSXRELATIONSHIPSUPPORT + "/" + SLOT_RELATIONSHIP_LOOKUP;
 
-      Map params = new HashMap();
+      Map<String, Object> params = new HashMap<>();
       params.put(IPSHtmlParameters.SYS_SLOTID, slotid);
 
       IPSInternalRequest ir = request.getInternalRequest(resource, params, false);
@@ -187,17 +187,13 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
 
     if (dependents == null) throw new IllegalArgumentException("dependents cannot be null");
 
-    Map slotDependentMap = buildSlotDependentMap(dependents);
-    Iterator slots = slotDependentMap.keySet().iterator();
-    String slotid = null;
-    List deps = null;
-    while (slots.hasNext()) {
-      slotid = (String) slots.next();
-      deps = (List) slotDependentMap.get(slotid);
+    Map<String, List<PSDependent>> slotDependentMap = buildSlotDependentMap(dependents);
+    for (Map.Entry<String, List<PSDependent>> entry : slotDependentMap.entrySet()) {
+      String slotid = entry.getKey();
+      List<PSDependent> deps = entry.getValue();
       if (deps == null) continue;
       int relationshipIds[] = new int[dependents.size()];
-      for (int i = 0; i < deps.size(); i++)
-        relationshipIds[i] = ((PSDependent) deps.get(i)).getRelationshipId();
+      for (int i = 0; i < deps.size(); i++) relationshipIds[i] = deps.get(i).getRelationshipId();
       delete(getConfigForSlot(m_request, slotid).getName(), owner, relationshipIds);
     }
   }
@@ -211,17 +207,13 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
 
     if (dependents == null) throw new IllegalArgumentException("dependents cannot be null");
 
-    Map slotDependentMap = buildSlotDependentMap(dependents);
-    Iterator slots = slotDependentMap.keySet().iterator();
-    String slotid = null;
-    List deps = null;
-    while (slots.hasNext()) {
-      slotid = (String) slots.next();
-      deps = (List) slotDependentMap.get(slotid);
+    Map<String, List<PSDependent>> slotDependentMap = buildSlotDependentMap(dependents);
+    for (Map.Entry<String, List<PSDependent>> entry : slotDependentMap.entrySet()) {
+      String slotid = entry.getKey();
+      List<PSDependent> deps = entry.getValue();
       if (deps == null) continue;
       int relationshipIds[] = new int[dependents.size()];
-      for (int i = 0; i < deps.size(); i++)
-        relationshipIds[i] = ((PSDependent) deps.get(i)).getRelationshipId();
+      for (int i = 0; i < deps.size(); i++) relationshipIds[i] = deps.get(i).getRelationshipId();
       delete(getConfigForSlot(m_request, slotid).getName(), owner, relationshipIds);
     }
   }
@@ -234,17 +226,16 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
    * @return map of slotid (String) and dependents for this slot (List), never <code>null</code> may
    *     be empty.
    */
-  private Map buildSlotDependentMap(PSDependentSet dependents) {
-    Map slotDependentMap = new HashMap();
-    PSDependent dependent = null;
+  private Map<String, List<PSDependent>> buildSlotDependentMap(PSDependentSet dependents) {
+    Map<String, List<PSDependent>> slotDependentMap = new HashMap<>();
     for (int i = 0; i < dependents.size(); i++) {
-      dependent = (PSDependent) dependents.get(i);
+      PSDependent dependent = (PSDependent) dependents.get(i);
       PSPropertySet props = dependent.getProperties();
       String slotid = props.getProperty(IPSHtmlParameters.SYS_SLOTID).getValue().toString();
       if (slotid == null || slotid.length() < 1) continue;
-      List deps = (List) slotDependentMap.get(slotid);
+      List<PSDependent> deps = slotDependentMap.get(slotid);
       if (deps == null) {
-        deps = new ArrayList();
+        deps = new ArrayList<>();
         slotDependentMap.put(slotid, deps);
       }
       deps.add(dependent);
@@ -336,7 +327,7 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
             slotId);
 
     // create a map sorted based on the sort rank property
-    Map relationshipMap = new TreeMap();
+    Map<Integer, PSRelationshipSet> relationshipMap = new TreeMap<>();
     for (int i = 0; i < relationships.size(); i++) {
       PSRelationship relationship = (PSRelationship) relationships.get(i);
       String sortRank = relationship.getProperty(IPSHtmlParameters.SYS_SORTRANK);
@@ -354,7 +345,7 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
         throw new PSCmsException(IPSCmsErrors.INVALID_RELATIONSHIP_PROP_VALUE, args);
       }
 
-      PSRelationshipSet set = (PSRelationshipSet) relationshipMap.get(intRank);
+      PSRelationshipSet set = relationshipMap.get(intRank);
       if (set == null) {
         set = new PSRelationshipSet();
         relationshipMap.put(intRank, set);
@@ -364,10 +355,8 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
     }
 
     PSRelationshipSet resultSet = new PSRelationshipSet();
-    Iterator keys = relationshipMap.keySet().iterator();
-    while (keys.hasNext()) {
-      Integer key = (Integer) keys.next();
-      resultSet.addAll((PSRelationshipSet) relationshipMap.get(key));
+    for (PSRelationshipSet set : relationshipMap.values()) {
+      resultSet.addAll(set);
     }
     normalizeSortRank(resultSet);
 
@@ -404,11 +393,9 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
 
     PSRelationshipSet updates = new PSRelationshipSet();
 
-    Map slotDepMap = buildSlotDependentMap(dependents);
-    Iterator slots = slotDepMap.keySet().iterator();
+    Map<String, List<PSDependent>> slotDepMap = buildSlotDependentMap(dependents);
     PSRelationshipSet relationships = new PSRelationshipSet();
-    while (slots.hasNext()) {
-      String slotid = (String) slots.next();
+    for (String slotid : slotDepMap.keySet()) {
       relationships.addAll(getDependents(getConfigForSlot(m_request, slotid).getName(), owner));
     }
 
@@ -433,7 +420,7 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
    *     assumed not <code>null</code>.
    */
   private void updateProperties(PSRelationship relationship, PSDependent dependent) {
-    Iterator properties = dependent.getProperties().iterator();
+    Iterator<?> properties = dependent.getProperties().iterator();
     while (properties.hasNext()) {
       PSProperty property = (PSProperty) properties.next();
       Object value = property.getValue();
@@ -452,7 +439,8 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
    *     null</code> otherwise.
    * @throws PSCmsException if the supplied list contains invalid locators.
    */
-  private PSDependent contains(Iterator list, PSRelationship relationship) throws PSCmsException {
+  private PSDependent contains(Iterator<?> list, PSRelationship relationship)
+      throws PSCmsException {
     while (list.hasNext()) {
       PSDependent dependent = (PSDependent) list.next();
       int test = dependent.getRelationshipId();
@@ -475,7 +463,7 @@ public class PSActiveAssemblerProcessor extends PSRelationshipProcessor {
   private String checkPropertyValue(String propertyName, int owner, PSDependentSet dependents)
       throws PSCmsException {
     String propVal = null;
-    Iterator deps = dependents.iterator();
+    Iterator<?> deps = dependents.iterator();
     while (deps.hasNext()) {
       PSDependent dep = (PSDependent) deps.next();
       PSPropertySet props = dep.getProperties();

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSRelationshipProcessor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSRelationshipProcessor.java
@@ -58,7 +58,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * java.lang.String, java.lang.String, java.util.List, com.percussion.
    * cms.objectstore.PSKey)
    */
-  public void add(String componentType, String relationshipType, List children, PSKey targetParent)
+  public void add(
+      String componentType, String relationshipType, List<?> children, PSKey targetParent)
       throws PSCmsException {
     validateComponentType(componentType);
     add(relationshipType, children, (PSLocator) targetParent);
@@ -68,14 +69,13 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * @see com.percussion.cms.objectstore.IPSRelationshipProcessor#add(java.
    * lang.String, java.util.List, com.percussion.design.objectstore.PSLocator)
    */
-  public void add(String relationshipType, List children, PSLocator targetParent)
+  public void add(String relationshipType, List<?> children, PSLocator targetParent)
       throws PSCmsException {
     PSRelationshipConfig config = getConfig(relationshipType);
 
     PSRelationshipSet set = new PSRelationshipSet();
-    Iterator dependentKeys = children.iterator();
-    while (dependentKeys.hasNext()) {
-      PSLocator dependent = validateKey((PSKey) dependentKeys.next());
+    for (Object child : children) {
+      PSLocator dependent = validateKey((PSKey) child);
       set.add(new PSRelationship(-1, validateKey(targetParent), dependent, config));
     }
     m_dbProcessor.modifyRelationships(set);
@@ -84,7 +84,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
   /* (non-Javadoc)
    * @see com.percussion.cms.objectstore.IPSRelationshipProcessor#copy(java.lang.String, java.util.List, com.percussion.cms.objectstore.PSKey)
    */
-  public void copy(String relationshipType, List children, PSKey parent) throws PSCmsException {
+  public void copy(String relationshipType, List<?> children, PSKey parent) throws PSCmsException {
     throw new UnsupportedOperationException("Not supported by this processor.");
   }
 
@@ -151,7 +151,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *     silently be skipped.
    * @throws PSCmsException if any errors occur processing the request.
    */
-  public void delete(String relationshipType, PSKey owner, List dependents) throws PSCmsException {
+  public void delete(String relationshipType, PSKey owner, List<?> dependents)
+      throws PSCmsException {
     PSRelationshipSet deletes = new PSRelationshipSet();
     // Get all the relationships irrespective of community and permissions
     PSRelationshipSet relationships =
@@ -161,9 +162,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
             PSRelationshipConfig.FILTER_TYPE_COMMUNITY
                 | PSRelationshipConfig.FILTER_TYPE_FOLDER_PERMISSIONS);
 
-    Iterator it = relationships.iterator();
-    while (it.hasNext()) {
-      PSRelationship relationship = (PSRelationship) it.next();
+    for (PSRelationship relationship : (Iterable<PSRelationship>) relationships) {
       if (dependents == null || containsDependent(dependents.iterator(), relationship)) {
         deletes.add(relationship);
       }
@@ -207,7 +206,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    */
   public PSComponentSummary[] getChildren(String relationshipType, PSKey parent)
       throws PSCmsException {
-    List locatorList = getDependentLocators(relationshipType, parent);
+    List<PSLocator> locatorList = getDependentLocators(relationshipType, parent);
 
     return getComponentSummaries(locatorList);
   }
@@ -281,7 +280,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
   public PSComponentSummary[] getChildren(String type, String relationshipType, PSKey parent)
       throws PSCmsException {
     validateComponentType(type);
-    List locatorList = getDependentLocators(relationshipType, parent);
+    List<PSLocator> locatorList = getDependentLocators(relationshipType, parent);
 
     return getComponentSummaries(locatorList);
   }
@@ -290,7 +289,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * Convenience method that calls {@link #getDependentLocators(String, PSKey, int)
    * getDependentLocators(String, PSKey, 0)}
    */
-  public List getDependentLocators(String type, PSKey owner) throws PSCmsException {
+  public List<PSLocator> getDependentLocators(String type, PSKey owner) throws PSCmsException {
     return getDependentLocators(type, owner, 0);
   }
 
@@ -391,7 +390,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
   /** See {@link IPSRelationshipProcessor#getParents(String, String, PSKey) interface} */
   public PSComponentSummary[] getParents(String type, String relationshipType, PSKey locator)
       throws PSCmsException {
-    List locatorList = getParents(relationshipType, locator);
+    List<PSLocator> locatorList = getParents(relationshipType, locator);
 
     return getComponentSummaries(locatorList);
   }
@@ -437,7 +436,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * Convenience method that calls {@link #getSiblings(String, PSKey, int)} passes doNotApplyFilters
    * = 0.
    */
-  public List getSiblings(String type, PSKey owner) throws PSCmsException {
+  public List<PSLocator> getSiblings(String type, PSKey owner) throws PSCmsException {
     return getSiblings(type, owner, 0);
   }
 
@@ -451,34 +450,25 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *     folder permissions (bitwise OR the FILTER_BY_xxx constants defined in <code>
    *     PSRelationshipConfig</code> to restrict filtering on both), should be set to <code>0</code>
    *     if filtering is to be performed.
-   * @return a list of <code>List</code> objects for each parent found, each containing a <code>List
-   *     </code> of <code>PSKey</code> objects for all siblings found in that particular parent. The
+   * @return a list of <code>PSLocator</code> objects for all siblings found across all parents. The
    *     returned list does not include the object key itself. Never <code>null</code>, may be
    *     empty.
    * @throws PSCmsException if any errors occur processing the request.
    */
-  public List getSiblings(String type, PSKey object, int doNotApplyFilters) throws PSCmsException {
+  public List<PSLocator> getSiblings(String type, PSKey object, int doNotApplyFilters)
+      throws PSCmsException {
     validateKey(object);
     PSLocator locator = (PSLocator) object;
-    List siblings = new ArrayList();
+    List<PSLocator> siblings = new ArrayList<>();
 
-    Iterator parents = getParents(type, object).iterator();
-    while (parents.hasNext()) {
-      PSKey parent = (PSKey) parents.next();
-
-      List parentSiblings = new ArrayList();
-      Iterator relationships =
-          m_dbProcessor
-              .queryRelationships(getConfig(type), validateKey(parent), doNotApplyFilters)
-              .iterator();
-      while (relationships.hasNext()) {
-        PSRelationship sibling = (PSRelationship) relationships.next();
-
+    for (PSLocator parent : getParents(type, object)) {
+      for (PSRelationship sibling :
+          (Iterable<PSRelationship>)
+              m_dbProcessor.queryRelationships(
+                  getConfig(type), validateKey(parent), doNotApplyFilters)) {
         // don't add object itself
-        if (!equalsDependent(locator, sibling)) parentSiblings.add(sibling.getDependent());
+        if (!equalsDependent(locator, sibling)) siblings.add(sibling.getDependent());
       }
-
-      siblings.addAll(parentSiblings);
     }
 
     return siblings;
@@ -493,10 +483,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
     PSRelationshipSet relationships = getRelationships(filter);
     if (relationships.isEmpty()) return new PSComponentSummaries();
 
-    Set itemSet = new HashSet();
-    Iterator iter = relationships.iterator();
-    while (iter.hasNext()) {
-      PSRelationship rel = (PSRelationship) iter.next();
+    Set<PSLocator> itemSet = new HashSet<>();
+    for (PSRelationship rel : (Iterable<PSRelationship>) relationships) {
       PSLocator loc = owner ? rel.getOwner() : rel.getDependent();
       itemSet.add(loc);
     }
@@ -514,7 +502,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
     int itemId = getIdByPath(componentType, path, relationshipTypeName);
     if (itemId == -1) return null;
 
-    Collection locators = new ArrayList(1);
+    Collection<PSLocator> locators = new ArrayList<>(1);
     locators.add(new PSLocator(itemId));
 
     return getComponentSummaries(locators)[0];
@@ -552,7 +540,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *     bigger then the current size of relationships, the new dependents will be appendend.
    * @throws PSCmsException if any errors occur processing the request.
    */
-  public void insert(String type, PSKey owner, List dependents, int index) throws PSCmsException {
+  public void insert(String type, PSKey owner, List<?> dependents, int index)
+      throws PSCmsException {
     if (index <= 0) throw new IllegalArgumentException("index must be > 0");
 
     PSRelationshipConfig config = getConfig(type);
@@ -568,9 +557,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
 
     // build the insert set starting the sortrank at the supplied index
     PSRelationshipSet inserts = new PSRelationshipSet();
-    Iterator dependentKeys = dependents.iterator();
-    while (dependentKeys.hasNext()) {
-      PSLocator dependent = validateKey((PSKey) dependentKeys.next());
+    for (Object dependentKey : dependents) {
+      PSLocator dependent = validateKey((PSKey) dependentKey);
       PSRelationship relationship = new PSRelationship(-1, validateKey(owner), dependent, config);
       relationship.setProperty(IPSHtmlParameters.SYS_SORTRANK, Integer.toString(sortrank++));
 
@@ -597,7 +585,10 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * java.util.List, com.percussion.design.objectstore.PSLocator)
    */
   public void move(
-      String relationshipTypeName, PSLocator sourceParent, List children, PSLocator targetParent)
+      String relationshipTypeName,
+      PSLocator sourceParent,
+      List<?> children,
+      PSLocator targetParent)
       throws PSCmsException {
     if (children == null) throw new IllegalArgumentException("children must not be null");
     if (sourceParent == null) throw new IllegalArgumentException("sourceParent must not be null");
@@ -640,7 +631,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * com.percussion.cms.objectstore.PSKey)
    */
   public void move(
-      String relationshipTypeName, PSKey sourceParent, List children, PSKey targetParent)
+      String relationshipTypeName, PSKey sourceParent, List<?> children, PSKey targetParent)
       throws PSCmsException {
     move(relationshipTypeName, (PSLocator) sourceParent, children, (PSLocator) targetParent);
   }
@@ -674,7 +665,7 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *     otherwise.
    * @throws PSCmsException if the supplied list contains invalid locators.
    */
-  private boolean containsDependent(Iterator possibleDeps, PSRelationship relationship)
+  private boolean containsDependent(Iterator<?> possibleDeps, PSRelationship relationship)
       throws PSCmsException {
     boolean found = false;
 
@@ -715,12 +706,15 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *     .
    * @throws PSCmsException if encounters any problems while fetching or parsing the XML document.
    */
-  private PSComponentSummary[] getComponentSummaries(Collection locators) throws PSCmsException {
+  private PSComponentSummary[] getComponentSummaries(Collection<? extends PSLocator> locators)
+      throws PSCmsException {
     if (locators.isEmpty()) return new PSComponentSummary[0];
 
+    // Copy into a concrete list so the iterator is Iterator<PSLocator> for the folder API.
+    List<PSLocator> locatorList = new ArrayList<>(locators);
     PSComponentSummaries sums =
         PSServerFolderProcessor.getInstance()
-            .getComponentSummaries(locators.iterator(), null, true);
+            .getComponentSummaries(locatorList.iterator(), null, true);
 
     return sums.toArray();
   }
@@ -780,10 +774,8 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
     if (relationshipTypeName == null)
       throw new IllegalArgumentException("relationshipTypeName must not be null");
 
-    List ancestors = m_dbProcessor.getOwnerLocators(child, relationshipTypeName);
-    Iterator iter = ancestors.iterator();
-    while (iter.hasNext()) {
-      PSLocator element = (PSLocator) iter.next();
+    List<PSLocator> ancestors = m_dbProcessor.getOwnerLocators(child, relationshipTypeName);
+    for (PSLocator element : ancestors) {
       if (element.getId() == parent.getId()) return true;
     }
 
@@ -796,10 +788,10 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
     if (relationshipTypeName == null)
       throw new IllegalArgumentException("relationshipTypeName must not be null");
 
-    List results = new ArrayList();
+    List<PSLocator> results = new ArrayList<>();
     getDescendentLocators(relationshipTypeName, parent, results);
 
-    return (PSKey[]) results.toArray(new PSKey[results.size()]);
+    return results.toArray(new PSKey[0]);
   }
 
   /**
@@ -813,16 +805,12 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    *     {@link PSLocator} objects. Assume it is not <code>null</code>, may be empty.
    * @throws PSCmsException if any error occurs
    */
-  private void getDescendentLocators(String relationshipTypeName, PSKey parent, List results)
-      throws PSCmsException {
+  private void getDescendentLocators(
+      String relationshipTypeName, PSKey parent, List<PSLocator> results) throws PSCmsException {
 
     PSRelationshipSet dependents = getDependents(relationshipTypeName, parent);
-    Iterator rels = dependents.iterator();
-    PSRelationship rel;
-    PSLocator depLocator;
-    while (rels.hasNext()) {
-      rel = (PSRelationship) rels.next();
-      depLocator = rel.getDependent();
+    for (PSRelationship rel : (Iterable<PSRelationship>) dependents) {
+      PSLocator depLocator = rel.getDependent();
 
       // First check to be sure that this item has
       // not yet been processed, we don't want to
@@ -889,12 +877,11 @@ public class PSRelationshipProcessor implements IPSRelationshipProcessor {
    * @return <code>true</code> if the list contains the specified locator, <code>false</code>
    *     otherwise.
    */
-  private boolean listContains(List locatorList, PSLocator locator, boolean revisionSensitive) {
+  private boolean listContains(List<?> locatorList, PSLocator locator, boolean revisionSensitive) {
     if (revisionSensitive) return locatorList.contains(locator);
 
-    Iterator iter = locatorList.iterator();
-    while (iter.hasNext()) {
-      PSLocator element = (PSLocator) iter.next();
+    for (Object obj : locatorList) {
+      PSLocator element = (PSLocator) obj;
       if (element.getId() == locator.getId()) return true;
     }
     return false;

--- a/system/src/test/java/com/percussion/cms/objectstore/PSSearchParseParametersTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSSearchParseParametersTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed {@link PSSearch#parseParameters(String, Map)} (rawtypes/unchecked
+ * cleanup for issue #2311).
+ */
+public class PSSearchParseParametersTest {
+
+  @Test
+  public void nullUrlReturnsEmptyMapWhenParamsNull() {
+    Map<String, String> result = PSSearch.parseParameters(null, null);
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void nullUrlReturnsSameMapWhenSupplied() {
+    Map<String, String> params = new HashMap<>();
+    params.put("keep", "me");
+    Map<String, String> result = PSSearch.parseParameters(null, params);
+    assertSame(params, result);
+    assertEquals("me", result.get("keep"));
+  }
+
+  @Test
+  public void emptyUrlOrNoQueryLeavesMapEmpty() {
+    assertTrue(PSSearch.parseParameters("", null).isEmpty());
+    assertTrue(PSSearch.parseParameters("/app/resource.xml", null).isEmpty());
+  }
+
+  @Test
+  public void parsesQueryPairsIntoTypedMap() {
+    Map<String, String> result =
+        PSSearch.parseParameters("/sys/app.xml?sys_contentid=10&sys_revision=1", null);
+    assertEquals(2, result.size());
+    assertEquals("10", result.get("sys_contentid"));
+    assertEquals("1", result.get("sys_revision"));
+  }
+
+  @Test
+  public void mergesIntoSuppliedMapAndSkipsTokensWithoutEquals() {
+    Map<String, String> params = new HashMap<>();
+    params.put("existing", "value");
+    Map<String, String> result =
+        PSSearch.parseParameters("x?a=1&bare&b=two", params);
+    assertSame(params, result);
+    assertEquals("value", result.get("existing"));
+    assertEquals("1", result.get("a"));
+    assertEquals("two", result.get("b"));
+    assertEquals(3, result.size());
+  }
+}


### PR DESCRIPTION
## Summary

Slice **2b** of parent **#2022** (grandparent **#2200**): real generics for residual rawtypes/unchecked in `com.percussion.cms.objectstore` after #2296 / PR #2310.

### Changes
- **`PSRemoteAgent`** — `List<PSEntry>` / `List<String>` catalog APIs; typed request params `Map<String,String|Object>`; typed field iterators
- **`PSRelationshipProcessor` (client + server)** + **`PSRelationshipProcessorProxy`** — align `List<?>` with `IPSRelationshipProcessor`; typed locator/sibling/summaries helpers (`List<PSLocator>`, `Set<PSLocator>`, `Map<String,String>`)
- **`PSActiveAssemblerProcessor`** — `Map<String,List<PSDependent>>` slot map; typed TreeMap/params/iterators
- **`PSSearch` (partial)** — `parseParameters` → `Map<String,String>`; `setShowTo(Collection<?>)`; typed property value collection / internal names / non-editable props
- **Companion compile fix:** `PSNavonNodeInvocationHandler` copy from `Map<?,?>` (`PSItemIterator.getMap`)
- **Tests** — JUnit 5 `PSSearchParseParametersTest` (5)
- **Erlang** — approve (`docs/ai-generated/code-reviews/issue-2311-cms-objectstore-rawtypes-erlang.md`)

### Before / after (raw-type declaration sites on touched production files; approximate)
| File | Before | After |
| --- | ---: | ---: |
| `client/PSRemoteAgent.java` | **~15** | **~0** |
| `client/PSRelationshipProcessor.java` | **~10** | **0** |
| `server/PSRelationshipProcessor.java` | **~25** | **~0–2** |
| `PSRelationshipProcessorProxy.java` | **~7** | **0** |
| `server/PSActiveAssemblerProcessor.java` | **~12** | **~0** |
| `PSSearch.java` (partial) | **~8 of many** | residual iterators remain |
| **Batch total** | **~45–55** | residual package still large |

### Residual
Follow-up **#2349** (PSSearch Iterator APIs, `PSServerFolderProcessor` raw List overrides, other package residual).

### Out of scope (per #2311)
- design.objectstore, this-escape/serial, data.jdbc

## Test plan
- [x] `cd system` → `../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Module tests: **1180** run, **0** failures, **0** errors (237 skipped pre-existing)
- [x] Focused: `PSSearchParseParametersTest` 5 green
- [x] Erlang self-review: approve

## Gates evidence
| Gate | Result |
| --- | --- |
| Standalone module clean install (`cd system`) | BUILD SUCCESS |
| Behavioral unit tests | 5 green |
| Scope confined to cms.objectstore batch + one compile companion | yes |
| Erlang | approve |

Parent tracker: #2022  
Grandparent: #2200  
Residual: #2349  

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2311  
Refs #2022 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.