### PR TITLE
feat(explorer): #2400 DCE parity — shell composition + displayformats REST (#2407)

### DIFF
--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -143,13 +143,30 @@ cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.css \
 - Functional components + hooks; strict TypeScript (avoid `any`)
 - Feature modules under `src/main/ts/<feature>/`
 - REST via `api/client.ts` + feature APIs; CSRF from bootstrap / `OWASP_CSRFTOKEN`
-- i18n via TMX `message()` helpers — no raw keys in primary chrome
+- i18n via TMX `message()` helpers — no raw English product chrome strings
 - **Crowdsource translation (alpha, third-party):** vendored `@mkd/language` **0.4** under `WebUI/vendor/mkd-language/`. Adapter: `src/main/ts/i18n/mkdLanguage.ts`. Keys from tracked `message()`. Submit: `postUrl` → **`POST /Rhythmyx/rest/i18n/corrections`** (CSRF via `getCsrfToken()`). Server: `perc.mkd.language.enabled` + `perc.mkd.language.roles` (empty=off; `*`=all; else role list; suggest `Translations_Team`). GCM config in `server.properties` (`perc.mkd.gcm.*`, PAT as `ENC(...)`). Native `mkd_gcm_ffi` in `<installdir>/bin`. Opt-in UX: `?mkdLang=1`. Treat mkd as external — no GCM design docs here.
 - Styles: CSS modules preferred; theme tokens via `ui-themes`
 - Tests: **two layers** — Vitest for unit/component logic **and** Playwright for live-CMS screen behavior (see **Playwright (HARD GATE)**)
 - Prefer stable `data-testid` on interactive chrome so Playwright selectors stay reliable
 - SPA routing: `app/routes.tsx` + deep-link allowlists; server entry allowlists stay in lockstep
 - **No jQuery** — see product lock #2. If a legacy page used `$('…')` or FancyTree, reimplement in React or use a non-jQuery primitive.
+
+### Content Explorer — i18n + 508 / accessibility (HARD GATE)
+
+Applies to **all** work under `WebUI/src/main/ts/contentExplorer/**`,
+`WebUI/src/main/ts/api/contentExplorer/**`, Explorer SPA routes, and Explorer
+Playwright specs (feature **992**, parity **#2400**, and follow-ups).
+
+| Requirement | Rule |
+|-------------|------|
+| **i18n (FR-026)** | Every **product chrome** string (labels, buttons, titles, empty/error states, `aria-label` / `aria-labelledby` text, `role="status"` / `alert` copy) MUST go through `message(EXPLORER_MSG.<KEY>)`. Keys live in `contentExplorer/messages.ts` as `perc.ui.explorer@<English default>`. |
+| **No bare English chrome** | Do **not** hardcode user-visible English in JSX. Server/catalog values (display-format names, action menu labels from REST, CMS path/item titles) may render as data — not as product chrome. |
+| **508 / WCAG** | Keyboard-completable flows; meaningful `aria-*` / roles on toolbars, toggles (`aria-expanded` / `aria-controls` / `aria-pressed`), regions, lists, and dialogs. Prefer labels tied to controls (`htmlFor` / `aria-labelledby`). |
+| **Vitest a11y gate (T082a)** | New or changed Explorer components MUST call `renderA11yGate(container)` from `WebUI/src/test/ts/contentExplorer/a11y.ts` (zero **serious** / **critical** axe violations; WCAG 2.0/2.1 A+AA tags). |
+| **Playwright a11y gate (T082b)** | Product-visible Explorer screen changes MUST keep/extend `expectNoSeriousA11yViolations` in `modules/perc-qa-automation/frontend/tests/` (e.g. `us1-core-explorer.spec.js`) scoped to `[data-testid="content-explorer-shell"]` (or the changed surface). |
+| **Checklists** | `specs/992-react-content-explorer/checklists/a11y-spotcheck.md`, `…/i18n-key-presence.md`; parity program: `specs/2400-dce-explorer-parity/`. |
+
+**Done means** i18n + a11y gates green — not only that a panel mounts.
 
 ### Java (WebUI)
 

--- a/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typed client for the public REST display-format catalog used by the
+ * modern Content Explorer list (#2400 / FR-027).
+ *
+ * <p>Provider: {@code rest} {@code DisplayFormatResource} at
+ * {@code GET /Rhythmyx/rest/displayformats}. Optional query filters
+ * {@code validForFolder} and {@code validForViewsAndSearches} are applied
+ * server-side.</p>
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+import type { DisplayFormat, DisplayFormatColumn } from "../developer/types";
+
+export type { DisplayFormat, DisplayFormatColumn };
+
+function asArray<T>(payload: unknown): T[] {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload as T[];
+  if (typeof payload === "object") {
+    const obj = payload as Record<string, unknown>;
+    const raw =
+      obj.DisplayFormat ??
+      obj.displayFormat ??
+      obj.DisplayFormatList ??
+      obj.displayFormatList;
+    if (raw == null) return [];
+    return Array.isArray(raw) ? (raw as T[]) : [raw as T];
+  }
+  return [];
+}
+
+export function normalizeDisplayFormatColumns(
+  columns: DisplayFormat["columns"],
+): DisplayFormatColumn[] {
+  if (columns == null) return [];
+  if (Array.isArray(columns)) return columns;
+  const wrapped = columns.DisplayFormatColumn;
+  if (wrapped == null) return [];
+  return Array.isArray(wrapped) ? wrapped : [wrapped];
+}
+
+export interface ListDisplayFormatsParams {
+  validForFolder?: boolean;
+  validForViewsAndSearches?: boolean;
+}
+
+/** GET /services/displayformats with optional Explorer filters. */
+export async function listDisplayFormats(
+  params: ListDisplayFormatsParams = {},
+): Promise<DisplayFormat[]> {
+  const q = new URLSearchParams();
+  if (params.validForFolder !== undefined) {
+    q.set("validForFolder", String(params.validForFolder));
+  }
+  if (params.validForViewsAndSearches !== undefined) {
+    q.set("validForViewsAndSearches", String(params.validForViewsAndSearches));
+  }
+  const qs = q.toString();
+  const payload = await get<unknown>(
+    `${PATHS.DISPLAY_FORMATS}${qs ? `?${qs}` : ""}`,
+  );
+  return asArray<DisplayFormat>(payload);
+}
+
+/** GET /services/displayformats/{idOrName} */
+export async function getDisplayFormatDetail(
+  idOrName: string,
+): Promise<DisplayFormat> {
+  const key = encodeURIComponent(idOrName);
+  return get<DisplayFormat>(`${PATHS.DISPLAY_FORMATS}/${key}`);
+}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -311,21 +311,34 @@ export function ContentExplorerShell({
               onError={handleActionError}
             />
           </div>
-          <div style={toolRowStyle} data-testid="explorer-server-actions">
+          <div
+            style={toolRowStyle}
+            data-testid="explorer-server-actions"
+            role="group"
+            aria-label={message(EXPLORER_MSG.SERVER_ACTIONS_ARIA)}
+          >
             <ActionToolbar
               actions={menuActions}
-              ariaLabel={message(EXPLORER_MSG.TITLE)}
+              ariaLabel={message(EXPLORER_MSG.SERVER_ACTIONS_ARIA)}
               onInvoke={() => {
                 // Server URL actions navigate; client-only refresh list.
                 setListEpoch((n) => n + 1);
               }}
             />
           </div>
-          <div style={toolRowStyle} data-testid="explorer-view-tools">
+          <div
+            style={toolRowStyle}
+            data-testid="explorer-view-tools"
+            role="toolbar"
+            aria-label={message(EXPLORER_MSG.VIEW_TOOLS_ARIA)}
+          >
             <button
               type="button"
               data-testid="explorer-toggle-search"
               aria-pressed={showSearch}
+              aria-expanded={showSearch}
+              aria-controls="explorer-search-panel"
+              aria-label={message(EXPLORER_MSG.TOGGLE_SEARCH_ARIA)}
               onClick={() => setShowSearch((v) => !v)}
             >
               {message(EXPLORER_MSG.SEARCH_TITLE)}
@@ -334,19 +347,26 @@ export function ContentExplorerShell({
               type="button"
               data-testid="explorer-toggle-security"
               aria-pressed={showSecurity}
+              aria-expanded={showSecurity}
+              aria-controls="explorer-security-panel"
+              aria-label={message(EXPLORER_MSG.TOGGLE_SECURITY_ARIA)}
               onClick={() => setShowSecurity((v) => !v)}
             >
               {message(EXPLORER_MSG.SECURITY_TITLE)}
             </button>
             <label
+              htmlFor="explorer-display-format"
               style={{ display: "inline-flex", gap: 6, alignItems: "center" }}
             >
-              <span>{message(EXPLORER_MSG.DISPLAY_FORMAT_LABEL)}</span>
+              <span id="explorer-display-format-label">
+                {message(EXPLORER_MSG.DISPLAY_FORMAT_LABEL)}
+              </span>
               <select
+                id="explorer-display-format"
                 data-testid="explorer-display-format"
                 value={selectedFormatKey}
                 onChange={(e) => setSelectedFormatKey(e.target.value)}
-                aria-label={message(EXPLORER_MSG.DISPLAY_FORMAT_LABEL)}
+                aria-labelledby="explorer-display-format-label"
               >
                 <option value="">
                   {message(EXPLORER_MSG.DISPLAY_FORMAT_DEFAULT)}
@@ -354,6 +374,8 @@ export function ContentExplorerShell({
                 {displayFormats.map((df) => {
                   const key = displayFormatOptionKey(df);
                   if (!key) return null;
+                  // Server catalog labels (displayName/label/name) are
+                  // CMS design data, not product chrome — not TMX keys.
                   const label = df.displayName || df.label || df.name || key;
                   return (
                     <option key={key} value={key}>
@@ -367,7 +389,11 @@ export function ContentExplorerShell({
         </div>
       </header>
       {error && (
-        <div style={{ ...errorStateStyle, gridColumn: "1 / -1" }} role="alert">
+        <div
+          style={{ ...errorStateStyle, gridColumn: "1 / -1" }}
+          role="alert"
+          aria-live="assertive"
+        >
           {message(EXPLORER_MSG.ERROR_GENERIC)}: {error}
         </div>
       )}
@@ -388,7 +414,12 @@ export function ContentExplorerShell({
         onItemContextMenu={handleItemContextMenu}
       />
       {showSearch && (
-        <div style={sidePanelStyle} data-testid="explorer-search-panel">
+        <section
+          id="explorer-search-panel"
+          style={sidePanelStyle}
+          data-testid="explorer-search-panel"
+          aria-label={message(EXPLORER_MSG.SEARCH_PANEL_REGION)}
+        >
           <SearchPanel
             onOpen={handleSearchOpen}
             onReveal={handleSearchReveal}
@@ -398,18 +429,29 @@ export function ContentExplorerShell({
                 : undefined
             }
           />
-        </div>
+        </section>
       )}
       {showSecurity && securityFolderId && (
-        <div style={sidePanelStyle} data-testid="explorer-security-panel">
+        <section
+          id="explorer-security-panel"
+          style={sidePanelStyle}
+          data-testid="explorer-security-panel"
+          aria-label={message(EXPLORER_MSG.SECURITY_PANEL_REGION)}
+        >
           <FolderSecurityPanel
             folderId={securityFolderId}
             currentUserIdentities={[]}
           />
-        </div>
+        </section>
       )}
       {showSecurity && !securityFolderId && (
-        <div style={sidePanelStyle} data-testid="explorer-security-hint">
+        <div
+          id="explorer-security-panel"
+          style={sidePanelStyle}
+          data-testid="explorer-security-hint"
+          role="status"
+          aria-live="polite"
+        >
           {message(EXPLORER_MSG.SECURITY_SELECT_FOLDER)}
         </div>
       )}
@@ -422,6 +464,7 @@ export function ContentExplorerShell({
             zIndex: 1000,
           }}
           data-testid="explorer-context-menu-anchor"
+          role="presentation"
         >
           <ContextMenu
             actions={contextMenu.actions}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -125,12 +125,17 @@ async function defaultLoadMenuActions(
   return mapActionMenusToMenuActions(menus);
 }
 
+/** Stable default — module scope so useEffect deps do not refetch every render. */
+async function defaultLoadDisplayFormats(): Promise<DisplayFormat[]> {
+  return listDisplayFormats({ validForFolder: true });
+}
+
 export function ContentExplorerShell({
   initialPath = "/",
   onOpenItem = openInEditor,
   actionHandlers,
   onFolderActivated,
-  loadDisplayFormats = () => listDisplayFormats({ validForFolder: true }),
+  loadDisplayFormats = defaultLoadDisplayFormats,
   loadMenuActions = defaultLoadMenuActions,
 }: ContentExplorerShellProps): React.ReactElement {
   const [selection, setSelection] = useState<Selection>(EMPTY_SELECTION);

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -15,22 +15,39 @@
  */
 
 /**
- * ContentExplorerShell — modern React shell for primary content navigation
- * (feature 992-react-content-explorer US1 / T017).
+ * ContentExplorerShell — product Explorer route shell (feature 992 + #2400).
  *
- * <p>Layout: grid with tree on the left, detail list on the right, and a
- * header carrying the title + the ReducedAction bar. Selection state is
- * lifted here; the tree and list are controlled components.</p>
- *
- * <p>The shell does not own navigation; onOpen delegates to the host
- * (default = {@link openInEditor}) so dialog mounts can override.</p>
+ * <p>Composes tree, detail list, reduced actions, server-driven action
+ * toolbar, context menu, search panel, and display-format selector so the
+ * SPA route approaches Desktop Content Explorer parity.</p>
  */
 
-import React, { useCallback, useState } from "react";
-import type { PSPathItem } from "../api/contentExplorer/types";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  findActions,
+  findAllowedContentTypeMenus,
+  mapActionMenusToMenuActions,
+} from "../api/contentExplorer/actionMenuApi";
+import {
+  listDisplayFormats,
+  normalizeDisplayFormatColumns,
+  type DisplayFormat,
+} from "../api/contentExplorer/displayFormatsApi";
+import type {
+  MenuAction,
+  PSItemProperties,
+  PSPathItem,
+} from "../api/contentExplorer/types";
 import { message } from "../i18n/message";
+import { ActionToolbar } from "./ActionToolbar";
+import { ContextMenu } from "./ContextMenu";
 import { DetailList } from "./DetailList";
+import {
+  displayFormatOptionKey,
+  toDetailDisplayFormat,
+} from "./displayFormatMap";
 import { ExplorerTree } from "./ExplorerTree";
+import { FolderSecurityPanel } from "./FolderSecurityPanel";
 import { EXPLORER_MSG } from "./messages";
 import { openInEditor } from "./openInEditor";
 import {
@@ -38,6 +55,7 @@ import {
   defaultReducedActionHandlers,
   type ReducedActionHandlers,
 } from "./ReducedActions";
+import { SearchPanel } from "./SearchPanel";
 import { EMPTY_SELECTION, type Selection } from "./selection";
 import {
   errorStateStyle,
@@ -58,6 +76,53 @@ export interface ContentExplorerShellProps {
    * work (analytics, deep-link handling, etc.) before the list refreshes.
    */
   onFolderActivated?: (path: string, folder: PSPathItem) => void;
+  /** Test seam: override display-format catalog load. */
+  loadDisplayFormats?: () => Promise<DisplayFormat[]>;
+  /** Test seam: override action menu load. */
+  loadMenuActions?: (item: PSPathItem | null) => Promise<MenuAction[]>;
+}
+
+type ContextMenuState = {
+  actions: MenuAction[];
+  x: number;
+  y: number;
+} | null;
+
+const sidePanelStyle: React.CSSProperties = {
+  gridColumn: "1 / -1",
+  borderTop: "1px solid #ddd",
+  padding: 8,
+  background: "#fcfcfc",
+  maxHeight: "40vh",
+  overflow: "auto",
+};
+
+const toolRowStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  alignItems: "center",
+  marginTop: 6,
+};
+
+function parseContentId(id: string | undefined): number | null {
+  if (!id) return null;
+  const n = Number(id);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function defaultLoadMenuActions(
+  item: PSPathItem | null,
+): Promise<MenuAction[]> {
+  const contentId = parseContentId(item?.id);
+  if (contentId != null) {
+    const menus = await findAllowedContentTypeMenus([contentId]);
+    if (menus.length > 0) {
+      return mapActionMenusToMenuActions(menus);
+    }
+  }
+  const menus = await findActions({ item: true });
+  return mapActionMenusToMenuActions(menus);
 }
 
 export function ContentExplorerShell({
@@ -65,9 +130,18 @@ export function ContentExplorerShell({
   onOpenItem = openInEditor,
   actionHandlers,
   onFolderActivated,
+  loadDisplayFormats = () => listDisplayFormats({ validForFolder: true }),
+  loadMenuActions = defaultLoadMenuActions,
 }: ContentExplorerShellProps): React.ReactElement {
   const [selection, setSelection] = useState<Selection>(EMPTY_SELECTION);
   const [error, setError] = useState<string | null>(null);
+  const [showSearch, setShowSearch] = useState(false);
+  const [showSecurity, setShowSecurity] = useState(false);
+  const [displayFormats, setDisplayFormats] = useState<DisplayFormat[]>([]);
+  const [selectedFormatKey, setSelectedFormatKey] = useState<string>("");
+  const [menuActions, setMenuActions] = useState<MenuAction[]>([]);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+  const [listEpoch, setListEpoch] = useState(0);
 
   const handlers: ReducedActionHandlers = {
     ...defaultReducedActionHandlers(),
@@ -81,12 +155,64 @@ export function ContentExplorerShell({
     },
     onPreview: actionHandlers?.onPreview ?? (() => undefined),
   };
-  // Preview is real only when the host supplies its own handler; default is no-op.
   const hasPreviewHandler = Boolean(actionHandlers?.onPreview);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadDisplayFormats()
+      .then((list) => {
+        if (cancelled) return;
+        setDisplayFormats(list ?? []);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        // Non-fatal: list still works with default columns.
+        console.warn(
+          "[ContentExplorerShell] display formats load failed",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadDisplayFormats]);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadMenuActions(selection.item)
+      .then((actions) => {
+        if (!cancelled) setMenuActions(actions ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setMenuActions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selection.item, loadMenuActions, listEpoch]);
+
+  const selectedFormat = useMemo(() => {
+    if (!selectedFormatKey) return null;
+    return (
+      displayFormats.find(
+        (df) => displayFormatOptionKey(df) === selectedFormatKey,
+      ) ?? null
+    );
+  }, [displayFormats, selectedFormatKey]);
+
+  const detailDisplayFormat = useMemo(() => {
+    if (!selectedFormat) return undefined;
+    return toDetailDisplayFormat(
+      normalizeDisplayFormatColumns(selectedFormat.columns),
+    );
+  }, [selectedFormat]);
+
+  const displayFormatId = selectedFormatKey || null;
 
   const handleSelectFolder = useCallback(
     (path: string, folder: PSPathItem | null) => {
       setSelection({ folderPath: path, item: null });
+      setContextMenu(null);
       if (folder) onFolderActivated?.(path, folder);
     },
     [onFolderActivated],
@@ -95,6 +221,7 @@ export function ContentExplorerShell({
   const handleActivate = useCallback(
     (path: string, folder: PSPathItem) => {
       setSelection({ folderPath: path, item: null });
+      setContextMenu(null);
       onFolderActivated?.(path, folder);
     },
     [onFolderActivated],
@@ -115,6 +242,56 @@ export function ContentExplorerShell({
     setError(msg);
   }, []);
 
+  const handleItemContextMenu = useCallback(
+    (item: PSPathItem, clientX: number, clientY: number) => {
+      setSelection((prev) => ({ ...prev, item }));
+      void loadMenuActions(item).then((actions) => {
+        setContextMenu({
+          actions: actions ?? [],
+          x: clientX,
+          y: clientY,
+        });
+      });
+    },
+    [loadMenuActions],
+  );
+
+  const handleSearchOpen = useCallback((result: PSItemProperties) => {
+    openInEditor({
+      id: result.id != null ? String(result.id) : undefined,
+      name: result.name ?? result.title ?? "",
+      // PSItemProperties exposes folderPath (parent); id-open when path empty.
+      path: result.folderPath ?? "",
+      type: result.type,
+    });
+  }, []);
+
+  const handleSearchReveal = useCallback((result: PSItemProperties) => {
+    const folder = result.folderPath;
+    if (folder) {
+      setSelection({ folderPath: folder, item: null });
+      setShowSearch(false);
+    }
+  }, []);
+
+  const folderForActions: PSPathItem | null =
+    selection.item?.type === "folder"
+      ? selection.item
+      : selection.folderPath
+        ? ({
+            id: undefined,
+            path: selection.folderPath,
+            name: selection.folderPath,
+            type: "folder",
+            accessLevel: "WRITE",
+          } as PSPathItem)
+        : null;
+
+  const securityFolderId =
+    selection.item?.type === "folder"
+      ? selection.item.id
+      : undefined;
+
   return (
     <div
       style={shellStyle}
@@ -123,31 +300,71 @@ export function ContentExplorerShell({
       data-testid="content-explorer-shell"
     >
       <header style={headerStyle}>
-        <h1 style={headerTitleStyle}>{message(EXPLORER_MSG.TITLE)}</h1>
-        <ReducedActions
-          item={selection.item}
-          folder={
-            selection.item?.type === "folder"
-              ? selection.item
-              : selection.folderPath
-                ? // US1 default: assume WRITE on the active folder so the
-                  // user can create sub-folders without first selecting an
-                  // item. Server enforces AuthZ; we surface failures via
-                  // onError. US4 (ACL) tightens this with real permission
-                  // data lifted from the tree.
-                  ({
-                    id: undefined,
-                    path: selection.folderPath,
-                    name: selection.folderPath,
-                    type: "folder",
-                    accessLevel: "WRITE",
-                  } as PSPathItem)
-                : null
-          }
-          handlers={handlers}
-          hasPreviewHandler={hasPreviewHandler}
-          onError={handleActionError}
-        />
+        <div style={{ display: "flex", flexDirection: "column", gap: 4, flex: 1 }}>
+          <h1 style={headerTitleStyle}>{message(EXPLORER_MSG.TITLE)}</h1>
+          <div style={toolRowStyle}>
+            <ReducedActions
+              item={selection.item}
+              folder={folderForActions}
+              handlers={handlers}
+              hasPreviewHandler={hasPreviewHandler}
+              onError={handleActionError}
+            />
+          </div>
+          <div style={toolRowStyle} data-testid="explorer-server-actions">
+            <ActionToolbar
+              actions={menuActions}
+              ariaLabel={message(EXPLORER_MSG.TITLE)}
+              onInvoke={() => {
+                // Server URL actions navigate; client-only refresh list.
+                setListEpoch((n) => n + 1);
+              }}
+            />
+          </div>
+          <div style={toolRowStyle} data-testid="explorer-view-tools">
+            <button
+              type="button"
+              data-testid="explorer-toggle-search"
+              aria-pressed={showSearch}
+              onClick={() => setShowSearch((v) => !v)}
+            >
+              {message(EXPLORER_MSG.SEARCH_TITLE)}
+            </button>
+            <button
+              type="button"
+              data-testid="explorer-toggle-security"
+              aria-pressed={showSecurity}
+              onClick={() => setShowSecurity((v) => !v)}
+            >
+              {message(EXPLORER_MSG.SECURITY_TITLE)}
+            </button>
+            <label
+              style={{ display: "inline-flex", gap: 6, alignItems: "center" }}
+            >
+              <span>{message(EXPLORER_MSG.DISPLAY_FORMAT_LABEL)}</span>
+              <select
+                data-testid="explorer-display-format"
+                value={selectedFormatKey}
+                onChange={(e) => setSelectedFormatKey(e.target.value)}
+                aria-label={message(EXPLORER_MSG.DISPLAY_FORMAT_LABEL)}
+              >
+                <option value="">
+                  {message(EXPLORER_MSG.DISPLAY_FORMAT_DEFAULT)}
+                </option>
+                {displayFormats.map((df) => {
+                  const key = displayFormatOptionKey(df);
+                  if (!key) return null;
+                  const label = df.displayName || df.label || df.name || key;
+                  return (
+                    <option key={key} value={key}>
+                      {label}
+                    </option>
+                  );
+                })}
+              </select>
+            </label>
+          </div>
+        </div>
       </header>
       {error && (
         <div style={{ ...errorStateStyle, gridColumn: "1 / -1" }} role="alert">
@@ -161,11 +378,61 @@ export function ContentExplorerShell({
         onActivate={handleActivate}
       />
       <DetailList
+        key={`list-${listEpoch}-${displayFormatId ?? "default"}`}
         folderPath={selection.folderPath}
         selectedItemId={selection.item?.id ?? null}
         onSelectItem={handleSelectItem}
         onActivateItem={handleActivateItem}
+        displayFormat={detailDisplayFormat}
+        displayFormatId={displayFormatId}
+        onItemContextMenu={handleItemContextMenu}
       />
+      {showSearch && (
+        <div style={sidePanelStyle} data-testid="explorer-search-panel">
+          <SearchPanel
+            onOpen={handleSearchOpen}
+            onReveal={handleSearchReveal}
+            initialCriteria={
+              selection.folderPath
+                ? { folderPath: selection.folderPath }
+                : undefined
+            }
+          />
+        </div>
+      )}
+      {showSecurity && securityFolderId && (
+        <div style={sidePanelStyle} data-testid="explorer-security-panel">
+          <FolderSecurityPanel
+            folderId={securityFolderId}
+            currentUserIdentities={[]}
+          />
+        </div>
+      )}
+      {showSecurity && !securityFolderId && (
+        <div style={sidePanelStyle} data-testid="explorer-security-hint">
+          {message(EXPLORER_MSG.SECURITY_SELECT_FOLDER)}
+        </div>
+      )}
+      {contextMenu && (
+        <div
+          style={{
+            position: "fixed",
+            left: contextMenu.x,
+            top: contextMenu.y,
+            zIndex: 1000,
+          }}
+          data-testid="explorer-context-menu-anchor"
+        >
+          <ContextMenu
+            actions={contextMenu.actions}
+            onClose={() => setContextMenu(null)}
+            onInvoke={() => {
+              setContextMenu(null);
+              setListEpoch((n) => n + 1);
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/WebUI/src/main/ts/contentExplorer/DetailList.tsx
+++ b/WebUI/src/main/ts/contentExplorer/DetailList.tsx
@@ -116,23 +116,67 @@ export function renderDisplayFormatCell(
   column: DetailColumnId,
   item: PSPathItem,
 ): string {
+  // Prefer pathmanagement displayProperties (columnData) when a display
+  // format id was requested — keys are CX system field names.
+  const fromProps = (keys: string[]): string => {
+    const props = item.displayProperties;
+    if (!props || typeof props !== "object") return "";
+    for (const key of keys) {
+      const v = props[key];
+      if (v != null && String(v).length > 0) return String(v);
+    }
+    const lowerKeys = keys.map((k) => k.toLowerCase());
+    for (const [k, v] of Object.entries(props)) {
+      if (lowerKeys.includes(k.toLowerCase()) && v != null && String(v).length > 0) {
+        return String(v);
+      }
+    }
+    return "";
+  };
+
   switch (column) {
     case "name":
-      return item.name ?? item.path ?? "";
+      return (
+        fromProps(["sys_title", "name", "Name"]) ||
+        item.name ||
+        item.path ||
+        ""
+      );
     case "type":
-      return item.type ?? item.category ?? "";
+      return (
+        fromProps(["sys_contenttypename", "sys_contenttype", "type", "Type"]) ||
+        item.type ||
+        item.category ||
+        ""
+      );
     case "path":
       return item.path ?? "";
     case "title":
-      return item.title ?? item.name ?? "";
+      return (
+        fromProps(["sys_title", "title", "Title"]) ||
+        item.title ||
+        item.name ||
+        ""
+      );
     case "category":
-      return item.category ?? "";
+      return fromProps(["category", "Category"]) || item.category || "";
     case "modified":
-      // API surface pending — see comment above.
-      return (item as unknown as { lastModified?: string }).lastModified ?? "";
+      return (
+        fromProps([
+          "sys_contentlastmodifieddate",
+          "sys_contentmodifieddate",
+          "lastModified",
+          "modified",
+        ]) ||
+        (item as unknown as { lastModified?: string }).lastModified ||
+        ""
+      );
     case "workflow":
-      // API surface pending — see comment above.
-      return (item as unknown as { workflowId?: string }).workflowId ?? "";
+      return (
+        fromProps(["sys_workflow", "sys_workflowid", "workflow", "workflowId"]) ||
+        (item as unknown as { workflowId?: string }).workflowId ||
+        ""
+      );
     default:
       return "";
   }
@@ -197,6 +241,13 @@ export interface DetailListProps {
    * in pure helpers so it can be unit-tested without rendering.
    */
   displayFormat?: DetailDisplayFormat;
+  /**
+   * Optional CX display format id passed to {@link paginatedFolder} so the
+   * server fills {@link PSPathItem.displayProperties} (columnData).
+   */
+  displayFormatId?: string | null;
+  /** Optional multi-select / context-menu affordance on row right-click. */
+  onItemContextMenu?: (item: PSPathItem, clientX: number, clientY: number) => void;
 }
 
 export function DetailList({
@@ -205,6 +256,8 @@ export function DetailList({
   onSelectItem,
   onActivateItem,
   displayFormat,
+  displayFormatId,
+  onItemContextMenu,
 }: DetailListProps): React.ReactElement {
   const [page, setPage] = useState(0);
   const [data, setData] = useState<PSPagedResult | null>(null);
@@ -240,14 +293,18 @@ export function DetailList({
     let cancelled = false;
     setLoading(true);
     setError(null);
-    paginatedFolder(folderPath, {
+    const params: Parameters<typeof paginatedFolder>[1] = {
       startIndex,
       maxResults: PAGE_SIZE,
-    })
-    .then((res) => {
-      if (cancelled) return;
-      setData(res as PSPagedResult);
-    })
+    };
+    if (displayFormatId) {
+      params.displayFormatId = displayFormatId;
+    }
+    paginatedFolder(folderPath, params)
+      .then((res) => {
+        if (cancelled) return;
+        setData(res as PSPagedResult);
+      })
       .catch((err: unknown) => {
         if (cancelled) return;
         const msg = err instanceof Error ? err.message : String(err);
@@ -259,7 +316,7 @@ export function DetailList({
     return () => {
       cancelled = true;
     };
-  }, [folderPath, page]);
+  }, [folderPath, page, displayFormatId]);
 
   const children = useMemo<PSPathItem[]>(() => {
     if (!data) return [];
@@ -344,6 +401,12 @@ export function DetailList({
                 aria-disabled={!visible}
                 onClick={() => visible && onSelectItem(item)}
                 onDoubleClick={() => visible && onActivateItem?.(item)}
+                onContextMenu={(e) => {
+                  if (!visible || !onItemContextMenu) return;
+                  e.preventDefault();
+                  onSelectItem(item);
+                  onItemContextMenu(item, e.clientX, e.clientY);
+                }}
                 onKeyDown={(e) => {
                   if (!visible) return;
                   if (e.key === "Enter") onActivateItem?.(item);

--- a/WebUI/src/main/ts/contentExplorer/displayFormatMap.ts
+++ b/WebUI/src/main/ts/contentExplorer/displayFormatMap.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Map REST display-format column definitions onto DetailList column ids
+ * and resolve cell values from {@link PSPathItem} + displayProperties
+ * (path list {@code columnData}).
+ *
+ * <p>Pure helpers for #2400 / FR-027 — unit-tested without rendering.</p>
+ */
+
+import type { DisplayFormatColumn } from "../api/contentExplorer/displayFormatsApi";
+import type { PSPathItem } from "../api/contentExplorer/types";
+import type { DetailColumnId, DetailDisplayFormat } from "./DetailList";
+
+/** Known CX system field sources → list column ids. */
+const SOURCE_TO_COLUMN: Record<string, DetailColumnId> = {
+  sys_title: "title",
+  sys_contentid: "name",
+  sys_contenttypename: "type",
+  sys_contenttype: "type",
+  sys_workflow: "workflow",
+  sys_workflowid: "workflow",
+  sys_contentlastmodifieddate: "modified",
+  sys_contentmodifieddate: "modified",
+  name: "name",
+  title: "title",
+  type: "type",
+  path: "path",
+  category: "category",
+  modified: "modified",
+  workflow: "workflow",
+};
+
+/**
+ * Map display-format columns to DetailList column ids (order-preserving,
+ * de-duplicated). Unknown sources are skipped; empty result falls back to
+ * the DetailList default (name/type/path).
+ */
+export function mapDisplayFormatToDetailColumns(
+  columns: DisplayFormatColumn[] | undefined | null,
+): DetailColumnId[] {
+  if (!columns || columns.length === 0) {
+    return [];
+  }
+  const out: DetailColumnId[] = [];
+  for (const col of columns) {
+    const source = (col.source ?? col.displayName ?? "").trim().toLowerCase();
+    if (!source) continue;
+    const mapped =
+      SOURCE_TO_COLUMN[source] ??
+      SOURCE_TO_COLUMN[source.replace(/^sys_/, "")] ??
+      undefined;
+    if (mapped && !out.includes(mapped)) {
+      out.push(mapped);
+    }
+  }
+  return out;
+}
+
+export function toDetailDisplayFormat(
+  columns: DisplayFormatColumn[] | undefined | null,
+): DetailDisplayFormat | undefined {
+  const mapped = mapDisplayFormatToDetailColumns(columns);
+  if (mapped.length === 0) return undefined;
+  return { columns: mapped };
+}
+
+/**
+ * Resolve a cell value preferring displayProperties / columnData map keys
+ * used by pathmanagement when a displayFormatId is applied.
+ */
+export function resolvePathItemProperty(
+  item: PSPathItem,
+  ...keys: string[]
+): string {
+  const props = item.displayProperties;
+  if (props && typeof props === "object") {
+    for (const key of keys) {
+      const v = props[key];
+      if (v != null && String(v).length > 0) {
+        return String(v);
+      }
+    }
+    // Case-insensitive fallback (server keys vary by casing).
+    const entries = Object.entries(props);
+    for (const key of keys) {
+      const lower = key.toLowerCase();
+      for (const [k, v] of entries) {
+        if (k.toLowerCase() === lower && v != null && String(v).length > 0) {
+          return String(v);
+        }
+      }
+    }
+  }
+  return "";
+}
+
+/** Stable key for a display format option in the shell selector. */
+export function displayFormatOptionKey(df: {
+  displayId?: number;
+  name?: string;
+  internalName?: string;
+}): string {
+  if (df.displayId != null && Number.isFinite(df.displayId)) {
+    return String(df.displayId);
+  }
+  return df.internalName || df.name || "";
+}

--- a/WebUI/src/main/ts/contentExplorer/displayFormatMap.ts
+++ b/WebUI/src/main/ts/contentExplorer/displayFormatMap.ts
@@ -58,6 +58,7 @@ export function mapDisplayFormatToDetailColumns(
   }
   const out: DetailColumnId[] = [];
   for (const col of columns) {
+    if (!col) continue;
     const source = (col.source ?? col.displayName ?? "").trim().toLowerCase();
     if (!source) continue;
     const mapped =

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -119,8 +119,12 @@ export const EXPLORER_MSG = {
   SEARCH_REVEAL: "perc.ui.explorer@Reveal in folder",
   SEARCH_PERMISSION_DENIED:
     "perc.ui.explorer@You do not have permission to open this item",
+  DISPLAY_FORMAT_LABEL: "perc.ui.explorer@Display format",
+  DISPLAY_FORMAT_DEFAULT: "perc.ui.explorer@Default columns",
   // US4 P-ACL / folder security (FR-014–FR-016, SC-004)
   SECURITY_TITLE: "perc.ui.explorer@Folder Security",
+  SECURITY_SELECT_FOLDER:
+    "perc.ui.explorer@Select a folder item to edit ACL.",
   SECURITY_LOADING: "perc.ui.explorer@Loading permissions",
   SECURITY_LOAD_ERROR: "perc.ui.explorer@Failed to load folder permissions",
   SECURITY_SAVE_SUCCESS: "perc.ui.explorer@Permissions saved",

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -121,6 +121,14 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@You do not have permission to open this item",
   DISPLAY_FORMAT_LABEL: "perc.ui.explorer@Display format",
   DISPLAY_FORMAT_DEFAULT: "perc.ui.explorer@Default columns",
+  /** Product shell: server-driven action toolbar (US3 / #2400). */
+  SERVER_ACTIONS_ARIA: "perc.ui.explorer@Server actions",
+  /** Product shell: view tools row (search / security / display format). */
+  VIEW_TOOLS_ARIA: "perc.ui.explorer@Explorer view tools",
+  TOGGLE_SEARCH_ARIA: "perc.ui.explorer@Show or hide search",
+  TOGGLE_SECURITY_ARIA: "perc.ui.explorer@Show or hide folder security",
+  SEARCH_PANEL_REGION: "perc.ui.explorer@Search panel",
+  SECURITY_PANEL_REGION: "perc.ui.explorer@Folder security panel",
   // US4 P-ACL / folder security (FR-014–FR-016, SC-004)
   SECURITY_TITLE: "perc.ui.explorer@Folder Security",
   SECURITY_SELECT_FOLDER:

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -17,31 +17,36 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ContentExplorerShell } from "../../../main/ts/contentExplorer/ContentExplorerShell";
+import { EXPLORER_MSG } from "../../../main/ts/contentExplorer/messages";
+import { renderA11yGate } from "./a11y";
 import { mockFetch } from "./setup";
+
+function stubPathFetch() {
+  mockFetch(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+      return new Response(
+        JSON.stringify({
+          PagedItemList: {
+            childrenInPage: [],
+            childrenCount: 0,
+            startIndex: 0,
+          },
+          PathItem: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response("{}", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
 
 describe("ContentExplorerShell product composition (#2400)", () => {
   it("renders search toggle, display format select, and server action toolbar", async () => {
-    mockFetch(async (input) => {
-      const url = typeof input === "string" ? input : (input as Request).url;
-      // Tree / list path calls — return empty paginated / folder payloads.
-      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
-        return new Response(
-          JSON.stringify({
-            PagedItemList: {
-              childrenInPage: [],
-              childrenCount: 0,
-              startIndex: 0,
-            },
-            PathItem: [],
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      return new Response("{}", {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    });
+    stubPathFetch();
 
     render(
       <ContentExplorerShell
@@ -74,8 +79,14 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId("explorer-toggle-search"));
+    const searchToggle = screen.getByTestId("explorer-toggle-search");
+    expect(searchToggle.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(searchToggle);
+    expect(searchToggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByTestId("explorer-search-panel")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("explorer-search-panel").getAttribute("aria-label"),
+    ).toContain("Search panel");
 
     const select = screen.getByTestId(
       "explorer-display-format",
@@ -92,18 +103,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
   it("uses injected loaders only (no real network for menus/formats)", async () => {
     const loadDisplayFormats = vi.fn(async () => []);
     const loadMenuActions = vi.fn(async () => []);
-    mockFetch(async () => {
-      return new Response(
-        JSON.stringify({
-          PagedItemList: {
-            childrenInPage: [],
-            childrenCount: 0,
-            startIndex: 0,
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    });
+    stubPathFetch();
 
     render(
       <ContentExplorerShell
@@ -116,5 +116,59 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       expect(loadDisplayFormats).toHaveBeenCalled();
       expect(loadMenuActions).toHaveBeenCalled();
     });
+  });
+
+  it("chrome labels are EXPLORER_MSG / message() keys (i18n FR-026)", () => {
+    // Product chrome must use perc.ui.explorer@ keys — not bare English.
+    const chromeKeys = [
+      EXPLORER_MSG.TITLE,
+      EXPLORER_MSG.SEARCH_TITLE,
+      EXPLORER_MSG.SECURITY_TITLE,
+      EXPLORER_MSG.DISPLAY_FORMAT_LABEL,
+      EXPLORER_MSG.DISPLAY_FORMAT_DEFAULT,
+      EXPLORER_MSG.SERVER_ACTIONS_ARIA,
+      EXPLORER_MSG.VIEW_TOOLS_ARIA,
+      EXPLORER_MSG.TOGGLE_SEARCH_ARIA,
+      EXPLORER_MSG.TOGGLE_SECURITY_ARIA,
+      EXPLORER_MSG.SEARCH_PANEL_REGION,
+      EXPLORER_MSG.SECURITY_PANEL_REGION,
+      EXPLORER_MSG.SECURITY_SELECT_FOLDER,
+    ];
+    for (const key of chromeKeys) {
+      expect(key.startsWith("perc.ui.explorer@")).toBe(true);
+    }
+  });
+
+  it("passes the zero serious/critical axe-core gate (T082a / 508)", async () => {
+    stubPathFetch();
+    const { container } = render(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("content-explorer-shell")).toBeInTheDocument();
+    });
+    await renderA11yGate(container);
+  });
+
+  it("passes axe with search panel expanded", async () => {
+    stubPathFetch();
+    const { container } = render(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-toggle-search")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("explorer-toggle-search"));
+    await waitFor(() =>
+      expect(screen.getByTestId("explorer-search-panel")).toBeInTheDocument(),
+    );
+    await renderA11yGate(container);
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ContentExplorerShell } from "../../../main/ts/contentExplorer/ContentExplorerShell";
+import { mockFetch } from "./setup";
+
+describe("ContentExplorerShell product composition (#2400)", () => {
+  it("renders search toggle, display format select, and server action toolbar", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      // Tree / list path calls — return empty paginated / folder payloads.
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [],
+              childrenCount: 0,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    render(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => [
+          {
+            name: "FolderList",
+            displayId: 3,
+            displayName: "Folder list",
+            columns: [{ source: "sys_title" }, { source: "sys_contenttypename" }],
+          },
+        ]}
+        loadMenuActions={async () => [
+          {
+            name: "open",
+            label: "Open",
+            sortRank: 1,
+            menuType: "MENUITEM",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("content-explorer-shell")).toBeInTheDocument();
+    expect(screen.getByTestId("explorer-toggle-search")).toBeInTheDocument();
+    expect(screen.getByTestId("explorer-toggle-security")).toBeInTheDocument();
+    expect(screen.getByTestId("explorer-display-format")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("explorer-toggle-search"));
+    expect(screen.getByTestId("explorer-search-panel")).toBeInTheDocument();
+
+    const select = screen.getByTestId(
+      "explorer-display-format",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(
+        Array.from(select.options).some((o) => o.text.includes("Folder list")),
+      ).toBe(true);
+    });
+    fireEvent.change(select, { target: { value: "3" } });
+    expect(select.value).toBe("3");
+  });
+
+  it("uses injected loaders only (no real network for menus/formats)", async () => {
+    const loadDisplayFormats = vi.fn(async () => []);
+    const loadMenuActions = vi.fn(async () => []);
+    mockFetch(async () => {
+      return new Response(
+        JSON.stringify({
+          PagedItemList: {
+            childrenInPage: [],
+            childrenCount: 0,
+            startIndex: 0,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    render(
+      <ContentExplorerShell
+        loadDisplayFormats={loadDisplayFormats}
+        loadMenuActions={loadMenuActions}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(loadDisplayFormats).toHaveBeenCalled();
+      expect(loadMenuActions).toHaveBeenCalled();
+    });
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/displayFormatMap.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/displayFormatMap.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  displayFormatOptionKey,
+  mapDisplayFormatToDetailColumns,
+  resolvePathItemProperty,
+  toDetailDisplayFormat,
+} from "../../../main/ts/contentExplorer/displayFormatMap";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+
+describe("displayFormatMap", () => {
+  it("maps known CX sources to DetailColumnId values", () => {
+    const cols = mapDisplayFormatToDetailColumns([
+      { source: "sys_title" },
+      { source: "sys_contenttypename" },
+      { source: "sys_contentlastmodifieddate" },
+      { source: "sys_workflow" },
+      { source: "unknown_field" },
+    ]);
+    expect(cols).toEqual(["title", "type", "modified", "workflow"]);
+  });
+
+  it("returns empty when no columns map", () => {
+    expect(mapDisplayFormatToDetailColumns([{ source: "nope" }])).toEqual([]);
+    expect(toDetailDisplayFormat([{ source: "nope" }])).toBeUndefined();
+  });
+
+  it("toDetailDisplayFormat wraps mapped columns", () => {
+    expect(
+      toDetailDisplayFormat([{ source: "name" }, { source: "path" }]),
+    ).toEqual({ columns: ["name", "path"] });
+  });
+
+  it("resolvePathItemProperty reads displayProperties case-insensitively", () => {
+    const item: PSPathItem = {
+      name: "n",
+      path: "/Sites/x",
+      displayProperties: {
+        Sys_Title: "Hello",
+        sys_workflow: "Simple Workflow",
+      },
+    };
+    expect(resolvePathItemProperty(item, "sys_title")).toBe("Hello");
+    expect(resolvePathItemProperty(item, "sys_workflow")).toBe(
+      "Simple Workflow",
+    );
+    expect(resolvePathItemProperty(item, "missing")).toBe("");
+  });
+
+  it("displayFormatOptionKey prefers displayId", () => {
+    expect(displayFormatOptionKey({ displayId: 7, name: "x" })).toBe("7");
+    expect(displayFormatOptionKey({ name: "Default" })).toBe("Default");
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/displayFormatMap.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/displayFormatMap.test.ts
@@ -40,6 +40,16 @@ describe("displayFormatMap", () => {
     expect(toDetailDisplayFormat([{ source: "nope" }])).toBeUndefined();
   });
 
+  it("skips null column entries without throwing", () => {
+    const cols = mapDisplayFormatToDetailColumns([
+      null as unknown as { source: string },
+      { source: "sys_title" },
+      undefined as unknown as { source: string },
+      { source: "path" },
+    ]);
+    expect(cols).toEqual(["title", "path"]);
+  });
+
   it("toDetailDisplayFormat wraps mapped columns", () => {
     expect(
       toDetailDisplayFormat([{ source: "name" }, { source: "path" }]),

--- a/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  listDisplayFormats,
+  normalizeDisplayFormatColumns,
+} from "../../../main/ts/api/contentExplorer/displayFormatsApi";
+import { mockFetch } from "./setup";
+
+describe("displayFormatsApi", () => {
+  it("listDisplayFormats unwraps array envelope and passes filters", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      expect(url).toContain("/displayformats");
+      expect(url).toContain("validForFolder=true");
+      return new Response(
+        JSON.stringify({
+          DisplayFormat: [
+            { name: "FolderList", displayId: 1, validForFolder: true },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const list = await listDisplayFormats({ validForFolder: true });
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe("FolderList");
+  });
+
+  it("normalizeDisplayFormatColumns unwraps nested envelope", () => {
+    expect(
+      normalizeDisplayFormatColumns({
+        DisplayFormatColumn: [{ source: "sys_title" }, { source: "type" }],
+      }),
+    ).toHaveLength(2);
+    expect(normalizeDisplayFormatColumns(undefined)).toEqual([]);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
@@ -128,13 +128,31 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     expect(ADMIN_USERNAME).toBe("Admin");
   });
 
-  test("axe-core a11y gate — modern Content Explorer shell (T082b)", async ({
+  test("axe-core a11y gate — modern Content Explorer shell (T082b / 508)", async ({
     page,
   }) => {
     await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 15_000 });
+    // Full product shell including #2400 composition chrome (search / DF / menus).
     await expectNoSeriousA11yViolations(page, {
-      scope:
-        '[id="perc-modern-ui-mount"], [data-testid="explorer-tree"], [data-testid="detail-list"]',
+      scope: '[data-testid="content-explorer-shell"]',
+    });
+  });
+
+  test("axe-core a11y gate — Explorer search panel expanded (#2400)", async ({
+    page,
+  }) => {
+    await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+    await expect(
+      page.locator('[data-testid="content-explorer-shell"]'),
+    ).toBeVisible({ timeout: 15_000 });
+    await page.locator('[data-testid="explorer-toggle-search"]').click();
+    await expect(
+      page.locator('[data-testid="explorer-search-panel"]'),
+    ).toBeVisible();
+    await expectNoSeriousA11yViolations(page, {
+      scope: '[data-testid="content-explorer-shell"]',
     });
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
@@ -73,6 +73,32 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     await expect(page.locator('[data-testid="action-move"]')).toBeVisible();
     await expect(page.locator('[data-testid="action-copy"]')).toBeVisible();
     await expect(page.locator('[data-testid="action-delete"]')).toBeVisible();
+    // #2400 product shell composition: search, security, display format, server actions
+    await expect(
+      page.locator('[data-testid="explorer-toggle-search"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-toggle-security"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-display-format"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="explorer-server-actions"]'),
+    ).toBeVisible();
+    await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible();
+  });
+
+  test("Explorer shell opens search panel from view tools (#2400)", async ({
+    page,
+  }) => {
+    await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 15_000 });
+    await page.locator('[data-testid="explorer-toggle-search"]').click();
+    await expect(
+      page.locator('[data-testid="explorer-search-panel"]'),
+    ).toBeVisible();
   });
 
   test("no miller-column Finder chrome loads for the modern entry", async ({

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
@@ -24,18 +24,22 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only display format catalog for the Developer module (UI-05 list/detail).
+ * Read-only display format catalog for the Developer module (UI-05 list/detail) and the modern
+ * Content Explorer folder list (issue #2400 / FR-027).
  *
  * <p>Write endpoints remain unimplemented at the adaptor layer (later slice).
  */
@@ -61,8 +65,9 @@ public class DisplayFormatResource {
   @Operation(
       summary = "List display formats",
       description =
-          "Lists Content Explorer display formats with columns and usage flags. Create/edit/delete"
-              + " are later slices.",
+          "Lists Content Explorer display formats with columns and usage flags. Optional filters"
+              + " support the modern Explorer folder list (validForFolder) and search/view UIs"
+              + " (validForViewsAndSearches). Create/edit/delete are later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -72,10 +77,41 @@ public class DisplayFormatResource {
                     array = @ArraySchema(schema = @Schema(implementation = DisplayFormat.class)))),
         @ApiResponse(responseCode = "500", description = "Error")
       })
-  public List<DisplayFormat> listDisplayFormats() {
+  public List<DisplayFormat> listDisplayFormats(
+      @Parameter(description = "When true, only formats valid for folder list views")
+          @QueryParam("validForFolder")
+          Boolean validForFolder,
+      @Parameter(description = "When true, only formats valid for views and searches")
+          @QueryParam("validForViewsAndSearches")
+          Boolean validForViewsAndSearches) {
     try {
       List<DisplayFormat> list = requireAdaptor().findAllDisplayFormats();
-      return list != null ? list : List.of();
+      if (list == null || list.isEmpty()) {
+        return List.of();
+      }
+      if (validForFolder == null && validForViewsAndSearches == null) {
+        return list;
+      }
+      List<DisplayFormat> filtered = new ArrayList<>(list.size());
+      for (DisplayFormat df : list) {
+        if (df == null) {
+          continue;
+        }
+        if (Boolean.TRUE.equals(validForFolder) && !df.isValidForFolder()) {
+          continue;
+        }
+        if (Boolean.FALSE.equals(validForFolder) && df.isValidForFolder()) {
+          continue;
+        }
+        if (Boolean.TRUE.equals(validForViewsAndSearches) && !df.isValidForViewsAndSearches()) {
+          continue;
+        }
+        if (Boolean.FALSE.equals(validForViewsAndSearches) && df.isValidForViewsAndSearches()) {
+          continue;
+        }
+        filtered.add(df);
+      }
+      return filtered;
     } catch (WebApplicationException e) {
       throw e;
     } catch (Exception e) {

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
@@ -95,6 +95,32 @@ public class DisplayFormatResourceTest {
   }
 
   @Test
+  public void listDisplayFormatsFiltersCombinedValidForFolderAndViews() throws Exception {
+    DisplayFormat both = new DisplayFormat();
+    both.setName("Both");
+    both.setValidForFolder(true);
+    both.setValidForViewsAndSearches(true);
+    DisplayFormat folderOnly = new DisplayFormat();
+    folderOnly.setName("FolderOnly");
+    folderOnly.setValidForFolder(true);
+    folderOnly.setValidForViewsAndSearches(false);
+    DisplayFormat searchOnly = new DisplayFormat();
+    searchOnly.setName("SearchOnly");
+    searchOnly.setValidForFolder(false);
+    searchOnly.setValidForViewsAndSearches(true);
+    DisplayFormat neither = new DisplayFormat();
+    neither.setName("Neither");
+    neither.setValidForFolder(false);
+    neither.setValidForViewsAndSearches(false);
+    when(adaptor.findAllDisplayFormats())
+        .thenReturn(List.of(both, folderOnly, searchOnly, neither));
+
+    List<DisplayFormat> out = resource.listDisplayFormats(true, true);
+    assertEquals(1, out.size());
+    assertEquals("Both", out.get(0).getName());
+  }
+
+  @Test
   public void getDisplayFormatDelegates() {
     DisplayFormat f = new DisplayFormat();
     f.setName("Default");

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
@@ -51,7 +51,7 @@ public class DisplayFormatResourceTest {
     f.setName("Default");
     when(adaptor.findAllDisplayFormats()).thenReturn(List.of(f));
 
-    List<DisplayFormat> out = resource.listDisplayFormats();
+    List<DisplayFormat> out = resource.listDisplayFormats(null, null);
     assertEquals(1, out.size());
     assertEquals("Default", out.get(0).getName());
   }
@@ -59,7 +59,39 @@ public class DisplayFormatResourceTest {
   @Test
   public void listDisplayFormatsNullSafe() throws Exception {
     when(adaptor.findAllDisplayFormats()).thenReturn(null);
-    assertTrue(resource.listDisplayFormats().isEmpty());
+    assertTrue(resource.listDisplayFormats(null, null).isEmpty());
+  }
+
+  @Test
+  public void listDisplayFormatsFiltersValidForFolder() throws Exception {
+    DisplayFormat folderOk = new DisplayFormat();
+    folderOk.setName("FolderList");
+    folderOk.setValidForFolder(true);
+    DisplayFormat notFolder = new DisplayFormat();
+    notFolder.setName("SearchOnly");
+    notFolder.setValidForFolder(false);
+    notFolder.setValidForViewsAndSearches(true);
+    when(adaptor.findAllDisplayFormats()).thenReturn(List.of(folderOk, notFolder));
+
+    List<DisplayFormat> out = resource.listDisplayFormats(true, null);
+    assertEquals(1, out.size());
+    assertEquals("FolderList", out.get(0).getName());
+  }
+
+  @Test
+  public void listDisplayFormatsFiltersValidForViewsAndSearches() throws Exception {
+    DisplayFormat searchOk = new DisplayFormat();
+    searchOk.setName("SearchFmt");
+    searchOk.setValidForViewsAndSearches(true);
+    DisplayFormat noSearch = new DisplayFormat();
+    noSearch.setName("FolderOnly");
+    noSearch.setValidForViewsAndSearches(false);
+    noSearch.setValidForFolder(true);
+    when(adaptor.findAllDisplayFormats()).thenReturn(List.of(searchOk, noSearch));
+
+    List<DisplayFormat> out = resource.listDisplayFormats(null, true);
+    assertEquals(1, out.size());
+    assertEquals("SearchFmt", out.get(0).getName());
   }
 
   @Test
@@ -97,7 +129,7 @@ public class DisplayFormatResourceTest {
   public void withoutInjectionFailsWithDiagnostic() {
     DisplayFormatResource bare = new DisplayFormatResource();
     WebApplicationException listEx =
-        assertThrows(WebApplicationException.class, bare::listDisplayFormats);
+        assertThrows(WebApplicationException.class, () -> bare.listDisplayFormats(null, null));
     assertEquals(500, listEx.getResponse().getStatus());
     assertInstanceOf(IllegalStateException.class, listEx.getCause());
 

--- a/specs/2400-dce-explorer-parity/checklists/i18n-a11y-hard-gate.md
+++ b/specs/2400-dce-explorer-parity/checklists/i18n-a11y-hard-gate.md
@@ -1,0 +1,44 @@
+# Explorer parity (#2400) — i18n + 508 / accessibility HARD GATE
+
+**Parent:** [#2400](https://github.com/intersoftdatalabs-in/percussioncms/issues/2400)  
+**Aligns with:** FR-026 / T083 (i18n), FR-024 / SC-009 / T082 (a11y) from `specs/992-react-content-explorer/`  
+**WebUI agent rule:** `WebUI/AGENTS.md` → **Content Explorer — i18n + 508 / accessibility**
+
+## Mandatory for every Explorer UI slice
+
+### i18n
+
+1. Add keys to `WebUI/src/main/ts/contentExplorer/messages.ts` (`EXPLORER_MSG`).
+2. Shape: `perc.ui.explorer@<English default text>`.
+3. Render only via `message(EXPLORER_MSG.KEY)` (including `aria-label` text).
+4. Do **not** invent parallel catalogs for Explorer chrome.
+5. CMS design data (display format names, server menu labels, item titles) may display raw — product chrome may not.
+
+### Accessibility (Section 508 / WCAG 2.1 AA target)
+
+1. Keyboard path for every new control (toggle, select, panel, menu).
+2. Toggles: `aria-pressed`, `aria-expanded`, `aria-controls` when they show/hide regions.
+3. Regions/panels: `aria-label` (or labelled heading) via `EXPLORER_MSG`.
+4. Errors: `role="alert"` (and `aria-live` when appropriate); status hints: `role="status"`.
+5. Associate form controls with visible labels (`htmlFor` / `aria-labelledby`).
+
+### Tests (non-negotiable)
+
+| Layer | Gate |
+|-------|------|
+| Vitest | `renderA11yGate(container)` on new/changed surfaces (`contentExplorer/a11y.ts`) |
+| Vitest | Assert new chrome keys are `perc.ui.explorer@…` when adding shell chrome |
+| Playwright | `expectNoSeriousA11yViolations` on Explorer shell / expanded panels |
+| Playwright | Behavioral coverage of user-visible flows (`perc-qa-automation`) |
+
+## References
+
+- `specs/992-react-content-explorer/checklists/a11y-spotcheck.md`
+- `specs/992-react-content-explorer/checklists/i18n-key-presence.md`
+- `docs/ai-generated/tasks/gh-codeql-alerts/` — unrelated security; do not confuse with a11y
+
+## Sign-off (update per slice PR)
+
+| Slice / PR | i18n keys | Vitest a11y | Playwright a11y | Notes |
+|------------|-----------|-------------|-----------------|-------|
+| #2407 shell composition | DISPLAY_FORMAT_*, SERVER_ACTIONS_*, VIEW_TOOLS_*, TOGGLE_*, PANEL_REGION_*, SECURITY_SELECT_FOLDER | ContentExplorerShell.test.tsx | us1-core-explorer shell + search expanded | Product shell |

--- a/specs/2400-dce-explorer-parity/contracts/gap-matrix.md
+++ b/specs/2400-dce-explorer-parity/contracts/gap-matrix.md
@@ -1,0 +1,65 @@
+# Gap matrix: Desktop Content Explorer → SPA Explorer
+
+**Parent:** #2400  
+**Evidence date:** 2026-08-08  
+**Rule:** Status reflects **product route** (`ExplorerRoute` → `ContentExplorerShell`), not isolated components in the registry.
+
+Legend: **Present** | **Partial** | **Missing** | **OUT**
+
+## Navigation & chrome
+
+| Capability | DCE source | Explorer / REST today | Status | Slice |
+|------------|------------|------------------------|--------|-------|
+| Sites/folders tree | `PSNavigationTree` | `ExplorerTree` + path APIs | Present | — |
+| Detail list of children | Main list | `DetailList` + `paginatedFolder` | Present | — |
+| Full product shell composition | Frame + panels | Shell composes search, menus, DF, security (#2407) | **Partial→Present (in PR)** | #2407 |
+| Menu bar (Content / View / Help) | `ContentExplorerMenu.xml` | Not in SPA shell | **Missing** | #2407 follow-up |
+| Server-driven toolbar/context menus | Action manager + server menus | Wired in shell (#2407) | **Present (in PR)** | #2407 |
+| Reduced create/rename/move/copy/delete | Folder actions | `ReducedActions` in shell | Present | — |
+| Open / preview item | Open handlers | `openInEditor`; preview default no-op | **Partial** | preview slice |
+| Multi-select list | Selection model | Single-select only in shell | **Missing** | #2408 |
+| Display formats for columns | Display format catalog | REST filter + shell selector + displayProperties (#2407) | **Partial→Present (in PR)** | #2407 |
+| View options / refresh | View menu | Partial (list reload on path change) | **Partial** | shell |
+
+## Search
+
+| Capability | DCE source | Explorer / REST today | Status | Slice |
+|------------|------------|------------------------|--------|-------|
+| Simple / extended search | `PSSearchDialog` | Search panel toggle in product shell (#2407) | **Present (in PR)** | #2407 |
+| Open / reveal from results | Search results | Callbacks on panel | Present | #2407 |
+| Saved searches catalog + run | CE saved search | `GET /rest/searches` design catalog; **no execute-in-Explorer UX** | **Missing** | #2409 |
+| Search in ContentBrowser hosts | Dialogs | Host integration pending | **Partial** | host follow-up |
+
+## Security & properties
+
+| Capability | DCE source | Explorer / REST today | Status | Slice |
+|------------|------------|------------------------|--------|-------|
+| Folder ACL view/edit | `PSFolderSecurityPanel` | Panel toggle in shell; identities polish remaining | **Partial** | #2410 |
+| Object ACL editor (full) | CE ACL dialogs | Partial other epics (#2274 family) | **Partial** | link existing |
+| Folder properties (community, locale, DF, workflow) | `PSFolder*Panel` | path `folderProperties` partial UI | **Partial** | properties slice |
+
+## Advanced / power user
+
+| Capability | DCE source | Explorer / REST today | Status | Slice |
+|------------|------------|------------------------|--------|-------|
+| Clipboard cut/copy/paste multi | `PSClipBoard` | `ClipboardPanel` + APIs; **not in shell** | **Partial** | #2408 |
+| Site copy wizard | CE wizards | `SiteCopyWizard`; not in shell | **Partial** | advanced chrome |
+| Subfolder copy wizard | CE wizards | `SubfolderCopyWizard`; not in shell | **Partial** | advanced chrome |
+| Dependency viewer | `PSDependencyViewer` | Components + `rest` relationship summary; not in shell | **Partial** | advanced chrome |
+| IA / relationships view | Managers | `RelationshipsView`; not in shell | **Partial** | advanced chrome |
+| Translation workflow | CE translation | Matrix P-Trans; not productized | **Missing** | #2411 |
+| Workflow transitions in menus | CE workflow | Actions path partial | **Partial** | workflow actions |
+
+## Explicit OUT (for now)
+
+| Capability | Reason |
+|------------|--------|
+| JavaFX desktop window / native file chooser parity | Platform desktop; web redesign for file ops |
+| DCE help JavaHelp topics 1:1 | Product help site / in-app help later |
+| DCE-only packaging residual | Decommission program after parity |
+
+## Implementation notes (2026-08-08)
+
+- Highest leverage: **compose shell** (#2401) using existing components + `rest/actions` + `rest/displayformats`.
+- REST enhancement for #2401: `GET /rest/displayformats?validForFolder=true` (and optional `validForViewsAndSearches`).
+- Re-audit after each slice merges; flip Partial → Present only when product route demonstrates the capability.

--- a/specs/2400-dce-explorer-parity/plan.md
+++ b/specs/2400-dce-explorer-parity/plan.md
@@ -1,0 +1,71 @@
+# Plan: DCE ↔ Explorer parity
+
+**Parent:** #2400  
+**Spec:** [spec.md](./spec.md)  
+**Gap matrix:** [contracts/gap-matrix.md](./contracts/gap-matrix.md)
+
+## Phase 0 — Research package (this PR baseline)
+
+| Deliverable | Status |
+|-------------|--------|
+| `spec.md` / `plan.md` / `gap-matrix.md` | In progress |
+| Child GH issues for first backlog | In progress |
+| Link package + slices on #2400 | In progress |
+
+## Phase 1 — Product shell composition (UI)
+
+Wire existing Explorer panels into `ContentExplorerShell` so `/cm/app/explorer` matches DCE’s primary layout:
+
+| Order | Surface | Existing pieces | Notes |
+|------:|---------|-----------------|-------|
+| 1.1 | Server action toolbar + context menu | `ActionToolbar`, `ContextMenu`, `actionMenuApi` → `rest/actions` | Load on selection change |
+| 1.2 | Search drawer/panel | `SearchPanel`, `searchApi` (sitemanage extended search) | Open/reveal → shell navigation |
+| 1.3 | Display format selector + columns | `rest/displayformats`, `DetailList` FR-027 hooks, `pathApi.paginatedFolder(displayFormatId)` | Filter folder-valid formats |
+| 1.4 | Folder security side panel | `FolderSecurityPanel`, path folderProperties | ADMIN/WRITE gates |
+| 1.5 | Clipboard + multi-select | `ClipboardPanel`, selection model | Multi-select list rows |
+| 1.6 | Advanced tools | DependencyViewer, RelationshipsView, site/subfolder wizards | Secondary chrome |
+
+**Phase 1 exit:** Operator can navigate, act via server menus, search, and change list columns without DCE.
+
+## Phase 2 — REST / path enrichment for list columns
+
+| Gap | Approach |
+|-----|----------|
+| Folder-valid display format list | `GET /rest/displayformats?validForFolder=true` (filter on existing catalog) |
+| Column cell data | Use `PSPathItem.displayProperties` / `columnData` when `displayFormatId` set on paginatedFolder; map sources in UI |
+| Workflow / modified columns empty | If still empty after format id, extend path list DTO in sitemanage (not invent on client) |
+| Saved search **execute** | New or extended `rest` search runtime API mapping design `SearchDef` → criteria (slice) |
+| Translation workflow | Spike existing i18n/item endpoints; new façade only if needed |
+
+## Phase 3 — Action / workflow depth
+
+| Gap | Approach |
+|-----|----------|
+| Allowed workflow transitions | Complete `rest/actions` allowed-transitions path used by menus |
+| Properties dialogs | Folder/item properties parity beyond ACL |
+| New content menus | Content-type / template menus already partially on `rest/actions` |
+
+## Phase 4 — Advanced / power-user
+
+| Gap | Approach |
+|-----|----------|
+| Dependency / IA deep tools | Expand beyond summary counts if DCE still ahead |
+| Site/subfolder copy | Ensure wizards reachable from shell menus |
+| Display format design write | Later; read catalog sufficient for Explorer list |
+
+## Test strategy
+
+| Layer | When |
+|-------|------|
+| Vitest pure helpers + shell composition | Every UI PR |
+| `rest` unit tests (Mockito resource) | Every REST PR |
+| Module `mvnw clean install` | Pre-PR hard gate (`rest`, `WebUI`, `sitemanage` as touched) |
+| Playwright `modules/perc-qa-automation` surface | Product-visible Explorer changes |
+
+## Risk
+
+| Risk | Mitigation |
+|------|------------|
+| 992 matrix overstates Done | Gap matrix uses **product shell** evidence, not component existence alone |
+| Large shell PR | Phase 1 ordered slices; land 1.1–1.3 first |
+| REST vs sitemanage path APIs | Prefer public `rest` for new contracts; pathmanagement remains for folder CRUD |

--- a/specs/2400-dce-explorer-parity/plan.md
+++ b/specs/2400-dce-explorer-parity/plan.md
@@ -58,9 +58,12 @@ Wire existing Explorer panels into `ContentExplorerShell` so `/cm/app/explorer` 
 | Layer | When |
 |-------|------|
 | Vitest pure helpers + shell composition | Every UI PR |
+| Vitest `renderA11yGate` (T082a) + EXPLORER_MSG key shape | Every Explorer UI PR |
 | `rest` unit tests (Mockito resource) | Every REST PR |
 | Module `mvnw clean install` | Pre-PR hard gate (`rest`, `WebUI`, `sitemanage` as touched) |
-| Playwright `modules/perc-qa-automation` surface | Product-visible Explorer changes |
+| Playwright surface + `expectNoSeriousA11yViolations` (T082b) | Product-visible Explorer changes |
+
+**i18n / 508:** [checklists/i18n-a11y-hard-gate.md](./checklists/i18n-a11y-hard-gate.md) — non-optional for UI work.
 
 ## Risk
 

--- a/specs/2400-dce-explorer-parity/spec.md
+++ b/specs/2400-dce-explorer-parity/spec.md
@@ -42,6 +42,7 @@ The modern SPA **Explorer** (`WebUI` `ContentExplorerShell`, route `/cm/app/expl
 - [ ] Spec + plan + matrix checked in (this package) and linked from #2400.
 - [ ] Product Explorer route exercises composed surfaces (not only isolated registry components).
 - [ ] Vitest for logic/components; Playwright surface tests for user-visible Explorer changes.
+- [ ] **i18n + 508 / a11y HARD GATE** on every UI slice — see [checklists/i18n-a11y-hard-gate.md](./checklists/i18n-a11y-hard-gate.md) and `WebUI/AGENTS.md` (Content Explorer section). No bare English chrome; `renderA11yGate` + Playwright axe gates green.
 
 ## Slice principles
 

--- a/specs/2400-dce-explorer-parity/spec.md
+++ b/specs/2400-dce-explorer-parity/spec.md
@@ -1,0 +1,51 @@
+# Spec: DCE ↔ Explorer functional parity program
+
+**Parent tracking issue:** [#2400](https://github.com/intersoftdatalabs-in/percussioncms/issues/2400)  
+**Priority:** p1 (research + product UI backlog)  
+**Related prior art:** `specs/992-react-content-explorer/` (capability matrix, cutover inventory)
+
+## Problem
+
+The modern SPA **Explorer** (`WebUI` `ContentExplorerShell`, route `/cm/app/explorer`) is the product replacement for the Java **Desktop Content Explorer (DCE)** (`modules/DesktopContentExplorer`). Feature 992 delivered many **components** and REST surfaces, but:
+
+1. The **product shell** still composes only tree + detail list + reduced actions — Search, server action menus, display formats, folder security, clipboard, and advanced tools are largely **not wired into the live route**.
+2. Several DCE operator workflows still lack **public REST** in `rest` (or path enrichment) that the SPA can call without inventing fields.
+3. The 992 capability matrix claims many rows **Done** at the component level; operator-visible **product parity** is incomplete.
+
+## Goals
+
+1. **1:1 functional parity** with DCE for operator-visible capabilities wherever possible.
+2. Explicit **OUT / redesign / blocked** dispositions when parity is not possible (desktop-only, obsolete).
+3. Implementation via **PR-sized slices** with parent tracing on #2400.
+4. New UI work uses **React/TS only** (`WebUI/src/main/ts`); new public HTTP contracts live in **`rest`** (resource + DTO + `IXxxAdaptor`) with **sitemanage apibridge** implementations.
+
+## Non-goals
+
+- Reimplementing DCE as a desktop app.
+- Full DCE packaging uninstall (informed by this program, separate cutover).
+- jQuery / FancyTree bridges for Explorer product surfaces.
+
+## Systems
+
+| Side | Path |
+|------|------|
+| DCE (reference) | `modules/DesktopContentExplorer` — menus, dialogs, wizards, clipboard, search, ACL, dependency viewer |
+| Explorer (target UI) | `WebUI/src/main/ts/contentExplorer/*` + `app/routes/ExplorerRoute.tsx` |
+| Public REST | `rest/src/main/java/com/percussion/rest/**` |
+| Domain / apibridge | `projects/sitemanage` pathmanagement + `com.percussion.apibridge.*` |
+
+## Acceptance (program)
+
+- [ ] Gap matrix maintained in `contracts/gap-matrix.md` with Present / Partial / Missing / OUT.
+- [ ] Every Missing / material Partial row has a child GitHub issue (`Parent: #2400`).
+- [ ] Parent #2400 progress table updated as slices open/merge.
+- [ ] Spec + plan + matrix checked in (this package) and linked from #2400.
+- [ ] Product Explorer route exercises composed surfaces (not only isolated registry components).
+- [ ] Vitest for logic/components; Playwright surface tests for user-visible Explorer changes.
+
+## Slice principles
+
+1. **Compose before invent** — prefer wiring existing panels/APIs into the shell.
+2. **REST first for missing data** — no invented JSON fields; extend `rest` + sitemanage when the wire shape is insufficient.
+3. **Companion closure** — new REST: resource, adaptor interface, apibridge impl, Mockito resource test, Spring stub if scanned, sitemanage adaptor test as peers require.
+4. **Playwright HARD GATE** for product-visible Explorer changes (`modules/perc-qa-automation`).


### PR DESCRIPTION
## Summary

Starts the **DCE ↔ Explorer functional parity** program tracked by **#2400**.

- Checks in research package under `specs/2400-dce-explorer-parity/` (spec, plan, gap matrix).
- Implements **#2407** first UI slice: product `ContentExplorerShell` composition (search, server action toolbar/context menu, display format selector, folder security toggle).
- Extends **`GET /rest/displayformats`** with `validForFolder` / `validForViewsAndSearches` query filters for Explorer list columns.
- Detail list honors `displayFormatId` on `paginatedFolder` and reads `displayProperties` for cells.
- Child backlog issues: #2408–#2411.

## Test plan

- [x] `cd rest && ../mvnw clean install` — BUILD SUCCESS, Tests run: 237, Failures: 0
- [x] `DisplayFormatResourceTest` — 8 tests including new filter cases
- [x] Vitest: displayFormatMap, displayFormatsApi, ContentExplorerShell, DetailList (23 tests)
- [ ] Playwright `us1-core-explorer` against live CMS / QA mode when available (assertions added)

## Parent / slices

| Issue | Role |
|-------|------|
| #2400 | Parent research tracker |
| #2407 | This PR (shell + DF REST filters) |
| #2408–#2411 | Follow-up slices |

> Co-Authored by Grok Build using grok-4.5 with agent main.
