### PR TITLE
fix(perc-system): cms.objectstore rawtypes batch 2d — Key/ItemDef/proxies (#2376)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2376-cms-objectstore-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2376-cms-objectstore-rawtypes-erlang.md
@@ -1,0 +1,32 @@
+# Erlang self-review — issue #2376 (cms.objectstore rawtypes batch 2d)
+
+**Date:** 2026-08-08  
+**Branch:** `fix/issue-2376-cms-objectstore-rawtypes-2d`  
+**Verdict:** **approve**
+
+## Scope reviewed
+- `PSKey` — `HashMap<String,String>` name/value map; typed fromXml/toXml/clone locals
+- `PSProcessorProxy` / `PSComponentProcessorProxy` — `createComponentProcessorGroups` → `Map<PSProcessorCommon, Collection<IPSDbComponent>>`; typed property sets; `Class<?>` reflection
+- `PSItemDefinition` — typed display-mapper / field-set iterators; `Map<String,PSCollection>` options; slot/variant `Iterator` types
+- `PSCloningOptions` — `Map<Integer,Integer>` community/site mappings (ctors + getters + field)
+- `PSCmsProperty` — `Collection<String>` getValues/setValues; typed key parts
+- `PSComponentUtils` — `List<String>` enums; `Iterator<Element>` children
+- `PSDbComponentSet` clone residual diamond constructors
+- Companion: `PSServerFolderProcessor` site/community mapping consumers
+- Tests: `PSKeyTest.testTypedNameValueMapRoundTrip`, `PSCloningOptionsTest.testTypedMappingApis`, `PSComponentUtilsAndPropertyGenericsTest` (3)
+
+## Checks
+| Gate | Result |
+| --- | --- |
+| Behavior change | None intentional — real generics only; cast removals match prior runtime types |
+| Bug risk | Low — processor grouping still keys on `PSProcessorCommon` (was always cast); mapping maps already documented as Integer→Integer |
+| Portable paths | N/A (no path I/O) |
+| Behavioral tests | New/extended tests for key map, cloning maps, component utils/property XML |
+| Companion types | Folder processor updated for typed `getSiteMappings`/`getCommunityMappings` |
+| Copyright | New test file uses Intersoft 2026 header |
+
+## Notes
+- Residual package rawtypes remain (e.g. more `PSItemDefinition`/`PSCoreItem`/`server/*` handlers, display-format iterators, IPSComponent `List` parentComponents from design.objectstore interface). File next residual under #2022 if inventory still large after this batch.
+- `@SuppressWarnings("unchecked")` on `PSDisplayMapper.iterator()` sites: design.objectstore collection iterators still raw; local variables typed as `Iterator<PSDisplayMapping>`.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
@@ -23,7 +23,6 @@ import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.w3c.dom.Document;
@@ -44,7 +43,11 @@ public class PSCloningOptions extends PSComponent {
    * @see #PSCloningOptions(int, String, String, String, int, int, Map) for documentation
    */
   public PSCloningOptions(
-      int type, String folderName, int copyOption, int copyContentOption, Map communityMappings) {
+      int type,
+      String folderName,
+      int copyOption,
+      int copyContentOption,
+      Map<? extends Integer, ? extends Integer> communityMappings) {
     this(type, null, null, folderName, copyOption, copyContentOption, communityMappings);
   }
 
@@ -70,7 +73,7 @@ public class PSCloningOptions extends PSComponent {
       String folderName,
       int copyOption,
       int copyContentOption,
-      Map communityMappings) {
+      Map<? extends Integer, ? extends Integer> communityMappings) {
     if (!isValid(type, ms_typeEnum))
       throw new IllegalArgumentException("type must be one of TYPE_XXX");
     m_type = type;
@@ -327,7 +330,7 @@ public class PSCloningOptions extends PSComponent {
    *
    * @return the source - target community mappings, never <code>null</code>, may be empty.
    */
-  public Map getCommunityMappings() {
+  public Map<Integer, Integer> getCommunityMappings() {
     return m_communityMappings;
   }
 
@@ -336,7 +339,7 @@ public class PSCloningOptions extends PSComponent {
    *
    * @return the source to target site id mappings, never <code>null</code>, may be empty.
    */
-  public Map getSiteMappings() {
+  public Map<Integer, Integer> getSiteMappings() {
     return m_siteMappings;
   }
 
@@ -491,14 +494,10 @@ public class PSCloningOptions extends PSComponent {
       Element communityMappings = doc.createElement(COMMUNITY_MAPPINGS_ELEM);
       root.appendChild(communityMappings);
 
-      Iterator sources = m_communityMappings.keySet().iterator();
-      while (sources.hasNext()) {
-        Integer source = (Integer) sources.next();
-        Integer target = (Integer) m_communityMappings.get(source);
-
+      for (Map.Entry<Integer, Integer> entry : m_communityMappings.entrySet()) {
         Element mapping = doc.createElement(MAPPING_ELEM);
-        mapping.setAttribute(SOURCEID_ATTR, source.toString());
-        mapping.setAttribute(TARGETID_ATTR, target.toString());
+        mapping.setAttribute(SOURCEID_ATTR, entry.getKey().toString());
+        mapping.setAttribute(TARGETID_ATTR, entry.getValue().toString());
         communityMappings.appendChild(mapping);
       }
     }
@@ -507,14 +506,10 @@ public class PSCloningOptions extends PSComponent {
       Element siteMappings = doc.createElement(SITE_MAPPINGS_ELEM);
       root.appendChild(siteMappings);
 
-      Iterator sources = m_siteMappings.keySet().iterator();
-      while (sources.hasNext()) {
-        Integer source = (Integer) sources.next();
-        Integer target = (Integer) m_siteMappings.get(source);
-
+      for (Map.Entry<Integer, Integer> entry : m_siteMappings.entrySet()) {
         Element mapping = doc.createElement(MAPPING_ELEM);
-        mapping.setAttribute(SOURCEID_ATTR, source.toString());
-        mapping.setAttribute(TARGETID_ATTR, target.toString());
+        mapping.setAttribute(SOURCEID_ATTR, entry.getKey().toString());
+        mapping.setAttribute(TARGETID_ATTR, entry.getValue().toString());
         siteMappings.appendChild(mapping);
       }
     }
@@ -655,7 +650,7 @@ public class PSCloningOptions extends PSComponent {
    * Maps source site ids as <code>Integer</code> to target site ids as <code>Integer</code>.
    * Initialized to an empty map, updated through {@link #addSiteMapping(Integer, Integer)}.
    */
-  private Map m_siteMappings = new HashMap();
+  private Map<Integer, Integer> m_siteMappings = new HashMap<>();
 
   /**
    * Indicates if source items workflow should be used as long as it is valid. Transient value that

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCmsProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCmsProperty.java
@@ -23,7 +23,6 @@ import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -136,12 +135,10 @@ public abstract class PSCmsProperty extends PSDbComponent {
   protected String[] getKeyPartValues(IPSKeyGenerator gen) throws PSCmsException {
     if (m_keyControl == 0) return super.getKeyPartValues(gen);
 
-    List keyParts = new ArrayList();
+    List<String> keyParts = new ArrayList<>();
     if ((m_keyControl & KEYASSIGN_NAME_AS_KEYPART) == 0) keyParts.add(m_strName);
     if ((m_keyControl & KEYASSIGN_VALUE_AS_KEYPART) == 0) keyParts.add(m_strValue);
-    String[] keyValues = new String[keyParts.size()];
-    keyParts.toArray(keyValues);
-    return keyValues;
+    return keyParts.toArray(new String[0]);
   }
 
   /**
@@ -225,10 +222,8 @@ public abstract class PSCmsProperty extends PSDbComponent {
     root.setAttribute(XML_ATTR_PROPERTYNAME, m_strName);
     if (m_keyControl != 0) root.setAttribute(XML_ATTR_KEYCONTROL, "" + m_keyControl);
 
-    Iterator it = getValues().iterator();
-    while (it.hasNext()) {
-      Element elVal =
-          PSXmlDocumentBuilder.addElement(doc, root, XML_NODE_PROPERTYVALUE, (String) it.next());
+    for (String value : getValues()) {
+      Element elVal = PSXmlDocumentBuilder.addElement(doc, root, XML_NODE_PROPERTYVALUE, value);
 
       if (elVal == null)
         throw new IllegalStateException("Unable to create " + XML_NODE_PROPERTYVALUE + " element.");
@@ -253,8 +248,8 @@ public abstract class PSCmsProperty extends PSDbComponent {
    * @return Never <code>null</code>. Must contain at least 1 entry. All entries must be of type
    *     String.
    */
-  protected Collection getValues() {
-    Collection c = new ArrayList();
+  protected Collection<String> getValues() {
+    Collection<String> c = new ArrayList<>();
     c.add(getValue());
     return c;
   }
@@ -270,13 +265,13 @@ public abstract class PSCmsProperty extends PSDbComponent {
     int keyControl = PSXMLDomUtil.checkAttributeInt(src, XML_ATTR_KEYCONTROL, false);
     if (keyControl >= 0) m_keyControl = keyControl & KEYASSIGN_ALL;
 
-    Collection values = new ArrayList();
+    Collection<String> values = new ArrayList<>();
     Element el = PSXMLDomUtil.getNextElementSibling(kEl);
     while (el != null && el.getTagName().equals(XML_NODE_PROPERTYVALUE)) {
       values.add(PSXMLDomUtil.getElementData(el));
       el = PSXMLDomUtil.getNextElementSibling(el);
     }
-    if (values.size() == 0) {
+    if (values.isEmpty()) {
       String[] args = {getNodeName(), "Value", "missing node"};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
@@ -297,10 +292,10 @@ public abstract class PSCmsProperty extends PSDbComponent {
    *     type String. This class only uses the first entry.
    * @see #getValues
    */
-  protected void setValues(Collection values) {
-    if (null == values || values.size() == 0)
+  protected void setValues(Collection<String> values) {
+    if (null == values || values.isEmpty())
       throw new IllegalArgumentException("Must supply at least 1 value.");
-    m_strValue = (String) values.iterator().next();
+    m_strValue = values.iterator().next();
   }
 
   // see interface for description

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentProcessorProxy.java
@@ -20,7 +20,6 @@ import com.percussion.cms.PSCmsException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.w3c.dom.Element;
@@ -91,16 +90,15 @@ public class PSComponentProcessorProxy extends PSProcessorProxy implements IPSCo
   public PSSaveResults save(IPSDbComponent[] components) throws PSCmsException {
     if (null == components) throw new IllegalArgumentException("Supplied array cannot be null.");
 
-    Map procGroups = createComponentProcessorGroups(components);
+    Map<PSProcessorCommon, Collection<IPSDbComponent>> procGroups =
+        createComponentProcessorGroups(components);
 
     PSProcessingStatistics totals = new PSProcessingStatistics(0, 0);
     List<IPSDbComponent> resultComps = new ArrayList<>();
-    Iterator iter = procGroups.keySet().iterator();
-    while (iter.hasNext()) {
-      PSProcessorCommon proc = (PSProcessorCommon) iter.next();
-      Collection coll = (Collection) procGroups.get(proc);
-      IPSDbComponent[] comps = new IPSDbComponent[coll.size()];
-      coll.toArray(comps);
+    for (Map.Entry<PSProcessorCommon, Collection<IPSDbComponent>> entry : procGroups.entrySet()) {
+      PSProcessorCommon proc = entry.getKey();
+      Collection<IPSDbComponent> coll = entry.getValue();
+      IPSDbComponent[] comps = coll.toArray(new IPSDbComponent[0]);
       PSSaveResults results = proc.save(comps);
       PSProcessingStatistics stats = results.getResultStats();
       totals =
@@ -112,8 +110,7 @@ public class PSComponentProcessorProxy extends PSProcessorProxy implements IPSCo
               totals.getErroredCount() + stats.getErroredCount());
       resultComps.addAll(Arrays.asList(results.getResults()));
     }
-    IPSDbComponent[] res = new IPSDbComponent[resultComps.size()];
-    resultComps.toArray(res);
+    IPSDbComponent[] res = resultComps.toArray(new IPSDbComponent[0]);
     return new PSSaveResults(res, totals);
   }
 
@@ -135,16 +132,14 @@ public class PSComponentProcessorProxy extends PSProcessorProxy implements IPSCo
       throw new IllegalArgumentException("Component array and members cannot be null.");
     }
 
-    Map procGroups = createComponentProcessorGroups(components);
+    Map<PSProcessorCommon, Collection<IPSDbComponent>> procGroups =
+        createComponentProcessorGroups(components);
 
     int total = 0;
-    Iterator iter = procGroups.keySet().iterator();
-    while (iter.hasNext()) {
-      PSProcessorCommon proc = (PSProcessorCommon) iter.next();
-      Collection coll = (Collection) procGroups.get(proc);
-      IPSDbComponent[] comps = new IPSDbComponent[coll.size()];
-      coll.toArray(comps);
-      total += proc.delete(comps);
+    for (Map.Entry<PSProcessorCommon, Collection<IPSDbComponent>> entry : procGroups.entrySet()) {
+      Collection<IPSDbComponent> coll = entry.getValue();
+      IPSDbComponent[] comps = coll.toArray(new IPSDbComponent[0]);
+      total += entry.getKey().delete(comps);
     }
     return total;
   }
@@ -155,7 +150,7 @@ public class PSComponentProcessorProxy extends PSProcessorProxy implements IPSCo
   }
 
   // see interface for description
-  public void reorder(int insertAt, List comp) throws PSCmsException {
+  public void reorder(int insertAt, List<?> comp) throws PSCmsException {
     throw new UnsupportedOperationException("Not Implemented");
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentUtils.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentUtils.java
@@ -41,8 +41,8 @@ public class PSComponentUtils {
    * @throws PSUnknownNodeTypeException if the attribute exists and its value is not one of the
    *     allowed values.
    */
-  public static String getEnumeratedAttribute(Element el, String attrib, List allowedValues)
-      throws PSUnknownNodeTypeException {
+  public static String getEnumeratedAttribute(
+      Element el, String attrib, List<String> allowedValues) throws PSUnknownNodeTypeException {
     if (el == null) throw new IllegalArgumentException("el may not be null.");
 
     if (attrib == null || attrib.trim().length() == 0)
@@ -58,7 +58,7 @@ public class PSComponentUtils {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
     }
 
-    if (value == null || value.trim().length() == 0) value = (String) allowedValues.get(0);
+    if (value == null || value.trim().length() == 0) value = allowedValues.get(0);
 
     return value;
   }
@@ -108,14 +108,14 @@ public class PSComponentUtils {
     if (childName == null || childName.trim().length() == 0)
       throw new IllegalArgumentException("childName may not be null or empty.");
 
-    Iterator list = getChildElements(el, childName);
+    Iterator<Element> list = getChildElements(el, childName);
     if (!list.hasNext() && required) {
       Object[] args = {el.getTagName(), "null"};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     Element child = null;
-    if (list.hasNext()) child = (Element) list.next();
+    if (list.hasNext()) child = list.next();
 
     return child;
   }
@@ -129,18 +129,18 @@ public class PSComponentUtils {
    * null</code>
    * @throws IllegalArgumentException if any parameter is invalid.
    */
-  public static Iterator getChildElements(Element element, String childName) {
+  public static Iterator<Element> getChildElements(Element element, String childName) {
     if (element == null) throw new IllegalArgumentException("el may not be null.");
 
     if (childName == null || childName.trim().length() == 0)
       throw new IllegalArgumentException("childName may not be null or empty.");
 
-    List children = new ArrayList();
+    List<Element> children = new ArrayList<>();
     NodeList list = element.getElementsByTagName(childName);
     int length = list.getLength();
     for (int i = 0; i < length; i++) {
       Node item = list.item(i);
-      if (item.getParentNode() == element) children.add(item);
+      if (item.getParentNode() == element) children.add((Element) item);
     }
 
     return children.iterator();

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentSet.java
@@ -826,12 +826,12 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
       m_isCloning = false;
     }
 
-    copy.m_set = new HashSet(); // objects added below
-    copy.m_deleteList = new ArrayList();
+    copy.m_set = new HashSet<>(); // objects added below
+    copy.m_deleteList = new ArrayList<>();
 
     Iterator<T> iter = iterator();
     while (iter.hasNext()) {
-      IPSDbComponent c = (IPSDbComponent) iter.next();
+      IPSDbComponent c = iter.next();
       if (c.getState() != DBSTATE_MARKEDFORDELETE) copy.add((IPSDbComponent) c.clone());
     }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
@@ -24,6 +24,7 @@ import com.percussion.design.objectstore.IPSDocument;
 import com.percussion.design.objectstore.IPSValidationContext;
 import com.percussion.design.objectstore.PSBackEndColumn;
 import com.percussion.design.objectstore.PSBackEndTable;
+import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSContainerLocator;
 import com.percussion.design.objectstore.PSContentEditor;
 import com.percussion.design.objectstore.PSContentEditorMapper;
@@ -185,9 +186,10 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
     PSContentEditorMapper mapper = getContentEditorMapper();
     PSUIDefinition def = mapper.getUIDefinition();
     PSDisplayMapper parent = def.getDisplayMapper();
-    Iterator mappings = parent.iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> mappings = parent.iterator();
     while (mappings.hasNext()) {
-      PSDisplayMapping mapping = (PSDisplayMapping) mappings.next();
+      PSDisplayMapping mapping = mappings.next();
       PSDisplayMapper childMapper = mapping.getDisplayMapper();
       if (childMapper != null) childMappers.add(childMapper);
     }
@@ -233,9 +235,10 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    */
   private List<PSField> getFields(PSFieldSet fieldSet, PSDisplayMapper mapper) {
     List<PSField> fields = new ArrayList<>();
-    Iterator mappings = mapper.iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> mappings = mapper.iterator();
     while (mappings.hasNext()) {
-      PSDisplayMapping mapping = (PSDisplayMapping) mappings.next();
+      PSDisplayMapping mapping = mappings.next();
       String fieldName = mapping.getFieldRef();
 
       Object o = fieldSet.get(fieldName);
@@ -257,9 +260,10 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
         PSFieldSet childFs = (PSFieldSet) o;
         if (childFs.getType() == PSFieldSet.TYPE_SIMPLE_CHILD) {
           PSDisplayMapper childMapper = mapping.getDisplayMapper();
-          Iterator childMappings = childMapper.iterator();
+          @SuppressWarnings("unchecked")
+          Iterator<PSDisplayMapping> childMappings = childMapper.iterator();
           while (childMappings.hasNext()) {
-            PSDisplayMapping childMapping = (PSDisplayMapping) childMappings.next();
+            PSDisplayMapping childMapping = childMappings.next();
             fieldName = childMapping.getFieldRef();
             o = fieldSet.getChildField(fieldName, PSFieldSet.TYPE_SIMPLE_CHILD);
           }
@@ -315,10 +319,11 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
   public List<String> getSingleDimensionParentTextFieldNames() {
     List<String> fn = new ArrayList<>();
     PSContentEditorMapper mapper = getContentEditorMapper();
-    Iterator iter = mapper.getUIDefinition().getDisplayMapper().iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> iter = mapper.getUIDefinition().getDisplayMapper().iterator();
     PSFieldSet fieldSet = mapper.getFieldSet();
     while (iter.hasNext()) {
-      PSDisplayMapping dm = (PSDisplayMapping) iter.next();
+      PSDisplayMapping dm = iter.next();
       if (dm.getDisplayMapper() == null) {
         String fieldName = dm.getFieldRef();
         PSField fld = fieldSet.getFieldByName(fieldName);
@@ -458,7 +463,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
     PSFieldSet fs = def.getFieldSet();
     PSUIDefinition ui = def.getUIDefinition();
     Collection<PSField> results = new ArrayList<>();
-    Iterator fields = fs.getAll(false);
+    Iterator<PSComponent> fields = fs.getAll(false);
     while (fields.hasNext()) {
       PSField field = (PSField) fields.next();
       if (!field.isReadOnly() && null == ui.getMapping(field.getSubmitName())) {
@@ -476,7 +481,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
   }
 
   /** Returns clone of Options map */
-  protected Map getOptionsMap() {
+  protected Map<String, PSCollection> getOptionsMap() {
     return null;
   }
 
@@ -494,7 +499,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    *
    * @return <code>null</code>.
    */
-  public Iterator getSlotNames() {
+  public Iterator<String> getSlotNames() {
     return null;
   }
 
@@ -503,7 +508,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    *
    * @return <code>null</code>.
    */
-  public Iterator getSlotIds() {
+  public Iterator<Integer> getSlotIds() {
     return null;
   }
 
@@ -513,7 +518,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    * @param slotName
    * @return <code>null</code>.
    */
-  public Iterator getVariantNames(@SuppressWarnings("unused") String slotName) {
+  public Iterator<String> getVariantNames(@SuppressWarnings("unused") String slotName) {
     return null;
   }
 
@@ -522,7 +527,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    *
    * @param slotId
    */
-  public Iterator getVariantIds(@SuppressWarnings("unused") int slotId) {
+  public Iterator<Integer> getVariantIds(@SuppressWarnings("unused") int slotId) {
     return null;
   }
 
@@ -713,15 +718,15 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
       PSContentEditorPipe pipe = (PSContentEditorPipe) m_contentEditorDef.getPipe();
       PSContentEditorMapper ceMapper = pipe.getMapper();
       PSFieldSet fs = ceMapper.getFieldSet(); // Get parent
-      Iterator setiter = fs.getAll();
+      Iterator<PSComponent> setiter = fs.getAll();
       while (setiter.hasNext()) {
-        Object x = setiter.next();
+        PSComponent x = setiter.next();
         if (x instanceof PSFieldSet) {
           PSFieldSet set = (PSFieldSet) x;
           if (set.getType() == PSFieldSet.TYPE_SIMPLE_CHILD) {
-            Iterator fields = set.getAll();
+            Iterator<PSComponent> fields = set.getAll();
             while (fields.hasNext()) {
-              Object f = fields.next();
+              PSComponent f = fields.next();
               if (f instanceof PSField) {
                 PSField field = (PSField) f;
                 m_simpleChildFieldSets.put(field.getSubmitName(), set);
@@ -780,9 +785,10 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
   private int getPageId(String fieldName, PSDisplayMapper mapper, PSFieldSet fs, int[] curPageId) {
     int pageId = -1;
     int currentPage = curPageId[0];
-    Iterator mappings = mapper.iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> mappings = mapper.iterator();
     while (mappings.hasNext() && pageId == -1) {
-      PSDisplayMapping mapping = (PSDisplayMapping) mappings.next();
+      PSDisplayMapping mapping = mappings.next();
       Object o = fs.get(mapping.getFieldRef());
       if (o == null) continue;
       boolean isComplexChild =
@@ -945,8 +951,10 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
     List<PSFieldSet> results = new ArrayList<>();
     PSUIDefinition def = mapper.getUIDefinition();
     PSDisplayMapper dmapper = def.getDisplayMapper();
-    for (Iterator mappingIter = dmapper.iterator(); mappingIter.hasNext(); ) {
-      PSDisplayMapping entry = (PSDisplayMapping) mappingIter.next();
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> mappingIter = dmapper.iterator();
+    while (mappingIter.hasNext()) {
+      PSDisplayMapping entry = mappingIter.next();
       PSDisplayMapper childMapper = entry.getDisplayMapper();
       if (childMapper == null) continue;
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSKey.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSKey.java
@@ -286,7 +286,7 @@ public class PSKey implements IPSCmsComponent, Serializable {
    * @return The value for the named part, or "" if no value has been assigned.
    */
   public final String getPart(String name) {
-    String value = (String) m_nameValueMap.get(name.toLowerCase());
+    String value = m_nameValueMap.get(name.toLowerCase());
 
     if (value == null) return "";
     else return value;
@@ -383,11 +383,11 @@ public class PSKey implements IPSCmsComponent, Serializable {
       if (m_needGenerateId) root.setAttribute(XML_ATTR_NEED_GEN_ID, XML_TRUE);
     }
 
-    Iterator entries = Arrays.asList(m_definition).iterator();
+    Iterator<String> entries = Arrays.asList(m_definition).iterator();
     while (entries.hasNext()) {
-      String name = (String) entries.next();
+      String name = entries.next();
 
-      String val = (String) m_nameValueMap.get(name.toLowerCase());
+      String val = m_nameValueMap.get(name.toLowerCase());
 
       PSXmlDocumentBuilder.addElement(doc, root, name, val);
     }
@@ -423,8 +423,8 @@ public class PSKey implements IPSCmsComponent, Serializable {
     String sNeedGenerateId = PSXMLDomUtil.checkAttribute(src, XML_ATTR_NEED_GEN_ID, false);
 
     // get the properties / definition & values
-    List defs = new ArrayList();
-    Map nameValueMap = new HashMap();
+    List<String> defs = new ArrayList<>();
+    Map<String, String> nameValueMap = new HashMap<>();
     Element propEl = PSXMLDomUtil.getFirstElementChild(src);
     while (propEl != null) {
       String name = propEl.getNodeName();
@@ -436,7 +436,7 @@ public class PSKey implements IPSCmsComponent, Serializable {
       propEl = PSXMLDomUtil.getNextElementSibling(propEl);
     }
     String[] definition = new String[defs.size()];
-    for (int i = 0; i < defs.size(); i++) definition[i] = (String) defs.get(i);
+    for (int i = 0; i < defs.size(); i++) definition[i] = defs.get(i);
 
     // validate the key part
     if (validate && !isSameType(definition)) {
@@ -509,10 +509,10 @@ public class PSKey implements IPSCmsComponent, Serializable {
     try {
       copy = (PSKey) super.clone();
       copy.m_definition = m_definition.clone();
-      copy.m_nameValueMap = new HashMap();
-      Iterator pairs = m_nameValueMap.keySet().iterator();
+      copy.m_nameValueMap = new HashMap<>();
+      Iterator<String> pairs = m_nameValueMap.keySet().iterator();
       while (pairs.hasNext()) {
-        String key = (String) pairs.next();
+        String key = pairs.next();
         copy.m_nameValueMap.put(key, m_nameValueMap.get(key));
       }
     } catch (Exception e) {
@@ -609,7 +609,7 @@ public class PSKey implements IPSCmsComponent, Serializable {
    * <code>String</code>. Never <code>null</code>, but may be empty. Declared as {@link HashMap}
    * (not {@link Map}) so the field type is {@link Serializable} under {@code -Xlint:serial}.
    */
-  private HashMap m_nameValueMap = new HashMap();
+  private HashMap<String, String> m_nameValueMap = new HashMap<>();
 
   /**
    * The definitions in its original case sensitive form. Initialized by the constructor, never

--- a/system/src/main/java/com/percussion/cms/objectstore/PSProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSProcessorProxy.java
@@ -32,7 +32,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.w3c.dom.Document;
@@ -189,7 +188,6 @@ public abstract class PSProcessorProxy {
       String procType, PSXmlTreeWalker walker, ProcessorConfig cfg)
       throws PSUnknownNodeTypeException {
     final String COMPONENT_NODE = "CmsComponent";
-    Map result = new HashMap();
     Element e =
         walker.getNextElement(
             COMPONENT_NODE,
@@ -307,16 +305,16 @@ public abstract class PSProcessorProxy {
    * @throws PSCmsException If the processor cannot be found or instantiated for any of the
    *     components.
    */
-  protected Map createComponentProcessorGroups(IPSDbComponent[] components) throws PSCmsException {
-    Map procGroups = new HashMap();
+  protected Map<PSProcessorCommon, Collection<IPSDbComponent>> createComponentProcessorGroups(
+      IPSDbComponent[] components) throws PSCmsException {
+    Map<PSProcessorCommon, Collection<IPSDbComponent>> procGroups = new HashMap<>();
     for (int i = 0; i < components.length; i++) {
       IPSDbComponent c = components[i];
       if (null == c) continue;
-      Object proc = m_processorConfig.getProcessor(c);
-      Collection coll;
-      if (procGroups.containsKey(proc)) coll = (Collection) procGroups.get(proc);
-      else {
-        coll = new ArrayList();
+      PSProcessorCommon proc = (PSProcessorCommon) m_processorConfig.getProcessor(c);
+      Collection<IPSDbComponent> coll = procGroups.get(proc);
+      if (coll == null) {
+        coll = new ArrayList<>();
         procGroups.put(proc, coll);
       }
       coll.add(c);
@@ -345,17 +343,14 @@ public abstract class PSProcessorProxy {
       }
     }
 
-    Map procGroups = createComponentProcessorGroups(comps);
+    Map<PSProcessorCommon, Collection<IPSDbComponent>> procGroups =
+        createComponentProcessorGroups(comps);
 
-    int total = 0;
-    Iterator iter = procGroups.keySet().iterator();
-    while (iter.hasNext()) {
-      PSProcessorCommon proc = (PSProcessorCommon) iter.next();
-      Collection coll = (Collection) procGroups.get(proc);
+    for (Map.Entry<PSProcessorCommon, Collection<IPSDbComponent>> entry : procGroups.entrySet()) {
+      PSProcessorCommon proc = entry.getKey();
+      Collection<IPSDbComponent> coll = entry.getValue();
       proc.setNextAllocationSize(coll.size());
-      Iterator it = coll.iterator();
-      while (it.hasNext()) {
-        IPSDbComponent c = (IPSDbComponent) it.next();
+      for (IPSDbComponent c : coll) {
         c.assignKey(proc, parentKey);
       }
     }
@@ -408,7 +403,8 @@ public abstract class PSProcessorProxy {
      * @return <code>true</code> if the property already existed in this configuration, <code>false
      *     </code> otherwise.
      */
-    public boolean addComponentPropertySet(String componentType, Map props, String procClassName) {
+    public boolean addComponentPropertySet(
+        String componentType, Map<String, Object> props, String procClassName) {
       String type = componentType.toLowerCase();
       boolean present = m_componentProps.containsKey(type);
       m_componentProps.put(type, props);
@@ -437,7 +433,7 @@ public abstract class PSProcessorProxy {
 
         if (m_cachedProcs.containsKey(name)) return m_cachedProcs.get(name);
 
-        Class cl = Class.forName(name);
+        Class<?> cl = Class.forName(name);
 
         try {
           Method instanceMethod = cl.getMethod("getInstance");
@@ -449,7 +445,7 @@ public abstract class PSProcessorProxy {
           // Ignore
         }
 
-        Constructor[] ctors = cl.getConstructors();
+        Constructor<?>[] ctors = cl.getConstructors();
         // find the one w/ the Map param
         String paramType = "java.util.Map";
         boolean found = false;
@@ -458,8 +454,8 @@ public abstract class PSProcessorProxy {
         for (; i < ctors.length && !found; i++) {
           /* If no context, look for ctor(Map), otherwise look for
           ctor(m_context.getClass(), Map) */
-          Constructor ctor = ctors[i];
-          Class[] paramTypes = ctor.getParameterTypes();
+          Constructor<?> ctor = ctors[i];
+          Class<?>[] paramTypes = ctor.getParameterTypes();
           if (paramTypes.length == 2
               && paramTypes[paramIndex].getName().equals(paramType)
               && (m_context == null || paramTypes[0].isAssignableFrom(m_context.getClass()))) {
@@ -549,7 +545,7 @@ public abstract class PSProcessorProxy {
      *     contain name/value pairs. The value is either a String or an Element. This should be
      *     treated read- only by the caller.
      */
-    public Map getComponentPropertySets() {
+    public Map<String, Map<String, Object>> getComponentPropertySets() {
       return m_componentProps;
     }
 

--- a/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
@@ -4152,21 +4152,19 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
       logger.info("Community mappings:");
       Map<Integer, Integer> communityMappings = options.getCommunityMappings();
-      Iterator sourceCommunities = communityMappings.keySet().iterator();
-      while (sourceCommunities.hasNext()) {
-        Integer sourceCommunity = (Integer) sourceCommunities.next();
-        Integer targetCommunity = (Integer) communityMappings.get(sourceCommunity);
+      for (Map.Entry<Integer, Integer> entry : communityMappings.entrySet()) {
+        Integer sourceCommunity = entry.getKey();
+        Integer targetCommunity = entry.getValue();
         if (sourceCommunity == null || targetCommunity == null) break;
 
         logger.info("Source: {} --> Target: {}", sourceCommunity, targetCommunity);
       }
 
       logger.info("Site mappings:");
-      Map siteMappings = options.getSiteMappings();
-      Iterator sourceSites = siteMappings.keySet().iterator();
-      while (sourceSites.hasNext()) {
-        Integer sourceSite = (Integer) sourceSites.next();
-        Integer targetSite = (Integer) siteMappings.get(sourceSite);
+      Map<Integer, Integer> siteMappings = options.getSiteMappings();
+      for (Map.Entry<Integer, Integer> entry : siteMappings.entrySet()) {
+        Integer sourceSite = entry.getKey();
+        Integer targetSite = entry.getValue();
         if (sourceSite == null || targetSite == null) break;
 
         logger.info("Source: {} --> Target: {}", sourceSite, targetSite);
@@ -4411,7 +4409,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
       String siteId = PSUrlUtils.getUrlParameterValue(homePageUrl, IPSHtmlParameters.SYS_SITEID);
       if (siteId != null) {
-        Integer sid = (Integer) options.getSiteMappings().get(Integer.valueOf(siteId));
+        Integer sid = options.getSiteMappings().get(Integer.valueOf(siteId));
         if (sid != null) {
           homePageUrl =
               PSUrlUtils.replaceUrlParameterValue(
@@ -4629,8 +4627,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
 
         // change the community if mapped
         Integer newCommunity =
-            (Integer)
-                options.getCommunityMappings().get(Integer.valueOf(newFolder.getCommunityId()));
+            options.getCommunityMappings().get(Integer.valueOf(newFolder.getCommunityId()));
         if (newCommunity != null) {
           context.setSessionPrivateObject(IPSHtmlParameters.SYS_COMMUNITY, newCommunity.toString());
           newFolder.setCommunityId(newCommunity.intValue());
@@ -4907,7 +4904,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
               String originalSiteId = relationship.getProperty(IPSHtmlParameters.SYS_SITEID);
               if (originalSiteId != null && originalSiteId.trim().length() > 0) {
                 Integer newSiteId =
-                    (Integer) options.getSiteMappings().get(Integer.valueOf(originalSiteId));
+                    options.getSiteMappings().get(Integer.valueOf(originalSiteId));
                 if (newSiteId != null) {
                   newRelationship.setProperty(IPSHtmlParameters.SYS_SITEID, newSiteId.toString());
 

--- a/system/src/test/java/com/percussion/cms/objectstore/PSCloningOptionsTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSCloningOptionsTest.java
@@ -35,7 +35,7 @@ public class PSCloningOptionsTest {
    */
   @Test
   public void testConstructors() throws Exception {
-    Map communityMappings = new HashMap();
+    Map<Integer, Integer> communityMappings = new HashMap<>();
 
     // test valid site type
     new PSCloningOptions(
@@ -143,7 +143,7 @@ public class PSCloningOptionsTest {
    */
   @Test
   public void testPublicAPI() throws Exception {
-    Map communityMappings = new HashMap();
+    Map<Integer, Integer> communityMappings = new HashMap<>();
     communityMappings.put(Integer.valueOf(1), Integer.valueOf(2));
     communityMappings.put(Integer.valueOf(3), Integer.valueOf(4));
     communityMappings.put(Integer.valueOf(5), Integer.valueOf(6));
@@ -217,6 +217,45 @@ public class PSCloningOptionsTest {
     options_5.addSiteMapping(Integer.valueOf(102), Integer.valueOf(203));
     PSCloningOptions options_5_copy = new PSCloningOptions(options_5.toXml(doc), null, null);
     assertTrue(options_5.equals(options_5_copy));
+  }
+
+  /**
+   * Typed community / site mapping getters after generics batch (#2376): maps preserve entries
+   * through construction, addSiteMapping, and XML round-trip.
+   */
+  @Test
+  public void testTypedMappingApis() throws Exception {
+    Map<Integer, Integer> communities = new HashMap<>();
+    communities.put(10, 20);
+    communities.put(30, 40);
+
+    PSCloningOptions options =
+        new PSCloningOptions(
+            PSCloningOptions.TYPE_SITE,
+            "srcSite",
+            "newSite",
+            "folder",
+            PSCloningOptions.COPY_NO_CONTENT,
+            PSCloningOptions.COPYCONTENT_AS_LINK,
+            communities);
+
+    Map<Integer, Integer> gotCommunities = options.getCommunityMappings();
+    assertEquals(Integer.valueOf(20), gotCommunities.get(10));
+    assertEquals(Integer.valueOf(40), gotCommunities.get(30));
+    assertEquals(2, gotCommunities.size());
+
+    options.addSiteMapping(100, 200);
+    options.addSiteMapping(101, 201);
+    Map<Integer, Integer> sites = options.getSiteMappings();
+    assertEquals(Integer.valueOf(200), sites.get(100));
+    assertEquals(Integer.valueOf(201), sites.get(101));
+    assertEquals(2, sites.size());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSCloningOptions restored = new PSCloningOptions(options.toXml(doc), null, null);
+    assertEquals(options.getCommunityMappings(), restored.getCommunityMappings());
+    assertEquals(options.getSiteMappings(), restored.getSiteMappings());
+    assertEquals(options, restored);
   }
 
   // JUnit 3 style suite removed; using JUnit 5 test methods

--- a/system/src/test/java/com/percussion/cms/objectstore/PSComponentUtilsAndPropertyGenericsTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSComponentUtilsAndPropertyGenericsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for {@link PSComponentUtils} and {@link PSCmsProperty} generics
+ * parameterization (issue #2376 cms.objectstore rawtypes batch 2d).
+ */
+public class PSComponentUtilsAndPropertyGenericsTest {
+
+  @Test
+  public void testGetEnumeratedAttribute() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = doc.createElement("Test");
+    List<String> allowed = Arrays.asList("alpha", "beta", "gamma");
+
+    // missing attribute → first allowed value
+    assertEquals("alpha", PSComponentUtils.getEnumeratedAttribute(el, "kind", allowed));
+
+    el.setAttribute("kind", "beta");
+    assertEquals("beta", PSComponentUtils.getEnumeratedAttribute(el, "kind", allowed));
+
+    el.setAttribute("kind", "delta");
+    assertThrows(
+        PSUnknownNodeTypeException.class,
+        () -> PSComponentUtils.getEnumeratedAttribute(el, "kind", allowed));
+  }
+
+  @Test
+  public void testGetChildElementsTyped() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = doc.createElement("Root");
+    Element a = doc.createElement("Child");
+    a.setAttribute("id", "1");
+    Element b = doc.createElement("Child");
+    b.setAttribute("id", "2");
+    Element nested = doc.createElement("Nested");
+    Element deep = doc.createElement("Child");
+    deep.setAttribute("id", "deep");
+    nested.appendChild(deep);
+    root.appendChild(a);
+    root.appendChild(b);
+    root.appendChild(nested);
+    doc.appendChild(root);
+
+    Iterator<Element> children = PSComponentUtils.getChildElements(root, "Child");
+    assertTrue(children.hasNext());
+    assertEquals("1", children.next().getAttribute("id"));
+    assertTrue(children.hasNext());
+    assertEquals("2", children.next().getAttribute("id"));
+    assertFalse(children.hasNext()); // nested Child is not immediate
+  }
+
+  @Test
+  public void testCmsPropertyValueRoundTrip() throws Exception {
+    // concrete subclass of abstract PSCmsProperty
+    PSDFProperty prop = new PSDFProperty("sys_title", "Hello");
+    assertEquals("sys_title", prop.getName());
+    assertEquals("Hello", prop.getValue());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = prop.toXml(doc);
+    PSDFProperty restored = new PSDFProperty(xml);
+    assertEquals(prop.getName(), restored.getName());
+    assertEquals(prop.getValue(), restored.getValue());
+  }
+}

--- a/system/src/test/java/com/percussion/cms/objectstore/PSKeyTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSKeyTest.java
@@ -239,4 +239,38 @@ public class PSKeyTest {
       assertEquals(99, serSimple.getKeyValueAsInt());
     }
   }
+
+  /**
+   * After {@code HashMap<String,String>} parameterization (#2376): multi-part keys retain part
+   * names/values across toXml/fromXml and clone.
+   */
+  @Test
+  public void testTypedNameValueMapRoundTrip() throws Exception {
+    String[] def = new String[] {"CONTENTID", "REVISIONID", "FOLDERID"};
+    String[] vals = new String[] {"1001", "3", "55"};
+    PSKey key = new PSKey(def, vals, true);
+
+    assertEquals(3, key.getPartCount());
+    assertEquals("1001", key.getPart("CONTENTID"));
+    assertEquals("3", key.getPart("REVISIONID"));
+    assertEquals("55", key.getPart("FOLDERID"));
+    // map keys are lower-cased internally; part lookup is case-insensitive
+    assertEquals("1001", key.getPart("contentid"));
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = key.toXml(doc);
+    PSKey fromXml = new PSKey(el);
+    assertEquals(key, fromXml);
+    assertEquals("1001", fromXml.getPart("CONTENTID"));
+    assertEquals("3", fromXml.getPart("REVISIONID"));
+    assertEquals("55", fromXml.getPart("FOLDERID"));
+
+    PSKey clone = (PSKey) key.clone();
+    assertEquals(key, clone);
+    assertEquals("55", clone.getPart("FOLDERID"));
+    // mutate clone; original must stay independent
+    clone.setPart("FOLDERID", "99");
+    assertEquals("55", key.getPart("FOLDERID"));
+    assertEquals("99", clone.getPart("FOLDERID"));
+  }
 }


### PR DESCRIPTION
## Summary

Slice **2d** of parent **#2022** (grandparent **#2200**): real generics for residual rawtypes/unchecked in `com.percussion.cms.objectstore` after #2349 / PR #2377.

### Changes
- **`PSKey`** — `HashMap<String,String>` name/value map; typed fromXml/toXml/clone locals
- **`PSProcessorProxy` / `PSComponentProcessorProxy`** — `createComponentProcessorGroups` → `Map<PSProcessorCommon, Collection<IPSDbComponent>>`; typed property sets; `Class<?>` reflection
- **`PSItemDefinition`** — typed display-mapper / field-set iterators; `Map<String,PSCollection>` options; slot/variant `Iterator` types
- **`PSCloningOptions`** — `Map<Integer,Integer>` community/site mappings (ctors + getters + field)
- **`PSCmsProperty`** — `Collection<String>` getValues/setValues; typed key parts
- **`PSComponentUtils`** — `List<String>` enums; `Iterator<Element>` children
- **`PSDbComponentSet`** clone residual diamond constructors
- **Companion:** `PSServerFolderProcessor` site/community mapping consumers
- **Tests** — `PSKeyTest.testTypedNameValueMapRoundTrip`; `PSCloningOptionsTest.testTypedMappingApis`; `PSComponentUtilsAndPropertyGenericsTest` (3)
- **Erlang** — approve (`docs/ai-generated/code-reviews/issue-2376-cms-objectstore-rawtypes-erlang.md`)

### Residual
Follow-up **#2401** (PSCoreItem/DisplayFormat/Folder/action iterators, server handlers residual after this batch).

### Out of scope (per #2376)
- design.objectstore, this-escape/serial, data.jdbc

## Test plan
- [x] `cd system` → `../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Module tests: **1217** run, **0** failures, **0** errors (237 skipped pre-existing)
- [x] Focused: PSKeyTest + PSCloningOptionsTest + PSComponentUtilsAndPropertyGenericsTest → **12** green
- [x] Erlang self-review: approve

## Gates evidence
| Gate | Result |
| --- | --- |
| Standalone module clean install (`cd system`) | BUILD SUCCESS |
| Behavioral unit tests | 12 green (focused) |
| Scope confined to cms.objectstore batch + folder processor companion | yes |
| Erlang | approve |

Parent tracker: #2022  
Grandparent: #2200  
Residual: #2401  

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2376  
Refs #2022 #2200 #2349

> Co-Authored by Grok Build using grok-4.5 with agent main.