### PR TITLE
fix(perc-ant): clear main-source Xlint:all deprecation warnings (#2023)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md
@@ -1,36 +1,20 @@
-# Erlang self-review — issue #2023 perc-ant javac batch 1
+# Erlang self-review — issue #2023 perc-ant Xlint batch 1
 
-**Date:** 2026-08-07  
-**Branch:** `fix/issue-2023-perc-ant-javac-warnings-batch1`  
-**Module:** `modules/perc-ant`  
-**Verdict:** **Approve** (commit-ready)
+**Verdict:** approve
 
 ## Scope
+- Module: `modules/perc-ant`
+- Clear inventoriable main-source `-Xlint:all` diagnostics (34 deprecation → 0)
+- Project parent `-Xlint` / `-Xlint:-deprecation` was already 0 for main sources
 
-PR-sized batch 1: real-fix raw types, redundant casts, and unchecked calls under project `-Xlint` / `-Xlint:-deprecation` (~50 diagnostics). No behavior change intended beyond type parameters and removal of redundant casts.
+## Findings
+- No bugs identified in real API migrations (IOTools→NIO/commons-io, Ant getLocation/getFileUtils, File.toURI().toURL, Jericho getElement().getEndTag, WildcardFileFilter.builder, Class.forName without newInstance).
+- Portable paths: PSPropagateFile now uses `Path.resolve` instead of `"/" +` string join.
+- Intentional `@SuppressWarnings("deprecation")` only on legacy upgrade crypto / PSEntityResolver / Ant Main(String[]) — no blanket suppressions.
+- New `PSInstallIoUtils` covered by 6 unit tests; module suite 49 tests green.
+- Residual (not module-zero for issue acceptance): javadoc "no main description" on PSMigrateI18nLocaleCodes / PSStripSampleLocales (~8). Original issue "200" was inventory-cap noise; live main Xlint:all was 34.
 
-**In batch:** top-level ant helpers, help-hint / helptopic mapping tasks, install tasks (copy, extract jar, war update, table/data/rxfix/secure property/page tags/derby, etc.).
-
-**Out of batch (residual on #2023):** `PSJunitFileSelector` (~15), `PSRxBuildInput` (~19), constructor `this-escape` sites (~6).
-
-## Checklist
-
-| Gate | Result |
-|------|--------|
-| Bugs in typed refactors | None found — collections already held the typed elements; only declarations/casts updated |
-| Portable paths / file I/O | N/A for this batch (no path-string changes) |
-| Behavioral unit tests | Existing module suite green (39 tests); no new non-trivial logic |
-| Prefer real fix over suppress | Yes — no new `@SuppressWarnings` |
-| Standalone `mvnw clean install` | BUILD SUCCESS |
-| Scope confined to perc-ant | Yes |
-
-## Notes
-
-- Jericho HTML 2.1 APIs return raw `List` / `Iterator`; callers use enhanced-for + local cast to `StartTag`/`Tag` (no unchecked conversion to `List<StartTag>`).
-- `PSProperties.getProperty` already returns `String` — redundant casts removed.
-- `PSJdbcTableSchema.getKeyColumns()` / `PSJdbcTableData.getRows()` / `PSRxFixCmd.getResults()` already parameterized upstream.
-- Residual `this-escape` and large GUI/JUnit selector files deferred deliberately for PR size.
-
-## Residual issue
-
-Follow-up residual issue to be filed for remaining ~40 main-source diagnostics (batch 2+).
+## Hard gates
+- [x] No new non-portable path I/O
+- [x] Behavioral tests for new helper
+- [x] Standalone `cd modules/perc-ant && ../../mvnw.cmd clean install` BUILD SUCCESS

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSHelpHintFileCreator.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSHelpHintFileCreator.java
@@ -143,7 +143,7 @@ public class PSHelpHintFileCreator {
       String content = null;
       StartTag tagA = descTags.get(i);
       if (i == descTags.size() - 1) {
-        Tag lastTag = tagA.findEndTag();
+        Tag lastTag = tagA.getElement().getEndTag();
         while (true) {
           Tag nextTag = source.findNextTag(lastTag.getEnd());
           if (nextTag == null) break;
@@ -271,7 +271,7 @@ public class PSHelpHintFileCreator {
    */
   private boolean isRelatedItemTable(String text, StartTag tag) {
     if (!tag.getName().equals(ELEM_TABLE)) return false;
-    EndTag eTag = tag.findEndTag();
+    EndTag eTag = tag.getElement().getEndTag();
     Source source = new Source(text.substring(tag.getBegin(), eTag.getEnd()));
     for (Object tagObj : source.findAllStartTags(ELEM_P)) {
       StartTag sTag = (StartTag) tagObj;
@@ -312,7 +312,7 @@ public class PSHelpHintFileCreator {
       Attributes attrs = sTag.getAttributes();
       Attribute attr = attrs.get(ATTR_CLASS);
       if (attr != null && attr.getValue().equals(FIELDNAME)) {
-        EndTag eTag = sTag.findEndTag();
+        EndTag eTag = sTag.getElement().getEndTag();
         return stripTags(content.substring(sTag.getEnd(), eTag.getBegin()));
       }
     }

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSJunitFileSelector.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSJunitFileSelector.java
@@ -347,13 +347,13 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    * @return An array of url objects for each classpath element that is found to exist.
    */
   private URL[] pathToURLs(String classPath) {
-    List<URL> urlList = new ArrayList<URL>();
+    List<URL> urlList = new ArrayList<>();
     StringTokenizer st = new StringTokenizer(classPath, File.pathSeparator);
     while (st.hasMoreTokens()) {
       File file = new File(st.nextToken());
       if (file.exists()) {
         try {
-          urlList.add(file.toURL());
+          urlList.add(file.toURI().toURL());
         } catch (MalformedURLException e) {
           // ignore bad entries (that's what Java does)
           log.error(PSExceptionUtils.getMessageForLog(e));
@@ -362,7 +362,7 @@ public class PSJunitFileSelector extends BaseExtendSelector {
       }
     }
 
-    return urlList.toArray(new URL[urlList.size()]);
+    return urlList.toArray(new URL[0]);
   }
 
   /**

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSPropagateFile.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSPropagateFile.java
@@ -18,6 +18,7 @@ package com.percussion.ant;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -56,17 +57,17 @@ public class PSPropagateFile extends Task {
   public void execute() throws BuildException {
 
     if (m_srcFile == null) {
-      throw new BuildException("The src attribute must be present.", location);
+      throw new BuildException("The src attribute must be present.", getLocation());
     }
 
     if (!m_srcFile.exists()) {
-      throw new BuildException("src " + m_srcFile.toString() + " does not exist.", location);
+      throw new BuildException("src " + m_srcFile.toString() + " does not exist.", getLocation());
     }
 
     try {
-      List<String> directories = new ArrayList<String>();
+      List<String> directories = new ArrayList<>();
       Iterator<DirSet> it = m_fileSets.iterator();
-      FileUtils utils = FileUtils.newFileUtils();
+      FileUtils utils = FileUtils.getFileUtils();
       File baseDir = null;
       int count = 0;
       while (it.hasNext()) {
@@ -79,8 +80,9 @@ public class PSPropagateFile extends Task {
       Iterator<String> dirIt = directories.iterator();
 
       while (dirIt.hasNext()) {
-
-        File df = new File(baseDir + "/" + dirIt.next() + "/" + m_srcFile.getName());
+        Path destPath =
+            baseDir.toPath().resolve(dirIt.next()).resolve(m_srcFile.getName()).normalize();
+        File df = destPath.toFile();
 
         utils.copyFile(m_srcFile, df);
         count++;
@@ -95,5 +97,5 @@ public class PSPropagateFile extends Task {
   }
 
   private File m_srcFile;
-  private List<DirSet> m_fileSets = new ArrayList<DirSet>();
+  private List<DirSet> m_fileSets = new ArrayList<>();
 }

--- a/modules/perc-ant/src/main/java/com/percussion/ant/gui/PSRxBuildInput.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/gui/PSRxBuildInput.java
@@ -1292,15 +1292,15 @@ public class PSRxBuildInput {
    */
   public static void main(String[] args) {
 
-    boolean obfuscation = (StringUtils.equalsIgnoreCase(System.getProperty("OBFUSCATION"), "true"));
+    boolean obfuscation = "true".equalsIgnoreCase(System.getProperty("OBFUSCATION"));
 
-    boolean debug = (StringUtils.equalsIgnoreCase(System.getProperty("DEBUG"), "true"));
+    boolean debug = "true".equalsIgnoreCase(System.getProperty("DEBUG"));
 
-    boolean manufacture = (StringUtils.equalsIgnoreCase(System.getProperty("MANUFACTURE"), "true"));
+    boolean manufacture = "true".equalsIgnoreCase(System.getProperty("MANUFACTURE"));
 
-    boolean sync = (StringUtils.equalsIgnoreCase(System.getProperty("SYNC"), "true"));
+    boolean sync = "true".equalsIgnoreCase(System.getProperty("SYNC"));
 
-    boolean verbose = (StringUtils.equalsIgnoreCase(System.getProperty("VERBOSE"), "true"));
+    boolean verbose = "true".equalsIgnoreCase(System.getProperty("VERBOSE"));
 
     if (args.length > 8) {
       new PSRxBuildInput(

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSAction.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSAction.java
@@ -62,6 +62,7 @@ public class PSAction extends Task {
    * for upgrades, and setting of the entity resolver's resolution home used to find DTD's. It also
    * determines if all files should be refreshed by date.
    */
+  @SuppressWarnings("deprecation") // PSEntityResolver remains the install-time DTD resolver
   public void execute() throws BuildException {
     PSLogger.init(ms_rootDir);
     InstallUtil.writePreviousVersion(ms_rootDir);

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSCheckInstallLog.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSCheckInstallLog.java
@@ -16,7 +16,6 @@
  */
 package com.percussion.ant.install;
 
-import com.percussion.util.IOTools;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
@@ -62,7 +61,7 @@ public class PSCheckInstallLog extends PSAction {
     File antLog = new File(rootDir, ANT_LOG_FILE);
 
     try {
-      String fullcontents = IOTools.getFileContent(installLog);
+      String fullcontents = PSInstallIoUtils.getFileContent(installLog);
       int index = fullcontents.lastIndexOf(START_ENTRY);
       if (index == -1) {
         // The log may have been rotated. TODO: Look into how to detect log rotation so this is more
@@ -74,7 +73,7 @@ public class PSCheckInstallLog extends PSAction {
       String antcontents = null;
 
       if (antLog.exists()) {
-        antcontents = IOTools.getFileContent(antLog);
+        antcontents = PSInstallIoUtils.getFileContent(antLog);
       }
 
       Iterator<String> iter = m_errorKeywords.iterator();

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSCopyFileAction.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSCopyFileAction.java
@@ -18,7 +18,6 @@
 package com.percussion.ant.install;
 
 import com.percussion.install.PSLogger;
-import com.percussion.util.IOTools;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -143,7 +142,7 @@ public class PSCopyFileAction extends PSAction {
       }
 
       PSLogger.logInfo("Copying : " + resolvedSource + " to " + resolvedDestination);
-      if (!destFile.exists() || destFile.canWrite()) IOTools.copyFileStreams(srcFile, destFile);
+      if (!destFile.exists() || destFile.canWrite()) PSInstallIoUtils.copyFile(srcFile, destFile);
       if (deleteSourceFile) srcFile.delete();
     } catch (IOException io) {
       PSLogger.logInfo(

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSDBXMLDataUpdate.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSDBXMLDataUpdate.java
@@ -30,7 +30,6 @@ import com.percussion.tablefactory.PSJdbcTableFactory;
 import com.percussion.tablefactory.PSJdbcTableSchema;
 import com.percussion.tablefactory.install.RxLogTables;
 import com.percussion.tablefactory.tools.DbUtils;
-import com.percussion.util.IOTools;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -288,7 +287,7 @@ public class PSDBXMLDataUpdate extends PSXMLFileUpdate {
       super.execute();
       fr = new FileReader(tempFile);
       sw = new StringWriter();
-      IOTools.writeStream(fr, sw);
+      PSInstallIoUtils.writeStream(fr, sw);
       String newColValue = sw.toString();
       columnData = new PSJdbcColumnData(columnName, newColValue);
     } catch (Exception e) {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSInstallIoUtils.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSInstallIoUtils.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant.install;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Portable install-time file I/O helpers replacing deprecated {@code
+ * com.percussion.util.IOTools} usage inside perc-ant install tasks.
+ *
+ * <p>Semantics for backup/temp helpers match the former IOTools methods used by the installer.
+ */
+final class PSInstallIoUtils {
+
+  private PSInstallIoUtils() {}
+
+  /**
+   * Reads file content as a UTF-8 string.
+   *
+   * @param file file to read, may not be {@code null}
+   * @return content, never {@code null}
+   * @throws IOException if the file cannot be read
+   */
+  static String getFileContent(File file) throws IOException {
+    if (file == null) {
+      throw new IllegalArgumentException("file may not be null");
+    }
+    return Files.readString(file.toPath(), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Copies {@code source} to {@code dest}, overwriting when present.
+   *
+   * @param source source file, may not be {@code null}
+   * @param dest destination file, may not be {@code null}
+   * @throws IOException if the copy fails
+   */
+  static void copyFile(File source, File dest) throws IOException {
+    if (source == null) {
+      throw new IllegalArgumentException("source may not be null");
+    }
+    if (dest == null) {
+      throw new IllegalArgumentException("dest may not be null");
+    }
+    FileUtils.copyFile(source, dest);
+  }
+
+  /**
+   * Copies all characters from {@code in} to {@code out}. Neither stream is closed.
+   *
+   * @param in reader, may not be {@code null}
+   * @param out writer, may not be {@code null}
+   * @throws IOException if the copy fails
+   */
+  static void writeStream(Reader in, Writer out) throws IOException {
+    if (in == null || out == null) {
+      throw new IllegalArgumentException("Reader and Writer must be supplied.");
+    }
+    IOUtils.copy(in, out);
+  }
+
+  /**
+   * Copies {@code file} (file or directory tree) into {@code targetDir} under the same name.
+   *
+   * @param file source file or directory, may not be {@code null}
+   * @param targetDir destination parent directory, may not be {@code null}
+   * @throws IOException if the copy fails
+   */
+  static void copyToDir(File file, File targetDir) throws IOException {
+    if (file == null) {
+      throw new IllegalArgumentException("file may not be null");
+    }
+    if (targetDir == null) {
+      throw new IllegalArgumentException("targetDir may not be null");
+    }
+    FileUtils.copyToDirectory(file, targetDir);
+  }
+
+  /**
+   * Creates a temp copy of {@code file} in the default temporary directory.
+   *
+   * @param file file to copy, may not be {@code null}
+   * @return the temporary file
+   * @throws IOException if the copy fails
+   */
+  static File createTempFile(File file) throws IOException {
+    if (file == null) {
+      throw new IllegalArgumentException("file may not be null");
+    }
+
+    String name = file.getName();
+    String prefix = name;
+    String suffix = null;
+    int dotIndex = name.indexOf('.');
+    if (dotIndex != -1) {
+      prefix = name.substring(0, dotIndex);
+      // File.createTempFile prepends '.' when suffix does not start with one.
+      suffix = name.substring(dotIndex + 1);
+    }
+    if (prefix.length() < 3) {
+      prefix = (prefix + "tmp");
+      if (prefix.length() < 3) {
+        prefix = "tmp";
+      }
+    }
+
+    File tempFile = File.createTempFile(prefix, suffix);
+    FileUtils.copyFile(file, tempFile);
+    return tempFile;
+  }
+
+  /**
+   * Creates a backup of {@code file} by appending {@code .000}, {@code .001}, etc. to its base
+   * name.
+   *
+   * @param file existing file to back up, may not be {@code null}
+   * @return the created backup file
+   * @throws IOException if the backup cannot be written
+   */
+  static File createBackupFile(File file) throws IOException {
+    if (file == null || !file.exists()) {
+      throw new IllegalArgumentException("file must not be null and must exist");
+    }
+
+    String name = file.getName();
+    int dotIndex = name.lastIndexOf('.');
+    if (dotIndex != -1) {
+      name = name.substring(0, dotIndex);
+    }
+
+    File parentFile = file.getParentFile();
+    File backupFile = new File(parentFile, name + ".000");
+    int backupNum = 1;
+
+    while (backupFile.exists()) {
+      String backupStr = Integer.toString(backupNum);
+      if (backupStr.length() == 1) {
+        backupStr = "00" + backupStr;
+      } else if (backupStr.length() == 2) {
+        backupStr = "0" + backupStr;
+      }
+
+      backupFile = new File(parentFile, name + "." + backupStr);
+      backupNum++;
+    }
+
+    FileUtils.copyFile(file, backupFile);
+    return backupFile;
+  }
+}

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMain.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMain.java
@@ -32,6 +32,7 @@ public class PSMain extends org.apache.tools.ant.Main {
    * @param args command-line arguments
    * @throws BuildException if an error occurs
    */
+  @SuppressWarnings("deprecation") // Ant Main(String[]) still required to processArgs before run
   public PSMain(String[] args) throws BuildException {
     super(args);
   }

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMakeLasagna.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMakeLasagna.java
@@ -80,6 +80,7 @@ public class PSMakeLasagna extends Task {
   // see base class
   // TODO: Remove me @SuppressFBWarnings({"HARD_CODE_PASSWORD", "HARD_CODE_PASSWORD"})
   @Override
+  @SuppressWarnings("deprecation") // last-resort PSLegacyEncrypter / getPartOneKey for upgrades
   public void execute() throws BuildException {
     FileOutputStream out = null;
     try {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSModifyProviders.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSModifyProviders.java
@@ -83,6 +83,7 @@ public final class PSModifyProviders extends PSAction {
 
   // see base class
   @Override
+  @SuppressWarnings("deprecation") // PSConfigurationCtx still requires getPartOneKey for convert
   public void execute() {
     try {
       PSLogger.logInfo("Modifying security providers");

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSSecureProperty.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSSecureProperty.java
@@ -67,6 +67,7 @@ public class PSSecureProperty {
    * @param encryptionType Optional. They type of encryption to use.
    */
   @ToDoVulnerability
+  @SuppressWarnings("deprecation") // default key still sourced from PSLegacyEncrypter for upgrades
   public static void secureProperties(
       File filepath, Collection<String> propnames, String k, String encryptionType) {
     if (propnames == null) throw new IllegalArgumentException(ERROR_PROPS);
@@ -194,6 +195,7 @@ public class PSSecureProperty {
    *     <code>null</code>.
    * @return the decrypted string, never <code>null</code>, may be empty.
    */
+  @SuppressWarnings("deprecation") // legacy decrypt fallbacks for pre-PSEncryptor values
   public static String getValue(String s, String k) {
     if (s == null) throw new IllegalArgumentException();
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpdateWebApps.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpdateWebApps.java
@@ -18,7 +18,6 @@
 package com.percussion.ant.install;
 
 import com.percussion.install.PSLogger;
-import com.percussion.util.IOTools;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -113,7 +112,7 @@ public final class PSUpdateWebApps extends PSAction {
         File[] webappFiles = webapp.listFiles();
         for (int j = 0; j < webappFiles.length; j++) {
           try {
-            IOTools.copyToDir(webappFiles[j], newWebapp);
+            PSInstallIoUtils.copyToDir(webappFiles[j], newWebapp);
           } catch (IOException e) {
             PSLogger.logError("Error deploying webapp: " + webappName);
             PSLogger.logError("Exception: " + e.getMessage());

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeDerby.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeDerby.java
@@ -247,7 +247,7 @@ public class PSUpgradeDerby extends PSAction {
     PSLogger.logInfo("Loading DerbyDriver at RunTime");
     File derbyJDBCDriver = null;
     File dir = new File(getRootDir() + File.separator + "Deployment/Server/common/lib");
-    FileFilter fileFilter = new WildcardFileFilter("derby-*.jar");
+    FileFilter fileFilter = WildcardFileFilter.builder().setWildcards("derby-*.jar").get();
     File[] files = dir.listFiles(fileFilter);
     if (files != null) {
       if (files.length == 1) {
@@ -282,16 +282,14 @@ public class PSUpgradeDerby extends PSAction {
     }
 
     try {
-      Class.forName(driver).newInstance();
+      Class.forName(driver);
     } catch (ClassNotFoundException e) {
       try {
         loadDerbyJDBCJar();
-        Class.forName(driver).newInstance();
+        Class.forName(driver);
       } catch (Exception ex) {
         throw new BuildException("Unable to load embedded Derby driver");
       }
-    } catch (InstantiationException | IllegalAccessException ex) {
-      throw new BuildException("Unable to load embedded Derby driver");
     }
 
     // Connection properties

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeServerPageTags.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSUpgradeServerPageTags.java
@@ -18,7 +18,6 @@
 package com.percussion.ant.install;
 
 import com.percussion.install.PSLogger;
-import com.percussion.util.IOTools;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.File;
@@ -89,13 +88,13 @@ public class PSUpgradeServerPageTags extends PSAction {
         return;
       } else {
         // create a backup of the existing file
-        File backupFile = IOTools.createBackupFile(diskXmlFile);
+        File backupFile = PSInstallIoUtils.createBackupFile(diskXmlFile);
       }
 
       // Create a temp file for serverPageTags.xml
       String xmlResFile;
       File archiveXmlFile = new File(serverPageTagsXmlE2FilePath);
-      xmlResFile = IOTools.createTempFile(archiveXmlFile).getAbsolutePath();
+      xmlResFile = PSInstallIoUtils.createTempFile(archiveXmlFile).getAbsolutePath();
 
       InputStream diskStream = null;
       InputStream resStream = null;

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSXMLFileUpdate.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSXMLFileUpdate.java
@@ -20,7 +20,6 @@ package com.percussion.ant.install;
 import com.percussion.install.PSLogger;
 import com.percussion.install.RxFileManager;
 import com.percussion.security.xml.PSSecureXMLUtils;
-import com.percussion.util.IOTools;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.BufferedInputStream;
@@ -182,7 +181,7 @@ public class PSXMLFileUpdate extends PSAction implements EntityResolver {
     try {
       // create a backup of the xml file, if specified
       if (m_backupXmlFile) {
-        File backupFile = IOTools.createBackupFile(fSrcXmlFile);
+        File backupFile = PSInstallIoUtils.createBackupFile(fSrcXmlFile);
       }
 
       if (deleteSrcFile) fSrcXmlFile.delete();
@@ -314,7 +313,7 @@ public class PSXMLFileUpdate extends PSAction implements EntityResolver {
    */
   private String resolveFile(String file) throws Exception {
     BufferedReader in = new BufferedReader(new FileReader(file));
-    String xslResolvedFile = IOTools.createTempFile(new File(file)).getAbsolutePath();
+    String xslResolvedFile = PSInstallIoUtils.createTempFile(new File(file)).getAbsolutePath();
 
     BufferedWriter out = null;
     try {

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/PSInstallIoUtilsTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/PSInstallIoUtilsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link PSInstallIoUtils} install-time file helpers. */
+@Tag("UnitTest")
+public class PSInstallIoUtilsTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  public void getFileContentReadsUtf8() throws Exception {
+    Path file = tempDir.resolve("sample.txt");
+    Files.writeString(file, "hello-utf8-✓", StandardCharsets.UTF_8);
+
+    assertEquals("hello-utf8-✓", PSInstallIoUtils.getFileContent(file.toFile()));
+  }
+
+  @Test
+  public void copyFileOverwritesDestination() throws Exception {
+    Path source = tempDir.resolve("src.bin");
+    Path dest = tempDir.resolve("dest.bin");
+    Files.writeString(source, "payload", StandardCharsets.UTF_8);
+    Files.writeString(dest, "old", StandardCharsets.UTF_8);
+
+    PSInstallIoUtils.copyFile(source.toFile(), dest.toFile());
+
+    assertEquals("payload", Files.readString(dest, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void writeStreamCopiesReaderToWriter() throws Exception {
+    StringWriter out = new StringWriter();
+    PSInstallIoUtils.writeStream(new StringReader("stream-data"), out);
+    assertEquals("stream-data", out.toString());
+  }
+
+  @Test
+  public void copyToDirCopiesFileAndDirectory() throws Exception {
+    Path srcFile = tempDir.resolve("item.txt");
+    Files.writeString(srcFile, "file-body", StandardCharsets.UTF_8);
+    Path srcDir = tempDir.resolve("nested");
+    Files.createDirectories(srcDir);
+    Files.writeString(srcDir.resolve("child.txt"), "child", StandardCharsets.UTF_8);
+
+    Path target = tempDir.resolve("target");
+    Files.createDirectories(target);
+
+    PSInstallIoUtils.copyToDir(srcFile.toFile(), target.toFile());
+    PSInstallIoUtils.copyToDir(srcDir.toFile(), target.toFile());
+
+    assertEquals("file-body", Files.readString(target.resolve("item.txt"), StandardCharsets.UTF_8));
+    assertEquals(
+        "child", Files.readString(target.resolve("nested").resolve("child.txt"), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void createBackupFileUsesSequentialSuffixes() throws Exception {
+    Path original = tempDir.resolve("config.properties");
+    Files.writeString(original, "v1", StandardCharsets.UTF_8);
+
+    File backup0 = PSInstallIoUtils.createBackupFile(original.toFile());
+    assertEquals("config.000", backup0.getName());
+    assertEquals("v1", Files.readString(backup0.toPath(), StandardCharsets.UTF_8));
+
+    File backup1 = PSInstallIoUtils.createBackupFile(original.toFile());
+    assertEquals("config.001", backup1.getName());
+    assertTrue(backup1.exists());
+    assertFalse(backup0.getName().equals(backup1.getName()));
+  }
+
+  @Test
+  public void createTempFileCopiesContents() throws Exception {
+    Path original = tempDir.resolve("template.xml");
+    Files.writeString(original, "<root/>", StandardCharsets.UTF_8);
+
+    File temp = PSInstallIoUtils.createTempFile(original.toFile());
+    temp.deleteOnExit();
+    assertTrue(temp.exists());
+    assertEquals("<root/>", Files.readString(temp.toPath(), StandardCharsets.UTF_8));
+  }
+}

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/TestExecSQLRemoveDupes.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/TestExecSQLRemoveDupes.java
@@ -92,8 +92,7 @@ public class TestExecSQLRemoveDupes {
   }
 
   @Test
-  public void testTask()
-      throws SQLException, ClassNotFoundException, IllegalAccessException, InstantiationException {
+  public void testTask() throws SQLException, ClassNotFoundException {
 
     PSExecSQLRemoveDupes task = new PSExecSQLRemoveDupes();
     task.setQualifyingTableName("CT_PAGE_PAGE_CATEGORIES_SET");
@@ -103,7 +102,7 @@ public class TestExecSQLRemoveDupes {
 
     // Now make sure that the data was updated correctly
     System.setProperty("derby.system.home", repoRoot);
-    Class.forName(driver).newInstance();
+    Class.forName(driver);
     try (Connection conn = DriverManager.getConnection(connectionURL)) {
       Statement statement = conn.createStatement();
       String sql =
@@ -130,10 +129,9 @@ public class TestExecSQLRemoveDupes {
   }
 
   @Test
-  public void testMultiLevelDupes()
-      throws SQLException, ClassNotFoundException, IllegalAccessException, InstantiationException {
+  public void testMultiLevelDupes() throws SQLException, ClassNotFoundException {
     System.setProperty("derby.system.home", repoRoot);
-    Class.forName(driver).newInstance();
+    Class.forName(driver);
     try (Connection conn = DriverManager.getConnection(connectionURL)) {
       Statement statement = conn.createStatement();
       String sql =
@@ -164,7 +162,7 @@ public class TestExecSQLRemoveDupes {
       newTask.execute();
     }
     System.setProperty("derby.system.home", repoRoot);
-    Class.forName(driver).newInstance();
+    Class.forName(driver);
     try (Connection connection = DriverManager.getConnection(connectionURL)) {
       Statement statement = connection.createStatement();
       String sql =


### PR DESCRIPTION
## Summary

PR-sized **batch 1** that clears inventoriable **main-source** javac diagnostics in `modules/perc-ant` (issue #2023).

**Inventory (JDK 21, raised `-Xmaxwarns`):**
- Project parent `-Xlint` / `-Xlint:-deprecation` / `-Xlint:serial`: **0** main-source warnings (already clean)
- Full `-Xlint:all` on main sources: **34** deprecation warnings → **0** after this PR
- Issue tracker's "200" figure is the historical inventory cap, not live main-source Xlint count

### Fixes (prefer real fixes over suppressions)

| Category | Change |
|----------|--------|
| IOTools deprecation | New `PSInstallIoUtils` (NIO `Files` + commons-io) for get/copy/backup/temp/stream |
| Ant APIs | `location` → `getLocation()`; `FileUtils.newFileUtils()` → `getFileUtils()`; portable `Path.resolve` |
| JDK APIs | `File.toURL()` → `toURI().toURL()`; `Class.newInstance()` → `Class.forName` only |
| Commons / Jericho | `WildcardFileFilter.builder()`; `StartTag.getElement().getEndTag()`; literal `String.equalsIgnoreCase` |
| Legacy upgrade paths | Targeted `@SuppressWarnings("deprecation")` only for `PSLegacyEncrypter` / `getPartOneKey` / `PSEntityResolver` / Ant `Main(String[])` |

### Tests
- `PSInstallIoUtilsTest` — 6 tests (UTF-8 read, copy, writeStream, copyToDir, backup sequence, temp copy)
- `TestExecSQLRemoveDupes` — drop deprecated `newInstance()`

### Residual (not module-zero for full #2023 acceptance)
Javadoc **"no main description"** on `PSMigrateI18nLocaleCodes` / `PSStripSampleLocales` (~8). Residual issue filed from this PR.

Parent tracker: #2200

## Test plan
- [x] `cd modules/perc-ant` → `../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **49**, Failures: **0**, Errors: **0**, Skipped: **0**
- [x] Main-source `-Xlint:all` warning lines: **0**
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Standalone module clean install | BUILD SUCCESS |
| Behavioral unit tests | 6 new green + suite 49 |
| Scope confined to perc-ant | yes |
| Prefer real fixes over blanket suppress | yes |
| Residual | javadoc main-description warnings (follow-up) |

Partial for #2023 (javac main-source batch 1 complete; javadoc residual remains).  
Refs #2200

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.