### PR TITLE
feat(WebUI): Profile shell + My profile entry + i18n/a11y skeleton (#2393)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -58,6 +58,7 @@ public class PSWebUiSpaFallbackFilter implements Filter {
           "widget-builder",
           "developer",
           "explorer",
+          "profile",
           "unavailable");
 
   private static final String APP_PREFIX = "/cm/app";

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -24,6 +24,7 @@ export const SPA_ENTRIES = [
   "widget-builder",
   "developer",
   "explorer",
+  "profile",
   "unavailable",
 ] as const;
 

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -117,6 +117,8 @@ export function parseEntryQuery(
       }
       return { entry, path, clientPath };
     }
+    case "profile":
+      return { entry, clientPath: "/profile" };
     case "unavailable":
       return { entry, clientPath: "/unavailable" };
     default:
@@ -225,6 +227,8 @@ export function parseClientPath(
       }
       return { entry, path: explorerPath, clientPath: cp };
     }
+    case "profile":
+      return { entry, clientPath: "/profile" };
     case "unavailable":
       return { entry, clientPath: "/unavailable" };
     default:

--- a/WebUI/src/main/ts/app/layout/AppLayout.module.css
+++ b/WebUI/src/main/ts/app/layout/AppLayout.module.css
@@ -81,14 +81,23 @@
   color: var(--color-text, #181c2c);
 }
 
+.profileLink,
 .logoutLink {
   color: var(--color-primary, #4a6aa3);
   font-weight: 600;
   text-decoration: none;
 }
 
+.profileLink:hover,
 .logoutLink:hover {
   text-decoration: underline;
+}
+
+.profileLink:focus-visible,
+.logoutLink:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .placeholder {

--- a/WebUI/src/main/ts/app/layout/UserMenu.tsx
+++ b/WebUI/src/main/ts/app/layout/UserMenu.tsx
@@ -16,9 +16,11 @@
  */
 
 import React from "react";
+import { Link } from "react-router";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import { i18nKeyAttr } from "../../i18n/i18nDom";
 import { message, MSG } from "../../i18n/message";
+import { PROFILE_MSG } from "../../profile/messages";
 import styles from "./AppLayout.module.css";
 
 export function UserMenu(): React.ReactElement {
@@ -40,6 +42,14 @@ export function UserMenu(): React.ReactElement {
           {name}
         </span>
       </span>
+      <Link
+        className={styles.profileLink}
+        to="/profile"
+        data-testid="perc-spa-my-profile"
+        {...i18nKeyAttr(PROFILE_MSG.MENU_MY_PROFILE)}
+      >
+        {message(PROFILE_MSG.MENU_MY_PROFILE)}
+      </Link>
       <a
         className={styles.logoutLink}
         href="/logout"

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -24,6 +24,7 @@ import { DeveloperRoute } from "./routes/DeveloperRoute";
 import { ExplorerRoute } from "./routes/ExplorerRoute";
 import { HomeRoute } from "./routes/HomeRoute";
 import { PublishRoute } from "./routes/PublishRoute";
+import { ProfileRoute } from "./routes/ProfileRoute";
 import { WidgetBuilderRoute } from "./routes/WidgetBuilderRoute";
 import { WorkflowRoute } from "./routes/WorkflowRoute";
 
@@ -49,6 +50,7 @@ export function AppRoutes(): React.ReactElement {
         <Route path="developer" element={<DeveloperRoute />} />
         <Route path="developer/:section" element={<DeveloperRoute />} />
         <Route path="explorer" element={<ExplorerRoute />} />
+        <Route path="profile" element={<ProfileRoute />} />
         <Route
           path="unavailable"
           element={

--- a/WebUI/src/main/ts/app/routes/ProfileRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/ProfileRoute.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { lazy } from "react";
+import { LazyRouteFrame } from "./RouteErrorBoundary";
+
+const ProfileShellLazy = lazy(() =>
+  import("../../profile/ProfileShell").then((m) => ({ default: m.ProfileShell })),
+);
+
+/**
+ * SPA My profile route — available to any authenticated user (self profile hub).
+ * No admin/designer gate: slice 1 is shell + entry only.
+ */
+export function ProfileRoute(): React.ReactElement {
+  return (
+    <LazyRouteFrame
+      label="Profile"
+      fallback={
+        <div data-testid="route-profile-loading" style={{ padding: "1.5rem" }}>
+          Loading…
+        </div>
+      }
+    >
+      <ProfileShellLazy embedded />
+    </LazyRouteFrame>
+  );
+}

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -219,6 +219,8 @@ export const MSG = {
   USER_SIGNED_IN_AS: "perc.ui.dashboard.modern@Signed in as",
   USER_DEFAULT_NAME: "perc.ui.dashboard.modern@user",
   USER_LOGOUT: "perc.ui.common.label@Log Out",
+  /** Profile hub menu entry (#2393) — prefer PROFILE_MSG in profile/messages.ts for new code */
+  USER_MY_PROFILE: "perc.ui.profile.modern@My profile",
   // Dashboard / Gadgets chrome
   DASHBOARD_TITLE: "perc.ui.dashboard.title@Dashboard",
   DASHBOARD_EMBEDDED_TITLE: "perc.ui.dashboard.modern@Gadgets",

--- a/WebUI/src/main/ts/login/redirect.ts
+++ b/WebUI/src/main/ts/login/redirect.ts
@@ -29,6 +29,7 @@ const ALLOWED_ENTRIES = new Set([
   "admin",
   "widget-builder",
   "explorer",
+  "profile",
   "unavailable",
 ]);
 

--- a/WebUI/src/main/ts/profile/ProfileShell.module.css
+++ b/WebUI/src/main/ts/profile/ProfileShell.module.css
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.shell {
+  margin: 1.5rem auto;
+  max-width: 56rem;
+  width: 100%;
+  padding: 0 1rem 2rem;
+  box-sizing: border-box;
+}
+
+.header {
+  margin-bottom: 1.25rem;
+}
+
+.title {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text, #181c2c);
+  line-height: 1.25;
+}
+
+.intro {
+  margin: 0;
+  color: var(--color-text-muted, #5b6478);
+  line-height: 1.5;
+  max-width: 42rem;
+}
+
+.sectionNav {
+  margin: 0 0 1.25rem;
+}
+
+.sectionNavList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sectionNavLink {
+  display: inline-block;
+  padding: 0.35rem 0.65rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, #d8dee9);
+  background: var(--color-surface, #fff);
+  color: var(--color-primary, #4a6aa3);
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.sectionNavLink:hover {
+  background: var(--color-surface-alt, #eef2f8);
+  text-decoration: underline;
+}
+
+.sectionNavLink:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+}
+
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 12px;
+  padding: 1.15rem 1.25rem 1.25rem;
+  box-sizing: border-box;
+}
+
+.sectionHeading {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text, #181c2c);
+  line-height: 1.3;
+}
+
+.sectionBody {
+  margin: 0 0 0.65rem;
+  color: var(--color-text-muted, #5b6478);
+  line-height: 1.5;
+}
+
+.comingSoon {
+  display: inline-block;
+  margin: 0;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: var(--color-surface-alt, #eef2f8);
+  color: var(--color-text-muted, #5b6478);
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.4;
+}

--- a/WebUI/src/main/ts/profile/ProfileShell.tsx
+++ b/WebUI/src/main/ts/profile/ProfileShell.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useId } from "react";
+import { i18nKeyAttr } from "../i18n/i18nDom";
+import { message } from "../i18n/message";
+import { PROFILE_MSG } from "./messages";
+import styles from "./ProfileShell.module.css";
+
+export interface ProfileShellProps {
+  /**
+   * When true (SPA AppLayout), shell content only — chrome comes from AppLayout.
+   * Kept for symmetry with other feature shells; always embedded under SPA routes.
+   */
+  embedded?: boolean;
+}
+
+type ProfileSectionId = "account" | "security" | "preferences" | "avatar";
+
+const SECTIONS: {
+  id: ProfileSectionId;
+  titleKey: string;
+  bodyKey: string;
+  testId: string;
+}[] = [
+  {
+    id: "account",
+    titleKey: PROFILE_MSG.SECTION_ACCOUNT,
+    bodyKey: PROFILE_MSG.SECTION_ACCOUNT_BODY,
+    testId: "perc-profile-section-account",
+  },
+  {
+    id: "security",
+    titleKey: PROFILE_MSG.SECTION_SECURITY,
+    bodyKey: PROFILE_MSG.SECTION_SECURITY_BODY,
+    testId: "perc-profile-section-security",
+  },
+  {
+    id: "preferences",
+    titleKey: PROFILE_MSG.SECTION_PREFERENCES,
+    bodyKey: PROFILE_MSG.SECTION_PREFERENCES_BODY,
+    testId: "perc-profile-section-preferences",
+  },
+  {
+    id: "avatar",
+    titleKey: PROFILE_MSG.SECTION_AVATAR,
+    bodyKey: PROFILE_MSG.SECTION_AVATAR_BODY,
+    testId: "perc-profile-section-avatar",
+  },
+];
+
+/**
+ * User profile hub shell (slice 1): landmarks, heading hierarchy, and
+ * placeholder sections for later account / security / preferences / avatar work.
+ * Does not load or mutate account data.
+ */
+export function ProfileShell(_props: ProfileShellProps = {}): React.ReactElement {
+  const reactId = useId();
+  const titleId = `perc-profile-title-${reactId}`;
+  const sectionsNavId = `perc-profile-sections-nav-${reactId}`;
+
+  return (
+    <div
+      className={styles.shell}
+      data-testid="perc-profile-shell"
+      aria-labelledby={titleId}
+    >
+      <header className={styles.header}>
+        <h1
+          id={titleId}
+          className={styles.title}
+          data-testid="perc-profile-title"
+          {...i18nKeyAttr(PROFILE_MSG.TITLE)}
+        >
+          {message(PROFILE_MSG.TITLE)}
+        </h1>
+        <p
+          className={styles.intro}
+          data-testid="perc-profile-intro"
+          {...i18nKeyAttr(PROFILE_MSG.INTRO)}
+        >
+          {message(PROFILE_MSG.INTRO)}
+        </p>
+      </header>
+
+      <nav
+        className={styles.sectionNav}
+        aria-labelledby={sectionsNavId}
+        data-testid="perc-profile-section-nav"
+      >
+        <h2 id={sectionsNavId} className="visually-hidden" style={visuallyHidden}>
+          <span {...i18nKeyAttr(PROFILE_MSG.SECTIONS_NAV)}>
+            {message(PROFILE_MSG.SECTIONS_NAV)}
+          </span>
+        </h2>
+        <ul className={styles.sectionNavList}>
+          {SECTIONS.map((section) => (
+            <li key={section.id}>
+              <a
+                className={styles.sectionNavLink}
+                href={`#perc-profile-${section.id}`}
+                data-testid={`perc-profile-nav-${section.id}`}
+                {...i18nKeyAttr(section.titleKey)}
+              >
+                {message(section.titleKey)}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className={styles.sections}>
+        {SECTIONS.map((section) => {
+          const headingId = `perc-profile-${section.id}-heading`;
+          return (
+            <section
+              key={section.id}
+              id={`perc-profile-${section.id}`}
+              className={styles.section}
+              aria-labelledby={headingId}
+              data-testid={section.testId}
+              tabIndex={-1}
+            >
+              <h2
+                id={headingId}
+                className={styles.sectionHeading}
+                {...i18nKeyAttr(section.titleKey)}
+              >
+                {message(section.titleKey)}
+              </h2>
+              <p className={styles.sectionBody} {...i18nKeyAttr(section.bodyKey)}>
+                {message(section.bodyKey)}
+              </p>
+              <p
+                className={styles.comingSoon}
+                data-testid={`${section.testId}-status`}
+                {...i18nKeyAttr(PROFILE_MSG.COMING_SOON)}
+              >
+                {message(PROFILE_MSG.COMING_SOON)}
+              </p>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Inline visually-hidden styles so we do not depend on a global a11y utility class. */
+const visuallyHidden: React.CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+};

--- a/WebUI/src/main/ts/profile/index.ts
+++ b/WebUI/src/main/ts/profile/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ProfileShell } from "./ProfileShell";
+export type { ProfileShellProps } from "./ProfileShell";
+export { PROFILE_MSG } from "./messages";

--- a/WebUI/src/main/ts/profile/messages.ts
+++ b/WebUI/src/main/ts/profile/messages.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * User profile hub catalog keys (slice 1 shell — #2393 / parent #2374).
+ * English after {@code @} is the source fallback when TMX is not loaded.
+ */
+export const PROFILE_MSG = {
+  MENU_MY_PROFILE: "perc.ui.profile.modern@My profile",
+  TITLE: "perc.ui.profile.modern@My profile",
+  INTRO:
+    "perc.ui.profile.modern@View and manage your account settings. Sections below will open as they become available.",
+  SECTIONS_NAV: "perc.ui.profile.modern@Profile sections",
+  SECTION_ACCOUNT: "perc.ui.profile.modern@Account",
+  SECTION_ACCOUNT_BODY:
+    "perc.ui.profile.modern@Your name, login id, email, and role summary will appear here.",
+  SECTION_SECURITY: "perc.ui.profile.modern@Security",
+  SECTION_SECURITY_BODY:
+    "perc.ui.profile.modern@Password and authentication options for your account will appear here.",
+  SECTION_PREFERENCES: "perc.ui.profile.modern@Preferences",
+  SECTION_PREFERENCES_BODY:
+    "perc.ui.profile.modern@Language and personal UI preferences will appear here.",
+  SECTION_AVATAR: "perc.ui.profile.modern@Avatar",
+  SECTION_AVATAR_BODY:
+    "perc.ui.profile.modern@Avatar and Gravatar email settings will appear here.",
+  COMING_SOON: "perc.ui.profile.modern@Coming soon",
+} as const;

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -54,6 +54,7 @@
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "developer".equals(n)
+                || "profile".equals(n)
                 || "unavailable".equals(n)) {
             return n;
         }

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -54,6 +54,7 @@
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "developer".equals(n)
+                || "profile".equals(n)
                 || "unavailable".equals(n)) {
             return n;
         }

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -65,6 +65,16 @@ public class PSWebUiSpaFallbackFilterTest {
   }
 
   @Test
+  public void forwardsProfileEntry() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=profile",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/profile", null));
+    assertEquals(
+        "/cm/pages/app/spa.jsp?entry=profile",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/pages/app/profile", null));
+  }
+
+  @Test
   public void forwardsDeveloperWithSection() {
     assertEquals(
         "/cm/app/spa.jsp?entry=developer",

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -70,6 +70,13 @@ describe("parseEntryQuery", () => {
     expect(parseEntryQuery("?entry=nope").entry).toBe("home");
   });
 
+  it("maps profile entry to /profile client path", () => {
+    expect(parseEntryQuery("?entry=profile").entry).toBe("profile");
+    expect(parseEntryQuery("?entry=profile").clientPath).toBe("/profile");
+    expect(parseClientPath("/profile").entry).toBe("profile");
+    expect(parseClientPath("/profile").clientPath).toBe("/profile");
+  });
+
   it("toSpaEntryUrl rebuilds query contract", () => {
     const url = toSpaEntryUrl({
       entry: "home",

--- a/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
+++ b/WebUI/src/test/ts/app/layout/UserMenu.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router";
+import { render, screen } from "@testing-library/react";
+import { BootstrapProvider } from "../../../../main/ts/app/bootstrap/BootstrapContext";
+import type { SpaBootstrap } from "../../../../main/ts/app/bootstrap/types";
+import { UserMenu } from "../../../../main/ts/app/layout/UserMenu";
+
+const bootstrap: SpaBootstrap = {
+  userName: "editor1",
+  locale: "en-us",
+  entry: "home",
+  isAdmin: false,
+  isDesigner: false,
+  isWidgetBuilderActive: false,
+};
+
+function renderMenu(user?: Partial<SpaBootstrap>): void {
+  render(
+    <BootstrapProvider value={{ ...bootstrap, ...user }}>
+      <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/home"]}>
+        <UserMenu />
+      </MemoryRouter>
+    </BootstrapProvider>,
+  );
+}
+
+describe("UserMenu", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+  });
+
+  it("shows signed-in name, My profile entry, and logout", () => {
+    renderMenu();
+    expect(screen.getByTestId("perc-spa-user-menu")).toBeTruthy();
+    expect(screen.getByTestId("perc-spa-user-name").textContent).toContain(
+      "editor1",
+    );
+    const profile = screen.getByTestId("perc-spa-my-profile");
+    expect(profile.textContent).toBe("My profile");
+    expect(profile.getAttribute("href")).toBe("/cm/app/profile");
+    const logout = screen.getByTestId("perc-spa-logout");
+    expect(logout.getAttribute("href")).toBe("/logout");
+  });
+
+  it("falls back to default user label when userName is blank", () => {
+    renderMenu({ userName: "  " });
+    expect(screen.getByTestId("perc-spa-user-name").textContent).toBe("user");
+  });
+});

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -203,6 +203,7 @@ describe("PR-9 path-based SPA URLs + fallback filter", () => {
     expect(text).toContain("spa.jsp?entry=");
     expect(text).toContain("widget-builder");
     expect(text).toContain("explorer");
+    expect(text).toContain("profile");
     expect(text).not.toMatch(/sendRedirect/);
   });
 });

--- a/WebUI/src/test/ts/login/redirect.test.ts
+++ b/WebUI/src/test/ts/login/redirect.test.ts
@@ -30,6 +30,7 @@ describe("login redirect helpers", () => {
 
   it("allowlists entries and rejects unknown", () => {
     expect(buildSpaEntryRedirect("publish")).toContain("entry=publish");
+    expect(buildSpaEntryRedirect("profile")).toContain("entry=profile");
     expect(buildSpaEntryRedirect("evil")).toBe("/cm/app/spa.jsp?entry=home");
   });
 

--- a/WebUI/src/test/ts/profile/ProfileShell.test.tsx
+++ b/WebUI/src/test/ts/profile/ProfileShell.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProfileShell } from "../../../main/ts/profile/ProfileShell";
+import { PROFILE_MSG } from "../../../main/ts/profile/messages";
+
+describe("ProfileShell", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+  });
+
+  it("renders title, intro, and four placeholder sections", () => {
+    render(<ProfileShell embedded />);
+    expect(screen.getByTestId("perc-profile-shell")).toBeTruthy();
+    expect(screen.getByTestId("perc-profile-title").textContent).toBe("My profile");
+    expect(screen.getByTestId("perc-profile-intro").textContent).toContain(
+      "account settings",
+    );
+    expect(screen.getByTestId("perc-profile-section-account")).toBeTruthy();
+    expect(screen.getByTestId("perc-profile-section-security")).toBeTruthy();
+    expect(screen.getByTestId("perc-profile-section-preferences")).toBeTruthy();
+    expect(screen.getByTestId("perc-profile-section-avatar")).toBeTruthy();
+  });
+
+  it("exposes landmark heading hierarchy and section jump links", () => {
+    render(<ProfileShell embedded />);
+    const h1 = screen.getByRole("heading", { level: 1, name: "My profile" });
+    expect(h1).toBeTruthy();
+
+    const account = screen.getByRole("heading", { level: 2, name: "Account" });
+    const security = screen.getByRole("heading", { level: 2, name: "Security" });
+    const preferences = screen.getByRole("heading", {
+      level: 2,
+      name: "Preferences",
+    });
+    const avatar = screen.getByRole("heading", { level: 2, name: "Avatar" });
+    expect(account).toBeTruthy();
+    expect(security).toBeTruthy();
+    expect(preferences).toBeTruthy();
+    expect(avatar).toBeTruthy();
+
+    const nav = screen.getByTestId("perc-profile-section-nav");
+    expect(nav.getAttribute("aria-labelledby")).toBeTruthy();
+    expect(screen.getByTestId("perc-profile-nav-account").getAttribute("href")).toBe(
+      "#perc-profile-account",
+    );
+    expect(screen.getByTestId("perc-profile-nav-security").getAttribute("href")).toBe(
+      "#perc-profile-security",
+    );
+  });
+
+  it("marks section status as coming soon via catalog keys", () => {
+    render(<ProfileShell embedded />);
+    const statuses = screen.getAllByText("Coming soon");
+    expect(statuses.length).toBe(4);
+    expect(PROFILE_MSG.COMING_SOON).toContain("Coming soon");
+  });
+});

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -26730,5 +26730,42 @@ Niet-opgeslagen wijzigingen in '{1}' kunnen verloren gaan.</seg></tuv>
     <tu tuid="perc.ui.publish.servers.s3@Optional credentials hint">
       <tuv xml:lang="en-us"><seg>Optional when using an EC2 instance profile or Assume Role. Leave empty only if alternate AWS credentials will be available at publish time. Saving with empty fields shows a footer warning.</seg></tuv>
     <tuv xml:lang="lou"><seg>Optional when using yon EC2 instance profile oswa Assume Role. Leave vid only if alternate AWS credentials will été disponib at pibliyé time. Saving épi vid fields shows yon footer warning.</seg></tuv></tu>
+      <!-- Issue #2393 / parent #2374 slice 1: Profile hub shell + My profile entry (en-us source; other locales fall back / translate later) -->
+    <tu tuid="perc.ui.profile.modern@My profile">
+      <tuv xml:lang="en-us"><seg>My profile</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@View and manage your account settings. Sections below will open as they become available.">
+      <tuv xml:lang="en-us"><seg>View and manage your account settings. Sections below will open as they become available.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Profile sections">
+      <tuv xml:lang="en-us"><seg>Profile sections</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Account">
+      <tuv xml:lang="en-us"><seg>Account</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Your name, login id, email, and role summary will appear here.">
+      <tuv xml:lang="en-us"><seg>Your name, login id, email, and role summary will appear here.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Security">
+      <tuv xml:lang="en-us"><seg>Security</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Password and authentication options for your account will appear here.">
+      <tuv xml:lang="en-us"><seg>Password and authentication options for your account will appear here.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Preferences">
+      <tuv xml:lang="en-us"><seg>Preferences</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Language and personal UI preferences will appear here.">
+      <tuv xml:lang="en-us"><seg>Language and personal UI preferences will appear here.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Avatar">
+      <tuv xml:lang="en-us"><seg>Avatar</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Avatar and Gravatar email settings will appear here.">
+      <tuv xml:lang="en-us"><seg>Avatar and Gravatar email settings will appear here.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.profile.modern@Coming soon">
+      <tuv xml:lang="en-us"><seg>Coming soon</seg></tuv>
+    </tu>
   </body>
 </tmx>

--- a/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Profile hub shell smoke (#2393 / parent #2374 slice 1).
+ *
+ * Surface-filtered only — not full suite:
+ *   npm run test:surface -- --path tests/profile-shell.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function profileDeepLink() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
+}
+
+function homeUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+}
+
+test.describe("Profile shell @profile @smoke", () => {
+  test("deep link opens profile shell with section landmarks", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("perc-profile-title")).toContainText(
+      /my profile/i,
+    );
+    await expect(page.getByTestId("perc-profile-section-account")).toBeVisible();
+    await expect(page.getByTestId("perc-profile-section-security")).toBeVisible();
+    await expect(
+      page.getByTestId("perc-profile-section-preferences"),
+    ).toBeVisible();
+    await expect(page.getByTestId("perc-profile-section-avatar")).toBeVisible();
+
+    // Client path after entry handoff (or still query — accept either)
+    await expect(page).toHaveURL(/profile/i, { timeout: 15_000 });
+  });
+
+  test("My profile menu entry navigates to profile shell", async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const menuLink = page.getByTestId("perc-spa-my-profile");
+    await expect(menuLink).toBeVisible();
+    await expect(menuLink).toBeEnabled();
+    await menuLink.click();
+
+    await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("perc-profile-title")).toContainText(
+      /my profile/i,
+    );
+    await expect(page).toHaveURL(/profile/i, { timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## Summary
Partial delivery for **#2393** (slice 1 of parent epic **#2374**): first-class **My profile** hub shell for any authenticated user.

- UserMenu **My profile** entry (localized, keyboard-focusable, SPA `Link` to `/profile`)
- React route `profile` under AppLayout + deep link `spa.jsp?entry=profile` (TS allowlists, dual-tree spa.jsp, `PSWebUiSpaFallbackFilter`, login redirect allowlist)
- `ProfileShell` with landmarks, h1/h2 hierarchy, section jump nav, placeholder Account / Security / Preferences / Avatar
- All new user-visible strings externalized via `PROFILE_MSG` + **en-us** `CmsUi.tmx` keys (`perc.ui.profile.modern@…`)
- Vitest: UserMenu + ProfileShell + deep-link/filter peers
- Playwright surface spec: `modules/perc-qa-automation/frontend/tests/profile-shell.spec.js` (`@profile @smoke`)

**Out of scope (already filed):** #2395 account, #2394 password, #2396 preferences, #2397 Gravatar.

### a11y note (WCAG 2.1 AA — shell + entry)
- Profile lives inside existing SPA `<main>`; shell uses labelled `header` + `section`s with `aria-labelledby` and unique heading ids
- In-page section nav has accessible name; section jump targets are focusable (`tabIndex={-1}`)
- My profile + logout links have `:focus-visible` outlines
- No forms/mutations in this slice (no aria-invalid / live regions yet — later slices)

## Test plan
- [x] `cd modules/perc-i18n && ../../mvnw clean install` — BUILD SUCCESS
- [x] `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS
- [x] `cd WebUI && ../mvnw clean install` — BUILD SUCCESS; Vitest **1512** tests, 0 failures (includes new UserMenu/ProfileShell)
- [x] Surface Playwright **authored** (`tests/profile-shell.spec.js`)
- [ ] Live surface run blocked this session: `perc-devctl qa-up` H2 cell failed CMS Spring boot (`folderHelper` circular dependency + empty H2 package tables) on existing dist jar — residual filed for green run on healthy QA stack

```bash
# When QA is healthy:
python docker/scripts/perc-devctl.py qa-up
cd modules/perc-qa-automation/frontend
TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… npm run test:surface -- --path tests/profile-shell.spec.js
python docker/scripts/perc-devctl.py qa-down
```

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

## Links
- Fixes (slice scope): #2393
- Parent tracker: #2374
- Residual issues: (filed after PR open)

> Co-Authored by Grok Build using grok-4.5 with agent main.