### PR TITLE
fix(perc-ant): javadoc main descriptions residual (#2416)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2023-perc-ant-javac-batch1-erlang.md
@@ -12,7 +12,7 @@
 - Portable paths: PSPropagateFile now uses `Path.resolve` instead of `"/" +` string join.
 - Intentional `@SuppressWarnings("deprecation")` only on legacy upgrade crypto / PSEntityResolver / Ant Main(String[]) — no blanket suppressions.
 - New `PSInstallIoUtils` covered by 6 unit tests; module suite 49 tests green.
-- Residual (not module-zero for issue acceptance): javadoc "no main description" on PSMigrateI18nLocaleCodes / PSStripSampleLocales (~8). Original issue "200" was inventory-cap noise; live main Xlint:all was 34.
+- Residual (not module-zero for issue acceptance at batch-1 time): javadoc "no main description" on PSMigrateI18nLocaleCodes / PSStripSampleLocales (~8) — **cleared in #2416** (one-line main descriptions on dryRun/failOnError and inputFile/stagingFile getters/setters). Original issue "200" was inventory-cap noise; live main Xlint:all was 34.
 
 ## Hard gates
 - [x] No new non-portable path I/O

--- a/docs/ai-generated/code-reviews/issue-2416-perc-ant-javadoc-main-desc-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2416-perc-ant-javadoc-main-desc-erlang.md
@@ -1,0 +1,22 @@
+# Erlang self-review — issue #2416 perc-ant javadoc main descriptions
+
+**Verdict:** approve
+
+## Scope
+- Module: `modules/perc-ant`
+- Add one-line main description above `@param`/`@return`-only Javadoc on:
+  - `PSMigrateI18nLocaleCodes`: `setDryRun` / `isDryRun` / `setFailOnError` / `isFailOnError`
+  - `PSStripSampleLocales`: `setInputFile` / `getInputFile` / `setStagingFile` / `getStagingFile`
+- No Xlint scope change; no behavior change.
+
+## Findings
+- Documentation-only; no path I/O, no new logic, no companions beyond existing suite.
+- Existing `PSStripSampleLocalesTest` + suite (49) remain green; no new behavioral tests required for comment text.
+- Standalone clean install: BUILD SUCCESS; no "no main description" warnings for the listed methods.
+
+## Hard gates
+- [x] No new non-portable path I/O
+- [x] Javadoc-only — existing tests cover methods
+- [x] Standalone `cd modules/perc-ant && ../../mvnw.cmd clean install` BUILD SUCCESS
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMigrateI18nLocaleCodes.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMigrateI18nLocaleCodes.java
@@ -51,6 +51,8 @@ public class PSMigrateI18nLocaleCodes extends PSAction {
   private boolean failOnError = true;
 
   /**
+   * Sets whether migration runs in dry-run mode (count/log only).
+   *
    * @param dryRun when true, count and log only (rollback / no updates)
    */
   public void setDryRun(boolean dryRun) {
@@ -58,6 +60,8 @@ public class PSMigrateI18nLocaleCodes extends PSAction {
   }
 
   /**
+   * Returns whether dry-run mode is enabled.
+   *
    * @return whether dry-run mode is enabled
    */
   public boolean isDryRun() {
@@ -65,6 +69,8 @@ public class PSMigrateI18nLocaleCodes extends PSAction {
   }
 
   /**
+   * Sets whether SQL/config failures abort the install task.
+   *
    * @param failOnError when true (default), SQL/config failures throw {@link BuildException}
    */
   public void setFailOnError(boolean failOnError) {
@@ -72,6 +78,8 @@ public class PSMigrateI18nLocaleCodes extends PSAction {
   }
 
   /**
+   * Returns whether failures abort the install.
+   *
    * @return whether failures abort the install
    */
   public boolean isFailOnError() {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSStripSampleLocales.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSStripSampleLocales.java
@@ -64,6 +64,8 @@ public class PSStripSampleLocales extends Task {
   public PSStripSampleLocales() {}
 
   /**
+   * Sets the path to the shipped sample seed XML (never modified).
+   *
    * @param inputFile path to the shipped sample seed XML (never modified)
    */
   public void setInputFile(String inputFile) {
@@ -71,6 +73,8 @@ public class PSStripSampleLocales extends Task {
   }
 
   /**
+   * Returns the input file path.
+   *
    * @return input file path
    */
   public String getInputFile() {
@@ -78,6 +82,8 @@ public class PSStripSampleLocales extends Task {
   }
 
   /**
+   * Sets the path for the stripped staging copy written for {@code PSTableAction}.
+   *
    * @param stagingFile path for the stripped staging copy written for {@code PSTableAction}
    */
   public void setStagingFile(String stagingFile) {
@@ -85,6 +91,8 @@ public class PSStripSampleLocales extends Task {
   }
 
   /**
+   * Returns the staging output path.
+   *
    * @return staging output path
    */
   public String getStagingFile() {


### PR DESCRIPTION
## Summary

Clears the **perc-ant residual javadoc "no main description"** warnings left after batch 1 (issue #2023 / PR #2415).

Adds a one-line main description above each `@param`/`@return`-only method Javadoc on:

| Class | Methods |
|-------|---------|
| `PSMigrateI18nLocaleCodes` | `setDryRun` / `isDryRun` / `setFailOnError` / `isFailOnError` |
| `PSStripSampleLocales` | `setInputFile` / `getInputFile` / `setStagingFile` / `getStagingFile` |

- **No** behavior change
- **No** Xlint scope broadening
- Residual note in the #2023 Erlang review updated to mark this residual cleared

Parent tracker: #2200  
Module issue: #2023

## Test plan

- [x] `cd modules/perc-ant` → `../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **49**, Failures: **0**, Errors: **0**, Skipped: **0**
- [x] Javadoc jar step: no "no main description" warnings for the listed methods
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2416-perc-ant-javadoc-main-desc-erlang.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Standalone module clean install | BUILD SUCCESS |
| Behavioral unit tests | suite 49 green (javadoc-only change) |
| Scope confined to perc-ant + review notes | yes |
| Residual | this residual is complete; do **not** claim broader module-wide zero javadoc without re-inventory |

Fixes #2416  
Partial for #2023 (javadoc residual of batch 1)  
Refs #2200

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.