### PR TITLE
fix(extensions-main): clear module javac warnings (#2029)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2029-extensions-main-javac-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2029-extensions-main-javac-batch1-erlang.md
@@ -1,0 +1,43 @@
+# Erlang review — issue #2029 extensions-main javac batch 1
+
+**Date:** 2026-08-08  
+**Branch:** `fix/issue-2029-extensions-main-javac-batch1`  
+**Reviewer persona:** Erlang (strict pre-commit)  
+**Base:** `origin/main`
+
+## Summary
+
+Clears all project `-Xlint` javac diagnostics in `modules/extensions-main` (baseline inventory: 40 main-source warnings; post-fix: 0). Prefer real fixes over suppressions: static constant/method qualification, removal-deprecation constructors → `valueOf`, redundant cast removal, `@Deprecated` + `serialVersionUID` on compatibility shims, try-with-resources without redundant `close()`, remove `return` from `finally` (exception-swallowing bug), and harden `PSExtensionParamsHelper` (final class, instance logger, private helpers, null-safe `doLog`).
+
+## Scope
+
+- **Module:** `modules/extensions-main` only
+- **Production files:** 20 Java sources under cas/general/publishing/usersearch/utils/validate/xmldom
+- **Tests:** `PSExtensionParamsHelperTest`, `PSDateDifferenceTest` (new)
+- **Memory patterns:** similar overnight javac batches (#2034 nav, #2035 sfp, #2036 workflow)
+- **Cross-platform path review:** no path/file I/O changes; N/A clean
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none found |
+| Behavioral tests for non-trivial logic | present (helper + date UDF) |
+| Portable paths / I/O | N/A (no path changes) |
+| Scope creep | none |
+| New suppressions | none |
+| Module clean install | BUILD SUCCESS, Tests run: 55, Failures: 0; 0 javac `warning:` lines |
+| May commit/push | **yes** |
+
+## Issues
+
+_None at bug/suggestion severity._
+
+### Notes (nit)
+
+- `PSDatabasePublisher` finally-return removal is a correctness fix (exceptions no longer swallowed). Not unit-tested with a full request stack; acceptable for this warning cleanup given private method surface and high fixture cost.
+- Legacy Percussion copyright headers left unchanged on pre-2023 files; new test files use Intersoft 2026 headers per AGENTS.md.

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAutoRelatedContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAutoRelatedContent.java
@@ -152,7 +152,7 @@ public class PSAutoRelatedContent extends PSDefaultExtension implements IPSResul
         request.printTraceMessage("Query result \n" + PSXmlDocumentBuilder.toString(results));
 
         Element resultLink =
-            resultWalker.getNextElement(RELATEDLINKURL, resultWalker.GET_NEXT_ALLOW_CHILDREN);
+            resultWalker.getNextElement(RELATEDLINKURL, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
         String authtype = request.getParameter(IPSHtmlParameters.SYS_AUTHTYPE, "0").trim();
 
         int resultCount = 0;
@@ -164,7 +164,7 @@ public class PSAutoRelatedContent extends PSDefaultExtension implements IPSResul
               request.printTraceMessage(
                   "Skipping non-publishable url \n" + PSXmlDocumentBuilder.toString(resultLink));
               resultLink =
-                  resultWalker.getNextElement(RELATEDLINKURL, resultWalker.GET_NEXT_ALLOW_SIBLINGS);
+                  resultWalker.getNextElement(RELATEDLINKURL, PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
               continue;
             }
 
@@ -191,7 +191,7 @@ public class PSAutoRelatedContent extends PSDefaultExtension implements IPSResul
                             + PSXmlDocumentBuilder.toString(resultLink));
                     resultLink =
                         resultWalker.getNextElement(
-                            RELATEDLINKURL, resultWalker.GET_NEXT_ALLOW_SIBLINGS);
+                            RELATEDLINKURL, PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
                     continue;
                   }
                   valElem.setAttribute("current", correctedUrl);
@@ -202,7 +202,7 @@ public class PSAutoRelatedContent extends PSDefaultExtension implements IPSResul
                           + PSXmlDocumentBuilder.toString(resultLink));
                   resultLink =
                       resultWalker.getNextElement(
-                          RELATEDLINKURL, resultWalker.GET_NEXT_ALLOW_SIBLINGS);
+                          RELATEDLINKURL, PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
                   continue;
                 }
               }
@@ -215,7 +215,7 @@ public class PSAutoRelatedContent extends PSDefaultExtension implements IPSResul
 
           resultCount++;
           resultLink =
-              resultWalker.getNextElement(RELATEDLINKURL, resultWalker.GET_NEXT_ALLOW_SIBLINGS);
+              resultWalker.getNextElement(RELATEDLINKURL, PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
         }
       }
     } catch (PSExtensionProcessingException e) {

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
@@ -134,8 +134,6 @@ public class PSDatabasePublisher implements IPSResultDocumentProcessor {
       log.error(t.getMessage());
       log.debug(t.getMessage(), t);
       throw new PSExtensionProcessingException(0, t.getLocalizedMessage());
-    } finally {
-      return resultDoc;
     }
   }
 
@@ -383,9 +381,8 @@ public class PSDatabasePublisher implements IPSResultDocumentProcessor {
       result = resultDoc.getDocumentElement();
     } catch (PSInternalRequestCallException e) {
       throw new PSExtensionProcessingException(ms_fullExtensionName, e);
-    } finally {
-      return result;
     }
+    return result;
   }
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAppendUserRoles.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAppendUserRoles.java
@@ -59,10 +59,10 @@ public class PSAppendUserRoles implements IPSResultDocumentProcessor {
         String tmp = params[0].toString().trim();
         if (tmp.length() > 0) userRolesElemeName = tmp;
       }
-      urelem = (Element) resultDoc.createElement(userRolesElemeName);
+      urelem = resultDoc.createElement(userRolesElemeName);
       while (tokenizer.hasMoreTokens()) {
         role = tokenizer.nextElement().toString().trim();
-        elem = (Element) resultDoc.createElement("Role");
+        elem = resultDoc.createElement("Role");
         elem.appendChild(resultDoc.createTextNode(role));
         urelem.appendChild(elem);
       }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSDateDifference.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSDateDifference.java
@@ -78,7 +78,7 @@ public class PSDateDifference extends PSDefaultExtension implements IPSUdfProces
     long diffMillis = Math.abs(cal1.getTimeInMillis() - cal2.getTimeInMillis());
     long diffDays = diffMillis / (24 * 60 * 60 * 1000);
 
-    return new Long(diffDays);
+    return Long.valueOf(diffDays);
   }
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
@@ -112,7 +112,7 @@ public class PSFileInfo extends PSDefaultExtension implements IPSRequestPreProce
             && (wifxFlag.equalsIgnoreCase("true") || (wifxFlag.equalsIgnoreCase("yes")));
     if (isWifxUpload) parseWifxMultiValueFields(request);
     while (iter.hasNext()) {
-      String paramName = (String) iter.next();
+      String paramName = iter.next();
       Object obj = request.getParameterObject(paramName);
 
       if (obj instanceof PSPurgableTempFile) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSIncrementalContentFilter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSIncrementalContentFilter.java
@@ -147,17 +147,17 @@ public class PSIncrementalContentFilter extends PSDefaultExtension
       PSXmlTreeWalker resultWalker = new PSXmlTreeWalker(rootNode);
 
       Element resElem =
-          resultWalker.getNextElement(NODE_CONTENTITEM, resultWalker.GET_NEXT_ALLOW_CHILDREN);
+          resultWalker.getNextElement(NODE_CONTENTITEM, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
       while (resElem != null) {
         if (PSUtils.isValid(resElem, request, internalReqName, context)) {
           request.printTraceMessage("Keeping Item");
           isEmpty = false;
           resElem =
-              resultWalker.getNextElement(NODE_CONTENTITEM, resultWalker.GET_NEXT_ALLOW_SIBLINGS);
+              resultWalker.getNextElement(NODE_CONTENTITEM, PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
         } else {
           request.printTraceMessage("Removing Item");
           Element nextRes =
-              resultWalker.getNextElement(NODE_CONTENTITEM, resultWalker.GET_NEXT_ALLOW_SIBLINGS);
+              resultWalker.getNextElement(NODE_CONTENTITEM, PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
           rootNode.removeChild((Node) resElem);
           resElem = nextRes;
         }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
@@ -134,7 +134,7 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     }
 
-    args[0] = new Long((System.currentTimeMillis() - startTime) / 1000);
+    args[0] = Long.valueOf((System.currentTimeMillis() - startTime) / 1000);
     traceMessage(request, "Completed the cleanup process in {0} seconds", args);
   }
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
@@ -124,7 +124,7 @@ public class PSParameterTokenizer extends PSDefaultExtension implements IPSReque
 
         // iterate across the list of input parameters
         for (String o : inputList) {
-          String inputValue = (String) o;
+          String inputValue = o;
           StringTokenizer tok = new StringTokenizer(inputValue, SEPARATORS);
           // now iterate across the tokens of the string
           for (HTMLParameter currParam : outputParams) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
@@ -135,7 +135,7 @@ public class PSSimpleJavaUdf_dateAdjust extends PSSimpleJavaUdfExtension {
     for (int i = 1; i < size; i++) {
       if (params[i] != null && !params[i].toString().equals("")) {
         try {
-          paramArray[i - 1] = (Number) (PSCalculation.numberVerify(params[i]));
+          paramArray[i - 1] = PSCalculation.numberVerify(params[i]);
         } catch (IllegalArgumentException e) {
           int errCode = 0;
           Object[] args = {e.toString(), "PSSimpleJavaUdf_dateAdjust/processUdf"};

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSUploadFileAttrs.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSUploadFileAttrs.java
@@ -86,11 +86,11 @@ public class PSUploadFileAttrs extends PSDefaultExtension implements IPSRequestP
       dateFormatString = "MM/dd/yyyy hh:mm:ss a";
     } else dateFormatString = dateFormatString.trim();
 
-    Long fileSizeMax = new Long(0L);
+    Long fileSizeMax = Long.valueOf(0L);
     if (params.length > 4) {
       try {
         String tmp = params[4].toString().trim();
-        if (null != tmp) fileSizeMax = new Long(tmp);
+        if (null != tmp) fileSizeMax = Long.valueOf(tmp);
       } catch (Exception e) {
       }
     }
@@ -106,7 +106,7 @@ public class PSUploadFileAttrs extends PSDefaultExtension implements IPSRequestP
     PSPurgableTempFile tmpFile = (PSPurgableTempFile) htmlParams.get(fileNameParam);
 
     if (tmpFile != null) {
-      Long fileSize = new Long(tmpFile.length());
+      Long fileSize = Long.valueOf(tmpFile.length());
 
       // check for maximum size limit
       if (fileSizeMax.intValue() > 0 && fileSize.compareTo(fileSizeMax) > 0) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
@@ -111,10 +111,8 @@ public class PSPublishEditionForPreview extends PSDefaultExtension
           try (InputStreamReader inputReader = new InputStreamReader(content)) {
             try (BufferedReader reader = new BufferedReader(inputReader)) {
               String tmpStatus = toString(reader);
-              reader.close();
 
               stat = tmpStatus;
-              content.close();
               // TODO: Ideally this code should check for the edition
               // being in an in process state and continue rather than
               // counting down.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
@@ -221,7 +221,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
     Element el = tree.getNextElement("CommunityId");
-    String ret = tree.getElementData(el);
+    String ret = PSXmlTreeWalker.getElementData(el);
 
     if (ret == null || ret.trim().length() == 0)
       throw new PSInternalRequestCallException(

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.Logger;
  * @author adamgent
  * @see #getParameter(String)
  */
-public class PSExtensionParamsHelper {
+public final class PSExtensionParamsHelper {
 
   Object[] params;
   IPSExtensionDef extensionDef;
@@ -50,7 +50,7 @@ public class PSExtensionParamsHelper {
   IPSRequestContext request;
 
   /** The log instance to use for this class if one is not provided, never <code>null</code>. */
-  private static Logger log = LogManager.getLogger(PSExtensionParamsHelper.class);
+  private Logger log = LogManager.getLogger(PSExtensionParamsHelper.class);
 
   /**
    * Constructor
@@ -296,8 +296,7 @@ public class PSExtensionParamsHelper {
   public Boolean paramToBoolean(String paramName, String param) {
     Converter cvt = new BooleanConverter();
     try {
-      Boolean val = (Boolean) cvt.convert(Boolean.class, param);
-      return val;
+      return cvt.convert(Boolean.class, param);
     } catch (ConversionException ex) {
       String message = "Parameter " + paramName + " is not a boolean. " + "Param value=" + param;
       log.error(message, ex);
@@ -317,16 +316,18 @@ public class PSExtensionParamsHelper {
   }
 
   /**
-   * Sets the logger for this helper.
+   * Sets the logger for this helper. Null keeps the default class logger.
    *
-   * @param log the logger to use.
+   * @param log the logger to use, or null to keep the default.
    */
-  protected void doLog(Logger log) {
-    this.log = log;
+  private void doLog(Logger log) {
+    if (log != null) {
+      this.log = log;
+    }
   }
 
   /** Populates the extension parameters map from the extension definition. */
-  protected void doParameters() {
+  private void doParameters() {
     extensionParameters = new HashMap<>();
 
     if (params != null) {

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateDate.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateDate.java
@@ -100,7 +100,7 @@ public class PSValidateDate extends PSRangeValidator {
   private Double toDouble(Date value) {
     if (value == null) return null;
 
-    return new Double((double) value.getTime());
+    return Double.valueOf((double) value.getTime());
   }
 
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateStringLength.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateStringLength.java
@@ -71,7 +71,7 @@ public class PSValidateStringLength extends PSRangeValidator {
       return false;
     }
 
-    return checkRange(toDouble(min), new Double(value.length()), toDouble(max), true, true);
+    return checkRange(toDouble(min), Double.valueOf(value.length()), toDouble(max), true, true);
   }
 
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {}

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSNodePrinter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSNodePrinter.java
@@ -30,6 +30,7 @@ import java.io.Writer;
  *     in a class in com.percussion.cms package. This class is a deprecated class that simply
  *     extends com.percussion.xml.PSNodePrinter and is kept around for backward compatibility.
  */
+@Deprecated
 public class PSNodePrinter extends com.percussion.xml.PSNodePrinter {
   /**
    * Only constructor. Takes the print writer as the argument.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToParams.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToParams.java
@@ -129,17 +129,17 @@ public class PSXdDomToParams extends PSDefaultExtension implements IPSRequestPre
       }
     }
     // Find the first child of PSXParam
-    Element currNode = walker.getNextElement(walker.GET_NEXT_ALLOW_CHILDREN);
+    Element currNode = walker.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     for (int i = 0; currNode != null; i++) {
       String tagName = currNode.getTagName();
-      String tagData = walker.getElementData(currNode);
+      String tagData = PSXmlTreeWalker.getElementData(currNode);
       if (m_appendParam) {
         request.appendParameter(tagName, tagData);
       } else {
         request.setParameter(tagName, tagData);
       }
 
-      currNode = walker.getNextElement(walker.GET_NEXT_ALLOW_SIBLINGS);
+      currNode = walker.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
     }
   }
 

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdRemoveElements.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdRemoveElements.java
@@ -71,7 +71,7 @@ public class PSXdRemoveElements extends PSDefaultExtension implements IPSResultD
       PSXmlTreeWalker nodeWalker = new PSXmlTreeWalker(resultDoc);
       Element docRoot = (Element) nodeWalker.getCurrent();
       Element elementNode =
-          nodeWalker.getNextElement(sourceNodeName, nodeWalker.GET_NEXT_ALLOW_CHILDREN);
+          nodeWalker.getNextElement(sourceNodeName, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
 
       if (null == elementNode) {
         request.printTraceMessage("Element not found:" + sourceNodeName);

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDocumentBuilder.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDocumentBuilder.java
@@ -20,6 +20,7 @@ package com.percussion.xmldom;
 /**
  * @deprecated Use com.percussion.xml.PSXmlDocumentBuilder instead
  */
+@Deprecated
 public class PSXmlDocumentBuilder extends com.percussion.xml.PSXmlDocumentBuilder {
   /** Creates a new PSXmlDocumentBuilder. */
   public PSXmlDocumentBuilder() {}

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlTreeWalker.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlTreeWalker.java
@@ -29,7 +29,12 @@ import org.w3c.dom.Node;
  *
  * @deprecated Use com.percussion.xml.PSXmlTreeWalker instead
  */
+@Deprecated
 public class PSXmlTreeWalker extends com.percussion.xml.PSXmlTreeWalker implements Serializable {
+
+  /** Serialization version for this compatibility shim. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Constructs a new tree walker for the supplied document.
    *

--- a/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSDateDifferenceTest.java
+++ b/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSDateDifferenceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extensions.general;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.data.PSConversionException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral unit tests for {@link PSDateDifference} (javac warning cleanup #2029). */
+public class PSDateDifferenceTest {
+
+  @Test
+  public void processUdf_returnsLongDayDifference() throws Exception {
+    PSDateDifference udf = new PSDateDifference();
+    Calendar cal = new GregorianCalendar(2020, Calendar.JANUARY, 1);
+    Date start = cal.getTime();
+    cal.add(Calendar.DAY_OF_MONTH, 10);
+    Date end = cal.getTime();
+
+    Object result = udf.processUdf(new Object[] {start, end}, null);
+    assertTrue(result instanceof Long);
+    assertEquals(10L, ((Long) result).longValue());
+  }
+
+  @Test
+  public void processUdf_absoluteDifferenceOrderIndependent() throws Exception {
+    PSDateDifference udf = new PSDateDifference();
+    Calendar cal = new GregorianCalendar(2021, Calendar.MARCH, 1);
+    Date earlier = cal.getTime();
+    cal.add(Calendar.DAY_OF_MONTH, 3);
+    Date later = cal.getTime();
+
+    Long forward = (Long) udf.processUdf(new Object[] {earlier, later}, null);
+    Long reverse = (Long) udf.processUdf(new Object[] {later, earlier}, null);
+    assertEquals(3L, forward.longValue());
+    assertEquals(3L, reverse.longValue());
+  }
+
+  @Test
+  public void processUdf_missingParamsThrows() {
+    PSDateDifference udf = new PSDateDifference();
+    assertThrows(PSConversionException.class, () -> udf.processUdf(null, null));
+    assertThrows(PSConversionException.class, () -> udf.processUdf(new Object[] {}, null));
+  }
+}

--- a/modules/extensions-main/src/test/java/com/percussion/extensions/utils/PSExtensionParamsHelperTest.java
+++ b/modules/extensions-main/src/test/java/com/percussion/extensions/utils/PSExtensionParamsHelperTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extensions.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.server.IPSRequestContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral unit tests for {@link PSExtensionParamsHelper} (javac warning cleanup #2029). */
+public class PSExtensionParamsHelperTest {
+
+  private static PSExtensionParamsHelper helperFromMap(Map<String, String> params) {
+    return new PSExtensionParamsHelper(params, (IPSRequestContext) null, (Logger) null);
+  }
+
+  @Test
+  public void mapConstructor_returnsExtensionParameters() {
+    Map<String, String> params = new HashMap<>();
+    params.put("foo", "bar");
+    PSExtensionParamsHelper helper = helperFromMap(params);
+
+    assertEquals("bar", helper.getParameter("foo"));
+    assertNull(helper.getParameter("missing"));
+    assertEquals("bar", helper.getRequiredParameter("foo"));
+    assertEquals("fallback", helper.getOptionalParameter("missing", "fallback"));
+  }
+
+  @Test
+  public void requiredParameter_missingThrows() {
+    Map<String, String> params = new HashMap<>();
+    PSExtensionParamsHelper helper = helperFromMap(params);
+
+    assertThrows(IllegalArgumentException.class, () -> helper.getRequiredParameter("required"));
+  }
+
+  @Test
+  public void paramToBoolean_acceptsTrueFalse() {
+    Map<String, String> params = new HashMap<>();
+    params.put("flag", "true");
+    params.put("off", "false");
+    PSExtensionParamsHelper helper = helperFromMap(params);
+
+    assertTrue(helper.getRequiredParameterAsBoolean("flag"));
+    assertFalse(helper.getRequiredParameterAsBoolean("off"));
+    assertTrue(helper.paramToBoolean("x", "yes"));
+    assertFalse(helper.paramToBoolean("x", "no"));
+  }
+
+  @Test
+  public void paramToNumber_parsesInteger() {
+    Map<String, String> params = new HashMap<>();
+    params.put("count", "42");
+    PSExtensionParamsHelper helper = helperFromMap(params);
+
+    assertEquals(42, helper.getRequiredParameterAsNumber("count").intValue());
+    assertEquals(7, helper.paramToNumber("n", "7").intValue());
+  }
+
+  @Test
+  public void slotConstructor_rejectsNullArgsOrSelectors() {
+    Map<String, Object> selectors = new HashMap<>();
+    Map<String, Object> args = new HashMap<>();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSExtensionParamsHelper((Map<String, ? extends Object>) null, selectors, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSExtensionParamsHelper(args, (Map<String, Object>) null, null));
+  }
+
+  @Test
+  public void slotConstructor_prefersSelectorsOverArguments() {
+    Map<String, Object> args = new HashMap<>();
+    args.put("name", "fromArgs");
+    Map<String, Object> selectors = new HashMap<>();
+    selectors.put("name", "fromSelectors");
+
+    PSExtensionParamsHelper helper = new PSExtensionParamsHelper(args, selectors, null);
+    assertEquals("fromSelectors", helper.getParameter("name"));
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized **batch 1** that **zeros** project `-Xlint` javac diagnostics in `modules/extensions-main` (issue #2029).

Baseline inventory under parent `-Xlint` / `-Xlint:-deprecation` / `-Xlint:serial`: **40** main-source warnings → **0**.

### Fixes (prefer real fixes over suppressions)

| Category | Examples |
|----------|----------|
| static-access | Qualify `PSXmlTreeWalker.GET_NEXT_*` / `getElementData` by type |
| removal deprecation | `new Long`/`Double` → `valueOf` |
| cast | Remove redundant casts (`Element`, `String`, `Number`, `Boolean`) |
| dep-ann | `@Deprecated` on xmldom compatibility shims (`PSXmlTreeWalker`, `PSXmlDocumentBuilder`, `PSNodePrinter`) |
| serial | `serialVersionUID` on `com.percussion.xmldom.PSXmlTreeWalker` |
| try | Drop redundant `close()` inside try-with-resources (`PSPublishEditionForPreview`) |
| finally | Remove `return` from `finally` in `PSDatabasePublisher` (exceptions no longer swallowed) |
| this-escape / design | `PSExtensionParamsHelper` made `final`; instance logger; private helpers; null-safe `doLog` |

### Tests

- `PSExtensionParamsHelperTest` — map/slot constructors, required/optional params, boolean/number conversion
- `PSDateDifferenceTest` — absolute day difference returns `Long`

Parent tracker: #2200

## Test plan

- [x] `cd modules/extensions-main` → `../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **55**, Failures: **0**, Errors: **0**, Skipped: **0**
- [x] Zero javac `warning:` lines under project `-Xlint`
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2029-extensions-main-javac-batch1-erlang.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Standalone module clean install | BUILD SUCCESS |
| Behavioral unit tests | 9 new green (helper + date UDF) |
| Scope confined to extensions-main | yes |
| Prefer real fixes over blanket suppress | yes |
| Residual warnings | **none** — module zeroed |

Fixes #2029  
Refs #2200

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.