### PR TITLE
fix: lenient metadata extraction for unbound XML prefixes (#2355)

### DIFF
--- a/system/business/src/com/percussion/delivery/metadata/PSMetadataExtractorService.java
+++ b/system/business/src/com/percussion/delivery/metadata/PSMetadataExtractorService.java
@@ -32,17 +32,25 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.lang3.StringUtils.contains;
 import static org.apache.commons.lang3.StringUtils.endsWith;
@@ -72,6 +80,20 @@ public class PSMetadataExtractorService implements IPSMetadataExtractorService {
     public static final String TYPE_PROPERTY_NAME = "dterms:type";
 
     private static final String APPS_SUFFIX = "apps";
+
+    /**
+     * HTML named entities that are not the five XML predefined entities and must be
+     * rewritten to numeric character references before SAX/RDFa parse.
+     */
+    private static final Pattern NON_XML_NAMED_ENTITY =
+            Pattern.compile("&(?!(?:lt|gt|amp|apos|quot);)([a-zA-Z0-9]+);");
+
+    /**
+     * SAX / RDF parse messages that indicate an undeclared XML-style namespace prefix
+     * (e.g. vendor tags such as {@code gcse:search} without {@code xmlns:gcse}).
+     */
+    private static final Pattern UNBOUND_PREFIX_MESSAGE =
+            Pattern.compile("prefix\\s+\"([^\"]+)\"\\s+for\\s+(?:element|attribute)", Pattern.CASE_INSENSITIVE);
 
     public PSMetadataExtractorService() {
 
@@ -234,7 +256,8 @@ public class PSMetadataExtractorService implements IPSMetadataExtractorService {
              parser.setRDFHandler(handler);
 
              // Parse the document to extract RDF triples (RDFa metadata)
-             // Sanitize HTML first to handle malformed entities (e.g., bare '&')
+             // Sanitize HTML first: entities, scripts, and unbound XML-style prefixes
+             // (e.g. <gcse:search> without xmlns:gcse) so SAX does not fail the whole page.
              String baseIri = documentSource.getDocumentIRI();
              String sanitizedHtml;
              try (InputStream inputStream = documentSource.openInputStream()) {
@@ -242,35 +265,39 @@ public class PSMetadataExtractorService implements IPSMetadataExtractorService {
                    // Remove script/style to avoid malformed entities (&) within text nodes breaking XML parsing
                    // But preserve JSON-LD scripts
                    doc.select("script:not([type='application/ld+json']), style").remove();
+                 // Vendor embeds often use prefixed custom elements without xmlns declarations.
+                 // Strip those before XHTML-like serialization so RDFa SAX parse stays lenient.
+                 stripUnboundPrefixedMarkup(doc, pagePath);
                  doc.outputSettings()
                         .escapeMode(org.jsoup.nodes.Entities.EscapeMode.base)
                         .charset("UTF-8")
                         .syntax(Document.OutputSettings.Syntax.xml); // XHTML-like output
-                 sanitizedHtml = doc.outerHtml();
-
-                 // Regex replace named entities that are NOT XML predefined (lt, gt, amp, apos, quot)
-                 // to numeric entities, because the SAX parser used by RDF4J/Semargl doesn't know HTML entities.
-                 java.util.regex.Pattern entityPattern = java.util.regex.Pattern.compile("&(?!(?:lt|gt|amp|apos|quot);)([a-zA-Z0-9]+);");
-                 java.util.regex.Matcher matcher = entityPattern.matcher(sanitizedHtml);
-                 StringBuffer sb = new StringBuffer();
-                 while (matcher.find()) {
-                     String entityName = matcher.group(1);
-                     // Use StringEscapeUtils to resolve the entity to a character
-                     String resolved = org.apache.commons.text.StringEscapeUtils.unescapeHtml4("&" + entityName + ";");
-                     if (resolved.length() == 1) {
-                         // Replace with numeric entity
-                         matcher.appendReplacement(sb, "&#" + (int) resolved.charAt(0) + ";");
-                     } else {
-                         // Fallback: keep as is if resolution fails or returns multiple chars
-                         matcher.appendReplacement(sb, matcher.group());
-                     }
-                 }
-                 matcher.appendTail(sb);
-                 sanitizedHtml = sb.toString();
+                 sanitizedHtml = rewriteNonXmlNamedEntities(doc.outerHtml());
              }
 
              try (java.io.Reader rdr = new java.io.StringReader(sanitizedHtml)) {
                  parser.parse(rdr, baseIri);
+             } catch (Exception parseEx) {
+                 if (!isUnboundPrefixParseFailure(parseEx)) {
+                     throw parseEx;
+                 }
+                 // Defensive fallback: pre-sanitize should prevent this path, but if SAX still
+                 // reports an unbound prefix, do not fail the whole page's metadata delivery.
+                 String unboundPrefix = extractUnboundPrefix(parseEx);
+                 if (unboundPrefix != null) {
+                     log.warn(
+                             "RDFa metadata parse hit unbound prefix '{}' for page path {}. "
+                                     + "Continuing with non-RDFa fields only. Cause: {}",
+                             unboundPrefix,
+                             pagePath,
+                             parseEx.getMessage());
+                 } else {
+                     log.warn(
+                             "RDFa metadata parse hit unbound XML-style prefix for page path {}. "
+                                     + "Continuing with non-RDFa fields only. Cause: {}",
+                             pagePath,
+                             parseEx.getMessage());
+                 }
              }
 
              /** Redo Abstract as any23 is corrupting it. */
@@ -438,5 +465,172 @@ public class PSMetadataExtractorService implements IPSMetadataExtractorService {
     private boolean metadataEntryHasRequiredFields(IPSMetadataEntry metadataEntry)
     {
         return true;
+    }
+
+    /**
+     * Rewrite HTML named entities that are not among the five XML predefined entities
+     * ({@code lt}, {@code gt}, {@code amp}, {@code apos}, {@code quot}) to numeric
+     * character references. SAX used by RDF4J/Semargl does not understand HTML entities.
+     *
+     * @param html HTML/XHTML text after Jsoup serialization; never {@code null}
+     * @return HTML with non-XML named entities rewritten where resolvable
+     */
+    private static String rewriteNonXmlNamedEntities(String html) {
+        Matcher matcher = NON_XML_NAMED_ENTITY.matcher(html);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String entityName = matcher.group(1);
+            String resolved =
+                    org.apache.commons.text.StringEscapeUtils.unescapeHtml4("&" + entityName + ";");
+            if (resolved.length() == 1) {
+                matcher.appendReplacement(sb, "&#" + (int) resolved.charAt(0) + ";");
+            } else {
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group()));
+            }
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Remove or unwrap elements and attributes that use XML-style namespace prefixes
+     * not declared via {@code xmlns:*} on the document. Customer pages often embed vendor
+     * tags such as {@code <gcse:search>} without a corresponding namespace declaration;
+     * those are fine in browsers but cause SAX {@code SAXParseException} during RDFa parse.
+     *
+     * <p>RDFa metadata of interest ({@code property="dcterms:…"}, {@code og:…} values, etc.)
+     * lives in attribute <em>values</em>, not in unbound element/attribute names, so stripping
+     * unbound prefixed markup preserves normal metadata extraction.
+     *
+     * @param doc Jsoup document mutated in place
+     * @param pagePath page path for WARN log context
+     */
+    void stripUnboundPrefixedMarkup(Document doc, String pagePath) {
+        Set<String> declared = new HashSet<>();
+        // Always allow the reserved XML prefixes
+        declared.add("xml");
+        declared.add("xmlns");
+
+        for (Element el : doc.getAllElements()) {
+            for (Attribute attr : el.attributes()) {
+                String key = attr.getKey();
+                if (key.regionMatches(true, 0, "xmlns:", 0, 6) && key.length() > 6) {
+                    declared.add(key.substring(6).toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+
+        Set<String> unboundPrefixes = new LinkedHashSet<>();
+        List<Element> elementsToUnwrap = new ArrayList<>();
+
+        for (Element el : doc.getAllElements()) {
+            String tag = el.tagName();
+            int colon = tag.indexOf(':');
+            if (colon > 0) {
+                String prefix = tag.substring(0, colon).toLowerCase(Locale.ROOT);
+                if (!declared.contains(prefix)) {
+                    unboundPrefixes.add(prefix);
+                    elementsToUnwrap.add(el);
+                }
+            }
+
+            List<String> attrsToRemove = new ArrayList<>();
+            for (Attribute attr : el.attributes()) {
+                String key = attr.getKey();
+                if (key.regionMatches(true, 0, "xmlns:", 0, 6)) {
+                    continue;
+                }
+                int attrColon = key.indexOf(':');
+                if (attrColon > 0) {
+                    String prefix = key.substring(0, attrColon).toLowerCase(Locale.ROOT);
+                    if (!declared.contains(prefix)) {
+                        unboundPrefixes.add(prefix);
+                        attrsToRemove.add(key);
+                    }
+                }
+            }
+            for (String attrKey : attrsToRemove) {
+                el.removeAttr(attrKey);
+            }
+        }
+
+        // Deepest first so children move to the parent before the parent is unwrapped
+        elementsToUnwrap.sort(Comparator.comparingInt(this::elementDepth).reversed());
+        for (Element el : elementsToUnwrap) {
+            // Element may already have been detached if an ancestor was unwrapped
+            if (el.parent() != null) {
+                el.unwrap();
+            }
+        }
+
+        if (!unboundPrefixes.isEmpty()) {
+            log.warn(
+                    "Stripped unbound XML-style prefix(es) {} from page path {} before RDFa metadata extraction",
+                    unboundPrefixes,
+                    pagePath);
+        }
+    }
+
+    /**
+     * Nesting depth of an element under its document root (root == 0).
+     */
+    private int elementDepth(Element el) {
+        int depth = 0;
+        Element cur = el;
+        while (cur.parent() instanceof Element) {
+            depth++;
+            cur = cur.parent();
+        }
+        return depth;
+    }
+
+    /**
+     * @return {@code true} if the failure (or a cause) is a SAX unbound-prefix parse error
+     */
+    static boolean isUnboundPrefixParseFailure(Throwable ex) {
+        Throwable cur = ex;
+        while (cur != null) {
+            if (cur instanceof org.xml.sax.SAXParseException
+                    || (cur.getClass().getName().contains("SAX")
+                            && cur.getMessage() != null
+                            && cur.getMessage().toLowerCase(Locale.ROOT).contains("not bound"))) {
+                String msg = cur.getMessage();
+                if (msg != null) {
+                    String lower = msg.toLowerCase(Locale.ROOT);
+                    if (lower.contains("not bound") || UNBOUND_PREFIX_MESSAGE.matcher(msg).find()) {
+                        return true;
+                    }
+                }
+            }
+            String msg = cur.getMessage();
+            if (msg != null) {
+                String lower = msg.toLowerCase(Locale.ROOT);
+                if (lower.contains("is not bound") && lower.contains("prefix")) {
+                    return true;
+                }
+            }
+            cur = cur.getCause();
+        }
+        return false;
+    }
+
+    /**
+     * Best-effort extraction of the unbound prefix name from a SAX/RDF parse failure message.
+     *
+     * @return prefix without colon, or {@code null} if not found
+     */
+    static String extractUnboundPrefix(Throwable ex) {
+        Throwable cur = ex;
+        while (cur != null) {
+            String msg = cur.getMessage();
+            if (msg != null) {
+                Matcher m = UNBOUND_PREFIX_MESSAGE.matcher(msg);
+                if (m.find()) {
+                    return m.group(1);
+                }
+            }
+            cur = cur.getCause();
+        }
+        return null;
     }
 }

--- a/system/src/test/java/com/percussion/delivery/PSMetadataExtractorServiceTests.java
+++ b/system/src/test/java/com/percussion/delivery/PSMetadataExtractorServiceTests.java
@@ -17,9 +17,11 @@
 
 package com.percussion.delivery;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.delivery.metadata.IPSMetadataProperty;
 import com.percussion.delivery.metadata.PSMetadataExtractorService;
@@ -28,6 +30,8 @@ import com.percussion.delivery.metadata.rdfa.PSTripleHandler;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
@@ -188,5 +192,74 @@ public class PSMetadataExtractorServiceTests {
             "inline script must be stripped from metadata properties: " + value);
       }
     }
+  }
+
+  /**
+   * Issue #2355: HTML with unbound XML-style prefixes (Google CSE {@code gcse:search} without
+   * {@code xmlns:gcse}) must not throw out of {@link PSMetadataExtractorService}; RDFa/dcterms
+   * present elsewhere on the page must still be extracted.
+   */
+  @Test
+  public void testUnboundPrefixGcseSearch() throws IOException {
+    InputStream is =
+        PSMetadataExtractorServiceTests.class.getResourceAsStream(
+            "/com/percussion/delivery/unbound-prefix-gcse.html");
+    assertNotNull(is, "unbound-prefix-gcse.html fixture must be on the test classpath");
+
+    try (InputStreamReader inputStreamReader =
+        new InputStreamReader(is, StandardCharsets.UTF_8)) {
+      PSMetadataExtractorService svc = new PSMetadataExtractorService();
+      PSMetadataEntry entry =
+          assertDoesNotThrow(
+              () ->
+                  svc.process(
+                      inputStreamReader,
+                      "text/html",
+                      "/Sites/test/error.html",
+                      null),
+              "unbound gcse: prefix must not fail metadata extraction");
+
+      assertNotNull(entry);
+      assertEquals("page", entry.getType());
+      assertEquals("/Sites/test/error.html", entry.getPagepath());
+
+      HashMap<String, String> map = new HashMap<>();
+      for (IPSMetadataProperty prop : entry.getProperties()) {
+        map.put(prop.getName(), prop.getValue());
+      }
+
+      assertEquals("gcse-fixture", map.get("dcterms:source"));
+      assertEquals("CSE Page Title", map.get("dcterms:title"));
+      assertEquals("Page with Google CSE embed", map.get("dcterms:description"));
+
+      String abstractText = map.get("dcterms:abstract");
+      assertNotNull(abstractText, "dcterms:abstract should still be extracted");
+      assertTrue(
+          abstractText.contains("Abstract survives unbound vendor prefix strip"),
+          "abstract content should survive prefix sanitize: " + abstractText);
+    }
+  }
+
+  /**
+   * Minimal inline HTML: unbound {@code gcse:search} alone must not throw; page still gets a
+   * default type of {@code page}.
+   */
+  @Test
+  public void testUnboundPrefixOnlyDoesNotThrow() {
+    String html =
+        "<!DOCTYPE html><html><head><title>x</title></head>"
+            + "<body><gcse:search></gcse:search><p>ok</p></body></html>";
+    PSMetadataExtractorService svc = new PSMetadataExtractorService();
+    PSMetadataEntry entry =
+        assertDoesNotThrow(
+            () ->
+                svc.process(
+                    new StringReader(html),
+                    "text/html",
+                    "/Sites/test/minimal-gcse.html",
+                    null));
+    assertNotNull(entry);
+    assertEquals("page", entry.getType());
+    assertEquals("/Sites/test/minimal-gcse.html", entry.getPagepath());
   }
 }

--- a/system/src/test/resources/com/percussion/delivery/unbound-prefix-gcse.html
+++ b/system/src/test/resources/com/percussion/delivery/unbound-prefix-gcse.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+  Fixture for PSMetadataExtractorServiceTests#testUnboundPrefixGcseSearch (#2355):
+  Google Custom Search vendor tag without xmlns:gcse must not fail RDFa metadata
+  extraction; dcterms/RDFa elsewhere on the page must still be extracted.
+-->
+<html
+  lang="en"
+  prefix="dcterms: http://purl.org/dc/terms/ perc: http://percussion.com/perc/elements/1.0/"
+>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="content-type" />
+    <title>Unbound Prefix CSE Fixture</title>
+    <meta property="dcterms:title" content="CSE Page Title" />
+    <meta property="dcterms:source" content="gcse-fixture" />
+    <meta property="dcterms:description" content="Page with Google CSE embed" />
+  </head>
+  <body>
+    <h1 property="dcterms:title">CSE Page Title</h1>
+    <!-- Unbound XML-style prefix — no xmlns:gcse declared -->
+    <gcse:search></gcse:search>
+    <div class="search-wrapper">
+      <gcse:searchbox-only></gcse:searchbox-only>
+    </div>
+    <div property="dcterms:abstract">
+      Abstract survives unbound vendor prefix strip.
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #2355: `PSMetadataExtractorService` no longer fails the whole page's metadata path when published HTML contains **unbound XML-style prefixes** such as Google Custom Search `<gcse:search>` without `xmlns:gcse`.

### Root cause
RDFa parse (Semargl/RDF4J SAX) treats vendor tags like `gcse:search` as namespaced elements. Without a matching `xmlns:` declaration this throws `SAXParseException` ("prefix is not bound"), which was wrapped as a hard `RuntimeException` and logged as ERROR by `PSMetadataDeliveryHandler` even when file publish succeeded.

### Fix
1. **Pre-sanitize** after Jsoup load: unwrap elements and strip attributes that use XML-style prefixes not declared via `xmlns:*` (always allow `xml`/`xmlns`). Log **WARN** with page path + unbound prefix set.
2. **Defensive catch**: if RDFa parse still reports an unbound-prefix SAX failure, log **WARN** (page path + prefix) and continue with non-RDFa fields instead of failing the item.
3. **Preserve RDFa**: `dcterms:*` / property values are attribute *values*, not unbound element names, so they still extract after strip.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] Unit fixture `unbound-prefix-gcse.html` with `<gcse:search>` (no xmlns) + dcterms elsewhere
- [x] `testUnboundPrefixGcseSearch` — no throw; `dcterms:source`/`title`/`description`/`abstract` extracted
- [x] `testUnboundPrefixOnlyDoesNotThrow` — minimal gcse-only HTML returns entry with type `page`
- [x] Existing `PSMetadataExtractorServiceTests` still green

## Gates evidence
- Erlang-style self-review: no new path I/O; sanitize is pure DOM; WARN includes page path + prefix; change-class companions = service + behavioral tests + fixture (no Spring/DI surface change)
- Module: `cd system && ../mvnw clean install` → **BUILD SUCCESS**
- Commit: `2352d9cbc6598b47958ce84d3ca0a509341dd136`

## Related
- Parent tracker: #2355 (self)
- Do not require customer pages to declare vendor `xmlns` for clean publish metadata

> Co-Authored by Grok Build using grok-4.5 with agent main.