### PR TITLE
fix(preinstall): post-install verification report for selected DB backend (#2337)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2337-post-install-db-report-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2337-post-install-db-report-erlang.md
@@ -1,0 +1,44 @@
+# Erlang review: issue #2337 post-install DB verification report
+
+**Branch:** `fix/issue-2337-post-install-db-report`  
+**Date:** 2026-08-07  
+**Reviewer persona:** Erlang (strict pre-commit gate)  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Adds a durable, operator-readable post-install verification section for the
+selected RDBMS backend after successful silent and interactive installs (parent
+#934 AC-5). Pure formatting from `ResolvedDbConfig` + install path; wired once
+in `Main` after ANT success. Unit tests cover embedded H2, external MySQL,
+source labels, and password redaction.
+
+## Scope
+
+- `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/PostInstallVerificationReport.java` (new)
+- `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java` (emit after success)
+- `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/PostInstallVerificationReportTest.java` (new)
+- Diff vs `origin/main` limited to the above.
+
+**Cross-platform path review:** `formatEmbeddedPath` uses `Path.toAbsolutePath().normalize().resolve("Repository/CMDB")` — portable; no hardcoded `\`/`C:\` joins. Report uses `System.lineSeparator()`; `emit` splits on `\R`.
+
+**Memory patterns:** secret redaction (never dump full property maps with PWD/cmdb.password); post-success only; non-fatal report failures.
+
+## Issues
+
+None (bug / missing behavioral tests / non-portable I/O).
+
+### Suggestions (non-blocking)
+
+1. **nit** — `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/PostInstallVerificationReport.java`: empty CLI resolve still labels source `structured` (product `DbInstallConfigResolver` behavior). Report surfaces the label faithfully; no change required for AC-5.
+
+## Gates evidence
+
+- `cd modules/perc-distribution-tree && ../../mvnw clean install` → BUILD SUCCESS (242 tests, 0 failures; `PostInstallVerificationReportTest` 7/7).
+- Secrets: tests assert operator password and structured MySQL password never appear in report text.
+- Silent + interactive share `Main` success path → single emit covers both.
+
+## Recommendation
+
+**approve** — ship as PR Fixes #2337; update parent #934 Agent progress AC-5 row to `pr_opened`.

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -290,6 +290,10 @@ public class Main {
         System.exit(exitCode);
       }
 
+      // Issue #2337 / parent #934 AC-5: durable post-install verification of selected backend.
+      // Runs for silent and interactive paths after a successful ANT install; never prints secrets.
+      emitPostInstallVerificationReport(installPath, resolvedDbConfig);
+
       // Persist non-secret defaults for the next install (no passwords).
       try {
         String versionToSave = percVersion != null ? percVersion : "";
@@ -317,6 +321,27 @@ public class Main {
       return;
     }
     System.out.println("Done extracting");
+  }
+
+  /**
+   * Emits the post-install DB verification report to the console and installer log (issue #2337).
+   * Failures are non-fatal so a reporting glitch cannot reverse a successful install.
+   *
+   * @param installPath install root used for embedded path display
+   * @param resolvedDbConfig resolved backend config from Phase 1
+   */
+  static void emitPostInstallVerificationReport(
+      Path installPath, DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig) {
+    try {
+      String report = PostInstallVerificationReport.build(installPath, resolvedDbConfig);
+      System.out.println(report);
+      log.info(report);
+    } catch (Exception reportEx) {
+      System.out.println(
+          "Warning: could not emit post-install DB verification report: "
+              + reportEx.getMessage());
+      log.warn("Post-install DB verification report failed", reportEx);
+    }
   }
 
   /**

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/PostInstallVerificationReport.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/PostInstallVerificationReport.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.preinstall;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Builds the durable post-install verification report for the selected RDBMS backend (parent #934
+ * AC-5 / issue #2337).
+ *
+ * <p>Emitted after a <em>successful</em> new or upgrade install on both silent CLI and interactive
+ * paths. Reuses {@link DbInstallConfigResolver.ResolvedDbConfig} field conventions already used by
+ * {@link InteractiveInstallWizard#buildSummary} / {@link InteractiveInstallWizard#formatDbSummary}.
+ *
+ * <p><strong>Security:</strong> never includes passwords, truststore/keystore passwords, or other
+ * secret property values. Only explicitly allow-listed non-secret fields are printed.
+ */
+public final class PostInstallVerificationReport {
+
+  /** Operator-visible section banner (must appear in console / install log). */
+  public static final String SECTION_TITLE = "Post-install verification: database backend";
+
+  /**
+   * Product-relative location of the embedded H2/Derby repository data directory under the install
+   * root (matches ship {@code rxrepository.properties} {@code DB_SERVER=file:…/Repository/CMDB}).
+   */
+  public static final String EMBEDDED_REPOSITORY_RELATIVE = "Repository/CMDB";
+
+  private PostInstallVerificationReport() {}
+
+  /**
+   * Builds a multi-line, clearly labeled post-install verification section.
+   *
+   * @param installPath resolved install root (may be null; embedded path falls back to relative)
+   * @param dbConfig resolved DB config from Phase 1; when null a minimal unknown report is built
+   * @return multi-line report text (platform line separators)
+   */
+  public static String build(Path installPath, DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
+    List<String> lines = new ArrayList<>();
+    lines.add("");
+    lines.add("========================================");
+    lines.add(SECTION_TITLE);
+    lines.add("========================================");
+
+    if (dbConfig == null) {
+      lines.add("Backend      : (unknown)");
+      lines.add("Config source: (unknown)");
+      lines.add("========================================");
+      return String.join(System.lineSeparator(), lines);
+    }
+
+    Map<String, String> p =
+        dbConfig.systemProperties() != null ? dbConfig.systemProperties() : Map.of();
+    String type = firstNonBlank(p.get("perc.db.type"), DbInstallConfigResolver.DB_TYPE_DEFAULT);
+    String backendLabel;
+    try {
+      backendLabel = DbInstallConfigResolver.backendLabelForType(type);
+    } catch (IllegalArgumentException ex) {
+      backendLabel = type;
+    }
+
+    lines.add("Backend      : " + type + " (" + backendLabel + ")");
+    lines.add("db.type      : " + type);
+
+    if (isEmbedded(type)) {
+      lines.add("Location     : " + formatEmbeddedPath(installPath) + " (embedded)");
+    } else {
+      appendLabeled(lines, "Host         : ", p.get("perc.db.host"));
+      appendLabeled(lines, "Port         : ", p.get("perc.db.port"));
+      // Server form from dbprops (DB_SERVER) when host/port not split out
+      if (isBlank(p.get("perc.db.host"))) {
+        appendLabeled(lines, "Server       : ", p.get("perc.db.cms.server"));
+      }
+    }
+
+    String database =
+        firstNonBlank(p.get("perc.db.name"), p.get("perc.db.cms.name"));
+    String schema =
+        firstNonBlank(p.get("perc.db.schema"), p.get("perc.db.cms.schema"));
+    if (isEmbedded(type)) {
+      // Product default for ship H2 props: empty DB_NAME, schema PUBLIC
+      lines.add("Database     : " + (database != null ? database : "(embedded)"));
+      lines.add("Schema       : " + (schema != null ? schema : "PUBLIC"));
+      String user = p.get("perc.db.user");
+      lines.add("User         : " + (isBlank(user) ? "sa (product default)" : user.trim()));
+    } else {
+      appendLabeled(lines, "Database     : ", database);
+      appendLabeled(lines, "Schema       : ", schema);
+      appendLabeled(lines, "User         : ", p.get("perc.db.user"));
+    }
+
+    String source = dbConfig.source() != null ? dbConfig.source() : "default";
+    lines.add("Config source: " + source);
+    lines.add("========================================");
+    return String.join(System.lineSeparator(), lines);
+  }
+
+  /**
+   * Emits the report to the given line consumer (typically {@code System.out::println}) without
+   * throwing for null inputs.
+   *
+   * @param installPath install root
+   * @param dbConfig resolved config
+   * @param lineOut consumer for each report line (including blanks)
+   */
+  public static void emit(
+      Path installPath,
+      DbInstallConfigResolver.ResolvedDbConfig dbConfig,
+      Consumer<String> lineOut) {
+    Objects.requireNonNull(lineOut, "lineOut");
+    String report = build(installPath, dbConfig);
+    // Split on both \r\n and \n so tests on any platform can re-join predictably
+    for (String line : report.split("\\R", -1)) {
+      lineOut.accept(line);
+    }
+  }
+
+  static boolean isEmbedded(String dbType) {
+    if (dbType == null) {
+      return false;
+    }
+    String n = dbType.trim().toLowerCase(Locale.ROOT);
+    return "h2".equals(n) || "derby".equals(n);
+  }
+
+  static String formatEmbeddedPath(Path installPath) {
+    if (installPath == null) {
+      return EMBEDDED_REPOSITORY_RELATIVE;
+    }
+    return installPath
+        .toAbsolutePath()
+        .normalize()
+        .resolve(EMBEDDED_REPOSITORY_RELATIVE)
+        .toString();
+  }
+
+  private static void appendLabeled(List<String> lines, String label, String value) {
+    if (!isBlank(value)) {
+      lines.add(label + value.trim());
+    }
+  }
+
+  private static String firstNonBlank(String a, String b) {
+    if (!isBlank(a)) {
+      return a.trim();
+    }
+    if (!isBlank(b)) {
+      return b.trim();
+    }
+    return null;
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/PostInstallVerificationReportTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/PostInstallVerificationReportTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral coverage for post-install DB verification report (issue #2337 / parent #934 AC-5):
+ * field inclusion for embedded H2 and one external backend, plus password/secret redaction.
+ */
+@Tag("UnitTest")
+class PostInstallVerificationReportTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void embeddedH2DefaultIncludesTypePathSourceAndNeverPassword() {
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(Map.of());
+    Path install = tempDir.resolve("cms-h2");
+    String report = PostInstallVerificationReport.build(install, cfg);
+
+    assertTrue(
+        report.contains(PostInstallVerificationReport.SECTION_TITLE),
+        "must use a clearly labeled section; was:\n" + report);
+    assertTrue(report.contains("db.type"), report);
+    assertTrue(report.toLowerCase().contains("h2"), report);
+    // Empty CLI options still resolve via the structured path with product H2 defaults
+    // (source label is "structured" today; explicit "default" covered below).
+    assertTrue(
+        report.contains("Config source: structured") || report.contains("Config source: default"),
+        report);
+    assertTrue(
+        report.contains(PostInstallVerificationReport.EMBEDDED_REPOSITORY_RELATIVE)
+            || report.contains("Repository"),
+        "embedded path expected; was:\n" + report);
+    assertTrue(report.contains("Location"), report);
+    assertTrue(report.contains("Database"), report);
+    assertTrue(report.contains("Schema"), report);
+    assertTrue(report.contains("User"), report);
+    // Default resolve may not put cmdb.password on the map, but still assert no secret leakage
+    // patterns if a future change injects one.
+    assertFalse(report.toLowerCase().contains("password="), report);
+    assertFalse(report.contains("cmdb.password"), report);
+  }
+
+  @Test
+  void embeddedH2WithOperatorPasswordNeverEchoesSecret() {
+    Map<String, String> props = new HashMap<>();
+    props.put("perc.db.type", "h2");
+    props.put("cmdb.password", "super-secret-h2-pwd");
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        new DbInstallConfigResolver.ResolvedDbConfig(props, "structured");
+    Path install = tempDir.resolve("cms-h2-op");
+    String report = PostInstallVerificationReport.build(install, cfg);
+
+    assertTrue(report.contains("h2"), report);
+    assertTrue(report.contains("Config source: structured"), report);
+    assertTrue(report.contains("embedded"), report.toLowerCase());
+    assertFalse(
+        report.contains("super-secret-h2-pwd"),
+        "must never echo operator H2 password; was:\n" + report);
+    assertFalse(report.contains("cmdb.password"), report);
+  }
+
+  @Test
+  void externalMysqlIncludesHostPortDatabaseUserSourceAndRedactsPassword() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "mysql");
+    opts.put("db.host", "db.example.com");
+    opts.put("db.port", "3306");
+    opts.put("db.name", "percussion");
+    opts.put("db.user", "cms_user");
+    opts.put("db.password", "s3cret-must-not-appear");
+    DbInstallConfigResolver.ResolvedDbConfig cfg = DbInstallConfigResolver.resolveDbConfig(opts);
+
+    Path install = tempDir.resolve("cms-mysql");
+    String report = PostInstallVerificationReport.build(install, cfg);
+
+    assertTrue(report.contains(PostInstallVerificationReport.SECTION_TITLE), report);
+    assertTrue(report.contains("mysql"), report.toLowerCase());
+    assertTrue(report.contains("db.example.com"), report);
+    assertTrue(report.contains("3306"), report);
+    assertTrue(report.contains("percussion"), report);
+    assertTrue(report.contains("cms_user"), report);
+    assertTrue(report.contains("Config source: structured"), report);
+    assertTrue(report.contains("Host"), report);
+    assertTrue(report.contains("Port"), report);
+    assertTrue(report.contains("Database"), report);
+    assertTrue(report.contains("User"), report);
+    assertFalse(
+        report.contains("s3cret-must-not-appear"),
+        "password must be redacted from post-install report; was:\n" + report);
+    assertFalse(report.toLowerCase().contains("password="), report);
+    // Embedded path line should not appear for external backends
+    assertFalse(
+        report.contains(PostInstallVerificationReport.EMBEDDED_REPOSITORY_RELATIVE),
+        "external backend must not claim embedded Repository/CMDB; was:\n" + report);
+  }
+
+  @Test
+  void defaultSourceLabelIsReportedWhenConstructedAsDefault() {
+    Map<String, String> props = new HashMap<>();
+    props.put("perc.db.type", "h2");
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        new DbInstallConfigResolver.ResolvedDbConfig(props, "default");
+    String report = PostInstallVerificationReport.build(tempDir.resolve("def"), cfg);
+    assertTrue(report.contains("Config source: default"), report);
+    assertTrue(report.contains("h2"), report);
+  }
+
+  @Test
+  void dbpropsSourceLabelIsReported() {
+    Map<String, String> props = new HashMap<>();
+    props.put("perc.db.type", "postgresql");
+    props.put("perc.db.host", "pg.internal");
+    props.put("perc.db.port", "5432");
+    props.put("perc.db.name", "rxdb");
+    props.put("perc.db.schema", "public");
+    props.put("perc.db.user", "rx");
+    props.put("perc.db.password", "dbprops-pwd-hidden");
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        new DbInstallConfigResolver.ResolvedDbConfig(props, "dbprops");
+    String report = PostInstallVerificationReport.build(tempDir.resolve("pg"), cfg);
+
+    assertTrue(report.contains("Config source: dbprops"), report);
+    assertTrue(report.contains("postgresql") || report.contains("POSTGRES"), report);
+    assertTrue(report.contains("pg.internal"), report);
+    assertTrue(report.contains("5432"), report);
+    assertTrue(report.contains("rxdb"), report);
+    assertTrue(report.contains("public"), report);
+    assertTrue(report.contains("rx"), report);
+    assertFalse(report.contains("dbprops-pwd-hidden"), report);
+  }
+
+  @Test
+  void emitSendsEveryLineToConsumer() {
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(Map.of());
+    List<String> lines = new ArrayList<>();
+    PostInstallVerificationReport.emit(tempDir.resolve("emit"), cfg, lines::add);
+    assertFalse(lines.isEmpty());
+    assertTrue(
+        lines.stream().anyMatch(l -> l.contains(PostInstallVerificationReport.SECTION_TITLE)),
+        lines.toString());
+  }
+
+  @Test
+  void nullConfigProducesUnknownReportWithoutThrowing() {
+    String report = PostInstallVerificationReport.build(tempDir.resolve("x"), null);
+    assertTrue(report.contains(PostInstallVerificationReport.SECTION_TITLE), report);
+    assertTrue(report.contains("unknown"), report.toLowerCase());
+  }
+}


### PR DESCRIPTION
## Summary

Implements parent #934 **AC-5** residual (#2337): after a **successful** new/upgrade install (silent CLI **and** interactive), emit a durable, clearly labeled **post-install verification** report of the selected RDBMS backend and non-secret connection settings.

- New `PostInstallVerificationReport` builds the section from `ResolvedDbConfig` (same field conventions as `InteractiveInstallWizard.formatDbSummary` / pre-install summary).
- Fields: backend/`db.type`, host/port **or** embedded `Repository/CMDB` path, database/schema, user (never password), effective config source (`dbprops` / `structured` / `default`).
- Wired once in `Main` after ANT success (`emitPostInstallVerificationReport`) → console + installer log; reporting failures are non-fatal.
- Does **not** reopen #949 / `DbInstallConfigResolver` selection scope.

## Test plan

- [x] Unit tests: embedded H2 field inclusion + path; MySQL host/port/name/user + password redaction; `dbprops`/`default` source labels; null-config safety
- [x] `cd modules/perc-distribution-tree && ../../mvnw clean install` → BUILD SUCCESS (242 tests, 0 failures)
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2337-post-install-db-report-erlang.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | `PostInstallVerificationReportTest` 7/7 |
| Module clean install | `perc-distribution-tree` BUILD SUCCESS |
| Secret redaction | passwords / `cmdb.password` never in report |
| Portable paths | `Path.resolve` for embedded location |
| Erlang | approve |

## Links

- **Fixes #2337**
- Parent tracker: #934 (AC-5 slice)
- Sibling residual (out of scope): #2338 (DTS AC-2)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.