### PR TITLE
fix(utils): test-source Xlint batch 3 — ItemIterator/Jexl/test helpers (#2347)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2347-utils-test-xlint-batch3-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2347-utils-test-xlint-batch3-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review — issue #2347 utils test-source Xlint batch 3
+
+**Verdict:** approve  
+**Change class:** test-source generics / Xlint cleanup (no production API change)  
+**Module:** `modules/utils`  
+**Date:** 2026-08-07
+
+## Scope reviewed
+
+| File | Change |
+|------|--------|
+| `PSItemIteratorTest` | `MultiValuedMap<String,String>`; ctor `Map<?,?>` matches production `PSItemIterator` |
+| `PSJexlEvaluatorTest` | Typed `Map`/`List` locals; `createScript`/`createExpression` via type name; method-level unchecked only where binder nests |
+| `PSPropertyWrapperTest` | `Long`/`Double.valueOf` (removal constructors) |
+| `PSTestUtils` | `Class<?>` / `Constructor<?>` reflection helpers |
+| `PSTestPrinter` | `Map<?,?>` + typed entry iteration |
+| `PSTestResourceUtils` | `Class<?>` (matches `PSResourceUtils`) |
+| `TestAllHTML5Tags` | `Map.Entry<String,String>` |
+| `PSFacadeMapTest` | Documented unchecked clone cast (`HashMap.clone()` → Object) |
+| `PSTestBeanConfig` | Empty-if → explicit `return` |
+
+## Hard gates
+
+| Gate | Result |
+|------|--------|
+| Bugs / behavior change | Pass — type parameters only; multi-map iteration path still exercises `asMap()` |
+| Behavioral unit tests | Pass — existing suite covers changed tests; no new production logic |
+| Portable paths / file I/O | Pass — no path changes (`PSTestResourceUtils` still uses `createTempFile` / `createTempDirectory`) |
+| Companion completeness | Pass — test-only; no Spring/rest companions |
+| No new blanket suppressions | Pass — only method-level unchecked on binder cast navigation + clone cast |
+
+## Residual (out of this PR)
+
+- `PSWorkflowUtilsBaseTest` intentional raw public-API probes (~34+ under full `-Xmaxwarns`)
+- Open batch 2 PR #2346: `PSReflectionHelper` + `PSMultiMapIterTest`
+- Main-source `@SuppressWarnings` strip (`InstallUtil`, `PSCollection`, `PSJexlEvaluator`, …)
+
+## Verification
+
+- Standalone `modules/utils`: `mvnw clean install` — **BUILD SUCCESS**
+- Tests: **311** run, **0** failures, **9** pre-existing skips
+- Fixed files: **0** project-Xlint warnings after change
+
+## Operator
+
+Operator: Grok: night-issue-prs (model grok-4.5)
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/utils/src/test/java/com/percussion/html/TestAllHTML5Tags.java
+++ b/modules/utils/src/test/java/com/percussion/html/TestAllHTML5Tags.java
@@ -161,8 +161,8 @@ public class TestAllHTML5Tags {
 
   private void verifyAttributes(Element tag, Map<String, String> attrList) {
 
-    for (Map.Entry attr : attrList.entrySet()) {
-      String attrValue = tag.attr((String) attr.getKey());
+    for (Map.Entry<String, String> attr : attrList.entrySet()) {
+      String attrValue = tag.attr(attr.getKey());
       assertTrue(attrValue != null);
       System.out.println("Attribute Value: " + attrValue);
       System.out.println("Attribute Name: " + attr.getKey());
@@ -173,8 +173,8 @@ public class TestAllHTML5Tags {
 
   private void verifyAttributes(Attributes attributes, Map<String, String> attrList) {
 
-    for (Map.Entry attr : attrList.entrySet()) {
-      String attrValue = attributes.get((String) attr.getKey());
+    for (Map.Entry<String, String> attr : attrList.entrySet()) {
+      String attrValue = attributes.get(attr.getKey());
       assertEquals(attrValue, attr.getValue());
     }
   }

--- a/modules/utils/src/test/java/com/percussion/utils/PSItemIteratorTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/PSItemIteratorTest.java
@@ -54,10 +54,11 @@ public class PSItemIteratorTest {
     /**
      * Ctor
      *
-     * @param things
+     * @param things map of values (simple map or multi-map {@code asMap()} view); production accepts
+     *     {@code Map<?, ?>}
      * @param filterpattern
      */
-    protected TestItemIterator(Map<String, Item> things, String filterpattern) {
+    protected TestItemIterator(Map<?, ?> things, String filterpattern) {
       super(things, filterpattern);
     }
   }
@@ -138,7 +139,7 @@ public class PSItemIteratorTest {
   }
 
   /** Test data for multi map testing */
-  static MultiValuedMap ms_mm = new ArrayListValuedHashMap<>();
+  static MultiValuedMap<String, String> ms_mm = new ArrayListValuedHashMap<>();
 
   static {
     ms_mm.put("aa", "1");
@@ -217,7 +218,7 @@ public class PSItemIteratorTest {
     ti = new TestItemIterator(ms_mm.asMap(), null);
 
     int count = 0;
-    Iterator<Object> v = ms_mm.values().iterator();
+    Iterator<String> v = ms_mm.values().iterator();
     while (v.hasNext()) {
       v.next();
       count++;

--- a/modules/utils/src/test/java/com/percussion/utils/beans/PSPropertyWrapperTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/beans/PSPropertyWrapperTest.java
@@ -124,10 +124,10 @@ public class PSPropertyWrapperTest {
         return mi_aaa;
       }
       if (prop.equals("bbb")) {
-        return new Long(mi_bbb);
+        return Long.valueOf(mi_bbb);
       }
       if (prop.equals("ccc")) {
-        return new Double(mi_ccc);
+        return Double.valueOf(mi_ccc);
       }
       throw new IllegalArgumentException("Unknown property " + prop);
     }
@@ -156,7 +156,7 @@ public class PSPropertyWrapperTest {
   public void testLongAccess() throws Exception {
     Object rval = testWrapper.getPropertyValue("bbb");
     assertEquals(rval.getClass(), Long.class);
-    assertEquals(rval, new Long(testObj.getBbb()));
+    assertEquals(rval, Long.valueOf(testObj.getBbb()));
   }
 
   /**
@@ -169,7 +169,7 @@ public class PSPropertyWrapperTest {
   public void testDoubleAccess() throws Exception {
     Object rval = testWrapper.getPropertyValue("ccc");
     assertEquals(rval.getClass(), Double.class);
-    assertEquals(rval, new Double(testObj.getCcc()));
+    assertEquals(rval, Double.valueOf(testObj.getCcc()));
   }
 
   /**

--- a/modules/utils/src/test/java/com/percussion/utils/collections/PSFacadeMapTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/collections/PSFacadeMapTest.java
@@ -49,6 +49,8 @@ public class PSFacadeMapTest {
   @Test
   public void testClone() throws Exception {
     fmap = new PSFacadeMap<String, String>(inner);
+    // HashMap.clone() is Object; production does not override with a typed return.
+    @SuppressWarnings("unchecked")
     PSFacadeMap<String, String> c = (PSFacadeMap<String, String>) fmap.clone();
 
     assertEquals(fmap, c);

--- a/modules/utils/src/test/java/com/percussion/utils/jexl/PSJexlEvaluatorTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/jexl/PSJexlEvaluatorTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.TestMethodOrder;
  *
  * @author dougrand
  */
-@SuppressWarnings(value = "unchecked")
 @TestMethodOrder(MethodName.class)
 @Tag("UnitTest")
 public class PSJexlEvaluatorTest {
@@ -46,6 +45,7 @@ public class PSJexlEvaluatorTest {
    * @throws Exception
    */
   @Test
+  @SuppressWarnings("unchecked")
   public void test_01_Binder() throws Exception {
     PSJexlEvaluator eval = new PSJexlEvaluator();
 
@@ -62,15 +62,16 @@ public class PSJexlEvaluatorTest {
     eval.evaluate("$e", PSJexlEvaluator.createScript("if ($x > 1) {3;} else {4;}"));
 
     Map<String, Object> vars = eval.getVars();
-    Map z = (Map) vars.get("$z");
-    Map a = (Map) z.get("a");
-    Map b = (Map) z.get("b");
-    Map z_a_b = (Map) a.get("b");
-    List y = (List) vars.get("$y");
-    List z_a_c = (List) a.get("c");
-    Map z_b_x = (Map) b.get("x");
-    List z_b_x_y = (List) z_b_x.get("y");
-    Map y_0 = (Map) z_b_x_y.get(0);
+    // Binder builds nested Map/List graphs as Object values; cast once per navigation step.
+    Map<String, Object> z = (Map<String, Object>) vars.get("$z");
+    Map<String, Object> a = (Map<String, Object>) z.get("a");
+    Map<String, Object> b = (Map<String, Object>) z.get("b");
+    Map<String, Object> z_a_b = (Map<String, Object>) a.get("b");
+    List<Object> y = (List<Object>) vars.get("$y");
+    List<Object> z_a_c = (List<Object>) a.get("c");
+    Map<String, Object> z_b_x = (Map<String, Object>) b.get("x");
+    List<Object> z_b_x_y = (List<Object>) z_b_x.get("y");
+    Map<String, Object> y_0 = (Map<String, Object>) z_b_x_y.get(0);
     assertEquals("n3", z_a_c.get(0));
     assertEquals("n2", z_a_c.get(1));
     assertEquals("n1", z_a_b.get("c"));
@@ -160,7 +161,8 @@ public class PSJexlEvaluatorTest {
 
     PSJexlEvaluator eval = new PSJexlEvaluator(initial);
     IPSScript exp =
-        eval.createScript("if ($c) {$a = $val1;} else {$a = $val2;}\n$b = $a + ' brown fox'");
+        PSJexlEvaluator.createScript(
+            "if ($c) {$a = $val1;} else {$a = $val2;}\n$b = $a + ' brown fox'");
     assertEquals("the quick brown fox", eval.evaluate(exp));
   }
 
@@ -176,9 +178,9 @@ public class PSJexlEvaluatorTest {
     initial.put("$a", 4);
 
     PSJexlEvaluator eval = new PSJexlEvaluator(initial);
-    IPSScript exp = eval.createScript("$c");
+    IPSScript exp = PSJexlEvaluator.createScript("$c");
     assertEquals(Integer.valueOf(2147483647), eval.evaluate(exp));
-    exp = eval.createScript("$c * $a");
+    exp = PSJexlEvaluator.createScript("$c * $a");
     Object result = eval.evaluate(exp);
     assertEquals(Long.valueOf(8589934588L), result);
   }
@@ -210,7 +212,7 @@ public class PSJexlEvaluatorTest {
    */
   private void doExceptionTest(PSJexlEvaluator eval, String expression) throws Exception {
     try {
-      IPSScript exp = eval.createExpression(expression);
+      IPSScript exp = PSJexlEvaluator.createExpression(expression);
 
       exp.setUseDebugMode(true);
       exp.setUseSilentMode(false);

--- a/modules/utils/src/test/java/com/percussion/utils/spring/PSTestBeanConfig.java
+++ b/modules/utils/src/test/java/com/percussion/utils/spring/PSTestBeanConfig.java
@@ -31,8 +31,10 @@ public class PSTestBeanConfig implements IPSBeanConfig {
   }
 
   public void fromXml(Element source) throws PSInvalidXmlException {
-    if (null == source)
-      ;
+    // Test stub: no state to hydrate from XML.
+    if (null == source) {
+      return;
+    }
   }
 
   public String getBeanName() {

--- a/modules/utils/src/test/java/com/percussion/utils/testing/PSTestPrinter.java
+++ b/modules/utils/src/test/java/com/percussion/utils/testing/PSTestPrinter.java
@@ -16,7 +16,6 @@
  */
 package com.percussion.utils.testing;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
@@ -32,20 +31,18 @@ public class PSTestPrinter {
    *
    * @param map the map, never <code>null</code>
    */
-  public static void printMapEntries(Map map) {
+  public static void printMapEntries(Map<?, ?> map) {
     if (map == null) {
       throw new IllegalArgumentException("map may not be null");
     }
-    Map<String, String> values = new TreeMap<String, String>();
-    Iterator<Map.Entry> i = map.entrySet().iterator();
-    while (i.hasNext()) {
-      Map.Entry e = i.next();
-      values.put(e.getKey().toString(), e.getValue().toString());
+    Map<String, String> values = new TreeMap<>();
+    for (Map.Entry<?, ?> e : map.entrySet()) {
+      Object key = e.getKey();
+      Object value = e.getValue();
+      values.put(String.valueOf(key), String.valueOf(value));
     }
 
-    Iterator<Map.Entry<String, String>> is = values.entrySet().iterator();
-    while (is.hasNext()) {
-      Map.Entry<String, String> e = is.next();
+    for (Map.Entry<String, String> e : values.entrySet()) {
       System.out.println(e.getKey() + ": " + e.getValue());
     }
   }
@@ -59,16 +56,12 @@ public class PSTestPrinter {
     if (props == null) {
       throw new IllegalArgumentException("props may not be null");
     }
-    Map<String, String> values = new TreeMap<String, String>();
-    Iterator<Map.Entry<Object, Object>> i = props.entrySet().iterator();
-    while (i.hasNext()) {
-      Map.Entry e = i.next();
-      values.put(e.getKey().toString(), e.getValue().toString());
+    Map<String, String> values = new TreeMap<>();
+    for (Map.Entry<Object, Object> e : props.entrySet()) {
+      values.put(String.valueOf(e.getKey()), String.valueOf(e.getValue()));
     }
 
-    Iterator<Map.Entry<String, String>> is = values.entrySet().iterator();
-    while (is.hasNext()) {
-      Map.Entry<String, String> e = is.next();
+    for (Map.Entry<String, String> e : values.entrySet()) {
       System.out.println(e.getKey() + ": " + e.getValue());
     }
   }

--- a/modules/utils/src/test/java/com/percussion/utils/testing/PSTestResourceUtils.java
+++ b/modules/utils/src/test/java/com/percussion/utils/testing/PSTestResourceUtils.java
@@ -36,7 +36,7 @@ public class PSTestResourceUtils {
    * @param dir  May be null
    *
    */
-  public static File getFile(Class clazz, String resourcePath, File dir) throws IOException {
+  public static File getFile(Class<?> clazz, String resourcePath, File dir) throws IOException {
     File ret = File.createTempFile("test", "tmp", dir);
     ret.deleteOnExit();
 
@@ -52,7 +52,7 @@ public class PSTestResourceUtils {
     return ret;
   }
 
-  public static File getFakeRxDirFile(Class clazz, String resourcePath) throws IOException {
+  public static File getFakeRxDirFile(Class<?> clazz, String resourcePath) throws IOException {
     return getFile(clazz, resourcePath, getFakeRxDir());
   }
 }

--- a/modules/utils/src/test/java/com/percussion/utils/tools/PSTestUtils.java
+++ b/modules/utils/src/test/java/com/percussion/utils/tools/PSTestUtils.java
@@ -50,7 +50,8 @@ public class PSTestUtils {
    * @throws Exception If the test fails.
    */
   public static void testSetter(
-      Object obj, String prop, Object val, Class valClass, boolean shouldThrow) throws Exception {
+      Object obj, String prop, Object val, Class<?> valClass, boolean shouldThrow)
+      throws Exception {
     if (obj == null) throw new IllegalArgumentException("obj may not be null");
 
     if (StringUtils.isBlank(prop))
@@ -58,13 +59,13 @@ public class PSTestUtils {
 
     if (valClass == null) throw new IllegalArgumentException("valClass may not be null");
 
-    Class objClass = obj.getClass();
-    Method setter = objClass.getMethod("set" + prop, new Class[] {valClass});
-    Method getter = objClass.getMethod("get" + prop, new Class[] {});
+    Class<?> objClass = obj.getClass();
+    Method setter = objClass.getMethod("set" + prop, valClass);
+    Method getter = objClass.getMethod("get" + prop);
 
     boolean didThrow = false;
     try {
-      setter.invoke(obj, new Object[] {val});
+      setter.invoke(obj, val);
     } catch (InvocationTargetException e) {
       if (e.getCause() instanceof IllegalArgumentException) didThrow = true;
       else {
@@ -86,9 +87,8 @@ public class PSTestUtils {
    * @return The constructed object.
    * @throws Exception If the test fails.
    */
-  @SuppressWarnings(value = {"unchecked"})
-  public static Object testCtor(Class objClass, Class[] params, Object[] args, boolean shouldThrow)
-      throws Exception {
+  public static Object testCtor(
+      Class<?> objClass, Class<?>[] params, Object[] args, boolean shouldThrow) throws Exception {
     if (objClass == null) throw new IllegalArgumentException("objClass may not be null");
     if (params == null) throw new IllegalArgumentException("params may not be null");
     if (args == null) throw new IllegalArgumentException("args may not be null");
@@ -96,7 +96,7 @@ public class PSTestUtils {
     boolean result = !shouldThrow;
     Object test = null;
     try {
-      Constructor ctor = objClass.getConstructor(params);
+      Constructor<?> ctor = objClass.getConstructor(params);
       test = ctor.newInstance(args);
     } catch (Exception e) {
       result = shouldThrow;


### PR DESCRIPTION
## Summary

Partial implement for **#2347** (modules/utils javac residual after batch 2) — **batch 3** (hottest remaining test-source).

Clears non-intentional test-source project-default `-Xlint` warnings with **real generics** (no new blanket suppressions):

| Area | Fix | ~diags |
|------|-----|-------:|
| `PSItemIteratorTest` | `MultiValuedMap<String,String>`; ctor `Map<?,?>` (matches production) | ~29 |
| `PSJexlEvaluatorTest` | Typed `Map`/`List` locals; static `createScript`/`createExpression` | ~13 |
| `PSTestUtils` | `Class<?>` / `Constructor<?>` | ~9 |
| `PSTestPrinter` | `Map<?,?>` + typed entries | ~5 |
| `PSPropertyWrapperTest` | `Long`/`Double.valueOf` | ~4 |
| `TestAllHTML5Tags`, `PSTestResourceUtils`, `PSFacadeMapTest`, `PSTestBeanConfig` | Entry/Class generics, clone cast doc, empty-if | ~6 |

**~60** test-source project-Xlint diags cleared. Main project-Xlint remains 0 (batch 1). Batch 2 PR #2346 still covers `PSReflectionHelper` + `PSMultiMapIterTest`.

Parent module issue: **#2016**. Tracker: **#2200**. Prior residual: #2328.

### Residual (follow-up)

- #2362 — `PSWorkflowUtilsBaseTest` intentional raw API probes + main-source `@SuppressWarnings` strip

## Test plan

- [x] Standalone `modules/utils`: `mvnw clean install` — BUILD SUCCESS
- [x] Suite: 311 tests, 0 failures (9 pre-existing skips)
- [x] Fixed files: 0 project-Xlint warnings after fix
- [x] No production API changes; existing ItemIterator / Jexl tests exercise typed paths

## Gates evidence

- Erlang-style self-review: approve — `docs/ai-generated/code-reviews/issue-2347-utils-test-xlint-batch3-erlang.md`
- Per-module standalone clean install: pass
- No monorepo-wide reformat

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2347. Refs #2016 #2200. Residual #2362.

> Co-Authored by Grok Build using grok-4.5 with agent main.
