### PR TITLE
fix(perc-content-explorer): applet + nav tree/display residual (#2370)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2370-applet-nav-display-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2370-applet-nav-display-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review: issue #2370 applet + nav tree/display residual batch
+
+Date: 2026-08-07  
+Branch: fix/issue-2370-applet-nav-display-residual  
+Reviewer persona: Erlang (pre-commit gate)
+
+## Scope
+- `PSContentExplorerApplet`: serial (transient non-Serializable fields), rawtypes/unchecked (maps, sets, iterators, column widths, searchable fields cache, image cache), `@SuppressWarnings("removal")` for legacy `JApplet` base
+- `PSNavigationTree`: rawtypes/unchecked (expanded list, dirty nodes, leaf children, iterators), serial (transient managers), this-escape suppress on Swing/ctor association, **bug fix** `setLoadedChildren` empty-statement always-false
+- `PSExpandedOption` / `PSColumnWidthsOption`: typed path/width collections for consumers
+- `PSNavigationalSelection`: `Iterator<? extends PSNode>`
+- Behavioral tests: applet flagged folders, nav refresh-node types, expanded option, column widths
+
+## Findings
+### Bugs
+- Fixed pre-existing empty-statement bug in `PSTreeNode.setLoadedChildren`: previously always assigned `loadedChildren = false` regardless of flag (call site only used `false`, so runtime behavior for current callers is preserved; API now matches javadoc).
+
+### Behavioral tests
+- `PSContentExplorerAppletTest`: toggle add/remove, defensive copy, invalid id rejection
+- `PSNavigationTreeTest`: `getRefreshNodeType` mapping + null reject
+- `PSExpandedOptionTest`: typed paths add/get, null setPaths
+- `PSColumnWidthsOptionTest`: add/get/remove widths, blank path reject
+- Module suite: Tests run: 25, Failures: 0
+
+### Cross-platform paths
+No path/file I/O changes. Portable paths N/A.
+
+### Change-class companions
+- Generics consumer typing for nav/display options used by applet state save/restore
+- Target files `PSContentExplorerApplet` and `PSNavigationTree` compile with **0** `[WARNING]` under module inventory
+- `PSMainDisplayPanel` / `PSDisplayFormatTableModel` already clean (0 diags) — no residual there
+- Remaining module warnings (catalogers, `PSDesktopExplorerWindow`, status dialog, etc.) are outside this named file set → residual under #2045
+
+## Gate
+PASS for commit/PR (no bug findings remaining; tests present; DesktopContentExplorer clean install green).
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSColumnWidthsOption.java
@@ -69,7 +69,7 @@ public class PSColumnWidthsOption implements IPSClientObjects {
 
         String tmp = PSXMLDomUtil.getElementData(el);
         if (tmp != null && tmp.trim().length() > 0) {
-          List tmpList = PSStringOperation.getSplittedList(tmp, ',');
+          List<String> tmpList = PSStringOperation.getSplittedList(tmp, ',');
 
           addItemColumnWidths(itemPath, tmpList);
         }
@@ -92,10 +92,10 @@ public class PSColumnWidthsOption implements IPSClientObjects {
     // create temp element
     Element el = null;
 
-    Iterator iter = m_map.keySet().iterator();
+    Iterator<String> iter = m_map.keySet().iterator();
     while (iter.hasNext()) {
-      String itemPath = (String) iter.next();
-      List widths = (List) m_map.get(itemPath);
+      String itemPath = iter.next();
+      List<String> widths = m_map.get(itemPath);
       if (widths != null) {
         String strWidths = PSStringOperation.append(widths, ",");
 
@@ -149,11 +149,11 @@ public class PSColumnWidthsOption implements IPSClientObjects {
    * @return a list representing the saved column widths for the given item path, if the item path
    *     is not found returns null.
    */
-  public List getItemColumnWidths(String itemPath) {
+  public List<String> getItemColumnWidths(String itemPath) {
     if (itemPath == null || itemPath.trim().length() == 0)
       throw new IllegalArgumentException("itemPath must not be null or empty");
 
-    return (List) m_map.get(itemPath);
+    return m_map.get(itemPath);
   }
 
   /**
@@ -164,7 +164,7 @@ public class PSColumnWidthsOption implements IPSClientObjects {
    * @param widths a list representing the width of each column for the specified item path, may be
    *     <code>null</code> or empty.
    */
-  public void addItemColumnWidths(String itemPath, List widths) {
+  public void addItemColumnWidths(String itemPath, List<String> widths) {
     if (itemPath == null || itemPath.trim().length() == 0)
       throw new IllegalArgumentException("itemPath must not be null or empty");
 
@@ -197,7 +197,7 @@ public class PSColumnWidthsOption implements IPSClientObjects {
    * The map representing the items column widths, set to an empty map here, may be changed. The key
    * is the item path, the value is the column width list for the specific item.
    */
-  private Map m_map = new HashMap();
+  private Map<String, List<String>> m_map = new HashMap<>();
 
   /** Name of the Root element of the XML document representing a item column width list option. */
   private static final String ELEM_COLUMN_WIDTHS_OPTION = "PSXColumnWidthsOption";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerApplet.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerApplet.java
@@ -20,6 +20,7 @@ package com.percussion.cx;
 import com.percussion.border.PSFocusBorder;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSDisplayFormat;
+import com.percussion.cms.objectstore.client.PSContentEditorFieldCataloger;
 import com.percussion.cms.objectstore.PSRelationshipInfo;
 import com.percussion.cms.objectstore.PSRelationshipInfoSet;
 import com.percussion.cms.objectstore.PSUserInfo;
@@ -96,6 +97,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /** The main class for 'Content Explorer Applet'. */
+@SuppressWarnings("removal") // still extends javax.swing.JApplet for legacy desktop embed
 public class PSContentExplorerApplet extends JApplet implements IPSActionListener {
 
   private static final String RESOURCE_NAME = "com.percussion.cx.PSContentExplorerResources";
@@ -113,7 +115,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
   static Logger log = LogManager.getLogger(PSContentExplorerApplet.class);
 
   /** The HTTP connection used to communicate with the Rhythmyx server. */
-  private PSHttpConnection m_httpConnection;
+  private transient PSHttpConnection m_httpConnection;
 
   /** Set to <code>true</code> once the applet has completed initialization. */
   private boolean m_initialized = false;
@@ -128,19 +130,19 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
   private boolean isApplication = false;
 
   /** Session manager used to monitor the user session. */
-  private PSCESessionManager check = null;
+  private transient PSCESessionManager check = null;
 
   /** The header panel rendered at the top of the CX view, may be <code>null</code>. */
-  private PSContentExplorerHeader dceHeader = null;
+  private transient PSContentExplorerHeader dceHeader = null;
 
   /** The JavaFX web engine associated with the applet, may be <code>null</code>. */
-  private WebEngine webEngine = null;
+  private transient WebEngine webEngine = null;
 
   /** <code>true</code> if this applet was created from a hosting frame rather than as an applet. */
   private boolean m_createdFromFrame = false;
 
   /** The Server Admin resources */
-  private ResourceBundle m_res = null;
+  private transient ResourceBundle m_res = null;
 
   /**
    * Gets the resource bundle used by the applet for localized strings, lazily loading it from the
@@ -333,7 +335,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
       // default to cache the searchable fields per JVM
       m_searchableFields = ms_searchableFieldsPerJVM;
       if (cacheSearchFields != null && cacheSearchFields.equalsIgnoreCase("CachePerApplet"))
-        m_searchableFields = new HashMap();
+        m_searchableFields = new HashMap<>();
       else if (cacheSearchFields != null && cacheSearchFields.equalsIgnoreCase("None"))
         m_searchableFields = null;
 
@@ -709,7 +711,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    * @return the column widths for the specified node, <code>null</code> if the node is not found or
    *     the column width options have not been initialized properly
    */
-  public List getColumnWidthsFromOptions(PSNode node) {
+  public List<String> getColumnWidthsFromOptions(PSNode node) {
     if (m_cwo == null) return null;
 
     String nodePath = ((PSMainView) m_mainView).getNavTree().convertNodeToPath(node);
@@ -726,7 +728,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    * @param widths the column widths of the specified node. If <code>null</code> or empty, we remove
    *     this entry from the column widths object map.
    */
-  public void saveColumnWidthsToOptions(PSNode node, List widths) {
+  public void saveColumnWidthsToOptions(PSNode node, List<String> widths) {
     if (m_cwo == null) m_cwo = new PSColumnWidthsOption();
 
     if (node != null) {
@@ -1029,7 +1031,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
       PSRelationshipInfoSet relationships =
           m_actManager.getRelationshipsManager().getRelationships();
       getRelMap().clear();
-      Iterator iter = relationships.getComponents();
+      Iterator<?> iter = relationships.getComponents();
       while (iter.hasNext()) {
         PSRelationshipInfo info = (PSRelationshipInfo) iter.next();
         getRelMap().put(info.getName(), info);
@@ -1163,7 +1165,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
 
     // execute the search
     PSNode tmpNode = new PSNode("temp", "temp", PSNode.TYPE_PARENT, null, null, false, -1);
-    Iterator results = search.executeSearch(tmpNode).iterator();
+    Iterator<?> results = search.executeSearch(tmpNode).iterator();
     PSNode resNode = (PSNode) results.next();
     return resNode.getProperties();
   }
@@ -1736,7 +1738,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    *     None</code>.
    * @see PSContentExplorerConstants#PARAM_CACHE_SEARCHABLE_FIELDS
    */
-  public Map getSearachableFieldsCache() {
+  public Map<String, PSContentEditorFieldCataloger> getSearachableFieldsCache() {
     return m_searchableFields;
   }
 
@@ -1879,7 +1881,8 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
   public Icon getIcon(String strUrl) throws MalformedURLException {
     URL url = new URL(getRhythmyxCodeBase(), strUrl);
 
-    ImageIcon icon = (ImageIcon) m_imgCache.get(url.toString());
+    Icon cached = m_imgCache.get(url.toString());
+    ImageIcon icon = cached instanceof ImageIcon ? (ImageIcon) cached : null;
     if (icon == null) {
       Image image = Toolkit.getDefaultToolkit().createImage(url);
       icon = new ImageIcon(image);
@@ -1889,7 +1892,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
     return icon;
   }
 
-  private static HashMap m_imgCache = new HashMap();
+  private static final HashMap<String, Icon> m_imgCache = new HashMap<>();
 
   /**
    * Determine if an external search engine is available on the server.
@@ -1974,8 +1977,8 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    *
    * @return Never <code>null</code>.
    */
-  public Set getFlaggedFolderSet() {
-    return new HashSet(ms_flaggedFolders);
+  public Set<String> getFlaggedFolderSet() {
+    return new HashSet<>(ms_flaggedFolders);
   }
 
   /**
@@ -2011,7 +2014,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    */
   public void loadFlaggedFoldersSet()
       throws IOException, SAXException, ParserConfigurationException {
-    Set flags = new HashSet();
+    Set<String> flags = new HashSet<>();
     final Document doc = getXMLDocument(PSContentExplorerConstants.APP_RESOURCE_FLAGGED_FOLDERS);
     final NodeList nl = doc.getElementsByTagName(PSContentExplorerConstants.ELEM_PUBLISH_FLAG);
     Element flag = null;
@@ -2024,7 +2027,8 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
         flags.add(flag.getAttribute(PSContentExplorerConstants.ATTR_FOLDERID));
       }
     }
-    ms_flaggedFolders = flags;
+    ms_flaggedFolders.clear();
+    ms_flaggedFolders.addAll(flags);
   }
 
   /**
@@ -2108,7 +2112,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
      * Reference to the parent frame for which the cursor style was set, initialized in the
      * constructor, never <code>null</code> after that.
      */
-    private Frame m_frame = null;
+    private transient Frame m_frame = null;
 
     /**
      * Cursor which is set for the Parent frame for every designated interval of time. Initialized
@@ -2254,32 +2258,32 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    * Reference to the self correcting cursor object that is constructed during initialization of the
    * applet, never <code>null</code> after that.
    */
-  private CxCursor m_cursor = null;
+  private transient CxCursor m_cursor = null;
 
   /**
    * The singleton instance of the help to hold on for not garbage collecting, initialized when the
    * first time the applet is loaded and never <code>null
    * </code> or modified after that.
    */
-  private PSJavaHelp ms_help = null;
+  private transient PSJavaHelp ms_help = null;
 
   /**
    * The action manager to handle all actions (local, system and custom actions), initialized in
    * <code>init()</code> method and is not modified and never <code>null</code> after that.
    */
-  PSActionManager m_actManager;
+  transient PSActionManager m_actManager;
 
   /**
    * The manager that handles loading and saving of options, initialized in <code>init()</code>
    * method and is not modified and never <code>null</code> after that.
    */
-  private PSOptionManager m_optionsManager;
+  private transient PSOptionManager m_optionsManager;
 
   /**
    * The object that holds on to the loaded applets and updates the display options when it is
    * informed, initialized when the applet is loaded and never <code>null</code> after that.
    */
-  private OptionsUpdater ms_optChangeUpdater = null;
+  private transient OptionsUpdater ms_optChangeUpdater = null;
 
   /**
    * The main view panel that represents the current view of the applet, initialized in the <code>
@@ -2291,7 +2295,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    * The action bar that represents the menu bar of the applet, initialized in the <code>initView()
    * </code> and never <code>null</code> or modified after that.
    */
-  private PSActionBar m_actionBar;
+  private transient PSActionBar m_actionBar;
 
   /**
    * The current view represented by this applet, initialized in <code>
@@ -2314,29 +2318,29 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
   private boolean ms_isManagedNavUsed = false;
 
   /** Initialized in the init, never <code>null</code> after that and invariant. */
-  private PSI18NTranslationKeyValues ms_i18nKeyValue = null;
+  private transient PSI18NTranslationKeyValues ms_i18nKeyValue = null;
 
   /**
    * The menu bar that represents the global menu of the applet, initialized in <code>initView()
    * </code> and never <code>null</code> or modified after that.
    */
-  private PSContentExplorerMenuBar m_globalMenuBar;
+  private transient PSContentExplorerMenuBar m_globalMenuBar;
 
   /** Set of all folders with the publish folder flag set */
-  private Set ms_flaggedFolders = new HashSet();
+  private final HashSet<String> ms_flaggedFolders = new HashSet<>();
 
   /**
    * Object representing current user's state inofrmation. Initialized on applet initialization.
    * Povides easy access to all required user state variables such as user name, community etc.,
    * never <code>null</code> after applet is successfully initialized.
    */
-  PSUserInfo ms_userInfo;
+  transient PSUserInfo ms_userInfo;
 
   /**
    * SessionKeeper object that is initialized during applet start and never <code>null</code> after
    * that.
    */
-  PSCESessionManager m_sessionCheck = null;
+  transient PSCESessionManager m_sessionCheck = null;
 
   /**
    * The parent frame of this applet, initialized when this applet is initialized and never <code>
@@ -2351,25 +2355,25 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
   private boolean ms_restrictContent = false;
 
   /** The splash screen\progress screen used while waiting for cx to load. */
-  SplashScreen m_splash;
+  transient SplashScreen m_splash;
 
   /**
    * static reference to the instance of this applet. Never <code>null</code> after successful
    * initialization of the applet.
    */
-  private PSContentExplorerApplet ms_thisApplet = null;
+  private transient PSContentExplorerApplet ms_thisApplet = null;
 
   /**
    * Storage for the column width options, need to keep in memory since the columns when refreshed
    * lose the widths.
    */
-  private PSColumnWidthsOption m_cwo = null;
+  private transient PSColumnWidthsOption m_cwo = null;
 
   /**
    * Storage for the display format options, need to keep in memory since the folders when refreshed
    * lose the display format.
    */
-  private PSDisplayFormatOption m_dfo = null;
+  private transient PSDisplayFormatOption m_dfo = null;
 
   /** Storage for the initial selection path stored as user options */
   String m_selPath = null;
@@ -2442,7 +2446,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    * behavior". Set only by both {@link #registerKeyEventPostProcessor()}and {@link
    * #unregisterKeyEventPostProcessor()}
    */
-  private PSKeyEventPostProcessor m_keyEventPostProcessor = null;
+  private transient PSKeyEventPostProcessor m_keyEventPostProcessor = null;
 
   /**
    * This is used to (lazily) cache the catalogged searchable fields. It maps cataloger flag of the
@@ -2453,7 +2457,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    *
    * @see PSContentExplorerConstants#PARAM_CACHE_SEARCHABLE_FIELDS
    */
-  private Map m_searchableFields = null;
+  private transient Map<String, PSContentEditorFieldCataloger> m_searchableFields = null;
 
   /**
    * Just like {@link #m_searchableFields}, except this is used when cached per JVM. It is never
@@ -2463,7 +2467,8 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    *
    * @see PSContentExplorerConstants#PARAM_CACHE_SEARCHABLE_FIELDS
    */
-  private Map ms_searchableFieldsPerJVM = new HashMap();
+  private final transient Map<String, PSContentEditorFieldCataloger> ms_searchableFieldsPerJVM =
+      new HashMap<>();
 
   /** The flag is used to indicate if AjaxSwing is being used to access the applet. */
   private boolean ms_useAjaxSwing = false;

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
@@ -56,7 +56,7 @@ public class PSExpandedOption implements IPSClientObjects {
    *
    * @param paths a list of paths of the expanded items, may not be <code>null</code>
    */
-  public PSExpandedOption(List paths) {
+  public PSExpandedOption(List<String> paths) {
     setPaths(paths);
   }
 
@@ -95,7 +95,7 @@ public class PSExpandedOption implements IPSClientObjects {
     // create temp text node
     Text StringNode = null;
 
-    Iterator iter = m_paths.iterator();
+    Iterator<String> iter = m_paths.iterator();
     while (iter.hasNext()) {
       el = doc.createElement(ELEM_PATH);
       StringNode = doc.createTextNode((String) iter.next());
@@ -144,12 +144,12 @@ public class PSExpandedOption implements IPSClientObjects {
    * @param paths a list of strings respresenting the expanded items, must not be <code>null</code>,
    *     may be an empty list.
    */
-  public void setPaths(List paths) {
+  public void setPaths(List<String> paths) {
     if (paths == null) throw new IllegalArgumentException("paths must not be null");
 
-    Iterator iter = paths.iterator();
+    Iterator<String> iter = paths.iterator();
     while (iter.hasNext()) {
-      String path = (String) iter.next();
+      String path = iter.next();
       addPath(path);
     }
   }
@@ -159,7 +159,7 @@ public class PSExpandedOption implements IPSClientObjects {
    *
    * @return the set of expanded paths, never <code>null</code>.
    */
-  public Set getPaths() {
+  public Set<String> getPaths() {
     return m_paths;
   }
 
@@ -179,7 +179,7 @@ public class PSExpandedOption implements IPSClientObjects {
   /**
    * The list of paths representing the expanded items, set to an empty list here, may be changed.
    */
-  private Set m_paths = new TreeSet();
+  private final Set<String> m_paths = new TreeSet<>();
 
   /** Name of the Root element of the XML document representing an expanded item. */
   private static final String ELEM_EXPANDED = "PSXExpandedOption";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSNavigationTree.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSNavigationTree.java
@@ -83,6 +83,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    * @param ignoreRoot supply <code>true</code> to not to show the root node in the tree and do not
    *     consider the root in the path, otherwise supply <code>false</code>
    */
+  @SuppressWarnings("this-escape") // Swing selection model / listeners registered in ctor
   public PSNavigationTree(PSNode root, String view, PSActionManager manager, boolean ignoreRoot) {
     if (root == null) throw new IllegalArgumentException("root may not be null.");
 
@@ -250,16 +251,16 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    *
    * @return a list of expanded items as <code>String</code> objects
    */
-  public List getExpandedList() {
+  public List<String> getExpandedList() {
     DefaultTreeModel model = getTreeModel();
     PSTreeNode root = (PSTreeNode) model.getRoot();
 
     TreePath tp = new TreePath(model.getPathToRoot(root));
-    Enumeration e = getExpandedDescendants(tp);
+    Enumeration<TreePath> e = getExpandedDescendants(tp);
 
-    List ret = new ArrayList();
+    List<String> ret = new ArrayList<>();
     while (e.hasMoreElements()) {
-      tp = (TreePath) e.nextElement();
+      tp = e.nextElement();
       ret.add(convertTreePathToString(tp, true));
     }
     return ret;
@@ -271,10 +272,10 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    * @param expandSet the list of strings representing the paths to the nodes, if a node is not
    *     found it is skipped.
    */
-  public void setExpandedList(Set expandSet) {
-    Iterator iter = expandSet.iterator();
+  public void setExpandedList(Set<String> expandSet) {
+    Iterator<String> iter = expandSet.iterator();
     while (iter.hasNext()) {
-      String path = (String) iter.next();
+      String path = iter.next();
 
       PSTreeNode treeNode = getTreeNode(path, true);
       if (treeNode != null) {
@@ -487,10 +488,10 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
   private PSNode getMatchingNode(PSNode checkNode, PSNode matchNode) {
     // check child nodes for matches
     PSNode match = null;
-    Iterator children = checkNode.getChildren();
+    Iterator<PSNode> children = checkNode.getChildren();
     if (children != null) {
       while (children.hasNext() && match == null) {
-        PSNode test = (PSNode) children.next();
+        PSNode test = children.next();
         if (test.isMatchingType(matchNode.getType())
             && test.getContentId().equals(matchNode.getContentId())) {
           match = test;
@@ -511,7 +512,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    * @param types A collection of types defining which types of nodes the child should be dirtied
    *     in/added to. May not be <code>null</code> or emtpy.
    */
-  public void dirtyChildNodes(PSNode node, Collection types) {
+  public void dirtyChildNodes(PSNode node, Collection<String> types) {
     if (node == null) throw new IllegalArgumentException("node may not be null");
     if (types == null || types.isEmpty())
       throw new IllegalArgumentException("types may not be null or empty");
@@ -530,7 +531,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    * @param node The node to dirty or add, assumed not <code>null</code>.
    * @param types The collection of types, assumed not <code>null</code>.
    */
-  private void dirtyChildNode(PSNode parent, PSNode node, Collection types) {
+  private void dirtyChildNode(PSNode parent, PSNode node, Collection<String> types) {
     PSNode addNode = null;
     if (types.contains(parent.getType()) && parent.getChildren() != null) {
       PSNode match = getMatchingNode(parent, node);
@@ -563,9 +564,9 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
     }
 
     // now recurse children
-    Iterator children = parent.getChildren();
+    Iterator<PSNode> children = parent.getChildren();
     if (children != null) {
-      while (children.hasNext()) dirtyChildNode((PSNode) children.next(), node, types);
+      while (children.hasNext()) dirtyChildNode(children.next(), node, types);
     }
 
     // if no match, add clone as child marked as dirty.  Must do this after
@@ -947,9 +948,9 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
     // expand the node if the user node specifies to expand other wise not.
     PSNode node = (PSNode) treeNode.getUserObject();
     if (node.shouldExpand()) {
-      Iterator leafNodes = treeNode.getLeafChildren().iterator();
+      Iterator<DefaultMutableTreeNode> leafNodes = treeNode.getLeafChildren().iterator();
       while (leafNodes.hasNext()) {
-        DefaultMutableTreeNode childNode = (DefaultMutableTreeNode) leafNodes.next();
+        DefaultMutableTreeNode childNode = leafNodes.next();
         makeVisible(new TreePath(childNode.getPath()));
       }
     }
@@ -967,8 +968,9 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
      * @param node the user object of the node, may not be <code>null</code>
      * @throws IllegalArgumentException if node is <code>null</code>
      */
+    @SuppressWarnings("this-escape") // associates this node with user object after super()
     public PSTreeNode(PSNode node) {
-      super(node, new Vector());
+      super(node, new Vector<>());
 
       if (node == null) throw new IllegalArgumentException("node may not be null.");
       node.setAssociatedTreeNode(this);
@@ -983,7 +985,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
       if (loadedChildren) return;
       PSNode node = (PSNode) getUserObject();
 
-      Iterator lchildren = node.getChildren();
+      Iterator<PSNode> lchildren = node.getChildren();
 
       if (lchildren == null) lchildren = m_actManager.loadChildren(node);
 
@@ -991,7 +993,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
       int i = 0;
       if (lchildren != null) {
         while (lchildren.hasNext()) {
-          PSNode child = (PSNode) lchildren.next();
+          PSNode child = lchildren.next();
           // Nodes that are container only should be added to the tree
           if (child.isContainer()) {
             PSTreeNode childNode = new PSTreeNode(child);
@@ -1010,10 +1012,10 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
      *
      * @return the list of leaf child nodes, never <code>null</code> or empty.
      */
-    public List getLeafChildren() {
+    public List<DefaultMutableTreeNode> getLeafChildren() {
       DefaultMutableTreeNode node = this;
 
-      List lchildren = new ArrayList();
+      List<DefaultMutableTreeNode> lchildren = new ArrayList<>();
       getLeafChildren(node, lchildren);
 
       return lchildren;
@@ -1027,12 +1029,13 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
      * @param uchildren the list of child leaf nodes that gets updated, assumed not to be <code>null
      *     </code>
      */
-    private void getLeafChildren(DefaultMutableTreeNode node, List uchildren) {
+    private void getLeafChildren(
+        DefaultMutableTreeNode node, List<DefaultMutableTreeNode> uchildren) {
       // A node is leaf if it does not have any children loaded.
       PSNode userObj = (PSNode) node.getUserObject();
       if (node.isLeaf() || !userObj.shouldExpand()) uchildren.add(node);
       else {
-        for (Enumeration e = node.children(); e.hasMoreElements(); ) {
+        for (Enumeration<?> e = node.children(); e.hasMoreElements(); ) {
           getLeafChildren((DefaultMutableTreeNode) e.nextElement(), uchildren);
         }
       }
@@ -1045,9 +1048,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
      *     <code>true</code>.
      */
     public void setLoadedChildren(boolean flag) {
-      if (flag)
-        ;
-      loadedChildren = false;
+      loadedChildren = flag;
     }
 
     /**
@@ -1114,7 +1115,8 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
     }
 
     /** Create the accessible context for this node */
-    private AccessibleContext m_accessibleContext =
+    @SuppressWarnings("this-escape") // accessibility context needs outer/this refs
+    private final transient AccessibleContext m_accessibleContext =
         new PSTreeNodeAccContext(PSNavigationTree.this, this);
 
     /**
@@ -1213,7 +1215,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    */
   JPopupMenu displayPopupMenu(PSMenuAction action, TreePath path, Point loc) {
     DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
-    Iterator selNodes = PSIteratorUtils.iterator(node.getUserObject());
+    Iterator<PSNode> selNodes = PSIteratorUtils.iterator((PSNode) node.getUserObject());
 
     PSNode parent = null;
     TreePath parentPath = path.getParentPath();
@@ -1283,12 +1285,12 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    * @param nodes the nodes to refresh, may not be <code>null</code>
    * @throws IllegalArgumentException if nodes are <code>null</code>
    */
-  public void refreshNodes(Iterator nodes) {
+  public void refreshNodes(Iterator<? extends PSNode> nodes) {
     if (nodes == null) throw new IllegalArgumentException("nodes may not be null.");
 
     PSNode firstNode = null;
     while (nodes.hasNext()) {
-      PSNode refreshNode = (PSNode) nodes.next();
+      PSNode refreshNode = nodes.next();
       PSTreeNode treeNode = getTreeNode(refreshNode);
       if (treeNode != null) {
         refresh(refreshNode, treeNode);
@@ -1366,7 +1368,7 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
    * The action manager to use to load the children for a specific node, initialized in the ctor and
    * never <code>null</code> or modified after that.
    */
-  PSActionManager m_actManager;
+  transient PSActionManager m_actManager;
 
   /**
    * The current view of the tree, one of the <code>PSUiMode.TYPE_VIEW_xxx
@@ -1425,5 +1427,5 @@ public class PSNavigationTree extends JTree implements DragGestureListener, Drop
   private boolean m_isInDragUnder = false;
 
   /** A reference back to the applet that initiated this action manager. */
-  private PSContentExplorerApplet m_applet;
+  private transient PSContentExplorerApplet m_applet;
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSNavigationalSelection.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSNavigationalSelection.java
@@ -31,7 +31,8 @@ public class PSNavigationalSelection extends PSSelection {
    *     null</code> or empty.
    * @param path the selection path, may not be <code>null</code> or empty.
    */
-  public PSNavigationalSelection(PSUiMode uiMode, PSNode parent, Iterator nodeList, String path) {
+  public PSNavigationalSelection(
+      PSUiMode uiMode, PSNode parent, Iterator<? extends PSNode> nodeList, String path) {
     super(uiMode, parent, nodeList);
 
     if (path == null || path.trim().length() == 0)

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSColumnWidthsOptionTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSColumnWidthsOptionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for typed column-width option map used by the applet display panels. */
+public class PSColumnWidthsOptionTest {
+
+  @Test
+  public void addGetAndRemoveItemColumnWidths() {
+    PSColumnWidthsOption option = new PSColumnWidthsOption();
+    assertFalse(option.haveColumnWidths());
+
+    List<String> widths = Arrays.asList("100", "200", "50");
+    option.addItemColumnWidths("//Sites/Home", widths);
+
+    assertTrue(option.haveColumnWidths());
+    List<String> stored = option.getItemColumnWidths("//Sites/Home");
+    assertEquals(widths, stored);
+
+    option.removeItemColumnWidths("//Sites/Home");
+    assertNull(option.getItemColumnWidths("//Sites/Home"));
+    assertFalse(option.haveColumnWidths());
+  }
+
+  @Test
+  public void addItemColumnWidthsRejectsBlankPath() {
+    PSColumnWidthsOption option = new PSColumnWidthsOption();
+    assertThrows(
+        IllegalArgumentException.class, () -> option.addItemColumnWidths("  ", Arrays.asList("1")));
+    assertThrows(
+        IllegalArgumentException.class, () -> option.addItemColumnWidths(null, Arrays.asList("1")));
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSContentExplorerAppletTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSContentExplorerAppletTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for typed flagged-folder APIs on {@link PSContentExplorerApplet}. */
+public class PSContentExplorerAppletTest {
+
+  @Test
+  public void toggleFlaggedFolderAddsAndRemoves() {
+    PSContentExplorerApplet applet = new PSContentExplorerApplet(true);
+
+    applet.toggleFlaggedFolder("42", true);
+    Set<String> flagged = applet.getFlaggedFolderSet();
+    assertTrue(flagged.contains("42"));
+    assertEquals(1, flagged.size());
+
+    // Defensive copy: mutating returned set must not affect applet state
+    flagged.clear();
+    assertTrue(applet.getFlaggedFolderSet().contains("42"));
+
+    applet.toggleFlaggedFolder("42", false);
+    assertFalse(applet.getFlaggedFolderSet().contains("42"));
+    assertTrue(applet.getFlaggedFolderSet().isEmpty());
+  }
+
+  @Test
+  public void toggleFlaggedFolderRejectsInvalidIds() {
+    PSContentExplorerApplet applet = new PSContentExplorerApplet(true);
+
+    assertThrows(IllegalArgumentException.class, () -> applet.toggleFlaggedFolder(null, true));
+    assertThrows(IllegalArgumentException.class, () -> applet.toggleFlaggedFolder("  ", true));
+    assertThrows(IllegalArgumentException.class, () -> applet.toggleFlaggedFolder("abc", true));
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExpandedOptionTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSExpandedOptionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for typed expanded-path option APIs used by the nav tree. */
+public class PSExpandedOptionTest {
+
+  @Test
+  public void constructorAndGetPathsPreserveTypedPaths() {
+    PSExpandedOption option =
+        new PSExpandedOption(Arrays.asList("//Sites/Home", "//Sites/About"));
+    Set<String> paths = option.getPaths();
+    assertEquals(2, paths.size());
+    assertTrue(paths.contains("//Sites/Home"));
+    assertTrue(paths.contains("//Sites/About"));
+  }
+
+  @Test
+  public void setPathsAddsPathsToExistingSet() {
+    PSExpandedOption option = new PSExpandedOption(Arrays.asList("//a"));
+    option.setPaths(Arrays.asList("//b", "//c"));
+    Set<String> paths = option.getPaths();
+    assertEquals(3, paths.size());
+    assertTrue(paths.contains("//a"));
+    assertTrue(paths.contains("//b"));
+    assertTrue(paths.contains("//c"));
+  }
+
+  @Test
+  public void setPathsRejectsNull() {
+    PSExpandedOption option = new PSExpandedOption(Arrays.asList("//a"));
+    assertThrows(IllegalArgumentException.class, () -> option.setPaths(null));
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSNavigationTreeTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSNavigationTreeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for pure {@link PSNavigationTree} helpers (full tree construction requires a
+ * live {@link PSActionManager} HTTP session).
+ */
+public class PSNavigationTreeTest {
+
+  @Test
+  public void getRefreshNodeTypeMapsKnownHints() {
+    assertEquals(
+        PSNavigationTree.NODE_ROOT,
+        PSNavigationTree.getRefreshNodeType(PSActionEvent.REFRESH_NAV_ROOT));
+    assertEquals(
+        PSNavigationTree.NODE_SELECTED,
+        PSNavigationTree.getRefreshNodeType(PSActionEvent.REFRESH_NAV_SELECTED));
+    assertEquals(
+        PSNavigationTree.NODE_SEL_PARENT,
+        PSNavigationTree.getRefreshNodeType(PSActionEvent.REFRESH_NAV_SEL_PARENT));
+    assertEquals(-1, PSNavigationTree.getRefreshNodeType("unknown-hint"));
+  }
+
+  @Test
+  public void getRefreshNodeTypeRejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> PSNavigationTree.getRefreshNodeType(null));
+  }
+}


### PR DESCRIPTION
## Summary
Residual javac `-Xlint` batch for `perc-content-explorer` (#2370 / parent #2045, monorepo #2200): applet + navigation tree/display consumers after PSNode/selection generics.

- **PSContentExplorerApplet**: `transient` on non-Serializable service/UI fields; typed maps/sets/iterators (flagged folders, searchable fields cache, image cache, column widths); `@SuppressWarnings("removal")` for legacy `JApplet`
- **PSNavigationTree**: generics for expanded list, dirty nodes, leaf children, refresh nodes; transient managers; this-escape suppress on intentional Swing ctor registration; **bug fix** `PSTreeNode.setLoadedChildren` (empty-statement always forced `false`)
- **PSExpandedOption** / **PSColumnWidthsOption**: typed `List`/`Set`/`Map` for path and width persistence consumers
- **PSNavigationalSelection**: `Iterator<? extends PSNode>`
- Behavioral tests: flagged folders, refresh node types, expanded paths, column widths
- Erlang pre-commit: `docs/ai-generated/code-reviews/issue-2370-applet-nav-display-erlang.md`

`PSMainDisplayPanel` / `PSDisplayFormatTableModel` already had **0** diagnostics — no product change needed.

### Inventory (target files)
| File | Before | After |
|------|--------|-------|
| PSContentExplorerApplet | ~41 | **0** |
| PSNavigationTree | ~28 | **0** |

### Residual
- #2384 cataloger + desktop window residual under #2045

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Tests run: **25**, Failures: 0
- [x] Full javac inventory: applet + nav tree clean

## Gates
- Erlang self-review: pass (bug fix for setLoadedChildren; portable paths N/A; tests present)
- Per-module clean install: perc-content-explorer green
- No product behavior change intended except setLoadedChildren now honors `true` (callers only passed `false`)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent trackers: #2045, #2200

Fixes #2370
Refs #2045 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.