### PR TITLE
chore(githooks): rename pre-commit to post-checkout and force LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,8 @@
 # Betwixt mapping files (force LF so Betwixt parses identically on Windows and Linux;
 # core.autocrlf=true on Windows would otherwise rewrite them with CRLF on checkout).
 *.betwixt       text eol=lf
+# .githooks scripts (no .sh extension by convention; force LF so bash shebang parses on Linux/WSL)
+.githooks/*     text eol=lf
 # Java sources
 *.java          text diff=java
 *.gradle        text diff=java

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -41,7 +41,7 @@ if [ "$CURRENT_WORKTREE_DIR" != "$PARENT_REPO_DIR" ]; then
         if [ -e "$src_path" ]; then
             # Ensure parent directories exist in the new worktree
             mkdir -p "$(dirname "$target_dest")"
-            
+
             # Use cp -R to safely handle both single files and folders (like .grok/rules)
             cp -R "$src_path" "$target_dest"
             echo "✅ Synchronized: $relative_path"
@@ -56,12 +56,12 @@ if [ "$CURRENT_WORKTREE_DIR" != "$PARENT_REPO_DIR" ]; then
     find . -type f -name "AGENTS.local.md" | while read -r relative_path; do
         clean_path="${relative_path#./}"
         target_dest="$CURRENT_WORKTREE_DIR/$clean_path"
-        
+
         mkdir -p "$(dirname "$target_dest")"
         cp "$clean_path" "$target_dest"
         echo "✅ Synchronized: $clean_path"
     done
-    
+
     # 3. spotless indexes
     cd "$CURRENT_WORKTREE_DIR" || exit
 


### PR DESCRIPTION
## Summary

Rename `.githooks/pre-commit` → `.githooks/post-checkout` and force LF line endings via `.gitattributes`.

The shared hook at `.githooks/pre-commit` contained worktree-init logic (detects `PREV_HEAD == 0000...0000` with `CHECKOUT_FLAG == 1`) but lived at the wrong filename. `pre-commit` only fires on `git commit` and never on `git worktree add`, so the hook had never run for any new worktree created since the file was added. `post-checkout` fires on the initial checkout during `git worktree add` with the args the script's worktree-detection block expects.

While testing I also found the hook files had CRLF line endings in the working tree (LF blobs being rewritten on checkout by `core.autocrlf=true` from `C:/Tools/Git/etc/gitconfig`). Bash on the working tree would die with `$'\r': command not found` the moment any hook ever did run. The hook files have no .sh extension by convention, so the existing `*.sh text eol=lf` rule in `.gitattributes` never matched them. Added `.githooks/* text eol=lf` so future renames/additions also stay bash-safe.

## Important caveat (must be read before relying on this)

`git worktree add` on Git for Windows 2.55.0 does **not** fire `post-checkout` for the initial checkout. The trace shows `git reset --hard` is used to set up the worktree, and `git reset --hard` does not invoke hook dispatch. The script's `PREV_HEAD == "0000…0000"` check also does not match the args that regular `git checkout` actually passes (PREV_HEAD will be the prior SHA, not the null SHA).

So this PR is **purely file hygiene** (correct filename + LF), not a working worktree-init gate. A follow-up PR (separate branch) will introduce a `git-wt` wrapper script that calls `git worktree add` and then runs the sync logic explicitly, since hooks cannot reliably fire on worktree-add in this Git.

## Test evidence

- `git worktree add` after the rename + LF fix: no AGENTS.local.md copied (confirms post-checkout doesn't fire on worktree-add — same as before this PR).
- Manually invoked `bash .githooks/post-checkout 0000…0000 <sha> 1` from inside a fresh worktree: hook runs without CRLF errors, prints `✅ Synchronized: .grok/rules` and `✅ Synchronized: AGENTS.local.md`, copies both into the worktree. So the hook *code* is correct and works under Git Bash once invoked; the only gap is the auto-fire.

## Files

- `.githooks/post-checkout` (renamed from `pre-commit`)
- `.gitattributes` (one new line: `.githooks/* text eol=lf`)

## Follow-up

Tracking issue: a wrapper script (`git-wt` in `scripts/`) that handles `git worktree add ... && sync-personal-files` will be a separate PR on a new branch.

> Co-Authored by Kilo 7.4.20 using MiniMax-M3 with agent Kilo.

Operator: Kilo (minimax-m3)