### PR TITLE
fix(sitemanage): break folderHelper<->contentItemDao Spring cycle with @Lazy (#2435)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
@@ -63,6 +63,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.Errors;
 
@@ -91,7 +92,7 @@ public class PSContentItemDao implements IPSContentItemDao {
       IPSContentWs contentWs,
       IPSIdMapper idMapper,
       @Qualifier("itemSummaryService") IPSDataItemSummaryService itemSummaryService,
-      IPSFolderHelper folderHelper,
+      @Lazy IPSFolderHelper folderHelper,
       IPSCmsObjectMgr cmsObjectMgr,
       @Qualifier("relationshipCataloger") IPSRelationshipCataloger relationshipHelper,
       IPSSystemWs systemWs) {

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSContentItemDaoCycleLazyWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSContentItemDaoCycleLazyWiringTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.share.dao.IPSFolderHelper;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Regression test for the Spring constructor-injection cycle
+ *
+ * <pre>
+ * folderHelper -> recycleService -> widgetAssetRelationshipService
+ *             -> assetDao        -> contentItemDao       -> folderHelper
+ * </pre>
+ *
+ * <p>The cycle blocks Rhythmyx startup (#2423 / slice A #2435). The fix marks {@code IPSFolderHelper}
+ * in {@link PSContentItemDao}'s constructor as {@link Lazy @Lazy} so Spring injects a proxy and does
+ * not try to fully resolve {@code folderHelper} while {@code folderHelper} is still being created.
+ *
+ * <p>This test fails if the {@code @Lazy} annotation is removed or applied to the wrong parameter,
+ * which would re-introduce the {@code BeanCurrentlyInCreationException} on Jetty/Rhythmyx startup.
+ */
+@Tag("UnitTest")
+public class PSContentItemDaoCycleLazyWiringTest {
+
+  @Test
+  public void folderHelperConstructorParameterIsLazy() throws NoSuchMethodException {
+    Constructor<PSContentItemDao> ctor = PSContentItemDao.class.getDeclaredConstructor(
+        com.percussion.webservices.content.IPSContentDesignWs.class,
+        com.percussion.webservices.content.IPSContentWs.class,
+        com.percussion.share.service.IPSIdMapper.class,
+        com.percussion.share.service.IPSDataItemSummaryService.class,
+        IPSFolderHelper.class,
+        com.percussion.services.legacy.IPSCmsObjectMgr.class,
+        com.percussion.share.dao.IPSRelationshipCataloger.class,
+        com.percussion.webservices.system.IPSSystemWs.class);
+
+    assertNotNull(ctor, "PSContentItemDao constructor signature must match");
+
+    Parameter[] params = ctor.getParameters();
+    Parameter folderHelperParam = null;
+    for (Parameter p : params) {
+      if (IPSFolderHelper.class.isAssignableFrom(p.getType())) {
+        folderHelperParam = p;
+        break;
+      }
+    }
+
+    assertNotNull(folderHelperParam, "Expected an IPSFolderHelper constructor parameter");
+    assertTrue(
+        folderHelperParam.isAnnotationPresent(Lazy.class),
+        "IPSFolderHelper constructor parameter must be @Lazy to break the "
+            + "folderHelper<->contentItemDao Spring cycle (see #2423 / #2435)");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the p1 Spring constructor-injection cycle that blocks Rhythmyx/Jetty
startup on Docker CMS (perc-matrix-cms-h2) and any local Jetty install
built against the same SNAPSHOT wiring.

**Parent:** #2423 (p1 — blocks all QA automation)
**This PR:** slice A (#2435) — break the cycle in DI.

## Cycle (before)

\\\
pSRedirectService
  -> folderHelper               (PSFolderHelper)
    -> recycleService           (PSRecycleService)
      -> widgetAssetRelationshipService  (PSWidgetAssetRelationshipService)
        -> assetDao             (PSAssetDao)
          -> contentItemDao     (PSContentItemDao)
            -> folderHelper     <-- cycle
\\\

Both \PSFolderHelper\ and \PSRecycleService\ already carry a class-level
\@Lazy\, but class-level @Lazy on the depended-on bean does not always
break a constructor-injection cycle when the dependency is requested via
constructor parameters. Result on Jetty 12.1.11 / JDK 21:

\\\
BeanCurrentlyInCreationException: Error creating bean with name 'folderHelper':
Requested bean is currently in creation
\\\

## Fix

Mark the \IPSFolderHelper\ constructor parameter of \PSContentItemDao\
as \@Lazy\ so Spring injects a lazy proxy. \olderHelper\ is only used
at runtime (findFolderItems, addItemToPath, etc.), so deferred initialization
is safe.

\\\diff
-      IPSFolderHelper folderHelper,
+      @Lazy IPSFolderHelper folderHelper,
\\\

## Companion regression test

\PSContentItemDaoCycleLazyWiringTest\ (JUnit 5, reflection) asserts the
\IPSFolderHelper\ constructor parameter of \PSContentItemDao\ carries
\@Lazy\. Fails if the annotation is removed or moved off the parameter,
which would re-introduce \BeanCurrentlyInCreationException\ at Rhythmyx
startup. Slice B (#2436) will add the full Spring-context startup test
covering this wiring plus the rest of the cycle; slice C (#2437) covers
the Docker \qa-up\ health/login smoke.

## Files changed

- \projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java\ (+1 import, +1 @Lazy on the folderHelper parameter)
- \projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSContentItemDaoCycleLazyWiringTest.java\ (new, regression test)

## Pre-PR Maven verification

\\\ash
cd projects/sitemanage && ../../mvnw.cmd clean install
\\\

- **BUILD SUCCESS** (54.672 s)
- \PSContentItemDaoCycleLazyWiringTest\: Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
- All other sitemanage tests pass; no new warnings introduced (pre-existing
  warnings on \PSAbstractWorkflowExtensionConcurrencyTest.java\ serialVersionUID
  untouched by this change).

No reactor build needed: standalone module build only touches
\projects/sitemanage\; no shared parent \pom.xml\ or upstream module
changed. The downstream \est\ module does not import \PSContentItemDao\,
so no \-am\ rebuild is required.

## Cross-platform

N/A — this is a Spring DI annotation change. No filesystem path or
process spawning touched.

## Out of scope

- Slice B (#2436): full Spring-context startup test for the cycle.
- Slice C (#2437): Docker \perc-devctl qa-up\ health/login smoke.
- Any unrelated sitemanage Xlint or refactor.

Operator: Kilo (minimax-coding-plan/MiniMax-M3)