### PR TITLE
feat(ops): default logrotate samples for CMS Jetty and DTS Tomcat (#2348)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -127,6 +127,16 @@ before writing Procrun `--JavaHome` or `/etc/default/<service>`. See
 `specs/991-system-java-home/quickstart.md` for re-point steps (edit
 `java.properties`, restart — no JRE folder required).
 
+## Log rotation samples (GH-2348)
+
+Standalone DTS ships **opt-in** Linux `logrotate` samples under `logrotate/` at the install root (`percussion-dts` + README). They are **not** copied into `/etc/logrotate.d` automatically.
+
+- Covers `Deployment/Server/logs` (`*.log`, `*.out` including `catalina.out`)
+- Defaults: daily, rotate 14, compress, **copytruncate**
+- Dry-run: `logrotate -d /etc/logrotate.d/percussion-dts` after path substitution
+- Co-located CMS installs also keep the full CMS+DTS samples under `rxconfig/Installer/logrotate/`
+- Windows: schedule `perc-doctor clean-logs --older-than 14d` (see CMS logrotate README)
+
 ## Linux services (systemd) — GH-962 / dual-ship (GH-1978)
 
 Production and Staging installers under `src/main/rootFiles/` prefer **native systemd**

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/logrotate/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/logrotate/README.md
@@ -1,0 +1,29 @@
+# DTS logrotate sample (standalone package)
+
+**Issue:** [#2348](https://github.com/intersoftdatalabs-in/percussioncms/issues/2348)
+
+Standalone DTS ships `logrotate/percussion-dts` at the install root for operators who run DTS on a host without a full CMS tree.
+
+| File | Role |
+|------|------|
+| `percussion-dts` | Linux `logrotate` fragment for `Deployment/Server/logs` (`*.log`, `*.out` including `catalina.out`) |
+| `README.md` | This note |
+
+**Not auto-enabled.** Copy to `/etc/logrotate.d/` only with operator consent after substituting the install root and running `logrotate -d`.
+
+```bash
+INSTALL_ROOT=/opt/Percussion   # this DTS install root
+sed "s|/opt/Percussion|${INSTALL_ROOT}|g" \
+  "${INSTALL_ROOT}/logrotate/percussion-dts" \
+  | sudo tee /etc/logrotate.d/percussion-dts >/dev/null
+sudo chmod 0644 /etc/logrotate.d/percussion-dts
+sudo logrotate -d /etc/logrotate.d/percussion-dts
+```
+
+Defaults: daily, rotate 14, compress, delaycompress, **copytruncate**, missingok, notifempty.
+
+Full operator guide (CMS + DTS coexistence with Log4j2 and `perc-doctor clean-logs`, Windows Task Scheduler sample) lives with the CMS distribution at:
+
+`rxconfig/Installer/logrotate/README.md`
+
+Related: `README-systemd.md` (Linux service dual-ship), `README-windows-service.md`.

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/logrotate/percussion-dts
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/logrotate/percussion-dts
@@ -1,0 +1,37 @@
+# Percussion DTS / Tomcat — sample logrotate policy (issue #2348)
+#
+# Shipped with standalone DTS under:
+#   <dts-install-root>/logrotate/percussion-dts
+#
+# When co-located with CMS, prefer the CMS install tree copy:
+#   <install-root>/rxconfig/Installer/logrotate/percussion-dts
+#
+# This file is a SAMPLE. It is NOT installed into /etc/logrotate.d automatically.
+# Operators must copy (or symlink) it after substituting the install root.
+#
+# Default placeholder root (document substitution):
+#   /opt/Percussion
+# Split-host DTS: substitute $DTS_HOME / this install root so paths resolve to
+# Deployment/Server/logs (catalina.base/logs).
+#
+# Install (Linux, as root — only with operator consent):
+#   1. Edit paths below (or sed-replace /opt/Percussion).
+#   2. install -m 0644 percussion-dts /etc/logrotate.d/percussion-dts
+#   3. Dry-run: logrotate -d /etc/logrotate.d/percussion-dts
+#
+# Prefer copytruncate so Tomcat keeps writing without a hard restart.
+# Coexistence: DTS Log4j2 rolling + this OS policy + optional perc-doctor clean-logs.
+# See logrotate/README.md in this directory (and CMS rxconfig/Installer/logrotate).
+
+/opt/Percussion/Deployment/Server/logs/*.log
+/opt/Percussion/Deployment/Server/logs/*.out
+{
+    daily
+    rotate 14
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    sharedscripts
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
@@ -517,6 +517,19 @@
 					</copy>
 
 					<!--
+					  GH-2348: sample logrotate policy for Deployment/Server/logs.
+					  rootFiles/logrotate/ is a directory — install-root bulk copy uses
+					  name="*" (files only), so ship the tree explicitly. SAMPLE only;
+					  operators copy into /etc/logrotate.d with consent (not auto-enabled).
+					-->
+					<copy todir="${install.dir}${staging.dir}/logrotate" verbose="true"
+						failonerror="false">
+						<fileset dir="${install.src}/logrotate" erroronmissingdir="false">
+							<include name="**" />
+						</fileset>
+					</copy>
+
+					<!--
 					  Role-specific service installer lives under Deployment/Server.
 					  Service scripts are excluded from the install-root * copy above so
 					  only Production OR Staging lands here (not both). Windows binaries
@@ -842,6 +855,17 @@
 							<exclude name="DTSProductionService.sh" />
 							<exclude name="DTSStagingService.sh" />
 
+						</fileset>
+					</copy>
+
+					<!--
+					  GH-2348: refresh sample logrotate tree on upgrade (directory is not
+					  covered by install-root name="*" bulk copy). SAMPLE only; not auto-enabled.
+					-->
+					<copy todir="${install.dir}${staging.dir}/logrotate" overwrite="true"
+						force="true" verbose="true" failonerror="false">
+						<fileset dir="${install.src}/logrotate" erroronmissingdir="false">
+							<include name="**" />
 						</fileset>
 					</copy>
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsLogrotateSamplePackagingTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsLogrotateSamplePackagingTest.java
@@ -78,8 +78,8 @@ class DtsLogrotateSamplePackagingTest {
         xml.contains("logrotate"),
         "installDts.xml must reference logrotate sample packaging (GH-2348)");
     assertTrue(
-        xml.contains("install.src}/logrotate") || xml.contains("${install.src}/logrotate"),
-        "installDts must copy from install.src/logrotate");
+        xml.contains("${install.src}/logrotate"),
+        "installDts must copy from ${install.src}/logrotate");
     assertTrue(
         xml.contains("/logrotate"),
         "installDts must land samples under install-root logrotate/");

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsLogrotateSamplePackagingTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsLogrotateSamplePackagingTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.delivery.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #2348: standalone DTS ships sample logrotate under {@code rootFiles/logrotate/} and {@code
+ * installDts.xml} copies that tree to the install root (bulk {@code *} copy is files-only).
+ *
+ * <p>Structural only — no live logrotate, no root.
+ */
+class DtsLogrotateSamplePackagingTest {
+
+  private static final Path ROOT_FILES = Path.of("src", "main", "rootFiles");
+  private static final Path LOGROTATE_DIR = ROOT_FILES.resolve("logrotate");
+  private static final Path POLICY = LOGROTATE_DIR.resolve("percussion-dts");
+  private static final Path README = LOGROTATE_DIR.resolve("README.md");
+  private static final Path INSTALL_DTS =
+      ROOT_FILES.resolve(Path.of("rxconfig", "Installer", "installDts.xml"));
+
+  private static final Pattern HARDCODED_USER_HOME =
+      Pattern.compile(
+          "(?i)(C:\\\\Users\\\\[A-Za-z]|/home/[a-zA-Z0-9._-]+|/Users/[A-Za-z]|\\\\Users\\\\Nate)");
+
+  @Test
+  @DisplayName("rootFiles ship DTS logrotate sample + README")
+  void rootFilesShipLogrotateSample() {
+    assertTrue(Files.isDirectory(LOGROTATE_DIR), () -> "missing " + LOGROTATE_DIR.toAbsolutePath());
+    assertTrue(Files.isRegularFile(POLICY), () -> "missing " + POLICY.toAbsolutePath());
+    assertTrue(Files.isRegularFile(README), () -> "missing " + README.toAbsolutePath());
+  }
+
+  @Test
+  @DisplayName("DTS logrotate sample covers Deployment/Server/logs with copytruncate")
+  void policyContent() throws IOException {
+    String text = Files.readString(POLICY, StandardCharsets.UTF_8);
+    assertFalse(HARDCODED_USER_HOME.matcher(text).find(), "policy must not hardcode user home");
+    assertTrue(text.contains("Deployment/Server/logs"), "must target Tomcat logs dir");
+    assertTrue(text.contains("*.out"), "must cover catalina.out via *.out");
+    assertTrue(text.contains("copytruncate"), "must prefer copytruncate");
+    assertTrue(text.contains("rotate 14"), "default rotate 14");
+    assertTrue(
+        text.toLowerCase().contains("sample") || text.contains("NOT installed"),
+        "must state sample / not auto-installed");
+  }
+
+  @Test
+  @DisplayName("installDts.xml copies logrotate tree on fresh install and upgrade")
+  void installDtsCopiesLogrotateTree() throws IOException {
+    assertTrue(Files.isRegularFile(INSTALL_DTS), () -> "missing " + INSTALL_DTS.toAbsolutePath());
+    String xml = Files.readString(INSTALL_DTS, StandardCharsets.UTF_8);
+    assertTrue(
+        xml.contains("logrotate"),
+        "installDts.xml must reference logrotate sample packaging (GH-2348)");
+    assertTrue(
+        xml.contains("install.src}/logrotate") || xml.contains("${install.src}/logrotate"),
+        "installDts must copy from install.src/logrotate");
+    assertTrue(
+        xml.contains("/logrotate"),
+        "installDts must land samples under install-root logrotate/");
+    // Expect at least two copy blocks (fresh + upgrade) mentioning logrotate
+    int idx = 0;
+    int count = 0;
+    while ((idx = xml.indexOf("logrotate", idx)) >= 0) {
+      count++;
+      idx += "logrotate".length();
+    }
+    assertTrue(count >= 4, "expect multiple logrotate references (comment + fresh + upgrade)");
+  }
+
+  @Test
+  @DisplayName("DTS logrotate README documents dry-run and opt-in install")
+  void readmeDocumentsOptIn() throws IOException {
+    String text = Files.readString(README, StandardCharsets.UTF_8);
+    assertFalse(HARDCODED_USER_HOME.matcher(text).find(), "README must not hardcode user home");
+    assertTrue(text.contains("logrotate -d"), "README must document dry-run");
+    assertTrue(text.contains("/etc/logrotate.d"), "README must document logrotate.d path");
+    assertTrue(
+        text.toLowerCase().contains("not auto")
+            || text.toLowerCase().contains("operator consent")
+            || text.contains("Not auto-enabled"),
+        "README must state not auto-enabled");
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-2348-logrotate-samples-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2348-logrotate-samples-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — issue #2348 default logrotate samples
+
+**Branch:** `fix/issue-2348-default-logrotate`  
+**Change class:** installer/packaging samples + operator docs (no runtime Java behavior change beyond packaging tests)
+
+## Verdict
+
+**PASS** for commit/PR. Packaging samples + structural unit tests + docs; opt-in only; portable paths.
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in new logic | N/A runtime — samples are static config; installDts copy is failonerror=false + erroronmissingdir=false |
+| Behavioral unit tests | Structural packaging tests (CMS 6, DTS 4, perc-doctor guide assertion) |
+| Portable path / file I/O | Pass — generic `/opt/Percussion`, `C:\Percussion`; no developer homes; PS1 resolves install root via script location + `Join-Path` |
+| Change-class companions | Samples + README + installDts wiring + packaging tests + perc-doctor docs |
+| Auto-enable without consent | Documented opt-in; not written to `/etc/logrotate.d` by installer |
+| copytruncate / catalina.out | Present on both CMS and DTS samples (`*.out`) |
+
+## Module clean install
+
+| Module | Result |
+|--------|--------|
+| `modules/perc-doctor` | BUILD SUCCESS |
+| `modules/perc-distribution-tree` | BUILD SUCCESS (LogrotateSamplePackagingTest 6/6) |
+| `delivery-tier-distribution` | BUILD SUCCESS (DtsLogrotateSamplePackagingTest 4/4) |
+
+## Residual
+
+None for acceptance criteria. Optional future: installer checkbox to copy into logrotate.d (explicitly out of scope).

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/README.md
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/README.md
@@ -1,0 +1,144 @@
+# Default log rotation samples (CMS / Jetty + DTS / Tomcat)
+
+**Issue:** [#2348](https://github.com/intersoftdatalabs-in/percussioncms/issues/2348)  
+**Ship path (CMS install tree):** `<install-root>/rxconfig/Installer/logrotate/`
+
+These files are **operator samples**. They are **not** auto-enabled on Linux or Windows. Copy or schedule them only with operator consent after path substitution and a dry-run.
+
+## Contents
+
+| File | Role |
+|------|------|
+| `percussion-cms` | Linux `logrotate` fragment for CMS Jetty log roots |
+| `percussion-dts` | Linux `logrotate` fragment for DTS Tomcat `Deployment/Server/logs` (includes `catalina.out` via `*.out`) |
+| `schedule-clean-logs.ps1` | Windows sample: scheduled `perc-doctor clean-logs` (14-day default) |
+| `README.md` | This guide |
+
+Standalone DTS packages also ship `logrotate/percussion-dts` (+ this guide) at the DTS install root for split-host layouts.
+
+## Log roots covered
+
+Aligned with `perc-doctor` `InstallRootGuard.LOG_DIR_RELATIVE` and install layout:
+
+| Product | Relative root | Typical files |
+|---------|---------------|---------------|
+| CMS / Jetty | `jetty/base/logs` | Jetty / request / layout logs, `audit/` |
+| CMS / Jetty | `jetty/base/modules/perc-logging/logs` | Log4j2 app logs (`server.log`, rotations) |
+| DTS / Tomcat | `Deployment/Server/logs` | `catalina.out`, `catalina.*.log`, access / host-manager / manager logs |
+
+Globs are limited to `*.log` and `*.out` (same spirit as `InstallRootGuard.isLogFileName`).
+
+## Linux: enable logrotate (manual)
+
+**Default retention:** daily, keep 14 compressed archives, `copytruncate`, `missingok`, `notifempty`, `delaycompress`.
+
+1. Substitute the install root (`/opt/Percussion` is the documented placeholder).
+
+   ```bash
+   INSTALL_ROOT=/opt/Percussion   # or $PERCUSSION_HOME / $DTS_HOME
+   sed "s|/opt/Percussion|${INSTALL_ROOT}|g" \
+     "${INSTALL_ROOT}/rxconfig/Installer/logrotate/percussion-cms" \
+     > /tmp/percussion-cms
+   ```
+
+2. Install into `logrotate.d` **only when you intend to enable OS rotation**:
+
+   ```bash
+   sudo install -m 0644 /tmp/percussion-cms /etc/logrotate.d/percussion-cms
+   # Optional second host / co-located DTS:
+   sed "s|/opt/Percussion|${INSTALL_ROOT}|g" \
+     "${INSTALL_ROOT}/rxconfig/Installer/logrotate/percussion-dts" \
+     | sudo tee /etc/logrotate.d/percussion-dts >/dev/null
+   sudo chmod 0644 /etc/logrotate.d/percussion-dts
+   ```
+
+3. Dry-run (no changes):
+
+   ```bash
+   sudo logrotate -d /etc/logrotate.d/percussion-cms
+   sudo logrotate -d /etc/logrotate.d/percussion-dts
+   ```
+
+4. Optional one-shot force after dry-run looks correct:
+
+   ```bash
+   sudo logrotate -f /etc/logrotate.d/percussion-cms
+   ```
+
+### Why `copytruncate`
+
+Jetty, Log4j2, and Tomcat often keep log file handles open. `copytruncate` rotates without requiring a process restart or signal. Optional `postrotate` `systemctl reload` stanzas are commented in the samples for sites that standardize on dual-ship systemd units (GH-962).
+
+### Split CMS vs DTS hosts
+
+- CMS-only host: install `percussion-cms` only.
+- DTS-only host: install `percussion-dts` with paths under that host’s DTS install root (`…/Deployment/Server/logs`). Use the copy shipped under CMS `rxconfig/Installer/logrotate/` or the standalone DTS package `logrotate/` directory.
+- Co-located: install both fragments; both may share the same `/opt/Percussion` (or site-specific) root.
+
+## Coexistence: Log4j2, logrotate, perc-doctor
+
+| Layer | Owns | Default behaviour |
+|-------|------|-------------------|
+| **Log4j2 RollingFile** (CMS perc-logging / DTS service configs) | Active application log streams | Size-based rollover (CMS pattern: ~10 MB × keep 10) |
+| **OS logrotate** (these samples) | Continuous `*.log` / `*.out` under known roots, especially `catalina.out` and anything not fully handled by Log4j | Daily, 14 rotations, compress, **copytruncate** |
+| **perc-doctor `clean-logs`** | Allowlisted log **files** under the same roots | Age / keep-current purge — **manual or scheduled CLI**, not a replacement for rotation |
+
+Recommended production posture:
+
+1. Leave Log4j2 defaults as shipped (size caps for app logs).
+2. Enable OS logrotate for Linux hosts that need a hard ceiling on `catalina.out` / unbounded `*.out` and long-lived archives.
+3. Schedule `perc-doctor clean-logs --older-than 14d` (or site policy) to reclaim aged rotated/compressed files when disk policy requires it.
+
+Double-rotation (Log4j + logrotate on the same basename) is an acceptable safety net: Log4j bounds active size; logrotate ages leftover handles; `clean-logs` deletes old allowlisted files. Prefer **not** excluding Log4j paths from logrotate unless support has a site-specific reason.
+
+## Windows: scheduled clean-logs
+
+Windows does not use classic `logrotate`. Documented equivalent:
+
+1. Prefer dry-run:
+
+   ```bat
+   cd /d C:\Percussion
+   bin\perc-doctor.bat --dry-run -v clean-logs --older-than 14d
+   ```
+
+2. Or use the sample script (defaults to dry-run):
+
+   ```powershell
+   cd C:\Percussion\rxconfig\Installer\logrotate
+   .\schedule-clean-logs.ps1 -InstallRoot 'C:\Percussion' -DryRun $true
+   ```
+
+3. After review, schedule apply with Task Scheduler (example action):
+
+   ```text
+   Program: powershell.exe
+   Arguments:
+     -NoProfile -ExecutionPolicy Bypass -File "C:\Percussion\rxconfig\Installer\logrotate\schedule-clean-logs.ps1" -InstallRoot "C:\Percussion" -OlderThan "14d" -DryRun:$false
+   Trigger: Daily (off-hours recommended)
+   ```
+
+4. Alternate Task Scheduler action without the script:
+
+   ```text
+   Program: C:\Percussion\bin\perc-doctor.bat
+   Arguments: --install-root C:\Percussion -v clean-logs --older-than 14d
+   ```
+
+Always validate with `--dry-run` / `-DryRun $true` before enabling unattended apply.
+
+## Support baseline
+
+| Item | Default |
+|------|---------|
+| Canonical sample path | `<install-root>/rxconfig/Installer/logrotate/` |
+| Linux retention | 14 daily compressed archives, `copytruncate` |
+| Windows retention | `perc-doctor clean-logs --older-than 14d` (keep-current default) |
+| Auto-enable on install | **No** — operator consent required |
+
+## Related
+
+- `modules/perc-doctor` — `clean-logs`, operator install guide
+- `modules/perc-jetty` — Log4j2 / Jetty logging layout
+- DTS dual-ship systemd notes — `README-systemd.md` (optional postrotate)
+- Parent packaging: `modules/perc-distribution-tree`, `delivery-tier-distribution`

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/percussion-cms
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/percussion-cms
@@ -1,0 +1,56 @@
+# Percussion CMS / Jetty — sample logrotate policy (issue #2348)
+#
+# Canonical install path (after CMS install/upgrade):
+#   <install-root>/rxconfig/Installer/logrotate/percussion-cms
+#
+# This file is a SAMPLE. It is NOT installed into /etc/logrotate.d automatically.
+# Operators must copy (or symlink) it after substituting the install root.
+#
+# Default placeholder root (document substitution):
+#   /opt/Percussion
+# Also common: $PERCUSSION_HOME, /usr/local/Percussion, custom mounts.
+#
+# Install (Linux, as root — only with operator consent):
+#   1. Edit INSTALL_ROOT below (or sed-replace /opt/Percussion).
+#   2. install -m 0644 percussion-cms /etc/logrotate.d/percussion-cms
+#   3. Dry-run: logrotate -d /etc/logrotate.d/percussion-cms
+#   4. Force once (optional): logrotate -f /etc/logrotate.d/percussion-cms
+#
+# Why copytruncate:
+#   Jetty / Log4j2 keep file handles open. copytruncate rotates without requiring
+#   a process signal or restart. Prefer this over create + postrotate unless you
+#   have a documented reload path.
+#
+# Coexistence (who owns what):
+#   - Log4j2 RollingFile (perc-logging): size-based rollover for app logs
+#     (typically 10 MB × keep 10). Primary owner of server.log / velocity.log etc.
+#   - This logrotate policy: OS safety net for continuous *.log / *.out under
+#     Jetty log roots, including audit and any non-Log4j handles.
+#   - perc-doctor clean-logs: age-based purge of allowlisted log names under the
+#     same roots (manual or scheduled). Complements rotation; does not replace it.
+#   Double-rotation is acceptable: Log4j keeps active size bounds; logrotate
+#   compresses/ages leftover files; clean-logs removes aged archives operators
+#   no longer need.
+#
+# Globs align with perc-doctor InstallRootGuard log roots + isLogFileName spirit
+# (.log / .out only — not arbitrary junk under the log trees).
+
+/opt/Percussion/jetty/base/logs/*.log
+/opt/Percussion/jetty/base/logs/*.out
+/opt/Percussion/jetty/base/logs/audit/*.log
+/opt/Percussion/jetty/base/modules/perc-logging/logs/*.log
+/opt/Percussion/jetty/base/modules/perc-logging/logs/*.out
+{
+    daily
+    rotate 14
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    sharedscripts
+    # Optional when CMS systemd units are installed (GH-962 dual-ship):
+    # postrotate
+    #     systemctl reload percussion-cms.service >/dev/null 2>&1 || true
+    # endscript
+}

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/percussion-dts
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/percussion-dts
@@ -1,0 +1,54 @@
+# Percussion DTS / Tomcat — sample logrotate policy (issue #2348)
+#
+# Canonical install path when co-located with CMS (after CMS install/upgrade):
+#   <install-root>/rxconfig/Installer/logrotate/percussion-dts
+#
+# Standalone DTS package also ships the same sample under:
+#   <dts-install-root>/logrotate/percussion-dts
+#
+# This file is a SAMPLE. It is NOT installed into /etc/logrotate.d automatically.
+# Operators must copy (or symlink) it after substituting the install root.
+#
+# Default placeholder root (document substitution):
+#   /opt/Percussion
+# Split-host DTS often uses a dedicated root; substitute $DTS_HOME / install dir
+# so paths resolve to Deployment/Server/logs (catalina.base/logs).
+#
+# Install (Linux, as root — only with operator consent):
+#   1. Edit INSTALL_ROOT below (or sed-replace /opt/Percussion).
+#   2. install -m 0644 percussion-dts /etc/logrotate.d/percussion-dts
+#   3. Dry-run: logrotate -d /etc/logrotate.d/percussion-dts
+#   4. Force once (optional): logrotate -f /etc/logrotate.d/percussion-dts
+#
+# Why copytruncate:
+#   Tomcat and JUL often keep catalina.out / continuous log handles open.
+#   copytruncate rotates without a hard restart. Prefer this over create +
+#   signal unless postrotate is wired to a known safe reload.
+#
+# Coexistence (who owns what):
+#   - DTS / Tomcat Log4j2 configs: app-level rolling for service logs.
+#   - This logrotate policy: OS safety net for catalina.out, catalina.*.log,
+#     localhost/host-manager/manager/access logs, and other *.log / *.out under
+#     Deployment/Server/logs.
+#   - perc-doctor clean-logs: age-based purge under the same allowlisted root
+#     (manual or scheduled). Complements rotation.
+#
+# Globs align with perc-doctor InstallRootGuard (Deployment/Server/logs) and
+# isLogFileName (.log / .out). catalina.out is explicitly covered by *.out.
+
+/opt/Percussion/Deployment/Server/logs/*.log
+/opt/Percussion/Deployment/Server/logs/*.out
+{
+    daily
+    rotate 14
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    sharedscripts
+    # Optional when DTS systemd units are installed (GH-962 dual-ship):
+    # postrotate
+    #     systemctl reload PercussionDTSProduction.service >/dev/null 2>&1 || true
+    # endscript
+}

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/schedule-clean-logs.ps1
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/schedule-clean-logs.ps1
@@ -28,7 +28,7 @@
 
 .PARAMETER InstallRoot
   CMS (or co-located CMS+DTS) install root. Defaults to parent of this script's
-  install tree when placed under rxconfig/Installer/logrotate (four levels up),
+  install tree when placed under rxconfig/Installer/logrotate (three levels up),
   otherwise requires an explicit path. Generic examples: C:\Percussion
 
 .PARAMETER OlderThan
@@ -63,11 +63,12 @@ $ErrorActionPreference = 'Stop'
 
 function Resolve-DefaultInstallRoot {
     # This sample lives at <install-root>/rxconfig/Installer/logrotate/
+    # Climb three levels: logrotate -> Installer -> rxconfig -> install-root
     $here = $PSScriptRoot
     if (-not $here) {
         $here = Split-Path -Parent $MyInvocation.MyCommand.Path
     }
-    $candidate = (Resolve-Path (Join-Path $here '..\..\..\..')).Path
+    $candidate = (Resolve-Path (Join-Path $here '..\..\..')).Path
     $doctorBat = Join-Path $candidate 'bin\perc-doctor.bat'
     if (Test-Path -LiteralPath $doctorBat) {
         return $candidate

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/schedule-clean-logs.ps1
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/logrotate/schedule-clean-logs.ps1
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Intersoft Data Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+<#
+.SYNOPSIS
+  Sample Windows scheduled retention for Percussion CMS / DTS logs via perc-doctor.
+
+.DESCRIPTION
+  Classic Linux logrotate is not available on Windows. Operators should schedule
+  perc-doctor clean-logs (age-based purge of allowlisted files under known log
+  roots) as the documented Windows counterpart to the Linux logrotate samples
+  in this directory (issue #2348).
+
+  This script is a SAMPLE. It is not registered with Task Scheduler automatically.
+  Prefer dry-run first. Do not enable unattended apply without operator review.
+
+.PARAMETER InstallRoot
+  CMS (or co-located CMS+DTS) install root. Defaults to parent of this script's
+  install tree when placed under rxconfig/Installer/logrotate (four levels up),
+  otherwise requires an explicit path. Generic examples: C:\Percussion
+
+.PARAMETER OlderThan
+  Duration passed to clean-logs (e.g. 14d). Default 14d matches logrotate rotate 14.
+
+.PARAMETER DryRun
+  When set, pass --dry-run (report only). Default: $true for safety.
+
+.EXAMPLE
+  # Preview only (safe)
+  .\schedule-clean-logs.ps1 -InstallRoot 'C:\Percussion' -DryRun
+
+.EXAMPLE
+  # Apply after operator review (Task Scheduler action)
+  .\schedule-clean-logs.ps1 -InstallRoot 'C:\Percussion' -OlderThan '14d' -DryRun:$false
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string] $InstallRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string] $OlderThan = '14d',
+
+    [Parameter(Mandatory = $false)]
+    [bool] $DryRun = $true
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-DefaultInstallRoot {
+    # This sample lives at <install-root>/rxconfig/Installer/logrotate/
+    $here = $PSScriptRoot
+    if (-not $here) {
+        $here = Split-Path -Parent $MyInvocation.MyCommand.Path
+    }
+    $candidate = (Resolve-Path (Join-Path $here '..\..\..\..')).Path
+    $doctorBat = Join-Path $candidate 'bin\perc-doctor.bat'
+    if (Test-Path -LiteralPath $doctorBat) {
+        return $candidate
+    }
+    return $null
+}
+
+if (-not $InstallRoot) {
+    $InstallRoot = Resolve-DefaultInstallRoot
+}
+
+if (-not $InstallRoot) {
+    Write-Error "InstallRoot is required (e.g. -InstallRoot 'C:\Percussion'). Could not infer from script location."
+}
+
+$InstallRoot = (Resolve-Path -LiteralPath $InstallRoot).Path
+$doctorBat = Join-Path $InstallRoot 'bin\perc-doctor.bat'
+$doctorJar = Join-Path $InstallRoot 'bin\perc-doctor.jar'
+
+if (-not (Test-Path -LiteralPath $doctorBat) -and -not (Test-Path -LiteralPath $doctorJar)) {
+    Write-Error "perc-doctor not found under install root: $InstallRoot (expected bin\perc-doctor.bat or bin\perc-doctor.jar)"
+}
+
+$argsList = @(
+    '--install-root', $InstallRoot
+)
+if ($DryRun) {
+    $argsList += '--dry-run'
+}
+$argsList += @('-v', 'clean-logs', '--older-than', $OlderThan)
+
+Write-Host "perc-doctor clean-logs (DryRun=$DryRun OlderThan=$OlderThan)"
+Write-Host "InstallRoot=$InstallRoot"
+
+if (Test-Path -LiteralPath $doctorBat) {
+    & $doctorBat @argsList
+    exit $LASTEXITCODE
+}
+
+# Fallback: java -jar when .bat is missing but jar is present
+$java = if ($env:JAVA_HOME) { Join-Path $env:JAVA_HOME 'bin\java.exe' } else { 'java' }
+& $java -jar $doctorJar @argsList
+exit $LASTEXITCODE

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/LogrotateSamplePackagingTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/LogrotateSamplePackagingTest.java
@@ -17,6 +17,7 @@
 
 package com.percussion.distribution.install;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -146,6 +147,30 @@ class LogrotateSamplePackagingTest {
     assertTrue(
         text.contains("DryRun") || text.contains("dry-run"),
         "Windows sample must default to / support dry-run");
+    // Resolve-DefaultInstallRoot: sample is at <install-root>/rxconfig/Installer/logrotate/
+    // so climb exactly three parents (not four, which would leave install-root entirely).
+    assertTrue(
+        text.contains("..\\..\\..") || text.contains("../.."),
+        "Resolve-DefaultInstallRoot must climb three levels from logrotate/ to install root");
+    assertFalse(
+        text.contains("..\\..\\..\\..") || text.contains("../../../.."),
+        "must not climb four levels (parent of install root)");
+    assertTrue(
+        text.toLowerCase().contains("three levels") || text.contains("three levels up"),
+        "doc comment must describe three-level climb");
+    // Behavioral path math: three parents of .../rxconfig/Installer/logrotate == install root
+    Path installRoot = Path.of("install-root").toAbsolutePath().normalize();
+    Path scriptDir =
+        installRoot.resolve("rxconfig").resolve("Installer").resolve("logrotate");
+    Path resolved = scriptDir.resolve("..").resolve("..").resolve("..").normalize();
+    assertEquals(
+        installRoot,
+        resolved,
+        "three-level climb from rxconfig/Installer/logrotate must yield install root");
+    Path overshoot = scriptDir.resolve("..").resolve("..").resolve("..").resolve("..").normalize();
+    assertFalse(
+        installRoot.equals(overshoot),
+        "four-level climb must leave the install root (regression for 4-parent bug)");
   }
 
   @Test

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/LogrotateSamplePackagingTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/LogrotateSamplePackagingTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #2348: CMS distribution ships default Linux logrotate samples + Windows clean-logs
+ * guidance under {@code rxconfig/Installer/logrotate/}.
+ *
+ * <p>Structural source contracts only (no live logrotate, no root). Samples must stay portable
+ * (no developer home paths), cover CMS Jetty + DTS Tomcat roots, prefer {@code copytruncate}, and
+ * remain opt-in (not auto-enabled).
+ */
+class LogrotateSamplePackagingTest {
+
+  private static final Path LOGROTATE_DIR =
+      Path.of(
+          "src",
+          "main",
+          "resources",
+          "distribution",
+          "rxconfig",
+          "Installer",
+          "logrotate");
+
+  private static final Path PERCUSSION_CMS = LOGROTATE_DIR.resolve("percussion-cms");
+  private static final Path PERCUSSION_DTS = LOGROTATE_DIR.resolve("percussion-dts");
+  private static final Path WINDOWS_SAMPLE = LOGROTATE_DIR.resolve("schedule-clean-logs.ps1");
+  private static final Path README = LOGROTATE_DIR.resolve("README.md");
+  private static final Path INSTALL_XML =
+      Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer", "install.xml");
+
+  private static final Pattern HARDCODED_USER_HOME =
+      Pattern.compile(
+          "(?i)(C:\\\\Users\\\\[A-Za-z]|/home/[a-zA-Z0-9._-]+|/Users/[A-Za-z]|\\\\Users\\\\Nate)");
+
+  @Test
+  @DisplayName("logrotate sample tree ships CMS, DTS, Windows script, and README")
+  void sampleTreeExists() {
+    assertTrue(Files.isDirectory(LOGROTATE_DIR), () -> "missing " + LOGROTATE_DIR.toAbsolutePath());
+    assertTrue(Files.isRegularFile(PERCUSSION_CMS), () -> "missing " + PERCUSSION_CMS);
+    assertTrue(Files.isRegularFile(PERCUSSION_DTS), () -> "missing " + PERCUSSION_DTS);
+    assertTrue(Files.isRegularFile(WINDOWS_SAMPLE), () -> "missing " + WINDOWS_SAMPLE);
+    assertTrue(Files.isRegularFile(README), () -> "missing " + README);
+  }
+
+  @Test
+  @DisplayName("CMS policy covers Jetty + perc-logging + audit globs with copytruncate")
+  void cmsPolicyCoversJettyRoots() throws IOException {
+    String text = Files.readString(PERCUSSION_CMS, StandardCharsets.UTF_8);
+    assertFalse(HARDCODED_USER_HOME.matcher(text).find(), "CMS policy must not hardcode user home");
+    assertTrue(text.contains("jetty/base/logs"), "CMS policy must include jetty/base/logs");
+    assertTrue(
+        text.contains("jetty/base/modules/perc-logging/logs"),
+        "CMS policy must include perc-logging logs");
+    assertTrue(text.contains("logs/audit"), "CMS policy must include audit log dir");
+    assertTrue(text.contains("*.log"), "CMS policy must rotate *.log");
+    assertTrue(text.contains("*.out"), "CMS policy must rotate *.out");
+    assertTrue(text.contains("copytruncate"), "CMS policy must prefer copytruncate");
+    assertTrue(text.contains("rotate 14"), "CMS policy default rotate 14");
+    assertTrue(
+        text.toLowerCase().contains("sample") || text.contains("NOT installed"),
+        "CMS policy must state it is a sample / not auto-installed");
+  }
+
+  @Test
+  @DisplayName("DTS policy covers Deployment/Server/logs and catalina.out via *.out")
+  void dtsPolicyCoversTomcatLogs() throws IOException {
+    String text = Files.readString(PERCUSSION_DTS, StandardCharsets.UTF_8);
+    assertFalse(HARDCODED_USER_HOME.matcher(text).find(), "DTS policy must not hardcode user home");
+    assertTrue(
+        text.contains("Deployment/Server/logs"),
+        "DTS policy must include Deployment/Server/logs");
+    assertTrue(text.contains("*.log") && text.contains("*.out"), "DTS globs for log and out");
+    assertTrue(
+        text.contains("catalina.out") || text.contains("*.out"),
+        "DTS policy must cover catalina.out");
+    assertTrue(text.contains("copytruncate"), "DTS policy must prefer copytruncate");
+    assertTrue(text.contains("rotate 14"), "DTS policy default rotate 14");
+  }
+
+  @Test
+  @DisplayName("README documents install dry-run, coexistence, and Windows clean-logs")
+  void readmeOperatorGuidance() throws IOException {
+    String text = Files.readString(README, StandardCharsets.UTF_8);
+    assertFalse(HARDCODED_USER_HOME.matcher(text).find(), "README must not hardcode user home");
+    assertTrue(text.contains("logrotate -d"), "README must document logrotate dry-run");
+    assertTrue(text.contains("/etc/logrotate.d"), "README must document logrotate.d install path");
+    assertTrue(
+        text.toLowerCase().contains("copytruncate"), "README must explain copytruncate");
+    assertTrue(
+        text.contains("Log4j") || text.contains("Log4j2"),
+        "README must document Log4j coexistence");
+    assertTrue(
+        text.contains("clean-logs") && text.contains("perc-doctor"),
+        "README must document perc-doctor clean-logs coexistence");
+    assertTrue(
+        text.contains("Task Scheduler") || text.contains("schedule-clean-logs"),
+        "README must document Windows scheduled clean-logs");
+    assertTrue(
+        text.toLowerCase().contains("not")
+            && (text.toLowerCase().contains("auto-enable")
+                || text.toLowerCase().contains("not auto")
+                || text.contains("operator consent")),
+        "README must state samples are not auto-enabled");
+  }
+
+  @Test
+  @DisplayName("Windows sample invokes perc-doctor clean-logs with portable install-root")
+  void windowsSampleUsesPercDoctor() throws IOException {
+    String text = Files.readString(WINDOWS_SAMPLE, StandardCharsets.UTF_8);
+    assertFalse(
+        HARDCODED_USER_HOME.matcher(text).find(), "Windows sample must not hardcode user home");
+    assertTrue(text.contains("clean-logs"), "Windows sample must call clean-logs");
+    assertTrue(
+        text.contains("perc-doctor") || text.contains("perc-doctor.bat"),
+        "Windows sample must invoke perc-doctor");
+    assertTrue(
+        text.contains("OlderThan") || text.contains("14d"),
+        "Windows sample must expose retention (default 14d)");
+    assertTrue(
+        text.contains("DryRun") || text.contains("dry-run"),
+        "Windows sample must default to / support dry-run");
+  }
+
+  @Test
+  @DisplayName("install.xml upgrade.overwrite includes rxconfig/Installer/** (logrotate refresh)")
+  void installXmlUpgradeIncludesInstallerTree() throws IOException {
+    assertTrue(Files.isRegularFile(INSTALL_XML), () -> "missing " + INSTALL_XML.toAbsolutePath());
+    String xml = Files.readString(INSTALL_XML, StandardCharsets.UTF_8);
+    assertTrue(
+        xml.contains("upgrade.overwrite"), "install.xml must define upgrade.overwrite patternset");
+    assertTrue(
+        xml.contains("rxconfig/Installer/**") || xml.contains("name=\"rxconfig/Installer/**\""),
+        "upgrade.overwrite must include rxconfig/Installer/** so logrotate samples refresh");
+    assertFalse(
+        xml.contains("<exclude name=\"rxconfig/Installer/logrotate")
+            || xml.contains("<exclude name=\"**/logrotate/**\""),
+        "must not exclude logrotate samples from install packaging");
+  }
+}

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -207,6 +207,15 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
   --install-root /opt/Percussion --dry-run -v clean-logs
 ```
 
+##### OS log rotation coexistence (#2348)
+
+`clean-logs` complements (does not replace) app Log4j2 rolling and OS `logrotate`. Product samples:
+
+- CMS install: `<install-root>/rxconfig/Installer/logrotate/` (`percussion-cms`, `percussion-dts`, Windows `schedule-clean-logs.ps1`)
+- Standalone DTS: `<dts-root>/logrotate/percussion-dts`
+
+Samples are **opt-in** (not auto-installed to `/etc/logrotate.d`). Prefer `copytruncate`; dry-run with `logrotate -d`. On Windows, schedule `clean-logs --older-than 14d` (or the PowerShell sample). See the README in that directory and `docs/operator-install-guide.md`.
+
 #### `clean-temp`
 
 Reclaim space from **known** install temp / work directories under the install root. Prefer stopping CMS / DTS processes before apply so temp files are not locked.

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -176,6 +176,27 @@ bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-logs --older
 bin\perc-doctor.bat --install-root C:\Percussion -v clean-logs --older-than 14d
 ```
 
+#### OS log rotation (Linux logrotate + Windows schedule)
+
+`clean-logs` is an **age-based purge** of allowlisted files. It does **not** replace OS-level rotation of continuous files such as `catalina.out`. Default samples ship with the product (issue [#2348](https://github.com/intersoftdatalabs-in/percussioncms/issues/2348)):
+
+| Path | Contents |
+|------|----------|
+| `<install-root>/rxconfig/Installer/logrotate/` | `percussion-cms`, `percussion-dts`, `schedule-clean-logs.ps1`, `README.md` |
+| Standalone DTS: `<dts-root>/logrotate/` | `percussion-dts`, short README |
+
+**Not auto-enabled.** Operators copy the Linux fragments into `/etc/logrotate.d/` only with consent after path substitution and `logrotate -d` dry-run. Prefer **`copytruncate`** so Jetty/Tomcat keep writing without a restart.
+
+Coexistence:
+
+| Layer | Role |
+|-------|------|
+| Log4j2 RollingFile | Size-based app log rollover (CMS perc-logging, DTS service configs) |
+| OS logrotate samples | Daily / 14 compressed archives for `*.log` / `*.out` under known roots |
+| `perc-doctor clean-logs` | Manual or scheduled purge of aged allowlisted files |
+
+**Windows:** schedule `perc-doctor clean-logs --older-than 14d` (Task Scheduler) or use `rxconfig/Installer/logrotate/schedule-clean-logs.ps1` (defaults to dry-run). Full steps: `rxconfig/Installer/logrotate/README.md`.
+
 ### `clean-temp`
 
 Removes **files** under known install temp / work directories only. Prefer stopping CMS / DTS first so files are not locked. Allowlisted roots themselves are retained.

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -155,5 +155,8 @@ class PercDoctorPackagingTest {
     assertTrue(
         guideText.contains("/opt/") || guideText.contains("C:\\Percussion"),
         "install guide should use generic install-root examples (not a user home)");
+    assertTrue(
+        guideText.contains("logrotate") && guideText.contains("clean-logs"),
+        "install guide must document OS logrotate coexistence with clean-logs (#2348)");
   }
 }


### PR DESCRIPTION
## Summary

Ships **opt-in** default Linux `logrotate` samples and Windows retention guidance so long-running CMS/Jetty and DTS/Tomcat installs do not fill disks with unbounded `*.log` / `*.out` growth.

**Canonical CMS path:** `<install-root>/rxconfig/Installer/logrotate/`
- `percussion-cms` — Jetty `jetty/base/logs`, audit, `perc-logging/logs`
- `percussion-dts` — `Deployment/Server/logs` (`*.log` / `*.out` including `catalina.out`)
- `schedule-clean-logs.ps1` — Windows Task Scheduler sample via `perc-doctor clean-logs`
- `README.md` — install, `logrotate -d` dry-run, Log4j2 / clean-logs coexistence

**Standalone DTS:** `<dts-root>/logrotate/` (`installDts.xml` copies tree on fresh + upgrade; bulk `*` copy is files-only).

Defaults: daily, rotate **14**, compress, delaycompress, **copytruncate**, missingok, notifempty. **Not auto-enabled** on install (operator consent required).

Parent tracker: #2348 (self)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `modules/perc-doctor`: `mvnw clean install` (BUILD SUCCESS)
- [x] `modules/perc-distribution-tree`: `mvnw clean install` — `LogrotateSamplePackagingTest` 6/6
- [x] `delivery-tier-distribution`: `mvnw clean install` — `DtsLogrotateSamplePackagingTest` 4/4
- [x] Distribution jars contain logrotate sample trees
- [ ] Operator dry-run on a Linux host: `logrotate -d /etc/logrotate.d/percussion-cms` after path substitution (manual / support)

## Gates evidence

| Gate | Evidence |
|------|----------|
| A Implement + tests | Structural packaging tests + docs; installDts copy wiring |
| B Erlang | `docs/ai-generated/code-reviews/issue-2348-logrotate-samples-erlang.md` PASS |
| C Module clean install | perc-doctor, perc-distribution-tree, delivery-tier-distribution |
| Portable paths | `/opt/Percussion`, `C:\Percussion`; no developer homes |

## Residual

None for acceptance criteria. Optional future installer checkbox to install into `/etc/logrotate.d` remains out of scope.

Fixes #2348

> Co-Authored by Grok Build using grok-4.5 with agent main.