### PR TITLE
chore(kilo): add /pickup-issue workflow for highest-priority open issue

### DIFF
--- a/.kilo/workflows/pickup-issue.md
+++ b/.kilo/workflows/pickup-issue.md
@@ -16,12 +16,12 @@ worked (no `in progress` label) and pick it up.
    workflow attribution, not assignment (see
    `.kilo/rules/operator-pr-labels.md`); do **not** filter on them.
 3. Among available issues at the chosen priority, pick the **oldest**
-   by `createdAt` (ascending). The discovery query must sort
-   `created` ascending so the first survivor is the oldest available.
+   one by `createdAt` (first row in the ascending sort below).
 
 ## Discovery
 
-For each priority `p<N>` in `p1..p8`:
+For each priority `p<N>` in `p1..p8`, query with explicit
+ascending-`createdAt` order so "first row" = "oldest":
 
 ```bash
 gh issue list \
@@ -29,40 +29,14 @@ gh issue list \
   --label "p<N>" \
   --json number,title,labels,createdAt \
   --limit 100 \
-  --jq 'sort_by(.createdAt)'
+  --sort created \
+  --direction asc
 ```
 
-Prefer also passing sort flags when the installed `gh` supports them:
-
-```bash
-gh issue list \
-  --state open \
-  --label "p<N>" \
-  --json number,title,labels,createdAt \
-  --limit 100 \
-  --search "sort:created-asc"
-```
-
-If neither `--jq` post-sort nor `sort:created-asc` is available, sort the
-JSON array by `createdAt` ascending with the host shell before filtering.
-
-For each candidate **in oldest-first order**, filter out any issue whose
-`labels[].name` equals `in progress` (case-insensitive match for
-`in progress` / `In Progress`). The first survivor at the highest
-non-empty priority is the chosen issue.
-
-**Capture fields from that survivor (required for later steps):**
-
-```bash
-ISSUE=<number from survivor.number>
-TITLE=<title from survivor.title>
-```
-
-Do **not** leave `$TITLE` unset. Re-fetch if needed:
-
-```bash
-TITLE=$(gh issue view "$ISSUE" --json title --jq .title)
-```
+For each candidate, filter out any issue whose `labels[].name` equals
+`in progress`. The first survivor at the highest non-empty priority is
+the chosen issue. Capture `ISSUE=<number>` and
+`TITLE=<title>` from that row for the steps below.
 
 If every `p1..p8` query returns an empty filtered list, report
 `No open p1..p8 issue is available.` and **stop** — do not invent work.
@@ -70,72 +44,65 @@ If every `p1..p8` query returns an empty filtered list, report
 ## Take the issue
 
 On the chosen issue, perform the **state transition** before any code
-work. Use `gh issue edit`:
+work.
+
+### Resolve `KILO_MODEL`
+
+`KILO_MODEL` is the **session model id** reported by the host (e.g.
+`minimax-coding-plan/MiniMax-M3`). Use a stable lowercase slug with no
+spaces.
+
+> **Hard rule: do not invent a label name.** If `$KILO_MODEL` is unset,
+> `echo` a clear error and stop:
+>
+> ```bash
+> : "${KILO_MODEL:?KILO_MODEL is required (session model id); aborting.}"
+> ```
+>
+> This is a fatal guard, not a fallback. The previous `: "${...:-unknown}"`
+> pattern silently created an undocumented `model:unknown` label that is
+> not in the documented allowlist. Fail loudly instead.
+
+### Strip stale attribution
+
+`gh issue edit` cannot remove labels by glob. Fetch the current label
+list, filter to `operator:*` and `model:*`, and remove those — so any
+new operator/model label added under
+`.kilo/rules/operator-pr-labels.md` is also handled without a code edit:
 
 ```bash
-ISSUE=<number>
-# TITLE already set in Discovery
+mapfile -t STALE < <(
+  gh issue view "$ISSUE" --json labels \
+    --jq '.labels[].name | select(startswith("operator:") or startswith("model:"))'
+)
+if [ "${#STALE[@]}" -gt 0 ]; then
+  gh issue edit "$ISSUE" "${STALE[@]/#/--remove-label }"
+fi
+```
 
+> Maintainer note: if `.kilo/rules/operator-pr-labels.md` adds a label
+> prefix outside `operator:` / `model:`, update the `select(...)` filter
+> here too.
+
+### Apply Kilo attribution + `in progress`
+
+```bash
 # 1. Make sure the in-progress label exists (idempotent).
 gh label create "in progress" --force --color "5CD5E1" \
   --description "Agent or human actively working"
 
-# 2. Remove ALL stale operator/model attribution so the agent that
-#    picks it up does not appear as Grok / Minimax / etc.
-#    Do not rely only on a hardcoded list — new operator:* / model:*
-#    names appear over time (.kilo/rules/operator-pr-labels.md).
-#
-#    List current labels, then remove every name matching operator:*
-#    or model:* (and keep the small fixed allowlist removals for
-#    common known labels as a belt-and-suspenders pass).
-LABELS=$(gh issue view "$ISSUE" --json labels --jq '.labels[].name')
-for lab in $LABELS; do
-  case "$lab" in
-    operator:*|model:*)
-      gh issue edit "$ISSUE" --remove-label "$lab" || true
-      ;;
-  esac
-done
-# Belt-and-suspenders for known names (ok if already gone):
-gh issue edit "$ISSUE" \
-  --remove-label "operator:grok" \
-  --remove-label "operator:night-issue-prs" \
-  --remove-label "operator:minimax" \
-  --remove-label "operator:nate" \
-  --remove-label "operator:kilo" \
-  --remove-label "model:grok-4.5" \
-  --remove-label "model:minimax" \
-  --remove-label "model:claude-sonnet-4" \
-  --remove-label "model:gpt-4.1" \
-  || true
-
-# 3. Apply Kilo attribution for this session's model.
-#    KILO_MODEL is required. Do NOT invent model:unknown or any other
-#    undocumented model label ("Never invent a label name").
-if [ -z "${KILO_MODEL:-}" ]; then
-  echo "ERROR: KILO_MODEL is unset. Set the session model id (e.g. minimax-coding-plan/MiniMax-M3) and re-run. Refusing model:unknown." >&2
-  exit 1
-fi
-MODEL=$(echo "$KILO_MODEL" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9._/-' '-' | sed 's/^-*//;s/-*$//')
-if [ -z "$MODEL" ] || [ "$MODEL" = "unknown" ]; then
-  echo "ERROR: KILO_MODEL resolved empty or 'unknown'. Refusing to create model:unknown." >&2
-  exit 1
-fi
+# 2. Kilo + session model labels (idempotent).
 gh label create "operator:kilo" --force --color "d73a4a" \
   --description "Work produced by Kilo Code agent"
-gh label create "model:$MODEL" --force --color "1d76db" \
-  --description "Model: $MODEL"
+gh label create "model:$KILO_MODEL" --force --color "1d76db" \
+  --description "Model: $KILO_MODEL"
 
+# 3. Apply them.
 gh issue edit "$ISSUE" \
   --add-label "in progress" \
   --add-label "operator:kilo" \
-  --add-label "model:$MODEL"
+  --add-label "model:$KILO_MODEL"
 ```
-
-`$KILO_MODEL` is the **session model id** reported by the host (e.g.
-`minimax-coding-plan/MiniMax-M3`). Use a stable lowercase slug with no
-spaces. **Never invent a label name.** If the model id is unavailable,
-**stop** and ask the operator — do not invent `model:unknown`.
 
 > **Never** force-push to `main` and never commit directly to `main`.
 > Create a feature branch first — see
@@ -143,24 +110,28 @@ spaces. **Never invent a label name.** If the model id is unavailable,
 
 ## Start the feature branch
 
+Use the captured `$ISSUE` and `$TITLE` (from the Discovery row) to
+produce a meaningful branch slug:
+
 ```bash
 git fetch origin
 git worktree list --porcelain          # see whether to reuse a worktree
 
-# $TITLE must be set from Discovery (or re-fetched via gh issue view).
-if [ -z "${TITLE:-}" ]; then
-  TITLE=$(gh issue view "$ISSUE" --json title --jq .title)
-fi
-if [ -z "${TITLE:-}" ]; then
-  echo "ERROR: could not resolve issue title for branch slug" >&2
-  exit 1
-fi
-
-BRANCH="fix/${ISSUE}-$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \
-  | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//' | cut -c1-60)"
+# Title -> kebab-case slug, max 60 chars, no leading/trailing dashes.
+SLUG=$(printf '%s' "$TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | tr -cs 'a-z0-9' '-' \
+  | sed 's/^-*//;s/-*$//' \
+  | cut -c1-60)
+BRANCH="fix/${ISSUE}-${SLUG}"
 
 git checkout -b "$BRANCH" origin/main
 ```
+
+If `$SLUG` is empty after normalization (rare but possible — e.g. a
+title that is purely punctuation), fall back to `fix/${ISSUE}` with no
+suffix and log a warning. **Never** create `fix/<issue>-` with a
+trailing dash.
 
 Prefer a fresh worktree under `.kilo/worktrees/<branch>/` if one does
 not already exist; otherwise work in the current checkout. Record the
@@ -209,13 +180,12 @@ Report back to the user with:
 - Do **not** filter on `operator:*` labels — they are workflow
   attribution, not assignment.
 - Do **not** invent a `daily-status` label or any new label outside this
-  command's allowlist (including **`model:unknown`**).
+  command's allowlist.
+- Do **not** silently default `KILO_MODEL` to a placeholder. If it is
+  unset, stop.
 - Do **not** skip the empty-check when a priority returns zero issues;
   continue to the next priority.
 - Do **not** commit or push to `main` directly — always branch.
 - Do **not** skip the pre-PR Maven `clean install` for changed modules.
 - Do **not** mark `in progress` removed without first opening or
   updating the PR (i.e. keep the label while still drafting locally).
-- Do **not** assume `gh issue list` is oldest-first without sorting
-  (`createdAt` ascending).
-- Do **not** build a branch slug without a resolved `$TITLE`.

--- a/.kilo/workflows/pickup-issue.md
+++ b/.kilo/workflows/pickup-issue.md
@@ -15,8 +15,9 @@ worked (no `in progress` label) and pick it up.
    `in progress` label. The `operator:*` and `model:*` labels are
    workflow attribution, not assignment (see
    `.kilo/rules/operator-pr-labels.md`); do **not** filter on them.
-3. Among available issues at the chosen priority, pick the **first**
-   `gh issue list` row (oldest `createdAt`). Do not re-sort.
+3. Among available issues at the chosen priority, pick the **oldest**
+   by `createdAt` (ascending). The discovery query must sort
+   `created` ascending so the first survivor is the oldest available.
 
 ## Discovery
 
@@ -27,12 +28,41 @@ gh issue list \
   --state open \
   --label "p<N>" \
   --json number,title,labels,createdAt \
-  --limit 100
+  --limit 100 \
+  --jq 'sort_by(.createdAt)'
 ```
 
-For each candidate, filter out any issue whose `labels[].name` equals
-`in progress`. The first survivor at the highest non-empty priority is
-the chosen issue.
+Prefer also passing sort flags when the installed `gh` supports them:
+
+```bash
+gh issue list \
+  --state open \
+  --label "p<N>" \
+  --json number,title,labels,createdAt \
+  --limit 100 \
+  --search "sort:created-asc"
+```
+
+If neither `--jq` post-sort nor `sort:created-asc` is available, sort the
+JSON array by `createdAt` ascending with the host shell before filtering.
+
+For each candidate **in oldest-first order**, filter out any issue whose
+`labels[].name` equals `in progress` (case-insensitive match for
+`in progress` / `In Progress`). The first survivor at the highest
+non-empty priority is the chosen issue.
+
+**Capture fields from that survivor (required for later steps):**
+
+```bash
+ISSUE=<number from survivor.number>
+TITLE=<title from survivor.title>
+```
+
+Do **not** leave `$TITLE` unset. Re-fetch if needed:
+
+```bash
+TITLE=$(gh issue view "$ISSUE" --json title --jq .title)
+```
 
 If every `p1..p8` query returns an empty filtered list, report
 `No open p1..p8 issue is available.` and **stop** — do not invent work.
@@ -44,26 +74,53 @@ work. Use `gh issue edit`:
 
 ```bash
 ISSUE=<number>
+# TITLE already set in Discovery
 
 # 1. Make sure the in-progress label exists (idempotent).
 gh label create "in progress" --force --color "5CD5E1" \
   --description "Agent or human actively working"
 
-# 2. Remove stale operator/model attribution so the agent that picks
-#    it up does not appear as Grok / Minimax / etc.
+# 2. Remove ALL stale operator/model attribution so the agent that
+#    picks it up does not appear as Grok / Minimax / etc.
+#    Do not rely only on a hardcoded list — new operator:* / model:*
+#    names appear over time (.kilo/rules/operator-pr-labels.md).
+#
+#    List current labels, then remove every name matching operator:*
+#    or model:* (and keep the small fixed allowlist removals for
+#    common known labels as a belt-and-suspenders pass).
+LABELS=$(gh issue view "$ISSUE" --json labels --jq '.labels[].name')
+for lab in $LABELS; do
+  case "$lab" in
+    operator:*|model:*)
+      gh issue edit "$ISSUE" --remove-label "$lab" || true
+      ;;
+  esac
+done
+# Belt-and-suspenders for known names (ok if already gone):
 gh issue edit "$ISSUE" \
   --remove-label "operator:grok" \
   --remove-label "operator:night-issue-prs" \
   --remove-label "operator:minimax" \
   --remove-label "operator:nate" \
+  --remove-label "operator:kilo" \
   --remove-label "model:grok-4.5" \
   --remove-label "model:minimax" \
   --remove-label "model:claude-sonnet-4" \
   --remove-label "model:gpt-4.1" \
-  || true   # ok if a label is absent
+  || true
 
 # 3. Apply Kilo attribution for this session's model.
-MODEL="${KILO_MODEL:-unknown}"
+#    KILO_MODEL is required. Do NOT invent model:unknown or any other
+#    undocumented model label ("Never invent a label name").
+if [ -z "${KILO_MODEL:-}" ]; then
+  echo "ERROR: KILO_MODEL is unset. Set the session model id (e.g. minimax-coding-plan/MiniMax-M3) and re-run. Refusing model:unknown." >&2
+  exit 1
+fi
+MODEL=$(echo "$KILO_MODEL" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9._/-' '-' | sed 's/^-*//;s/-*$//')
+if [ -z "$MODEL" ] || [ "$MODEL" = "unknown" ]; then
+  echo "ERROR: KILO_MODEL resolved empty or 'unknown'. Refusing to create model:unknown." >&2
+  exit 1
+fi
 gh label create "operator:kilo" --force --color "d73a4a" \
   --description "Work produced by Kilo Code agent"
 gh label create "model:$MODEL" --force --color "1d76db" \
@@ -77,7 +134,8 @@ gh issue edit "$ISSUE" \
 
 `$KILO_MODEL` is the **session model id** reported by the host (e.g.
 `minimax-coding-plan/MiniMax-M3`). Use a stable lowercase slug with no
-spaces. Never invent a label name.
+spaces. **Never invent a label name.** If the model id is unavailable,
+**stop** and ask the operator — do not invent `model:unknown`.
 
 > **Never** force-push to `main` and never commit directly to `main`.
 > Create a feature branch first — see
@@ -88,6 +146,16 @@ spaces. Never invent a label name.
 ```bash
 git fetch origin
 git worktree list --porcelain          # see whether to reuse a worktree
+
+# $TITLE must be set from Discovery (or re-fetched via gh issue view).
+if [ -z "${TITLE:-}" ]; then
+  TITLE=$(gh issue view "$ISSUE" --json title --jq .title)
+fi
+if [ -z "${TITLE:-}" ]; then
+  echo "ERROR: could not resolve issue title for branch slug" >&2
+  exit 1
+fi
+
 BRANCH="fix/${ISSUE}-$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \
   | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//' | cut -c1-60)"
 
@@ -141,10 +209,13 @@ Report back to the user with:
 - Do **not** filter on `operator:*` labels — they are workflow
   attribution, not assignment.
 - Do **not** invent a `daily-status` label or any new label outside this
-  command's allowlist.
+  command's allowlist (including **`model:unknown`**).
 - Do **not** skip the empty-check when a priority returns zero issues;
   continue to the next priority.
 - Do **not** commit or push to `main` directly — always branch.
 - Do **not** skip the pre-PR Maven `clean install` for changed modules.
 - Do **not** mark `in progress` removed without first opening or
   updating the PR (i.e. keep the label while still drafting locally).
+- Do **not** assume `gh issue list` is oldest-first without sorting
+  (`createdAt` ascending).
+- Do **not** build a branch slug without a resolved `$TITLE`.

--- a/.kilo/workflows/pickup-issue.md
+++ b/.kilo/workflows/pickup-issue.md
@@ -1,0 +1,150 @@
+---
+description: Pick up the highest-priority open GitHub issue that is not already in progress, mark it in-progress, swap the operator labels to Kilo, and start a feature branch + PR for it. Iterates priorities p1 to p8 and stops at the first available issue.
+---
+
+## Goal
+
+Find the **highest-priority** open issue that is **not** already being
+worked (no `in progress` label) and pick it up.
+
+1. **Search order:** `p1`, `p2`, `p3`, … `p8`. Stop at the first
+   priority that yields at least one available issue; if a priority
+   yields none, move to the next. Stop entirely only when **every**
+   priority returned zero issues.
+2. **Available =** state == `OPEN` **AND** does **not** carry the
+   `in progress` label. The `operator:*` and `model:*` labels are
+   workflow attribution, not assignment (see
+   `.kilo/rules/operator-pr-labels.md`); do **not** filter on them.
+3. Among available issues at the chosen priority, pick the **first**
+   `gh issue list` row (oldest `createdAt`). Do not re-sort.
+
+## Discovery
+
+For each priority `p<N>` in `p1..p8`:
+
+```bash
+gh issue list \
+  --state open \
+  --label "p<N>" \
+  --json number,title,labels,createdAt \
+  --limit 100
+```
+
+For each candidate, filter out any issue whose `labels[].name` equals
+`in progress`. The first survivor at the highest non-empty priority is
+the chosen issue.
+
+If every `p1..p8` query returns an empty filtered list, report
+`No open p1..p8 issue is available.` and **stop** — do not invent work.
+
+## Take the issue
+
+On the chosen issue, perform the **state transition** before any code
+work. Use `gh issue edit`:
+
+```bash
+ISSUE=<number>
+
+# 1. Make sure the in-progress label exists (idempotent).
+gh label create "in progress" --force --color "5CD5E1" \
+  --description "Agent or human actively working"
+
+# 2. Remove stale operator/model attribution so the agent that picks
+#    it up does not appear as Grok / Minimax / etc.
+gh issue edit "$ISSUE" \
+  --remove-label "operator:grok" \
+  --remove-label "operator:night-issue-prs" \
+  --remove-label "operator:minimax" \
+  --remove-label "operator:nate" \
+  --remove-label "model:grok-4.5" \
+  --remove-label "model:minimax" \
+  --remove-label "model:claude-sonnet-4" \
+  --remove-label "model:gpt-4.1" \
+  || true   # ok if a label is absent
+
+# 3. Apply Kilo attribution for this session's model.
+MODEL="${KILO_MODEL:-unknown}"
+gh label create "operator:kilo" --force --color "d73a4a" \
+  --description "Work produced by Kilo Code agent"
+gh label create "model:$MODEL" --force --color "1d76db" \
+  --description "Model: $MODEL"
+
+gh issue edit "$ISSUE" \
+  --add-label "in progress" \
+  --add-label "operator:kilo" \
+  --add-label "model:$MODEL"
+```
+
+`$KILO_MODEL` is the **session model id** reported by the host (e.g.
+`minimax-coding-plan/MiniMax-M3`). Use a stable lowercase slug with no
+spaces. Never invent a label name.
+
+> **Never** force-push to `main` and never commit directly to `main`.
+> Create a feature branch first — see
+> `.kilo/rules/no-force-push-development.md`.
+
+## Start the feature branch
+
+```bash
+git fetch origin
+git worktree list --porcelain          # see whether to reuse a worktree
+BRANCH="fix/${ISSUE}-$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \
+  | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//' | cut -c1-60)"
+
+git checkout -b "$BRANCH" origin/main
+```
+
+Prefer a fresh worktree under `.kilo/worktrees/<branch>/` if one does
+not already exist; otherwise work in the current checkout. Record the
+worktree path in the session summary so
+`.kilo/rules/worktree-hygiene.md` cleanup can find it later.
+
+## Work the issue to a PR
+
+Follow the standard Kilo flow for this repo (see root `AGENTS.md`):
+
+- **Companion closure** for the change class (peer production + test +
+  docs; see root **Change-class completeness**).
+- **Pre-PR build:** `cd <module> && …/mvnw[.cmd] clean install` (not a
+  default root `-pl -am` reactor build).
+- **Pre-commit Erlang review** before `git commit` / `git push` /
+  `gh pr create`.
+- **Operator + model labels** on the PR (see
+  `.kilo/rules/operator-pr-labels.md`).
+- **Co-Authored footer** on commits (see
+  `.kilo/rules/co-author-attribution.md`).
+
+## Close the loop — remove `in progress` on PR submission
+
+When the PR is **opened or updated** (not just when work ends), remove
+the `in progress` label so other agents and humans see the issue is no
+longer available:
+
+```bash
+gh issue edit "$ISSUE" --remove-label "in progress"
+```
+
+If the PR is later closed without merging, **re-add** `in progress` so
+the next pickup pass does not re-pick it as fresh work.
+
+## Output
+
+Report back to the user with:
+
+- Chosen issue number, title, priority, and link
+- Branch name and worktree path
+- One-line summary of the implementation plan
+- PR URL once opened
+
+## Do **not** do
+
+- Do **not** filter on `operator:*` labels — they are workflow
+  attribution, not assignment.
+- Do **not** invent a `daily-status` label or any new label outside this
+  command's allowlist.
+- Do **not** skip the empty-check when a priority returns zero issues;
+  continue to the next priority.
+- Do **not** commit or push to `main` directly — always branch.
+- Do **not** skip the pre-PR Maven `clean install` for changed modules.
+- Do **not** mark `in progress` removed without first opening or
+  updating the PR (i.e. keep the label while still drafting locally).


### PR DESCRIPTION
## Summary

Adds \.kilo/workflows/pickup-issue.md\ (auto-loaded as the
\/pickup-issue\ slash command). Picks the highest-priority open GitHub
issue that is not already in progress, marks it in-progress, swaps the
operator labels to Kilo, and starts a feature branch + PR.

## Rule file / HARD GATE

Per root \AGENTS.md\ -> **Human review of agent rules (HARD GATE)**,
this rule file was drafted uncommitted in the working tree and
committed only after explicit human approval. It lives under
\	ool-host project rules / workflows\ in the in-scope table.

## Behavior

1. Iterates \p1\ -> \p8\ and stops at the first priority that yields
   an available issue. **Available** = \state=OPEN\ AND no
   \in progress\ label.
2. Operator/model attribution is **not** an assignment filter (see
   \.kilo/rules/operator-pr-labels.md\).
3. On the chosen issue, transitions:
   - adds \in progress\
   - removes stale \operator:*\ / \model:*\ attribution
   - adds \operator:kilo\ + \model:<session model id>\
4. Branches \ix/<issue>-<slug>\ off \origin/main\ (never on \main\).
5. Standard Kilo follow-through (companion closure, \clean install\ in
   each changed module, Erlang pre-commit, operator/model labels on the
   PR, Co-Authored footer).
6. Closes the loop: removes \in progress\ once the PR is
   opened/updated; re-adds it if the PR is later closed without merge.

## Why a workflow not a shell script

Decisions like "operator:grok is attribution, not assignment" and
"remove in progress only when the PR is opened, not when the branch is
created" are agent-behavior rules. Embedding them in a markdown prompt
keeps them discoverable, reviewable, and governed by the same human-
review-of-rules gate as other agent instructions.

## Test plan

- Manual: run \/pickup-issue\ in a fresh session and verify it picks
  a p1 (or next priority) issue, applies the right labels, and creates
  the feature branch.
- Negative: with a single \p1\ issue already carrying \in progress\,
  verify it skips to \p2\ rather than re-picking.

## Out of scope

- This PR only adds the workflow file; no product code or tests
  change. The first live invocation of \/pickup-issue\ will be a
  separate PR-driven session.

Operator: Kilo (minimax-coding-plan/MiniMax-M3)