### PR TITLE
fix(perc-toolkit): Xlint batch 1 — real generics + easy wins (#2030)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2030-perc-toolkit-xlint-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2030-perc-toolkit-xlint-batch1-erlang.md
@@ -1,0 +1,42 @@
+# Erlang self-review — issue #2030 perc-toolkit Xlint batch 1
+
+**Date:** 2026-08-08  
+**Branch:** `fix/issue-2030-perc-toolkit-xlint-batch1`  
+**Module:** `modules/perc-toolkit`  
+**Verdict:** **Approve** (commit-ready)
+
+## Scope
+
+PR-sized batch 1 for parent #2200 / issue #2030. Live main-source project `-Xlint` diagnostics **87 → 26** (~61 cleared). Prefer real generics and mechanical easy wins; no blanket suppressions.
+
+### In batch
+
+- For-removal boxed constructors (`Long`/`Double`/`Boolean`) → valueOf / primitive casts
+- `serialVersionUID` on `ArchivedException`, `UniqueIdLocatorSet`, `TrashTask.FatalTaskException`
+- Missing `@Deprecated` on `QueuedEdition` + `PublishEditionService` deprecated API surface
+- Real generics: `MutableHttpServletRequestWrapper` servlet override maps/enumerations; `PSOMutableUrl` entry iteration; `PSOParseUrlQueryString` multi-value lists; `SimplifyParameters` `List<?>`; `PSOListTools` reverse/`Class<?>`/`sublist` cast
+- JAXB `Class[]` → `JAXBContext.newInstance(Item.class)` style
+- Raw upstream iterators consumed as `Iterator<?>` + element cast (folder properties, extensions, ACL, AA relations)
+- `SlotItemComparator.hashCode` consistent with all-equal `equals`
+
+### Out of batch (residual)
+
+- `this-escape` constructor sites (~14): Error/Field/Http*Response/FolderTools/PSOExtensionParamsHelper/relationship builders/PSORequestContext
+- `PSORequestContext` cascade of parent `PSRequestContext` override rawtype/unchecked mismatches (~11) — fix belongs with parent API typing in perc-system or local suppress after parent work
+- `PropertyData` non-serializable field type (~1)
+- Any remaining test-source diagnostics under uncapped inventory
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in typed refactors | None found — collections already held typed elements; only declarations/casts updated |
+| Portable paths / file I/O | N/A (no path-string changes) |
+| Behavioral unit tests | New: `PSOMutableUrlTest`, `PSOParseUrlQueryStringTest`; extended `PSOSlotContentsTest`, `UniqueIdLocatorSetTest`; existing image/simplify/wrapper tests cover easy wins |
+| Prefer real fix over suppress | Yes — no new blanket `@SuppressWarnings` |
+| Standalone `mvnw clean install` | BUILD SUCCESS — Tests run: 223, Failures: 0, Errors: 0, Skipped: 16 |
+| Scope confined to perc-toolkit | Yes |
+
+## Residual issue
+
+Follow-up residual child for remaining ~26 main-source diagnostics (this-escape + PSORequestContext cascade + serial field).

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageEditorWizard.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageEditorWizard.java
@@ -396,12 +396,7 @@ public class ImageEditorWizard {
     long y = Math.max(Math.round(rect.getY() * scaleFactor), 0l);
     long h = Math.min(Math.round(rect.getHeight() * scaleFactor), imageSize.height - y);
     long w = Math.min(Math.round(rect.getWidth() * scaleFactor), imageSize.width - x);
-    Rectangle out =
-        new Rectangle(
-            new Long(x).intValue(),
-            new Long(y).intValue(),
-            new Long(w).intValue(),
-            new Long(h).intValue());
+    Rectangle out = new Rectangle((int) x, (int) y, (int) w, (int) h);
     return out;
   }
 
@@ -960,9 +955,9 @@ public class ImageEditorWizard {
         && width < maxDisplayWidth) { // image is small enough that we don't need to scale it.
       return 1.0;
     }
-    Double hr = new Double(height) / new Double(maxDisplayHeight);
-    Double wr = new Double(width) / new Double(maxDisplayWidth);
-    return Math.max(hr.doubleValue(), wr.doubleValue());
+    double hr = (double) height / (double) maxDisplayHeight;
+    double wr = (double) width / (double) maxDisplayWidth;
+    return Math.max(hr, wr);
   }
 
   public UserSessionData getUserSessionData(HttpServletRequest request) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
@@ -249,7 +249,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
       if (box.height > 0) {
         scale = size.getWidth() / box.getWidth();
         log.debug("scale is {}", scale);
-        height = new Long(Math.round(box.getHeight() * scale)).intValue();
+        height = (int) Math.round(box.getHeight() * scale);
       } else {
         height = 0;
       }
@@ -257,7 +257,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
       height = size.height;
       if (box.height > 0) {
         scale = size.getHeight() / box.getHeight();
-        width = new Long(Math.round(box.getWidth() * scale)).intValue();
+        width = (int) Math.round(box.getWidth() * scale);
       } else {
         width = 0;
       }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOListTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOListTools.java
@@ -157,10 +157,10 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
       end = 0;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    List tmp = subListUnSafe(c, start, end);
-    rvalue = tmp;
-    return rvalue;
+    List<Object> tmp = subListUnSafe(c, start, end);
+    @SuppressWarnings("unchecked")
+    List<T> typed = (List<T>) (List<?>) tmp;
+    return typed;
   }
 
   /**
@@ -343,7 +343,7 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
       params = {
         @IPSJexlParam(name = "list", description = "the list whose elements are to be reversed.")
       })
-  public void reverse(List list) {
+  public void reverse(List<?> list) {
     Collections.reverse(list);
   }
 
@@ -364,7 +364,7 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
           s.append(",");
         }
         s.append(m.getName() + "(");
-        Class[] params = m.getParameterTypes();
+        Class<?>[] params = m.getParameterTypes();
         for (int j = 0; j < params.length; j++) {
           s.append(params[j].getName());
           if (j < (params.length - 1)) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOProxyQueryResource.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOProxyQueryResource.java
@@ -118,12 +118,11 @@ public class PSOProxyQueryResource extends PSDefaultExtension
     }
   }
 
-  @SuppressWarnings({"unused", "unchecked"})
   private String buildUrlQueryString(IPSRequestContext request, List<String> ignore) {
-    Iterator it = request.getParametersIterator();
-    List<String> params = new ArrayList<String>();
+    Iterator<Entry<String, Object>> it = request.getParametersIterator();
+    List<String> params = new ArrayList<>();
     while (it.hasNext()) {
-      Entry<String, Object> element = (Entry<String, Object>) it.next();
+      Entry<String, Object> element = it.next();
       String name = element.getKey();
       if (ignore != null && ignore.contains(name)) continue;
       Object value = element.getValue();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipHelperService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipHelperService.java
@@ -400,8 +400,8 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
             + trueOwnerIdsFalseDependentIds);
 
     // remove any relationships from the set that are not being removed
-    for (Iterator iter = relationships.iterator(); iter.hasNext(); ) {
-      PSRelationship relationship = (PSRelationship) iter.next();
+    for (Iterator<PSRelationship> iter = relationships.iterator(); iter.hasNext(); ) {
+      PSRelationship relationship = iter.next();
       Integer ownerId;
       if (trueOwnerIdsFalseDependentIds)
         ownerId = Integer.valueOf((relationship.getOwner().getId()));

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ArchivedException.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ArchivedException.java
@@ -18,6 +18,8 @@
 package com.percussion.pso.restservice.impl;
 
 public class ArchivedException extends Exception {
+  private static final long serialVersionUID = 1L;
+
   private String message;
 
   public ArchivedException(String message) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ItemRestServiceImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ItemRestServiceImpl.java
@@ -341,7 +341,7 @@ public class ItemRestServiceImpl implements IItemRestService {
           log.debug("Folder communityname is {}", aclComm);
           List<AclItem> aclitems = new ArrayList<AclItem>();
 
-          Iterator entries = acls[0].iterator();
+          Iterator<?> entries = acls[0].iterator();
           PSObjectAclEntry entry;
           while (entries.hasNext()) {
             log.debug("Found AclEntry");
@@ -939,12 +939,12 @@ public class ItemRestServiceImpl implements IItemRestService {
           rows.add(cr);
           List<Field> fields = new ArrayList<Field>();
           cr.setFields(fields);
-          Iterator<PSField> iterator = child.getEveryField();
+          Iterator<?> fieldIter = child.getEveryField();
 
-          while (iterator.hasNext()) {
+          while (fieldIter.hasNext()) {
 
             try {
-              PSField psfield = iterator.next();
+              PSField psfield = (PSField) fieldIter.next();
               String type = psfield.getDataType();
               String fieldname = psfield.getSubmitName();
               log.debug("adding child field " + fieldname);
@@ -1456,7 +1456,7 @@ public class ItemRestServiceImpl implements IItemRestService {
     StringWriter sw = new StringWriter();
     try {
 
-      JAXBContext jc = JAXBContext.newInstance(new Class[] {Item.class});
+      JAXBContext jc = JAXBContext.newInstance(Item.class);
       Marshaller m = jc.createMarshaller();
       m.setProperty("jaxb.fragment", Boolean.TRUE);
       m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
@@ -1478,7 +1478,7 @@ public class ItemRestServiceImpl implements IItemRestService {
    * @throws JAXBException
    */
   public Item getItemFromStream(InputStream is) throws JAXBException {
-    JAXBContext jc = JAXBContext.newInstance(new Class[] {Item.class});
+    JAXBContext jc = JAXBContext.newInstance(Item.class);
     Unmarshaller um = jc.createUnmarshaller();
     return (Item) um.unmarshal(is);
   }
@@ -1493,7 +1493,7 @@ public class ItemRestServiceImpl implements IItemRestService {
     DocumentResult dr = new DocumentResult();
     try {
 
-      JAXBContext jc = JAXBContext.newInstance(new Class[] {Item.class});
+      JAXBContext jc = JAXBContext.newInstance(Item.class);
       Marshaller m = jc.createMarshaller();
       m.setProperty("jaxb.fragment", Boolean.TRUE);
       m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/ItemServiceHelper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/ItemServiceHelper.java
@@ -46,7 +46,7 @@ public class ItemServiceHelper {
     StringWriter sw = new StringWriter();
     try {
 
-      JAXBContext jc = JAXBContext.newInstance(new Class[] {Item.class});
+      JAXBContext jc = JAXBContext.newInstance(Item.class);
       Marshaller m = jc.createMarshaller();
       m.setProperty("jaxb.fragment", Boolean.TRUE);
       m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
@@ -67,7 +67,7 @@ public class ItemServiceHelper {
    * @throws JAXBException
    */
   public static Item getItemFromXml(InputStream is) throws JAXBException {
-    JAXBContext jc = JAXBContext.newInstance(new Class[] {Item.class});
+    JAXBContext jc = JAXBContext.newInstance(Item.class);
     Unmarshaller um = jc.createUnmarshaller();
     Item item = (Item) um.unmarshal(is);
     return item;
@@ -81,7 +81,7 @@ public class ItemServiceHelper {
    * @throws JAXBException
    */
   public static Items getItemsFromXml(InputStream is) throws JAXBException {
-    JAXBContext jc = JAXBContext.newInstance(new Class[] {Items.class});
+    JAXBContext jc = JAXBContext.newInstance(Items.class);
     Unmarshaller um = jc.createUnmarshaller();
     Items items = (Items) um.unmarshal(is);
     return items;
@@ -121,7 +121,7 @@ public class ItemServiceHelper {
     DocumentResult dr = new DocumentResult();
     try {
 
-      JAXBContext jc = JAXBContext.newInstance(new Class[] {Item.class});
+      JAXBContext jc = JAXBContext.newInstance(Item.class);
       Marshaller m = jc.createMarshaller();
       m.setProperty("jaxb.fragment", Boolean.TRUE);
       m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/tasks/TrashTask.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/tasks/TrashTask.java
@@ -910,6 +910,8 @@ public class TrashTask implements IPSTask {
 
   /** */
   public class FatalTaskException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     /**
      * Constructor for FatalTaskException.
      *

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/MutableHttpServletRequestWrapper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/MutableHttpServletRequestWrapper.java
@@ -124,7 +124,7 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
    * @see jakarta.servlet.ServletRequestWrapper#getParameterMap()
    */
   @Override
-  public Map getParameterMap() {
+  public Map<String, String[]> getParameterMap() {
     return Collections.unmodifiableMap(localParams);
   }
 
@@ -132,8 +132,8 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
    * @see jakarta.servlet.ServletRequestWrapper#getParameterNames()
    */
   @Override
-  public Enumeration getParameterNames() {
-    return Collections.<String>enumeration(localParams.keySet());
+  public Enumeration<String> getParameterNames() {
+    return Collections.enumeration(localParams.keySet());
   }
 
   /**
@@ -165,12 +165,12 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
    * @see jakarta.servlet.http.HttpServletRequestWrapper#getHeaderNames()
    */
   @Override
-  public Enumeration getHeaderNames() {
-    Set<String> names = new HashSet<String>();
+  public Enumeration<String> getHeaderNames() {
+    Set<String> names = new HashSet<>();
     names.addAll(localHeaders.keySet());
-    Enumeration e = super.getHeaderNames();
+    Enumeration<String> e = super.getHeaderNames();
     while (e.hasMoreElements()) {
-      String nm = e.nextElement().toString().toLowerCase();
+      String nm = e.nextElement().toLowerCase();
       if (!names.contains(nm)) // faster this way
       {
         names.add(nm);
@@ -183,7 +183,7 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
    * @see jakarta.servlet.http.HttpServletRequestWrapper#getHeaders(java.lang.String)
    */
   @Override
-  public Enumeration getHeaders(String name) {
+  public Enumeration<String> getHeaders(String name) {
     Validate.notEmpty(name);
     String key = name.toUpperCase();
     if (localHeaders.containsKey(key)) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOMutableUrl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOMutableUrl.java
@@ -93,11 +93,11 @@ public class PSOMutableUrl {
     sb.append(m_base);
 
     char sep = QUERY_SEP;
-    Iterator iter = this.m_param.entrySet().iterator();
+    Iterator<Map.Entry<String, Object>> iter = this.m_param.entrySet().iterator();
     while (iter.hasNext()) {
-      Map.Entry entry = (Map.Entry) iter.next();
+      Map.Entry<String, Object> entry = iter.next();
       sb.append(sep);
-      sb.append(entry.getKey().toString());
+      sb.append(entry.getKey());
       sb.append('=');
       sb.append(entry.getValue().toString());
       sep = PARAM_SEP;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOParseUrlQueryString.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOParseUrlQueryString.java
@@ -55,18 +55,20 @@ public class PSOParseUrlQueryString {
            *     no mapping for key. A <code>null</code> return can also indicate that the HashMap
            *     previously associated <code>null</code> with the specified key.
            */
-          @SuppressWarnings(value = {"unchecked"})
+          @Override
           public Object put(String key, Object value) {
             Object oldValue = super.put(key, value);
             if (oldValue != null) {
               if (oldValue instanceof ArrayList) {
-                ((ArrayList) oldValue).add(value);
-                super.put(key, oldValue);
+                @SuppressWarnings("unchecked")
+                ArrayList<Object> existing = (ArrayList<Object>) oldValue;
+                existing.add(value);
+                super.put(key, existing);
               } else {
-                ArrayList l = new ArrayList();
-                l.add(oldValue);
-                l.add(value);
-                super.put(key, l);
+                ArrayList<Object> list = new ArrayList<>();
+                list.add(oldValue);
+                list.add(value);
+                super.put(key, list);
               }
             }
             return oldValue;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotContents.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotContents.java
@@ -174,6 +174,14 @@ public class PSOSlotContents {
       }
       return super.equals(obj);
     }
+
+    /**
+     * All instances of this comparator are equal, so all share one hash code.
+     */
+    @Override
+    public int hashCode() {
+      return 1;
+    }
   }
 
   /**

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotRelations.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotRelations.java
@@ -183,10 +183,10 @@ public class PSOSlotRelations {
    */
   private static List<PSAaRelationship> fromRelList(PSAaRelationshipList relList)
       throws PSCmsException {
-    List<PSAaRelationship> relations = new ArrayList<PSAaRelationship>();
-    Iterator<PSAaRelationship> itr = relList.iterator();
+    List<PSAaRelationship> relations = new ArrayList<>();
+    Iterator<?> itr = relList.iterator();
     while (itr.hasNext()) {
-      relations.add(itr.next());
+      relations.add((PSAaRelationship) itr.next());
     }
     return relations;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/SimplifyParameters.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/SimplifyParameters.java
@@ -81,8 +81,8 @@ public class SimplifyParameters {
       sval = x[0];
       log.trace("Converted String[] to {} {}", sval, value);
     } else if (value instanceof List) {
-      List x = (List) value;
-      if (x.size() == 0) {
+      List<?> x = (List<?>) value;
+      if (x.isEmpty()) {
         log.debug("Empty List");
         return "";
       }
@@ -102,7 +102,7 @@ public class SimplifyParameters {
       return result;
     }
     if (value instanceof List) {
-      List<Object> ff = (List<Object>) value;
+      List<?> ff = (List<?>) value;
       for (Object vl : ff) {
         result.add(vl.toString());
       }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/UniqueIdLocatorSet.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/UniqueIdLocatorSet.java
@@ -36,6 +36,8 @@ import java.util.Set;
  */
 public class UniqueIdLocatorSet extends HashSet<PSLocator>
     implements Set<PSLocator>, Iterable<PSLocator> {
+  private static final long serialVersionUID = 1L;
+
   /** */
   public UniqueIdLocatorSet() {
     super();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOFileUploadValidation.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOFileUploadValidation.java
@@ -150,7 +150,7 @@ public class PSOFileUploadValidation implements IPSFieldValidator {
       }
     }
 
-    return new Boolean(doValidation(request));
+    return Boolean.valueOf(doValidation(request));
   }
 
   /**

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSwitchCommunityWorkflowAction.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSwitchCommunityWorkflowAction.java
@@ -352,9 +352,9 @@ public class PSOSwitchCommunityWorkflowAction implements IPSWorkflowAction {
       PSFolder folder = m_cws.loadFolders(folders).get(0);
 
       // Convert the folder properties into a map and return the result
-      Iterator<PSFolderProperty> it = folder.getProperties();
+      Iterator<?> it = folder.getProperties();
       while (it.hasNext()) {
-        PSFolderProperty prop = it.next();
+        PSFolderProperty prop = (PSFolderProperty) it.next();
         props.put(prop.getName(), prop.getValue());
       }
     } catch (PSErrorResultsException | PSCmsException | PSNotFoundException e) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionDispatcher.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionDispatcher.java
@@ -172,10 +172,10 @@ public class PSOWFActionDispatcher extends PSDefaultExtension implements IPSWork
       throws PSExtensionException, PSNotFoundException {
     IPSExtension ext = null;
     IPSExtensionManager extMgr = PSServer.getExtensionManager(null);
-    Iterator<PSExtensionRef> itr =
+    Iterator<?> itr =
         extMgr.getExtensionNames("Java", null, interfaceName, workflowActionName);
     while (itr.hasNext()) {
-      PSExtensionRef ref = itr.next();
+      PSExtensionRef ref = (PSExtensionRef) itr.next();
       log.debug("found extension {}", ref.getFQN());
       ext = extMgr.prepareExtension(ref, null);
       log.debug("prepared extension {}", ext.getClass().getCanonicalName());

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionService.java
@@ -184,11 +184,11 @@ public class PSOWFActionService implements IPSOWFActionService {
       throws PSExtensionException, PSNotFoundException {
     initServices();
     IPSWorkflowAction ext = null;
-    Iterator<PSExtensionRef> itr =
+    Iterator<?> itr =
         extMgr.getExtensionNames(
             "Java", null, IPSWorkflowAction.class.getName(), workflowActionName);
     while (itr.hasNext()) {
-      PSExtensionRef ref = itr.next();
+      PSExtensionRef ref = (PSExtensionRef) itr.next();
       log.debug("found extension " + ref.getFQN());
       ext = (IPSWorkflowAction) extMgr.prepareExtension(ref, null);
       log.debug("prepared extension " + ext.getClass().getCanonicalName());

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PublishEditionService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PublishEditionService.java
@@ -146,6 +146,7 @@ public class PublishEditionService implements InitializingBean {
    * @param sessionId
    * @deprecated
    */
+  @Deprecated
   @SuppressWarnings("deprecation")
   protected QueuedEdition makeQueuedEdition(String editionId, String sessionId) {
 
@@ -161,6 +162,7 @@ public class PublishEditionService implements InitializingBean {
    * @return Returns the baseUrl.
    * @deprecated
    */
+  @Deprecated
   public String getBaseUrl() {
     return baseUrl;
   }
@@ -171,6 +173,7 @@ public class PublishEditionService implements InitializingBean {
    * @param baseUrl The baseUrl to set.
    * @deprecated
    */
+  @Deprecated
   public void setBaseUrl(String baseUrl) {
     this.baseUrl = baseUrl;
   }
@@ -181,6 +184,7 @@ public class PublishEditionService implements InitializingBean {
    * @return Returns the listenerPort.
    * @deprecated
    */
+  @Deprecated
   public String getListenerPort() {
     return listenerPort;
   }
@@ -191,6 +195,7 @@ public class PublishEditionService implements InitializingBean {
    * @param listenerPort The listenerPort to set.
    * @deprecated
    */
+  @Deprecated
   public void setListenerPort(String listenerPort) {
     this.listenerPort = listenerPort;
   }
@@ -271,6 +276,7 @@ public class PublishEditionService implements InitializingBean {
    * @return Returns the retryCount.
    * @deprecated
    */
+  @Deprecated
   public int getRetryCount() {
     return retryCount;
   }
@@ -279,6 +285,7 @@ public class PublishEditionService implements InitializingBean {
    * @param retryCount The retryCount to set.
    * @deprecated
    */
+  @Deprecated
   public void setRetryCount(int retryCount) {
     this.retryCount = retryCount;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/QueuedEdition.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/QueuedEdition.java
@@ -31,6 +31,7 @@ package com.percussion.pso.workflow;
  * @author DavidBenua
  * @deprecated use the IPSRxPublisherService classes directly instead.
  */
+@Deprecated
 public class QueuedEdition {
   private boolean isLocal = false;
   private String editionId;

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/FolderTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/FolderTools.java
@@ -237,10 +237,10 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
   public Map<String, String> getFolderProperties(String path) {
     try {
       PSFolder folder = getContentWs().loadFolders(new String[] {path}).get(0);
-      Map<String, String> props = new HashMap<String, String>();
-      Iterator<PSFolderProperty> it = folder.getProperties();
+      Map<String, String> props = new HashMap<>();
+      Iterator<?> it = folder.getProperties();
       while (it.hasNext()) {
-        PSFolderProperty prop = it.next();
+        PSFolderProperty prop = (PSFolderProperty) it.next();
         props.put(prop.getName(), prop.getValue());
       }
       return props;

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOMutableUrlTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOMutableUrlTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.pso.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.pso.utils.PSOMutableUrl;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral coverage for typed param map iteration in {@link PSOMutableUrl#toString()}. */
+public class PSOMutableUrlTest {
+
+  @Test
+  void toStringIncludesBaseAndParams() throws Exception {
+    PSOMutableUrl url = new PSOMutableUrl("https://example.com/path?a=1&b=2");
+    String s = url.toString();
+    assertTrue(s.startsWith("https://example.com/path?"));
+    assertTrue(s.contains("a=1"));
+    assertTrue(s.contains("b=2"));
+  }
+
+  @Test
+  void setParamUpdatesQueryString() throws Exception {
+    PSOMutableUrl url = new PSOMutableUrl("https://example.com/item");
+    url.setParam("sys_contentid", "42");
+    assertEquals("42", url.getParam("sys_contentid"));
+    assertTrue(url.toString().contains("sys_contentid=42"));
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOParseUrlQueryStringTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOParseUrlQueryStringTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.pso.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.pso.utils.PSOParseUrlQueryString;
+import java.util.ArrayList;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Covers multi-value accumulation in typed {@link PSOParseUrlQueryString#parseParameters}. */
+public class PSOParseUrlQueryStringTest {
+
+  @Test
+  void singleValuesMapToStrings() throws Exception {
+    Map<String, Object> params = PSOParseUrlQueryString.parseParameters("a=1&b=2");
+    assertEquals("1", params.get("a"));
+    assertEquals("2", params.get("b"));
+  }
+
+  @Test
+  void repeatedKeysAccumulateInList() throws Exception {
+    Map<String, Object> params = PSOParseUrlQueryString.parseParameters("tag=one&tag=two&tag=three");
+    Object value = params.get("tag");
+    assertInstanceOf(ArrayList.class, value);
+    @SuppressWarnings("unchecked")
+    ArrayList<Object> list = (ArrayList<Object>) value;
+    assertEquals(3, list.size());
+    assertEquals("one", list.get(0));
+    assertEquals("two", list.get(1));
+    assertEquals("three", list.get(2));
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOSlotContentsTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOSlotContentsTest.java
@@ -125,4 +125,24 @@ public class PSOSlotContentsTest {
       log.error("Unexpected Exception " + ex, ex);
     }
   }
+
+  /**
+   * SlotItemComparator treats all instances as equal; hashCode must be consistent with equals.
+   */
+  @Test
+  public void testSlotItemComparatorEqualsHashCodeContract() {
+    TestableSlotContents contents = new TestableSlotContents();
+    Object c1 = contents.newComparator();
+    Object c2 = contents.newComparator();
+    assertEquals(c1, c2);
+    assertEquals(c1.hashCode(), c2.hashCode());
+    assertNotEquals(c1, new Object());
+  }
+
+  /** Exposes protected SlotItemComparator for contract checks. */
+  private static final class TestableSlotContents extends PSOSlotContents {
+    Object newComparator() {
+      return new SlotItemComparator();
+    }
+  }
 }

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/UniqueIdLocatorSetTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/UniqueIdLocatorSetTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.pso.utils.UniqueIdLocatorSet;
+import java.io.ObjectStreamClass;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -98,6 +99,12 @@ public class UniqueIdLocatorSetTest {
     assertTrue(has);
     has = cut.contains(l3);
     assertFalse(has);
+  }
+
+  @Test
+  void testDefinesSerialVersionUid() {
+    long uid = ObjectStreamClass.lookup(UniqueIdLocatorSet.class).getSerialVersionUID();
+    assertEquals(1L, uid);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Partial Xlint cleanup for **perc-toolkit** (issue #2030, parent tracker #2200). First PR-sized batch prefers **real generics** and mechanical easy wins over blanket suppressions.

Live **main-source** project `-Xlint` diagnostics: **87 → 26** (~61 cleared).

### Main changes

- **Boxed constructors (for-removal):** `ImageEditorWizard`, `ImageResizeManagerImpl`, `PSOFileUploadValidation` → primitive casts / `Boolean.valueOf`
- **serialVersionUID:** `ArchivedException`, `UniqueIdLocatorSet`, `TrashTask.FatalTaskException`
- **@Deprecated:** `QueuedEdition` class + `PublishEditionService` deprecated API surface (javadoc-only → annotation)
- **Servlet generics:** `MutableHttpServletRequestWrapper` `Map`/`Enumeration` overrides match Jakarta API
- **Collections:** `PSOMutableUrl`, `PSOParseUrlQueryString`, `SimplifyParameters`, `PSOListTools`, relationship/folder/extension raw `Iterator` consumers
- **JAXB:** `ItemRestServiceImpl` / `ItemServiceHelper` use `JAXBContext.newInstance(Item.class)`
- **equals/hashCode:** `PSOSlotContents.SlotItemComparator`

### Tests

- `PSOMutableUrlTest` — toString / setParam
- `PSOParseUrlQueryStringTest` — single + multi-value accumulation
- `PSOSlotContentsTest.testSlotItemComparatorEqualsHashCodeContract`
- `UniqueIdLocatorSetTest.testDefinesSerialVersionUid`

## Residual

Remaining diagnostics tracked in **#2419** (this-escape sites, PSORequestContext parent override cascade, PropertyData serial field).

## Test plan

- [x] `cd modules/perc-toolkit && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **223**, Failures: **0**, Errors: **0**, Skipped: **16**
- [x] Main-source warnings 87 → 26
- [x] No new production behavior beyond type-safe APIs already used with raw types

## Gates

- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2030-perc-toolkit-xlint-batch1-erlang.md`
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2030  
Refs #2200  
Residual: #2419

> Co-Authored by Grok Build using grok-4.5 with agent main.