### PR TITLE
fix(WebUI): decoration grid no longer stomps responsive themes (GH-2352)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,21 @@ This file documents changes that have been made to API's / public interfaces.
 
 ## Design / Development Changes
 
+### Editor decoration region grid (GH-2352 / 8.1.7 regression)
+
+In **8.1.7**, `perc_decoration.css` forced legacy fixed `vspan_*` heights with `!important` so editor placeholders could win over default-theme `min-height` (GH-757). That also **overrode responsive customer themes** that intentionally set `height`/`width: auto` on region spans, breaking **editor and preview** while published pages stayed correct.
+
+**Product fix (8.2+):** shipped `perc_decoration.css` copies use `height: auto` / `width: auto` for `.vspan_*` / `.hspan_*` and no longer use `!important` fixed pixel sizes on those classes. Published default-theme sidebar/footer `min-height` behavior remains in `theme.css` (GH-757).
+
+**Support (sites already on 8.1.7+ with broken editor/preview):** until upgraded, a temporary theme override is:
+
+```css
+.vspan_2, .vspan_4, .vspan_6, .vspan_8 { height: auto !important; min-height: 0; }
+.hspan_2, .hspan_8, .hspan_10, .hspan_12 { width: auto !important; }
+```
+
+Prefer product upgrade over permanent customer `!important` counters.
+
 ### Test / Debug Tools
 
 The Test / Debug tools have been disabled by default, and will all require user membership in the Admin role when enabled for all tool scripts.

--- a/WebUI/src/main/webapp/cm/app/css/legacy/perc_decoration.css
+++ b/WebUI/src/main/webapp/cm/app/css/legacy/perc_decoration.css
@@ -1,34 +1,35 @@
 /* Region CSS
 ----------------------------------*/
-
+/*
+ * Region span sizing for editor/preview decoration (GH-2352).
+ * Do not force the legacy fixed pixel grid with !important — that stomps
+ * responsive customer themes that set height/width: auto (or fluid sizes).
+ * Published default-theme #757 footer/sidebar min-height lives in theme.css.
+ */
 .vspan_2 {
-  height: 120px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_4 {
-  height: 240px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_6 {
-  height: 360px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_8 {
-  height: 480px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 
 .hspan_2 {
-  width: 160px;
+  width: auto;
 }
 .hspan_8 {
-  width: 640px;
+  width: auto;
 }
 .hspan_10 {
-  width: 800px;
+  width: auto;
 }
 .hspan_12 {
-  width: 960px;
+  width: auto;
 }
 
 #perc-content {

--- a/WebUI/src/main/webapp/cm/css/perc_decoration.css
+++ b/WebUI/src/main/webapp/cm/css/perc_decoration.css
@@ -1,34 +1,35 @@
 /* Region CSS
 ----------------------------------*/
-
+/*
+ * Region span sizing for editor/preview decoration (GH-2352).
+ * Do not force the legacy fixed pixel grid with !important — that stomps
+ * responsive customer themes that set height/width: auto (or fluid sizes).
+ * Published default-theme #757 footer/sidebar min-height lives in theme.css.
+ */
 .vspan_2 {
-  height: 120px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_4 {
-  height: 240px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_6 {
-  height: 360px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_8 {
-  height: 480px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 
 .hspan_2 {
-  width: 160px;
+  width: auto;
 }
 .hspan_8 {
-  width: 640px;
+  width: auto;
 }
 .hspan_10 {
-  width: 800px;
+  width: auto;
 }
 .hspan_12 {
-  width: 960px;
+  width: auto;
 }
 
 #perc-content {

--- a/WebUI/war/css/perc_decoration.css
+++ b/WebUI/war/css/perc_decoration.css
@@ -1,34 +1,35 @@
 /* Region CSS
 ----------------------------------*/
-
+/*
+ * Region span sizing for editor/preview decoration (GH-2352).
+ * Do not force the legacy fixed pixel grid with !important — that stomps
+ * responsive customer themes that set height/width: auto (or fluid sizes).
+ * Published default-theme #757 footer/sidebar min-height lives in theme.css.
+ */
 .vspan_2 {
-  height: 120px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_4 {
-  height: 240px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_6 {
-  height: 360px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 .vspan_8 {
-  height: 480px !important;
-  min-height: 0 !important;
+  height: auto;
 }
 
 .hspan_2 {
-  width: 160px;
+  width: auto;
 }
 .hspan_8 {
-  width: 640px;
+  width: auto;
 }
 .hspan_10 {
-  width: 800px;
+  width: auto;
 }
 .hspan_12 {
-  width: 960px;
+  width: auto;
 }
 
 #perc-content {

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/VspanFooterAlignmentCssTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/VspanFooterAlignmentCssTest.java
@@ -32,17 +32,25 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 /**
- * Regression for GH-757 / v8.1.7 PRs #763 and #767: published theme {@code vspan_*} regions use
- * {@code min-height} so sidebars grow with content (footer stays below), while editor decoration
- * CSS keeps fixed {@code height !important} and resets {@code min-height} so placeholders stay
- * sized.
+ * Regression for GH-757 / GH-2352:
+ *
+ * <ul>
+ *   <li>Published default theme {@code vspan_*} regions use {@code min-height} so sidebars grow
+ *       with content (footer stays below) — GH-757.
+ *   <li>Editor/preview decoration must <strong>not</strong> force the legacy fixed pixel grid with
+ *       {@code !important} (or hard-coded px heights/widths) so responsive customer themes that set
+ *       {@code height/width: auto} win in the CMS chrome — GH-2352.
+ * </ul>
  */
 class VspanFooterAlignmentCssTest {
 
   private static final Pattern VSPAN_BLOCK =
       Pattern.compile("\\.vspan_([2468])\\s*\\{([^}]*)\\}", Pattern.DOTALL);
 
-  /** Design floor heights for empty vspan regions (px), keyed by span index. */
+  private static final Pattern HSPAN_BLOCK =
+      Pattern.compile("\\.hspan_(2|8|10|12)\\s*\\{([^}]*)\\}", Pattern.DOTALL);
+
+  /** Design floor heights for empty vspan regions (px), keyed by span index (default theme). */
   private static final Map<String, String> VSPAN_FLOOR_PX =
       Map.of("2", "120", "4", "240", "6", "360", "8", "480");
 
@@ -97,7 +105,7 @@ class VspanFooterAlignmentCssTest {
   }
 
   @Test
-  void decorationCssOverridesMinHeightWithFixedHeightImportant() throws Exception {
+  void decorationCssDoesNotForceFixedPixelGridWithImportant() throws Exception {
     Path root = resolveRepoRoot();
     for (String rel : DECORATION_PATHS) {
       Path cssPath = root.resolve(rel);
@@ -105,40 +113,94 @@ class VspanFooterAlignmentCssTest {
         fail("expected decoration CSS at " + cssPath.toAbsolutePath());
       }
       String css = Files.readString(cssPath, StandardCharsets.UTF_8);
-      Matcher m = VSPAN_BLOCK.matcher(css);
-      Map<String, Integer> counts = new LinkedHashMap<>();
-      for (String k : VSPAN_FLOOR_PX.keySet()) {
-        counts.put(k, 0);
-      }
-      int blocks = 0;
-      while (m.find()) {
-        blocks++;
-        String span = m.group(1);
-        String body = m.group(2);
-        String floor = VSPAN_FLOOR_PX.get(span);
-        assertTrue(
-            Pattern.compile("height\\s*:\\s*" + floor + "px\\s*!important").matcher(body).find(),
-            rel
-                + " .vspan_"
-                + span
-                + " must fix height: "
-                + floor
-                + "px !important: "
-                + body.replace('\n', ' '));
-        assertTrue(
-            Pattern.compile("min-height\\s*:\\s*0\\s*!important").matcher(body).find(),
-            rel
-                + " .vspan_"
-                + span
-                + " must reset min-height: 0 !important: "
-                + body.replace('\n', ' '));
-        counts.merge(span, 1, Integer::sum);
-      }
-      // At least one rule per span class (allow extra legitimate editor variants later).
-      assertTrue(blocks >= 4, rel + ": expected at least vspan_2/4/6/8 rules, found " + blocks);
-      for (Map.Entry<String, Integer> e : counts.entrySet()) {
-        assertTrue(e.getValue() >= 1, rel + " .vspan_" + e.getKey() + " count=" + e.getValue());
-      }
+      assertVspanAllowsResponsiveThemes(rel, css);
+      assertHspanAllowsResponsiveThemes(rel, css);
+    }
+  }
+
+  private static void assertVspanAllowsResponsiveThemes(String rel, String css) {
+    Matcher m = VSPAN_BLOCK.matcher(css);
+    Map<String, Integer> counts = new LinkedHashMap<>();
+    for (String k : VSPAN_FLOOR_PX.keySet()) {
+      counts.put(k, 0);
+    }
+    int blocks = 0;
+    while (m.find()) {
+      blocks++;
+      String span = m.group(1);
+      String body = m.group(2);
+      // GH-2352: never lock height with !important over customer auto rules.
+      assertFalse(
+          Pattern.compile("(?<!min-|max-)height\\s*:[^;!]*!important").matcher(body).find(),
+          rel
+              + " .vspan_"
+              + span
+              + " must not force height with !important: "
+              + body.replace('\n', ' '));
+      assertFalse(
+          Pattern.compile("min-height\\s*:\\s*0\\s*!important").matcher(body).find(),
+          rel
+              + " .vspan_"
+              + span
+              + " must not reset min-height: 0 !important (kills theme floors): "
+              + body.replace('\n', ' '));
+      // Prefer auto so decoration does not re-impose the legacy 120/240/360/480 grid.
+      assertTrue(
+          Pattern.compile("(?<!min-|max-)height\\s*:\\s*auto").matcher(body).find(),
+          rel + " .vspan_" + span + " must use height: auto: " + body.replace('\n', ' '));
+      // No fixed design-floor px height on decoration (theme owns min-height floors).
+      String floor = VSPAN_FLOOR_PX.get(span);
+      assertFalse(
+          Pattern.compile("(?<!min-|max-)height\\s*:\\s*" + floor + "px").matcher(body).find(),
+          rel
+              + " .vspan_"
+              + span
+              + " must not set fixed height: "
+              + floor
+              + "px: "
+              + body.replace('\n', ' '));
+      counts.merge(span, 1, Integer::sum);
+    }
+    assertTrue(blocks >= 4, rel + ": expected at least vspan_2/4/6/8 rules, found " + blocks);
+    for (Map.Entry<String, Integer> e : counts.entrySet()) {
+      assertTrue(e.getValue() >= 1, rel + " .vspan_" + e.getKey() + " count=" + e.getValue());
+    }
+  }
+
+  private static void assertHspanAllowsResponsiveThemes(String rel, String css) {
+    Matcher m = HSPAN_BLOCK.matcher(css);
+    Map<String, Integer> counts = new LinkedHashMap<>();
+    for (String k : List.of("2", "8", "10", "12")) {
+      counts.put(k, 0);
+    }
+    int blocks = 0;
+    while (m.find()) {
+      blocks++;
+      String span = m.group(1);
+      String body = m.group(2);
+      assertFalse(
+          Pattern.compile("width\\s*:[^;!]*!important").matcher(body).find(),
+          rel
+              + " .hspan_"
+              + span
+              + " must not force width with !important: "
+              + body.replace('\n', ' '));
+      assertTrue(
+          Pattern.compile("width\\s*:\\s*auto").matcher(body).find(),
+          rel + " .hspan_" + span + " must use width: auto: " + body.replace('\n', ' '));
+      // Legacy fixed grid must not be reimposed (160/640/800/960).
+      assertFalse(
+          Pattern.compile("width\\s*:\\s*(160|640|800|960)px").matcher(body).find(),
+          rel
+              + " .hspan_"
+              + span
+              + " must not set fixed legacy grid width: "
+              + body.replace('\n', ' '));
+      counts.merge(span, 1, Integer::sum);
+    }
+    assertTrue(blocks >= 4, rel + ": expected at least hspan_2/8/10/12 rules, found " + blocks);
+    for (Map.Entry<String, Integer> e : counts.entrySet()) {
+      assertTrue(e.getValue() >= 1, rel + " .hspan_" + e.getKey() + " count=" + e.getValue());
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes **#2352**: editor/preview decoration CSS no longer forces the legacy fixed region grid with `!important`, so responsive customer themes (`height`/`width: auto`) render sanely in CMS chrome.

**Root cause (8.1.7 / GH-757 editor half):** `perc_decoration.css` set `.vspan_* { height: Npx !important; min-height: 0 !important; }` so decoration could win over default-theme `min-height`. That also stomped legitimate responsive themes (e.g. `cccc-theme.css`).

**Product fix:**
- All three shipped copies of `perc_decoration.css` now use `height: auto` / `width: auto` for `.vspan_*` / `.hspan_*` (no `!important` fixed px grid).
- Published default-theme **#757** footer/sidebar behavior remains in `theme.css` (`min-height` floors) — unchanged.
- `VspanFooterAlignmentCssTest` updated: still asserts theme min-height; now asserts decoration does **not** force `!important` fixed sizes and uses `auto`.
- Brief release/support note + temporary customer workaround in `CHANGES.md`.

**Paths:**
- `WebUI/war/css/perc_decoration.css`
- `WebUI/src/main/webapp/cm/css/perc_decoration.css`
- `WebUI/src/main/webapp/cm/app/css/legacy/perc_decoration.css`

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2352

## Test plan

- [x] `VspanFooterAlignmentCssTest` green (sitemanage)
- [x] `projects/sitemanage`: `mvnw clean install` BUILD SUCCESS
- [x] `WebUI`: `mvnw clean install` BUILD SUCCESS (frontend + WAR)
- [x] Static CSS review: no `height: Npx !important` / `min-height: 0 !important` on decoration vspan rules
- [ ] Manual / customer acceptance (recommended post-merge): Cloud-style theme (`height/width: auto` on all vspan/hspan) looks sane in editor + preview without customer `!important` counter; default theme published pages still clear tall sidebars above footer (#757)

## Gates evidence

| Gate | Result |
|------|--------|
| A) Behavioral tests | `VspanFooterAlignmentCssTest` rewritten for GH-2352 |
| B) Erlang self-review | CSS-only + test path I/O portable (`Path`/`Files`); no path hardcoding; companions: 3 CSS copies + regression + CHANGES note |
| C) Module clean install | sitemanage + WebUI both SUCCESS |
| D) In-scope commit only | 5 files |
| E) Issue ref | Fixes #2352 |
| F/G) Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |

Fixes #2352

> Co-Authored by Grok Build using grok-4.5 with agent main.