### PR TITLE
fix(utils): residual Xlint batch 4 — WorkflowUtilsBaseTest + main suppress strip (#2362)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2362-utils-residual-batch4-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2362-utils-residual-batch4-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review: fix/issue-2362-utils-residual-batch4
+
+## Summary
+
+Batch 4 residual after utils test-source Xlint batches 1–3. Clears **~72** `PSWorkflowUtilsBaseTest` project-Xlint diags with typed locals (keeps documented raw public-API probe). Strips main-source suppressions where real generics were already present or safe: `InstallUtil` class `@SuppressWarnings("all")`, `PSParseArguments` / `PSOrganizeProperties` class-level rawtypes. Bonus: 5 residual Xml test-source diags (`PSXmlDocumentBuilderTest` / `PSXmlTreeWalkerTest`). Module `mvnw clean install` green; **0** project-Xlint compiler warnings on compile.
+
+## Scope
+
+- Branch: `fix/issue-2362-utils-residual-batch4`
+- Module: `modules/utils` only
+- Parent module issue: #2016
+- Tracker: #2200
+- Issue: #2362
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+May commit/push: **yes**
+
+## Cross-platform path review
+
+N/A — no new file I/O or path handling. Existing portable `Paths.get` / `File.separator` usage in InstallUtil unchanged.
+
+## Issues
+
+None (bug).
+
+### suggestion
+
+- Remaining main-source method/class suppressions are intentional or larger refactors: `PSWorkflowUtilsBase` raw public List/Map API (source-compat PRRT), `PSCollection`, `PSJexlEvaluator`, `PSXmlSerializationHelper`, brand-code / connector `this-escape`. File residual under #2016.
+
+### nit
+
+- `PSWorkflowUtilsBaseTest.castList` bridges raw return values; acceptable for intentional raw production API.
+
+## Behavioral tests
+
+- Existing `PSWorkflowUtilsBaseTest` suite (typed locals + raw probe) still covers public API.
+- No new production logic paths; suppression strip only where code already clean under project Xlint.
+- Xml Book `Comparable<Book>` + static `getElementData` qualify are compile-warning fixes; existing tests exercise them.
+
+## Verification
+
+- `cd modules/utils && mvnw clean install` → BUILD SUCCESS
+- Tests: 311 run, 0 fail, 9 skip (pre-existing)
+- Project-Xlint compiler warnings during compile: **0**
+- `InstallUtil` compiles without class-level suppress (deprecation remains excluded by project `-Xlint:-deprecation`)

--- a/modules/utils/src/main/java/com/percussion/install/InstallUtil.java
+++ b/modules/utils/src/main/java/com/percussion/install/InstallUtil.java
@@ -71,7 +71,6 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
 /** The InstallUtil class contains some utility methods for the installer. */
-@SuppressWarnings("all")
 public class InstallUtil {
 
   private static final Logger log = LogManager.getLogger(InstallUtil.class);

--- a/modules/utils/src/main/java/com/percussion/utils/tools/PSOrganizeProperties.java
+++ b/modules/utils/src/main/java/com/percussion/utils/tools/PSOrganizeProperties.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -38,7 +37,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /** Utility class used to organize a property file into ascending order */
-@SuppressWarnings("rawtypes")
 public class PSOrganizeProperties {
 
   private static final Logger log = LogManager.getLogger(PSOrganizeProperties.class);
@@ -63,9 +61,7 @@ public class PSOrganizeProperties {
               }
             });
 
-    Iterator it = props.keySet().iterator();
-    while (it.hasNext()) {
-      String key = (String) it.next();
+    for (String key : props.stringPropertyNames()) {
       propsMap.put(key, props.getProperty(key, ""));
     }
     savePropsFile(file, propsMap, m_comments);
@@ -173,13 +169,10 @@ public class PSOrganizeProperties {
       props.remove(HEADER_COMMENTS);
     }
 
-    // iterator must be created after props remove the header_commonets
+    // iterate after props remove the header comments
     // to avoid concurrentmodificationexception.
-    Iterator it = props.keySet().iterator();
-
     String lastPrefix = "";
-    while (it.hasNext()) {
-      String key = (String) it.next();
+    for (String key : props.keySet()) {
       String val = escapeValue(props.get(key));
       int pos = key.indexOf('.');
       String prefix = pos == -1 ? key : key.substring(0, key.indexOf('.'));

--- a/modules/utils/src/main/java/com/percussion/utils/tools/PSParseArguments.java
+++ b/modules/utils/src/main/java/com/percussion/utils/tools/PSParseArguments.java
@@ -28,7 +28,6 @@ import java.util.Set;
  * the string "true", other arguments return their value. Arguments that have no value will return
  * <code>true</code> for the method {@link #isFlag(String)}
  */
-@SuppressWarnings("rawtypes")
 public class PSParseArguments {
   /**
    * Ctor
@@ -72,7 +71,7 @@ public class PSParseArguments {
    *
    * @return the unassociated args, never <code>null</code> but may be empty.
    */
-  public List getRest() {
+  public List<String> getRest() {
     return m_rest;
   }
 

--- a/modules/utils/src/test/java/com/percussion/workflow/PSWorkflowUtilsBaseTest.java
+++ b/modules/utils/src/test/java/com/percussion/workflow/PSWorkflowUtilsBaseTest.java
@@ -39,6 +39,9 @@ import org.junit.jupiter.api.Test;
  * backward source compatibility with downstream modules and XML apps. These tests pass raw {@link
  * ArrayList}, {@link HashMap}, and {@link List} arguments to assert that the public API still
  * accepts those shapes.
+ *
+ * <p>Behavioral tests use typed locals where safe. Intentional raw public-API source-compat probes
+ * are isolated in {@link #rawListSignaturesAreAcceptedByPublicAPI()} (documented suppressions).
  */
 @Tag("UnitTest")
 public class PSWorkflowUtilsBaseTest {
@@ -61,7 +64,7 @@ public class PSWorkflowUtilsBaseTest {
   @Test
   public void arrayToListAcceptsStringArray() {
     String[] input = {"alpha", "beta"};
-    List result = PSWorkflowUtilsBase.arrayToList(input);
+    List<?> result = castList(PSWorkflowUtilsBase.arrayToList(input));
     assertEquals(2, result.size());
     assertEquals("alpha", result.get(0));
   }
@@ -69,25 +72,25 @@ public class PSWorkflowUtilsBaseTest {
   @Test
   public void arrayToListAcceptsIntArray() {
     int[] input = {1, 2, 3};
-    List result = PSWorkflowUtilsBase.arrayToList(input);
+    List<?> result = castList(PSWorkflowUtilsBase.arrayToList(input));
     assertEquals(3, result.size());
     assertEquals(1, result.get(0));
   }
 
   @Test
   public void arrayToListOnNullReturnsEmptyList() {
-    List result = PSWorkflowUtilsBase.arrayToList(null);
+    List<?> result = castList(PSWorkflowUtilsBase.arrayToList(null));
     assertNotNull(result);
     assertTrue(result.isEmpty());
   }
 
   @Test
   public void compareRoleListThreeArgFindsAssignmentType() {
-    ArrayList assignmentTypes = new ArrayList();
+    ArrayList<Integer> assignmentTypes = new ArrayList<>();
     assignmentTypes.add(1);
     assignmentTypes.add(2);
     assignmentTypes.add(3);
-    ArrayList roleNames = new ArrayList();
+    ArrayList<String> roleNames = new ArrayList<>();
     roleNames.add("Author");
     roleNames.add("Editor");
     roleNames.add("Admin");
@@ -97,9 +100,9 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void compareRoleListThreeArgReturnsNoneForUnknown() {
-    ArrayList assignmentTypes = new ArrayList();
+    ArrayList<Integer> assignmentTypes = new ArrayList<>();
     assignmentTypes.add(1);
-    ArrayList roleNames = new ArrayList();
+    ArrayList<String> roleNames = new ArrayList<>();
     roleNames.add("Author");
     int result =
         PSWorkflowUtilsBase.compareRoleList(assignmentTypes, roleNames, "UnknownRole,Another");
@@ -108,20 +111,20 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void compareRoleListTwoArgFindsCommonRole() {
-    List roleList = Arrays.asList("Author", "Editor", "Admin");
+    List<String> roleList = Arrays.asList("Author", "Editor", "Admin");
     assertTrue(PSWorkflowUtilsBase.compareRoleList(roleList, "Editor,foo"));
   }
 
   @Test
   public void compareRoleListTwoArgReturnsFalseWhenNoMatch() {
-    List roleList = Arrays.asList("Author", "Editor");
+    List<String> roleList = Arrays.asList("Author", "Editor");
     assertEquals(false, PSWorkflowUtilsBase.compareRoleList(roleList, "Admin,Reviewer"));
   }
 
   @Test
   public void caseInsensitiveUniqueListDedupesCaseInsensitively() {
-    List input = Arrays.asList("alpha", "ALPHA", "Beta", "beta", "Gamma");
-    List result = PSWorkflowUtilsBase.caseInsensitiveUniqueList(input);
+    List<String> input = Arrays.asList("alpha", "ALPHA", "Beta", "beta", "Gamma");
+    List<?> result = castList(PSWorkflowUtilsBase.caseInsensitiveUniqueList(input));
     assertEquals(3, result.size());
     assertTrue(result.contains("alpha"));
     assertTrue(result.contains("Beta"));
@@ -144,23 +147,23 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void caseInsensitiveUniqueListOnEmptyReturnsEmptyList() {
-    List result = PSWorkflowUtilsBase.caseInsensitiveUniqueList(new ArrayList());
+    List<?> result = castList(PSWorkflowUtilsBase.caseInsensitiveUniqueList(new ArrayList<>()));
     assertNotNull(result);
     assertTrue(result.isEmpty());
   }
 
   @Test
   public void caseInsensitiveUniqueListTrimsAndDropsNulls() {
-    List input = Arrays.asList("alpha", null, "  alpha  ");
-    List result = PSWorkflowUtilsBase.caseInsensitiveUniqueList(input);
+    List<String> input = Arrays.asList("alpha", null, "  alpha  ");
+    List<?> result = castList(PSWorkflowUtilsBase.caseInsensitiveUniqueList(input));
     assertEquals(1, result.size());
   }
 
   @Test
   public void intersectListsReturnsCommonElements() {
-    List list1 = Arrays.asList("a", "b", "c");
-    List list2 = Arrays.asList("b", "c", "d");
-    List result = PSWorkflowUtilsBase.intersectLists(list1, list2);
+    List<String> list1 = Arrays.asList("a", "b", "c");
+    List<String> list2 = Arrays.asList("b", "c", "d");
+    List<?> result = castList(PSWorkflowUtilsBase.intersectLists(list1, list2));
     assertEquals(2, result.size());
     assertTrue(result.contains("b"));
     assertTrue(result.contains("c"));
@@ -168,7 +171,7 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void intersectListsOnEmptyReturnsEmpty() {
-    List result = PSWorkflowUtilsBase.intersectLists(new ArrayList(), Arrays.asList("a"));
+    List<?> result = castList(PSWorkflowUtilsBase.intersectLists(new ArrayList<>(), Arrays.asList("a")));
     assertNotNull(result);
     assertTrue(result.isEmpty());
   }
@@ -181,7 +184,7 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void getRoleIdFromMapFindsKey() {
-    Map roleMap = new HashMap();
+    Map<Integer, String> roleMap = new HashMap<>();
     roleMap.put(1, "Author");
     roleMap.put(2, "Editor");
     roleMap.put(3, "Admin");
@@ -190,14 +193,14 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void getRoleIdFromMapReturnsMinusOneForMissing() {
-    Map roleMap = new HashMap();
+    Map<Integer, String> roleMap = new HashMap<>();
     roleMap.put(1, "Author");
     assertEquals(-1, PSWorkflowUtilsBase.getRoleIdFromMap(roleMap, "Missing"));
   }
 
   @Test
   public void getRoleIdFromMapRejectsNullArgs() {
-    Map roleMap = new HashMap();
+    Map<Integer, String> roleMap = new HashMap<>();
     assertThrows(
         IllegalArgumentException.class, () -> PSWorkflowUtilsBase.getRoleIdFromMap(roleMap, null));
     assertThrows(
@@ -206,7 +209,7 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void listToDelimitedStringJoinsWithDelimiter() {
-    List input = Arrays.asList("a", "b", "c");
+    List<String> input = Arrays.asList("a", "b", "c");
     String result = PSWorkflowUtilsBase.listToDelimitedString(input, ",");
     assertEquals("a,b,c", result);
   }
@@ -215,32 +218,32 @@ public class PSWorkflowUtilsBaseTest {
   public void listToDelimitedStringRejectsEmpty() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> PSWorkflowUtilsBase.listToDelimitedString(new ArrayList(), ","));
+        () -> PSWorkflowUtilsBase.listToDelimitedString(new ArrayList<>(), ","));
     assertThrows(
         IllegalArgumentException.class,
-        () -> PSWorkflowUtilsBase.listToDelimitedString((List) null, ","));
+        () -> PSWorkflowUtilsBase.listToDelimitedString(null, ","));
   }
 
   @Test
   public void listToDelimitedStringSingleElementHasNoDelimiter() {
-    List input = Arrays.asList("only");
+    List<String> input = Arrays.asList("only");
     assertEquals("only", PSWorkflowUtilsBase.listToDelimitedString(input, ","));
   }
 
   @Test
   public void listToDelimitedStringUsesStringForNullForNullEntries() {
-    List input = Arrays.asList("a", null, "c");
+    List<String> input = Arrays.asList("a", null, "c");
     String result = PSWorkflowUtilsBase.listToDelimitedString(input, ",", "<null>");
     assertEquals("a,<null>,c", result);
   }
 
   @Test
   public void filterListReturnsMatchingEntries() {
-    List input = Arrays.asList("a", "b", "c");
-    Map filter = new HashMap();
+    List<String> input = Arrays.asList("a", "b", "c");
+    Map<String, Boolean> filter = new HashMap<>();
     filter.put("a", Boolean.TRUE);
     filter.put("c", Boolean.TRUE);
-    List result = PSWorkflowUtilsBase.filterList(input, filter);
+    List<?> result = castList(PSWorkflowUtilsBase.filterList(input, filter));
     assertEquals(2, result.size());
     assertTrue(result.contains("a"));
     assertTrue(result.contains("c"));
@@ -248,35 +251,35 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void filterListOnEmptyMapReturnsNull() {
-    assertNull(PSWorkflowUtilsBase.filterList(Arrays.asList("a"), new HashMap()));
+    assertNull(PSWorkflowUtilsBase.filterList(Arrays.asList("a"), new HashMap<>()));
   }
 
   @Test
   public void filterListOnNullInputReturnsNull() {
-    Map filter = new HashMap();
+    Map<String, Boolean> filter = new HashMap<>();
     filter.put("a", Boolean.TRUE);
     assertNull(PSWorkflowUtilsBase.filterList(null, filter));
   }
 
   @Test
   public void filterListOnEmptyInputReturnsEmptyList() {
-    Map filter = new HashMap();
+    Map<String, Boolean> filter = new HashMap<>();
     filter.put("a", Boolean.TRUE);
-    List result = PSWorkflowUtilsBase.filterList(new ArrayList(), filter);
+    List<?> result = castList(PSWorkflowUtilsBase.filterList(new ArrayList<>(), filter));
     assertNotNull(result);
     assertTrue(result.isEmpty());
   }
 
   @Test
   public void setTransitionCommentInHTMLParamsAcceptsRawHashMap() {
-    HashMap params = new HashMap();
+    HashMap<String, Object> params = new HashMap<>();
     PSWorkflowUtilsBase.setTransitionCommentInHTMLParams("my comment", params);
     assertEquals("my comment", params.get(PSWorkflowUtilsBase.TRANSITION_COMMENT));
   }
 
   @Test
   public void setTransitionCommentInHTMLParamsRejectsLongComment() {
-    HashMap params = new HashMap();
+    HashMap<String, Object> params = new HashMap<>();
     StringBuilder tooLong = new StringBuilder();
     for (int i = 0; i < 256; i++) tooLong.append('x');
     assertThrows(
@@ -293,7 +296,7 @@ public class PSWorkflowUtilsBaseTest {
 
   @Test
   public void setTransitionCommentInHTMLParamsIgnoresNullComment() {
-    HashMap params = new HashMap();
+    HashMap<String, Object> params = new HashMap<>();
     PSWorkflowUtilsBase.setTransitionCommentInHTMLParams(null, params);
     assertTrue(params.isEmpty());
   }
@@ -318,5 +321,14 @@ public class PSWorkflowUtilsBaseTest {
     assertEquals(2, PSWorkflowUtilsBase.intersectLists(rawList, rawList).size());
     assertEquals("a,b", PSWorkflowUtilsBase.listToDelimitedString(rawList, ","));
     assertEquals(2, PSWorkflowUtilsBase.caseInsensitiveUniqueList(rawList).size());
+  }
+
+  /**
+   * Bridges raw public-API return values to a typed local without per-call unchecked warnings.
+   * Production methods intentionally return raw {@link List} for source compatibility.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static List<?> castList(List raw) {
+    return raw;
   }
 }

--- a/modules/utils/src/test/java/com/percussion/xml/PSXmlDocumentBuilderTest.java
+++ b/modules/utils/src/test/java/com/percussion/xml/PSXmlDocumentBuilderTest.java
@@ -62,7 +62,7 @@ public class PSXmlDocumentBuilderTest {
 
     buf.append("<BookList>\n");
     for (int i = 0; i < m_books.size(); i++) {
-      buf.append(((Book) (m_books.get(i))).toXmlString());
+      buf.append(m_books.get(i).toXmlString());
     }
     buf.append("</BookList>");
     StringReader docStringReader = new StringReader(buf.toString());
@@ -85,7 +85,7 @@ public class PSXmlDocumentBuilderTest {
       String isbn = walker.getElementData("isbn", false);
 
       Element authorEl = walker.getNextElement("author", PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
-      String author = walker.getElementData(authorEl);
+      String author = PSXmlTreeWalker.getElementData(authorEl);
       String authorId = authorEl.getAttribute("id");
 
       assertEquals(new Book(title, isbn, author, authorId), m_books.get(i++));
@@ -172,7 +172,7 @@ public class PSXmlDocumentBuilderTest {
 
     for (int i = 0; i < b.getLength(); i++) {
       Attr att = (Attr) b.item(i);
-      String aVal = (String) aNodes.remove(att.getName());
+      String aVal = aNodes.remove(att.getName());
       assertTrue(aVal != null);
       assertEquals(aVal, att.getValue());
     }
@@ -207,7 +207,7 @@ public class PSXmlDocumentBuilderTest {
 
   private ArrayList<Book> m_books;
 
-  protected class Book implements Comparable {
+  protected class Book implements Comparable<Book> {
     public Book(String title, String isbn, String author, String authorId) {
       m_title = title;
       m_isbn = isbn;
@@ -231,8 +231,8 @@ public class PSXmlDocumentBuilderTest {
       return Objects.hash(m_title, m_isbn, m_author, m_authorId);
     }
 
-    public int compareTo(Object o) {
-      Book b = (Book) o;
+    @Override
+    public int compareTo(Book b) {
       int compare = m_title.compareTo(b.m_title);
       if (compare != 0) return compare;
       compare = m_isbn.compareTo(b.m_isbn);

--- a/modules/utils/src/test/java/com/percussion/xml/PSXmlTreeWalkerTest.java
+++ b/modules/utils/src/test/java/com/percussion/xml/PSXmlTreeWalkerTest.java
@@ -322,7 +322,7 @@ public class PSXmlTreeWalkerTest {
 
   private java.util.List<Book> m_books;
 
-  protected static class Book implements Comparable {
+  protected static class Book implements Comparable<Book> {
     public Book(String title, String isbn, String author, String authorId) {
       m_title = title;
       m_isbn = isbn;
@@ -346,8 +346,8 @@ public class PSXmlTreeWalkerTest {
       return Objects.hash(m_title, m_isbn, m_author, m_authorId);
     }
 
-    public int compareTo(Object o) {
-      Book b = (Book) o;
+    @Override
+    public int compareTo(Book b) {
       int compare = m_title.compareTo(b.m_title);
       if (compare != 0) return compare;
       compare = m_isbn.compareTo(b.m_isbn);


### PR DESCRIPTION
## Summary

Partial implement for **#2362** (modules/utils javac residual after batch 3) — **batch 4**.

Clears remaining test-source project-Xlint noise and strips **safe** main suppressions with real typing (no new blanket suppressions):

| Area | Fix | ~diags |
|------|-----|-------:|
| `PSWorkflowUtilsBaseTest` | Typed locals (`List<String>`, `Map<Integer,String>`, etc.); keep documented `rawListSignaturesAreAcceptedByPublicAPI` probe | ~72 |
| `InstallUtil` | Remove class `@SuppressWarnings("all")` (already clean under project Xlint) | suppress strip |
| `PSParseArguments` | `List<String> getRest()`; drop class rawtypes suppress | suppress strip |
| `PSOrganizeProperties` | Typed for-each over properties; drop class rawtypes suppress | suppress strip |
| `PSXmlDocumentBuilderTest` / `PSXmlTreeWalkerTest` | `Comparable<Book>`, remove redundant casts, static `getElementData` | ~5 |

Parent module issue: **#2016**. Tracker: **#2200**. Prior: batch 1 #2329, batch 2 #2346, batch 3 #2363.

### Residual (follow-up)

- #2382 — remaining main-source suppressions (`PSWorkflowUtilsBase` intentional raw API, `PSCollection`, `PSJexlEvaluator`, this-escape legacy types, etc.)

## Test plan

- [x] Standalone `modules/utils`: `mvnw clean install` — BUILD SUCCESS
- [x] Suite: 311 tests, 0 failures (9 pre-existing skips)
- [x] Project-Xlint compiler warnings during compile: **0**
- [x] Documented raw public-API probe test retained

## Gates evidence

- Erlang-style self-review: approve — `docs/ai-generated/code-reviews/issue-2362-utils-residual-batch4-erlang.md`
- Per-module standalone clean install: pass
- No monorepo-wide reformat

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2362. Fixes #2362. Refs #2016 #2200. Residual #2382.

> Co-Authored by Grok Build using grok-4.5 with agent main.
