### PR TITLE
fix(sitemanage): Xlint batch 1 — serialVersionUID + real generics (#2032)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2032-sitemanage-xlint-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2032-sitemanage-xlint-batch1-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review — issue #2032 sitemanage Xlint batch 1
+
+**Reviewer persona:** Erlang (strict, independent of implementer)  
+**Scope:** `projects/sitemanage` main-source project `-Xlint` cleanup batch 1  
+**Date:** 2026-08-08
+
+## Summary
+
+**Approve for PR.** Partial cleanup of sitemanage main-source Xlint diagnostics. Prefers real generics and mechanical `serialVersionUID` on JAXB/JSON `ArrayList` wrappers over blanket suppressions. No intentional behavior change beyond type-safe APIs already used with raw types.
+
+## Inventory
+
+| Metric | Value |
+|--------|-------|
+| Main-source project Xlint (uncapped `-Xmaxwarns`) before | **328** |
+| After batch 1 | **259** |
+| Cleared | **~69** |
+
+## Changes reviewed
+
+1. **serialVersionUID** on ~38 serializable list wrappers / DTOs / simple exceptions (asset, page, site, share, user, theme, comments, etc.).
+2. **Real generics:**
+   - `IPSExtensionService` / `PSExtensionService`: `Iterator<URL>`, `Iterator<?>` for install/update resources; unchecked only at raw `PSExtensionManager` boundary.
+   - `PSDispatchingPathService`: `List<PSItemProperties>` for workflow-state find APIs (matches `IPSPathService`).
+   - `PSSitePublishServiceHelper`: `List<Integer>` loaders + shared typed native-query helper (single `@SuppressWarnings("unchecked")` at Hibernate untyped `createNativeQuery(String)` boundary).
+   - `PSItemService.SecureKeyRotationListener`: `Set<Integer>` for processed page ids.
+3. **Easy wins:** redundant `(int)` cast, redundant Spring `getBean` cast, `Collections.emptyList()` vs raw `EMPTY_LIST`, remove redundant dom4j `List<Attribute>` casts.
+4. **Tests (new):**
+   - `PSSerializableListWrappersTest` — serialVersionUID + list contents
+   - `PSCategoryControlUtilsConvertTest` — old-format XML conversion
+   - `PSExtensionServiceTypingTest` — generic method signatures
+
+## Hard gates
+
+| Gate | Result |
+|------|--------|
+| Bugs / logic regressions | None found |
+| Behavioral unit tests for changed logic | Present |
+| Cross-platform path/file I/O | N/A (no path I/O changes) |
+| Change-class companions | List wrappers + extension interface typing stay in sitemanage; no rest API contract changes |
+| Spring/test wiring types | Unchanged bean names/types; only local generic params |
+| Module `mvnw clean install` | **BUILD SUCCESS** — Tests run: **790**, Failures: **0**, Errors: **0**, Skipped: **128** |
+
+## Residual (out of this PR)
+
+- ~259 remaining main diagnostics: serial-field (85), this-escape (55), unchecked (54), remaining serialVersionUID (32), static (12), rawtypes (2), other
+- Nested exception types in `IPSFileSystemService` / interface-nested serialVersionUID
+- Hibernate GenericGenerator deprecations-for-removal
+- Test-source Xlint
+
+Track residual as a child issue under parent #2200 / #2032.
+
+## Verdict
+
+**Approve.** Ship as partial for #2032; residual follow-up required for full module zero.

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetDropCriteriaList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetDropCriteriaList.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 /** List wrapper for asset drop criteria. */
 @JsonRootName("AssetDropCriteria")
 public class PSAssetDropCriteriaList extends ArrayList<PSAssetDropCriteria> {
+  private static final long serialVersionUID = 1L;
+
 
   public PSAssetDropCriteriaList(Collection<? extends PSAssetDropCriteria> c) {
     super(c);

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetEditorList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetEditorList.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 /** List wrapper for asset editors. */
 @JsonRootName("AssetEditor")
 public class PSAssetEditorList extends ArrayList<PSAssetEditor> {
+  private static final long serialVersionUID = 1L;
+
 
   public PSAssetEditorList(Collection<? extends PSAssetEditor> c) {
     super(c);

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetList.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 @XmlRootElement(name = "Asset")
 @ArraySchema(schema = @Schema(implementation = PSAsset.class))
 public class PSAssetList extends ArrayList<PSAsset> {
+  private static final long serialVersionUID = 1L;
+
 
   public PSAssetList() {
     super();

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAssetSummaryList.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 /** List wrapper for PSAssetSummary objects. */
 @XmlRootElement(name = "AssetSummary")
 public class PSAssetSummaryList extends ArrayList<PSAssetSummary> {
+  private static final long serialVersionUID = 1L;
+
 
   public PSAssetSummaryList() {
     super();

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSUnusedAssetSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSUnusedAssetSummaryList.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 /** List wrapper for PSUnusedAssetSummary. */
 @JsonRootName("UnusedAssetSummary")
 public class PSUnusedAssetSummaryList extends ArrayList<PSUnusedAssetSummary> {
+  private static final long serialVersionUID = 1L;
+
   public PSUnusedAssetSummaryList(Collection<? extends PSUnusedAssetSummary> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/forms/data/PSFormSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/forms/data/PSFormSummaryList.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 @XmlRootElement(name = "FormSummary")
 @ArraySchema(schema = @Schema(implementation = PSFormSummary.class))
 public class PSFormSummaryList extends ArrayList<PSFormSummary> {
+  private static final long serialVersionUID = 1L;
+
   public PSFormSummaryList(Collection<? extends PSFormSummary> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
@@ -1755,7 +1755,7 @@ public class PSAssetService extends PSAbstractFullDataService<PSAsset, PSAssetSu
     IPSCmsObjectMgr objMgr = PSCmsObjectMgrLocator.getObjectManager();
     try {
       objMgr.changeWorkflowForItem(
-          (int) idMapper.getGuid(assetId).getUUID(), wfId, steppedWfMetadata.getSystemStatesList());
+          idMapper.getGuid(assetId).getUUID(), wfId, steppedWfMetadata.getSystemStatesList());
     } catch (PSORMException e) {
       String msg =
           "Failed to assign workflow for asset with ID \""

--- a/projects/sitemanage/src/main/java/com/percussion/category/extension/PSCategoryControlUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/extension/PSCategoryControlUtils.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.dom4j.Attribute;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
@@ -141,7 +140,7 @@ public class PSCategoryControlUtils {
   public static Document convertToOldFormatXml(Document doc) {
     var document = DocumentHelper.createDocument();
     var root = document.addElement("Tree");
-    for (var attr : (List<Attribute>) doc.getRootElement().attributes()) {
+    for (var attr : doc.getRootElement().attributes()) {
       if ("title".equalsIgnoreCase(attr.getName())) {
         root.addAttribute("label", attr.getStringValue());
       }
@@ -150,7 +149,7 @@ public class PSCategoryControlUtils {
       var e = it.next();
       if ("Children".equalsIgnoreCase(e.getName())) {
         var newElement = root.addElement("Node");
-        for (var attr : (List<Attribute>) e.attributes()) {
+        for (var attr : e.attributes()) {
           if ("id".equalsIgnoreCase(attr.getName()))
             newElement.addAttribute("id", attr.getStringValue());
           if ("title".equalsIgnoreCase(attr.getName()))
@@ -179,7 +178,7 @@ public class PSCategoryControlUtils {
    */
   private static void createChildElement(Element source, Element targetParent) {
     var newChild = targetParent.addElement("Node");
-    for (var attr : (List<Attribute>) source.attributes()) {
+    for (var attr : source.attributes()) {
       if ("id".equalsIgnoreCase(attr.getName())) newChild.addAttribute("id", attr.getStringValue());
       if ("title".equalsIgnoreCase(attr.getName()))
         newChild.addAttribute("label", attr.getStringValue());

--- a/projects/sitemanage/src/main/java/com/percussion/comments/data/PSCommentList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/comments/data/PSCommentList.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 @ArraySchema(schema = @Schema(implementation = PSComment.class))
 @JsonRootName("comments")
 public class PSCommentList extends ArrayList<PSComment> {
+  private static final long serialVersionUID = 1L;
+
   public PSCommentList(Collection<? extends PSComment> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/comments/data/PSCommentsSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/comments/data/PSCommentsSummaryList.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 /** List wrapper for PSCommentsSummary. */
 @XmlRootElement(name = "commentsSummary")
 public class PSCommentsSummaryList extends ArrayList<PSCommentsSummary> {
+  private static final long serialVersionUID = 1L;
+
   public PSCommentsSummaryList(Collection<? extends PSCommentsSummary> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/contentmigration/service/PSContentMigrationException.java
+++ b/projects/sitemanage/src/main/java/com/percussion/contentmigration/service/PSContentMigrationException.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PSContentMigrationException extends Exception {
+  private static final long serialVersionUID = 1L;
+
   private Map<String, String> failedItems = new HashMap<>();
 
   public PSContentMigrationException() {

--- a/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSGadgetList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSGadgetList.java
@@ -27,6 +27,8 @@ import java.util.List;
 @XmlRootElement(name = "gadget")
 @ArraySchema(schema = @Schema(implementation = PSGadget.class))
 public class PSGadgetList extends ArrayList<PSGadget> {
+  private static final long serialVersionUID = 1L;
+
   public PSGadgetList(Collection<? extends PSGadget> c) {
     super(c != null ? c : List.of());
   }

--- a/projects/sitemanage/src/main/java/com/percussion/extensions/IPSExtensionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/extensions/IPSExtensionService.java
@@ -21,14 +21,14 @@ import com.percussion.error.PSNonUniqueException;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.*;
 import java.io.File;
-import java.util.*;
+import java.net.URL;
+import java.util.Iterator;
 
 /****
  * Service wrapper for the extension manager.
  * <p>
  * Sunny Sal says: "ExtensionService, now Java 11 and Google-styled!"
  */
-@SuppressWarnings("rawtypes")
 public interface IPSExtensionService {
 
   /**
@@ -78,7 +78,8 @@ public interface IPSExtensionService {
    * @throws IllegalArgumentException If ref is <code>null</code>.
    * @throws PSExtensionException If there is an error attempting to locate the files.
    */
-  Iterator getExtensionFiles(PSExtensionRef ref) throws PSNotFoundException, PSExtensionException;
+  Iterator<URL> getExtensionFiles(PSExtensionRef ref)
+      throws PSNotFoundException, PSExtensionException;
 
   /**
    * Returns <CODE>true</CODE> if and only if the given extension ref refers to an installed
@@ -146,7 +147,7 @@ public interface IPSExtensionService {
    * @throws PSNonUniqueException If the extension already exists. Use updateExtension instead. The
    *     defined extension will not be installed.
    */
-  void installExtension(IPSExtensionDef def, Iterator resources)
+  void installExtension(IPSExtensionDef def, Iterator<?> resources)
       throws PSExtensionException, PSNotFoundException, PSNonUniqueException;
 
   /**
@@ -170,7 +171,8 @@ public interface IPSExtensionService {
    * @throws PSNonUniqueException If the extension already exists. Use updateExtension instead. The
    *     defined extension will not be installed.
    */
-  void installExtension(IPSExtensionDef def, Iterator resources, IPSExtensionListener listener)
+  void installExtension(
+      IPSExtensionDef def, Iterator<?> resources, IPSExtensionListener listener)
       throws PSExtensionException, PSNotFoundException, PSNonUniqueException;
 
   /**
@@ -202,7 +204,7 @@ public interface IPSExtensionService {
    * @see #removeExtension
    * @see #installExtension
    */
-  void updateExtension(IPSExtensionDef def, Iterator resources)
+  void updateExtension(IPSExtensionDef def, Iterator<?> resources)
       throws PSExtensionException, PSNotFoundException;
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/extensions/PSExtensionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/extensions/PSExtensionService.java
@@ -22,6 +22,7 @@ import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.*;
 import com.percussion.server.PSServer;
 import java.io.File;
+import java.net.URL;
 import java.util.Iterator;
 
 // REFACTORED: CP-JAVA11
@@ -34,11 +35,13 @@ public class PSExtensionService implements IPSExtensionService {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Iterator<PSExtensionRef> getExtensionHandlerNames() {
     return manager.getExtensionHandlerNames();
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Iterator<PSExtensionRef> getExtensionNames(
       String handlerNamePattern,
       String context,
@@ -50,7 +53,8 @@ public class PSExtensionService implements IPSExtensionService {
   }
 
   @Override
-  public Iterator getExtensionFiles(PSExtensionRef ref)
+  @SuppressWarnings("unchecked")
+  public Iterator<URL> getExtensionFiles(PSExtensionRef ref)
       throws PSNotFoundException, PSExtensionException {
     return manager.getExtensionFiles(ref);
   }
@@ -79,14 +83,14 @@ public class PSExtensionService implements IPSExtensionService {
   }
 
   @Override
-  public void installExtension(IPSExtensionDef def, Iterator resources)
+  public void installExtension(IPSExtensionDef def, Iterator<?> resources)
       throws PSExtensionException, PSNotFoundException, PSNonUniqueException {
     manager.installExtension(def, resources);
   }
 
   @Override
   public void installExtension(
-      IPSExtensionDef def, Iterator resources, IPSExtensionListener listener)
+      IPSExtensionDef def, Iterator<?> resources, IPSExtensionListener listener)
       throws PSExtensionException, PSNotFoundException, PSNonUniqueException {
     manager.installExtension(def, resources, listener);
   }
@@ -97,7 +101,7 @@ public class PSExtensionService implements IPSExtensionService {
   }
 
   @Override
-  public void updateExtension(IPSExtensionDef def, Iterator resources)
+  public void updateExtension(IPSExtensionDef def, Iterator<?> resources)
       throws PSExtensionException, PSNotFoundException {
     manager.updateExtension(def, resources);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/feeds/error/PSFeedInfoServiceException.java
+++ b/projects/sitemanage/src/main/java/com/percussion/feeds/error/PSFeedInfoServiceException.java
@@ -22,6 +22,8 @@ package com.percussion.feeds.error;
  * and Google-styled!"
  */
 public class PSFeedInfoServiceException extends Exception {
+  private static final long serialVersionUID = 1L;
+
   public PSFeedInfoServiceException() {
     super();
   }

--- a/projects/sitemanage/src/main/java/com/percussion/integritymanagement/data/PSIntegrityStatusList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/integritymanagement/data/PSIntegrityStatusList.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 @XmlRootElement(name = "integritystatus")
 @ArraySchema(schema = @Schema(implementation = PSIntegrityStatus.class))
 public class PSIntegrityStatusList extends java.util.ArrayList<PSIntegrityStatus> {
+  private static final long serialVersionUID = 1L;
+
   public PSIntegrityStatusList(Collection<? extends PSIntegrityStatus> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
@@ -1705,7 +1705,7 @@ public class PSItemService implements IPSItemService {
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
       try {
-        Set processedPages = new HashSet();
+        Set<Integer> processedPages = new HashSet<>();
         Collection<PSAsset> assets = assetDao.findAllAssetsUsingEncryption();
         for (PSAsset asset : assets) {
           Set<String> pages = waRelService.getRelationshipOwners(asset.getId());
@@ -1713,11 +1713,11 @@ public class PSItemService implements IPSItemService {
             if (workflowHelper.isTemplate(page)) {
               Collection<Integer> pageIds = templateService.getPageIdsForTemplate(page);
               for (Integer pageContentId : pageIds) {
-                if (processedPages.contains(pageContentId.intValue())) {
+                if (processedPages.contains(pageContentId)) {
                   continue;
                 }
                 if (addToIncrementalQueue(pageContentId)) {
-                  processedPages.add(pageContentId.intValue());
+                  processedPages.add(pageContentId);
                 }
               }
             } else if (workflowHelper.isPage(page)) {

--- a/projects/sitemanage/src/main/java/com/percussion/licensemanagement/error/PSLicenseServiceException.java
+++ b/projects/sitemanage/src/main/java/com/percussion/licensemanagement/error/PSLicenseServiceException.java
@@ -23,6 +23,8 @@ package com.percussion.licensemanagement.error;
  * <p>Sunny Sal says: "License to throw, license to catch!"
  */
 public class PSLicenseServiceException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
 
   public static final String ERROR_SAVING_LICENSES =
       "Error occurred while saving the module licenses. Please see log for more details.";

--- a/projects/sitemanage/src/main/java/com/percussion/metadata/data/PSMetadataList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/metadata/data/PSMetadataList.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 @XmlRootElement(name = "metadata")
 @ArraySchema(schema = @Schema(implementation = PSMetadata.class))
 public class PSMetadataList extends ArrayList<PSMetadata> {
+  private static final long serialVersionUID = 1L;
+
 
   public PSMetadataList(Collection<? extends PSMetadata> c) {
     super(c);

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRenderLinkList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRenderLinkList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @XmlRootElement(name = "RenderLink")
 @ArraySchema(schema = @Schema(implementation = PSRenderLink.class))
 public class PSRenderLinkList extends ArrayList<PSRenderLink> {
+  private static final long serialVersionUID = 1L;
+
   public PSRenderLinkList() {
     super();
   }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSResourceLinkAndLocationList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSResourceLinkAndLocationList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @XmlRootElement(name = "psResourceLinkAndLocation")
 @ArraySchema(schema = @Schema(implementation = PSResourceLinkAndLocation.class))
 public class PSResourceLinkAndLocationList extends ArrayList<PSResourceLinkAndLocation> {
+  private static final long serialVersionUID = 1L;
+
   public PSResourceLinkAndLocationList() {
     super();
   }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSSEOStatisticsList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSSEOStatisticsList.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 @ArraySchema(schema = @Schema(implementation = PSSEOStatistics.class))
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class PSSEOStatisticsList extends ArrayList<PSSEOStatistics> {
+  private static final long serialVersionUID = 1L;
+
   public PSSEOStatisticsList() {
     super();
   }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSTemplateSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSTemplateSummaryList.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 @ArraySchema(schema = @Schema(implementation = PSTemplateSummary.class))
 @JsonRootName("TemplateSummary")
 public class PSTemplateSummaryList extends ArrayList<PSTemplateSummary> {
+  private static final long serialVersionUID = 1L;
+
   public PSTemplateSummaryList() {
     super();
   }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetContentTypeList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetContentTypeList.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 @XmlRootElement(name = "WidgetContentType")
 @JsonRootName("WidgetContentType")
 public class PSWidgetContentTypeList extends ArrayList<PSWidgetContentType> {
+  private static final long serialVersionUID = 1L;
+
   public PSWidgetContentTypeList() {
     super();
   }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetPackageInfo.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetPackageInfo.java
@@ -28,6 +28,8 @@ import org.apache.commons.lang3.Validate;
  */
 @XmlRootElement(name = "WidgetPackageInfo")
 public class PSWidgetPackageInfo extends PSAbstractPersistantObject {
+  private static final long serialVersionUID = 1L;
+
 
   private String id;
   private String widgetName;

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetSummaryList.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 @XmlRootElement(name = "WidgetSummary")
 @ArraySchema(schema = @Schema(implementation = PSWidgetSummary.class))
 public class PSWidgetSummaryList extends ArrayList<PSWidgetSummary> {
+  private static final long serialVersionUID = 1L;
+
   public PSWidgetSummaryList() {
     super();
   }

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItemList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItemList.java
@@ -33,6 +33,8 @@ import java.util.Collection;
 @ArraySchema(schema = @Schema(implementation = PSPathItem.class))
 @JsonRootName("PathItemList")
 public class PSPathItemList extends ArrayList<PSPathItem> {
+  private static final long serialVersionUID = 1L;
+
   public PSPathItemList(Collection<? extends PSPathItem> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSDispatchingPathService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSDispatchingPathService.java
@@ -325,7 +325,7 @@ public class PSDispatchingPathService implements IPSPathService, IPSPathRecycleS
     return pm.validateFolderDelete();
   }
 
-  public List findItemProperties(PSItemByWfStateRequest request)
+  public List<PSItemProperties> findItemProperties(PSItemByWfStateRequest request)
       throws PSPathNotFoundServiceException,
           PSPathServiceException,
           PSValidationException,
@@ -335,7 +335,8 @@ public class PSDispatchingPathService implements IPSPathService, IPSPathRecycleS
     return findItemProperties(pm, request.getWorkflow(), request.getState());
   }
 
-  protected List findItemProperties(PathMatch pm, String workflowName, String stateName)
+  protected List<PSItemProperties> findItemProperties(
+      PathMatch pm, String workflowName, String stateName)
       throws PSPathNotFoundServiceException,
           PSPathServiceException,
           IPSDataService.DataServiceNotFoundException,
@@ -579,7 +580,7 @@ public class PSDispatchingPathService implements IPSPathService, IPSPathRecycleS
       return pathService.validateFolderDelete(path);
     }
 
-    public List findItemProperties(PSItemByWfStateRequest request)
+    public List<PSItemProperties> findItemProperties(PSItemByWfStateRequest request)
         throws PSPathNotFoundServiceException,
             PSPathServiceException,
             IPSDataService.DataServiceNotFoundException,

--- a/projects/sitemanage/src/main/java/com/percussion/pubserver/data/PSPublishServerInfoList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pubserver/data/PSPublishServerInfoList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @XmlRootElement(name = "serverInfo")
 @ArraySchema(schema = @Schema(implementation = PSPublishServerInfo.class))
 public class PSPublishServerInfoList extends ArrayList<PSPublishServerInfo> {
+  private static final long serialVersionUID = 1L;
+
   /**
    * Constructs a new list from the given collection.
    *

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSItemPropertiesList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSItemPropertiesList.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 @JsonRootName(value = "ItemProperties")
 @ArraySchema(schema = @Schema(implementation = PSItemProperties.class))
 public class PSItemPropertiesList extends ArrayList<PSItemProperties> {
+  private static final long serialVersionUID = 1L;
+
   public PSItemPropertiesList(Collection<? extends PSItemProperties> c) {
     super(Objects.requireNonNull(c, "Collection cannot be null"));
   }

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSLightWeightObjectList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSLightWeightObjectList.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 @JsonRootName(value = "psobj")
 @ArraySchema(schema = @Schema(implementation = PSLightWeightObjectList.class))
 public class PSLightWeightObjectList extends ArrayList<PSLightWeightObject> {
+  private static final long serialVersionUID = 1L;
+
 
   public PSLightWeightObjectList(Collection<? extends PSLightWeightObject> c) {
     super(Objects.requireNonNull(c, "Collection cannot be null"));

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSCreateSectionFromFolderRequest.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSCreateSectionFromFolderRequest.java
@@ -28,6 +28,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "CreateSectionFromFolderRequest")
 @JsonRootName("PSCreateSectionFromFolderRequest")
 public class PSCreateSectionFromFolderRequest extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
 
   public String getSourceFolderPath() {
     return sourceFolderPath;

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSCreateSiteSection.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSCreateSiteSection.java
@@ -32,6 +32,8 @@ import net.sf.oval.constraint.NotNull;
  */
 @JsonRootName("CreateSiteSection")
 public class PSCreateSiteSection extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
 
   public String getPageName() {
     return pageName;

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSMoveSiteSection.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSMoveSiteSection.java
@@ -30,6 +30,8 @@ import net.sf.oval.constraint.NotNull;
 @XmlRootElement(name = "MoveSiteSection")
 @JsonRootName("MoveSiteSection")
 public class PSMoveSiteSection extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
 
   /**
    * Gets the ID of the target (parent) navigation node.

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSPublishingActionList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSPublishingActionList.java
@@ -26,6 +26,8 @@ import java.util.Collection;
  * playlist—make sure it's got all the hits!"
  */
 public class PSPublishingActionList extends ArrayList<PSPublishingAction> {
+  private static final long serialVersionUID = 1L;
+
 
   public PSPublishingActionList(Collection<? extends PSPublishingAction> c) {
     super(c);

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteBlogPosts.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteBlogPosts.java
@@ -29,6 +29,8 @@ import net.sf.oval.constraint.NotEmpty;
 @XmlRootElement(name = "SiteBlogPosts")
 @JsonRootName("SiteBlogPosts")
 public class PSSiteBlogPosts extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
 
   @NotEmpty private String blogTitle;
 

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSitePublishItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSitePublishItem.java
@@ -26,6 +26,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "SitePublishItem")
 @JsonRootName("SitePublishItem")
 public class PSSitePublishItem extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
 
   @Min(1)
   private long itemStatusId;

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteSectionProperties.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteSectionProperties.java
@@ -32,6 +32,8 @@ import net.sf.oval.constraint.NotNull;
 @XmlRootElement(name = "SiteSectionProperties")
 @JsonRootName("SiteSectionProperties")
 public class PSSiteSectionProperties extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
   /** The ID of the section, not blank for a valid request. */
   @NotBlank @NotNull private String id;
 

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/error/PSTemplateImportException.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/error/PSTemplateImportException.java
@@ -21,6 +21,8 @@ import com.percussion.share.service.exception.PSDataServiceException;
 
 /** Exception thrown when a template import operation fails. */
 public class PSTemplateImportException extends PSDataServiceException {
+  private static final long serialVersionUID = 1L;
+
 
   /** Constructs a new exception with no detail message. */
   public PSTemplateImportException() {

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/AssignTemplateList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/AssignTemplateList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @XmlRootElement(name = "TemplateSummary")
 @ArraySchema(schema = @Schema(implementation = AssignTemplate.class))
 public class AssignTemplateList extends ArrayList<AssignTemplate> {
+  private static final long serialVersionUID = 1L;
+
   public AssignTemplateList(Collection<AssignTemplate> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
@@ -1890,7 +1890,7 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
         if (!localIds.isEmpty()) {
           // update the copied page's assets
           widgetAssetRelationshipService.removeAssetWidgetRelationships(
-              pageId, Collections.EMPTY_LIST);
+              pageId, Collections.emptyList());
           assetIds =
               widgetAssetRelationshipService.copyAssetWidgetRelationships(origPage.getId(), pageId);
 
@@ -2212,9 +2212,8 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
   private IPSPubServerService getPubServerService() {
     if (pubserverService == null)
       pubserverService =
-          (IPSPubServerService)
-              PSSpringWebApplicationContextUtils.getWebApplicationContext()
-                  .getBean("pubServerService", IPSPubServerService.class);
+          PSSpringWebApplicationContextUtils.getWebApplicationContext()
+              .getBean("pubServerService", IPSPubServerService.class);
     return pubserverService;
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSitePublishServiceHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSitePublishServiceHelper.java
@@ -146,8 +146,7 @@ public class PSSitePublishServiceHelper implements IPSSitePublishServiceHelper {
             allSharedAssetContentTypeIds,
             allValidRelationshipConfigs);
     org.hibernate.query.NativeQuery<Integer> query =
-        sess.createNativeQuery(sql)
-            .addScalar("DEPENDENT_ID", org.hibernate.type.StandardBasicTypes.INTEGER);
+        createIntegerNativeQuery(sess, sql, "DEPENDENT_ID");
     return new HashSet<>(query.list());
   }
 
@@ -167,8 +166,7 @@ public class PSSitePublishServiceHelper implements IPSSitePublishServiceHelper {
             join(cids, ","),
             join(getPublishableContentTypeIds(sess), ","));
     org.hibernate.query.NativeQuery<Integer> query =
-        sess.createNativeQuery(sql)
-            .addScalar("DEPENDENT_ID", org.hibernate.type.StandardBasicTypes.INTEGER);
+        createIntegerNativeQuery(sess, sql, "DEPENDENT_ID");
     return new HashSet<>(query.list());
   }
 
@@ -187,8 +185,7 @@ public class PSSitePublishServiceHelper implements IPSSitePublishServiceHelper {
             join(cids, ","),
             join(getNonPublishableContentTypeIds(sess), ","));
     org.hibernate.query.NativeQuery<Integer> query =
-        sess.createNativeQuery(sql)
-            .addScalar("DEPENDENT_ID", org.hibernate.type.StandardBasicTypes.INTEGER);
+        createIntegerNativeQuery(sess, sql, "DEPENDENT_ID");
     return new HashSet<>(query.list());
   }
 
@@ -232,26 +229,33 @@ public class PSSitePublishServiceHelper implements IPSSitePublishServiceHelper {
     }
   }
 
-  private List loadSharedAssetContentType(Session sess) throws SQLException {
+  private List<Integer> loadSharedAssetContentType(Session sess) throws SQLException {
     String sql =
         String.format(
             "SELECT DISTINCT CONTENTTYPEID FROM %s WHERE CONTENTTYPENAME NOT IN (%s)",
             qualifyTableName("CONTENTTYPES"), binaryAssetTypesStr);
-    org.hibernate.query.NativeQuery<Integer> query =
-        sess.createNativeQuery(sql)
-            .addScalar("CONTENTTYPEID", org.hibernate.type.StandardBasicTypes.INTEGER);
+    org.hibernate.query.NativeQuery<Integer> query = createIntegerNativeQuery(sess, sql, "CONTENTTYPEID");
     return query.list();
   }
 
-  private List loadValidRelationshipConfigNames(Session sess) throws SQLException {
+  private List<Integer> loadValidRelationshipConfigNames(Session sess) throws SQLException {
     String sql =
         String.format(
             "SELECT DISTINCT CONFIG_ID FROM %s WHERE CONFIG_NAME NOT IN (%s)",
             qualifyTableName("PSX_RELATIONSHIPCONFIGNAME"), invalidRelationshipConfigName);
-    org.hibernate.query.NativeQuery<Integer> query =
-        sess.createNativeQuery(sql)
-            .addScalar("CONFIG_ID", org.hibernate.type.StandardBasicTypes.INTEGER);
+    org.hibernate.query.NativeQuery<Integer> query = createIntegerNativeQuery(sess, sql, "CONFIG_ID");
     return query.list();
+  }
+
+  /**
+   * Builds a typed integer native query. Hibernate's {@code createNativeQuery(String)} is untyped;
+   * centralize the scalar mapping so callers stay fully generic.
+   */
+  @SuppressWarnings("unchecked")
+  private static org.hibernate.query.NativeQuery<Integer> createIntegerNativeQuery(
+      Session sess, String sql, String scalarAlias) {
+    return sess.createNativeQuery(sql)
+        .addScalar(scalarAlias, org.hibernate.type.StandardBasicTypes.INTEGER);
   }
 
   private List<Integer> getPublishableContentTypeIds(Session sess) {

--- a/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRichTextCustomStyleList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRichTextCustomStyleList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @XmlRootElement(name = "RichTextCustomStyle")
 @ArraySchema(schema = @Schema(implementation = PSRichTextCustomStyle.class))
 public class PSRichTextCustomStyleList extends ArrayList<PSRichTextCustomStyle> {
+  private static final long serialVersionUID = 1L;
+
   public PSRichTextCustomStyleList(Collection<? extends PSRichTextCustomStyle> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/theme/data/PSThemeSummaryList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/data/PSThemeSummaryList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @XmlRootElement(name = "ThemeSummary")
 @ArraySchema(schema = @Schema(implementation = PSThemeSummary.class))
 public class PSThemeSummaryList extends ArrayList<PSThemeSummary> {
+  private static final long serialVersionUID = 1L;
+
   public PSThemeSummaryList(Collection<? extends PSThemeSummary> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSExternalUserList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSExternalUserList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @ArraySchema(schema = @Schema(implementation = PSExternalUser.class))
 @JsonRootName("ExternalUser")
 public class PSExternalUserList extends ArrayList<PSExternalUser> {
+  private static final long serialVersionUID = 1L;
+
   public PSExternalUserList(Collection<? extends PSExternalUser> c) {
     super(c);
   }

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSImportedUserList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSImportedUserList.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 @ArraySchema(schema = @Schema(implementation = PSImportedUser.class))
 @JsonRootName("ImportedUser")
 public class PSImportedUserList extends ArrayList<PSImportedUser> {
+  private static final long serialVersionUID = 1L;
+
   public PSImportedUserList(Collection<? extends PSImportedUser> c) {
     super(c);
   }

--- a/projects/sitemanage/src/test/java/com/percussion/category/extension/PSCategoryControlUtilsConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/category/extension/PSCategoryControlUtilsConvertTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.category.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.dom4j.DocumentHelper;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral coverage for category XML conversion after removing redundant attribute casts. */
+public class PSCategoryControlUtilsConvertTest {
+
+  @Test
+  public void convertToOldFormatXmlMapsTitleAndSelectable() {
+    var source = DocumentHelper.createDocument();
+    var root = source.addElement("Category").addAttribute("title", "RootCats");
+    root.addElement("Children")
+        .addAttribute("id", "c1")
+        .addAttribute("title", "Child One")
+        .addAttribute("selectable", "true");
+
+    var converted = PSCategoryControlUtils.convertToOldFormatXml(source);
+    assertNotNull(converted);
+    assertEquals("Tree", converted.getRootElement().getName());
+    assertEquals("RootCats", converted.getRootElement().attributeValue("label"));
+
+    var node = converted.getRootElement().element("Node");
+    assertNotNull(node);
+    assertEquals("c1", node.attributeValue("id"));
+    assertEquals("Child One", node.attributeValue("label"));
+    assertEquals("yes", node.attributeValue("selectable"));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/extensions/PSExtensionServiceTypingTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/extensions/PSExtensionServiceTypingTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.extension.IPSExtensionDef;
+import com.percussion.extension.IPSExtensionListener;
+import com.percussion.extension.PSExtensionRef;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.net.URL;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+/** Ensures IPSExtensionService surface uses real generic Iterator types (issue #2032 batch 1). */
+public class PSExtensionServiceTypingTest {
+
+  @Test
+  public void getExtensionFilesReturnsIteratorOfUrl() throws Exception {
+    Method m = IPSExtensionService.class.getMethod("getExtensionFiles", PSExtensionRef.class);
+    assertEquals(Iterator.class, m.getReturnType());
+    var generic = m.getGenericReturnType();
+    assertTrue(generic instanceof ParameterizedType);
+    var args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(URL.class, args[0]);
+  }
+
+  @Test
+  public void installAndUpdateAcceptWildcardIterator() throws Exception {
+    Method install =
+        IPSExtensionService.class.getMethod("installExtension", IPSExtensionDef.class, Iterator.class);
+    Method installListener =
+        IPSExtensionService.class.getMethod(
+            "installExtension", IPSExtensionDef.class, Iterator.class, IPSExtensionListener.class);
+    Method update =
+        IPSExtensionService.class.getMethod("updateExtension", IPSExtensionDef.class, Iterator.class);
+
+    for (Method m : new Method[] {install, installListener, update}) {
+      var params = m.getGenericParameterTypes();
+      // resources parameter is the second parameter
+      assertTrue(params[1] instanceof ParameterizedType);
+      var pt = (ParameterizedType) params[1];
+      assertEquals(Iterator.class, pt.getRawType());
+      assertEquals(1, pt.getActualTypeArguments().length);
+      assertEquals("?", pt.getActualTypeArguments()[0].getTypeName());
+    }
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.assetmanagement.data.PSAssetList;
+import com.percussion.assetmanagement.data.PSAssetSummaryList;
+import com.percussion.pagemanagement.data.PSWidgetContentTypeList;
+import com.percussion.pagemanagement.data.PSWidgetSummaryList;
+import com.percussion.sitemanage.data.PSPublishingActionList;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards serialVersionUID + construction for JAXB/JSON list wrappers cleaned in issue #2032 batch
+ * 1.
+ */
+public class PSSerializableListWrappersTest {
+
+  @Test
+  public void listWrappersDefineSerialVersionUid() throws Exception {
+    assertSerialVersionUid(PSItemPropertiesList.class);
+    assertSerialVersionUid(PSLightWeightObjectList.class);
+    assertSerialVersionUid(PSAssetList.class);
+    assertSerialVersionUid(PSAssetSummaryList.class);
+    assertSerialVersionUid(PSWidgetContentTypeList.class);
+    assertSerialVersionUid(PSWidgetSummaryList.class);
+    assertSerialVersionUid(PSPublishingActionList.class);
+  }
+
+  @Test
+  public void itemPropertiesListPreservesOrderAndContents() {
+    var a = new PSItemProperties();
+    a.setId("1");
+    var b = new PSItemProperties();
+    b.setId("2");
+    var list = new PSItemPropertiesList(List.of(a, b));
+    assertEquals(2, list.size());
+    assertEquals("1", list.get(0).getId());
+    assertEquals("2", list.get(1).getId());
+  }
+
+  private static void assertSerialVersionUid(Class<?> type) throws Exception {
+    assertTrue(Serializable.class.isAssignableFrom(type), type.getName() + " should be Serializable");
+    Field f = type.getDeclaredField("serialVersionUID");
+    f.setAccessible(true);
+    assertNotNull(f.get(null));
+    assertEquals(long.class, f.getType());
+  }
+}


### PR DESCRIPTION
## Summary

Partial Xlint cleanup for **sitemanage** (issue #2032, parent tracker #2200). First PR-sized batch prefers **real generics** and mechanical **serialVersionUID** on JAXB/JSON list wrappers over blanket suppressions.

Live **main-source** project `-Xlint` diagnostics (uncapped `-Xmaxwarns`): **328 → 259** (~69 cleared).

### Main changes

- **serialVersionUID:** ~38 serializable `ArrayList` wrappers / DTOs / simple exceptions across asset, page, site, share, user, theme, comments, metadata, integrity, etc.
- **IPSExtensionService / PSExtensionService:** `Iterator<URL>` for files; `Iterator<?>` for install/update resources; unchecked only at raw `PSExtensionManager` boundary
- **PSDispatchingPathService:** `List<PSItemProperties>` for workflow-state find APIs (matches `IPSPathService`)
- **PSSitePublishServiceHelper:** `List<Integer>` loaders + shared typed native-query helper
- **PSItemService:** `Set<Integer>` in secure-key rotation listener
- **Easy wins:** remove redundant `(int)` / Spring `getBean` casts; `Collections.emptyList()`; drop redundant dom4j `List<Attribute>` casts

### Tests

- `PSSerializableListWrappersTest` — serialVersionUID + list construction
- `PSCategoryControlUtilsConvertTest` — old-format category XML conversion
- `PSExtensionServiceTypingTest` — generic method signatures on the service interface

## Residual

Remaining diagnostics tracked in **#2421** (serial-field, this-escape, remaining unchecked/serialVersionUID/static, test sources).

## Test plan

- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **790**, Failures: **0**, Errors: **0**, Skipped: **128**
- [x] Main-source warnings 328 → 259 (uncapped)
- [x] No new production behavior beyond type-safe APIs already used with raw types

## Gates

- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2032-sitemanage-xlint-batch1-erlang.md`
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2032  
Refs #2200  
Residual: #2421

> Co-Authored by Grok Build using grok-4.5 with agent main.
