### PR TITLE
fix(perc-system): cms.objectstore rawtypes batch 2c — PSSearch iterators + folder processor (#2349)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2349-cms-objectstore-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2349-cms-objectstore-rawtypes-erlang.md
@@ -1,0 +1,25 @@
+# Erlang self-review — issue #2349 (cms.objectstore rawtypes batch 2c)
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2349-cms-objectstore-rawtypes`  
+**Verdict:** **approve**
+
+## Scope reviewed
+- `PSSearch` / `PSSFields` / `PSMultiValuedProperty` typed iterators and property loops
+- `PSServerFolderProcessor` + `PSFolderProcessorProxy` relationship/folder `List` parameterization
+- Unit test `PSSearchFieldsPropertiesTest`
+
+## Checks
+| Gate | Result |
+| --- | --- |
+| Behavior change | None intentional — generics only; property/field mutation paths preserve prior casts |
+| Bug risk | Low — IPSRelationship uses `List<?>`, IPSFolder uses `List<PSLocator>` matching interfaces |
+| Portable paths | N/A (no path I/O) |
+| Behavioral tests | 4 new tests for get/set/remove fields + property iterator/value APIs |
+| Companion types | Proxy methods aligned with `IPSFolderProcessor` |
+
+## Notes
+- Residual package rawtypes remain (other `cms.objectstore` / folder processor internal collections); file next residual under #2022.
+- Clone-folder path still uses mixed `PSLocator` / `PSLocatorWithName` via `List<Object>` + cast into summary APIs (pre-existing dual-type pattern).
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolderProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolderProcessorProxy.java
@@ -51,7 +51,8 @@ public class PSFolderProcessorProxy extends PSProcessorProxy implements IPSFolde
   }
 
   // see IPSFolderProcessor interface
-  public void copyChildren(List children, PSLocator targetFolderId) throws PSCmsException {
+  public void copyChildren(List<PSLocator> children, PSLocator targetFolderId)
+      throws PSCmsException {
     getProcessor().copyChildren(children, targetFolderId);
   }
 
@@ -61,19 +62,21 @@ public class PSFolderProcessorProxy extends PSProcessorProxy implements IPSFolde
   }
 
   // see IPSFolderProcessor interface
-  public void moveChildren(PSLocator sourceFolderId, List children, PSLocator targetFolderId)
+  public void moveChildren(
+      PSLocator sourceFolderId, List<PSLocator> children, PSLocator targetFolderId)
       throws PSCmsException {
     getProcessor().moveChildren(sourceFolderId, children, targetFolderId);
   }
 
   // see IPSFolderProcessor interface
-  public void removeChildren(PSLocator sourceFolderId, List children)
+  public void removeChildren(PSLocator sourceFolderId, List<PSLocator> children)
       throws PSCmsException, PSNotFoundException {
     getProcessor().removeChildren(sourceFolderId, children);
   }
 
   // see IPSFolderProcessor interface
-  public void addChildren(List children, PSLocator targetFolderId) throws PSCmsException {
+  public void addChildren(List<PSLocator> children, PSLocator targetFolderId)
+      throws PSCmsException {
     getProcessor().addChildren(children, targetFolderId);
   }
 
@@ -89,7 +92,7 @@ public class PSFolderProcessorProxy extends PSProcessorProxy implements IPSFolde
   }
 
   // see IPSFolderProcessor interface
-  public Set getFolderCommunities(PSLocator source) throws PSCmsException {
+  public Set<Integer> getFolderCommunities(PSLocator source) throws PSCmsException {
     return getProcessor().getFolderCommunities(source);
   }
 
@@ -134,14 +137,17 @@ public class PSFolderProcessorProxy extends PSProcessorProxy implements IPSFolde
   }
 
   // implement the interface method
-  public void removeChildren(PSLocator sourceFolderId, List children, boolean force)
+  public void removeChildren(PSLocator sourceFolderId, List<PSLocator> children, boolean force)
       throws PSCmsException, PSNotFoundException {
     getProcessor().removeChildren(sourceFolderId, children, force);
   }
 
   // implement the interface method
   public void moveChildren(
-      PSLocator sourceFolderId, List children, PSLocator targetFolderId, boolean force)
+      PSLocator sourceFolderId,
+      List<PSLocator> children,
+      PSLocator targetFolderId,
+      boolean force)
       throws PSCmsException {
     getProcessor().moveChildren(sourceFolderId, children, targetFolderId, force);
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSMultiValuedProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSMultiValuedProperty.java
@@ -151,11 +151,11 @@ public abstract class PSMultiValuedProperty extends PSCmsProperty {
     // Base class handling even
     super.markForDeletion();
 
-    Iterator propsIter = m_props.iterator();
+    Iterator<PSCmsProperty> propsIter = m_props.iterator();
 
     while (propsIter.hasNext()) {
       // Mark each contained property for deletion
-      PSCmsProperty aProp = (PSCmsProperty) propsIter.next();
+      PSCmsProperty aProp = propsIter.next();
       aProp.markForDeletion();
     }
   }
@@ -217,10 +217,10 @@ public abstract class PSMultiValuedProperty extends PSCmsProperty {
    */
   public boolean contains(String value) {
     // Check the properties
-    Iterator iter = m_props.iterator();
+    Iterator<PSCmsProperty> iter = m_props.iterator();
 
     while (iter.hasNext()) {
-      PSCmsProperty p = (PSCmsProperty) iter.next();
+      PSCmsProperty p = iter.next();
 
       if (p.getValue().equalsIgnoreCase(value)) return true;
     }
@@ -242,10 +242,10 @@ public abstract class PSMultiValuedProperty extends PSCmsProperty {
    *
    * @return An iterator over 0 or more entries, each of which is a String. Never <code>null</code>.
    */
-  public Iterator iterator() {
-    Collection c = new ArrayList();
-    Iterator it = m_props.iterator();
-    while (it.hasNext()) c.add(((PSCmsProperty) it.next()).getValue());
+  public Iterator<String> iterator() {
+    Collection<String> c = new ArrayList<>();
+    Iterator<PSCmsProperty> it = m_props.iterator();
+    while (it.hasNext()) c.add(it.next().getValue());
     return c.iterator();
   }
 
@@ -259,10 +259,10 @@ public abstract class PSMultiValuedProperty extends PSCmsProperty {
    */
   public boolean remove(String value) {
     // Check the properties
-    Iterator iter = m_props.iterator();
+    Iterator<PSCmsProperty> iter = m_props.iterator();
 
     while (iter.hasNext()) {
-      PSCmsProperty p = (PSCmsProperty) iter.next();
+      PSCmsProperty p = iter.next();
 
       if (p.getValue().equalsIgnoreCase(value)) {
         return m_props.remove(p);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSFields.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSFields.java
@@ -60,7 +60,7 @@ public class PSSFields extends PSDbComponentList {
   public PSSearchField haveThisFieldKey(PSSearchField field) {
     if (field == null) throw new IllegalArgumentException("field must not be null");
 
-    Iterator iter = iterator();
+    Iterator<IPSDbComponent> iter = iterator();
     PSKey key = field.getLocator();
 
     while (iter.hasNext()) {
@@ -81,14 +81,14 @@ public class PSSFields extends PSDbComponentList {
    *     com.percussion.cms.objectstore.PSSearchField} objects.
    * @throws ClassCastException if the objects returned by the iterator are not PSSearchFields.
    */
-  public void setFields(Iterator fields) {
+  public void setFields(Iterator<? extends PSSearchField> fields) {
     if (fields == null || !fields.hasNext()) {
       clear();
       return;
     }
 
     for (int i = 0; fields.hasNext(); i++) {
-      PSSearchField f = (PSSearchField) fields.next();
+      PSSearchField f = fields.next();
       if (i < size() && ((PSSearchField) get(i)).equals(f)) continue;
       set(i, f);
     }
@@ -101,9 +101,9 @@ public class PSSFields extends PSDbComponentList {
    *     removed
    * @throws ClassCastException if the objects returned by the iterator are not PSSearchFields.
    */
-  public void removeFields(Iterator fields) {
+  public void removeFields(Iterator<? extends PSSearchField> fields) {
     if (fields == null) return;
-    while (fields.hasNext()) remove((IPSDbComponent) fields.next());
+    while (fields.hasNext()) remove(fields.next());
   }
 
   /** The XML node name for this class. */

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
@@ -291,8 +291,9 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
    * @return An iterator containing one or more {@link com.percussion.cms.objectstore.PSSearchField}
    *     objects. Never <code>null</code>.
    */
-  public Iterator getFields() {
-    return m_fields.iterator();
+  @SuppressWarnings("unchecked")
+  public Iterator<PSSearchField> getFields() {
+    return (Iterator<PSSearchField>) (Iterator<?>) m_fields.iterator();
   }
 
   /**
@@ -321,7 +322,7 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
    * @param fields iterator over {@link com.percussion.cms.objectstore.PSSearchField} objects. Never
    *     <code>null</code>.
    */
-  public void setFields(Iterator fields) {
+  public void setFields(Iterator<? extends PSSearchField> fields) {
     if (fields == null) throw new IllegalArgumentException("fields must not be null");
 
     m_fields.setFields(fields);
@@ -346,7 +347,7 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
    * @param fields iterator over {@link com.percussion.cms.objectstore.PSSearchField} objects. If
    *     <code>null</code> fields will not be removed.
    */
-  public void removeFields(Iterator fields) {
+  public void removeFields(Iterator<? extends PSSearchField> fields) {
     if (fields == null || !fields.hasNext()) return;
     m_fields.removeFields(fields);
   }
@@ -368,9 +369,10 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
   /**
    * Get this search objects properties.
    *
-   * @return a iterator containing zero or more objects. Never <code>null</code>.
+   * @return a iterator containing zero or more {@link PSSearchMultiProperty} objects. Never <code>
+   *     null</code>.
    */
-  public Iterator getProperties() {
+  public Iterator<PSSearchMultiProperty> getProperties() {
     return m_properties.iterator();
   }
 
@@ -769,10 +771,10 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
     // Threshold
     if (m_properties.size() < 1) return false;
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSSearchMultiProperty> iter = m_properties.iterator();
 
     while (iter.hasNext()) {
-      PSSearchMultiProperty prop = (PSSearchMultiProperty) iter.next();
+      PSSearchMultiProperty prop = iter.next();
 
       if (prop.getName().equalsIgnoreCase(name) && prop.contains(value)) return true;
     }
@@ -1201,11 +1203,11 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
 
     resetAllowedCommunities();
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSSearchMultiProperty> iter = m_properties.iterator();
     boolean bFound = false;
 
     while (iter.hasNext()) {
-      PSSearchMultiProperty prop = (PSSearchMultiProperty) iter.next();
+      PSSearchMultiProperty prop = iter.next();
 
       if (prop.getName().equalsIgnoreCase(strName)) {
         // Threshold - if prop already contains this value
@@ -1223,10 +1225,10 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
           // Remove the values of the old property
           // add the new one and clone it to bring over
           // any other attributes (e.g. description ...)
-          Iterator values = newProp.iterator(); // cms property(s)
+          Iterator<String> values = newProp.iterator(); // cms property(s)
           while (values.hasNext()) {
             // remove each entry and add
-            newProp.remove((String) values.next());
+            newProp.remove(values.next());
           }
 
           // Single value
@@ -1279,15 +1281,15 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
   public String[] getPropertyValues(String strName) {
     if (strName == null || strName.trim().length() == 0) return null;
 
-    Iterator<?> iter = m_properties.iterator();
+    Iterator<PSSearchMultiProperty> iter = m_properties.iterator();
     Collection<String> results = null;
     while (iter.hasNext()) {
-      PSSearchMultiProperty prop = (PSSearchMultiProperty) iter.next();
+      PSSearchMultiProperty prop = iter.next();
       if (prop.getName().equalsIgnoreCase(strName)) {
-        Iterator<?> propIter = prop.iterator();
+        Iterator<String> propIter = prop.iterator();
         results = new ArrayList<>();
         while (propIter.hasNext()) {
-          results.add((String) propIter.next());
+          results.add(propIter.next());
         }
       }
     }
@@ -1308,10 +1310,10 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
     if (strName == null || strName.trim().length() == 0)
       throw new IllegalArgumentException("strName must not be null or empty");
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSSearchMultiProperty> iter = m_properties.iterator();
 
     while (iter.hasNext()) {
-      PSSearchMultiProperty prop = (PSSearchMultiProperty) iter.next();
+      PSSearchMultiProperty prop = iter.next();
 
       if (prop.getName().equalsIgnoreCase(strName)) return true;
     }
@@ -1348,10 +1350,10 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
     // Threshold
     if (m_properties.size() < 1) return;
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSSearchMultiProperty> iter = m_properties.iterator();
 
     while (iter.hasNext()) {
-      PSSearchMultiProperty prop = (PSSearchMultiProperty) iter.next();
+      PSSearchMultiProperty prop = iter.next();
 
       if (prop.getName().equalsIgnoreCase(strName)) {
         if (bMulti) {
@@ -1703,9 +1705,9 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
     removeProperty(PSSearch.PROP_FULLTEXTQUERY, null);
 
     // now convert the fields
-    Iterator fields = getFields();
+    Iterator<PSSearchField> fields = getFields();
     while (fields.hasNext()) {
-      PSSearchField field = (PSSearchField) fields.next();
+      PSSearchField field = fields.next();
       field.setExternalOperator(null);
     }
   }
@@ -1763,14 +1765,14 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
   public Object tuneClone(long newId) {
     PSKey newKey = createKey(new String[] {newId + ""});
     setKey(newKey);
-    Iterator cols = m_fields.iterator();
+    Iterator<IPSDbComponent> cols = m_fields.iterator();
     while (cols.hasNext()) {
       PSSearchField field = (PSSearchField) cols.next();
       field.setKey(newKey);
     }
-    Iterator props = m_properties.iterator();
+    Iterator<PSSearchMultiProperty> props = m_properties.iterator();
     while (props.hasNext()) {
-      PSSearchMultiProperty prop = (PSSearchMultiProperty) props.next();
+      PSSearchMultiProperty prop = props.next();
       prop.setKey(newKey);
     }
     return this;

--- a/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
@@ -1237,9 +1237,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     if (!children.isEmpty()) {
       PSRelationshipProcessor relation = PSRelationshipProcessor.getInstance();
 
+      List<PSLocator> childLocators = toLocatorList(children);
       PSComponentSummaries childSummaries =
-          getComponentSummaries(
-              (Iterator<PSLocator>) (Iterator<?>) children.iterator(), null, false);
+          getComponentSummaries(childLocators.iterator(), null, false);
 
       validateChildNames(childSummaries, targetParent);
 
@@ -1528,7 +1528,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
   public void move(
       String componentType, PSKey sourceParent, List<?> children, PSKey targetParent)
       throws PSCmsException {
-    moveFolderChildren(sourceParent, children, targetParent, true);
+    moveFolderChildren(sourceParent, toLocatorList(children), targetParent, true);
   }
 
   /**
@@ -1542,26 +1542,24 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @throws PSCmsException if an error occurs.
    */
   public void moveFolderChildren(
-      PSKey sourceParent, List<?> children, PSKey targetParent, boolean checkFolderPermission)
+      PSKey sourceParent,
+      List<PSLocator> children,
+      PSKey targetParent,
+      boolean checkFolderPermission)
       throws PSCmsException {
     validateKeys(children.iterator());
     validateKey(sourceParent);
     validateKey(targetParent);
 
     // validating all ids, make sure they all exist in database
-    List<PSLocator> allIds = new ArrayList<>();
-    for (Object child : children) {
-      allIds.add((PSLocator) child);
-    }
+    List<PSLocator> allIds = new ArrayList<>(children);
     allIds.add((PSLocator) sourceParent);
     allIds.add((PSLocator) targetParent);
     PSComponentSummaries summaries = getComponentSummaries(allIds.iterator(), null, false);
 
     // the moved children must not contain target parent
     int targetId = ((PSLocator) targetParent).getId();
-    Iterator<?> childIt = children.iterator();
-    while (childIt.hasNext()) {
-      PSLocator child = (PSLocator) childIt.next();
+    for (PSLocator child : children) {
       if (child.getId() == ((PSLocator) targetParent).getId())
         throw new IllegalArgumentException(
             "children must not contain targetParent, id=" + targetId);
@@ -1699,27 +1697,51 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @param source List of folder and item ids. Assumed not <code>null</code>.
    * @return A new list with just the folder ids. Never <code>null</code>.
    */
-  private List<PSLocator> filterItems(List<?> source) {
+  private List<PSLocator> filterItems(List<PSLocator> source) {
     List<PSLocator> results = new ArrayList<>();
     PSItemSummaryCache cache = PSItemSummaryCache.getInstance();
     if (cache == null) {
       List<Integer> ids = new ArrayList<>();
-      for (Object o : source) {
-        ids.add(((PSLocator) o).getId());
+      for (PSLocator l : source) {
+        ids.add(l.getId());
       }
       IPSCmsObjectMgr cms = PSCmsObjectMgrLocator.getObjectManager();
       List<PSComponentSummary> summarylist = cms.loadComponentSummaries(ids);
       for (int i = 0; i < summarylist.size(); i++) {
-        if (summarylist.get(i).isFolder()) results.add((PSLocator) source.get(i));
+        if (summarylist.get(i).isFolder()) results.add(source.get(i));
       }
     } else {
-      for (Object o : source) {
-        PSLocator l = (PSLocator) o;
+      for (PSLocator l : source) {
         IPSItemEntry e = cache.getItem(l.getId());
         if (e.isFolder()) results.add(l);
       }
     }
     return results;
+  }
+
+  /**
+   * Coerce a list of {@link PSLocator} and/or {@link PSLocatorWithName} elements to a typed {@code
+   * List<PSLocator>}. {@link PSLocatorWithName} does not extend {@link PSLocator}; project each
+   * instance to a new locator so callers of {@link #getComponentSummaries} stay type-safe.
+   *
+   * @param source list of locators (or name-overrides), never {@code null}
+   * @return new list of {@link PSLocator}, never {@code null}
+   */
+  private static List<PSLocator> toLocatorList(List<?> source) {
+    List<PSLocator> result = new ArrayList<>(source.size());
+    for (Object o : source) {
+      if (o instanceof PSLocator) {
+        result.add((PSLocator) o);
+      } else if (o instanceof PSLocatorWithName) {
+        PSLocatorWithName named = (PSLocatorWithName) o;
+        result.add(new PSLocator(named.getId(), named.getRevision()));
+      } else {
+        throw new IllegalArgumentException(
+            "Expected PSLocator or PSLocatorWithName, got "
+                + (o == null ? "null" : o.getClass().getName()));
+      }
+    }
+    return result;
   }
 
   /**
@@ -1911,11 +1933,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
     // recurvisely delete the child folder objects and its relationship with
     // its own children.
+    List<PSLocator> childLocators = toLocatorList(children);
     PSComponentSummaries summaries =
-        getComponentSummaries(
-            (Iterator<PSLocator>) (Iterator<?>) children.iterator(),
-            (PSLocator) sourceParent,
-            false);
+        getComponentSummaries(childLocators.iterator(), (PSLocator) sourceParent, false);
     List<PSLocator> childFolders =
         summaries.getComponentLocators(
             PSComponentSummary.TYPE_FOLDER, PSComponentSummary.GET_CURRENT_LOCATOR);
@@ -2152,9 +2172,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
       boolean isOverrideName = false;
       if (children.get(0) instanceof PSLocatorWithName && copyItem) isOverrideName = true;
 
+      List<PSLocator> childLocators = toLocatorList(children);
       PSComponentSummaries childSummaries =
-          getComponentSummaries(
-              (Iterator<PSLocator>) (Iterator<?>) children.iterator(), null, false);
+          getComponentSummaries(childLocators.iterator(), null, false);
 
       // make sure targetParent is not a descendent of the childen
       validateTargetParentIsNotDescendent(
@@ -3030,22 +3050,17 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @throws PSCmsException if any error occurs getting the component summaries for the specified
    *     locators
    */
-  private PSKey[] getFolderLocators(List<?> locators) throws PSCmsException {
+  private PSKey[] getFolderLocators(List<PSLocator> locators) throws PSCmsException {
     PSKey[] keys = new PSKey[0];
     PSItemSummaryCache cache = getItemCache();
     List<PSLocator> folderIds = null;
     if (cache != null) {
-      Iterator<?> it = locators.iterator();
-      PSLocator locator = null;
       folderIds = new ArrayList<>();
-      while (it.hasNext()) {
-        locator = (PSLocator) it.next();
+      for (PSLocator locator : locators) {
         if (cache.isFolderExist(locator.getId())) folderIds.add(locator);
       }
     } else {
-      PSComponentSummaries summaries =
-          getComponentSummaries(
-              (Iterator<PSLocator>) (Iterator<?>) locators.iterator(), null, false);
+      PSComponentSummaries summaries = getComponentSummaries(locators.iterator(), null, false);
 
       folderIds =
           summaries.getComponentLocators(
@@ -3086,7 +3101,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
     if (locators == null) throw new IllegalArgumentException("locators may not be null");
 
-    locators = getFolderLocators(Arrays.asList(locators));
+    locators = getFolderLocators(toLocatorList(Arrays.asList(locators)));
     if (locators.length < 1) return true;
 
     // verify write access on the parent folders
@@ -3146,7 +3161,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     if (children == null) throw new IllegalArgumentException("children may not be null");
     if (targetParent == null) throw new IllegalArgumentException("targetParent may not be null");
 
-    PSKey[] locators = getFolderLocators(children);
+    PSKey[] locators = getFolderLocators(toLocatorList(children));
     if (locators.length < 1) return true;
 
     // verify write access on the source parent folder
@@ -3211,7 +3226,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
     if (!hasPermission) return false;
 
-    PSKey[] locators = getFolderLocators(children);
+    PSKey[] locators = getFolderLocators(toLocatorList(children));
     if (locators.length < 1) return true;
 
     // read access on the folder being copied and
@@ -4174,9 +4189,10 @@ public class PSServerFolderProcessor extends PSProcessorCommon
         // disable the nav folder effect
         request.setParameter(IPSHtmlParameters.RXS_DISABLE_NAV_FOLDER_EFFECT, "y");
 
+        // PSLocatorWithName is not a PSLocator; project to locators for summaries
+        List<PSLocator> childLocators = toLocatorList(children);
         PSComponentSummaries childSummaries =
-            getComponentSummaries(
-                (Iterator<PSLocator>) (Iterator<?>) children.iterator(), null, false);
+            getComponentSummaries(childLocators.iterator(), null, false);
 
         // make sure target is not a descendent of the copied childen
         validateTargetParentIsNotDescendent(

--- a/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
@@ -155,7 +155,7 @@ import org.w3c.dom.Element;
 public class PSServerFolderProcessor extends PSProcessorCommon
     implements IPSRelationshipProcessor, IPSFolderProcessor {
 
-  public PSServerFolderProcessor(PSRemoteFolderAgent ctx, Map procConfig) {
+  public PSServerFolderProcessor(PSRemoteFolderAgent ctx, Map<?, ?> procConfig) {
     this();
     log.debug("Proxy constructor called");
   }
@@ -182,7 +182,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
   public void add(
       String componentType,
       @SuppressWarnings("unused") String relationshipType,
-      List children,
+      List<?> children,
       PSKey targetParent)
       throws PSCmsException {
     add(componentType, children, targetParent);
@@ -742,7 +742,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
   }
 
   /** validates a list of keys. */
-  private void validateKeys(Iterator locators) {
+  private void validateKeys(Iterator<?> locators) {
     while (locators.hasNext()) {
       PSKey key = (PSKey) locators.next();
       validateKey(key);
@@ -1218,7 +1218,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
   /** Not supported. */
   @SuppressWarnings("unused")
-  public void reorder(int insertAt, List comp) throws PSCmsException {
+  public void reorder(int insertAt, List<?> comp) throws PSCmsException {
     throw new IllegalStateException("reorder(int, List) is not supported");
   }
 
@@ -1227,7 +1227,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * {@link #validateKey(PSKey)} for the requirement of the locators, <code>children</code> and
    * <code>targetParent</code>.
    */
-  public void add(String componentType, List children, PSKey targetParent) throws PSCmsException {
+  public void add(String componentType, List<?> children, PSKey targetParent)
+      throws PSCmsException {
     validateComponentType(componentType);
     validateKeys(children.iterator());
     validateKey(targetParent);
@@ -1279,13 +1280,13 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     public ComponentGroup(PSComponentSummaries summaries) throws PSCmsException {
       PSRelationshipProcessor relation = PSRelationshipProcessor.getInstance();
 
-      Iterator componenties = summaries.getSummaries();
+      Iterator<?> componenties = summaries.getSummaries();
       while (componenties.hasNext()) {
         PSComponentSummary comp = (PSComponentSummary) componenties.next();
         PSLocator locator = comp.getCurrentLocator();
 
         if (comp.isFolder()) {
-          List parents = relation.getParents(FOLDER_RELATE_TYPE, locator);
+          List<PSLocator> parents = relation.getParents(FOLDER_RELATE_TYPE, locator);
 
           // if has parent already, get the locator from a cloned folder
           if (parents.isEmpty()) linkedList.add(locator);
@@ -1301,14 +1302,14 @@ public class PSServerFolderProcessor extends PSProcessorCommon
      * folder cannot have more than one parent, so this list of folders will be cloned to a new
      * parent. Initialized by constructor, never <code>null</code>, but may be empty.
      */
-    private List copiedList = new ArrayList();
+    private List<PSLocator> copiedList = new ArrayList<>();
 
     /**
      * A list of folders and non-folder items. Each folder components has no parent. This list of
      * items can be simply linked to a parent folder. Initialized by constructor, never <code>null
      * </code>, but may be empty.
      */
-    private List linkedList = new ArrayList();
+    private List<PSLocator> linkedList = new ArrayList<>();
   }
 
   /**
@@ -1327,13 +1328,13 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @throws PSCmsException if the validation fails.
    */
   private PSComponentSummaries validateChildren(
-      List children, PSComponentSummaries childSummaries, PSKey target) throws PSCmsException {
+      List<?> children, PSComponentSummaries childSummaries, PSKey target) throws PSCmsException {
 
     PSComponentSummaries existingObjectsSummaries = validateChildNames(childSummaries, target);
 
     // remove the components from the "children", where the components
     // already exist in the "target" folder
-    Iterator walker = existingObjectsSummaries.iterator();
+    Iterator<?> walker = existingObjectsSummaries.iterator();
     while (walker.hasNext()) {
       PSComponentSummary summary = (PSComponentSummary) walker.next();
       for (int i = 0; i < children.size(); i++) {
@@ -1360,8 +1361,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @throws PSCmsException if the test described above is successful.
    */
   private void validateTargetParentIsNotDescendent(
-      PSLocator targetParent, List folderChildren, boolean copyItem) throws PSCmsException {
-    Iterator childs = folderChildren.iterator();
+      PSLocator targetParent, List<?> folderChildren, boolean copyItem) throws PSCmsException {
+    Iterator<?> childs = folderChildren.iterator();
     PSComponentSummary subFolder;
     while (childs.hasNext()) {
       subFolder = (PSComponentSummary) childs.next();
@@ -1370,7 +1371,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
       if (isDescendent(
           FOLDER_PROXY_TYPE, subFolder.getCurrentLocator(), targetParent, FOLDER_RELATE_TYPE)) {
         // get the name of the targetParent for error message
-        List pl = new ArrayList();
+        List<PSLocator> pl = new ArrayList<>();
         pl.add(targetParent);
         PSComponentSummaries ps = getComponentSummaries(pl.iterator(), null, false);
         String targetParentName = "";
@@ -1507,7 +1508,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @return a string with all summary names of the supplied summaries separated by comma, never
    *     <code>null</code>, may be empty.
    */
-  private String formatSummaryNames(Iterator summaries) {
+  private String formatSummaryNames(Iterator<?> summaries) {
     StringBuilder names = new StringBuilder();
 
     while (summaries.hasNext()) {
@@ -1524,7 +1525,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * description. See {@link #validateKey(PSKey)} for the requirement of the locators, <code>
    * children</code> and <code>sourceParent</code>.
    */
-  public void move(String componentType, PSKey sourceParent, List children, PSKey targetParent)
+  public void move(
+      String componentType, PSKey sourceParent, List<?> children, PSKey targetParent)
       throws PSCmsException {
     moveFolderChildren(sourceParent, children, targetParent, true);
   }
@@ -1540,21 +1542,24 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @throws PSCmsException if an error occurs.
    */
   public void moveFolderChildren(
-      PSKey sourceParent, List children, PSKey targetParent, boolean checkFolderPermission)
+      PSKey sourceParent, List<?> children, PSKey targetParent, boolean checkFolderPermission)
       throws PSCmsException {
     validateKeys(children.iterator());
     validateKey(sourceParent);
     validateKey(targetParent);
 
     // validating all ids, make sure they all exist in database
-    List<PSLocator> allIds = new ArrayList<PSLocator>(children);
+    List<PSLocator> allIds = new ArrayList<>();
+    for (Object child : children) {
+      allIds.add((PSLocator) child);
+    }
     allIds.add((PSLocator) sourceParent);
     allIds.add((PSLocator) targetParent);
     PSComponentSummaries summaries = getComponentSummaries(allIds.iterator(), null, false);
 
     // the moved children must not contain target parent
     int targetId = ((PSLocator) targetParent).getId();
-    Iterator childIt = children.iterator();
+    Iterator<?> childIt = children.iterator();
     while (childIt.hasNext()) {
       PSLocator child = (PSLocator) childIt.next();
       if (child.getId() == ((PSLocator) targetParent).getId())
@@ -1694,21 +1699,22 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @param source List of folder and item ids. Assumed not <code>null</code>.
    * @return A new list with just the folder ids. Never <code>null</code>.
    */
-  private List<PSLocator> filterItems(List<PSLocator> source) {
+  private List<PSLocator> filterItems(List<?> source) {
     List<PSLocator> results = new ArrayList<>();
     PSItemSummaryCache cache = PSItemSummaryCache.getInstance();
     if (cache == null) {
       List<Integer> ids = new ArrayList<>();
-      for (PSLocator l : source) {
-        ids.add(l.getId());
+      for (Object o : source) {
+        ids.add(((PSLocator) o).getId());
       }
       IPSCmsObjectMgr cms = PSCmsObjectMgrLocator.getObjectManager();
       List<PSComponentSummary> summarylist = cms.loadComponentSummaries(ids);
       for (int i = 0; i < summarylist.size(); i++) {
-        if (summarylist.get(i).isFolder()) results.add(source.get(i));
+        if (summarylist.get(i).isFolder()) results.add((PSLocator) source.get(i));
       }
     } else {
-      for (PSLocator l : source) {
+      for (Object o : source) {
+        PSLocator l = (PSLocator) o;
         IPSItemEntry e = cache.getItem(l.getId());
         if (e.isFolder()) results.add(l);
       }
@@ -1762,7 +1768,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @deprecated Use {@link PSFolderProcessorProxy#copyChildren(List, PSLocator)}.
    */
   public void copy(
-      @SuppressWarnings("unused") String relationshipType, List children, PSKey targetParent)
+      @SuppressWarnings("unused") String relationshipType, List<?> children, PSKey targetParent)
       throws PSCmsException {
     checkHasCopyPermission(children, targetParent, true);
 
@@ -1830,13 +1836,12 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     try {
       PSRelationshipProcessor processor = PSRelationshipProcessor.getInstance();
 
-      List children =
+      List<PSLocator> children =
           getDependentLocators(
               processor, parentFolder, getFilterFlags(), recurse, relationshipTypeName);
 
       Set<Integer> locators = new HashSet<>();
-      for (Object child : children) {
-        PSLocator loc = (PSLocator) child;
+      for (PSLocator loc : children) {
         locators.add(loc.getId());
       }
       return locators;
@@ -1899,7 +1904,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    *
    * @deprecated Use {@link PSFolderProcessorProxy#removeChildren(PSLocator, List)}.
    */
-  public void delete(String relType, PSKey sourceParent, List children) throws PSCmsException {
+  public void delete(String relType, PSKey sourceParent, List<?> children) throws PSCmsException {
     validateRelType(relType);
     validateKeys(children.iterator());
     validateKey(sourceParent);
@@ -1907,13 +1912,16 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     // recurvisely delete the child folder objects and its relationship with
     // its own children.
     PSComponentSummaries summaries =
-        getComponentSummaries(children.iterator(), (PSLocator) sourceParent, false);
-    List childFolders =
+        getComponentSummaries(
+            (Iterator<PSLocator>) (Iterator<?>) children.iterator(),
+            (PSLocator) sourceParent,
+            false);
+    List<PSLocator> childFolders =
         summaries.getComponentLocators(
             PSComponentSummary.TYPE_FOLDER, PSComponentSummary.GET_CURRENT_LOCATOR);
     PSKey[] locators = new PSKey[childFolders.size()];
-    Iterator it = childFolders.iterator();
-    for (int i = 0; it.hasNext(); i++) locators[i] = (PSKey) it.next();
+    Iterator<PSLocator> it = childFolders.iterator();
+    for (int i = 0; it.hasNext(); i++) locators[i] = it.next();
 
     // delete the descendents of the child folders and child folders
     // themselves
@@ -2474,7 +2482,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
       // Otherwise relationship processor will load them and
       // getComponentSummaries() will load them again.
       PSFolderSecurityManager.setCheckFolderPermissions(false);
-      List children = null;
+      List<PSLocator> children = null;
       try {
         children =
             processor.getDependentLocators(
@@ -2512,7 +2520,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @return Each entry is a PSLocator. Never <code>null</code>, may be empty.
    * @throws PSCmsException If any problems getting the relationships.
    */
-  private static List getDependentLocators(
+  private static List<PSLocator> getDependentLocators(
       PSRelationshipProcessor proc, PSKey folderId, int doNotApplyFilters, boolean recursive)
       throws PSCmsException {
     return getDependentLocators(proc, folderId, doNotApplyFilters, recursive, FOLDER_RELATE_TYPE);
@@ -3022,27 +3030,29 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @throws PSCmsException if any error occurs getting the component summaries for the specified
    *     locators
    */
-  private PSKey[] getFolderLocators(List locators) throws PSCmsException {
+  private PSKey[] getFolderLocators(List<?> locators) throws PSCmsException {
     PSKey[] keys = new PSKey[0];
     PSItemSummaryCache cache = getItemCache();
-    List folderIds = null;
+    List<PSLocator> folderIds = null;
     if (cache != null) {
-      Iterator it = locators.iterator();
+      Iterator<?> it = locators.iterator();
       PSLocator locator = null;
-      folderIds = new ArrayList();
+      folderIds = new ArrayList<>();
       while (it.hasNext()) {
         locator = (PSLocator) it.next();
         if (cache.isFolderExist(locator.getId())) folderIds.add(locator);
       }
     } else {
-      PSComponentSummaries summaries = getComponentSummaries(locators.iterator(), null, false);
+      PSComponentSummaries summaries =
+          getComponentSummaries(
+              (Iterator<PSLocator>) (Iterator<?>) locators.iterator(), null, false);
 
       folderIds =
           summaries.getComponentLocators(
               PSComponentSummary.TYPE_FOLDER, PSComponentSummary.GET_CURRENT_LOCATOR);
     }
 
-    if (!folderIds.isEmpty()) keys = (PSKey[]) folderIds.toArray(new PSKey[folderIds.size()]);
+    if (!folderIds.isEmpty()) keys = folderIds.toArray(new PSKey[0]);
 
     return keys;
   }
@@ -3129,7 +3139,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    *     children</code> or <code>targetParent</code> is <code>null</code>
    */
   private boolean checkHasMovePermission(
-      PSKey sourceParent, List children, PSKey targetParent, boolean throwException)
+      PSKey sourceParent, List<?> children, PSKey targetParent, boolean throwException)
       throws PSCmsException {
 
     if (sourceParent == null) throw new IllegalArgumentException("sourceParent may not be null");
@@ -3189,8 +3199,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @throws IllegalArgumentException if <code>request</code> or or <code>children</code> or <code>
    *     targetParent</code> is <code>null</code>
    */
-  private boolean checkHasCopyPermission(List children, PSKey targetParent, boolean throwException)
-      throws PSCmsException {
+  private boolean checkHasCopyPermission(
+      List<?> children, PSKey targetParent, boolean throwException) throws PSCmsException {
     if (children == null) throw new IllegalArgumentException("children may not be null");
     if (targetParent == null) throw new IllegalArgumentException("targetParent may not be null");
 
@@ -3380,11 +3390,10 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
       PSRelationshipProcessor processor = PSRelationshipProcessor.getInstance();
 
-      List children = processor.getDependentLocators(FOLDER_RELATE_TYPE, locator, donotfilterby);
-      Iterator folderChilds = children.iterator();
+      List<PSLocator> children =
+          processor.getDependentLocators(FOLDER_RELATE_TYPE, locator, donotfilterby);
 
-      while (folderChilds.hasNext()) {
-        PSLocator childLocator = (PSLocator) folderChilds.next();
+      for (PSLocator childLocator : children) {
         boolean hasPermission =
             checkHasFolderPermission(childLocator, accessLevel, recursive, throwException);
         if (!hasPermission) return false;
@@ -3497,7 +3506,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * com.percussion.cms.objectstore.PSKey, java.util.List)
    */
   @Transactional(propagation = Propagation.REQUIRED)
-  public void delete(PSKey sourceParent, List children, String relationshipTypeName)
+  public void delete(PSKey sourceParent, List<?> children, String relationshipTypeName)
       throws PSCmsException {
     delete(relationshipTypeName, sourceParent, children);
   }
@@ -3523,7 +3532,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @deprecated Use {@link PSFolderProcessorProxy#addChildren(List, PSLocator)}.
    */
   @Deprecated
-  public void add(String relationshipType, List children, PSLocator targetParent)
+  public void add(String relationshipType, List<?> children, PSLocator targetParent)
       throws PSCmsException {
     validateRelationshipType(relationshipType);
     add(FOLDER_PROXY_TYPE, children, (PSKey) targetParent);
@@ -3568,9 +3577,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    * @return summaries for all the owners/children of the relationships supplied.
    * @throws PSCmsException if it could not fetch the summaries for any reason.
    */
-  private PSComponentSummaries getSummaries(Iterator relationships, boolean owner)
+  private PSComponentSummaries getSummaries(Iterator<?> relationships, boolean owner)
       throws PSCmsException {
-    List locators = new ArrayList();
+    List<PSLocator> locators = new ArrayList<>();
     while (relationships.hasNext()) {
       PSRelationship element = (PSRelationship) relationships.next();
       PSLocator temp = null;
@@ -3584,7 +3593,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
   public void move(
       @SuppressWarnings("unused") String relationshipType,
       PSLocator sourceParent,
-      List children,
+      List<?> children,
       PSLocator targetParent)
       throws PSCmsException {
     move(
@@ -3705,7 +3714,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
   }
 
   // see IPSFolderProcessor
-  public void addChildren(List children, PSLocator targetFolderId) throws PSCmsException {
+  public void addChildren(List<PSLocator> children, PSLocator targetFolderId)
+      throws PSCmsException {
     add(FOLDER_RELATE_TYPE, children, targetFolderId);
   }
 
@@ -3722,14 +3732,15 @@ public class PSServerFolderProcessor extends PSProcessorCommon
   }
 
   // see IPSFolderProcessor
-  public void copyChildren(List children, PSLocator targetFolderId) throws PSCmsException {
+  public void copyChildren(List<PSLocator> children, PSLocator targetFolderId)
+      throws PSCmsException {
     copy(FOLDER_RELATE_TYPE, children, targetFolderId);
   }
 
   // see IPSFolderProcessor
 
   @Transactional
-  public void removeChildren(PSLocator sourceFolderId, List children, boolean force)
+  public void removeChildren(PSLocator sourceFolderId, List<PSLocator> children, boolean force)
       throws PSCmsException, PSNotFoundException {
     validateKey(sourceFolderId);
     validateKeys(children.iterator());
@@ -3788,7 +3799,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
   // see IPSFolderProcessor
 
-  public void removeChildren(PSLocator sourceFolderId, List children)
+  public void removeChildren(PSLocator sourceFolderId, List<PSLocator> children)
       throws PSCmsException, PSNotFoundException {
     removeChildren(sourceFolderId, children, false);
   }
@@ -3809,7 +3820,10 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
   // see IPSFolderProcessor
   public void moveChildren(
-      PSLocator sourceFolderId, List children, PSLocator targetFolderId, boolean force)
+      PSLocator sourceFolderId,
+      List<PSLocator> children,
+      PSLocator targetFolderId,
+      boolean force)
       throws PSCmsException {
     moveFolderChildren(sourceFolderId, children, targetFolderId, force, true);
   }
@@ -3829,7 +3843,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
    */
   public void moveFolderChildren(
       PSLocator sourceFolderId,
-      List children,
+      List<PSLocator> children,
       PSLocator targetFolderId,
       boolean force,
       boolean checkFolderPermission)
@@ -3895,7 +3909,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
   }
 
   // see IPSFolderProcessor
-  public void moveChildren(PSLocator sourceFolderId, List children, PSLocator targetFolderId)
+  public void moveChildren(
+      PSLocator sourceFolderId, List<PSLocator> children, PSLocator targetFolderId)
       throws PSCmsException {
     moveChildren(sourceFolderId, children, targetFolderId, false);
   }
@@ -4142,7 +4157,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
         logger.info("Source: {} --> Target: {}", sourceSite, targetSite);
       }
 
-      List children = new ArrayList();
+      // May hold PSLocator or PSLocatorWithName (override name for clone)
+      List<Object> children = new ArrayList<>();
       PSLocatorWithName newSource =
           new PSLocatorWithName(source.getId(), source.getRevision(), options.getFolderName());
       children.add(newSource);
@@ -4159,7 +4175,8 @@ public class PSServerFolderProcessor extends PSProcessorCommon
         request.setParameter(IPSHtmlParameters.RXS_DISABLE_NAV_FOLDER_EFFECT, "y");
 
         PSComponentSummaries childSummaries =
-            getComponentSummaries(children.iterator(), null, false);
+            getComponentSummaries(
+                (Iterator<PSLocator>) (Iterator<?>) children.iterator(), null, false);
 
         // make sure target is not a descendent of the copied childen
         validateTargetParentIsNotDescendent(
@@ -4425,15 +4442,15 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
   // see IPSFolderProcessor
 
-  public Set getFolderCommunities(PSLocator source) throws PSCmsException {
+  public Set<Integer> getFolderCommunities(PSLocator source) throws PSCmsException {
     if (source == null) throw new IllegalArgumentException("source cannot be null");
 
-    Set communities = new HashSet();
+    Set<Integer> communities = new HashSet<>();
 
     PSComponentSummaries summaries = new PSComponentSummaries();
     collectComponentSummaries(source, summaries);
 
-    Iterator walker = summaries.iterator();
+    Iterator<?> walker = summaries.iterator();
     while (walker.hasNext()) {
       PSComponentSummary summary = (PSComponentSummary) walker.next();
       communities.add(Integer.valueOf(summary.getCommunityId()));

--- a/system/src/test/java/com/percussion/cms/objectstore/PSSearchFieldsPropertiesTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSSearchFieldsPropertiesTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed {@link PSSearch} field/property iterators and property helpers
+ * (rawtypes cleanup for issue #2349).
+ */
+public class PSSearchFieldsPropertiesTest {
+
+  @Test
+  public void getFieldsReturnsTypedIteratorOverAddedFields() throws Exception {
+    PSSearch search = new PSSearch();
+    PSSearchField field =
+        new PSSearchField("sys_title", "Title", "", PSSearchField.TYPE_TEXT, "desc");
+    search.addField(field);
+
+    Iterator<PSSearchField> fields = search.getFields();
+    assertTrue(fields.hasNext());
+    PSSearchField next = fields.next();
+    assertEquals("sys_title", next.getFieldName());
+    assertFalse(fields.hasNext());
+  }
+
+  @Test
+  public void setFieldsReplacesCollectionWithTypedIterator() throws Exception {
+    PSSearch search = new PSSearch();
+    search.addField(
+        new PSSearchField("old_field", "Old", "", PSSearchField.TYPE_TEXT, ""));
+
+    List<PSSearchField> replacements = new ArrayList<>();
+    replacements.add(
+        new PSSearchField("new_field", "New", "", PSSearchField.TYPE_NUMBER, ""));
+    search.setFields(replacements.iterator());
+
+    Iterator<PSSearchField> fields = search.getFields();
+    assertTrue(fields.hasNext());
+    assertEquals("new_field", fields.next().getFieldName());
+    assertFalse(fields.hasNext());
+  }
+
+  @Test
+  public void removeFieldsDropsMatchingFields() throws Exception {
+    PSSearch search = new PSSearch();
+    PSSearchField keep =
+        new PSSearchField("keep_me", "Keep", "", PSSearchField.TYPE_TEXT, "");
+    PSSearchField drop =
+        new PSSearchField("drop_me", "Drop", "", PSSearchField.TYPE_TEXT, "");
+    search.addField(keep);
+    search.addField(drop);
+
+    List<PSSearchField> toRemove = new ArrayList<>();
+    toRemove.add(drop);
+    search.removeFields(toRemove.iterator());
+
+    List<String> names = new ArrayList<>();
+    Iterator<PSSearchField> fields = search.getFields();
+    while (fields.hasNext()) {
+      names.add(fields.next().getFieldName());
+    }
+    assertTrue(names.contains("keep_me"));
+    assertFalse(names.contains("drop_me"));
+  }
+
+  @Test
+  public void propertyApisUseTypedIteratorsAndValues() throws Exception {
+    PSSearch search = new PSSearch();
+    search.setProperty("sys_community", "100");
+    search.setProperty("sys_community", "200", true);
+
+    assertTrue(search.hasProperty("sys_community"));
+    assertTrue(search.doesPropertyHaveValue("sys_community", "100"));
+    assertTrue(search.doesPropertyHaveValue("sys_community", "200"));
+
+    String[] values = search.getPropertyValues("sys_community");
+    assertEquals(2, values.length);
+
+    Iterator<PSSearchMultiProperty> props = search.getProperties();
+    boolean foundCommunity = false;
+    while (props.hasNext()) {
+      PSSearchMultiProperty prop = props.next();
+      if ("sys_community".equalsIgnoreCase(prop.getName())) {
+        foundCommunity = true;
+        List<String> collected = new ArrayList<>();
+        Iterator<String> propValues = prop.iterator();
+        while (propValues.hasNext()) {
+          collected.add(propValues.next());
+        }
+        assertTrue(collected.contains("100"));
+        assertTrue(collected.contains("200"));
+      }
+    }
+    assertTrue(foundCommunity, "expected typed getProperties to include sys_community");
+
+    search.removeProperty("sys_community", "100", true);
+    assertFalse(search.doesPropertyHaveValue("sys_community", "100"));
+    assertTrue(search.doesPropertyHaveValue("sys_community", "200"));
+  }
+}


### PR DESCRIPTION
## Summary

Slice **2c** of parent **#2022** (grandparent **#2200**): real generics for residual rawtypes/unchecked in `com.percussion.cms.objectstore` after #2311 / PR #2350.

### Changes
- **`PSSearch`** — `Iterator<PSSearchField> getFields`; `setFields`/`removeFields(Iterator<? extends PSSearchField>)`; `Iterator<PSSearchMultiProperty> getProperties`; typed property-loop iterators
- **`PSSFields`** — typed set/remove fields APIs
- **`PSMultiValuedProperty`** — `Iterator<String>` values; typed internal property iterators
- **`PSServerFolderProcessor`** — `IPSRelationshipProcessor` methods use `List<?>`; `IPSFolderProcessor` methods use `List<PSLocator>`; helpers (validateKeys, getFolderLocators, ComponentGroup, getFolderCommunities, etc.) parameterized
- **`PSFolderProcessorProxy`** — aligned with `IPSFolderProcessor` List/Set types
- **Tests** — JUnit 5 `PSSearchFieldsPropertiesTest` (4)
- **Erlang** — approve (`docs/ai-generated/code-reviews/issue-2349-cms-objectstore-rawtypes-erlang.md`)

### Residual
Follow-up **#2376** (other package residuals / folder processor internals after this surface batch).

### Out of scope (per #2349)
- design.objectstore, this-escape/serial, data.jdbc

## Test plan
- [x] `cd system` → `../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Module tests: **1236** run, **0** failures, **0** errors (240 skipped pre-existing)
- [x] Focused: `PSSearchFieldsPropertiesTest` 4 green
- [x] Erlang self-review: approve

## Gates evidence
| Gate | Result |
| --- | --- |
| Standalone module clean install (`cd system`) | BUILD SUCCESS |
| Behavioral unit tests | 4 green |
| Scope confined to cms.objectstore + folder processor batch | yes |
| Erlang | approve |

Parent tracker: #2022  
Grandparent: #2200  
Residual: #2376  

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2349  
Refs #2022 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.