### PR TITLE
fix(perc-content-explorer): PSExecutableSearch rawtypes residual (#2368)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2368-psexecutablesearch-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2368-psexecutablesearch-rawtypes-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review: issue #2368 PSExecutableSearch rawtypes residual batch
+
+Date: 2026-08-07
+Branch: fix/issue-2368-psexecutablesearch-rawtypes
+Reviewer persona: Erlang (pre-commit gate)
+
+## Scope
+- Parameterize `PSExecutableSearch` constructors, search result children, row-data maps, iterators, category lists, and display-format table meta
+- Typed `List<PSNode>` return from `executeSearch`; call-site typing in ActionManager adapters, SearchView, FolderActionManager, ItemRelationshipsManager
+- Behavioral tests: category label comparator + `sortCategoryChildren` (order, recurse, skip non-category)
+
+## Findings
+### Bugs
+None. No product behavior change intended; casts removed only where types are now proven. Parent `PSBaseExecutableSearch`/`PSDisplayFormat` raw boundaries use `Iterator<?>` / single unchecked cast for `getContentIdList()` / raw prop-set copy.
+
+### Behavioral tests
+- `PSExecutableSearchTest`: comparator order, top-level category sort, nested recurse, non-category skip
+- Module suite green: Tests run: 20, Failures: 0
+
+### Cross-platform paths
+No new path/file I/O. Existing URL/document base handling unchanged.
+
+### Change-class companions
+- Consumer call sites updated for `List<Integer>` / `List<PSNode>` / `List<String>` constructors and return types
+- `asNodeListIterator(List<PSNode>)` no longer needs rawtypes suppress
+- Residual this-escape on ctor→init (6 diags) pre-existing pattern; not rawtypes; out of scope for #2368
+
+## Gate
+PASS for commit/PR (no bug findings; tests present; module clean install green).
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
@@ -233,8 +233,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
     return children;
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  private static Iterator<PSNode> asNodeListIterator(List results) {
+  private static Iterator<PSNode> asNodeListIterator(List<PSNode> results) {
     return results == null ? Collections.emptyIterator() : results.iterator();
   }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExecutableSearch.java
@@ -111,7 +111,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
   public PSExecutableSearch(
       URL documentBaseURL,
       PSDisplayFormat displayFormat,
-      List contentIdList,
+      List<Integer> contentIdList,
       PSContentExplorerApplet applet) {
     this(documentBaseURL, displayFormat, contentIdList, null, null, applet);
   }
@@ -135,8 +135,8 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
   public PSExecutableSearch(
       URL documentBaseURL,
       PSDisplayFormat displayFormat,
-      List contentIdList,
-      Collection contentTypeIdList,
+      List<Integer> contentIdList,
+      Collection<?> contentTypeIdList,
       PSSearch search,
       PSContentExplorerApplet applet) {
     if (documentBaseURL == null || documentBaseURL.getPath().length() == 0)
@@ -167,7 +167,10 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    *     </code>.
    */
   public PSExecutableSearch(
-      URL documentBaseURL, List columnNames, List contentIdList, PSContentExplorerApplet applet) {
+      URL documentBaseURL,
+      List<String> columnNames,
+      List<Integer> contentIdList,
+      PSContentExplorerApplet applet) {
     if (documentBaseURL == null || documentBaseURL.getPath().length() == 0)
       throw new IllegalArgumentException("documentBaseURL must not be null or empty");
 
@@ -224,11 +227,11 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    */
   private void init(
       URL documentBaseURL,
-      List columnNames,
+      List<String> columnNames,
       PSSearch search,
       PSDisplayFormat displayFormat,
-      List contentIdList,
-      Collection contentTypeIdList) {
+      List<Integer> contentIdList,
+      Collection<?> contentTypeIdList) {
     PSRemoteAppletRequester requester =
         new PSRemoteAppletRequester(m_applet.getHttpConnection(), documentBaseURL);
     if (columnNames == null) columnNames = getColumnNames(displayFormat);
@@ -263,9 +266,9 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    * @param displayFormat Provides the column names, assumed not <code>null</code>.
    * @return The list of column names as <code>String</code> objects, never <code>null</code>.
    */
-  private List getColumnNames(PSDisplayFormat displayFormat) {
-    List result = new ArrayList();
-    Iterator resultFieldIter = displayFormat.getColumns();
+  private List<String> getColumnNames(PSDisplayFormat displayFormat) {
+    List<String> result = new ArrayList<>();
+    Iterator<?> resultFieldIter = displayFormat.getColumns();
     while (resultFieldIter.hasNext()) {
       PSDisplayColumn dc = (PSDisplayColumn) resultFieldIter.next();
       result.add(dc.getSource());
@@ -282,7 +285,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    * @return a list of search results, never <code>null</code>, may be empty.
    * @throws PSContentExplorerException if an error happens executing search.
    */
-  public List executeSearch(PSNode node) throws PSContentExplorerException {
+  public List<PSNode> executeSearch(PSNode node) throws PSContentExplorerException {
     return executeSearch(node, false, true);
   }
 
@@ -302,19 +305,19 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    * @return a list of search results, never <code>null</code>, may be empty
    * @throws PSContentExplorerException if an error happens executing search.
    */
-  public List executeSearch(PSNode node, boolean includeFolders, boolean useFolderRefs)
+  public List<PSNode> executeSearch(PSNode node, boolean includeFolders, boolean useFolderRefs)
       throws PSContentExplorerException {
     if (node == null) throw new IllegalArgumentException("node may not be null.");
 
     // see if only searching on dirty child item nodes
     boolean hasDirty = node.hasDirtyChildren();
     boolean hasDirtyItems = false;
-    List contentIdList = new ArrayList();
-    List<Integer> dirtyIds = new ArrayList<Integer>();
+    List<Integer> contentIdList = new ArrayList<>();
+    List<Integer> dirtyIds = new ArrayList<>();
     List<Integer> refreshIds = null;
-    List origContentIdList = getContentIdList();
-    Iterator dirtyIter;
-    Map origSearchState = null;
+    @SuppressWarnings("unchecked")
+    List<Integer> origContentIdList = (List<Integer>) getContentIdList();
+    Map<String, String> origSearchState = null;
 
     boolean expandSynonyms = false;
     try {
@@ -337,9 +340,9 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
     try {
       if (hasDirty) {
         // get list of dirty item node ids
-        Iterator nodes = node.getDirtyChildren(!node.isAnyFolderType());
+        Iterator<PSNode> nodes = node.getDirtyChildren(!node.isAnyFolderType());
         while (nodes.hasNext()) {
-          PSNode dirty = (PSNode) nodes.next();
+          PSNode dirty = nodes.next();
           String strContentId = dirty.getContentId();
           if (!StringUtils.isBlank(strContentId)) {
             Integer contentId;
@@ -354,7 +357,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
             if (contentId.intValue() == -1) {
               hasDirty = false;
               dirtyIds.clear();
-              refreshIds = new ArrayList<Integer>();
+              refreshIds = new ArrayList<>();
               break;
             }
             dirtyIds.add(contentId);
@@ -363,19 +366,17 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
 
         // if we didn't find dummy id, add all dirty
         if (refreshIds == null) {
-          refreshIds = new ArrayList<Integer>();
+          refreshIds = new ArrayList<>();
           refreshIds.addAll(dirtyIds);
         }
 
         hasDirtyItems = !dirtyIds.isEmpty();
 
         // now get intersection of dirty ids and original search ids
-        Set idSet = null;
+        Set<Integer> idSet = null;
         if (origContentIdList != null && !origContentIdList.isEmpty())
-          idSet = new HashSet(origContentIdList);
-        dirtyIter = dirtyIds.iterator();
-        while (dirtyIter.hasNext()) {
-          Integer ctId = (Integer) dirtyIter.next();
+          idSet = new HashSet<>(origContentIdList);
+        for (Integer ctId : dirtyIds) {
           // add is no original ids or if in that set
           if (idSet == null || idSet.contains(ctId)) contentIdList.add(ctId);
         }
@@ -399,7 +400,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
         if (!hasDirtyItems && (origContentIdList != null)) contentIdList.addAll(origContentIdList);
 
         // perform the search
-        Map params = new HashMap();
+        Map<String, String> params = new HashMap<>();
 
         if (m_displayFormat != null)
           params.put(
@@ -426,7 +427,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
            * again. We accomplish this be setting the defaults now and
            * restoring the original values before exiting this method.
            */
-          origSearchState = new HashMap();
+          origSearchState = new HashMap<>();
           for (int i = 0; i < advancedProps.length; i++) {
             String value = m_search.getProperty(advancedProps[i][0]);
             if (value != null && value.trim().length() > 0) {
@@ -453,11 +454,11 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
         else curRows = new PSWSSearchResponse(lastSearchResults);
 
         // create row list with dirty id rows removed
-        List newRowList = new ArrayList();
-        Set<Integer> dirtySet = new HashSet<Integer>(dirtyIds);
-        Iterator rows = curRows.getRows();
+        List<IPSSearchResultRow> newRowList = new ArrayList<>();
+        Set<Integer> dirtySet = new HashSet<>(dirtyIds);
+        Iterator<IPSSearchResultRow> rows = curRows.getRows();
         while (rows.hasNext()) {
-          IPSSearchResultRow row = (IPSSearchResultRow) rows.next();
+          IPSSearchResultRow row = rows.next();
           if (!dirtySet.contains(
               Integer.valueOf(row.getColumnValue(IPSHtmlParameters.SYS_CONTENTID)))) {
             newRowList.add(row);
@@ -493,7 +494,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
       // save results for next selective refresh processing
       node.setSearchResults(searchResultDoc);
 
-      if (node.getChildren() == null) return new ArrayList();
+      if (node.getChildren() == null) return new ArrayList<>();
 
       return PSIteratorUtils.cloneList(node.getChildren());
     } catch (Exception ex) {
@@ -530,8 +531,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
       // restore the search to its previous state
       if (origSearchState != null) {
         for (int i = 0; i < advancedProps.length; i++) {
-          Object prop = origSearchState.get(advancedProps[i][0]);
-          String value = null == prop ? null : prop.toString();
+          String value = origSearchState.get(advancedProps[i][0]);
           if (null != value) m_search.setProperty(advancedProps[i][0], value);
         }
         m_search.setCaseSensitive(originallyCaseSensitive);
@@ -552,7 +552,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
   private boolean addObjectFilterField() {
     if (m_search == null) throw new IllegalStateException("m_search has not been set yet.");
 
-    Iterator fields = m_search.getFields();
+    Iterator<?> fields = m_search.getFields();
     boolean found = false;
     while (fields.hasNext() && !found) {
       PSSearchField field = (PSSearchField) fields.next();
@@ -578,7 +578,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    */
   private void removeObjectFilterField() {
     PSSFields fields = m_search.getFieldContainer();
-    Iterator fieldIter = fields.iterator();
+    Iterator<?> fieldIter = fields.iterator();
     while (fieldIter.hasNext()) {
       PSSearchField field = (PSSearchField) fieldIter.next();
       if (field.getFieldName().equalsIgnoreCase(PROPERTY_OBJECTTYPE)) {
@@ -628,14 +628,14 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
 
     // build lists of categories, flat fields, and table meta columns, as well
     // column display name map
-    List categorized = new ArrayList();
-    List flat = new ArrayList();
-    List tableCols = new ArrayList();
-    List colDefs = null; // will be null if no display format, or no columns
-    Map colNames = new HashMap();
+    List<String> categorized = new ArrayList<>();
+    List<String> flat = new ArrayList<>();
+    List<Map.Entry<String, String>> tableCols = new ArrayList<>();
+    List<Map.Entry<String, String>> colDefs = null; // will be null if no display format, or no columns
+    Map<String, String> colNames = new HashMap<>();
 
     if (df != null) {
-      Iterator cols = df.getColumns();
+      Iterator<?> cols = df.getColumns();
       while (cols.hasNext()) {
         PSDisplayColumn col = (PSDisplayColumn) cols.next();
         String name = col.getSource();
@@ -644,7 +644,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
         if (col.isCategorized()) categorized.add(name);
         else {
           flat.add(col.getSource());
-          tableCols.add(new PSEntrySet(dispName, col.getRenderType()));
+          tableCols.add(new PSEntrySet<>(dispName, col.getRenderType()));
         }
       }
 
@@ -659,7 +659,7 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
     if (!categorized.isEmpty()) {
       baseNode.clearChildrenDisplayFormat();
     } else {
-      Iterator colDefIter = colDefs != null ? colDefs.iterator() : null;
+      Iterator<Map.Entry<String, String>> colDefIter = colDefs != null ? colDefs.iterator() : null;
       baseNode.setChildrenDisplayFormat(colDefIter);
     }
 
@@ -667,31 +667,27 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
      * Generate a property set to add to node. The set is the static set
      * for the search type combined with the display columns.
      */
-    Set propList = null;
-    if (isRCSearch) propList = new HashSet(ms_cxRCPropSet);
-    else propList = new HashSet(ms_cxPropSet);
-    Iterator colIter = colNames.keySet().iterator();
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    Set<String> propList =
+        isRCSearch ? new HashSet<String>(ms_cxRCPropSet) : new HashSet<String>(ms_cxPropSet);
     /*
      * With Rhythmyx 5.6, every display column by internal name is eleigible
      * to be submitted to server if a server action is configured to do so by
      * specifying $params. So add all display column internal names to the
      * standard set too.
      */
-    while (colIter.hasNext()) {
-      String colName = (String) colIter.next();
-      propList.add(colName);
-    }
+    propList.addAll(colNames.keySet());
 
     // Get the icon map
 
     Map<String, String> iconMap = getIconPathMap(resp);
     // walk each row and create a node for it
-    Iterator rows = resp.getRows();
+    Iterator<IPSSearchResultRow> rows = resp.getRows();
     String folder_type = useFolderRefs ? PSNode.TYPE_FOLDER_REF : PSNode.TYPE_FOLDER;
     PSFolderActionManager folderMgr =
         m_applet.getApplet().getActionManager().getFolderActionManager();
     while (rows.hasNext()) {
-      IPSSearchResultRow row = (IPSSearchResultRow) rows.next();
+      IPSSearchResultRow row = rows.next();
       String title = row.getColumnDisplayValue("sys_title");
       String ctypeId = row.getColumnValue(PROPERTY_CONTENTTYPEID).toString();
       Integer contentId = Integer.valueOf(row.getColumnValue(PROPERTY_CONTENTID));
@@ -724,17 +720,17 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
         itemNode = new PSNode(title, title, nodeType, null, iconKey, false, Integer.parseInt(perm));
 
         // add props and cols
-        Map rowData = new HashMap();
-        Iterator cols = row.getColumnNames().iterator();
+        Map<String, Object> rowData = new HashMap<>();
+        Iterator<String> cols = row.getColumnNames().iterator();
         while (cols.hasNext()) {
-          String name = cols.next().toString();
+          String name = cols.next();
           if (propList.contains(name)) {
             itemNode.setProperty(name, row.getColumnValue(name));
           }
 
           if (flat.contains(name)) {
             // get the display name of the column
-            String colName = (String) colNames.get(name);
+            String colName = colNames.get(name);
             if (colName == null) colName = name;
             rowData.put(colName, row.getColumnDisplayValue(name));
           }
@@ -747,9 +743,9 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
       if (!categorized.isEmpty()) {
         // need to build nested groups of results
         PSNode parent = baseNode;
-        Iterator catIter = categorized.iterator();
+        Iterator<String> catIter = categorized.iterator();
         while (catIter.hasNext()) {
-          String field = (String) catIter.next();
+          String field = catIter.next();
           String catVal = row.getColumnDisplayValue(field);
           String catName = catVal;
           // String catName = (String)colNames.get(field);
@@ -764,11 +760,11 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
           }
 
           // get the category node, add if not already found
-          Iterator children = parent.getChildren();
+          Iterator<PSNode> children = parent.getChildren();
           PSNode catNode = null;
           if (children != null) {
             while (children.hasNext() && catNode == null) {
-              PSNode child = (PSNode) children.next();
+              PSNode child = children.next();
               if (child.getType().equals(PSNode.TYPE_CATEGORY)
                   && child.getName().equals(catName)
                   && child.getLabel().equals(catVal)) {
@@ -786,7 +782,8 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
             // set table meta columns on the category node that will
             // contain the items.
             if (onLast) {
-              Iterator colDefIter = colDefs != null ? colDefs.iterator() : null;
+              Iterator<Map.Entry<String, String>> colDefIter =
+                  colDefs != null ? colDefs.iterator() : null;
               catNode.setChildrenDisplayFormat(colDefIter);
             }
           }
@@ -804,15 +801,18 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
 
     // now sort categories ascending
     if (!categorized.isEmpty()) {
-      Comparator comp =
-          new Comparator() {
-            public int compare(Object o1, Object o2) {
-              return o1.toString().compareTo(o2.toString());
-            }
-          };
-
-      sortCategories(baseNode, comp);
+      sortCategoryChildren(baseNode, categoryLabelComparator());
     }
+  }
+
+  /**
+   * Comparator used to sort category nodes by label ({@link PSNode#toString()}). Package-private
+   * for unit tests.
+   *
+   * @return a comparator that never returns {@code null}
+   */
+  static Comparator<PSNode> categoryLabelComparator() {
+    return (o1, o2) -> o1.toString().compareTo(o2.toString());
   }
 
   /**
@@ -824,12 +824,12 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    *     {@see PSCxUtil#getItemIcons(List)} for more details.
    */
   private Map<String, String> getIconPathMap(PSWSSearchResponse resp) {
-    Map<String, String> iconMap = new HashMap<String, String>();
-    Iterator rowiter = resp.getRows();
-    List<PSLocator> locs = new ArrayList<PSLocator>();
+    Map<String, String> iconMap = new HashMap<>();
+    Iterator<IPSSearchResultRow> rowiter = resp.getRows();
+    List<PSLocator> locs = new ArrayList<>();
     String curUser = StringUtils.defaultString(m_applet.getUserInfo().getUserName());
     while (rowiter.hasNext()) {
-      IPSSearchResultRow row = (IPSSearchResultRow) rowiter.next();
+      IPSSearchResultRow row = rowiter.next();
       String cid = row.getColumnValue(PROPERTY_CONTENTID);
       String rid = row.getColumnValue("sys_currentrevision");
       String chkUser = row.getColumnValue("sys_contentcheckoutusername");
@@ -851,21 +851,23 @@ public class PSExecutableSearch extends PSWSExecutableSearch {
    * then all children are of this type and they should be sorted, and the method should recurse
    * into these children. Otherwise, they are not sorted and the method does not recurse.
    *
+   * <p>Package-private static for unit tests (no instance state).
+   *
    * @param node The node whose children are to be sorted, assumed not <code>null</code>.
    * @param comp The comparator to use, assumed not <code>null</code>.
    */
-  private void sortCategories(PSNode node, Comparator comp) {
+  static void sortCategoryChildren(PSNode node, Comparator<? super PSNode> comp) {
     if (node.getChildren() == null) return;
 
-    List childList = PSIteratorUtils.cloneList(node.getChildren());
-    if (!childList.isEmpty() && ((PSNode) childList.get(0)).isOfType(PSNode.TYPE_CATEGORY)) {
+    List<PSNode> childList = PSIteratorUtils.cloneList(node.getChildren());
+    if (!childList.isEmpty() && childList.get(0).isOfType(PSNode.TYPE_CATEGORY)) {
       Collections.sort(childList, comp);
       node.setChildren(childList.iterator());
 
       // now recurse children
-      Iterator children = node.getChildren();
+      Iterator<PSNode> children = node.getChildren();
       while (children.hasNext()) {
-        sortCategories((PSNode) children.next(), comp);
+        sortCategoryChildren(children.next(), comp);
       }
     }
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
@@ -350,7 +350,7 @@ public class PSFolderActionManager {
           new PSExecutableSearch(m_appletBase, format, search, getApplet());
       searchEx.addColumnName(IPSHtmlParameters.SYS_PERMISSIONS);
 
-      List itemNodes = searchEx.executeSearch(parentFolderNode, true, false);
+      List<PSNode> itemNodes = searchEx.executeSearch(parentFolderNode, true, false);
 
       removeSystemFolder(itemNodes);
       if (parentFolderNode.getName().equals("Sites")) {

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
@@ -185,8 +185,8 @@ public class PSItemRelationshipsManager {
       }
     }
 
-    List resList = new ArrayList();
-    List idList = new ArrayList();
+    List<PSNode> resList = new ArrayList<>();
+    List<Integer> idList = new ArrayList<>();
     // Set the 'relationship', 'rs_type' and the locator as properties of each
     // node
     Iterator it = summaries.iterator();
@@ -232,21 +232,16 @@ public class PSItemRelationshipsManager {
               .getDisplayFormatById("0"); // get the default display format
 
       PSExecutableSearch searchEx = new PSExecutableSearch(m_docBase, format, idList, m_applet);
-      List list = searchEx.executeSearch(parentNode);
-      PSNode node = null;
-      Map rowData = null;
-      Iterator values = null;
-      String label = null;
-      for (int i = 0; i < list.size(); i++) {
-        node = (PSNode) list.get(i);
+      List<PSNode> list = searchEx.executeSearch(parentNode);
+      for (PSNode node : list) {
         node.setType(PSNode.TYPE_DTITEM);
         node.setProperty(IPSConstants.PROPERTY_RELATIONSHIP, relationship);
 
         node.setProperty(PROP_RS_LOOKUP_TYPE, rsType);
-        label = node.getLabel();
-        rowData = node.getRowData();
+        String label = node.getLabel();
+        Map<String, Object> rowData = node.getRowData();
         if (rowData != null) {
-          values = rowData.values().iterator();
+          Iterator<Object> values = rowData.values().iterator();
           int ii = 0;
           while (values.hasNext()) {
             if (ii == 0) label += " (";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -443,10 +444,16 @@ public class PSSearchViewActionManager {
               searchNode.setChildren(Collections.emptyIterator());
               return searchNode.getChildren();
             }
-            List retIdList = new ArrayList();
-            retIdList.addAll(idList);
+            List<Integer> retIdList = new ArrayList<>();
+            for (Object idObj : idList) {
+              retIdList.add((Integer) idObj);
+            }
+            Collection<Integer> typeIds = new ArrayList<>();
+            for (Object typeObj : typeList) {
+              typeIds.add((Integer) typeObj);
+            }
             searchEx =
-                new PSExecutableSearch(m_urlBase, format, retIdList, typeList, search, m_applet);
+                new PSExecutableSearch(m_urlBase, format, retIdList, typeIds, search, m_applet);
           } else {
             search = m_searchViewCatalog.getSearchById(searchId);
             searchEx = new PSExecutableSearch(m_urlBase, format, search, m_applet);

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExecutableSearchTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExecutableSearchTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cx.objectstore.PSNode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed category sorting helpers on {@link PSExecutableSearch}. Full search
+ * execution requires a live applet/server; these cover the pure sort surface parameterized for
+ * rawtypes clearance.
+ */
+public class PSExecutableSearchTest {
+
+  @Test
+  public void categoryLabelComparatorOrdersByLabel() {
+    Comparator<PSNode> comp = PSExecutableSearch.categoryLabelComparator();
+    PSNode zebra = new PSNode("z", "Zebra", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    PSNode apple = new PSNode("a", "Apple", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    assertTrue(comp.compare(apple, zebra) < 0);
+    assertTrue(comp.compare(zebra, apple) > 0);
+    assertEquals(0, comp.compare(apple, apple));
+  }
+
+  @Test
+  public void sortCategoryChildrenOrdersTopLevelCategoryChildren() {
+    PSNode root = new PSNode("root", "Root", PSNode.TYPE_PARENT, null, null, false, -1);
+    PSNode c = new PSNode("c", "Charlie", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    PSNode a = new PSNode("a", "Alpha", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    PSNode b = new PSNode("b", "Bravo", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    root.setChildren(Arrays.asList(c, a, b).iterator());
+
+    PSExecutableSearch.sortCategoryChildren(root, PSExecutableSearch.categoryLabelComparator());
+
+    List<String> labels = new ArrayList<>();
+    Iterator<PSNode> kids = root.getChildren();
+    while (kids.hasNext()) {
+      labels.add(kids.next().getLabel());
+    }
+    assertEquals(Arrays.asList("Alpha", "Bravo", "Charlie"), labels);
+  }
+
+  @Test
+  public void sortCategoryChildrenRecursesIntoNestedCategoryChildren() {
+    PSNode root = new PSNode("root", "Root", PSNode.TYPE_PARENT, null, null, false, -1);
+    PSNode catOuter = new PSNode("outer", "Outer", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    PSNode nestedZ = new PSNode("z", "Zulu", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    PSNode nestedA = new PSNode("a", "Able", PSNode.TYPE_CATEGORY, null, null, false, -1);
+    catOuter.setChildren(Arrays.asList(nestedZ, nestedA).iterator());
+    root.setChildren(Arrays.asList(catOuter).iterator());
+
+    PSExecutableSearch.sortCategoryChildren(root, PSExecutableSearch.categoryLabelComparator());
+
+    Iterator<PSNode> outerKids = root.getChildren().next().getChildren();
+    assertEquals("Able", outerKids.next().getLabel());
+    assertEquals("Zulu", outerKids.next().getLabel());
+    assertFalse(outerKids.hasNext());
+  }
+
+  @Test
+  public void sortCategoryChildrenSkipsNonCategoryChildren() {
+    PSNode root = new PSNode("root", "Root", PSNode.TYPE_PARENT, null, null, false, -1);
+    PSNode itemB = new PSNode("b", "Beta", PSNode.TYPE_ITEM, null, null, false, -1);
+    PSNode itemA = new PSNode("a", "Alpha", PSNode.TYPE_ITEM, null, null, false, -1);
+    root.setChildren(Arrays.asList(itemB, itemA).iterator());
+
+    PSExecutableSearch.sortCategoryChildren(root, PSExecutableSearch.categoryLabelComparator());
+
+    Iterator<PSNode> kids = root.getChildren();
+    // items are not reordered (first child is not TYPE_CATEGORY)
+    assertEquals("Beta", kids.next().getLabel());
+    assertEquals("Alpha", kids.next().getLabel());
+  }
+}


### PR DESCRIPTION
## Summary
Parameterizes residual rawtypes/unchecked in `PSExecutableSearch` (~101 diags under raised `-Xmaxwarns`) after PSActionManager batch (#2326/#2371) and PSNode batch 1 (#2045/#2327).

- Typed constructors: `List<Integer>` content ids, `List<String>` column names, `Collection<?>` content type ids
- `executeSearch` → `List<PSNode>`; dirty-id / row-list / category / row-data maps fully parameterized
- Call-site typing: `PSActionManager.asNodeListIterator`, `PSSearchViewActionManager`, `PSFolderActionManager`, `PSItemRelationshipsManager`
- Behavioral tests for category label comparator + `sortCategoryChildren` (order, recurse, non-category skip)
- No product behavior change

Parent module tracker: #2045 · monorepo: #2200

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] Tests run: **20**, Failures: **0** (incl. 4 new `PSExecutableSearchTest`)
- [x] Under raised `-Xmaxwarns`: **0** rawtypes/unchecked on `PSExecutableSearch` (was ~101); residual **6** this-escape on ctor→init only (out of scope)
- [x] Module warning inventory ~1024 → ~905 under maxwarns diagnostic compile
- [x] Erlang pre-commit review: PASS (`docs/ai-generated/code-reviews/issue-2368-psexecutablesearch-rawtypes-erlang.md`)

## Gates evidence
| Gate | Result |
|------|--------|
| Erlang self-review | PASS — no bugs; tests present; portable paths N/A |
| Module clean install | `modules/DesktopContentExplorer` `mvnw clean install` SUCCESS |
| Behavioral tests | `PSExecutableSearchTest` 4 tests green |
| No new warnings | PSE rawtypes/unchecked cleared; no new warning classes introduced |

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2368
Refs #2045 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.