### PR TITLE
fix(system): improve DTS rotateKey failure logging (#2354)

### DIFF
--- a/docs/ai-generated/code-reviews/2354-rotatekey-logging-erlang.md
+++ b/docs/ai-generated/code-reviews/2354-rotatekey-logging-erlang.md
@@ -1,0 +1,36 @@
+# Erlang self-review: #2354 rotateKey failure logging
+
+**Branch:** `fix/issue-2354-rotatekey-failure-logging`  
+**Scope:** system delivery client + PSDeliveryInfoService rotateKey WARN  
+**Date:** 2026-08-07
+
+## Change class
+
+Operator-facing structured logging for DTS admin HTTP failures (rotateKey push).
+
+### Companions delivered
+
+| Artifact | Status |
+|----------|--------|
+| `PSDeliveryHttpErrorSupport` helper | new |
+| `PSDeliveryClient` ERROR truncation + structured exception | done |
+| `PSDeliveryClientException` status/method/url/snippet fields | done |
+| `PSDeliveryInfoService` actionable WARN | done |
+| Unit tests for helper | 8 tests green |
+| Module `mvnw clean install` | BUILD SUCCESS |
+
+## Checklist
+
+- [x] No multi-KB HTML in ERROR/WARN (first-line snippet, max 200 chars)
+- [x] Full URL + PUT + HTTP status in rotateKey failure WARN
+- [x] Actionable operator hint (feeds WAR, deliverymanager, availableServices, key drift)
+- [x] Success path INFO unchanged on 204
+- [x] Behavioral unit tests for new logic
+- [x] No non-portable path/file I/O
+- [x] Intersoft copyright on new files (2026)
+- [x] No unrelated reformat churn
+- [x] Existing constructors of `PSDeliveryClientException` preserved (status -1)
+
+## Verdict
+
+**PASS** — ready to commit/PR.

--- a/system/business/src/com/percussion/delivery/client/IPSDeliveryClient.java
+++ b/system/business/src/com/percussion/delivery/client/IPSDeliveryClient.java
@@ -304,12 +304,25 @@ public interface IPSDeliveryClient
          */
         private static final long serialVersionUID = -7552921159505062022L;
 
+        /** HTTP status when known; {@code -1} if not an HTTP response failure. */
+        private final int statusCode;
+
+        /** HTTP method label (e.g. PUT); may be {@code null}. */
+        private final String httpMethod;
+
+        /** Full request URL when known; may be {@code null}. */
+        private final String requestUrl;
+
+        /**
+         * Short truncated response snippet (not multi-KB HTML); may be {@code null}.
+         */
+        private final String responseSnippet;
+
         /**
          *
          */
         public PSDeliveryClientException() {
-            super();
-
+            this(null, null, -1, null, null, null);
         }
 
         /**
@@ -317,24 +330,74 @@ public interface IPSDeliveryClient
          * @param cause
          */
         public PSDeliveryClientException(String message, Throwable cause) {
-            super(message, cause);
-
+            this(message, cause, -1, null, null, null);
         }
 
         /**
          * @param message
          */
         public PSDeliveryClientException(String message) {
-            super(message);
-
+            this(message, null, -1, null, null, null);
         }
 
         /**
          * @param cause
          */
         public PSDeliveryClientException(Throwable cause) {
-            super(cause);
+            this(cause != null ? cause.getMessage() : null, cause, -1, null, null, null);
+        }
 
+        /**
+         * Structured HTTP failure for operators and callers that need status/URL without parsing
+         * the message.
+         *
+         * @param message log/exception message (already truncated if body was included)
+         * @param statusCode HTTP status, or {@code -1} when unknown
+         * @param httpMethod method label; may be {@code null}
+         * @param requestUrl full URL; may be {@code null}
+         * @param responseSnippet short body snippet; may be {@code null}
+         */
+        public PSDeliveryClientException(
+                String message,
+                int statusCode,
+                String httpMethod,
+                String requestUrl,
+                String responseSnippet) {
+            this(message, null, statusCode, httpMethod, requestUrl, responseSnippet);
+        }
+
+        private PSDeliveryClientException(
+                String message,
+                Throwable cause,
+                int statusCode,
+                String httpMethod,
+                String requestUrl,
+                String responseSnippet) {
+            super(message, cause);
+            this.statusCode = statusCode;
+            this.httpMethod = httpMethod;
+            this.requestUrl = requestUrl;
+            this.responseSnippet = responseSnippet;
+        }
+
+        /** @return HTTP status when known; {@code -1} otherwise */
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        /** @return HTTP method label, or {@code null} */
+        public String getHttpMethod() {
+            return httpMethod;
+        }
+
+        /** @return full request URL when known, or {@code null} */
+        public String getRequestUrl() {
+            return requestUrl;
+        }
+
+        /** @return short response snippet when known, or {@code null} */
+        public String getResponseSnippet() {
+            return responseSnippet;
         }
     }
 }

--- a/system/business/src/com/percussion/delivery/client/PSDeliveryClient.java
+++ b/system/business/src/com/percussion/delivery/client/PSDeliveryClient.java
@@ -725,15 +725,23 @@ public class PSDeliveryClient implements IPSDeliveryClient
             if (!successfulHttpStatusCodes.contains(statusCode)) {
                 failureCount = 0;
                 offline = false;
+                String snippet =
+                        PSDeliveryHttpErrorSupport.firstLineSnippet(
+                                responseData, PSDeliveryHttpErrorSupport.DEFAULT_BODY_SNIPPET_MAX);
                 String msg;
                 if (statusCode == 401) {
-                    msg = String.format("Authentication error. Check user and password for this delivery server. HTTP status: %s",
-                            statusCode);
+                    msg = String.format(
+                            "Authentication error. Check user and password for this delivery server. %s %s (HTTP %s)%s",
+                            methodLabel,
+                            url,
+                            statusCode,
+                            snippet.isEmpty() ? "" : ": " + snippet);
                 } else {
-                    msg = String.format("Error when executing method : %s %s : %s", methodLabel, url, responseData);
+                    msg = PSDeliveryHttpErrorSupport.formatExecutionError(
+                            methodLabel, url, statusCode, responseData);
                 }
                 log.error(msg);
-                throw new PSDeliveryClientException(msg);
+                throw new PSDeliveryClientException(msg, statusCode, methodLabel, url, snippet);
             } else {
                 if (statusCode == 204)
                     return "";

--- a/system/business/src/com/percussion/delivery/client/PSDeliveryHttpErrorSupport.java
+++ b/system/business/src/com/percussion/delivery/client/PSDeliveryHttpErrorSupport.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.client;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Helpers for operator-friendly delivery-client failure messages: full action URL + HTTP method +
+ * status without dumping multi-KB Tomcat HTML error pages into logs.
+ *
+ * <p>Used by {@link PSDeliveryClient} and rotateKey / admin push callers such as {@code
+ * PSDeliveryInfoService}.
+ */
+public final class PSDeliveryHttpErrorSupport {
+
+  /** Default max length of a response-body snippet included in ERROR/WARN lines. */
+  public static final int DEFAULT_BODY_SNIPPET_MAX = 200;
+
+  /**
+   * Actionable operator guidance when security-key rotation push fails. Publish may continue but
+   * CMS/DTS keys can drift.
+   */
+  public static final String ROTATE_KEY_OPERATOR_HINT =
+      "Check DTS feeds app on admin port, deliverymanager credentials, and that availableServices"
+          + " includes feeds. Publish may continue but encryption keys may be out of sync.";
+
+  private PSDeliveryHttpErrorSupport() {
+    // utility
+  }
+
+  /**
+   * Joins an admin base URL with an action path (e.g. {@code /feeds/rss/rotateKey}) without
+   * introducing double slashes.
+   *
+   * @param adminBase admin host URL from delivery config; may be blank
+   * @param actionPath action path; may be blank
+   * @return combined URL, never {@code null}
+   */
+  public static String joinAdminActionUrl(String adminBase, String actionPath) {
+    String base = StringUtils.trimToEmpty(adminBase);
+    String path = StringUtils.trimToEmpty(actionPath);
+    if (base.isEmpty()) {
+      return path;
+    }
+    if (path.isEmpty()) {
+      return base;
+    }
+    boolean baseEndsWithSlash = base.endsWith("/");
+    boolean pathStartsWithSlash = path.startsWith("/");
+    if (baseEndsWithSlash && pathStartsWithSlash) {
+      return base + path.substring(1);
+    }
+    if (!baseEndsWithSlash && !pathStartsWithSlash) {
+      return base + "/" + path;
+    }
+    return base + path;
+  }
+
+  /**
+   * Returns a short, single-line snippet of an HTTP response body suitable for logs. Strips CR/LF
+   * noise, collapses whitespace for HTML-ish bodies, and caps length so Tomcat error pages do not
+   * flood logs.
+   *
+   * @param body raw response body; may be {@code null}
+   * @param maxLen maximum characters; values &lt;= 0 use {@link #DEFAULT_BODY_SNIPPET_MAX}
+   * @return snippet, never {@code null} (empty when body blank)
+   */
+  public static String firstLineSnippet(String body, int maxLen) {
+    int limit = maxLen > 0 ? maxLen : DEFAULT_BODY_SNIPPET_MAX;
+    if (StringUtils.isBlank(body)) {
+      return "";
+    }
+    String trimmed = body.trim();
+    // Prefer the first non-empty line (status text / short reason), not multi-line HTML.
+    String firstLine = trimmed;
+    int nl = indexOfAnyLineBreak(trimmed);
+    if (nl >= 0) {
+      firstLine = trimmed.substring(0, nl).trim();
+      if (firstLine.isEmpty()) {
+        // Leading blank lines (common in some servlet error pages) — take next content line.
+        String rest = trimmed.substring(nl).trim();
+        int nl2 = indexOfAnyLineBreak(rest);
+        firstLine = (nl2 >= 0 ? rest.substring(0, nl2) : rest).trim();
+      }
+    }
+    if (firstLine.isEmpty()) {
+      firstLine = trimmed.replace('\r', ' ').replace('\n', ' ').trim();
+    }
+    // Collapse internal whitespace so HTML dumps stay one short log token.
+    firstLine = firstLine.replaceAll("\\s+", " ").trim();
+    if (firstLine.length() > limit) {
+      return firstLine.substring(0, limit) + "...";
+    }
+    return firstLine;
+  }
+
+  /**
+   * Formats the ERROR message thrown/logged when a delivery HTTP call returns a non-success status.
+   *
+   * @param method HTTP method label (e.g. PUT)
+   * @param url full request URL
+   * @param statusCode HTTP status code
+   * @param responseBody raw body; may be HTML
+   * @return message including method, URL, status, and short reason
+   */
+  public static String formatExecutionError(
+      String method, String url, int statusCode, String responseBody) {
+    String methodLabel = StringUtils.defaultIfBlank(method, "?");
+    String urlLabel = StringUtils.defaultIfBlank(url, "?");
+    String reason = firstLineSnippet(responseBody, DEFAULT_BODY_SNIPPET_MAX);
+    if (reason.isEmpty()) {
+      return String.format(
+          "Error when executing method : %s %s (HTTP %d)", methodLabel, urlLabel, statusCode);
+    }
+    return String.format(
+        "Error when executing method : %s %s (HTTP %d): %s",
+        methodLabel, urlLabel, statusCode, reason);
+  }
+
+  /**
+   * Formats an actionable WARN when {@code PUT …/feeds/rss/rotateKey} (or similar) fails.
+   *
+   * @param method HTTP method (typically PUT)
+   * @param fullUrl full action URL
+   * @param statusCode HTTP status, or negative when unknown (e.g. connect failure)
+   * @param shortReason truncated reason / status text; may be blank
+   * @return single-line WARN text for operators
+   */
+  public static String formatRotateKeyFailureWarn(
+      String method, String fullUrl, int statusCode, String shortReason) {
+    String methodLabel = StringUtils.defaultIfBlank(method, "PUT");
+    String urlLabel = StringUtils.defaultIfBlank(fullUrl, "?");
+    String statusPart =
+        statusCode > 0 ? String.format("HTTP %d", statusCode) : "no HTTP status (transport error)";
+    String reason = StringUtils.trimToEmpty(shortReason);
+    if (!reason.isEmpty()) {
+      return String.format(
+          "Unable to %s %s (%s: %s). %s",
+          methodLabel, urlLabel, statusPart, reason, ROTATE_KEY_OPERATOR_HINT);
+    }
+    return String.format(
+        "Unable to %s %s (%s). %s", methodLabel, urlLabel, statusPart, ROTATE_KEY_OPERATOR_HINT);
+  }
+
+  /**
+   * Derives a short operator-facing reason from a delivery-client exception without re-including
+   * multi-line HTML.
+   *
+   * @param ex failure exception; may be {@code null}
+   * @return short reason, never {@code null}
+   */
+  public static String shortReasonFromException(Throwable ex) {
+    if (ex == null) {
+      return "";
+    }
+    if (ex instanceof IPSDeliveryClient.PSDeliveryClientException pce) {
+      String structured = firstLineSnippet(pce.getResponseSnippet(), DEFAULT_BODY_SNIPPET_MAX);
+      if (!structured.isEmpty()) {
+        return structured;
+      }
+    }
+    return firstLineSnippet(ex.getMessage(), DEFAULT_BODY_SNIPPET_MAX);
+  }
+
+  private static int indexOfAnyLineBreak(String s) {
+    int n = s.indexOf('\n');
+    int r = s.indexOf('\r');
+    if (n < 0) {
+      return r;
+    }
+    if (r < 0) {
+      return n;
+    }
+    return Math.min(n, r);
+  }
+}

--- a/system/business/src/com/percussion/delivery/service/impl/PSDeliveryInfoService.java
+++ b/system/business/src/com/percussion/delivery/service/impl/PSDeliveryInfoService.java
@@ -19,6 +19,7 @@ package com.percussion.delivery.service.impl;
 
 import com.percussion.delivery.client.IPSDeliveryClient;
 import com.percussion.delivery.client.PSDeliveryClient;
+import com.percussion.delivery.client.PSDeliveryHttpErrorSupport;
 import com.percussion.delivery.data.PSDeliveryInfo;
 import com.percussion.delivery.service.IPSDeliveryInfoService;
 import com.percussion.delivery.service.PSDeliveryInfoServiceLocator;
@@ -242,12 +243,16 @@ public class PSDeliveryInfoService implements IPSDeliveryInfoService
                 }
                 if (info.getAvailableServices().contains(PSDeliveryInfo.SERVICE_FEEDS)) {
                     PSDeliveryClient deliveryClient = new PSDeliveryClient();
+                    final String rotateKeyPath = "/feeds/rss/rotateKey";
+                    final String methodLabel = IPSDeliveryClient.HttpMethodType.PUT.name();
+                    String expectedUrl = PSDeliveryHttpErrorSupport.joinAdminActionUrl(
+                            info.getAdminUrl().orElse(""), rotateKeyPath);
                     try {
                         Set<Integer> successfullHttpStatusCodes = new HashSet<>();
                         successfullHttpStatusCodes.add(204);
                         deliveryClient.push(
                                 new IPSDeliveryClient.PSDeliveryActionOptions()
-                                        .setActionUrl("/feeds/rss/rotateKey")
+                                        .setActionUrl(rotateKeyPath)
                                         .setDeliveryInfo(info)
                                         .setHttpMethod(IPSDeliveryClient.HttpMethodType.PUT)
                                         .setSuccessfullHttpStatusCodes(successfullHttpStatusCodes)
@@ -255,8 +260,27 @@ public class PSDeliveryInfoService implements IPSDeliveryInfoService
                                 secureKey);
                         log.info("Updated security key pushed to DTS server: {}", info.getAdminUrl().orElse(""));
                     } catch (Exception ex) {
-                        log.warn("Unable to push updated security key to DTS server:{} ", info.getAdminUrl().orElse(""));
-                        log.debug("Unable to push updated security key to DTS server:{}  ERROR: {} ", info.getAdminUrl().orElse(""), ex.getMessage(), ex);
+                        String fullUrl = expectedUrl;
+                        String method = methodLabel;
+                        int statusCode = -1;
+                        if (ex instanceof IPSDeliveryClient.PSDeliveryClientException pce) {
+                            if (StringUtils.isNotBlank(pce.getRequestUrl())) {
+                                fullUrl = pce.getRequestUrl();
+                            }
+                            if (StringUtils.isNotBlank(pce.getHttpMethod())) {
+                                method = pce.getHttpMethod();
+                            }
+                            statusCode = pce.getStatusCode();
+                        }
+                        String shortReason = PSDeliveryHttpErrorSupport.shortReasonFromException(ex);
+                        log.warn(
+                                PSDeliveryHttpErrorSupport.formatRotateKeyFailureWarn(
+                                        method, fullUrl, statusCode, shortReason));
+                        log.debug(
+                                "Unable to push updated security key to DTS server: {} ERROR: {}",
+                                fullUrl,
+                                ex.getMessage(),
+                                ex);
                     }
                 }
             }

--- a/system/src/test/java/com/percussion/delivery/client/PSDeliveryHttpErrorSupportTest.java
+++ b/system/src/test/java/com/percussion/delivery/client/PSDeliveryHttpErrorSupportTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.delivery.client.IPSDeliveryClient.PSDeliveryClientException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for structured delivery HTTP error logging helpers (issue #2354): full URL +
+ * method + status without multi-KB Tomcat HTML dumps; actionable rotateKey WARN text.
+ */
+public class PSDeliveryHttpErrorSupportTest {
+
+  @Test
+  public void joinAdminActionUrlAvoidsDoubleSlash() {
+    assertEquals(
+        "https://localhost:8443/feeds/rss/rotateKey",
+        PSDeliveryHttpErrorSupport.joinAdminActionUrl(
+            "https://localhost:8443", "/feeds/rss/rotateKey"));
+    assertEquals(
+        "https://localhost:8443/feeds/rss/rotateKey",
+        PSDeliveryHttpErrorSupport.joinAdminActionUrl(
+            "https://localhost:8443/", "/feeds/rss/rotateKey"));
+    assertEquals(
+        "https://localhost:8443/feeds/rss/rotateKey",
+        PSDeliveryHttpErrorSupport.joinAdminActionUrl(
+            "https://localhost:8443", "feeds/rss/rotateKey"));
+  }
+
+  @Test
+  public void firstLineSnippetTruncatesHtmlErrorPage() {
+    String tomcatHtml =
+        "<!doctype html><html><head><title>HTTP Status 405 – Method Not Allowed</title></head>"
+            + "<body><h1>HTTP Status 405 – Method Not Allowed</h1>"
+            + StringUtilsRepeat("x", 5000)
+            + "</body></html>";
+    String snippet =
+        PSDeliveryHttpErrorSupport.firstLineSnippet(
+            tomcatHtml, PSDeliveryHttpErrorSupport.DEFAULT_BODY_SNIPPET_MAX);
+    assertFalse(snippet.isEmpty());
+    assertTrue(
+        snippet.length() <= PSDeliveryHttpErrorSupport.DEFAULT_BODY_SNIPPET_MAX + 3,
+        "snippet must not dump multi-KB HTML: len=" + snippet.length());
+    assertFalse(snippet.contains("\n"), "snippet must be single-line for log files");
+  }
+
+  @Test
+  public void firstLineSnippetUsesFirstNonEmptyLine() {
+    String body = "\nHTTP Status 405 – Method Not Allowed\nType Status Report\n";
+    assertEquals(
+        "HTTP Status 405 – Method Not Allowed",
+        PSDeliveryHttpErrorSupport.firstLineSnippet(body, 200));
+  }
+
+  @Test
+  public void formatExecutionErrorIncludesMethodUrlStatusAndShortReason() {
+    String msg =
+        PSDeliveryHttpErrorSupport.formatExecutionError(
+            "PUT",
+            "https://localhost:8443/feeds/rss/rotateKey",
+            405,
+            "HTTP Status 405 – Method Not Allowed\n" + StringUtilsRepeat("y", 3000));
+    assertTrue(msg.contains("PUT"));
+    assertTrue(msg.contains("https://localhost:8443/feeds/rss/rotateKey"));
+    assertTrue(msg.contains("HTTP 405"));
+    assertTrue(msg.contains("Method Not Allowed") || msg.contains("405"));
+    assertTrue(
+        msg.length() < 800,
+        "ERROR message must stay short (no multi-KB body): len=" + msg.length());
+  }
+
+  @Test
+  public void formatRotateKeyFailureWarnIsActionable() {
+    String warn =
+        PSDeliveryHttpErrorSupport.formatRotateKeyFailureWarn(
+            "PUT",
+            "https://localhost:8443/feeds/rss/rotateKey",
+            405,
+            "HTTP Status 405 – Method Not Allowed");
+    assertTrue(warn.contains("PUT"));
+    assertTrue(warn.contains("https://localhost:8443/feeds/rss/rotateKey"));
+    assertTrue(warn.contains("HTTP 405"));
+    assertTrue(warn.contains("feeds"));
+    assertTrue(warn.contains("deliverymanager"));
+    assertTrue(warn.contains("availableServices"));
+    assertTrue(warn.contains("encryption keys may be out of sync"));
+  }
+
+  @Test
+  public void formatRotateKeyFailureWarnHandlesUnknownStatus() {
+    String warn =
+        PSDeliveryHttpErrorSupport.formatRotateKeyFailureWarn(
+            "PUT", "https://localhost:8443/feeds/rss/rotateKey", -1, "Unable to connect");
+    assertTrue(warn.contains("no HTTP status") || warn.contains("transport"));
+    assertTrue(warn.contains("Unable to connect"));
+  }
+
+  @Test
+  public void shortReasonFromStructuredExceptionPrefersSnippet() {
+    PSDeliveryClientException ex =
+        new PSDeliveryClientException(
+            "Error when executing method : PUT https://localhost:8443/feeds/rss/rotateKey (HTTP 405): HTTP Status 405",
+            405,
+            "PUT",
+            "https://localhost:8443/feeds/rss/rotateKey",
+            "HTTP Status 405 – Method Not Allowed");
+    assertEquals(
+        "HTTP Status 405 – Method Not Allowed",
+        PSDeliveryHttpErrorSupport.shortReasonFromException(ex));
+    assertEquals(405, ex.getStatusCode());
+    assertEquals("PUT", ex.getHttpMethod());
+    assertEquals("https://localhost:8443/feeds/rss/rotateKey", ex.getRequestUrl());
+  }
+
+  @Test
+  public void firstLineSnippetBlankIsEmpty() {
+    assertEquals("", PSDeliveryHttpErrorSupport.firstLineSnippet(null, 100));
+    assertEquals("", PSDeliveryHttpErrorSupport.firstLineSnippet("   ", 100));
+  }
+
+  /** Avoid pulling in StringUtils.repeat dependency quirks; tiny local helper for tests. */
+  private static String StringUtilsRepeat(String s, int n) {
+    StringBuilder sb = new StringBuilder(s.length() * n);
+    for (int i = 0; i < n; i++) {
+      sb.append(s);
+    }
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
## Summary

Improves operator/support logging when CMS fails to push encryption key rotation to DTS (`PUT {admin}/feeds/rss/rotateKey`), typically seen as HTTP 405 after upgrades when the feeds WAR / admin path is misconfigured.

**Before:** WARN only showed admin base URL; ERROR dumped multi-KB Tomcat HTML.

**After:**
- WARN includes full action URL, HTTP method `PUT`, status code, short reason
- Actionable operator hint: feeds app on admin port, deliverymanager credentials, `availableServices` includes feeds; publish may continue but keys may drift
- `PSDeliveryClient` ERROR truncates response bodies (first line / max 200 chars)
- `PSDeliveryClientException` carries status/method/url/snippet for structured handling
- Success path unchanged (HTTP 204 → existing INFO)

Fixes #2354

## Changes

- New `PSDeliveryHttpErrorSupport` helper (join URL, snippet, format ERROR/WARN)
- `PSDeliveryClient#executeHttpRequest` uses truncated bodies + structured exception
- `PSDeliveryInfoService#copySecureKeyToDeliveryServer` rotateKey catch → actionable WARN
- Unit tests: `PSDeliveryHttpErrorSupportTest` (8 tests)

## Test plan

- [x] `system`: `mvnw -Dtest=PSDeliveryHttpErrorSupportTest test` — 8/8 green
- [x] `system`: standalone `mvnw clean install` — BUILD SUCCESS
- [x] Erlang self-review: `docs/ai-generated/code-reviews/2354-rotatekey-logging-erlang.md` PASS
- [ ] Manual (optional): trigger rotateKey against DTS without feeds WAR; confirm WARN shows full URL + HTTP 405 without HTML dump

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | yes (helper + structured exception) |
| Erlang review | PASS |
| Module clean install (system) | BUILD SUCCESS |
| In-scope commit only | yes |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2354

> Co-Authored by Grok Build using grok-4.5 with agent main.