### PR TITLE
fix(perc-system): design.objectstore serialVersionUID N–Z batch (#2319)

### DIFF
--- a/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
+++ b/system/services/src/com/percussion/services/assembly/impl/nav/PSNavonNodeInvocationHandler.java
@@ -209,11 +209,14 @@ public class PSNavonNodeInvocationHandler implements InvocationHandler
             PSPropertyIterator iter =
                (PSPropertyIterator) method.invoke(m_containedNode, args);
 
-            // Add nav properties (copy from Map<?,?> returned by getMap)
+            // Add nav properties. Copy from Map<?,?> (PSItemIterator.getMap) into a
+            // typed HashMap — diamond + wildcard source does not infer K=String.
             Map<String, Property> map = new HashMap<>();
             for (Map.Entry<?, ?> e : iter.getMap().entrySet())
             {
-               map.put((String) e.getKey(), (Property) e.getValue());
+               @SuppressWarnings("unchecked")
+               Map.Entry<String, Property> entry = (Map.Entry<String, Property>) e;
+               map.put(entry.getKey(), entry.getValue());
             }
             for(String prop : NAV_PROPERTIES)
             {

--- a/system/src/main/java/com/percussion/design/objectstore/PSNamedReplacementValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNamedReplacementValue.java
@@ -31,6 +31,8 @@ import org.w3c.dom.Element;
  */
 public abstract class PSNamedReplacementValue extends PSComponent
     implements IPSMutatableReplacementValue, IPSDocumentMapping, IPSBackEndMapping {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Initializes a newly created <code>PSNamedReplacementValue</code> object, using the specified
    * name.

--- a/system/src/main/java/com/percussion/design/objectstore/PSNotifier.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNotifier.java
@@ -37,6 +37,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSNotifier extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
@@ -23,6 +23,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXNullEntry DTD in BasicObjects.dtd. */
 public class PSNullEntry extends PSEntry {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new null entry for the provided parameters.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSNumericLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNumericLiteral.java
@@ -36,6 +36,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSNumericLiteral extends PSLiteral {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /** The value type associated with this instances of this class. */
   public static final String VALUE_TYPE = "NumericLiteral";
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSObjectException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSObjectException.java
@@ -24,6 +24,8 @@ import com.percussion.error.PSException;
  * should be derived from this class.
  */
 public class PSObjectException extends PSException {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Pass-through constructor to super class.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSOriginatingRelationshipProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSOriginatingRelationshipProperty.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
  * relationship.
  */
 public class PSOriginatingRelationshipProperty extends PSNamedReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a new relationship property from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
@@ -38,6 +38,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSPageDataTank extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSParam.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSParam.java
@@ -23,6 +23,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXParam DTD in BasicObjects.dtd. */
 public class PSParam extends PSComponent implements IPSParameter {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a new parameter for the provided name.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSPipe.java
@@ -33,6 +33,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  * @since 1.0
  */
 public abstract class PSPipe extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Get the name of the pipe.

--- a/system/src/main/java/com/percussion/design/objectstore/PSProcessCheck.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProcessCheck.java
@@ -27,6 +27,8 @@ import org.w3c.dom.Node;
 
 /** Implements the PSXProcessCheck element defined in sys_CloneHandlerConfig.dtd. */
 public class PSProcessCheck extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
@@ -25,6 +25,8 @@ import org.w3c.dom.Node;
 
 /** The class which defines a property in any Rx configuration. */
 public class PSProperty extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs this property from the supplied parameters.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSProvider.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProvider.java
@@ -24,6 +24,8 @@ import org.w3c.dom.Element;
 
 /** Container class used to define directory or role provider catalogers. */
 public class PSProvider extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
@@ -36,6 +36,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSQueryPipe extends PSPipe {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSRecipient.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRecipient.java
@@ -37,6 +37,8 @@ import org.w3c.dom.Node;
  * @since 1.0
  */
 public class PSRecipient extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSReference.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSReference.java
@@ -24,6 +24,8 @@ import org.w3c.dom.Element;
 
 /** A component that holds one reference to an other XML element. */
 public class PSReference extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfig.java
@@ -44,6 +44,8 @@ import org.w3c.dom.Element;
  * RelationshipConfig elements are expanded using the sys_RelationshipConfig.dtd.
  */
 public class PSRelationshipConfig extends PSComponent implements IPSCatalogSummary, IPSCloneTuner {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipProperty.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
  * that started the current request.
  */
 public class PSRelationshipProperty extends PSNamedReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a new relationship property from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipPropertyDataPk.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipPropertyDataPk.java
@@ -29,6 +29,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  */
 @Embeddable
 public class PSRelationshipPropertyDataPk implements Serializable {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /** The relationship (or parent) id. */
   @Basic
   @Column(name = "RID")

--- a/system/src/main/java/com/percussion/design/objectstore/PSRequestLink.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRequestLink.java
@@ -43,6 +43,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSRequestLink extends PSComponent implements IPSResults {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
@@ -44,6 +44,8 @@ import org.w3c.dom.Node;
  * @since 1.0
  */
 public class PSRequestor extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
@@ -27,6 +27,8 @@ import org.w3c.dom.Element;
 
 /** Class to represent the cache settings for a resource. */
 public class PSResourceCacheSettings extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct the cache settings with default values. This will be caching disabled, and no
    * additional keys or dependencies.

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
@@ -41,6 +41,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSResultPage extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
@@ -35,6 +35,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSResultPageSet extends PSComponent implements IPSResults {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
@@ -36,6 +36,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSResultPager extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSRevisionEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRevisionEntry.java
@@ -33,6 +33,8 @@ import org.w3c.dom.Element;
  * @see com.percussion.design.objectstore.PSRevisionHistory
  */
 public class PSRevisionEntry extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a new revision entry.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSRevisionHistory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRevisionHistory.java
@@ -29,6 +29,8 @@ import org.w3c.dom.Element;
  * revision associated with a component or document.
  */
 public class PSRevisionHistory extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a new revision history object.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSRule.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRule.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXRule DTD in BasicObjects.dtd. */
 public class PSRule extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new rule objects.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
@@ -39,6 +39,8 @@ import org.w3c.dom.Element;
  * attempts to be unaware of the implementation.
  */
 public class PSSearchConfig extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * This is the name of the custom property that contains the default value for the synonym
    * expansion. The presence of this property is optional. If present and has a value of yes then

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
@@ -39,6 +39,8 @@ import org.w3c.dom.Element;
  * @author paulhoward
  */
 public class PSSearchProperties extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   // we don't override clone as all members are immutable
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
@@ -45,6 +45,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSSecurityProviderInstance extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   private static final Logger logger = LogManager.getLogger(PSSecurityProviderInstance.class);
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSServerCacheSettings.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSServerCacheSettings.java
@@ -24,6 +24,8 @@ import org.w3c.dom.Element;
 
 /** Contains the configuration settings for the cache used by the server. */
 public class PSServerCacheSettings extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Intializes the default storage and aging settings for the manager. Caching is disabled by

--- a/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
 /** Implementation for the PSXSharedFieldGroup DTD in ContentEditorSharedDef.dtd. */
 @SuppressWarnings("serial")
 public class PSSharedFieldGroup extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new shared field group.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSSingleHtmlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSingleHtmlParameter.java
@@ -27,6 +27,8 @@ import org.w3c.dom.Element;
  * @see IPSReplacementValue
  */
 public class PSSingleHtmlParameter extends PSHtmlParameter {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSSortedColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSortedColumn.java
@@ -31,6 +31,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSSortedColumn extends PSBackEndColumn {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a PSSortedColumn object from its XML representation. See the {@link #toXml} method
    * for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSStylesheet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSStylesheet.java
@@ -24,6 +24,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXStylesheet DTD in BasicObjects.dtd. */
 public class PSStylesheet extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new stylesheet object.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSSyntaxException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSyntaxException.java
@@ -28,6 +28,8 @@ import com.percussion.error.PSException;
  * @since 1.0
  */
 public class PSSyntaxException extends PSException {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct an exception for messages taking only a single argument.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSSystemValidationException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSystemValidationException.java
@@ -29,6 +29,8 @@ import com.percussion.error.PSException;
  * @since 1.0
  */
 public class PSSystemValidationException extends PSException {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct an exception for messages taking only a single argument.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXTableLocator DTD in BasicObjects.dtd. */
 public class PSTableLocator extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new table locator for the provided credentials.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableRef.java
@@ -24,6 +24,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXTableRef DTD in BasicObjects.dtd. */
 public class PSTableRef extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Create a new table refernece.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXTableSet DTD in BasicObjects.dtd. */
 public class PSTableSet extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new table set.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSTextLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTextLiteral.java
@@ -32,6 +32,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSTextLiteral extends PSLiteral implements IPSMutatableReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /** The value type associated with this instances of this class. */
   public static final String VALUE_TYPE = "TextLiteral";
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
@@ -32,6 +32,8 @@ import org.w3c.dom.Element;
 
 /** Encapsulates all trace options contained in the application. */
 public class PSTraceInfo extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Constructor for this class. Calls fromXml to initialize itself using the supplied xml. The

--- a/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
@@ -27,6 +27,8 @@ import org.w3c.dom.Node;
 
 /** Implementation for the PSXUIDefinition DTD in BasicObjects.dtd. */
 public class PSUIDefinition extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new UI definition.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSUnknownDocTypeException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUnknownDocTypeException.java
@@ -29,6 +29,8 @@ import com.percussion.error.PSException;
  * @since 1.0
  */
 public class PSUnknownDocTypeException extends PSException {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct an exception for messages taking only a single argument.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSUpdateColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUpdateColumn.java
@@ -34,6 +34,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSUpdateColumn extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
@@ -37,6 +37,8 @@ import org.w3c.dom.Node;
  * @since 1.0
  */
 public class PSUpdatePipe extends PSPipe {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
@@ -28,6 +28,8 @@ import org.w3c.dom.Element;
 
 /** Implements the PSXUrlRequest DTD defined in BasicObjects.dtd. */
 public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new request object for the provided name, href and parameters.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSUserContext.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUserContext.java
@@ -29,6 +29,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSUserContext extends PSNamedReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSVersionConflictException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSVersionConflictException.java
@@ -28,6 +28,8 @@ import com.percussion.error.PSException;
  * @since 1.0
  */
 public class PSVersionConflictException extends PSException {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct an exception for messages taking only a single argument.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
@@ -39,6 +39,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSWhereClause extends PSConditional {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSWorkflow.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWorkflow.java
@@ -25,6 +25,8 @@ import org.w3c.dom.Element;
 
 /** Represents the metadata for a single workflow */
 public class PSWorkflow extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Initializes a newly created <code>PSWorkflow</code> object, from an XML representation. See
    * {@link #toXml(Document)} for the format.

--- a/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
@@ -32,6 +32,8 @@ import org.w3c.dom.Element;
  * @see PSContentEditor
  */
 public class PSWorkflowInfo extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Initializes a newly created <code>PSWorkflowInfo</code> object, from an XML representation. See

--- a/system/src/main/java/com/percussion/design/objectstore/PSXmlField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSXmlField.java
@@ -29,6 +29,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSXmlField extends PSNamedReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialVersionUidTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialVersionUidTest.java
@@ -23,13 +23,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.util.Date;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.junit.jupiter.api.Test;
 
 /**
  * Java serialization checks for design.objectstore types that received {@code serialVersionUID} in
- * the #2313 D–M batch (parent #2022).
+ * the #2313 D–M and #2319 N–Z batches (parent #2022).
  */
 public class PSObjectStoreSerialVersionUidTest {
 
@@ -70,6 +72,50 @@ public class PSObjectStoreSerialVersionUidTest {
     assertEquals(1L, readSerialVersionUid(PSDisplayTextLiteral.class));
     assertEquals(1L, readSerialVersionUid(PSExtensionCall.class));
     assertEquals(1L, readSerialVersionUid(PSFieldSet.class));
+  }
+
+  @Test
+  public void testNzBatchLiteralAndParamSerialization() throws Exception {
+    PSTextLiteral textLit = new PSTextLiteral("hello-nz");
+    textLit.setId(11);
+
+    PSNumericLiteral numLit =
+        new PSNumericLiteral(new BigDecimal("42.5"), new DecimalFormat("#0.0"));
+    numLit.setId(12);
+
+    PSSingleHtmlParameter singleHtml = new PSSingleHtmlParameter("sys_folderid");
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(textLit);
+      oos.writeObject(numLit);
+      oos.writeObject(singleHtml);
+      bytes = bos.toByteArray();
+    }
+
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      PSTextLiteral serText = (PSTextLiteral) ois.readObject();
+      PSNumericLiteral serNum = (PSNumericLiteral) ois.readObject();
+      PSSingleHtmlParameter serHtml = (PSSingleHtmlParameter) ois.readObject();
+
+      assertEquals(textLit, serText);
+      assertEquals(11, serText.getId());
+      assertEquals("hello-nz", serText.getText());
+      assertEquals(numLit, serNum);
+      assertEquals(12, serNum.getId());
+      assertEquals(0, new BigDecimal("42.5").compareTo(serNum.getNumber()));
+      assertEquals("sys_folderid", serHtml.getName());
+    }
+
+    assertEquals(1L, readSerialVersionUid(PSTextLiteral.class));
+    assertEquals(1L, readSerialVersionUid(PSNumericLiteral.class));
+    assertEquals(1L, readSerialVersionUid(PSSingleHtmlParameter.class));
+    assertEquals(1L, readSerialVersionUid(PSNamedReplacementValue.class));
+    assertEquals(1L, readSerialVersionUid(PSPipe.class));
+    assertEquals(1L, readSerialVersionUid(PSTableSet.class));
+    assertEquals(1L, readSerialVersionUid(PSSystemValidationException.class));
+    assertEquals(1L, readSerialVersionUid(PSRelationshipPropertyDataPk.class));
   }
 
   private static long readSerialVersionUid(Class<?> type) throws Exception {


### PR DESCRIPTION
## Summary

PR-sized batch for **#2319** (parent **#2022** / grandparent **#2200**): clear `-Xlint:serial` missing-`serialVersionUID` diagnostics for **design.objectstore** types in the **N–Z** alphabetical range (continuation of #2297 A–C and #2313 D–M batches).

### serialVersionUID batch (53 types)
`serialVersionUID = 1L` on Serializable `design.objectstore` classes including:
- Pipe/data path: `PSPipe`, `PSQueryPipe`, `PSUpdatePipe`, `PSPageDataTank`, `PSTableSet`/`PSTableLocator`/`PSTableRef`
- Named replacement values: `PSNamedReplacementValue`, `PSOriginatingRelationshipProperty`, `PSRelationshipProperty`, `PSUserContext`, `PSXmlField`, `PSSingleHtmlParameter`
- Literals: `PSTextLiteral`, `PSNumericLiteral`, `PSNullEntry`
- Rules/UI/config: `PSRule`, `PSSearchConfig`, `PSSearchProperties`, `PSUIDefinition`, `PSStylesheet`, `PSWorkflow`/`PSWorkflowInfo`
- Exceptions: `PSObjectException`, `PSSyntaxException`, `PSSystemValidationException`, `PSUnknownDocTypeException`, `PSVersionConflictException`
- Misc: `PSNotifier`, `PSParam`, `PSProperty`, `PSProvider`, `PSRecipient`, `PSRequestLink`/`PSRequestor`, cache settings, revision history, `PSRelationshipPropertyDataPk`, …

Skipped non-Serializable `PSDatabaseComponent` / `PSCollectionComponent` subclasses (no dead UID).

### Compile unblock (main)
`PSNavonNodeInvocationHandler`: copy `Map<?,?>` from `PSItemIterator.getMap()` into a typed `HashMap<String,Property>` so system compiles after the utils wildcard parameterization (diamond inference break on main).

### Metrics (this batch)
| Kind | Δ (this PR) |
| --- | ---: |
| missing serialVersionUID | **−53** (design.objectstore N–Z) |
| this-escape | 0 (deferred) |
| serial-field | 0 (deferred) |

Slightly over the ~40–50 soft cap to finish the N–Z range coherently.

### Residual
Follow-up: this-escape + serial-field + leftover A–C UIDs + cms.objectstore UIDs → **#2366**.

## Test plan
- [x] `cd system && ../mvnw clean install` — **BUILD SUCCESS**, Tests run: **1228**, Failures: **0**, Errors: **0**
- [x] `PSObjectStoreSerialVersionUidTest` — N–Z serialization round-trip for `PSTextLiteral` / `PSNumericLiteral` / `PSSingleHtmlParameter` + `serialVersionUID` field checks

## Gates evidence
- Erlang-style self-review: constant-only UID additions; no constructor/XML behavior change; non-Serializable types excluded; portable paths N/A; no suppress-only
- Change-class companions: serialVersionUID lint batch (peer #2313 / PR #2320) + behavioral serialization test
- Module install: `system` standalone `mvnw clean install` green (JDK 21)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2319
Refs #2022 #2200

### Residual issue
- #2366 — issue 2022 slice 3d residual this-escape/serial after #2319

> Co-Authored by Grok Build using grok-4.5 with agent main.
