### PR TITLE
fix(deployer): Xlint batch 1 — real generics + easy wins (#2028)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
@@ -198,7 +198,7 @@ public class PSCatalogResult implements IPSDeployComponent, Comparable<PSCatalog
       }
 
       while (column != null) {
-        String data = tree.getElementData(column);
+        String data = PSXmlTreeWalker.getElementData(column);
         String typeString = PSDeployComponentUtils.getRequiredAttribute(column, XML_COL_TYPE_ATTR);
         int type = PSCatalogResultColumn.getType(typeString);
         if (PSCatalogResultColumn.validateType(type)) {

--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
@@ -89,7 +89,7 @@ public class PSCatalogResultColumn implements IPSDeployComponent {
 
     if (obj == null) throw new IllegalArgumentException("obj may not be null.");
 
-    Integer colType = (Integer) ms_typeObjects.get(obj.getClass());
+    Integer colType = ms_typeObjects.get(obj.getClass());
     if (colType != null) {
       return colType.intValue() == type;
     } else return false;
@@ -105,7 +105,7 @@ public class PSCatalogResultColumn implements IPSDeployComponent {
    */
   static String getTypeString(Object obj) {
     if (obj == null) throw new IllegalArgumentException("obj may not be null.");
-    Integer type = (Integer) ms_typeObjects.get(obj.getClass());
+    Integer type = ms_typeObjects.get(obj.getClass());
     if (type != null) return TYPE_ENUM[type.intValue()];
     else throw new IllegalArgumentException("obj is not a supported column type object");
   }

--- a/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
@@ -91,7 +91,7 @@ public class PSCatalogHandler {
     for (var i = 0; i < children.getLength(); i++) {
       var child = children.item(i);
       if (child instanceof Element element) {
-        props.setProperty(element.getTagName(), tree.getElementData(child));
+        props.setProperty(element.getTagName(), PSXmlTreeWalker.getElementData(child));
       }
     }
 
@@ -372,10 +372,10 @@ public class PSCatalogHandler {
       throws PSDeployException, PSNotFoundException {
     if (props == null
         || props.getProperty("type") == null
-        || ((String) props.getProperty("type")).trim().length() == 0)
+        || props.getProperty("type").trim().length() == 0)
       throw new PSDeployException(IPSDeploymentErrors.CATALOG_REQD_PROP_NOT_SPECIFIED, "type");
 
-    String type = (String) props.getProperty("type");
+    String type = props.getProperty("type");
     PSCatalogResultSet typeObjects = new PSCatalogResultSet();
     PSDependencyManager mgr = (PSDependencyManager) ms_depHandler.getDependencyManager();
     mgr.getDependencies(tok, type)

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveDetail.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveDetail.java
@@ -102,7 +102,7 @@ public class PSArchiveDetail implements IPSDeployComponent {
    * @return An Iterator over one or more <code>PSDeployableElement</code> objects. Never <code>null
    *     </code>.
    */
-  public Iterator getPackages() {
+  public Iterator<PSDeployableElement> getPackages() {
     return m_exportDescriptor.getPackages();
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
@@ -47,7 +47,7 @@ public class PSArchiveSummary implements IPSDeployComponent {
    *     objects. It may not be <code>null</code> or empty.
    * @throws IllegalArgumentException if any parameter is invalid.
    */
-  public PSArchiveSummary(PSArchiveInfo archiveInfo, Date installDate, Iterator packageList) {
+  public PSArchiveSummary(PSArchiveInfo archiveInfo, Date installDate, Iterator<PSArchivePackage> packageList) {
     if (archiveInfo == null || archiveInfo.getArchiveDetail() != null)
       throw new IllegalArgumentException(
           "archiveInfo may not be null or may not include PSArchiveDetail");
@@ -159,9 +159,9 @@ public class PSArchiveSummary implements IPSDeployComponent {
       throw new IllegalArgumentException("pkgName may not be null or empty");
 
     PSArchivePackage pkgFound = null;
-    Iterator pList = m_packageList.iterator();
+    Iterator<PSArchivePackage> pList = m_packageList.iterator();
     while (pList.hasNext() && pkgFound == null) {
-      PSArchivePackage pkg = (PSArchivePackage) pList.next();
+      PSArchivePackage pkg = pList.next();
       if (pkgName.equals(pkg.getName())) pkgFound = pkg;
     }
     if (pkgFound == null) throw new IllegalArgumentException("pkgName cannot be found");

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
@@ -42,7 +42,7 @@ import org.w3c.dom.Element;
  * application, exit, etc.
  */
 public abstract class PSDependency
-    implements IPSDependencyBaseline, IPSDeployComponent, Comparable {
+    implements IPSDependencyBaseline, IPSDeployComponent, Comparable<PSDependency> {
 
   private static final Logger log = LogManager.getLogger(PSDependency.class);
 
@@ -302,19 +302,19 @@ public abstract class PSDependency
    * @throws IllegalArgumentException if <code>dependencies</code> contains a <code>null</code>
    *     element.
    */
-  public void setDependencies(Iterator dependencies) {
+  public void setDependencies(Iterator<? extends PSDependency> dependencies) {
     if (m_dependencies != null) {
       // clear the parent dependency on any current children
-      for (Iterator children = m_dependencies.iterator(); children.hasNext(); ) {
-        PSDependency child = (PSDependency) children.next();
+      for (Iterator<PSDependency> children = m_dependencies.iterator(); children.hasNext(); ) {
+        PSDependency child = children.next();
         child.setParentDependency(null);
       }
     }
     if (dependencies == null) m_dependencies = null;
     else {
-      m_dependencies = new TreeSet();
+      m_dependencies = new TreeSet<>();
       while (dependencies.hasNext()) {
-        PSDependency dep = (PSDependency) dependencies.next();
+        PSDependency dep = dependencies.next();
         if (dep == null)
           throw new IllegalArgumentException("dependencies may not contain null element");
 
@@ -376,7 +376,7 @@ public abstract class PSDependency
   public String printDependencyTree() {
     StringBuilder buf = new StringBuilder();
 
-    printDependencyTree(buf, new ArrayList(), "");
+    printDependencyTree(buf, new ArrayList<>(), "");
 
     return buf.toString();
   }
@@ -551,9 +551,9 @@ public abstract class PSDependency
 
     boolean removed = false;
 
-    Iterator deps = m_dependencies.iterator();
+    Iterator<PSDependency> deps = m_dependencies.iterator();
     while (deps.hasNext() && !removed) {
-      PSDependency dep = (PSDependency) deps.next();
+      PSDependency dep = deps.next();
       if (dep.getDependencyType() == PSDependency.TYPE_USER) {
         PSUserDependency userDep = (PSUserDependency) dep;
         if (userDep.getPath().getPath().equals(path.getPath())) {
@@ -689,7 +689,7 @@ public abstract class PSDependency
 
     if (dep.getKey().equals(getKey())) found = true;
     else {
-      List checked = new ArrayList();
+      List<PSDependency> checked = new ArrayList<>();
       found = containsDependency(dep, checked);
     }
 
@@ -747,8 +747,8 @@ public abstract class PSDependency
       }
     } else {
       // search all dependencies
-      List checked = new ArrayList();
-      List parentStack = new ArrayList();
+      List<PSDependency> checked = new ArrayList<>();
+      List<PSDependency> parentStack = new ArrayList<>();
       included = includesDependency(dep, sameInstance, parentStack, checked);
     }
     return included;
@@ -772,14 +772,13 @@ public abstract class PSDependency
    * java.lang.String#compareToIgnoreCase(String) compareToIgnoreCase} for more information about
    * return value.
    *
-   * @param obj the object to compare, may not be <code>null</code>
-   * @throws IllegalArgumentException if obj is <code>null</code>
-   * @throws ClassCastException if obj is not an instance of PSDependency.
+   * @param dep the dependency to compare, may not be <code>null</code>
+   * @throws IllegalArgumentException if dep is <code>null</code>
    */
-  public int compareTo(Object obj) {
-    if (obj == null) throw new IllegalArgumentException("obj may not be null");
+  @Override
+  public int compareTo(PSDependency dep) {
+    if (dep == null) throw new IllegalArgumentException("obj may not be null");
 
-    PSDependency dep = (PSDependency) obj;
     int result = getDisplayIdentifier().compareToIgnoreCase(dep.getDisplayIdentifier());
     if (result == 0) result = getDependencyId().compareToIgnoreCase(dep.getDependencyId());
 
@@ -821,10 +820,10 @@ public abstract class PSDependency
    * @return <code>true</code> if <code>dep</code> is one of this dependency's children,
    *     recursively, <code>false</code> otherwise.
    */
-  private boolean containsDependency(PSDependency dep, List checked) {
-    Iterator checkedDeps = checked.iterator();
+  private boolean containsDependency(PSDependency dep, List<PSDependency> checked) {
+    Iterator<PSDependency> checkedDeps = checked.iterator();
     while (checkedDeps.hasNext()) {
-      PSDependency checkedDep = (PSDependency) checkedDeps.next();
+      PSDependency checkedDep = checkedDeps.next();
       if (checkedDep == this) return false;
     }
     checked.add(this);
@@ -834,9 +833,9 @@ public abstract class PSDependency
     if (m_dependencies != null) {
       // first check each child dep
       String depKey = dep.getKey();
-      Iterator deps = m_dependencies.iterator();
+      Iterator<PSDependency> deps = m_dependencies.iterator();
       while (deps.hasNext() && !found) {
-        PSDependency childDep = (PSDependency) deps.next();
+        PSDependency childDep = deps.next();
         if (depKey.equals(childDep.getKey())) found = true;
       }
 
@@ -844,7 +843,7 @@ public abstract class PSDependency
       if (!found) {
         deps = m_dependencies.iterator();
         while (deps.hasNext() && !found) {
-          PSDependency child = (PSDependency) deps.next();
+          PSDependency child = deps.next();
           found = child.containsDependency(dep, checked);
         }
       }
@@ -868,10 +867,13 @@ public abstract class PSDependency
    * @return <code>true</code> if the supplied dep is included, <code>false</code> otherwise.
    */
   private boolean includesDependency(
-      PSDependency dep, boolean sameInstance, List parentStack, List checked) {
-    Iterator checkedDeps = checked.iterator();
+      PSDependency dep,
+      boolean sameInstance,
+      List<PSDependency> parentStack,
+      List<PSDependency> checked) {
+    Iterator<PSDependency> checkedDeps = checked.iterator();
     while (checkedDeps.hasNext()) {
-      PSDependency checkedDep = (PSDependency) checkedDeps.next();
+      PSDependency checkedDep = checkedDeps.next();
       if (checkedDep == this) return false;
     }
     checked.add(this);
@@ -885,9 +887,9 @@ public abstract class PSDependency
     if ((sameInstance && this == dep) || (!sameInstance && getKey().equals(dep.getKey()))) {
       // if local, walk back up the parent stack to first non-local
       if (getDependencyType() == PSDependency.TYPE_LOCAL) {
-        Iterator parents = parentStack.iterator();
+        Iterator<PSDependency> parents = parentStack.iterator();
         while (parents.hasNext()) {
-          PSDependency parent = (PSDependency) parents.next();
+          PSDependency parent = parents.next();
           if (parent.getDependencyType() != PSDependency.TYPE_LOCAL) {
             included = parent.isIncluded();
             break;
@@ -904,9 +906,9 @@ public abstract class PSDependency
       parentStack.add(0, this);
 
       // check each child dep
-      Iterator deps = m_dependencies.iterator();
+      Iterator<PSDependency> deps = m_dependencies.iterator();
       while (deps.hasNext() && !included) {
-        PSDependency child = (PSDependency) deps.next();
+        PSDependency child = deps.next();
         included = child.includesDependency(dep, sameInstance, parentStack, checked);
       }
 
@@ -945,9 +947,9 @@ public abstract class PSDependency
   public int getChildCount(boolean includedOnly) {
     int count = 0;
     if (m_dependencies != null) {
-      Iterator deps = m_dependencies.iterator();
+      Iterator<PSDependency> deps = m_dependencies.iterator();
       while (deps.hasNext()) {
-        PSDependency dep = (PSDependency) deps.next();
+        PSDependency dep = deps.next();
         if (!(dep instanceof PSDeployableElement)) {
           if ((includedOnly && dep.isIncluded()) || !includedOnly) count++;
         }
@@ -1006,10 +1008,10 @@ public abstract class PSDependency
    */
   public boolean containsIncludedDependency() {
     boolean hasIncluded = false;
-    Iterator deps = getDependencies();
+    Iterator<PSDependency> deps = getDependencies();
     if (deps != null) {
       while (deps.hasNext() && !hasIncluded) {
-        PSDependency dep = (PSDependency) deps.next();
+        PSDependency dep = deps.next();
         if (dep instanceof PSDeployableElement) continue;
         hasIncluded = (dep.getDependencyType() != PSDependency.TYPE_LOCAL) && dep.isIncluded();
         if (!hasIncluded) hasIncluded = dep.containsIncludedDependency();
@@ -1104,18 +1106,18 @@ public abstract class PSDependency
 
     if (m_dependencies != null) {
       Element deps = PSXmlDocumentBuilder.addEmptyElement(doc, root, XML_EL_DEPENDENCIES);
-      Iterator i = m_dependencies.iterator();
+      Iterator<PSDependency> i = m_dependencies.iterator();
       while (i.hasNext()) {
-        PSDependency dep = (PSDependency) i.next();
+        PSDependency dep = i.next();
         deps.appendChild(dep.toXml(doc));
       }
     }
 
     if (m_ancestors != null) {
       Element ancs = PSXmlDocumentBuilder.addEmptyElement(doc, root, XML_EL_ANCESTORS);
-      Iterator i = m_ancestors.iterator();
+      Iterator<PSDependency> i = m_ancestors.iterator();
       while (i.hasNext()) {
-        PSDependency dep = (PSDependency) i.next();
+        PSDependency dep = i.next();
         ancs.appendChild(dep.toXml(doc));
       }
     }
@@ -1184,7 +1186,7 @@ public abstract class PSDependency
     m_dependencies = null;
     Element deps = tree.getNextElement(XML_EL_DEPENDENCIES, firstFlags);
     if (deps != null) {
-      m_dependencies = new TreeSet();
+      m_dependencies = new TreeSet<>();
       Element dep = tree.getNextElement(firstFlags);
       while (dep != null) {
         PSDependency depObj;
@@ -1211,7 +1213,7 @@ public abstract class PSDependency
     m_ancestors = null;
     Element ancs = tree.getNextElement(XML_EL_ANCESTORS, firstFlags);
     if (ancs != null) {
-      m_ancestors = new TreeSet();
+      m_ancestors = new TreeSet<>();
       Element dep = tree.getNextElement(firstFlags);
       while (dep != null) {
         PSDependency depObj;
@@ -1262,13 +1264,13 @@ public abstract class PSDependency
 
     if (dep.m_ancestors == null) m_ancestors = null;
     else {
-      m_ancestors = new TreeSet();
+      m_ancestors = new TreeSet<>();
       m_ancestors.addAll(dep.m_ancestors);
     }
 
     if (dep.m_dependencies == null) m_dependencies = null;
     else {
-      m_dependencies = new TreeSet();
+      m_dependencies = new TreeSet<>();
       m_dependencies.addAll(dep.m_dependencies);
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
@@ -777,7 +777,7 @@ public abstract class PSDependency
    */
   @Override
   public int compareTo(PSDependency dep) {
-    if (dep == null) throw new IllegalArgumentException("obj may not be null");
+    if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
     int result = getDisplayIdentifier().compareToIgnoreCase(dep.getDisplayIdentifier());
     if (result == 0) result = getDependencyId().compareToIgnoreCase(dep.getDependencyId());

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSExportDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSExportDescriptor.java
@@ -181,7 +181,7 @@ public class PSExportDescriptor extends PSDescriptor {
    * @return A set of strings representing the keys of dependencies that should not be added to the
    *     exported archive, or <code>null</code> if no such set is defined.
    */
-  public Set getDepKeysToExclude() {
+  public Set<String> getDepKeysToExclude() {
     return m_depKeysToExclude;
   }
 
@@ -204,7 +204,7 @@ public class PSExportDescriptor extends PSDescriptor {
    *
    * @return Iterator over zero or more package names as <code>String</code> objects.
    */
-  public Iterator getModifiedPackages() {
+  public Iterator<String> getModifiedPackages() {
     return m_modifiedPackageNames.iterator();
   }
 
@@ -229,7 +229,7 @@ public class PSExportDescriptor extends PSDescriptor {
    *
    * @return Iterator over zero or more package names as <code>String</code> objects.
    */
-  public Iterator getMissingPackages() {
+  public Iterator<String> getMissingPackages() {
     return m_missingPackageNames.iterator();
   }
 
@@ -241,7 +241,7 @@ public class PSExportDescriptor extends PSDescriptor {
    *     be <code>null</code>.
    * @throws IllegalArgumentException if <code>names</code> is <code>null</code>.
    */
-  public void setMissingPackages(Iterator names) {
+  public void setMissingPackages(Iterator<String> names) {
     if (names == null) throw new IllegalArgumentException("names may not be null");
 
     clearMissingPackages();

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
@@ -188,10 +188,10 @@ public class PSIdMap implements IPSDeployComponent {
       throw new IllegalArgumentException("parentType may not be null or empty");
     }
 
-    Iterator mappings = m_mappingList.iterator();
+    Iterator<PSIdMapping> mappings = m_mappingList.iterator();
     PSIdMapping result = null;
     while (mappings.hasNext() && result == null) {
-      PSIdMapping mapping = (PSIdMapping) mappings.next();
+      PSIdMapping mapping = mappings.next();
       if (targetId.equals(mapping.getTargetId()) && objectType.equals(mapping.getObjectType())) {
         if (targetParentId != null) {
           if (targetParentId.equals(mapping.getTargetParentId())

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
@@ -253,9 +253,9 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     respDoc.appendChild(newRoot);
 
     // get the elements
-    Iterator deps = m_depMgr.getDependencies(req.getSecurityToken(), type);
+    Iterator<PSDependency> deps = m_depMgr.getDependencies(req.getSecurityToken(), type);
     while (deps.hasNext()) {
-      Object o = deps.next();
+      PSDependency o = deps.next();
 
       if (o instanceof PSDeployableElement) {
         PSDeployableElement de = (PSDeployableElement) o;
@@ -299,9 +299,9 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     respDoc.appendChild(newRoot);
 
     // get the elements
-    Iterator deps = m_depMgr.getDependencies(req.getSecurityToken(), type, parentId);
+    Iterator<PSDependency> deps = m_depMgr.getDependencies(req.getSecurityToken(), type, parentId);
     while (deps.hasNext()) {
-      PSDependency dep = (PSDependency) deps.next();
+      PSDependency dep = deps.next();
       newRoot.appendChild(dep.toXml(respDoc));
     }
 
@@ -482,7 +482,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // if no dependencies, get all dependencies that support id types and are
     // deployable.
-    Iterator deps;
+    Iterator<PSDependency> deps;
     if (depList.isEmpty())
       deps =
           m_depMgr.getDependencies(
@@ -491,13 +491,13 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     else deps = depList.iterator();
 
     // get the types for all dependencies in our list
-    Iterator types = PSIdTypeManager.loadIdTypes(req.getSecurityToken(), deps);
+    Iterator<PSApplicationIDTypes> types = PSIdTypeManager.loadIdTypes(req.getSecurityToken(), deps);
 
     // create the response
     Document respDoc = PSXmlDocumentBuilder.createXmlDocument();
     Element root = PSXmlDocumentBuilder.createRoot(respDoc, "PSXDeployGetIdTypesResponse");
     while (types.hasNext()) {
-      PSApplicationIDTypes type = (PSApplicationIDTypes) types.next();
+      PSApplicationIDTypes type = types.next();
       root.appendChild(type.toXml(respDoc));
     }
 
@@ -1549,7 +1549,8 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
    * @throws PSDeployException if there are any errors.
    */
   private IPSDeployComponent getRequiredComponentFromRequest(
-      PSRequest req, Class compClass, String xmlNodeName) throws PSDeployException {
+      PSRequest req, Class<? extends IPSDeployComponent> compClass, String xmlNodeName)
+      throws PSDeployException {
     Document doc = req.getInputDocument();
     if (doc == null) throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
 
@@ -1569,8 +1570,9 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     IPSDeployComponent comp = null;
     try {
-      Constructor compCtor = compClass.getConstructor(new Class[] {Element.class});
-      comp = (IPSDeployComponent) compCtor.newInstance(new Object[] {compEl});
+      Constructor<? extends IPSDeployComponent> compCtor =
+          compClass.getConstructor(Element.class);
+      comp = compCtor.newInstance(compEl);
     } catch (Exception e) {
       if (e instanceof PSUnknownNodeTypeException) {
         Object[] args = {compEl.getTagName(), e.toString()};
@@ -1980,7 +1982,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // get the dependency
     PSDependency dep = getDependencyFromRequestDoc(doc);
-    List deps =
+    List<PSDependency> deps =
         PSDeployComponentUtils.cloneList(m_depMgr.getDependencies(req.getSecurityToken(), dep));
 
     // check max count to return
@@ -2346,7 +2348,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (req == null) throw new IllegalArgumentException(NULL_REQUEST_ERROR);
 
     // get the file to save
-    Iterator params = req.getParametersIterator();
+    Iterator<?> params = req.getParametersIterator();
 
     String archiveRef = req.getParameter("archiveRef");
     if (archiveRef == null || archiveRef.trim().length() == 0) {
@@ -2356,7 +2358,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     File inFile = null;
     while (params.hasNext() && inFile == null) {
-      Map.Entry entry = (Map.Entry) params.next();
+      Map.Entry<?, ?> entry = (Map.Entry<?, ?>) params.next();
       Object val = entry.getValue();
       if (val instanceof File) {
         inFile = (File) val;
@@ -2413,7 +2415,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (req == null) throw new IllegalArgumentException(NULL_REQUEST_ERROR);
 
     // get the file to save
-    Iterator params = req.getParametersIterator();
+    Iterator<?> params = req.getParametersIterator();
 
     String configRef = req.getParameter("configRef");
     if (configRef == null || configRef.trim().length() == 0) {
@@ -2423,7 +2425,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     File inFile = null;
     while (params.hasNext() && inFile == null) {
-      Map.Entry entry = (Map.Entry) params.next();
+      Map.Entry<?, ?> entry = (Map.Entry<?, ?>) params.next();
       Object val = entry.getValue();
       if (val instanceof File) {
         inFile = (File) val;
@@ -2564,13 +2566,13 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // build our response node
     Element respRoot = PSXmlDocumentBuilder.createRoot(respDoc, "PSXDeployGetParentTypesResponse");
-    Map types = m_depMgr.getParentTypes();
-    Iterator entries = types.entrySet().iterator();
+    Map<String, String> types = m_depMgr.getParentTypes();
+    Iterator<Map.Entry<String, String>> entries = types.entrySet().iterator();
     while (entries.hasNext()) {
-      Map.Entry entry = (Map.Entry) entries.next();
+      Map.Entry<String, String> entry = entries.next();
       Element entryEl = PSXmlDocumentBuilder.addEmptyElement(respDoc, respRoot, "entry");
-      entryEl.setAttribute("childType", (String) entry.getKey());
-      entryEl.setAttribute("parentType", (String) entry.getValue());
+      entryEl.setAttribute("childType", entry.getKey());
+      entryEl.setAttribute("parentType", entry.getValue());
     }
 
     return respDoc;
@@ -2683,7 +2685,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
   }
 
   // Methods generated from interface IPSLoadableRequestHandler
-  public void init(Collection requestRoots, InputStream cfgFileIn) throws PSServerException {
+  public void init(Collection<String> requestRoots, InputStream cfgFileIn) throws PSServerException {
     PSConsole.printMsg(activeSubsystem.name(), "Initializing Deployment Handler");
     m_requestRoots = requestRoots;
 
@@ -2720,7 +2722,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
    *     least one entry, and should not contain duplicates. Never <code>null</code> or empty. If
    *     <code>null</code> or empty the server will ignore this handler.
    */
-  public Iterator getRequestRoots() {
+  public Iterator<String> getRequestRoots() {
     if (m_requestRoots != null) {
       return m_requestRoots.iterator();
     } else {
@@ -3164,7 +3166,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     pkgInfo.setPackageDescription(desc.getDescription());
     pkgInfo.setPackageVersion(desc.getVersion());
     pkgInfo.setLastActionByUser(installerName);
-    pkgInfo.setPackageDescriptorGuid(new PSGuid(new Long(desc.getId())));
+    pkgInfo.setPackageDescriptorGuid(new PSGuid(Long.valueOf(desc.getId())));
 
     // Save package info object
     pkgInfoService.savePkgInfo(pkgInfo);
@@ -3202,7 +3204,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       PSPkgDependency dep = pkgInfoService.createPkgDependency();
       dep.setOwnerPackageGuid(pkgInfo.getGuid());
       dep.setDependentPackageGuid(pkgNameToGuid.get(pkgDep.get(PSDescriptor.XML_PKG_DEP_NAME)));
-      dep.setImpliedDep(new Boolean(pkgDep.get(PSDescriptor.XML_PKG_DEP_IMPLIED)));
+      dep.setImpliedDep(Boolean.valueOf(pkgDep.get(PSDescriptor.XML_PKG_DEP_IMPLIED)));
       pkgInfoService.savePkgDependency(dep);
     }
 
@@ -3390,7 +3392,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
    * Request roots this handler will support, initialized during the <code>init()</code> method,
    * never <code>null</code>, empty, or modified after that.
    */
-  private Collection m_requestRoots;
+  private Collection<String> m_requestRoots;
 
   /**
    * Singleton instance of the deployment handler. Not <code>null</code> after call to ctor by the

--- a/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
@@ -141,7 +141,7 @@ public class PSLogHandler {
     if (tData != null) {
       var rows = tData.getRows();
       while (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         asList.add(getArchiveSummary(row));
       }
     }
@@ -175,7 +175,7 @@ public class PSLogHandler {
       PSJdbcRowData latestRow = null;
       var rows = tData.getRows();
       while (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         var date = m_dbmsHandle.getColumnDate(ALS_TABLE_NAME, ALS_INSTALL_DATE, row);
         if ((latestDate == null) || (date.compareTo(latestDate) > 0)) {
           latestDate = date;
@@ -210,7 +210,7 @@ public class PSLogHandler {
     if (tData != null) {
       var rows = tData.getRows();
       if (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         arSummary = getArchiveSummary(row);
       }
     }
@@ -266,7 +266,7 @@ public class PSLogHandler {
     if (tData != null) {
       var rows = tData.getRows();
       while (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         var name = m_dbmsHandle.getColumnString(AP_TABLE_NAME, AP_PACKAGE_NAME, row);
         var type = m_dbmsHandle.getColumnString(AP_TABLE_NAME, AP_PACKAGE_TYPE, row);
         int status = m_dbmsHandle.getColumnInt(AP_TABLE_NAME, AP_STATUS, row);
@@ -299,7 +299,7 @@ public class PSLogHandler {
     if (tableData != null) {
       var rows = tableData.getRows();
       while (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         logSmryList.add(getLogSummary(row, false));
       }
     }
@@ -331,7 +331,7 @@ public class PSLogHandler {
     if (tData != null) {
       var rows = tData.getRows();
       while (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         var archiveId = m_dbmsHandle.getColumnString(ALS_TABLE_NAME, ALS_ARCHIVE_LOG_ID, row);
         if (sArchiveIds.length() == 0) sArchiveIds.append("(").append(archiveId);
         else sArchiveIds.append(",").append(archiveId);
@@ -384,7 +384,7 @@ public class PSLogHandler {
     if (tData != null) {
       var rows = tData.getRows();
       if (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         logSummary = getLogSummary(row, includeDetail);
       }
     }
@@ -461,7 +461,7 @@ public class PSLogHandler {
 
       var rows = tData.getRows();
       while (rows.hasNext()) {
-        var row = (PSJdbcRowData) rows.next();
+        var row = rows.next();
         var depDesc = m_dbmsHandle.getColumnString(TXN_TABLE_NAME, TXN_DEPENDENCY, row);
         var name = m_dbmsHandle.getColumnString(TXN_TABLE_NAME, TXN_ELEMENT_NAME, row);
         var type = m_dbmsHandle.getColumnString(TXN_TABLE_NAME, TXN_ELEMENT_TYPE, row);
@@ -600,13 +600,13 @@ public class PSLogHandler {
     // get all summaries for this ref
     Iterator<PSArchiveSummary> summmaries = getArchiveSummaries(null, archiveRef);
     while (summmaries.hasNext()) {
-      PSArchiveSummary sum = (PSArchiveSummary) summmaries.next();
+      PSArchiveSummary sum = summmaries.next();
       int archiveId = sum.getId();
 
       // walk the packages and delete their logs
       Iterator<PSArchivePackage> pkgs = sum.getPackageList();
       while (pkgs.hasNext()) {
-        PSArchivePackage pkg = (PSArchivePackage) pkgs.next();
+        PSArchivePackage pkg = pkgs.next();
         if (pkg.isInstalled()) deleteLog(pkg.getLogId(), false);
       }
 
@@ -1067,12 +1067,12 @@ public class PSLogHandler {
    * @return The created table data object, never <code>null</code>.
    */
   private PSJdbcTableData getTableDataForAddPackages(
-      int archiveLogId, Iterator<PSDependency> pkgList) {
+      int archiveLogId, Iterator<? extends PSDependency> pkgList) {
     List<PSJdbcRowData> rowDataList = new ArrayList<>();
     PSJdbcRowData rowData;
 
     while (pkgList.hasNext()) {
-      PSDependency pkg = (PSDependency) pkgList.next();
+      PSDependency pkg = pkgList.next();
       rowData = getRowDataForAddPackage(archiveLogId, pkg);
       rowDataList.add(rowData);
     }

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSArchiveSummaryTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSArchiveSummaryTest.java
@@ -70,7 +70,7 @@ public class PSArchiveSummaryTest {
         new PSArchivePackage("pkg2", "pkgType2", PSArchivePackage.STATUS_IN_PROGRESS, -1);
     PSArchivePackage pkg3 =
         new PSArchivePackage("pkg3", "pkgType2", PSArchivePackage.STATUS_IN_PROGRESS, -1);
-    List pkgList = new ArrayList();
+    List<PSArchivePackage> pkgList = new ArrayList<>();
     pkgList.add(pkg1);
     pkgList.add(pkg2);
     pkgList.add(pkg3);
@@ -92,5 +92,13 @@ public class PSArchiveSummaryTest {
     as.setArchiveManifest(archman);
 
     return as;
+  }
+
+  /** Verifies typed package list lookup after Iterator&lt;PSArchivePackage&gt; cleanup. */
+  @Test
+  public void testGetPackageType() {
+    PSArchiveSummary as = getArchiveSummaryNoManifest();
+    assertEquals("pkgType1", as.getPackageType("pkg1"));
+    assertEquals("pkgType2", as.getPackageType("pkg2"));
   }
 }

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSArchiveTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSArchiveTest.java
@@ -224,8 +224,7 @@ public class PSArchiveTest {
           "Archive detail is: " + (info.getArchiveDetail() == null ? "NULL" : "PRESENT"));
 
       if (info.getArchiveDetail() != null) {
-        @SuppressWarnings("unchecked")
-        Iterator<PSDependency> pkgs = info.getArchiveDetail().getPackages();
+        Iterator<PSDeployableElement> pkgs = info.getArchiveDetail().getPackages();
         long pkgCount =
             java.util.stream.StreamSupport.stream(
                     java.util.Spliterators.spliteratorUnknownSize(pkgs, 0), false)
@@ -233,11 +232,10 @@ public class PSArchiveTest {
         System.out.println("Detail contains " + pkgCount + " packages");
 
         // Reset iterator since we consumed it
-        @SuppressWarnings("unchecked")
-        Iterator<PSDependency> pkgs2 = info.getArchiveDetail().getPackages();
+        Iterator<PSDeployableElement> pkgs2 = info.getArchiveDetail().getPackages();
         int pkgIndex = 0;
         while (pkgs2.hasNext()) {
-          PSDependency pkg = pkgs2.next();
+          PSDeployableElement pkg = pkgs2.next();
           Iterator<PSDependency> deps = pkg.getDependencies();
           long depCount =
               java.util.stream.StreamSupport.stream(

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.utils.collections.PSIteratorUtils;
@@ -31,6 +32,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
@@ -84,6 +86,48 @@ public class PSDependencyTest {
     assertEquals(0, lower.compareTo(lower));
     // same display identifier falls back to dependency id
     assertTrue(lower.compareTo(sameDisplayDifferentId) < 0);
+
+    IllegalArgumentException npeMsg =
+        assertThrows(IllegalArgumentException.class, () -> lower.compareTo(null));
+    assertEquals("dep may not be null", npeMsg.getMessage());
+  }
+
+  /**
+   * {@code Comparable<PSDependency>} is safe: no concrete subclass overrides {@code compareTo},
+   * and mixed {@link PSDeployableElement}/{@link PSDeployableObject} instances order correctly via
+   * the base implementation (and via {@link TreeSet}, which is how children are stored).
+   */
+  @Test
+  public void testCompareToAcrossSubclassesAndTreeSet() {
+    PSDeployableElement elem =
+        new PSDeployableElement(
+            PSDependency.TYPE_SHARED,
+            "e1",
+            "TypeE",
+            "Type E",
+            "alpha",
+            true,
+            false,
+            false);
+    PSDeployableObject obj =
+        new PSDeployableObject(
+            PSDependency.TYPE_SHARED,
+            "o1",
+            "TypeO",
+            "Type O",
+            "beta",
+            true,
+            false,
+            false);
+
+    // Polymorphic typed compare (not Object overload) — both use PSDependency.compareTo
+    assertTrue(elem.compareTo(obj) < 0);
+    assertTrue(obj.compareTo(elem) > 0);
+
+    TreeSet<PSDependency> set = new TreeSet<>();
+    set.add(obj);
+    set.add(elem);
+    assertEquals(List.of(elem, obj), new ArrayList<>(set));
   }
 
   /**

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyTest.java
@@ -43,6 +43,50 @@ public class PSDependencyTest {
   public PSDependencyTest() {}
 
   /**
+   * Behavioral coverage for {@link PSDependency#compareTo(PSDependency)} after
+   * {@code Comparable<PSDependency>} typing (issue #2028 batch 1).
+   */
+  @Test
+  public void testCompareToOrdersByDisplayIdentifier() {
+    PSDeployableObject lower =
+        new PSDeployableObject(
+            PSDependency.TYPE_SHARED,
+            "id-a",
+            "TypeA",
+            "Type A",
+            "alpha",
+            true,
+            false,
+            false);
+    PSDeployableObject higher =
+        new PSDeployableObject(
+            PSDependency.TYPE_SHARED,
+            "id-b",
+            "TypeA",
+            "Type A",
+            "beta",
+            true,
+            false,
+            false);
+    PSDeployableObject sameDisplayDifferentId =
+        new PSDeployableObject(
+            PSDependency.TYPE_SHARED,
+            "id-c",
+            "TypeA",
+            "Type A",
+            "alpha",
+            true,
+            false,
+            false);
+
+    assertTrue(lower.compareTo(higher) < 0);
+    assertTrue(higher.compareTo(lower) > 0);
+    assertEquals(0, lower.compareTo(lower));
+    // same display identifier falls back to dependency id
+    assertTrue(lower.compareTo(sameDisplayDifferentId) < 0);
+  }
+
+  /**
    * Tests the <code>getParentDependency</code> method.
    *
    * @throws Exception
@@ -75,7 +119,7 @@ public class PSDependencyTest {
     // parent dep should be null until this is assigned as a child
     assertNull(do2.getParentDependency());
 
-    List objList = new ArrayList();
+    List<PSDependency> objList = new ArrayList<>();
     objList.add(do1);
     objList.add(do2);
 
@@ -104,8 +148,8 @@ public class PSDependencyTest {
     Element el = de1.toXml(doc);
     PSDeployableElement de2 = new PSDeployableElement(el);
     assertEquals(de1, de2);
-    for (Iterator i = de2.getDependencies(); i.hasNext(); ) {
-      PSDependency dep = (PSDependency) i.next();
+    for (Iterator<PSDependency> i = de2.getDependencies(); i.hasNext(); ) {
+      PSDependency dep = i.next();
       assertNotNull(dep.getParentDependency());
       assertSame(de2, dep.getParentDependency());
     }
@@ -114,14 +158,14 @@ public class PSDependencyTest {
     PSDependency clone = (PSDependency) de1.clone();
     assertEquals(de1, clone);
     // de1's deps should point to de1
-    for (Iterator i = de1.getDependencies(); i.hasNext(); ) {
-      PSDependency dep = (PSDependency) i.next();
+    for (Iterator<PSDependency> i = de1.getDependencies(); i.hasNext(); ) {
+      PSDependency dep = i.next();
       assertNotNull(dep.getParentDependency());
       assertSame(de1, dep.getParentDependency());
     }
     // clone's deps should point to clone (clone is deep)
-    for (Iterator i = clone.getDependencies(); i.hasNext(); ) {
-      PSDependency dep = (PSDependency) i.next();
+    for (Iterator<PSDependency> i = clone.getDependencies(); i.hasNext(); ) {
+      PSDependency dep = i.next();
       assertNotNull(dep.getParentDependency());
       assertSame(clone, dep.getParentDependency());
     }
@@ -199,7 +243,7 @@ public class PSDependencyTest {
             false,
             false);
 
-    List objList = new ArrayList();
+    List<PSDependency> objList = new ArrayList<>();
     objList.add(do1);
     objList.add(do2);
 


### PR DESCRIPTION
## Summary
Partial Xlint cleanup for **perc-deployer** (issue #2028, parent tracker #2200). First PR-sized batch prefers **real generics** and mechanical easy wins over blanket suppressions.

### Main changes
- **PSDependency**: `Comparable<PSDependency>`, typed `setDependencies` / tree helpers (`List`/`Iterator`/`TreeSet` diamond), remove raw casts in walkers
- **PSArchiveSummary / PSExportDescriptor / PSArchiveDetail / PSIdMap**: typed package/iterator/set APIs
- **PSDeploymentHandler**: request roots `Collection<String>`/`Iterator<String>`, IdTypes iterators, parent type map, reflection `Class`/`Constructor` typing, `Long.valueOf`/`Boolean.valueOf` for-removal
- **PSLogHandler**: remove redundant casts once iterators are typed; `Iterator<? extends PSDependency>` for package rows
- **Catalog**: static `PSXmlTreeWalker.getElementData` qualification; drop redundant `String`/`Integer` casts

### Tests
- `PSDependencyTest.testCompareToOrdersByDisplayIdentifier`
- `PSArchiveSummaryTest.testGetPackageType`
- `PSArchiveTest` package iterator typing for `Iterator<PSDeployableElement>`

## Residual
Remaining diagnostics tracked in **#2417** (full module still has many warnings under uncapped `-Xmaxwarns`; default Maven reports cap at 100 per compile/testCompile phase).

## Test plan
- [x] `cd deployer && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **176**, Failures: **0**, Errors: **0**, Skipped: **19**
- [x] No new production behavior beyond type-safe API surfaces already used with raw types

## Gates
- Erlang-style self-review: real generics preferred; portable paths N/A (no path I/O changes)
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2028  
Refs #2200  
Residual: #2417

> Co-Authored by Grok Build using grok-4.5 with agent main.