### PR TITLE
fix(dts): Oracle DB resolve + fail-fast type parity for DTS installer (#2338)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -73,6 +73,9 @@ public class MainDTSPreInstall {
   /** Default SSL allow-self-signed value for new DTS installs. */
   public static final String DB_SSL_ALLOW_SELF_SIGNED_DEFAULT = "false";
 
+  /** Oracle JDBC driver class (parity with CMS {@code DbInstallConfigResolver}). */
+  public static final String ORACLE_DRIVER_CLASS = "oracle.jdbc.OracleDriver";
+
   /** CLI key for silent/non-interactive mode (--silent or --no-tty). */
   public static final String SILENT_KEY = "silent";
 
@@ -442,6 +445,11 @@ public class MainDTSPreInstall {
    * Resolve DTS database configuration into {@code perc.db.*} system properties for the ANT install
    * JVM.
    *
+   * <p>Supported structured {@code db.type} values match CMS installer parity: {@code h2}, {@code
+   * derby}, {@code mysql}, {@code sqlserver}, {@code oracle}, {@code postgresql} (aliases {@code
+   * mssql}, {@code ora}, {@code postgres}). Unknown types fail fast — they must not silently leave
+   * DTS on the embedded H2 default when the operator requested an external RDBMS (issue #2338).
+   *
    * @param cliOptions options from {@link #parseArgs(String[])}
    * @return resolved config (never null)
    */
@@ -459,7 +467,8 @@ public class MainDTSPreInstall {
       envFileValues.putAll(loadEnvFile(envFilePath));
     }
 
-    String dbType = getConfigValue("db.type", cliOptions, envFileValues, DB_TYPE_DEFAULT);
+    String dbTypeRaw = getConfigValue("db.type", cliOptions, envFileValues, DB_TYPE_DEFAULT);
+    String dbTypeNormalized = normalizeStructuredDbType(dbTypeRaw);
     String sslEnabled =
         normalizeBoolean(
             getConfigValue("db.ssl.enabled", cliOptions, envFileValues, DB_SSL_ENABLED_DEFAULT),
@@ -478,7 +487,7 @@ public class MainDTSPreInstall {
             "db.ssl.allowSelfSigned");
 
     Map<String, String> systemProperties = new HashMap<>();
-    systemProperties.put("perc.db.type", dbType.toLowerCase(Locale.ROOT));
+    systemProperties.put("perc.db.type", dbTypeNormalized);
     systemProperties.put("perc.db.ssl.enabled", sslEnabled);
     systemProperties.put("perc.db.ssl.verify", sslVerify);
     systemProperties.put("perc.db.ssl.allowSelfSigned", sslAllowSelfSigned);
@@ -516,7 +525,6 @@ public class MainDTSPreInstall {
         "perc.db.ssl.trustStorePassword",
         getConfigValue("db.ssl.trustStorePassword", cliOptions, envFileValues, null));
 
-    String dbTypeNormalized = dbType.toLowerCase(Locale.ROOT);
     String host = systemProperties.get("perc.db.host");
     String port = systemProperties.get("perc.db.port");
     String name = systemProperties.get("perc.db.name");
@@ -571,7 +579,8 @@ public class MainDTSPreInstall {
       systemProperties.put("perc.db.dts.jdbcDriver", "com.mysql.cj.jdbc.Driver");
       systemProperties.put(
           "perc.db.dts.hibernateDialect", "org.hibernate.dialect.MySQL5InnoDBDialect");
-      systemProperties.put("perc.db.dts.schema", firstNonBlank(schema, ""));
+      // Schema may be empty for MySQL; do not use firstNonBlank("", ...) (empty is blank).
+      systemProperties.put("perc.db.dts.schema", schema == null ? "" : schema);
     } else if ("sqlserver".equals(dbTypeNormalized)) {
       String trustServerCertificate =
           ("true".equals(sslAllowSelfSigned) || "false".equals(sslVerify)) ? "true" : "false";
@@ -593,16 +602,128 @@ public class MainDTSPreInstall {
           "perc.db.dts.hibernateDialect",
           "com.percussion.delivery.rdbms.PSUnicodeSQLServerDialect");
       systemProperties.put("perc.db.dts.schema", firstNonBlank(schema, "DBO"));
-    } else if ("postgresql".equals(dbTypeNormalized) || "postgres".equals(dbTypeNormalized)) {
+    } else if ("postgresql".equals(dbTypeNormalized)) {
       String dtsJdbcUrl = "jdbc:postgresql://" + host + ":" + port + "/" + name;
       systemProperties.put("perc.db.dts.jdbcUrl", dtsJdbcUrl);
       systemProperties.put("perc.db.dts.jdbcDriver", "org.postgresql.Driver");
       systemProperties.put(
           "perc.db.dts.hibernateDialect", "org.hibernate.dialect.PostgreSQLDialect");
       systemProperties.put("perc.db.dts.schema", firstNonBlank(schema, "public"));
+    } else if ("oracle".equals(dbTypeNormalized)) {
+      // Easy Connect service form: @//host:port/serviceOrSid — same as CMS DbInstallConfigResolver
+      // (multi-tenant PDB service names such as XEPDB1 are not classic SID forms).
+      String serviceOrSid = name == null ? "" : name.trim();
+      String resolvedSchema =
+          isBlank(schema) ? (user == null ? "" : user.trim()) : schema.trim();
+      String dtsJdbcUrl =
+          "jdbc:oracle:thin:@//" + host + ":" + port + "/" + serviceOrSid;
+      systemProperties.put("perc.db.dts.jdbcUrl", dtsJdbcUrl);
+      systemProperties.put("perc.db.dts.jdbcDriver", ORACLE_DRIVER_CLASS);
+      systemProperties.put(
+          "perc.db.dts.hibernateDialect", "org.hibernate.dialect.Oracle12cDialect");
+      systemProperties.put("perc.db.dts.schema", resolvedSchema);
     }
 
     return new ResolvedDbConfig(systemProperties);
+  }
+
+  /**
+   * Normalize structured installer {@code db.type} values (CMS parity).
+   *
+   * @param dbTypeRaw raw type from CLI / env / default
+   * @return canonical lower-case type
+   * @throws IllegalArgumentException when the type is not a supported DTS backend
+   */
+  static String normalizeStructuredDbType(String dbTypeRaw) {
+    if (isBlank(dbTypeRaw)) {
+      return DB_TYPE_DEFAULT;
+    }
+    String t = dbTypeRaw.trim().toLowerCase(Locale.ROOT);
+    return switch (t) {
+      case "h2", "derby", "mysql", "sqlserver", "oracle", "postgresql" -> t;
+      case "mssql" -> "sqlserver";
+      case "ora" -> "oracle";
+      case "postgres" -> "postgresql";
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown db.type='"
+                  + dbTypeRaw
+                  + "'. Allowed values: h2, derby, mysql, sqlserver, oracle, postgresql");
+    };
+  }
+
+  /**
+   * Whether {@code installDts.xml} should rewrite {@code perc-datasources.properties} for this
+   * backend (fresh install, non-embedded).
+   *
+   * @param dbType normalized {@code perc.db.type}
+   * @return true when external RDBMS datasource keys must be written
+   */
+  static boolean shouldWriteDtsDatasourceProperties(String dbType) {
+    if (isBlank(dbType)) {
+      return false;
+    }
+    String t = dbType.trim().toLowerCase(Locale.ROOT);
+    return !"h2".equals(t) && !"derby".equals(t);
+  }
+
+  /**
+   * Map resolved {@code perc.db.*} system properties to the {@code perc-datasources.properties}
+   * keys written by {@code installDts.xml} on fresh external-DB installs.
+   *
+   * <p>Keeps the Java resolve path and the ANT propertyfile write contract aligned for unit tests
+   * (issue #2338).
+   *
+   * @param systemProperties from {@link ResolvedDbConfig#systemProperties()}
+   * @return ordered map of datasource property keys (never null)
+   */
+  static Map<String, String> dtsDatasourcePropertyEntries(Map<String, String> systemProperties) {
+    Map<String, String> entries = new java.util.LinkedHashMap<>();
+    if (systemProperties == null) {
+      return entries;
+    }
+    entries.put("db.username", nullToEmpty(systemProperties.get("perc.db.user")));
+    entries.put("db.password", nullToEmpty(systemProperties.get("perc.db.password")));
+    entries.put("db.schema", nullToEmpty(systemProperties.get("perc.db.dts.schema")));
+    entries.put("jdbcDriver", nullToEmpty(systemProperties.get("perc.db.dts.jdbcDriver")));
+    entries.put("jdbcUrl", nullToEmpty(systemProperties.get("perc.db.dts.jdbcUrl")));
+    entries.put(
+        "hibernate.dialect", nullToEmpty(systemProperties.get("perc.db.dts.hibernateDialect")));
+    entries.put("db.ssl.enabled", nullToEmpty(systemProperties.get("perc.db.ssl.enabled")));
+    entries.put("db.ssl.verify", nullToEmpty(systemProperties.get("perc.db.ssl.verify")));
+    entries.put(
+        "db.ssl.allowSelfSigned",
+        nullToEmpty(systemProperties.get("perc.db.ssl.allowSelfSigned")));
+    return entries;
+  }
+
+  /**
+   * Write DTS datasource keys into a properties file using the same entry set as {@code
+   * installDts.xml}. Existing keys in the target file are preserved except those overwritten by
+   * this mapping.
+   *
+   * @param targetFile path to {@code perc-datasources.properties} (parent dirs must exist)
+   * @param systemProperties resolved {@code perc.db.*} map
+   * @throws IOException if the file cannot be read or written
+   */
+  static void writeDtsDatasourceProperties(Path targetFile, Map<String, String> systemProperties)
+      throws IOException {
+    java.util.Properties props = new java.util.Properties();
+    if (Files.isRegularFile(targetFile)) {
+      try (var in = Files.newInputStream(targetFile)) {
+        props.load(in);
+      }
+    }
+    for (Map.Entry<String, String> e : dtsDatasourcePropertyEntries(systemProperties).entrySet()) {
+      props.setProperty(e.getKey(), e.getValue());
+    }
+    try (var out = Files.newOutputStream(targetFile)) {
+      props.store(out, "DTS datasource configuration (MainDTSPreInstall)");
+    }
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
   }
 
   private static Map<String, String> loadEnvFile(String envFilePath) {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -186,6 +186,9 @@ public final class RepositoryConnectionProbe {
           "jdbc:postgresql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
       case "sqlserver" ->
           "jdbc:sqlserver://" + ep.host() + ":" + ep.port() + ";databaseName=" + ep.name();
+      // Easy Connect service form — same as MainDTSPreInstall.resolveDbConfig (issue #2338).
+      case "oracle", "ora" ->
+          "jdbc:oracle:thin:@//" + ep.host() + ":" + ep.port() + "/" + ep.name();
       default -> null;
     };
   }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/MainDTSPreInstallResolveDbConfigTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/MainDTSPreInstallResolveDbConfigTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral tests for {@link MainDTSPreInstall#resolveDbConfig(Map)} and the DTS datasource
+ * property-write contract (issue #2338 / parent #934 AC-2).
+ */
+@Tag("UnitTest")
+class MainDTSPreInstallResolveDbConfigTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void defaultIsH2WhenNoOptions() {
+    MainDTSPreInstall.ResolvedDbConfig cfg = MainDTSPreInstall.resolveDbConfig(Map.of());
+    assertEquals("h2", cfg.systemProperties().get("perc.db.type"));
+    assertFalse(cfg.systemProperties().containsKey("perc.db.dts.jdbcUrl"));
+    assertFalse(MainDTSPreInstall.shouldWriteDtsDatasourceProperties("h2"));
+  }
+
+  @Test
+  void structuredPostgresqlMapsDtsJdbcAndWriteContract() throws IOException {
+    Map<String, String> opts = externalOpts("postgresql", "pg.example.com", "5432", "percussion");
+    opts.put("db.schema", "public");
+
+    MainDTSPreInstall.ResolvedDbConfig cfg = MainDTSPreInstall.resolveDbConfig(opts);
+    Map<String, String> p = cfg.systemProperties();
+    assertEquals("postgresql", p.get("perc.db.type"));
+    assertEquals("jdbc:postgresql://pg.example.com:5432/percussion", p.get("perc.db.dts.jdbcUrl"));
+    assertEquals("org.postgresql.Driver", p.get("perc.db.dts.jdbcDriver"));
+    assertEquals("org.hibernate.dialect.PostgreSQLDialect", p.get("perc.db.dts.hibernateDialect"));
+    assertEquals("public", p.get("perc.db.dts.schema"));
+    assertTrue(MainDTSPreInstall.shouldWriteDtsDatasourceProperties(p.get("perc.db.type")));
+
+    Path propsFile = tempDir.resolve("perc-datasources.properties");
+    // Seed a sample default so write merges rather than creating only our keys.
+    Files.writeString(
+        propsFile,
+        "jdbcUrl=jdbc:h2:file:./DTSDB/percDB;IFEXISTS=TRUE\njdbcDriver=org.h2.Driver\n");
+    MainDTSPreInstall.writeDtsDatasourceProperties(propsFile, p);
+
+    Properties written = loadProps(propsFile);
+    assertEquals("jdbc:postgresql://pg.example.com:5432/percussion", written.getProperty("jdbcUrl"));
+    assertEquals("org.postgresql.Driver", written.getProperty("jdbcDriver"));
+    assertEquals("org.hibernate.dialect.PostgreSQLDialect", written.getProperty("hibernate.dialect"));
+    assertEquals("public", written.getProperty("db.schema"));
+    assertEquals("cms", written.getProperty("db.username"));
+    assertEquals("s3cret", written.getProperty("db.password"));
+    assertEquals("true", written.getProperty("db.ssl.enabled"));
+  }
+
+  @Test
+  void structuredOracleMapsDtsJdbcSymmetricallyWithCms() {
+    Map<String, String> opts = externalOpts("oracle", "ora.example.com", "1521", "ORCL");
+    opts.put("db.schema", "percuser");
+
+    MainDTSPreInstall.ResolvedDbConfig cfg = MainDTSPreInstall.resolveDbConfig(opts);
+    Map<String, String> p = cfg.systemProperties();
+    assertEquals("oracle", p.get("perc.db.type"));
+    assertEquals(
+        "jdbc:oracle:thin:@//ora.example.com:1521/ORCL", p.get("perc.db.dts.jdbcUrl"));
+    assertEquals(MainDTSPreInstall.ORACLE_DRIVER_CLASS, p.get("perc.db.dts.jdbcDriver"));
+    assertEquals("org.hibernate.dialect.Oracle12cDialect", p.get("perc.db.dts.hibernateDialect"));
+    assertEquals("percuser", p.get("perc.db.dts.schema"));
+  }
+
+  @Test
+  void structuredOracleDefaultsSchemaToUserWhenSchemaOmitted() {
+    Map<String, String> opts = externalOpts("oracle", "oracle", "1521", "XEPDB1");
+    // no db.schema → use db.user (CMS parity)
+    MainDTSPreInstall.ResolvedDbConfig cfg = MainDTSPreInstall.resolveDbConfig(opts);
+    assertEquals("cms", cfg.systemProperties().get("perc.db.dts.schema"));
+    assertEquals(
+        "jdbc:oracle:thin:@//oracle:1521/XEPDB1",
+        cfg.systemProperties().get("perc.db.dts.jdbcUrl"));
+  }
+
+  @Test
+  void oraAliasNormalizesToOracle() {
+    Map<String, String> opts = externalOpts("ora", "ora.example.com", "1521", "ORCL");
+    MainDTSPreInstall.ResolvedDbConfig cfg = MainDTSPreInstall.resolveDbConfig(opts);
+    assertEquals("oracle", cfg.systemProperties().get("perc.db.type"));
+    assertTrue(cfg.systemProperties().get("perc.db.dts.jdbcUrl").startsWith("jdbc:oracle:thin:"));
+  }
+
+  @Test
+  void structuredOracleWriteContractMatchesInstallDtsPropertyKeys() throws IOException {
+    Map<String, String> opts = externalOpts("oracle", "ora.example.com", "1521", "XEPDB1");
+    opts.put("db.schema", "PERC");
+    MainDTSPreInstall.ResolvedDbConfig cfg = MainDTSPreInstall.resolveDbConfig(opts);
+    Path propsFile = tempDir.resolve("perc-datasources-oracle.properties");
+    MainDTSPreInstall.writeDtsDatasourceProperties(propsFile, cfg.systemProperties());
+    Properties written = loadProps(propsFile);
+    assertEquals(
+        "jdbc:oracle:thin:@//ora.example.com:1521/XEPDB1", written.getProperty("jdbcUrl"));
+    assertEquals(MainDTSPreInstall.ORACLE_DRIVER_CLASS, written.getProperty("jdbcDriver"));
+    assertEquals("org.hibernate.dialect.Oracle12cDialect", written.getProperty("hibernate.dialect"));
+    assertEquals("PERC", written.getProperty("db.schema"));
+  }
+
+  @Test
+  void unknownDbTypeFailsFastWithoutSilentH2Fallback() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "cockroach");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> MainDTSPreInstall.resolveDbConfig(opts));
+    assertTrue(ex.getMessage().contains("cockroach"));
+    assertTrue(ex.getMessage().toLowerCase().contains("allowed"));
+  }
+
+  @Test
+  void structuredOracleMissingFieldsThrowsWithoutPasswordInMessage() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "oracle");
+    opts.put("db.password", "super-secret-pw");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> MainDTSPreInstall.resolveDbConfig(opts));
+    assertTrue(ex.getMessage().contains("db.host"));
+    assertFalse(ex.getMessage().contains("super-secret-pw"));
+  }
+
+  @Test
+  void normalizeStructuredDbTypeAliases() {
+    assertEquals("sqlserver", MainDTSPreInstall.normalizeStructuredDbType("MSSQL"));
+    assertEquals("oracle", MainDTSPreInstall.normalizeStructuredDbType("ORA"));
+    assertEquals("postgresql", MainDTSPreInstall.normalizeStructuredDbType("postgres"));
+    assertEquals("h2", MainDTSPreInstall.normalizeStructuredDbType(null));
+  }
+
+  @Test
+  void repositoryProbeBuildJdbcUrlSupportsOracle() {
+    Map<String, String> p = new HashMap<>();
+    p.put("perc.db.host", "ora.example.com");
+    p.put("perc.db.port", "1521");
+    p.put("perc.db.name", "XEPDB1");
+    assertEquals(
+        "jdbc:oracle:thin:@//ora.example.com:1521/XEPDB1",
+        RepositoryConnectionProbe.buildJdbcUrl("oracle", p));
+  }
+
+  private static Map<String, String> externalOpts(
+      String type, String host, String port, String name) {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", type);
+    opts.put("db.host", host);
+    opts.put("db.port", port);
+    opts.put("db.name", name);
+    opts.put("db.user", "cms");
+    opts.put("db.password", "s3cret");
+    return opts;
+  }
+
+  private static Properties loadProps(Path file) throws IOException {
+    Properties props = new Properties();
+    try (InputStream in = Files.newInputStream(file)) {
+      props.load(in);
+    }
+    return props;
+  }
+}


### PR DESCRIPTION
## Summary

Closes residual **#934 AC-2** holes so DTS effective DB config matches CMS for supported RDBMS platforms (parent tracker #934).

### AC-1 — CMS co-install write-through?

**Decision: No CMS-side DTS datasource write-through required.**

Evidence on `main`:

- Product path installs **CMS** (`perc-distribution-tree` / `Main` + `install.xml`) and **DTS** (`delivery-tier-distribution` / `MainDTSPreInstall` + `installDts.xml`) as **separate installer JARs** with separate install roots.
- CMS `DbInstallConfigResolver` already emits `perc.db.dts.*` hints for mysql/sqlserver/oracle/postgresql, but there is **no CMS ANT consumer** that writes `Deployment/Server/conf/perc/perc-datasources.properties`.
- Legacy `install.dts` in `system/installResources/install.xml` is a TODO stub (DTS install commented out); `modules/perc-distribution-tree` `install.dts` defaults to `false` and is unused for datasource writes.
- Dev/ops scripts (`install-dts.py`, docker compose) run the DTS JAR separately with the same operator `--db.*` inputs.

**Effective contract:** operators pass the same structured `--db.*` (or env file) to both installers. DTS write-through remains owned by `installDts.xml` (already rewrites `perc-datasources.properties` for non-h2/derby when `perc.db.dts.*` are set).

### AC-2 — Oracle on DTS (no silent H2 fallback)

- Extended `MainDTSPreInstall.resolveDbConfig` with **oracle** (Easy Connect `jdbc:oracle:thin:@//host:port/service`, `oracle.jdbc.OracleDriver`, `Oracle12cDialect`, schema defaults to user when omitted) — CMS parity.
- `normalizeStructuredDbType` accepts `ora`/`mssql`/`postgres` aliases and **fails fast** on unknown types (message lists allowed values).
- `RepositoryConnectionProbe.buildJdbcUrl` supports oracle for preinstall connectivity messaging.
- Package-visible `dtsDatasourcePropertyEntries` / `writeDtsDatasourceProperties` document the Java↔ANT property key contract used by `installDts.xml`.

### AC-3 — Unit tests

`MainDTSPreInstallResolveDbConfigTest` (10 tests):

- default H2
- **postgresql** resolve + **property write** to temp `perc-datasources.properties`
- **oracle** resolve + write + schema default + `ora` alias
- unknown type fail-fast (no silent H2)
- password not leaked in missing-field errors
- probe oracle URL

### AC-4 — Matrix waiver (optional)

Full `dts-mysql` / `dts-oracle` matrix cells remain **waived** for this slice: unit-level resolve+write covers the config contract; matrix expansion can follow under parent #934 if product prioritizes live install cells. Existing `dts-h2` / `dts-postgresql` smoke cells unchanged.

## Test plan

- [x] `./mvnw -f deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml clean install -DskipITs` — BUILD SUCCESS (110 tests, including 10 new resolve/write tests)
- [x] Erlang-style self-review: fail-fast unknown types; portable `Path`/`Files` I/O; no secrets in exception messages; Intersoft 2026 header on new test file; no CMS mega-scope reopen

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | Pass (`MainDTSPreInstallResolveDbConfigTest`) |
| Module `clean install` | Pass (delivery-tier-distribution) |
| Portable paths | `java.nio.file.Path` / `Files` only |
| Scope | DTS preinstall only; no #949 reopen |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2338  
Parent tracker: #934

> Co-Authored by Grok Build using grok-4.5 with agent main.