### PR TITLE
fix(perc-content-explorer): cataloger Collection/Iterator typing (#2384)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2384-cataloger-typing-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2384-cataloger-typing-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review — issue #2384 (DCE cataloger typing)
+
+**Scope:** `modules/DesktopContentExplorer` cataloger Collection/Iterator rawtypes +
+`PSDisplayFormatCatalog` + light consumers; `PSDesktopExplorerWindow` serialVersionUID only.
+
+**Verdict:** PASS for commit (no bugs found in typed cataloger paths; behavioral tests added).
+
+## Findings
+
+None blocking.
+
+### Notes (non-blocking residual)
+
+- `PSDesktopExplorerWindow` still has likely `this-escape` from field initializers
+  (`PSJavaBridge bridge = new PSJavaBridge(this)`, non-static inner state provider).
+  Only `serialVersionUID` landed in this batch; residual filed for this-escape +
+  status dialog / process monitor cluster.
+- Inner cataloger value types (`Community`/`Role`/`Subject`) still call `super.clone()`
+  without implementing `Cloneable` (pre-existing dead path).
+- Module remains hot with other Xlint clusters outside this batch.
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Real generics (not blanket suppress) | Yes |
+| Cross-platform paths | N/A (no path I/O change) |
+| Behavioral unit tests | `PSCatalogerTypingTest` (6), `PSDisplayFormatCatalogTest` (1) |
+| Change-class companions | Call sites updated for typed returns |
+| Module clean install | Required before PR |
+
+## Test evidence
+
+`cd modules/DesktopContentExplorer && ../../mvnw clean install` — BUILD SUCCESS.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatCatalog.java
@@ -141,7 +141,7 @@ public class PSDisplayFormatCatalog {
    * @return the list of all displayformats, never <code>null</code> or empty.
    * @see PSDisplayFormat
    */
-  public Iterator getAll() {
+  public Iterator<PSDisplayFormat> getAll() {
     return m_displayFormats.iterator();
   }
 
@@ -151,7 +151,7 @@ public class PSDisplayFormatCatalog {
    * @return the list of displayformats, never <code>null</code> or empty.
    * @see PSDisplayFormat
    */
-  public Iterator getFolderDisplayFormats() {
+  public Iterator<PSDisplayFormat> getFolderDisplayFormats() {
     return m_folderDisplayFormats.iterator();
   }
 
@@ -162,7 +162,7 @@ public class PSDisplayFormatCatalog {
    * @return the list of displayformats, never <code>null</code> or empty.
    * @see PSDisplayFormat
    */
-  public Iterator getRcDisplayFormats() {
+  public Iterator<PSDisplayFormat> getRcDisplayFormats() {
     return m_rcDisplayFormats.iterator();
   }
 
@@ -173,7 +173,7 @@ public class PSDisplayFormatCatalog {
    * @return the list of displayformats, never <code>null</code> or empty.
    * @see PSDisplayFormat
    */
-  public Iterator getViewsSearchDisplayFormats() {
+  public Iterator<PSDisplayFormat> getViewsSearchDisplayFormats() {
     return m_viewAndSearchDisplayFormats.iterator();
   }
 
@@ -211,19 +211,14 @@ public class PSDisplayFormatCatalog {
    * @return the matching display format, may be <code>null</code> if not found in cache.
    */
   private PSDisplayFormat getDisplayFormatByIdFromCache(String displayformatid) {
-    PSDisplayFormat match = null;
-
-    Iterator iter = m_displayFormats.iterator();
-    while (iter.hasNext()) {
-      PSDisplayFormat format = (PSDisplayFormat) iter.next();
+    for (PSDisplayFormat format : m_displayFormats) {
       String id = getDisplayFormatId(format);
       if (id.equals(displayformatid)) {
-        match = format;
-        break;
+        return format;
       }
     }
 
-    return match;
+    return null;
   }
 
   /**
@@ -243,25 +238,25 @@ public class PSDisplayFormatCatalog {
    * Array list of all display format objects cataloged, updated with list of available formats and
    * never <code>null</code>, empty or modified after that.
    */
-  private List m_displayFormats = new ArrayList();
+  private List<PSDisplayFormat> m_displayFormats = new ArrayList<>();
 
   /**
    * List of all display formats applicable to Folders, updated with list in the ctor and never
    * <code>null</code>, empty or modified after that.
    */
-  private List m_folderDisplayFormats = new ArrayList();
+  private List<PSDisplayFormat> m_folderDisplayFormats = new ArrayList<>();
 
   /**
    * List of all display formats applicable to related content, updated with list in the ctor and
    * never <code>null</code>, empty or modified after that.
    */
-  private List m_rcDisplayFormats = new ArrayList();
+  private List<PSDisplayFormat> m_rcDisplayFormats = new ArrayList<>();
 
   /**
    * List of all display formats applicable to searchs and views, updated with list in the ctor and
    * never <code>null</code>, empty or modified after that.
    */
-  private List m_viewAndSearchDisplayFormats = new ArrayList();
+  private List<PSDisplayFormat> m_viewAndSearchDisplayFormats = new ArrayList<>();
 
   /**
    * The proxy to use to load display formats from server, initialized in the ctor and never <code>

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderAclEditorDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderAclEditorDialog.java
@@ -259,15 +259,11 @@ public class PSFolderAclEditorDialog extends PSDialog implements ActionListener 
 
         // get Role ACLs
         PSRoleCataloger roleCatalog = m_folderMgr.getRoleCataloger();
-        Collection roles = roleCatalog.getRoles();
+        Collection<PSRoleCataloger.Role> roles = roleCatalog.getRoles();
 
-        Iterator itRoles = roles.iterator();
+        m_catalogedRoleAcls = new ArrayList<>();
 
-        m_catalogedRoleAcls = new ArrayList();
-
-        while (itRoles.hasNext()) {
-          PSRoleCataloger.Role role = (PSRoleCataloger.Role) itRoles.next();
-
+        for (PSRoleCataloger.Role role : roles) {
           // create ACL Entry out of the role
 
           PSObjectAclEntry aclEntry =
@@ -286,15 +282,11 @@ public class PSFolderAclEditorDialog extends PSDialog implements ActionListener 
 
         // get User ACLs
         PSSubjectCataloger subjectCatalog = m_folderMgr.getSubjectCataloger();
-        Collection subjects = subjectCatalog.getSubjects();
+        Collection<PSSubjectCataloger.Subject> subjects = subjectCatalog.getSubjects();
 
-        Iterator itSubjects = subjects.iterator();
+        m_catalogedUserAcls = new ArrayList<>();
 
-        m_catalogedUserAcls = new ArrayList();
-
-        while (itSubjects.hasNext()) {
-          PSSubjectCataloger.Subject subject = (PSSubjectCataloger.Subject) itSubjects.next();
-
+        for (PSSubjectCataloger.Subject subject : subjects) {
           // create ACL Entry out of the user
 
           PSObjectAclEntry aclEntry =

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderActionManager.java
@@ -516,7 +516,7 @@ public class PSFolderActionManager {
    *     bottom as <code>Integer</code> objects, never <code>null</code>, may be empty.
    * @throws PSCmsException for any error.
    */
-  public Set<?> getFolderCommunities(PSNode source) throws PSCmsException {
+  public Set<Integer> getFolderCommunities(PSNode source) throws PSCmsException {
     if (source == null) throw new IllegalArgumentException("source cannot be null");
 
     return m_folderProxy.getFolderCommunities(PSActionManager.nodeToLocator(source));
@@ -1001,7 +1001,7 @@ public class PSFolderActionManager {
    *
    * @return the list of display formats, never <code>null</code> or empty.
    */
-  public Iterator<?> getDisplayFormats() {
+  public Iterator<PSDisplayFormat> getDisplayFormats() {
     PSDisplayFormatCatalog dispFormatCatalog = m_actionManager.getDisplayFormatCatalog();
 
     return dispFormatCatalog.getFolderDisplayFormats();
@@ -1244,8 +1244,7 @@ public class PSFolderActionManager {
         String path = getFolderPath(parent);
         if (!path.endsWith("/")) path += "/";
         path += folderName;
-        for (Object siteObj : getSiteCataloger().getSites()) {
-          PSSite site = (PSSite) siteObj;
+        for (PSSite site : getSiteCataloger().getSites()) {
           String sitePath = site.getFolderRoot();
           sitePath = sitePath.replace('\\', '/');
           if (sitePath.endsWith("/")) sitePath = sitePath.substring(0, sitePath.length() - 1);

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderGeneralPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderGeneralPanel.java
@@ -178,9 +178,9 @@ public class PSFolderGeneralPanel extends PSPropertyPanel {
         m_comboFolderLocale,
         PSContentExploreAppletUtils.getResourceMnemonic(getClass(), "@Locale:", 'e'));
 
-    Iterator iter = m_folderMgr.getLocaleCataloger().getLocales();
-    while (iter.hasNext()) {
-      PSEntry element = (PSEntry) iter.next();
+    Iterator<PSEntry> localeIter = m_folderMgr.getLocaleCataloger().getLocales();
+    while (localeIter.hasNext()) {
+      PSEntry element = localeIter.next();
       m_comboFolderLocale.addItem(element);
       if (element.getValue().equals(m_folder.getLocale()))
         m_comboFolderLocale.setSelectedItem(element);
@@ -203,25 +203,15 @@ public class PSFolderGeneralPanel extends PSPropertyPanel {
         PSContentExploreAppletUtils.getResourceMnemonic(
             getClass(), "@Default display format:", 'f'));
 
-    iter = m_folderMgr.getDisplayFormats();
+    Iterator<PSDisplayFormat> formatIter = m_folderMgr.getDisplayFormats();
 
     // sort disp formats
-    List dispFormats = new ArrayList();
-    while (iter.hasNext()) dispFormats.add(iter.next());
+    List<PSDisplayFormat> dispFormats = new ArrayList<>();
+    while (formatIter.hasNext()) dispFormats.add(formatIter.next());
 
-    class DispFormatComparator implements Comparator {
-      public DispFormatComparator() {}
+    Collections.sort(dispFormats, Comparator.comparing(Object::toString));
 
-      public int compare(Object left, Object right) {
-        return left.toString().compareTo(right.toString());
-      }
-    }
-
-    Collections.sort(dispFormats, new DispFormatComparator());
-
-    iter = dispFormats.iterator();
-
-    while (iter.hasNext()) m_comboDisplayFormat.addItem(iter.next());
+    for (PSDisplayFormat format : dispFormats) m_comboDisplayFormat.addItem(format);
     if (m_isNewFolder) m_comboDisplayFormat.setSelectedIndex(0);
     else {
       PSDisplayFormat format =
@@ -260,11 +250,10 @@ public class PSFolderGeneralPanel extends PSPropertyPanel {
           m_comboGlobalTemplate,
           PSContentExploreAppletUtils.getResourceMnemonic(getClass(), "@Global Template:", 'T'));
 
-      Iterator globalTemplates =
+      Iterator<String> globalTemplates =
           m_folderMgr.getGlobalTemplateCataloger().getGlobalTemplates().iterator();
       m_comboGlobalTemplate.addItem(m_applet.getResourceString(getClass(), "Use default"));
-      while (globalTemplates.hasNext())
-        m_comboGlobalTemplate.addItem(globalTemplates.next().toString());
+      while (globalTemplates.hasNext()) m_comboGlobalTemplate.addItem(globalTemplates.next());
 
       String globalTemplate = m_folder.getGlobalTemplateProperty();
       if (globalTemplate == null || globalTemplate.trim().length() == 0)
@@ -308,14 +297,15 @@ public class PSFolderGeneralPanel extends PSPropertyPanel {
         m_comboFolderCommunity,
         PSContentExploreAppletUtils.getResourceMnemonic(getClass(), "@Folder Community:", 'M'));
     PSCommunityCataloger commCataloger = m_folderMgr.getCommunityCataloger();
-    Iterator itComm = commCataloger.getCommunities().iterator();
+    Iterator<PSCommunityCataloger.Community> itComm =
+        commCataloger.getCommunities().iterator();
 
     /*make an extra instance of the Community class, so that we
       can add a "All" entry to the combo box with the id = -1.
       The commCataloger itself is not holding to this new community instance.
     */
     PSCommunityCataloger.Community commAll =
-        commCataloger.createCommunity(
+        PSCommunityCataloger.createCommunity(
             -1, m_applet.getResourceString(getClass(), "All communities"), "");
 
     m_comboFolderCommunity.addItem(commAll);
@@ -325,7 +315,7 @@ public class PSFolderGeneralPanel extends PSPropertyPanel {
     // add only one entry for the current community and pick the community to
     // select
     while (itComm.hasNext()) {
-      PSCommunityCataloger.Community comm = (PSCommunityCataloger.Community) itComm.next();
+      PSCommunityCataloger.Community comm = itComm.next();
 
       if (comm.getId() == currCommunityId) {
         m_comboFolderCommunity.addItem(comm);

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
@@ -274,8 +274,8 @@ public class PSSearchViewActionManager {
    *
    * @return the list of display formats, never <code>null</code> or empty.
    */
-  public Iterator getDisplayFormats() {
-    Iterator dispFormats;
+  public Iterator<PSDisplayFormat> getDisplayFormats() {
+    Iterator<PSDisplayFormat> dispFormats;
 
     PSDisplayFormatCatalog dispFormatCatalog =
         m_applet.getActionManager().getDisplayFormatCatalog();

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityCataloger.java
@@ -26,7 +26,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -67,10 +66,14 @@ public class PSCommunityCataloger {
     try {
       clone = (PSCommunityCataloger) super.clone();
 
-      Collection clonedComm = new ArrayList();
+      Collection<Community> clonedComm = new ArrayList<>();
 
-      Iterator it = m_collCommunities.iterator();
-      while (it.hasNext()) clonedComm.add(((Community) it.next()).clone());
+      for (Community community : m_collCommunities) {
+        Object communityClone = community.clone();
+        if (communityClone instanceof Community) {
+          clonedComm.add((Community) communityClone);
+        }
+      }
 
       clone.m_collCommunities = clonedComm;
 
@@ -274,7 +277,7 @@ public class PSCommunityCataloger {
    *
    * @return unmodifiable collection of cataloged Community instances, never {@code null}
    */
-  public Collection getCommunities() {
+  public Collection<Community> getCommunities() {
     return Collections.unmodifiableCollection(m_collCommunities);
   }
 
@@ -293,7 +296,7 @@ public class PSCommunityCataloger {
   }
 
   /** collection of cataloged Community instances */
-  private Collection m_collCommunities = new ArrayList();
+  private Collection<Community> m_collCommunities = new ArrayList<>();
 
   /** The XML root element name containing all cataloged communities. */
   public static final String XML_ELEM_ROOT = "communities";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSCommunityContentTypeMapperCataloger.java
@@ -27,7 +27,6 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import org.w3c.dom.Document;
@@ -43,6 +42,12 @@ import org.w3c.dom.NodeList;
  * server. It only contains the commmunities which contain a list of non empty content types.
  */
 public class PSCommunityContentTypeMapperCataloger {
+  /**
+   * Default constructor for offline construction and tests. Must be followed by {@link
+   * #fromXml(Element)}.
+   */
+  PSCommunityContentTypeMapperCataloger() {}
+
   /**
    * Constructor meant to be used in the context of an applet. This may not work in other contexts
    * since there is no way of supplying credentials for logging in.
@@ -68,23 +73,26 @@ public class PSCommunityContentTypeMapperCataloger {
    * @return a list of zero or more <code>PSCommunityCataloger.Community</code> objects. It may be
    *     <code>null</code> if the source community is not in the mapper.
    */
-  public Collection getCompatibleCommunities(Integer srcCommunityId) {
+  public Collection<PSCommunityCataloger.Community> getCompatibleCommunities(
+      Integer srcCommunityId) {
     if (srcCommunityId == null) throw new IllegalArgumentException("srcCommunityId cannot be null");
 
-    Set retCommunities = new HashSet();
+    Set<PSCommunityCataloger.Community> retCommunities = new HashSet<>();
 
     PSCommunityCataloger.Community srcCommunity = getCommunity(srcCommunityId);
     if (srcCommunity == null) return null;
 
-    Collection srcContentTypes = (Collection) m_commCtMapper.get(srcCommunity);
+    Collection<PSEntry> srcContentTypes = m_commCtMapper.get(srcCommunity);
 
-    Collection tgtContentTypes;
-    Iterator communities = m_commCtMapper.keySet().iterator();
-    PSCommunityCataloger.Community community;
-    while (communities.hasNext()) {
-      community = (PSCommunityCataloger.Community) communities.next();
-      tgtContentTypes = (Collection) m_commCtMapper.get(community);
-      if (tgtContentTypes.containsAll(srcContentTypes)) retCommunities.add(community);
+    for (Map.Entry<PSCommunityCataloger.Community, Collection<PSEntry>> entry :
+        m_commCtMapper.entrySet()) {
+      PSCommunityCataloger.Community community = entry.getKey();
+      Collection<PSEntry> tgtContentTypes = entry.getValue();
+      if (tgtContentTypes != null
+          && srcContentTypes != null
+          && tgtContentTypes.containsAll(srcContentTypes)) {
+        retCommunities.add(community);
+      }
     }
 
     return retCommunities;
@@ -108,7 +116,7 @@ public class PSCommunityContentTypeMapperCataloger {
    * @param elemRoot the XML representation, assme not <code>null</code>.
    * @exception PSUnknownNodeTypeException if the XML does not conform its DTD.
    */
-  private void fromXml(Element elemRoot) throws PSUnknownNodeTypeException {
+  void fromXml(Element elemRoot) throws PSUnknownNodeTypeException {
     m_commCtMapper.clear();
 
     PSXMLDomUtil.checkNode(elemRoot, XML_ELEM_ROOT);
@@ -151,7 +159,7 @@ public class PSCommunityContentTypeMapperCataloger {
     PSCommunityCataloger.Community community = PSCommunityCataloger.createCommunity(id, name, null);
 
     // get a set of content types for this community
-    Collection<PSEntry> ctSet = new HashSet<PSEntry>();
+    Collection<PSEntry> ctSet = new HashSet<>();
     Element ctElem = PSXMLDomUtil.getFirstElementChild(mapping);
     while (ctElem != null) {
       PSXMLDomUtil.checkNode(ctElem, XML_ELEM_CONTENTTYPE);
@@ -165,7 +173,7 @@ public class PSCommunityContentTypeMapperCataloger {
     }
 
     if (m_commCtMapper.containsKey(community)) {
-      ((Collection<PSEntry>) m_commCtMapper.get(community)).addAll(ctSet);
+      m_commCtMapper.get(community).addAll(ctSet);
     } else {
       m_commCtMapper.put(community, ctSet);
     }
@@ -179,11 +187,7 @@ public class PSCommunityContentTypeMapperCataloger {
    *     the supplied id.
    */
   private PSCommunityCataloger.Community getCommunity(Integer id) {
-    Collection communitySet = m_commCtMapper.keySet();
-    Iterator communities = communitySet.iterator();
-    PSCommunityCataloger.Community community;
-    while (communities.hasNext()) {
-      community = (PSCommunityCataloger.Community) communities.next();
+    for (PSCommunityCataloger.Community community : m_commCtMapper.keySet()) {
       if (community.getId() == id.intValue()) return community;
     }
 
@@ -192,11 +196,12 @@ public class PSCommunityContentTypeMapperCataloger {
 
   /**
    * It maps a community to a list of content types which are specified for the community. The map
-   * key is <code>PSCommunityCataloger.PSCommunity</code> object. The map value is a <code>
+   * key is <code>PSCommunityCataloger.Community</code> object. The map value is a <code>
    * Collection</code> of zero or more <code>PSEntry</code> object, which contain the id and name of
    * the content type.
    */
-  private Map m_commCtMapper = new HashMap();
+  private Map<PSCommunityCataloger.Community, Collection<PSEntry>> m_commCtMapper =
+      new HashMap<>();
 
   /** Constants for XML elements and attributes */
   private static final String XML_ELEM_ROOT = "CommunityContentTypeMapper";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSGlobalTemplateCataloger.java
@@ -32,6 +32,12 @@ import org.w3c.dom.NodeList;
 /** This class catalogs all global template names found in rhythmyx. */
 public class PSGlobalTemplateCataloger {
   /**
+   * Default constructor for offline construction and tests. Must be followed by {@link
+   * #fromXml(Element)}.
+   */
+  PSGlobalTemplateCataloger() {}
+
+  /**
    * Constructs a new global template cataloger.
    *
    * @param urlBase the base URL to use for the catalog request, not <code>null</code>.
@@ -59,7 +65,7 @@ public class PSGlobalTemplateCataloger {
    *     <code>null</code>.
    * @throws PSUnknownNodeTypeException for any unknown XML node.
    */
-  private void fromXml(Element elemRoot) throws PSUnknownNodeTypeException {
+  void fromXml(Element elemRoot) throws PSUnknownNodeTypeException {
     m_globalTemplates.clear();
 
     PSXMLDomUtil.checkNode(elemRoot, ROOT_ELEM);
@@ -77,7 +83,7 @@ public class PSGlobalTemplateCataloger {
    * @return a collection of all global template names as <code>String</code> objects, never <code>
    *     null</code>, may be empty.
    */
-  public Collection getGlobalTemplates() {
+  public Collection<String> getGlobalTemplates() {
     return Collections.unmodifiableCollection(m_globalTemplates);
   }
 
@@ -85,7 +91,7 @@ public class PSGlobalTemplateCataloger {
    * The collection of all global template names, reset with each call to {@link #fromXml(Element)},
    * never <code>null</code>, may be empty.
    */
-  private Collection m_globalTemplates = new ArrayList();
+  private Collection<String> m_globalTemplates = new ArrayList<>();
 
   // private XML constants
   private static final String ROOT_ELEM = "GlobalTemplates";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSLocaleCataloger.java
@@ -86,7 +86,7 @@ public class PSLocaleCataloger {
    * @return iterator of {@link PSEntry} object representing each locale in the system. Never <code>
    *     null</code>.
    */
-  public Iterator getLocales() {
+  public Iterator<PSEntry> getLocales() {
     return m_locales.iterator();
   }
 
@@ -94,5 +94,5 @@ public class PSLocaleCataloger {
    * Collection of {@link PSEntry} objects. Each objects represents a locale in the CMS. Filled in
    * the constructor.
    */
-  private Collection m_locales = new ArrayList();
+  private Collection<PSEntry> m_locales = new ArrayList<>();
 }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSRoleCataloger.java
@@ -26,7 +26,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -65,10 +64,14 @@ public class PSRoleCataloger {
     try {
       clone = (PSRoleCataloger) super.clone();
 
-      Collection clonedRoles = new ArrayList();
+      Collection<Role> clonedRoles = new ArrayList<>();
 
-      Iterator it = m_collRoles.iterator();
-      while (it.hasNext()) clonedRoles.add(((Role) it.next()).clone());
+      for (Role role : m_collRoles) {
+        Object roleClone = role.clone();
+        if (roleClone instanceof Role) {
+          clonedRoles.add((Role) roleClone);
+        }
+      }
 
       clone.m_collRoles = clonedRoles;
 
@@ -224,12 +227,12 @@ public class PSRoleCataloger {
    *
    * @return unmodifiable collection of cataloged Role instances , never <code>null</code>.
    */
-  public Collection getRoles() {
+  public Collection<Role> getRoles() {
     return Collections.unmodifiableCollection(m_collRoles);
   }
 
   /** Collection of cataloged Role instances. */
-  private Collection m_collRoles = new ArrayList();
+  private Collection<Role> m_collRoles = new ArrayList<>();
 
   /** Root element name in the catalog response. */
   public static final String XML_ELEM_ROOT = "getRole";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSiteCataloger.java
@@ -102,7 +102,7 @@ public class PSSiteCataloger {
    * @return a collection of all site definitions as <code>PSSite</code> objects, never <code>null
    *     </code>, may be empty.
    */
-  public Collection getSites() {
+  public Collection<PSSite> getSites() {
     return Collections.unmodifiableCollection(m_sites);
   }
 
@@ -115,7 +115,7 @@ public class PSSiteCataloger {
    * The collection of all sites, reset with each call to {@link #fromXml(Element)}, never <code>
    * null</code>, may be empty.
    */
-  private Collection m_sites = new ArrayList();
+  private Collection<PSSite> m_sites = new ArrayList<>();
 
   // private XML constants
   private static final String ROOT_ELEM = "Sites";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/catalogers/PSSubjectCataloger.java
@@ -26,7 +26,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -67,10 +66,14 @@ public class PSSubjectCataloger {
     try {
       clone = (PSSubjectCataloger) super.clone();
 
-      Collection clonedSubjects = new ArrayList();
+      Collection<Subject> clonedSubjects = new ArrayList<>();
 
-      Iterator it = m_collSubjects.iterator();
-      while (it.hasNext()) clonedSubjects.add(((Subject) it.next()).clone());
+      for (Subject subject : m_collSubjects) {
+        Object subjectClone = subject.clone();
+        if (subjectClone instanceof Subject) {
+          clonedSubjects.add((Subject) subjectClone);
+        }
+      }
 
       clone.m_collSubjects = clonedSubjects;
 
@@ -270,12 +273,12 @@ public class PSSubjectCataloger {
    *
    * @return unmodifiable collection of cataloged Subject instances, never <code>null</code>.
    */
-  public Collection getSubjects() {
+  public Collection<Subject> getSubjects() {
     return Collections.unmodifiableCollection(m_collSubjects);
   }
 
   /** Collection of cataloged Subject instances. */
-  private Collection m_collSubjects = new ArrayList();
+  private Collection<Subject> m_collSubjects = new ArrayList<>();
 
   /** Root element name in the catalog response. */
   public static final String XML_ELEM_ROOT = "getSubject";

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/javafx/PSDesktopExplorerWindow.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/javafx/PSDesktopExplorerWindow.java
@@ -52,6 +52,8 @@ import org.jetbrains.annotations.NotNull;
  * PSSelection, PSMenuAction)}.
  */
 public abstract class PSDesktopExplorerWindow extends JFrame {
+  private static final long serialVersionUID = 1L;
+
   /**
    * State provider for the embedded JavaFX web view debugger, exposing a JSON-serializable state
    * blob to the page so it can be restored on reload.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCommunityMappingsPage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCommunityMappingsPage.java
@@ -135,8 +135,9 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
       throw new IllegalArgumentException(
           "the supplied data must be an array of Collection objects");
 
-    Collection allCommunities = ((InputData) data).getCommunityDefinitions();
-    List sourceCommunities = ((InputData) data).getSourceCommunities();
+    Collection<PSCommunityCataloger.Community> allCommunities =
+        ((InputData) data).getCommunityDefinitions();
+    List<Integer> sourceCommunities = ((InputData) data).getSourceCommunities();
     PSCommunityContentTypeMapperCataloger mapper = ((InputData) data).getCommCtMapper();
 
     // initialize the table
@@ -156,7 +157,7 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
 
     // initialize source and target community columns
     for (int row = 0; row < sourceCommunities.size(); row++) {
-      Integer srcCommunity = (Integer) sourceCommunities.get(row);
+      Integer srcCommunity = sourceCommunities.get(row);
       m_table.initTableCells(row, srcCommunity, allCommunities, mapper, model);
     }
   }
@@ -174,20 +175,19 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
      */
     public InputData(
         PSCommunityContentTypeMapperCataloger commCtMapper,
-        Collection communityDefinitions,
-        Collection sourceCommunities) {
+        Collection<PSCommunityCataloger.Community> communityDefinitions,
+        Collection<Integer> sourceCommunities) {
       if (commCtMapper == null) throw new IllegalArgumentException("commCtMapper may not be null");
 
-      if (!(communityDefinitions instanceof Collection))
-        throw new IllegalArgumentException(
-            "communityDefinitions must be an instance of Collection");
+      if (communityDefinitions == null)
+        throw new IllegalArgumentException("communityDefinitions may not be null");
 
-      if (!(sourceCommunities instanceof Collection))
-        throw new IllegalArgumentException("sourceCommunities must be an instance of Collection");
+      if (sourceCommunities == null)
+        throw new IllegalArgumentException("sourceCommunities may not be null");
 
       m_commCtMapper = commCtMapper;
       m_communityDefinitions = communityDefinitions;
-      m_sourceCommunities = new ArrayList(sourceCommunities);
+      m_sourceCommunities = new ArrayList<>(sourceCommunities);
       Collections.sort(m_sourceCommunities);
       Collections.reverse(m_sourceCommunities); // move smallest to the end
     }
@@ -198,7 +198,7 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
      * @return a collection of community definitions as <code>PSCommunityCataloger.Community</code>
      *     obejcts, never <code>null</code>, may be empty.
      */
-    public Collection getCommunityDefinitions() {
+    public Collection<PSCommunityCataloger.Community> getCommunityDefinitions() {
       return m_communityDefinitions;
     }
 
@@ -208,7 +208,7 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
      * @return a collection of source node community ids as <code>Integer</code> objects, never
      *     <code>null</code>, may be empty.
      */
-    public List getSourceCommunities() {
+    public List<Integer> getSourceCommunities() {
       return m_sourceCommunities;
     }
 
@@ -227,14 +227,14 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
      * PSCommunityCataloger.Community</code> objects, initialized during construction, never <code>
      * null</code> or changed after that.
      */
-    private Collection m_communityDefinitions = null;
+    private Collection<PSCommunityCataloger.Community> m_communityDefinitions = null;
 
     /**
      * A collection with all community ids found in the source object (typically a site or site
      * folder) as <code>integer</code> objects, initialized during constuction, never <code>null
      * </code> or changed after that.
      */
-    private List m_sourceCommunities = null;
+    private List<Integer> m_sourceCommunities = null;
 
     /**
      * The community and content type mapper. It is initialized by ctor, never <code>null</code>
@@ -289,7 +289,7 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
      * @param sourceCommunities a list of source community ids, each id is an <code>Integer</code>
      *     object. Assume not <code>null</code>
      */
-    private void setCellEditors(Collection sourceCommunities) {
+    private void setCellEditors(Collection<Integer> sourceCommunities) {
       // set the cell editor for source column
       m_sourceEditor =
           new DefaultCellEditor(new JTextField()) {
@@ -318,10 +318,11 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
     private void initTableCells(
         int row,
         Integer srcCommunity,
-        Collection allCommunities,
+        Collection<PSCommunityCataloger.Community> allCommunities,
         PSCommunityContentTypeMapperCataloger mapper,
         TableModel model) {
-      Collection communities = mapper.getCompatibleCommunities(srcCommunity);
+      Collection<PSCommunityCataloger.Community> communities =
+          mapper.getCompatibleCommunities(srcCommunity);
 
       // set the cell editor for the target column
       if (communities == null) {
@@ -333,10 +334,7 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
       }
 
       // find the source community & init the cell values for source & target
-      Iterator walker = communities.iterator();
-      while (walker.hasNext()) {
-        PSCommunityCataloger.Community community = (PSCommunityCataloger.Community) walker.next();
-
+      for (PSCommunityCataloger.Community community : communities) {
         if (community.getId() == srcCommunity.intValue()) {
           model.setValueAt(community, row, SOURCE_COLUMN_INDEX);
           model.setValueAt(community, row, TARGET_COLUMN_INDEX);
@@ -358,11 +356,10 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
      *     PSCommunityCataloger.Community} object. Assume not <code>null</code>, but may be empty.
      * @return the created cell editor, never <code>null</code>.
      */
-    private DefaultCellEditor createCellEditor(Collection communities) {
+    private DefaultCellEditor createCellEditor(
+        Collection<PSCommunityCataloger.Community> communities) {
       JComboBox cbox = new JComboBox();
-      Iterator walker = communities.iterator();
-      while (walker.hasNext()) {
-        PSCommunityCataloger.Community community = (PSCommunityCataloger.Community) walker.next();
+      for (PSCommunityCataloger.Community community : communities) {
         cbox.addItem(community);
       }
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCopySiteNamePage.java
@@ -151,10 +151,9 @@ public class PSCopySiteNamePage extends PSWizardPanel {
     super.setData(data);
 
     // update the main panel depending on the supplied input data
-    Collection sitesToCopy = m_input.getSitesToCopy();
+    Collection<PSSite> sitesToCopy = m_input.getSitesToCopy();
 
-    Iterator sites = sitesToCopy.iterator();
-    while (sites.hasNext()) m_siteSelector.addItem(sites.next());
+    for (PSSite site : sitesToCopy) m_siteSelector.addItem(site);
 
     if (sitesToCopy.size() > 0) m_siteSelector.setSelectedIndex(0);
   }
@@ -196,7 +195,8 @@ public class PSCopySiteNamePage extends PSWizardPanel {
      * @param folderNames all folder names already existing in the target folder of the copy action
      *     as collection of <code>String</code> objects.
      */
-    public InputData(PSNode source, Collection sites, Collection folderNames) {
+    public InputData(
+        PSNode source, Collection<PSSite> sites, Collection<String> folderNames) {
       if (source == null) throw new IllegalArgumentException("source cannot be null");
 
       if (sites == null) throw new IllegalArgumentException("sites cannot be null");
@@ -223,10 +223,9 @@ public class PSCopySiteNamePage extends PSWizardPanel {
      * @return a collection with all site names existing in the system as <code>String</code>
      *     objects, never <code>null</code>, may be empty.
      */
-    public Collection getSiteNames() {
-      Collection siteNames = new ArrayList();
-      Iterator sites = m_sites.iterator();
-      while (sites.hasNext()) siteNames.add(((PSSite) sites.next()).getName());
+    public Collection<String> getSiteNames() {
+      Collection<String> siteNames = new ArrayList<>();
+      for (PSSite site : m_sites) siteNames.add(site.getName());
 
       return siteNames;
     }
@@ -238,14 +237,12 @@ public class PSCopySiteNamePage extends PSWizardPanel {
      * @return a list will all site names which have the supplied folder root, never <code>null
      *     </code>, may be empty.
      */
-    public Collection getSitesToCopy() {
-      Collection siteNames = new ArrayList();
+    public Collection<PSSite> getSitesToCopy() {
+      Collection<PSSite> siteNames = new ArrayList<>();
 
       String folderRoot = m_source.getName().toLowerCase();
 
-      Iterator sites = m_sites.iterator();
-      while (sites.hasNext()) {
-        PSSite site = (PSSite) sites.next();
+      for (PSSite site : m_sites) {
         String test = site.getFolderRoot();
         if (test == null) continue;
 
@@ -270,7 +267,7 @@ public class PSCopySiteNamePage extends PSWizardPanel {
      * @return a collection with all folder names already existing in the target folder as <code>
      *     String</code> objects, never <code>null</code>, may be empty.
      */
-    public Collection getFolderNames() {
+    public Collection<String> getFolderNames() {
       return m_folderNames;
     }
 
@@ -284,13 +281,13 @@ public class PSCopySiteNamePage extends PSWizardPanel {
      * The collection of all existing sites as <code>PSSite</code> objects, initialized during
      * construction, never <code>null</code> or changed after that.
      */
-    private Collection m_sites = null;
+    private Collection<PSSite> m_sites = null;
 
     /**
      * The collection of all existing folder names in the target folder as <code>String</code>
      * objects, initialized during construction, never <code>null</code> or changed after that.
      */
-    private Collection m_folderNames = null;
+    private Collection<String> m_folderNames = null;
   }
 
   /** The data object returned by this wizard page. */

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatCatalogTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatCatalogTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for pure helpers on {@link PSDisplayFormatCatalog}. */
+public class PSDisplayFormatCatalogTest {
+
+  @Test
+  public void getDisplayFormatIdRejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> PSDisplayFormatCatalog.getDisplayFormatId(null));
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/catalogers/PSCatalogerTypingTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/catalogers/PSCatalogerTypingTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx.catalogers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSEntry;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.StringReader;
+import java.util.Collection;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Behavioral tests for typed cataloger APIs after Collection/Iterator rawtypes cleanup (#2384).
+ */
+public class PSCatalogerTypingTest {
+
+  @Test
+  public void communityCreateAndCatalogFromXml() throws Exception {
+    PSCommunityCataloger.Community all =
+        PSCommunityCataloger.createCommunity(-1, "All communities", "all");
+    assertEquals(-1, all.getId());
+    assertEquals("All communities", all.getName());
+    assertEquals("all", all.getDesc());
+
+    PSCommunityCataloger cataloger = new PSCommunityCataloger();
+    cataloger.fromXml(
+        parse(
+                "<communities>"
+                    + "<list>"
+                    + "<communityname>Default</communityname>"
+                    + "<communityid>1001</communityid>"
+                    + "<communitydesc>Default community</communitydesc>"
+                    + "</list>"
+                    + "<list>"
+                    + "<communityname>Editor</communityname>"
+                    + "<communityid>1002</communityid>"
+                    + "<communitydesc>Editors</communitydesc>"
+                    + "</list>"
+                    + "</communities>")
+            .getDocumentElement());
+
+    Collection<PSCommunityCataloger.Community> communities = cataloger.getCommunities();
+    assertEquals(2, communities.size());
+    Iterator<PSCommunityCataloger.Community> it = communities.iterator();
+    PSCommunityCataloger.Community first = it.next();
+    assertEquals(1001, first.getId());
+    assertEquals("Default", first.getName());
+    assertTrue(first.getDesc().contains("Default"));
+  }
+
+  @Test
+  public void roleCatalogFromXml() throws Exception {
+    PSRoleCataloger cataloger = new PSRoleCataloger();
+    cataloger.fromXml(
+        parse(
+                "<getRole>"
+                    + "<PSXRole><name>Admin</name></PSXRole>"
+                    + "<PSXRole><name>Author</name></PSXRole>"
+                    + "</getRole>")
+            .getDocumentElement());
+
+    Collection<PSRoleCataloger.Role> roles = cataloger.getRoles();
+    assertEquals(2, roles.size());
+    assertEquals("Admin", roles.iterator().next().getName());
+  }
+
+  @Test
+  public void subjectCatalogFromXml() throws Exception {
+    PSSubjectCataloger cataloger = new PSSubjectCataloger();
+    cataloger.fromXml(
+        parse(
+                "<getSubject>"
+                    + "<PSXSubject>"
+                    + "<name>admin</name>"
+                    + "<securityProviderType>0</securityProviderType>"
+                    + "<securityProviderInstance>rxbackend</securityProviderInstance>"
+                    + "</PSXSubject>"
+                    + "</getSubject>")
+            .getDocumentElement());
+
+    Collection<PSSubjectCataloger.Subject> subjects = cataloger.getSubjects();
+    assertEquals(1, subjects.size());
+    PSSubjectCataloger.Subject subject = subjects.iterator().next();
+    assertEquals("admin", subject.getName());
+    assertEquals(0, subject.getSecurityProviderTypeId());
+    assertEquals("rxbackend", subject.getSecurityProviderInstance());
+  }
+
+  @Test
+  public void localeCatalogFromXml() throws Exception {
+    PSLocaleCataloger cataloger = new PSLocaleCataloger();
+    // PSEntry expects PSXDisplayText child then Value sibling
+    cataloger.fromXml(
+        parse(
+                "<locales>"
+                    + "<PSXEntry>"
+                    + "<PSXDisplayText>English</PSXDisplayText>"
+                    + "<Value>en-us</Value>"
+                    + "</PSXEntry>"
+                    + "</locales>")
+            .getDocumentElement());
+
+    Iterator<PSEntry> locales = cataloger.getLocales();
+    assertTrue(locales.hasNext());
+    PSEntry locale = locales.next();
+    assertEquals("en-us", locale.getValue());
+  }
+
+  @Test
+  public void globalTemplateCatalogFromXml() throws Exception {
+    PSGlobalTemplateCataloger cataloger = new PSGlobalTemplateCataloger();
+    cataloger.fromXml(
+        parse(
+                "<GlobalTemplates>"
+                    + "<Template name=\"rffGiFin\"/>"
+                    + "<Template name=\"rffGiCal\"/>"
+                    + "</GlobalTemplates>")
+            .getDocumentElement());
+
+    Collection<String> templates = cataloger.getGlobalTemplates();
+    assertEquals(2, templates.size());
+    assertTrue(templates.contains("rffGiFin"));
+    assertTrue(templates.contains("rffGiCal"));
+  }
+
+  @Test
+  public void communityContentTypeMapperCompatibleCommunities() throws Exception {
+    PSCommunityContentTypeMapperCataloger mapper = new PSCommunityContentTypeMapperCataloger();
+    mapper.fromXml(
+        parse(
+                "<CommunityContentTypeMapper>"
+                    + "<CommunityContentTypeMapping communityName=\"Src\" communityId=\"1\">"
+                    + "<ContentType name=\"Page\" id=\"10\"/>"
+                    + "</CommunityContentTypeMapping>"
+                    + "<CommunityContentTypeMapping communityName=\"Superset\" communityId=\"2\">"
+                    + "<ContentType name=\"Page\" id=\"10\"/>"
+                    + "<ContentType name=\"Asset\" id=\"20\"/>"
+                    + "</CommunityContentTypeMapping>"
+                    + "<CommunityContentTypeMapping communityName=\"Other\" communityId=\"3\">"
+                    + "<ContentType name=\"Asset\" id=\"20\"/>"
+                    + "</CommunityContentTypeMapping>"
+                    + "</CommunityContentTypeMapper>")
+            .getDocumentElement());
+
+    Collection<PSCommunityCataloger.Community> compatible =
+        mapper.getCompatibleCommunities(Integer.valueOf(1));
+    assertNotNull(compatible);
+    // Src itself + Superset (has Page); Other lacks Page
+    assertEquals(2, compatible.size());
+    assertTrue(compatible.stream().anyMatch(c -> c.getId() == 1));
+    assertTrue(compatible.stream().anyMatch(c -> c.getId() == 2));
+
+    assertNull(mapper.getCompatibleCommunities(Integer.valueOf(99)));
+    assertThrows(
+        IllegalArgumentException.class, () -> mapper.getCompatibleCommunities(null));
+  }
+
+  private static Document parse(String xml) throws Exception {
+    return PSXmlDocumentBuilder.createXmlDocument(new StringReader(xml), false);
+  }
+}


### PR DESCRIPTION
## Summary
Residual javac `-Xlint` batch for `perc-content-explorer` under #2045 / #2200 (issue #2384): clear **cataloger** Collection/Iterator rawtypes and type **PSDisplayFormatCatalog**.

- Real generics on `PSCommunityCataloger`, `PSRoleCataloger`, `PSSubjectCataloger`, `PSSiteCataloger`, `PSLocaleCataloger`, `PSGlobalTemplateCataloger`, `PSCommunityContentTypeMapperCataloger`
- `PSDisplayFormatCatalog`: `List/Iterator<PSDisplayFormat>`
- Call sites: folder general/ACL editor, copy-site wizard pages, `PSFolderActionManager` (`Set<Integer> getFolderCommunities`, site loop), search view display formats
- `PSDesktopExplorerWindow`: `serialVersionUID` only (this-escape residual #2444)
- Tests: `PSCatalogerTypingTest` (6), `PSDisplayFormatCatalogTest` (1)
- Erlang: `docs/ai-generated/code-reviews/issue-2384-cataloger-typing-erlang.md`

**Partial for #2384.** Also closes cataloger slice #2440 (duplicate inventory of this batch).

### Residual filed
- #2444 PSDesktopExplorerWindow this-escape
- #2445 PSContentExplorerStatusDialog
- #2446 PSItemRelationshipsManager + PSProcessMonitor

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Tests run: **43**, Failures: 0 (includes 7 new)

## Gates
- Erlang self-review: pass
- Per-module clean install: perc-content-explorer
- No product behavior change intended

Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2384 (cataloger + display format + serialVersionUID; residual #2444–#2446)
Fixes #2440
Refs #2045 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.