### PR TITLE
feat(pipeline): where-clause IR + join product limit (#2359)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2359-where-clause-ir-join-limit-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2359-where-clause-ir-join-limit-erlang.md
@@ -1,0 +1,43 @@
+# Erlang review — #2359 where-clause IR + join product limit
+
+**Date:** 2026-08-08  
+**Branch:** `fix/issue-2359-where-clause-ir-join-limit`  
+**Module:** `system` (perc-system)  
+**Verdict:** **APPROVE**
+
+## Change class
+
+Pipeline IR / SQL planner residual: executable where-clause IR for generated SELECT; documented multi-table join product limit with rejection tests. Companions: classic importer mapping, IR model, planner, H2 runtime tests, `pipeline-ir-v1.md`.
+
+## Scope reviewed
+
+| Artifact | Role |
+|----------|------|
+| `WhereClauseIr` | New IR predicate model |
+| `SelectorStageIr` | `whereClauses` list + count sync |
+| `PSClassicPipelineImporter` | Map `PSWhereClause` → IR |
+| `PSPipelineSqlPlanner` | Executable WHERE; join product limit message |
+| `PSPipelineIrServiceTest` / `PSPipelineRuntimeServiceTest` | Import + H2 + planner tests |
+| `docs/developer-module/pipeline-ir-v1.md` | Product limit + IR shape |
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / logic | No defects found. Boolean connectors use previous clause op (classic semantics). Literals always JDBC-bound. omitWhenNull skips predicate without false-positive SQL. |
+| SQL injection | Identifiers via `SAFE_IDENT` + quote; values always `?` binds. Native path unchanged. |
+| Cross-platform paths | No filesystem path construction; N/A. |
+| Tests | IR import asserts `sys_key` clause; H2 PARAM + LIKE; joinCount>0 + multi-table rejection. 31 focused tests green; module clean install green. |
+| Companions | Residual join-graph planner filed as child (product limit documented, not full multi-table generation). |
+| Copyright | New files: Intersoft 2026. |
+
+## Residual (intentional)
+
+Full multi-table join SQL generation deferred; `joinCount > 0` remains a hard product limit with stable message constant `JOIN_PRODUCT_LIMIT_MESSAGE`.
+
+## Build evidence
+
+```
+cd system && ../mvnw.cmd clean install
+BUILD SUCCESS
+```

--- a/docs/developer-module/pipeline-ir-v1.md
+++ b/docs/developer-module/pipeline-ir-v1.md
@@ -72,6 +72,17 @@ Slice A part 1 delivers **IR model + load/save + classic import**. Execution, SQ
           "unique": false,
           "method": "whereClause | nativeStatement | unknown",
           "whereClauseCount": 1,
+          "whereClauses": [
+            {
+              "leftKind": "COLUMN",
+              "left": "PSX_ADMINLOOKUP.TYPE",
+              "operator": "=",
+              "rightKind": "PARAM",
+              "right": "sys_key",
+              "booleanOp": "AND",
+              "omitWhenNull": false
+            }
+          ],
           "sortedColumnCount": 0,
           "nativeStatement": null
         },
@@ -111,11 +122,12 @@ From classic `PSApplication` / `PSDataSet` / pipes:
 | `PSPageDataTank` | `stages.pageTank` |
 | `PSBackEndDataTank` | `stages.backendTank` (tables + join count) |
 | `PSDataMapper` | `stages.mapper` (field inventory) |
-| `PSDataSelector` | `stages.selector` (method + clause counts) |
+| `PSDataSelector` | `stages.selector` (method + whereClauses IR + counts) |
+| `PSWhereClause` / `PSConditional` | `selector.whereClauses[]` (COLUMN/PARAM/LITERAL/OTHER) |
 | `PSResultPager` | `stages.pager` |
 | `PSDataSynchronizer` | `stages.updater` |
 
-Not imported in v1 (deferred): full where-clause trees, join graphs, exits/hooks, result pages/XSL, ACLs, CE field maps.
+Not imported in v1 (deferred): join graphs (only `joinCount`), exits/hooks, result pages/XSL, ACLs, CE field maps. Unsupported where right-hand kinds stay as `OTHER` (planner requires native SQL for those).
 
 ## Service API
 
@@ -135,6 +147,7 @@ Not imported in v1 (deferred): full where-clause trees, join graphs, exits/hooks
 - `execute(document, resource, request)` — in-memory IR (tests / callers)
 - SQL via `IPSPipelineSqlAdapter` / `PSJdbcPipelineSqlAdapter` (parameterized JDBC only)
 - Planner: `PSPipelineSqlPlanner` (generated single-table SELECT/INSERT/**UPDATE**/**DELETE**, or native SELECT with `:param`)
+- Generated SELECT **WHERE** prefers `selector.whereClauses` IR when present (COLUMN left; operators `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`, `LIKE`, `NOT LIKE`, `IS NULL`, `IS NOT NULL`; right PARAM/LITERAL/COLUMN; AND/OR; `omitWhenNull`). Otherwise falls back to request-param equality on mapped columns.
 - Pre/post hooks: `IPSPipelinePreExecuteHook` / `IPSPipelinePostExecuteHook`
 - JSON I/O: `PipelineExecuteRequest` / `PipelineExecuteResult` + `PSPipelineExecuteJsonCodec`
 - Thin REST: `POST /services/pipelines/{app}/resources/{resource}/execute` (see #2269 / PR #2341)
@@ -188,7 +201,7 @@ Documented + covered by H2 tests in `PSPipelineRuntimeServiceTest` (`transaction
 | Parameterized SQL | Request values bound as JDBC `?` only |
 | Generated identifiers | Table/column must match `[A-Za-z_][A-Za-z0-9_]*` |
 | Native SQL escape hatch | Single `SELECT`/`WITH` only; named `:param`; rejects `;`, DML/DDL keywords |
-| Joins / multi-table | Not supported in Slice A2 planner (residual) |
+| Joins / multi-table | **Product limit:** `joinCount > 0` rejected (`PSPipelineSqlPlanner.JOIN_PRODUCT_LIMIT_MESSAGE`). Multi-table tanks without joins also rejected. Use single table or `nativeStatement` SELECT with hand-authored joins. Residual join-graph planner under parent epic #1690 / #2359 follow-up. |
 | Unrestricted DELETE/UPDATE | Rejected (WHERE keys required) |
 
 Manual raw multi-statement SQL is **not** a product surface.
@@ -196,13 +209,14 @@ Manual raw multi-statement SQL is **not** a product surface.
 ## Tests
 
 - IR JSON round-trip + file load/save
-- Golden classic fixture `sys_adminCataloger` → IR stage inventory (backend tank, mapper, selector, page tank)
-- H2 runtime: generated query + JSON params, native SELECT, pre/post hooks, INSERT, UPDATE/DELETE flag gates, multi-row `transactionMode` all/row (`PSPipelineRuntimeServiceTest`)
+- Golden classic fixture `sys_adminCataloger` → IR stage inventory (backend tank, mapper, selector whereClauses, page tank)
+- H2 runtime: generated query + JSON params, **where-clause IR** (PARAM/LIKE), native SELECT, pre/post hooks, INSERT, UPDATE/DELETE flag gates, multi-row `transactionMode` all/row, **joinCount product-limit rejection** (`PSPipelineRuntimeServiceTest`)
 
 ## Evolution
 
 - **1.x** additive fields preferred; bump `irVersion` only for breaking shape changes.
 - Slice A2 (#2248): SQL execute + JSON I/O + hooks consume this IR (landed).
 - Residual #2269: thin REST invoke (landed / PR #2341).
-- Residual #2340: richer UPDATE/DELETE + multi-row txn modes (this work); join graphs / full where-clause IR may remain a further residual.
+- Residual #2340: richer UPDATE/DELETE + multi-row txn modes (landed / PR #2360).
+- Residual #2359: where-clause IR executable path + documented join product limit (this work); **join-graph SQL generation** remains a further residual under #1690.
 - Slice B: designer writes native IR (`source=NATIVE`).

--- a/system/services/src/com/percussion/services/pipeline/PSClassicPipelineImporter.java
+++ b/system/services/src/com/percussion/services/pipeline/PSClassicPipelineImporter.java
@@ -17,6 +17,7 @@
 
 package com.percussion.services.pipeline;
 
+import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSApplication;
 import com.percussion.design.objectstore.PSBackEndColumn;
 import com.percussion.design.objectstore.PSBackEndDataTank;
@@ -28,14 +29,20 @@ import com.percussion.design.objectstore.PSDataSelector;
 import com.percussion.design.objectstore.PSDataSet;
 import com.percussion.design.objectstore.PSDataSynchronizer;
 import com.percussion.design.objectstore.PSExtensionCall;
+import com.percussion.design.objectstore.PSHtmlParameter;
+import com.percussion.design.objectstore.PSLiteral;
+import com.percussion.design.objectstore.PSNamedReplacementValue;
 import com.percussion.design.objectstore.PSPageDataTank;
 import com.percussion.design.objectstore.PSPipe;
 import com.percussion.design.objectstore.PSQueryPipe;
 import com.percussion.design.objectstore.PSRequestor;
 import com.percussion.design.objectstore.PSResultPager;
+import com.percussion.design.objectstore.PSSingleHtmlParameter;
+import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUpdatePipe;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.design.objectstore.PSWhereClause;
 import com.percussion.services.pipeline.model.BackendTableRefIr;
 import com.percussion.services.pipeline.model.BackendTankStageIr;
 import com.percussion.services.pipeline.model.MapperStageIr;
@@ -48,6 +55,7 @@ import com.percussion.services.pipeline.model.PipelineResourceIr;
 import com.percussion.services.pipeline.model.PipelineStagesIr;
 import com.percussion.services.pipeline.model.SelectorStageIr;
 import com.percussion.services.pipeline.model.UpdaterStageIr;
+import com.percussion.services.pipeline.model.WhereClauseIr;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.IOException;
@@ -278,10 +286,88 @@ public final class PSClassicPipelineImporter {
       stage.setMethod(SelectorStageIr.METHOD_UNKNOWN);
     }
     PSCollection wheres = selector.getWhereClauses();
-    stage.setWhereClauseCount(wheres != null ? wheres.size() : 0);
+    List<WhereClauseIr> whereIr = new ArrayList<>();
+    if (wheres != null) {
+      for (Object o : wheres) {
+        if (o instanceof PSWhereClause clause) {
+          whereIr.add(mapWhereClause(clause));
+        }
+      }
+    }
+    stage.setWhereClauses(whereIr);
     PSCollection sorts = selector.getSortedColumns();
     stage.setSortedColumnCount(sorts != null ? sorts.size() : 0);
     return stage;
+  }
+
+  private static WhereClauseIr mapWhereClause(PSWhereClause clause) {
+    WhereClauseIr ir = new WhereClauseIr();
+    ir.setOmitWhenNull(clause.isOmittedWhenNull());
+    ir.setOperator(clause.getOperator());
+    String bool = clause.getBoolean();
+    if (StringUtils.isNotBlank(bool)) {
+      ir.setBooleanOp(bool.trim().toUpperCase(java.util.Locale.ROOT));
+    }
+    mapReplacement(clause.getVariable(), ir, true);
+    mapReplacement(clause.getValue(), ir, false);
+    return ir;
+  }
+
+  /**
+   * Map a classic replacement value onto left or right of a where-clause IR entry.
+   *
+   * @param value classic replacement, may be {@code null}
+   * @param ir target clause
+   * @param left {@code true} for variable/left side; {@code false} for value/right side
+   */
+  private static void mapReplacement(IPSReplacementValue value, WhereClauseIr ir, boolean left) {
+    if (value == null) {
+      if (left) {
+        ir.setLeftKind(WhereClauseIr.KIND_OTHER);
+        ir.setLeft(null);
+      } else {
+        ir.setRightKind(WhereClauseIr.KIND_OTHER);
+        ir.setRight(null);
+      }
+      return;
+    }
+    String kind;
+    String text;
+    if (value instanceof PSBackEndColumn col) {
+      kind = WhereClauseIr.KIND_COLUMN;
+      String alias = col.getTable() != null ? col.getTable().getAlias() : null;
+      String column = col.getColumn();
+      if (StringUtils.isNotBlank(alias) && StringUtils.isNotBlank(column)) {
+        text = alias + "." + column;
+      } else {
+        text = column;
+      }
+    } else if (value instanceof PSHtmlParameter || value instanceof PSSingleHtmlParameter) {
+      kind = WhereClauseIr.KIND_PARAM;
+      text = value instanceof PSNamedReplacementValue n ? n.getName() : value.getValueText();
+    } else if (value instanceof PSTextLiteral lit) {
+      kind = WhereClauseIr.KIND_LITERAL;
+      text = lit.getText();
+    } else if (value instanceof PSLiteral) {
+      // NumericDate/other literals: display/value text from replacement interface
+      kind = WhereClauseIr.KIND_LITERAL;
+      text = value.getValueText();
+    } else if (value instanceof PSNamedReplacementValue named
+        && ("HtmlParameter".equals(value.getValueType())
+            || "SingleHtmlParameter".equals(value.getValueType()))) {
+      kind = WhereClauseIr.KIND_PARAM;
+      text = named.getName();
+    } else {
+      kind = WhereClauseIr.KIND_OTHER;
+      text = value.getValueText();
+    }
+    if (left) {
+      ir.setLeftKind(kind);
+      ir.setLeft(text);
+    } else {
+      ir.setRightKind(kind);
+      ir.setRight(text);
+    }
   }
 
   private static PagerStageIr mapPager(PSResultPager pager) {

--- a/system/services/src/com/percussion/services/pipeline/model/SelectorStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/SelectorStageIr.java
@@ -17,6 +17,8 @@
 
 package com.percussion.services.pipeline.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /** Query selector stage (classic {@code PSDataSelector}). */
@@ -29,9 +31,11 @@ public class SelectorStageIr {
   private boolean present;
   private boolean unique;
   private String method = METHOD_UNKNOWN;
+  /** Legacy count field; kept in sync when {@link #whereClauses} is set. */
   private int whereClauseCount;
   private int sortedColumnCount;
   private String nativeStatement;
+  private List<WhereClauseIr> whereClauses = new ArrayList<>();
 
   public boolean isPresent() {
     return present;
@@ -57,7 +61,14 @@ public class SelectorStageIr {
     this.method = method != null ? method : METHOD_UNKNOWN;
   }
 
+  /**
+   * Number of WHERE predicates. Prefer {@link #getWhereClauses()} for executable IR; this count
+   * remains for older JSON that only stored the inventory size.
+   */
   public int getWhereClauseCount() {
+    if (whereClauses != null && !whereClauses.isEmpty()) {
+      return whereClauses.size();
+    }
     return whereClauseCount;
   }
 
@@ -81,6 +92,15 @@ public class SelectorStageIr {
     this.nativeStatement = nativeStatement;
   }
 
+  public List<WhereClauseIr> getWhereClauses() {
+    return whereClauses;
+  }
+
+  public void setWhereClauses(List<WhereClauseIr> whereClauses) {
+    this.whereClauses = whereClauses != null ? whereClauses : new ArrayList<>();
+    this.whereClauseCount = this.whereClauses.size();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,15 +111,22 @@ public class SelectorStageIr {
     }
     return present == that.present
         && unique == that.unique
-        && whereClauseCount == that.whereClauseCount
+        && getWhereClauseCount() == that.getWhereClauseCount()
         && sortedColumnCount == that.sortedColumnCount
         && Objects.equals(method, that.method)
-        && Objects.equals(nativeStatement, that.nativeStatement);
+        && Objects.equals(nativeStatement, that.nativeStatement)
+        && Objects.equals(whereClauses, that.whereClauses);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        present, unique, method, whereClauseCount, sortedColumnCount, nativeStatement);
+        present,
+        unique,
+        method,
+        getWhereClauseCount(),
+        sortedColumnCount,
+        nativeStatement,
+        whereClauses);
   }
 }

--- a/system/services/src/com/percussion/services/pipeline/model/WhereClauseIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/WhereClauseIr.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/**
+ * One selector WHERE predicate in pipeline IR (classic {@code PSWhereClause} / {@code
+ * PSConditional}).
+ *
+ * <p>Executable planner path supports column left-hand side with relational operators and
+ * PARAM/LITERAL/COLUMN right-hand side. Unsupported right kinds or operators are stored for
+ * inventory but rejected when planning SQL unless the native-statement escape hatch is used.
+ */
+public class WhereClauseIr {
+
+  /** Left/right operand is a backend column ({@code alias.col} or {@code col}). */
+  public static final String KIND_COLUMN = "COLUMN";
+
+  /** Right (or left) operand is a request/HTML parameter name. */
+  public static final String KIND_PARAM = "PARAM";
+
+  /** Literal text/number bound as a JDBC parameter (never concatenated). */
+  public static final String KIND_LITERAL = "LITERAL";
+
+  /** Unmapped classic replacement type retained for inventory only. */
+  public static final String KIND_OTHER = "OTHER";
+
+  public static final String BOOL_AND = "AND";
+  public static final String BOOL_OR = "OR";
+
+  private String leftKind = KIND_OTHER;
+  private String left;
+  private String operator;
+  private String rightKind = KIND_OTHER;
+  private String right;
+  private String booleanOp = BOOL_AND;
+  private boolean omitWhenNull;
+
+  public String getLeftKind() {
+    return leftKind;
+  }
+
+  public void setLeftKind(String leftKind) {
+    this.leftKind = leftKind != null ? leftKind : KIND_OTHER;
+  }
+
+  public String getLeft() {
+    return left;
+  }
+
+  public void setLeft(String left) {
+    this.left = left;
+  }
+
+  public String getOperator() {
+    return operator;
+  }
+
+  public void setOperator(String operator) {
+    this.operator = operator;
+  }
+
+  public String getRightKind() {
+    return rightKind;
+  }
+
+  public void setRightKind(String rightKind) {
+    this.rightKind = rightKind != null ? rightKind : KIND_OTHER;
+  }
+
+  public String getRight() {
+    return right;
+  }
+
+  public void setRight(String right) {
+    this.right = right;
+  }
+
+  public String getBooleanOp() {
+    return booleanOp;
+  }
+
+  public void setBooleanOp(String booleanOp) {
+    this.booleanOp = booleanOp;
+  }
+
+  public boolean isOmitWhenNull() {
+    return omitWhenNull;
+  }
+
+  public void setOmitWhenNull(boolean omitWhenNull) {
+    this.omitWhenNull = omitWhenNull;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof WhereClauseIr that)) {
+      return false;
+    }
+    return omitWhenNull == that.omitWhenNull
+        && Objects.equals(leftKind, that.leftKind)
+        && Objects.equals(left, that.left)
+        && Objects.equals(operator, that.operator)
+        && Objects.equals(rightKind, that.rightKind)
+        && Objects.equals(right, that.right)
+        && Objects.equals(booleanOp, that.booleanOp);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(leftKind, left, operator, rightKind, right, booleanOp, omitWhenNull);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
@@ -25,6 +25,7 @@ import com.percussion.services.pipeline.model.PipelineExecuteRequest;
 import com.percussion.services.pipeline.model.PipelineResourceIr;
 import com.percussion.services.pipeline.model.SelectorStageIr;
 import com.percussion.services.pipeline.model.UpdaterStageIr;
+import com.percussion.services.pipeline.model.WhereClauseIr;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -46,12 +47,29 @@ import java.util.regex.Pattern;
  *   <li>Generated identifiers (table/column) are restricted to {@code [A-Za-z_][A-Za-z0-9_]*}.
  *   <li>Native SQL (selector {@code nativeStatement}) is an escape hatch: single {@code SELECT}
  *       only, named {@code :param} placeholders; multi-statement and non-SELECT rejected.
+ *   <li>Multi-table joins are a documented product limit: {@code joinCount &gt; 0} is rejected
+ *       (use native SELECT escape hatch or a residual join-graph planner).
  * </ul>
  */
 public final class PSPipelineSqlPlanner {
 
   private static final Pattern SAFE_IDENT = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
   private static final Pattern NAMED_PARAM = Pattern.compile(":([A-Za-z_][A-Za-z0-9_]*)");
+
+  /** Relational operators allowed in generated WHERE (case-insensitive match after normalize). */
+  private static final Set<String> BINARY_OPS =
+      Set.of("=", "<>", "!=", "<", "<=", ">", ">=", "LIKE", "NOT LIKE");
+
+  private static final Set<String> UNARY_OPS = Set.of("IS NULL", "IS NOT NULL");
+
+  /**
+   * Product-limit message for multi-table backend tanks. Keep stable for tests and API clients.
+   */
+  public static final String JOIN_PRODUCT_LIMIT_MESSAGE =
+      "Product limit: multi-table joins are not supported by the pipeline SQL planner"
+          + " (joinCount > 0). Use a single backend table, or the selector nativeStatement"
+          + " escape hatch for hand-authored SELECT with joins. Residual join-graph planner"
+          + " tracked under parent pipeline epic.";
 
   private PSPipelineSqlPlanner() {}
 
@@ -62,8 +80,9 @@ public final class PSPipelineSqlPlanner {
    *
    * <ol>
    *   <li>If selector uses {@code nativeStatement}, compile named-parameter SELECT.
-   *   <li>Else build projection from single backend table + COLUMN mapper mappings; optional WHERE
-   *       from request params that match mapped columns / JSON field names.
+   *   <li>Else build projection from single backend table + COLUMN mapper mappings; WHERE from
+   *       selector where-clause IR when present, otherwise request params that match mapped columns
+   *       / JSON field names (equality only).
    * </ol>
    */
   public static PSPipelineSqlPlan planQuery(
@@ -601,7 +620,14 @@ public final class PSPipelineSqlPlanner {
           "QUERY resource has no COLUMN mappings to project: " + resource.getName());
     }
 
+    SelectorStageIr selector =
+        resource.getStages() != null ? resource.getStages().getSelector() : null;
+    boolean distinct = selector != null && selector.isUnique();
+
     StringBuilder sql = new StringBuilder("SELECT ");
+    if (distinct) {
+      sql.append("DISTINCT ");
+    }
     for (int i = 0; i < mappings.size(); i++) {
       ColumnMapping m = mappings.get(i);
       if (i > 0) {
@@ -614,33 +640,203 @@ public final class PSPipelineSqlPlanner {
     List<Object> binds = new ArrayList<>();
     Map<String, Object> params =
         request.getParams() != null ? request.getParams() : Map.of();
-    if (!params.isEmpty()) {
-      List<String> whereParts = new ArrayList<>();
-      // Deduplicate by mapped column so case variants of the same param (TYPE vs type) do not
-      // produce duplicate WHERE "TYPE" = ? AND "TYPE" = ? with conflicting binds.
-      Set<String> usedColumns = new HashSet<>();
-      for (Map.Entry<String, Object> e : params.entrySet()) {
-        ColumnMapping match = findMappingForParam(mappings, e.getKey());
-        if (match == null) {
-          // Unknown params are ignored for generated WHERE (hooks may use them); only mapped cols
-          // become filters.
-          continue;
-        }
-        String colKey = match.column.toUpperCase(Locale.ROOT);
-        if (!usedColumns.add(colKey)) {
-          continue;
-        }
-        whereParts.add(quoteIdent(match.column) + " = ?");
-        binds.add(e.getValue());
-      }
-      if (!whereParts.isEmpty()) {
-        sql.append(" WHERE ");
-        sql.append(String.join(" AND ", whereParts));
-      }
+
+    List<WhereClauseIr> irClauses =
+        selector != null && selector.getWhereClauses() != null
+            ? selector.getWhereClauses()
+            : List.of();
+    if (!irClauses.isEmpty()) {
+      appendWhereFromIr(sql, binds, irClauses, params, resource.getName());
+    } else if (!params.isEmpty()) {
+      appendWhereFromRequestParams(sql, binds, mappings, params);
     }
 
     return new PSPipelineSqlPlan(
         PSPipelineSqlPlan.Kind.QUERY, sql.toString(), binds, "generatedSelect:" + table);
+  }
+
+  /**
+   * Build WHERE from selector where-clause IR (classic import / native IR). Values are always JDBC
+   * binds; identifiers are validated.
+   */
+  private static void appendWhereFromIr(
+      StringBuilder sql,
+      List<Object> binds,
+      List<WhereClauseIr> clauses,
+      Map<String, Object> params,
+      String resourceName)
+      throws PSPipelineIrException {
+    List<String> parts = new ArrayList<>();
+    // Connector after each emitted part (classic: boolean on a clause joins it to the next).
+    List<String> trailingConnectors = new ArrayList<>();
+    for (WhereClauseIr clause : clauses) {
+      if (clause == null) {
+        continue;
+      }
+      PredicateFrag frag = compileWherePredicate(clause, params, resourceName);
+      if (frag == null) {
+        // omitWhenNull skipped this predicate — do not consume its boolean either
+        continue;
+      }
+      parts.add(frag.sql);
+      binds.addAll(frag.binds);
+      trailingConnectors.add(frag.booleanOpAfter);
+    }
+    if (parts.isEmpty()) {
+      return;
+    }
+    sql.append(" WHERE ");
+    for (int i = 0; i < parts.size(); i++) {
+      if (i > 0) {
+        // Use the previous clause's boolean as the join to this clause
+        sql.append(' ').append(trailingConnectors.get(i - 1)).append(' ');
+      }
+      sql.append(parts.get(i));
+    }
+  }
+
+  /**
+   * @return null when predicate should be omitted (omitWhenNull + missing/null param)
+   */
+  private static PredicateFrag compileWherePredicate(
+      WhereClauseIr clause, Map<String, Object> params, String resourceName)
+      throws PSPipelineIrException {
+    String opRaw = clause.getOperator();
+    if (opRaw == null || opRaw.isBlank()) {
+      throw new PSPipelineIrException(
+          "Where-clause IR missing operator on resource: " + resourceName);
+    }
+    String op = normalizeOperator(opRaw);
+
+    if (!WhereClauseIr.KIND_COLUMN.equals(clause.getLeftKind())) {
+      throw new PSPipelineIrException(
+          "Where-clause IR left side must be COLUMN (got "
+              + clause.getLeftKind()
+              + ") on resource: "
+              + resourceName
+              + " — use nativeStatement for non-column predicates");
+    }
+    String leftCol = columnFromBackend(clause.getLeft() != null ? clause.getLeft() : "");
+    String leftSql = quoteIdent(leftCol);
+
+    String bool =
+        clause.getBooleanOp() != null && !clause.getBooleanOp().isBlank()
+            ? clause.getBooleanOp().trim().toUpperCase(Locale.ROOT)
+            : WhereClauseIr.BOOL_AND;
+    if (!WhereClauseIr.BOOL_AND.equals(bool) && !WhereClauseIr.BOOL_OR.equals(bool)) {
+      throw new PSPipelineIrException(
+          "Where-clause IR booleanOp must be AND or OR (got " + bool + "): " + resourceName);
+    }
+
+    if (UNARY_OPS.contains(op)) {
+      return new PredicateFrag(leftSql + " " + op, List.of(), bool);
+    }
+
+    if (!BINARY_OPS.contains(op)) {
+      throw new PSPipelineIrException(
+          "Where-clause IR operator not supported by generated planner: "
+              + opRaw
+              + " on resource: "
+              + resourceName
+              + " (supported: =, <>, !=, <, <=, >, >=, LIKE, NOT LIKE, IS NULL, IS NOT NULL)");
+    }
+
+    // SQL uses <> for inequality
+    String sqlOp = "!=".equals(op) ? "<>" : op;
+
+    String rightKind = clause.getRightKind() != null ? clause.getRightKind() : WhereClauseIr.KIND_OTHER;
+    if (WhereClauseIr.KIND_COLUMN.equals(rightKind)) {
+      String rightCol = columnFromBackend(clause.getRight() != null ? clause.getRight() : "");
+      return new PredicateFrag(leftSql + " " + sqlOp + " " + quoteIdent(rightCol), List.of(), bool);
+    }
+    if (WhereClauseIr.KIND_PARAM.equals(rightKind)) {
+      String paramName = clause.getRight();
+      if (paramName == null || paramName.isBlank()) {
+        throw new PSPipelineIrException(
+            "Where-clause IR PARAM right side missing name on resource: " + resourceName);
+      }
+      boolean present = containsKeyIgnoreCase(params, paramName);
+      Object value = present ? findParamIgnoreCase(params, paramName) : null;
+      if (clause.isOmitWhenNull() && (!present || value == null)) {
+        return null;
+      }
+      if (!present) {
+        throw new PSPipelineIrException(
+            "Missing request param for where-clause IR placeholder: "
+                + paramName
+                + " (resource: "
+                + resourceName
+                + ")");
+      }
+      return new PredicateFrag(leftSql + " " + sqlOp + " ?", List.of(value), bool);
+    }
+    if (WhereClauseIr.KIND_LITERAL.equals(rightKind)) {
+      // Always bind literals as parameters — never concatenate into SQL text.
+      Object lit = clause.getRight();
+      if (clause.isOmitWhenNull() && lit == null) {
+        return null;
+      }
+      return new PredicateFrag(leftSql + " " + sqlOp + " ?", List.of(lit), bool);
+    }
+    throw new PSPipelineIrException(
+        "Where-clause IR right side kind not executable ("
+            + rightKind
+            + ") on resource: "
+            + resourceName
+            + " — use nativeStatement for OTHER kinds");
+  }
+
+  private static String normalizeOperator(String opRaw) {
+    String t = opRaw.trim().replaceAll("\\s+", " ");
+    String upper = t.toUpperCase(Locale.ROOT);
+    // Preserve symbolic ops; upper-case word ops
+    if ("!=".equals(t) || "<>".equals(t) || "=".equals(t) || "<".equals(t) || ">".equals(t)
+        || "<=".equals(t) || ">=".equals(t)) {
+      return t;
+    }
+    return upper;
+  }
+
+  private static void appendWhereFromRequestParams(
+      StringBuilder sql,
+      List<Object> binds,
+      List<ColumnMapping> mappings,
+      Map<String, Object> params) {
+    List<String> whereParts = new ArrayList<>();
+    // Deduplicate by mapped column so case variants of the same param (TYPE vs type) do not
+    // produce duplicate WHERE "TYPE" = ? AND "TYPE" = ? with conflicting binds.
+    Set<String> usedColumns = new HashSet<>();
+    for (Map.Entry<String, Object> e : params.entrySet()) {
+      ColumnMapping match = findMappingForParam(mappings, e.getKey());
+      if (match == null) {
+        // Unknown params are ignored for generated WHERE (hooks may use them); only mapped cols
+        // become filters.
+        continue;
+      }
+      String colKey = match.column.toUpperCase(Locale.ROOT);
+      if (!usedColumns.add(colKey)) {
+        continue;
+      }
+      whereParts.add(quoteIdent(match.column) + " = ?");
+      binds.add(e.getValue());
+    }
+    if (!whereParts.isEmpty()) {
+      sql.append(" WHERE ");
+      sql.append(String.join(" AND ", whereParts));
+    }
+  }
+
+  private static final class PredicateFrag {
+    final String sql;
+    final List<Object> binds;
+    /** Boolean connector that joins this fragment to the next (classic clause boolean). */
+    final String booleanOpAfter;
+
+    PredicateFrag(String sql, List<Object> binds, String booleanOpAfter) {
+      this.sql = sql;
+      this.binds = binds;
+      this.booleanOpAfter = booleanOpAfter;
+    }
   }
 
   private static String requireSingleTable(PipelineResourceIr resource) throws PSPipelineIrException {
@@ -651,12 +847,15 @@ public final class PSPipelineSqlPlanner {
     }
     if (resource.getStages().getBackendTank().getJoinCount() > 0) {
       throw new PSPipelineIrException(
-          "Joined backend tanks are not supported in Slice A runtime: " + resource.getName());
+          JOIN_PRODUCT_LIMIT_MESSAGE + " Resource: " + resource.getName());
     }
     List<BackendTableRefIr> tables = resource.getStages().getBackendTank().getTables();
     if (tables == null || tables.size() != 1) {
       throw new PSPipelineIrException(
-          "Slice A runtime requires exactly one backend table: " + resource.getName());
+          "Pipeline SQL planner requires exactly one backend table (got "
+              + (tables == null ? 0 : tables.size())
+              + "); multi-table tanks without joins are also unsupported. Resource: "
+              + resource.getName());
     }
     String table = tables.get(0).getTable();
     if (table == null || table.isBlank()) {

--- a/system/src/test/java/com/percussion/services/pipeline/PSPipelineIrServiceTest.java
+++ b/system/src/test/java/com/percussion/services/pipeline/PSPipelineIrServiceTest.java
@@ -24,6 +24,7 @@ import com.percussion.services.pipeline.model.MapperStageIr;
 import com.percussion.services.pipeline.model.PipelineIrDocument;
 import com.percussion.services.pipeline.model.PipelineResourceIr;
 import com.percussion.services.pipeline.model.SelectorStageIr;
+import com.percussion.services.pipeline.model.WhereClauseIr;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -98,6 +99,14 @@ class PSPipelineIrServiceTest {
     SelectorStageIr selector = res.getStages().getSelector();
     assertEquals(SelectorStageIr.METHOD_WHERE, selector.getMethod());
     assertEquals(1, selector.getWhereClauseCount());
+    assertEquals(1, selector.getWhereClauses().size());
+    WhereClauseIr where = selector.getWhereClauses().get(0);
+    assertEquals(WhereClauseIr.KIND_COLUMN, where.getLeftKind());
+    assertEquals("PSX_ADMINLOOKUP.TYPE", where.getLeft());
+    assertEquals("=", where.getOperator());
+    assertEquals(WhereClauseIr.KIND_PARAM, where.getRightKind());
+    assertEquals("sys_key", where.getRight());
+    assertFalse(where.isOmitWhenNull());
     assertFalse(selector.isUnique());
   }
 

--- a/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
+++ b/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
@@ -32,6 +32,7 @@ import com.percussion.services.pipeline.model.PipelineResourceIr;
 import com.percussion.services.pipeline.model.PipelineStagesIr;
 import com.percussion.services.pipeline.model.SelectorStageIr;
 import com.percussion.services.pipeline.model.UpdaterStageIr;
+import com.percussion.services.pipeline.model.WhereClauseIr;
 import com.percussion.services.pipeline.sql.PSJdbcPipelineSqlAdapter;
 import com.percussion.services.pipeline.sql.PSPipelineSqlPlan;
 import com.percussion.services.pipeline.sql.PSPipelineSqlPlanner;
@@ -219,6 +220,170 @@ class PSPipelineRuntimeServiceTest {
     assertEquals(-1, sql.indexOf("\"TYPE\" = ?", idx + 1), sql);
     assertEquals(1, plan.getParameters().size());
     assertEquals("workflow", plan.getParameters().get(0));
+  }
+
+  @Test
+  @DisplayName("where-clause IR: PARAM filter executes against H2 (classic import shape)")
+  void executeQuery_whereClauseIrParam() throws Exception {
+    PipelineIrDocument doc = nativeQueryDoc("whereIrApp", "W1");
+    PipelineResourceIr res = doc.findResource("W1");
+    SelectorStageIr selector = res.getStages().getSelector();
+    WhereClauseIr clause = new WhereClauseIr();
+    clause.setLeftKind(WhereClauseIr.KIND_COLUMN);
+    clause.setLeft("PSX_ADMINLOOKUP.TYPE");
+    clause.setOperator("=");
+    clause.setRightKind(WhereClauseIr.KIND_PARAM);
+    clause.setRight("sys_key");
+    clause.setBooleanOp(WhereClauseIr.BOOL_AND);
+    clause.setOmitWhenNull(false);
+    selector.setWhereClauses(List.of(clause));
+    irService.save(doc);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    PipelineExecuteResult result =
+        runtime.execute(
+            "whereIrApp", "W1", PipelineExecuteRequest.ofParams(Map.of("sys_key", "locale")));
+
+    assertEquals(1, result.getRowCount());
+    assertEquals("locale", result.getRows().get(0).get("Type"));
+  }
+
+  @Test
+  @DisplayName("where-clause IR: LIKE + LITERAL bind; omitWhenNull skips missing param")
+  void planQuery_whereClauseIrLikeAndOmit() throws Exception {
+    PipelineIrDocument doc = nativeQueryDoc("likeApp", "L1");
+    PipelineResourceIr res = doc.findResource("L1");
+    SelectorStageIr selector = res.getStages().getSelector();
+
+    WhereClauseIr typeLike = new WhereClauseIr();
+    typeLike.setLeftKind(WhereClauseIr.KIND_COLUMN);
+    typeLike.setLeft("TYPE");
+    typeLike.setOperator("LIKE");
+    typeLike.setRightKind(WhereClauseIr.KIND_LITERAL);
+    typeLike.setRight("work%");
+    typeLike.setBooleanOp(WhereClauseIr.BOOL_AND);
+
+    WhereClauseIr optionalName = new WhereClauseIr();
+    optionalName.setLeftKind(WhereClauseIr.KIND_COLUMN);
+    optionalName.setLeft("NAME");
+    optionalName.setOperator("=");
+    optionalName.setRightKind(WhereClauseIr.KIND_PARAM);
+    optionalName.setRight("nameFilter");
+    optionalName.setOmitWhenNull(true);
+    optionalName.setBooleanOp(WhereClauseIr.BOOL_AND);
+
+    selector.setWhereClauses(List.of(typeLike, optionalName));
+
+    PSPipelineSqlPlan plan =
+        PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.empty());
+    String sql = plan.getSql();
+    assertTrue(sql.contains("\"TYPE\" LIKE ?"), sql);
+    assertFalse(
+        sql.contains("\"NAME\" = ?"), "optional param must not appear in WHERE: " + sql);
+    assertEquals(List.of("work%"), plan.getParameters());
+
+    // With param present, both predicates appear
+    PSPipelineSqlPlan plan2 =
+        PSPipelineSqlPlanner.planQuery(
+            res, PipelineExecuteRequest.ofParams(Map.of("nameFilter", "wf1")));
+    assertTrue(plan2.getSql().contains("\"TYPE\" LIKE ?"), plan2.getSql());
+    assertTrue(plan2.getSql().contains("\"NAME\" = ?"), plan2.getSql());
+    assertTrue(plan2.getSql().contains(" AND "), plan2.getSql());
+    assertEquals(List.of("work%", "wf1"), plan2.getParameters());
+  }
+
+  @Test
+  @DisplayName("where-clause IR: OR connector and missing required PARAM rejected")
+  void planQuery_whereClauseIrOrAndMissingParam() {
+    PipelineIrDocument doc = nativeQueryDoc("orApp", "O1");
+    PipelineResourceIr res = doc.findResource("O1");
+    SelectorStageIr selector = res.getStages().getSelector();
+
+    WhereClauseIr a = new WhereClauseIr();
+    a.setLeftKind(WhereClauseIr.KIND_COLUMN);
+    a.setLeft("TYPE");
+    a.setOperator("=");
+    a.setRightKind(WhereClauseIr.KIND_LITERAL);
+    a.setRight("workflow");
+    a.setBooleanOp(WhereClauseIr.BOOL_OR);
+
+    WhereClauseIr b = new WhereClauseIr();
+    b.setLeftKind(WhereClauseIr.KIND_COLUMN);
+    b.setLeft("TYPE");
+    b.setOperator("=");
+    b.setRightKind(WhereClauseIr.KIND_PARAM);
+    b.setRight("altType");
+    b.setOmitWhenNull(false);
+
+    selector.setWhereClauses(List.of(a, b));
+
+    PSPipelineIrException missing =
+        assertThrows(
+            PSPipelineIrException.class,
+            () -> PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.empty()));
+    assertTrue(missing.getMessage().contains("altType"), missing.getMessage());
+  }
+
+  @Test
+  @DisplayName("product limit: joinCount > 0 rejected with documented message")
+  void planQuery_rejectsJoins_productLimit() {
+    PipelineIrDocument doc = nativeQueryDoc("joinApp", "J1");
+    PipelineResourceIr res = doc.findResource("J1");
+    res.getStages().getBackendTank().setJoinCount(1);
+
+    PSPipelineIrException ex =
+        assertThrows(
+            PSPipelineIrException.class,
+            () -> PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.empty()));
+    assertTrue(
+        ex.getMessage().contains(PSPipelineSqlPlanner.JOIN_PRODUCT_LIMIT_MESSAGE)
+            || ex.getMessage().contains("multi-table joins"),
+        ex.getMessage());
+    assertTrue(ex.getMessage().contains("J1"), ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("product limit: multi-table tank without join also rejected")
+  void planQuery_rejectsMultiTableWithoutJoin() {
+    PipelineIrDocument doc = nativeQueryDoc("mtApp", "M1");
+    PipelineResourceIr res = doc.findResource("M1");
+    BackendTableRefIr t2 = new BackendTableRefIr();
+    t2.setTable("OTHER");
+    t2.setAlias("OTHER");
+    List<BackendTableRefIr> tables = new ArrayList<>(res.getStages().getBackendTank().getTables());
+    tables.add(t2);
+    res.getStages().getBackendTank().setTables(tables);
+    res.getStages().getBackendTank().setJoinCount(0);
+
+    PSPipelineIrException ex =
+        assertThrows(
+            PSPipelineIrException.class,
+            () -> PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.empty()));
+    assertTrue(ex.getMessage().contains("exactly one backend table"), ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("where-clause IR executes LIKE against H2 end-to-end")
+  void executeQuery_whereClauseIrLikeH2() throws Exception {
+    PipelineIrDocument doc = nativeQueryDoc("likeH2", "LH");
+    PipelineResourceIr res = doc.findResource("LH");
+    WhereClauseIr clause = new WhereClauseIr();
+    clause.setLeftKind(WhereClauseIr.KIND_COLUMN);
+    clause.setLeft("NAME");
+    clause.setOperator("LIKE");
+    clause.setRightKind(WhereClauseIr.KIND_LITERAL);
+    clause.setRight("wf%");
+    res.getStages().getSelector().setWhereClauses(List.of(clause));
+    irService.save(doc);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    PipelineExecuteResult result =
+        runtime.execute("likeH2", "LH", PipelineExecuteRequest.empty());
+
+    assertEquals(2, result.getRowCount());
+    assertTrue(
+        result.getRows().stream()
+            .allMatch(r -> String.valueOf(r.get("Name")).startsWith("wf")));
   }
 
   @Test


### PR DESCRIPTION
## Summary

**Partial** for **#2359** (parent **#1690**, residual of **#2340** / **#2269** / **#2248**): pipeline SQL planner residual — executable **where-clause IR** for generated SELECT/mutation filter path, and **documented multi-table join product limit** with rejection tests.

### Operator
Operator: Grok: night-issue-prs (model grok-4.5)

### Changes
- **`WhereClauseIr`** — COLUMN/PARAM/LITERAL/OTHER operands; operator; AND/OR; `omitWhenNull`
- **`SelectorStageIr`** — `whereClauses` list (count stays in sync / backward compatible)
- **`PSClassicPipelineImporter`** — maps classic `PSWhereClause` / replacement values into IR (golden `sys_adminCataloger` → `TYPE = :sys_key`)
- **`PSPipelineSqlPlanner`** — generated SELECT WHERE prefers IR (`=`, `<>`, `!=`, comparisons, LIKE, IS NULL/NOT NULL; PARAM/LITERAL binds; AND/OR; omitWhenNull); `JOIN_PRODUCT_LIMIT_MESSAGE` when `joinCount > 0`; multi-table tanks rejected
- **Docs** — `docs/developer-module/pipeline-ir-v1.md` product limit + IR shape
- **Tests** — IR import + H2 PARAM/LIKE + join rejection (`PSPipelineIrServiceTest`, `PSPipelineRuntimeServiceTest`)
- **Erlang** — APPROVE `docs/ai-generated/code-reviews/issue-2359-where-clause-ir-join-limit-erlang.md`

### Residual
Full multi-table **join-graph SQL generation** deferred: **#2391** (under parent #1690). Until then, use single table or `nativeStatement` SELECT with hand-authored joins.

### Out of scope
- Designer UI / graph editor
- REST rework (#2269 / #2341)
- Re-do UPDATE/DELETE flags / txn modes (#2340 / #2360)

## Test plan
- [x] `cd system && ../mvnw.cmd "-Dtest=PSPipelineIrServiceTest,PSPipelineRuntimeServiceTest" test` — 31/31 pass
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS** (Tests run: 1212, Failures: 0, Errors: 0, Skipped: 237)
- [x] Erlang self-review APPROVE

## Gates evidence
- Module standalone clean install: green (2026-08-08)
- Erlang: APPROVE in docs path above
- Commit: `af40f0066a2667fab756ae041facf13f6d503d5a`

## Links
- Partial for #2359
- Parent #1690
- Refs #2340 #2269 #2248
- Residual join-graph #2391

> Co-Authored by Grok Build using grok-4.5 with agent main.