### PR TITLE
fix(perc-system): design.objectstore serialVersionUID A–C leftover batch (#2366)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
@@ -36,6 +36,8 @@ import org.w3c.dom.Node;
  */
 @SuppressWarnings("serial")
 public class PSApplicationFlow extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Create a new map of command handler redirects for the provided name and default redirect.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
@@ -36,6 +36,8 @@ import org.w3c.dom.Node;
  */
 @SuppressWarnings("serial")
 public class PSCommandHandlerStylesheets extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Create a new map of command handler stylesheets for the provided name and default stylesheet.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
@@ -34,6 +34,8 @@ import org.w3c.dom.Node;
 
 /** Implements the PSXContentEditorMapper DTD defined in ContentEditorLocalDef.dtd. */
 public class PSContentEditorMapper extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new content editor mapper for the provided parameters.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
@@ -30,6 +30,8 @@ import org.w3c.dom.Node;
 
 /** Implements the PSXContentEditorPipe DTD defined in ContentEditorLocalDef.dtd. */
 public class PSContentEditorPipe extends PSPipe {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Create a new content editor pipe.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSharedDef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSharedDef.java
@@ -30,6 +30,8 @@ import org.w3c.dom.Element;
 
 /** Implements the PSXContentEditorSharedDef DTD defined in ContentEditorSharedDef.dtd. */
 public class PSContentEditorSharedDef extends PSComponent implements IPSDocument {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /** Creates a new empty shared content editor definition. */
   public PSContentEditorSharedDef() {}
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentItemData.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentItemData.java
@@ -21,6 +21,8 @@ import org.w3c.dom.Element;
 
 /** The replacement values used for content item data information. */
 public class PSContentItemData extends PSNamedReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a new content item data from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentItemStatus.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentItemStatus.java
@@ -23,6 +23,8 @@ import org.w3c.dom.Element;
 
 /** The replacement values used for content item status information. */
 public class PSContentItemStatus extends PSNamedReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a new content itme status from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentType.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentType.java
@@ -25,6 +25,8 @@ import org.w3c.dom.Element;
 
 /** Represents a content type from the content management system. */
 public class PSContentType extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Initializes a newly created <code>PSContentType</code> object, from an XML representation. See
    * {@link #toXml(Document)} for the format.

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
@@ -29,6 +29,8 @@ import org.w3c.dom.Element;
  * &lt;psxctl:ControlMeta&gt; node in <code>sys_LibraryControlDef.dtd</code>
  */
 public class PSControlMeta extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Initializes a newly created <code>PSControlMeta</code> object, from an XML representation. See
    * {@link #toXml(Document)} for the format.

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
@@ -31,6 +31,8 @@ import org.w3c.dom.NodeList;
  * sys_LibraryControlDef.dtd</code>
  */
 public class PSControlParameter extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Initializes a newly created <code>PSControlParameter</code> object, from an XML representation.
    * See {@link #toXml(Document)} for the format.

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXControlRef DTD in BasicObjects.dtd. */
 public class PSControlRef extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a new <code>PSControlRef</code> as a (shallow) copy of <code>source</code>.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSCookie.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCookie.java
@@ -29,6 +29,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSCookie extends PSNamedReplacementValue {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
@@ -28,6 +28,8 @@ import org.w3c.dom.Node;
 
 /** Implementation for the PSCustomActionGroup DTD in BasicObjects.dtd. */
 public class PSCustomActionGroup extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Creates a new custom action group for the provided location and actions.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomError.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomError.java
@@ -42,6 +42,8 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSCustomError extends PSComponent {
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialVersionUidTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialVersionUidTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Java serialization checks for design.objectstore types that received {@code serialVersionUID} in
- * the #2313 D–M and #2319 N–Z batches (parent #2022).
+ * the #2313 D–M, #2319 N–Z, and #2366 A–C leftover batches (parent #2022).
  */
 public class PSObjectStoreSerialVersionUidTest {
 
@@ -116,6 +116,55 @@ public class PSObjectStoreSerialVersionUidTest {
     assertEquals(1L, readSerialVersionUid(PSTableSet.class));
     assertEquals(1L, readSerialVersionUid(PSSystemValidationException.class));
     assertEquals(1L, readSerialVersionUid(PSRelationshipPropertyDataPk.class));
+  }
+
+  @Test
+  public void testAcLeftoverNamedValueSerialization() throws Exception {
+    PSCookie cookie = new PSCookie("rx_session");
+    cookie.setId(21);
+
+    PSContentItemData itemData = new PSContentItemData("sys_title");
+    itemData.setId(22);
+
+    PSContentItemStatus itemStatus = new PSContentItemStatus("CONTENTSTATUS", "CONTENTID");
+    itemStatus.setId(23);
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(cookie);
+      oos.writeObject(itemData);
+      oos.writeObject(itemStatus);
+      bytes = bos.toByteArray();
+    }
+
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      PSCookie serCookie = (PSCookie) ois.readObject();
+      PSContentItemData serData = (PSContentItemData) ois.readObject();
+      PSContentItemStatus serStatus = (PSContentItemStatus) ois.readObject();
+
+      assertEquals("rx_session", serCookie.getName());
+      assertEquals(21, serCookie.getId());
+      assertEquals("sys_title", serData.getName());
+      assertEquals(22, serData.getId());
+      assertEquals("CONTENTSTATUS.CONTENTID", serStatus.getName());
+      assertEquals(23, serStatus.getId());
+    }
+
+    assertEquals(1L, readSerialVersionUid(PSCookie.class));
+    assertEquals(1L, readSerialVersionUid(PSContentItemData.class));
+    assertEquals(1L, readSerialVersionUid(PSContentItemStatus.class));
+    assertEquals(1L, readSerialVersionUid(PSApplicationFlow.class));
+    assertEquals(1L, readSerialVersionUid(PSCommandHandlerStylesheets.class));
+    assertEquals(1L, readSerialVersionUid(PSContentEditorMapper.class));
+    assertEquals(1L, readSerialVersionUid(PSContentEditorPipe.class));
+    assertEquals(1L, readSerialVersionUid(PSContentEditorSharedDef.class));
+    assertEquals(1L, readSerialVersionUid(PSContentType.class));
+    assertEquals(1L, readSerialVersionUid(PSControlMeta.class));
+    assertEquals(1L, readSerialVersionUid(PSControlParameter.class));
+    assertEquals(1L, readSerialVersionUid(PSControlRef.class));
+    assertEquals(1L, readSerialVersionUid(PSCustomActionGroup.class));
+    assertEquals(1L, readSerialVersionUid(PSCustomError.class));
   }
 
   private static long readSerialVersionUid(Class<?> type) throws Exception {


### PR DESCRIPTION
## Summary

PR-sized batch for **#2366** (parent **#2022** / grandparent **#2200**): clear remaining `-Xlint:serial` missing-`serialVersionUID` diagnostics for **design.objectstore** types in the **A–C** alphabetical leftover range after #2297 / #2313 (D–M) / #2319 (N–Z).

### serialVersionUID batch (14 types)
`serialVersionUID = 1L` on Serializable `design.objectstore` classes:
- Flow/UI: `PSApplicationFlow`, `PSCommandHandlerStylesheets`, `PSCustomActionGroup`, `PSCustomError`
- Content editor graph: `PSContentEditorMapper`, `PSContentEditorPipe`, `PSContentEditorSharedDef`, `PSContentType`
- Named replacement values: `PSContentItemData`, `PSContentItemStatus`, `PSCookie`
- Controls: `PSControlMeta`, `PSControlParameter`, `PSControlRef`

Skipped non-Serializable `PSDatabaseComponent` / `PSCollectionComponent` subclasses (no dead UID). Did **not** blanket-suppress this-escape.

### Metrics (this batch)
| Kind | Δ (this PR) |
| --- | ---: |
| missing serialVersionUID | **−14** (design.objectstore A–C leftover) |
| this-escape | 0 (deferred → #2404) |
| serial-field | 0 (deferred → #2405) |

### Residual
- #2403 — cms.objectstore serialVersionUID
- #2404 — design.objectstore this-escape ctor/fromXml
- #2405 — serial-field on hottest editors

## Test plan
- [x] `cd system && ../mvnw clean install` — **BUILD SUCCESS**, Tests run: **1265**, Failures: **0**, Errors: **0**
- [x] `PSObjectStoreSerialVersionUidTest` — A–C serialization round-trip for `PSCookie` / `PSContentItemData` / `PSContentItemStatus` + `serialVersionUID` field checks for all 14 types

## Gates evidence
- Erlang-style self-review: constant-only UID additions; no constructor/XML behavior change; non-Serializable types excluded; portable paths N/A; no suppress-only this-escape
- Change-class companions: serialVersionUID lint batch (peer #2319 / PR #2367) + behavioral serialization test
- Module install: `system` standalone `mvnw clean install` green (JDK 21)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2366
Refs #2022 #2200 #2319

### Residual issues
- #2403 — cms.objectstore serialVersionUID after #2366
- #2404 — design.objectstore this-escape after #2366
- #2405 — serial-field hottest editors after #2366

> Co-Authored by Grok Build using grok-4.5 with agent main.