### PR TITLE
fix(system): richer pipeline UPDATE/DELETE + multi-row txn modes (#2340)

### DIFF
--- a/docs/developer-module/pipeline-ir-v1.md
+++ b/docs/developer-module/pipeline-ir-v1.md
@@ -127,20 +127,59 @@ Not imported in v1 (deferred): full where-clause trees, join graphs, exits/hooks
 - `toJson` / `fromJson`
 - `save` / `load` / `exists`
 
-### Runtime (Slice A part 2 — #2248)
+### Runtime (Slice A part 2 — #2248; richer UPDATE/DELETE — #2340)
 
 `IPSPipelineRuntimeService` / `PSPipelineRuntimeService` / `PSPipelineRuntimeServiceLocator`:
 
 - `execute(appName, resourceName, request)` — load native IR, run resource
 - `execute(document, resource, request)` — in-memory IR (tests / callers)
 - SQL via `IPSPipelineSqlAdapter` / `PSJdbcPipelineSqlAdapter` (parameterized JDBC only)
-- Planner: `PSPipelineSqlPlanner` (generated single-table SELECT/INSERT, or native SELECT with `:param`)
+- Planner: `PSPipelineSqlPlanner` (generated single-table SELECT/INSERT/**UPDATE**/**DELETE**, or native SELECT with `:param`)
 - Pre/post hooks: `IPSPipelinePreExecuteHook` / `IPSPipelinePostExecuteHook`
 - JSON I/O: `PipelineExecuteRequest` / `PipelineExecuteResult` + `PSPipelineExecuteJsonCodec`
+- Thin REST: `POST /services/pipelines/{app}/resources/{resource}/execute` (see #2269 / PR #2341)
 
 **Not** calling classic `PSQueryHandler` / `PSUpdateHandler` as the public path.
 
-Catalog list remains `GET /services/pipelines`. Optional thin REST **invoke** is deferred (Developer smoke residual).
+Catalog list remains `GET /services/pipelines`.
+
+### UPDATE resource mutations (`updater.*` flags)
+
+| Request | Planner | Flag gate |
+|---------|---------|-----------|
+| `operation=insert` (or only insert allowed) | `planInserts` | `allowInsert` |
+| `operation=update` (or only update allowed) | `planUpdates` | `allowUpdate` |
+| `operation=delete` (or only delete allowed) | `planDeletes` | `allowDelete` |
+
+- When more than one of insert/update/delete is allowed, **`request.operation` is required**.
+- When a flag is false, the runtime rejects with a clear API error naming the flag (e.g. `updater.allowUpdate=false`).
+- **UPDATE**: `SET` non-key mapped columns from each row; **WHERE** from `request.keyColumns` values on the row, or from mapped keys in `request.params` (shared WHERE).
+- **DELETE**: WHERE from `keyColumns` / mapped `params` / mapped columns present on each row. Empty WHERE (unrestricted delete) is rejected.
+- Unrestricted UPDATE/DELETE without keys is rejected.
+
+Example update body:
+
+```json
+{
+  "operation": "update",
+  "keyColumns": ["TYPE", "NAME"],
+  "rows": [
+    { "TYPE": "workflow", "NAME": "wf1", "LOOKUPVALUE": "99" }
+  ]
+}
+```
+
+### Multi-row transaction modes
+
+IR field `resource.transactionMode` (`none` | `row` | `all`) is honored for multi-plan mutations via `IPSPipelineSqlAdapter#updateAll`:
+
+| Mode | Behavior |
+|------|----------|
+| `none` (default) | Each plan uses its own connection; auto-commit per plan |
+| `row` | Each plan runs in its own explicit transaction (commit per plan); prior plans stay committed if a later plan fails |
+| `all` | All plans share one connection/transaction; **any failure rolls back the entire batch** |
+
+Documented + covered by H2 tests in `PSPipelineRuntimeServiceTest` (`transactionMode=all` commit + rollback; `row` keeps prior commits).
 
 ### Runtime security
 
@@ -149,7 +188,8 @@ Catalog list remains `GET /services/pipelines`. Optional thin REST **invoke** is
 | Parameterized SQL | Request values bound as JDBC `?` only |
 | Generated identifiers | Table/column must match `[A-Za-z_][A-Za-z0-9_]*` |
 | Native SQL escape hatch | Single `SELECT`/`WITH` only; named `:param`; rejects `;`, DML/DDL keywords |
-| Joins / multi-table | Not supported in Slice A2 planner |
+| Joins / multi-table | Not supported in Slice A2 planner (residual) |
+| Unrestricted DELETE/UPDATE | Rejected (WHERE keys required) |
 
 Manual raw multi-statement SQL is **not** a product surface.
 
@@ -157,11 +197,12 @@ Manual raw multi-statement SQL is **not** a product surface.
 
 - IR JSON round-trip + file load/save
 - Golden classic fixture `sys_adminCataloger` → IR stage inventory (backend tank, mapper, selector, page tank)
-- H2 runtime: generated query + JSON params, native SELECT, pre/post hooks, minimal INSERT (`PSPipelineRuntimeServiceTest`)
+- H2 runtime: generated query + JSON params, native SELECT, pre/post hooks, INSERT, UPDATE/DELETE flag gates, multi-row `transactionMode` all/row (`PSPipelineRuntimeServiceTest`)
 
 ## Evolution
 
 - **1.x** additive fields preferred; bump `irVersion` only for breaking shape changes.
 - Slice A2 (#2248): SQL execute + JSON I/O + hooks consume this IR (landed).
-- Residual: thin REST invoke for Developer smoke; richer UPDATE (update/delete); join graphs; full where-clause IR.
+- Residual #2269: thin REST invoke (landed / PR #2341).
+- Residual #2340: richer UPDATE/DELETE + multi-row txn modes (this work); join graphs / full where-clause IR may remain a further residual.
 - Slice B: designer writes native IR (`source=NATIVE`).

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeService.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeService.java
@@ -29,6 +29,7 @@ import com.percussion.services.pipeline.sql.PSPipelineSqlPlan;
 import com.percussion.services.pipeline.sql.PSPipelineSqlPlanner;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -112,15 +113,28 @@ public class PSPipelineRuntimeService implements IPSPipelineRuntimeService {
       result.getMeta().put("sqlDescription", plan.getDescription());
       result.getMeta().put("parameterCount", plan.getParameters().size());
     } else if (PipelineResourceIr.KIND_UPDATE.equals(resource.getKind())) {
-      List<PSPipelineSqlPlan> plans = PSPipelineSqlPlanner.planInserts(resource, req);
-      int affected = 0;
-      for (PSPipelineSqlPlan plan : plans) {
-        affected += sqlAdapter.update(plan);
+      String mutation = PSPipelineSqlPlanner.resolveMutationOperation(resource, req);
+      List<PSPipelineSqlPlan> plans;
+      if (PipelineExecuteRequest.OP_INSERT.equals(mutation)) {
+        plans = PSPipelineSqlPlanner.planInserts(resource, req);
+      } else if (PipelineExecuteRequest.OP_UPDATE.equals(mutation)) {
+        plans = PSPipelineSqlPlanner.planUpdates(resource, req);
+      } else if (PipelineExecuteRequest.OP_DELETE.equals(mutation)) {
+        plans = PSPipelineSqlPlanner.planDeletes(resource, req);
+      } else {
+        throw new PSPipelineIrException("Unsupported mutation operation: " + mutation);
       }
-      result.setOperation("insert");
+      String txMode = resource.getTransactionMode();
+      int affected = sqlAdapter.updateAll(plans, txMode);
+      result.setOperation(mutation);
       result.setAffectedRows(affected);
       result.setRowCount(0);
       result.getMeta().put("planCount", plans.size());
+      result.getMeta().put(
+          "transactionMode",
+          txMode != null && !txMode.isBlank()
+              ? txMode.trim().toLowerCase(Locale.ROOT)
+              : "none");
     } else {
       throw new PSPipelineIrException(
           "Unsupported resource kind for runtime execute: " + resource.getKind());

--- a/system/services/src/com/percussion/services/pipeline/model/PipelineExecuteRequest.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PipelineExecuteRequest.java
@@ -35,13 +35,42 @@ import java.util.Objects;
  * <p>Example insert body:
  *
  * <pre>
- * { "rows": [ { "TYPE": "workflow", "NAME": "wf1" } ] }
+ * { "operation": "insert", "rows": [ { "TYPE": "workflow", "NAME": "wf1" } ] }
  * </pre>
+ *
+ * <p>Example update body (SET non-key columns; WHERE from {@code keyColumns} values on each row):
+ *
+ * <pre>
+ * {
+ *   "operation": "update",
+ *   "keyColumns": ["TYPE", "NAME"],
+ *   "rows": [ { "TYPE": "workflow", "NAME": "wf1", "LOOKUPVALUE": "99" } ]
+ * }
+ * </pre>
+ *
+ * <p>Example delete body:
+ *
+ * <pre>
+ * {
+ *   "operation": "delete",
+ *   "keyColumns": ["TYPE", "NAME"],
+ *   "rows": [ { "TYPE": "locale", "NAME": "en-us" } ]
+ * }
+ * </pre>
+ *
+ * <p>When an UPDATE resource allows only one of insert/update/delete, {@code operation} may be
+ * omitted and is inferred. When more than one is allowed, {@code operation} is required.
  */
 public class PipelineExecuteRequest {
 
+  public static final String OP_INSERT = "insert";
+  public static final String OP_UPDATE = "update";
+  public static final String OP_DELETE = "delete";
+
+  private String operation;
   private Map<String, Object> params = new LinkedHashMap<>();
   private List<Map<String, Object>> rows = new ArrayList<>();
+  private List<String> keyColumns = new ArrayList<>();
 
   public static PipelineExecuteRequest ofParams(Map<String, Object> params) {
     PipelineExecuteRequest req = new PipelineExecuteRequest();
@@ -53,6 +82,14 @@ public class PipelineExecuteRequest {
 
   public static PipelineExecuteRequest empty() {
     return new PipelineExecuteRequest();
+  }
+
+  public String getOperation() {
+    return operation;
+  }
+
+  public void setOperation(String operation) {
+    this.operation = operation;
   }
 
   public Map<String, Object> getParams() {
@@ -71,6 +108,18 @@ public class PipelineExecuteRequest {
     this.rows = rows != null ? new ArrayList<>(rows) : new ArrayList<>();
   }
 
+  /**
+   * Mapped column names used as equality WHERE keys for update/delete. Values are taken from each
+   * row (or from {@link #params} when used as a single-row body).
+   */
+  public List<String> getKeyColumns() {
+    return keyColumns;
+  }
+
+  public void setKeyColumns(List<String> keyColumns) {
+    this.keyColumns = keyColumns != null ? new ArrayList<>(keyColumns) : new ArrayList<>();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -79,11 +128,14 @@ public class PipelineExecuteRequest {
     if (!(o instanceof PipelineExecuteRequest that)) {
       return false;
     }
-    return Objects.equals(params, that.params) && Objects.equals(rows, that.rows);
+    return Objects.equals(operation, that.operation)
+        && Objects.equals(params, that.params)
+        && Objects.equals(rows, that.rows)
+        && Objects.equals(keyColumns, that.keyColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(params, rows);
+    return Objects.hash(operation, params, rows, keyColumns);
   }
 }

--- a/system/services/src/com/percussion/services/pipeline/sql/IPSPipelineSqlAdapter.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/IPSPipelineSqlAdapter.java
@@ -28,6 +28,20 @@ import java.util.Map;
 public interface IPSPipelineSqlAdapter {
 
   /**
+   * Transaction modes for multi-plan mutation batches (mirrors IR {@code transactionMode}).
+   *
+   * <ul>
+   *   <li>{@link #TX_NONE} — each plan auto-commits independently (default when unset)
+   *   <li>{@link #TX_ROW} — each plan runs in its own explicit transaction (commit per plan)
+   *   <li>{@link #TX_ALL} — all plans share one connection/transaction; any failure rolls back all
+   * </ul>
+   */
+  String TX_NONE = "none";
+
+  String TX_ROW = "row";
+  String TX_ALL = "all";
+
+  /**
    * Execute a SELECT plan and return rows as ordered maps (column label → value).
    *
    * @param plan must be {@link PSPipelineSqlPlan.Kind#QUERY}
@@ -35,10 +49,19 @@ public interface IPSPipelineSqlAdapter {
   List<Map<String, Object>> query(PSPipelineSqlPlan plan) throws PSPipelineIrException;
 
   /**
-   * Execute an INSERT/UPDATE/DELETE plan.
+   * Execute a single INSERT/UPDATE/DELETE plan (auto-commit / connection-per-call).
    *
    * @param plan must be {@link PSPipelineSqlPlan.Kind#UPDATE}
    * @return total affected row count
    */
   int update(PSPipelineSqlPlan plan) throws PSPipelineIrException;
+
+  /**
+   * Execute multiple mutation plans under the given transaction mode.
+   *
+   * @param plans non-null; each must be {@link PSPipelineSqlPlan.Kind#UPDATE}
+   * @param transactionMode {@link #TX_NONE}, {@link #TX_ROW}, or {@link #TX_ALL} (null/blank → none)
+   * @return sum of affected row counts
+   */
+  int updateAll(List<PSPipelineSqlPlan> plans, String transactionMode) throws PSPipelineIrException;
 }

--- a/system/services/src/com/percussion/services/pipeline/sql/PSJdbcPipelineSqlAdapter.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSJdbcPipelineSqlAdapter.java
@@ -96,6 +96,144 @@ public class PSJdbcPipelineSqlAdapter implements IPSPipelineSqlAdapter {
     }
   }
 
+  @Override
+  public int updateAll(List<PSPipelineSqlPlan> plans, String transactionMode)
+      throws PSPipelineIrException {
+    Objects.requireNonNull(plans, "plans");
+    if (plans.isEmpty()) {
+      return 0;
+    }
+    for (PSPipelineSqlPlan plan : plans) {
+      if (plan == null) {
+        throw new PSPipelineIrException("Null SQL plan in mutation batch");
+      }
+      if (plan.getKind() != PSPipelineSqlPlan.Kind.UPDATE) {
+        throw new PSPipelineIrException("SQL plan is not an UPDATE: " + plan.getKind());
+      }
+    }
+    String mode = normalizeTransactionMode(transactionMode);
+    if (TX_ALL.equals(mode)) {
+      return updateAllInOneTransaction(plans);
+    }
+    if (TX_ROW.equals(mode)) {
+      return updateEachInOwnTransaction(plans);
+    }
+    // TX_NONE: independent connection per plan (legacy insert path)
+    int affected = 0;
+    for (PSPipelineSqlPlan plan : plans) {
+      affected += update(plan);
+    }
+    return affected;
+  }
+
+  private int updateAllInOneTransaction(List<PSPipelineSqlPlan> plans) throws PSPipelineIrException {
+    try (Connection conn = open()) {
+      boolean previousAutoCommit = conn.getAutoCommit();
+      try {
+        conn.setAutoCommit(false);
+        int affected = 0;
+        for (PSPipelineSqlPlan plan : plans) {
+          try (PreparedStatement ps = conn.prepareStatement(plan.getSql())) {
+            bind(ps, plan.getParameters());
+            affected += ps.executeUpdate();
+          }
+        }
+        conn.commit();
+        return affected;
+      } catch (SQLException e) {
+        try {
+          conn.rollback();
+        } catch (SQLException rollbackEx) {
+          e.addSuppressed(rollbackEx);
+        }
+        throw new PSPipelineIrException(
+            "Pipeline SQL batch failed (transactionMode=all); rolled back: "
+                + e.getMessage(),
+            e);
+      } catch (RuntimeException e) {
+        try {
+          conn.rollback();
+        } catch (SQLException rollbackEx) {
+          e.addSuppressed(rollbackEx);
+        }
+        throw new PSPipelineIrException(
+            "Pipeline SQL batch failed (transactionMode=all); rolled back", e);
+      } finally {
+        try {
+          conn.setAutoCommit(previousAutoCommit);
+        } catch (SQLException ignored) {
+          // connection closing next
+        }
+      }
+    } catch (SQLException e) {
+      throw new PSPipelineIrException("Pipeline SQL batch failed to open connection", e);
+    } catch (RuntimeException e) {
+      throw new PSPipelineIrException("Pipeline SQL batch failed to open connection", e);
+    }
+  }
+
+  private int updateEachInOwnTransaction(List<PSPipelineSqlPlan> plans)
+      throws PSPipelineIrException {
+    int affected = 0;
+    for (PSPipelineSqlPlan plan : plans) {
+      try (Connection conn = open()) {
+        boolean previousAutoCommit = conn.getAutoCommit();
+        try {
+          conn.setAutoCommit(false);
+          try (PreparedStatement ps = conn.prepareStatement(plan.getSql())) {
+            bind(ps, plan.getParameters());
+            affected += ps.executeUpdate();
+          }
+          conn.commit();
+        } catch (SQLException e) {
+          try {
+            conn.rollback();
+          } catch (SQLException rollbackEx) {
+            e.addSuppressed(rollbackEx);
+          }
+          throw new PSPipelineIrException(
+              "Pipeline SQL update failed (transactionMode=row): " + plan.getDescription(), e);
+        } catch (RuntimeException e) {
+          try {
+            conn.rollback();
+          } catch (SQLException rollbackEx) {
+            e.addSuppressed(rollbackEx);
+          }
+          throw new PSPipelineIrException(
+              "Pipeline SQL update failed (transactionMode=row): " + plan.getDescription(), e);
+        } finally {
+          try {
+            conn.setAutoCommit(previousAutoCommit);
+          } catch (SQLException ignored) {
+            // connection closing
+          }
+        }
+      } catch (SQLException e) {
+        throw new PSPipelineIrException(
+            "Pipeline SQL update failed (transactionMode=row): " + plan.getDescription(), e);
+      } catch (RuntimeException e) {
+        if (e.getCause() instanceof SQLException || e instanceof IllegalStateException) {
+          throw new PSPipelineIrException(
+              "Pipeline SQL update failed (transactionMode=row): " + plan.getDescription(), e);
+        }
+        throw e;
+      }
+    }
+    return affected;
+  }
+
+  static String normalizeTransactionMode(String transactionMode) {
+    if (transactionMode == null || transactionMode.isBlank()) {
+      return TX_NONE;
+    }
+    String m = transactionMode.trim().toLowerCase(java.util.Locale.ROOT);
+    if (TX_ALL.equals(m) || TX_ROW.equals(m) || TX_NONE.equals(m)) {
+      return m;
+    }
+    // Unknown modes degrade to none (documented); classic import only emits none|row|all
+    return TX_NONE;
+  }
+
   private Connection open() throws SQLException {
     try {
       Connection conn = connectionSupplier.get();

--- a/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
@@ -89,8 +89,90 @@ public final class PSPipelineSqlPlanner {
   }
 
   /**
-   * Plan a minimal UPDATE-resource insert when updater allows insert and request has rows (or
-   * params as a single row).
+   * Resolve the mutation operation for an UPDATE resource from request + updater flags.
+   *
+   * <p>If {@code request.operation} is set, it must be allowed by the updater. If omitted and
+   * exactly one of insert/update/delete is allowed, that operation is chosen. If multiple are
+   * allowed and operation is omitted, a clear API error is raised.
+   *
+   * @return one of {@link PipelineExecuteRequest#OP_INSERT}, {@link
+   *     PipelineExecuteRequest#OP_UPDATE}, {@link PipelineExecuteRequest#OP_DELETE}
+   */
+  public static String resolveMutationOperation(
+      PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
+    Objects.requireNonNull(resource, "resource");
+    Objects.requireNonNull(request, "request");
+    if (!PipelineResourceIr.KIND_UPDATE.equals(resource.getKind())) {
+      throw new PSPipelineIrException(
+          "Resource kind is not UPDATE: " + resource.getKind() + " (" + resource.getName() + ")");
+    }
+    UpdaterStageIr updater =
+        resource.getStages() != null ? resource.getStages().getUpdater() : null;
+    if (updater == null || !updater.isPresent()) {
+      throw new PSPipelineIrException(
+          "UPDATE resource has no updater stage: " + resource.getName());
+    }
+    boolean ins = updater.isAllowInsert();
+    boolean upd = updater.isAllowUpdate();
+    boolean del = updater.isAllowDelete();
+    if (!ins && !upd && !del) {
+      throw new PSPipelineIrException(
+          "UPDATE resource allows none of insert/update/delete: " + resource.getName());
+    }
+
+    String op = request.getOperation();
+    if (op != null && !op.isBlank()) {
+      String normalized = op.trim().toLowerCase(Locale.ROOT);
+      switch (normalized) {
+        case PipelineExecuteRequest.OP_INSERT:
+          if (!ins) {
+            throw new PSPipelineIrException(
+                "UPDATE resource does not allow insert (updater.allowInsert=false): "
+                    + resource.getName());
+          }
+          return PipelineExecuteRequest.OP_INSERT;
+        case PipelineExecuteRequest.OP_UPDATE:
+          if (!upd) {
+            throw new PSPipelineIrException(
+                "UPDATE resource does not allow update (updater.allowUpdate=false): "
+                    + resource.getName());
+          }
+          return PipelineExecuteRequest.OP_UPDATE;
+        case PipelineExecuteRequest.OP_DELETE:
+          if (!del) {
+            throw new PSPipelineIrException(
+                "UPDATE resource does not allow delete (updater.allowDelete=false): "
+                    + resource.getName());
+          }
+          return PipelineExecuteRequest.OP_DELETE;
+        default:
+          throw new PSPipelineIrException(
+              "Unknown mutation operation '"
+                  + op
+                  + "' (expected insert, update, or delete): "
+                  + resource.getName());
+      }
+    }
+
+    int allowed = (ins ? 1 : 0) + (upd ? 1 : 0) + (del ? 1 : 0);
+    if (allowed > 1) {
+      throw new PSPipelineIrException(
+          "UPDATE resource allows multiple mutations; request.operation is required"
+              + " (insert/update/delete): "
+              + resource.getName());
+    }
+    if (ins) {
+      return PipelineExecuteRequest.OP_INSERT;
+    }
+    if (upd) {
+      return PipelineExecuteRequest.OP_UPDATE;
+    }
+    return PipelineExecuteRequest.OP_DELETE;
+  }
+
+  /**
+   * Plan INSERT statements when updater allows insert and request has rows (or params as a single
+   * row).
    */
   public static List<PSPipelineSqlPlan> planInserts(
       PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
@@ -104,7 +186,8 @@ public final class PSPipelineSqlPlanner {
         resource.getStages() != null ? resource.getStages().getUpdater() : null;
     if (updater == null || !updater.isPresent() || !updater.isAllowInsert()) {
       throw new PSPipelineIrException(
-          "UPDATE resource does not allow insert: " + resource.getName());
+          "UPDATE resource does not allow insert (updater.allowInsert=false): "
+              + resource.getName());
     }
 
     String table = requireSingleTable(resource);
@@ -114,14 +197,7 @@ public final class PSPipelineSqlPlanner {
           "UPDATE resource has no COLUMN mappings for insert: " + resource.getName());
     }
 
-    List<Map<String, Object>> rows = new ArrayList<>();
-    if (request.getRows() != null && !request.getRows().isEmpty()) {
-      rows.addAll(request.getRows());
-    } else if (request.getParams() != null && !request.getParams().isEmpty()) {
-      rows.add(new LinkedHashMap<>(request.getParams()));
-    } else {
-      throw new PSPipelineIrException("Insert requires request.rows or request.params");
-    }
+    List<Map<String, Object>> rows = mutationRows(request, "Insert");
 
     List<PSPipelineSqlPlan> plans = new ArrayList<>();
     for (Map<String, Object> row : rows) {
@@ -157,6 +233,310 @@ public final class PSPipelineSqlPlanner {
               PSPipelineSqlPlan.Kind.UPDATE, sql.toString(), values, "insert:" + table));
     }
     return plans;
+  }
+
+  /**
+   * Plan UPDATE statements when updater allows update.
+   *
+   * <p>Each row produces {@code UPDATE table SET col=? ... WHERE key=? AND ...}. Key columns come
+   * from {@code request.keyColumns}, or — when empty — from {@code request.params} keys that map to
+   * columns (params supply shared WHERE values applied to every row). SET columns are mapped
+   * columns present on the row that are not keys.
+   */
+  public static List<PSPipelineSqlPlan> planUpdates(
+      PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
+    Objects.requireNonNull(resource, "resource");
+    Objects.requireNonNull(request, "request");
+    if (!PipelineResourceIr.KIND_UPDATE.equals(resource.getKind())) {
+      throw new PSPipelineIrException(
+          "Resource kind is not UPDATE: " + resource.getKind() + " (" + resource.getName() + ")");
+    }
+    UpdaterStageIr updater =
+        resource.getStages() != null ? resource.getStages().getUpdater() : null;
+    if (updater == null || !updater.isPresent() || !updater.isAllowUpdate()) {
+      throw new PSPipelineIrException(
+          "UPDATE resource does not allow update (updater.allowUpdate=false): "
+              + resource.getName());
+    }
+
+    String table = requireSingleTable(resource);
+    List<ColumnMapping> mappings = columnMappings(resource);
+    if (mappings.isEmpty()) {
+      throw new PSPipelineIrException(
+          "UPDATE resource has no COLUMN mappings for update: " + resource.getName());
+    }
+
+    KeySpec keys = resolveKeySpec(mappings, request, "Update");
+    List<Map<String, Object>> rows = mutationRows(request, "Update");
+
+    List<PSPipelineSqlPlan> plans = new ArrayList<>();
+    for (Map<String, Object> row : rows) {
+      List<String> setCols = new ArrayList<>();
+      List<Object> setValues = new ArrayList<>();
+      for (ColumnMapping m : mappings) {
+        if (keys.keyColumnNames.contains(m.column.toUpperCase(Locale.ROOT))) {
+          continue;
+        }
+        Object v = findValue(row, m);
+        if (v != null) {
+          setCols.add(m.column);
+          setValues.add(v);
+        }
+      }
+      if (setCols.isEmpty()) {
+        throw new PSPipelineIrException(
+            "Update row has no SET values (non-key mapped columns required)");
+      }
+
+      List<Object> whereValues = new ArrayList<>();
+      List<String> whereCols = new ArrayList<>();
+      for (String keyCol : keys.orderedKeyColumns) {
+        Object kv = resolveKeyValue(row, keyCol, keys.sharedParams, mappings);
+        if (kv == null && !hasKeyPresent(row, keyCol, keys.sharedParams, mappings)) {
+          throw new PSPipelineIrException(
+              "Update row missing key column value for WHERE: " + keyCol);
+        }
+        whereCols.add(keyCol);
+        whereValues.add(kv);
+      }
+
+      StringBuilder sql = new StringBuilder("UPDATE ").append(quoteIdent(table)).append(" SET ");
+      for (int i = 0; i < setCols.size(); i++) {
+        if (i > 0) {
+          sql.append(", ");
+        }
+        sql.append(quoteIdent(setCols.get(i))).append(" = ?");
+      }
+      sql.append(" WHERE ");
+      for (int i = 0; i < whereCols.size(); i++) {
+        if (i > 0) {
+          sql.append(" AND ");
+        }
+        sql.append(quoteIdent(whereCols.get(i))).append(" = ?");
+      }
+
+      List<Object> binds = new ArrayList<>(setValues.size() + whereValues.size());
+      binds.addAll(setValues);
+      binds.addAll(whereValues);
+      plans.add(
+          new PSPipelineSqlPlan(
+              PSPipelineSqlPlan.Kind.UPDATE, sql.toString(), binds, "update:" + table));
+    }
+    return plans;
+  }
+
+  /**
+   * Plan DELETE statements when updater allows delete.
+   *
+   * <p>WHERE is built from {@code keyColumns} (preferred) or mapped columns present on each row /
+   * shared {@code params}. Unrestricted deletes (empty WHERE) are rejected.
+   */
+  public static List<PSPipelineSqlPlan> planDeletes(
+      PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
+    Objects.requireNonNull(resource, "resource");
+    Objects.requireNonNull(request, "request");
+    if (!PipelineResourceIr.KIND_UPDATE.equals(resource.getKind())) {
+      throw new PSPipelineIrException(
+          "Resource kind is not UPDATE: " + resource.getKind() + " (" + resource.getName() + ")");
+    }
+    UpdaterStageIr updater =
+        resource.getStages() != null ? resource.getStages().getUpdater() : null;
+    if (updater == null || !updater.isPresent() || !updater.isAllowDelete()) {
+      throw new PSPipelineIrException(
+          "UPDATE resource does not allow delete (updater.allowDelete=false): "
+              + resource.getName());
+    }
+
+    String table = requireSingleTable(resource);
+    List<ColumnMapping> mappings = columnMappings(resource);
+    if (mappings.isEmpty()) {
+      throw new PSPipelineIrException(
+          "UPDATE resource has no COLUMN mappings for delete: " + resource.getName());
+    }
+
+    boolean keysExplicit = hasExplicitKeys(request);
+    KeySpec keys =
+        keysExplicit
+            ? resolveKeySpec(mappings, request, "Delete")
+            : new KeySpec(List.of(), Set.of(), Map.of());
+    List<Map<String, Object>> rows = mutationRows(request, "Delete");
+
+    List<PSPipelineSqlPlan> plans = new ArrayList<>();
+    for (Map<String, Object> row : rows) {
+      List<String> whereCols = new ArrayList<>();
+      List<Object> whereValues = new ArrayList<>();
+      if (keysExplicit) {
+        for (String keyCol : keys.orderedKeyColumns) {
+          Object kv = resolveKeyValue(row, keyCol, keys.sharedParams, mappings);
+          if (kv == null && !hasKeyPresent(row, keyCol, keys.sharedParams, mappings)) {
+            throw new PSPipelineIrException(
+                "Delete row missing key column value for WHERE: " + keyCol);
+          }
+          whereCols.add(keyCol);
+          whereValues.add(kv);
+        }
+      } else {
+        // No keyColumns/params: WHERE from mapped columns present on this row only
+        for (ColumnMapping m : mappings) {
+          if (!containsKeyForMapping(row, m)) {
+            continue;
+          }
+          whereCols.add(m.column);
+          whereValues.add(findValue(row, m));
+        }
+      }
+      if (whereCols.isEmpty()) {
+        throw new PSPipelineIrException(
+            "Delete requires a non-empty WHERE (keyColumns, params, or row key values): "
+                + resource.getName());
+      }
+
+      StringBuilder sql =
+          new StringBuilder("DELETE FROM ").append(quoteIdent(table)).append(" WHERE ");
+      for (int i = 0; i < whereCols.size(); i++) {
+        if (i > 0) {
+          sql.append(" AND ");
+        }
+        sql.append(quoteIdent(whereCols.get(i))).append(" = ?");
+      }
+      plans.add(
+          new PSPipelineSqlPlan(
+              PSPipelineSqlPlan.Kind.UPDATE, sql.toString(), whereValues, "delete:" + table));
+    }
+    return plans;
+  }
+
+  private static boolean hasExplicitKeys(PipelineExecuteRequest request) {
+    return (request.getKeyColumns() != null && !request.getKeyColumns().isEmpty())
+        || (request.getParams() != null && !request.getParams().isEmpty());
+  }
+
+  private static List<Map<String, Object>> mutationRows(
+      PipelineExecuteRequest request, String label) throws PSPipelineIrException {
+    List<Map<String, Object>> rows = new ArrayList<>();
+    if (request.getRows() != null && !request.getRows().isEmpty()) {
+      rows.addAll(request.getRows());
+    } else if (request.getParams() != null && !request.getParams().isEmpty()) {
+      rows.add(new LinkedHashMap<>(request.getParams()));
+    } else {
+      throw new PSPipelineIrException(label + " requires request.rows or request.params");
+    }
+    return rows;
+  }
+
+  private static KeySpec resolveKeySpec(
+      List<ColumnMapping> mappings, PipelineExecuteRequest request, String label)
+      throws PSPipelineIrException {
+    List<String> ordered = new ArrayList<>();
+    Set<String> upper = new HashSet<>();
+    Map<String, Object> shared =
+        request.getParams() != null ? request.getParams() : Map.of();
+
+    if (request.getKeyColumns() != null && !request.getKeyColumns().isEmpty()) {
+      for (String raw : request.getKeyColumns()) {
+        if (raw == null || raw.isBlank()) {
+          continue;
+        }
+        ColumnMapping match = findMappingForParam(mappings, raw.trim());
+        if (match == null) {
+          throw new PSPipelineIrException(
+              label + " keyColumns entry does not match a mapped column: " + raw);
+        }
+        String colKey = match.column.toUpperCase(Locale.ROOT);
+        if (upper.add(colKey)) {
+          ordered.add(match.column);
+        }
+      }
+    } else if (!shared.isEmpty()) {
+      // Shared params keys that map to columns become WHERE keys
+      for (Map.Entry<String, Object> e : shared.entrySet()) {
+        ColumnMapping match = findMappingForParam(mappings, e.getKey());
+        if (match == null) {
+          continue;
+        }
+        String colKey = match.column.toUpperCase(Locale.ROOT);
+        if (upper.add(colKey)) {
+          ordered.add(match.column);
+        }
+      }
+    }
+
+    if (ordered.isEmpty()) {
+      throw new PSPipelineIrException(
+          label
+              + " requires keyColumns or mapped params for WHERE (unrestricted mutation rejected): "
+              + "provide request.keyColumns or request.params matching mapped columns");
+    }
+    return new KeySpec(ordered, upper, shared);
+  }
+
+  private static Object resolveKeyValue(
+      Map<String, Object> row,
+      String keyCol,
+      Map<String, Object> sharedParams,
+      List<ColumnMapping> mappings) {
+    ColumnMapping m = findMappingForParam(mappings, keyCol);
+    if (m != null) {
+      Object fromRow = findValue(row, m);
+      if (fromRow != null || containsKeyForMapping(row, m)) {
+        return fromRow;
+      }
+    }
+    // Shared params (case-insensitive)
+    Object fromShared = findParamIgnoreCase(sharedParams, keyCol);
+    if (fromShared != null || containsKeyIgnoreCase(sharedParams, keyCol)) {
+      return fromShared;
+    }
+    if (m != null) {
+      Object byJson = findParamIgnoreCase(sharedParams, m.jsonField);
+      if (byJson != null || containsKeyIgnoreCase(sharedParams, m.jsonField)) {
+        return byJson;
+      }
+    }
+    return null;
+  }
+
+  private static boolean hasKeyPresent(
+      Map<String, Object> row,
+      String keyCol,
+      Map<String, Object> sharedParams,
+      List<ColumnMapping> mappings) {
+    ColumnMapping m = findMappingForParam(mappings, keyCol);
+    if (m != null && containsKeyForMapping(row, m)) {
+      return true;
+    }
+    if (containsKeyIgnoreCase(sharedParams, keyCol)) {
+      return true;
+    }
+    return m != null && containsKeyIgnoreCase(sharedParams, m.jsonField);
+  }
+
+  private static boolean containsKeyForMapping(Map<String, Object> row, ColumnMapping m) {
+    if (row.containsKey(m.column) || row.containsKey(m.jsonField)) {
+      return true;
+    }
+    for (String k : row.keySet()) {
+      if (k != null
+          && (k.equalsIgnoreCase(m.column) || k.equalsIgnoreCase(m.jsonField))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static final class KeySpec {
+    final List<String> orderedKeyColumns;
+    final Set<String> keyColumnNames;
+    final Map<String, Object> sharedParams;
+
+    KeySpec(
+        List<String> orderedKeyColumns,
+        Set<String> keyColumnNames,
+        Map<String, Object> sharedParams) {
+      this.orderedKeyColumns = orderedKeyColumns;
+      this.keyColumnNames = keyColumnNames;
+      this.sharedParams = sharedParams != null ? sharedParams : Map.of();
+    }
   }
 
   private static PSPipelineSqlPlan planNativeSelect(String nativeSql, PipelineExecuteRequest request)

--- a/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
+++ b/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -299,11 +300,265 @@ class PSPipelineRuntimeServiceTest {
   }
 
   @Test
+  @DisplayName("update: UPDATE when allowUpdate; SET non-keys WHERE keyColumns")
+  void executeUpdate_whenAllowed() throws Exception {
+    PipelineIrDocument doc =
+        nativeUpdateDocFlags("updAll", "Upd", true, true, false);
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("TYPE", "workflow");
+    row.put("NAME", "wf1");
+    row.put("LOOKUPVALUE", "42");
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    req.setOperation(PipelineExecuteRequest.OP_UPDATE);
+    req.setKeyColumns(List.of("TYPE", "NAME"));
+    req.setRows(List.of(row));
+
+    PipelineExecuteResult result = runtime.execute(doc, doc.findResource("Upd"), req);
+    assertEquals("update", result.getOperation());
+    assertEquals(1, result.getAffectedRows());
+
+    PipelineIrDocument qdoc = nativeQueryDoc("qUpd", "Q");
+    PipelineExecuteResult q =
+        runtime.execute(
+            qdoc,
+            qdoc.findResource("Q"),
+            PipelineExecuteRequest.ofParams(Map.of("TYPE", "workflow", "NAME", "wf1")));
+    assertEquals(1, q.getRowCount());
+    assertEquals("42", String.valueOf(q.getRows().get(0).get("Value")));
+  }
+
+  @Test
+  @DisplayName("update: DELETE when allowDelete")
+  void executeDelete_whenAllowed() throws Exception {
+    PipelineIrDocument doc =
+        nativeUpdateDocFlags("delApp", "Del", false, false, true);
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("TYPE", "locale");
+    row.put("NAME", "en-us");
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    req.setKeyColumns(List.of("TYPE", "NAME"));
+    req.setRows(List.of(row));
+
+    PipelineExecuteResult result = runtime.execute(doc, doc.findResource("Del"), req);
+    assertEquals("delete", result.getOperation());
+    assertEquals(1, result.getAffectedRows());
+
+    PipelineIrDocument qdoc = nativeQueryDoc("qDel", "Q");
+    PipelineExecuteResult q =
+        runtime.execute(
+            qdoc,
+            qdoc.findResource("Q"),
+            PipelineExecuteRequest.ofParams(Map.of("TYPE", "locale")));
+    assertEquals(0, q.getRowCount());
+  }
+
+  @Test
+  @DisplayName("update: reject UPDATE when allowUpdate=false with clear API error")
+  void executeUpdate_rejectedWhenNotAllowed() {
+    PipelineIrDocument doc = nativeUpdateDoc("noUpd", "InsOnly");
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    req.setOperation(PipelineExecuteRequest.OP_UPDATE);
+    req.setKeyColumns(List.of("TYPE", "NAME"));
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("TYPE", "workflow");
+    row.put("NAME", "wf1");
+    row.put("LOOKUPVALUE", "x");
+    req.setRows(List.of(row));
+
+    PSPipelineIrException ex =
+        assertThrows(
+            PSPipelineIrException.class,
+            () -> runtime.execute(doc, doc.findResource("InsOnly"), req));
+    assertTrue(
+        ex.getMessage().contains("does not allow update"),
+        () -> "message should mention allowUpdate: " + ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("update: reject DELETE when allowDelete=false with clear API error")
+  void executeDelete_rejectedWhenNotAllowed() {
+    PipelineIrDocument doc = nativeUpdateDoc("noDel", "InsOnly");
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    req.setOperation(PipelineExecuteRequest.OP_DELETE);
+    req.setKeyColumns(List.of("TYPE", "NAME"));
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("TYPE", "workflow");
+    row.put("NAME", "wf1");
+    req.setRows(List.of(row));
+
+    PSPipelineIrException ex =
+        assertThrows(
+            PSPipelineIrException.class,
+            () -> runtime.execute(doc, doc.findResource("InsOnly"), req));
+    assertTrue(
+        ex.getMessage().contains("does not allow delete"),
+        () -> "message should mention allowDelete: " + ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("update: multi-flag resource requires request.operation")
+  void execute_multiFlagRequiresOperation() {
+    PipelineIrDocument doc =
+        nativeUpdateDocFlags("multi", "M", true, true, true);
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("TYPE", "x");
+    row.put("NAME", "y");
+    row.put("LOOKUPVALUE", "z");
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    req.setRows(List.of(row));
+
+    PSPipelineIrException ex =
+        assertThrows(
+            PSPipelineIrException.class,
+            () -> runtime.execute(doc, doc.findResource("M"), req));
+    assertTrue(
+        ex.getMessage().contains("request.operation is required"),
+        () -> "message: " + ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("multi-row transactionMode=all commits all plans together")
+  void multiRow_transactionAll_commits() throws Exception {
+    PipelineIrDocument doc =
+        nativeUpdateDocFlags("txAll", "Ins", true, false, false);
+    doc.findResource("Ins").setTransactionMode("all");
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+
+    Map<String, Object> r1 = new LinkedHashMap<>();
+    r1.put("TYPE", "tx");
+    r1.put("NAME", "a");
+    r1.put("LOOKUPVALUE", "1");
+    Map<String, Object> r2 = new LinkedHashMap<>();
+    r2.put("TYPE", "tx");
+    r2.put("NAME", "b");
+    r2.put("LOOKUPVALUE", "2");
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    req.setRows(List.of(r1, r2));
+
+    PipelineExecuteResult result = runtime.execute(doc, doc.findResource("Ins"), req);
+    assertEquals(2, result.getAffectedRows());
+    assertEquals("all", result.getMeta().get("transactionMode"));
+
+    PipelineIrDocument qdoc = nativeQueryDoc("qTx", "Q");
+    PipelineExecuteResult q =
+        runtime.execute(
+            qdoc, qdoc.findResource("Q"), PipelineExecuteRequest.ofParams(Map.of("TYPE", "tx")));
+    assertEquals(2, q.getRowCount());
+  }
+
+  @Test
+  @DisplayName("multi-row transactionMode=all rolls back entire batch on failure")
+  void multiRow_transactionAll_rollsBackOnFailure() throws Exception {
+    // Seed one row; second insert in batch targets a not-null constrained table via dual plans:
+    // use DELETE of non-existent is fine; force failure with a plan against missing column via
+    // adapter updateAll directly after a successful first insert under same TX would need bad SQL.
+    // Instead: use two inserts then a third plan that fails — execute via adapter with mixed plans.
+    try (Connection c = DriverManager.getConnection(jdbcUrl);
+        Statement st = c.createStatement()) {
+      st.execute(
+          "CREATE TABLE \"TX_STRICT\" (\"ID\" VARCHAR(32) PRIMARY KEY, \"VAL\" VARCHAR(32) NOT NULL)");
+    }
+
+    List<Object> okBinds = new ArrayList<>();
+    okBinds.add("k1");
+    okBinds.add("v1");
+    List<Object> failBinds = new ArrayList<>();
+    failBinds.add("k2");
+    failBinds.add(null);
+    List<PSPipelineSqlPlan> plans =
+        List.of(
+            new PSPipelineSqlPlan(
+                PSPipelineSqlPlan.Kind.UPDATE,
+                "INSERT INTO \"TX_STRICT\" (\"ID\", \"VAL\") VALUES (?, ?)",
+                okBinds,
+                "ok1"),
+            new PSPipelineSqlPlan(
+                PSPipelineSqlPlan.Kind.UPDATE,
+                "INSERT INTO \"TX_STRICT\" (\"ID\", \"VAL\") VALUES (?, ?)",
+                failBinds,
+                "fail-null"));
+
+    PSPipelineIrException ex =
+        assertThrows(
+            PSPipelineIrException.class, () -> sqlAdapter.updateAll(plans, "all"));
+    assertTrue(
+        ex.getMessage().toLowerCase().contains("rolled back")
+            || ex.getMessage().toLowerCase().contains("batch failed"),
+        () -> "expected rollback message: " + ex.getMessage());
+
+    try (Connection c = DriverManager.getConnection(jdbcUrl);
+        Statement st = c.createStatement();
+        var rs = st.executeQuery("SELECT COUNT(*) FROM \"TX_STRICT\"")) {
+      assertTrue(rs.next());
+      assertEquals(0, rs.getInt(1), "first insert must roll back with the failed batch");
+    }
+  }
+
+  @Test
+  @DisplayName("multi-row transactionMode=row commits successful plans before a failure")
+  void multiRow_transactionRow_commitsPriorPlans() throws Exception {
+    try (Connection c = DriverManager.getConnection(jdbcUrl);
+        Statement st = c.createStatement()) {
+      st.execute(
+          "CREATE TABLE \"TX_ROW\" (\"ID\" VARCHAR(32) PRIMARY KEY, \"VAL\" VARCHAR(32) NOT NULL)");
+    }
+
+    List<Object> okBinds = new ArrayList<>();
+    okBinds.add("r1");
+    okBinds.add("ok");
+    List<Object> failBinds = new ArrayList<>();
+    failBinds.add("r2");
+    failBinds.add(null);
+    List<PSPipelineSqlPlan> plans =
+        List.of(
+            new PSPipelineSqlPlan(
+                PSPipelineSqlPlan.Kind.UPDATE,
+                "INSERT INTO \"TX_ROW\" (\"ID\", \"VAL\") VALUES (?, ?)",
+                okBinds,
+                "ok1"),
+            new PSPipelineSqlPlan(
+                PSPipelineSqlPlan.Kind.UPDATE,
+                "INSERT INTO \"TX_ROW\" (\"ID\", \"VAL\") VALUES (?, ?)",
+                failBinds,
+                "fail-null"));
+
+    assertThrows(PSPipelineIrException.class, () -> sqlAdapter.updateAll(plans, "row"));
+
+    try (Connection c = DriverManager.getConnection(jdbcUrl);
+        Statement st = c.createStatement();
+        var rs = st.executeQuery("SELECT COUNT(*) FROM \"TX_ROW\"")) {
+      assertTrue(rs.next());
+      assertEquals(1, rs.getInt(1), "row mode keeps prior committed plans");
+    }
+  }
+
+  @Test
   @DisplayName("JSON request codec parses params")
   void requestJsonCodec() throws Exception {
     PipelineExecuteRequest req =
         PSPipelineExecuteJsonCodec.requestFromJson("{\"params\":{\"TYPE\":\"workflow\"}}");
     assertEquals("workflow", req.getParams().get("TYPE"));
+  }
+
+  @Test
+  @DisplayName("JSON request codec parses operation and keyColumns")
+  void requestJsonCodec_operationAndKeys() throws Exception {
+    PipelineExecuteRequest req =
+        PSPipelineExecuteJsonCodec.requestFromJson(
+            "{\"operation\":\"update\",\"keyColumns\":[\"TYPE\",\"NAME\"],"
+                + "\"rows\":[{\"TYPE\":\"workflow\",\"NAME\":\"wf1\",\"LOOKUPVALUE\":\"1\"}]}");
+    assertEquals("update", req.getOperation());
+    assertEquals(List.of("TYPE", "NAME"), req.getKeyColumns());
+    assertEquals(1, req.getRows().size());
   }
 
   @Test
@@ -368,6 +623,15 @@ class PSPipelineRuntimeServiceTest {
   }
 
   private static PipelineIrDocument nativeUpdateDoc(String appName, String resourceName) {
+    return nativeUpdateDocFlags(appName, resourceName, true, false, false);
+  }
+
+  private static PipelineIrDocument nativeUpdateDocFlags(
+      String appName,
+      String resourceName,
+      boolean allowInsert,
+      boolean allowUpdate,
+      boolean allowDelete) {
     PipelineIrDocument doc = new PipelineIrDocument();
     doc.setSource(PipelineIrDocument.SOURCE_NATIVE);
     doc.getApp().setName(appName);
@@ -396,9 +660,9 @@ class PSPipelineRuntimeServiceTest {
 
     UpdaterStageIr updater = new UpdaterStageIr();
     updater.setPresent(true);
-    updater.setAllowInsert(true);
-    updater.setAllowUpdate(false);
-    updater.setAllowDelete(false);
+    updater.setAllowInsert(allowInsert);
+    updater.setAllowUpdate(allowUpdate);
+    updater.setAllowDelete(allowDelete);
     stages.setUpdater(updater);
 
     res.setStages(stages);


### PR DESCRIPTION
## Summary
Implements **Pipelines Slice A residual** (#2340): richer **UPDATE/DELETE** for pipeline runtime when IR `updater.allowUpdate` / `allowDelete` allow it; multi-row **transaction modes** (`none` / `row` / `all`) documented and H2-tested.

**Parent tracker:** #1690  
**Parent residual of:** #2269 (thin REST #2341)  
**Also refs:** #2248

### What shipped
- `PSPipelineSqlPlanner.resolveMutationOperation` + `planUpdates` / `planDeletes` gated on updater flags
- Clear API errors when flags disallow or multi-flag resource omits `request.operation`
- `PipelineExecuteRequest.operation` / `keyColumns` for mutation selection and WHERE keys
- `IPSPipelineSqlAdapter#updateAll` + JDBC implementation for `transactionMode`:
  - `none` — auto-commit per plan
  - `row` — commit per plan (prior plans kept on later failure)
  - `all` — single connection; full batch rollback on failure
- Docs: `docs/developer-module/pipeline-ir-v1.md` mutation + txn tables
- Unblock: `PSNavonNodeInvocationHandler` typed copy from `Map<?,?> getMap()` (main compile break after utils typing)

### Residual
- Joins / where-clause IR only: https://github.com/intersoftdatalabs-in/percussioncms/issues/2359

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (~1m40s)
- [x] `PSPipelineRuntimeServiceTest`: **20 tests**, 0 failures (UPDATE/DELETE flags, multi-flag requires operation, txn all commit+rollback, txn row keeps prior)
- [x] Existing insert/query/hooks paths still green

## Gates evidence
- Module clean install: standalone `system` `mvnw clean install`
- Erlang self-review: parameterized SQL only; unrestricted DELETE/UPDATE rejected; portable (no path I/O changes); Intersoft headers on existing 2026 files retained
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2340  
Refs #2269 #2248 #1690  
Residual https://github.com/intersoftdatalabs-in/percussioncms/issues/2359

> Co-Authored by Grok Build using grok-4.5 with agent main.