### PR TITLE
fix(perc-system): design.objectstore serial-field hottest editors (#2405)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/IPSReplacementValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/IPSReplacementValue.java
@@ -17,15 +17,23 @@
 
 package com.percussion.design.objectstore;
 
+import java.io.Serializable;
+
 /**
  * The IPSReplacementValue interface must be implemented by any class which can be used as a
  * replacement value for conditionals or exit parameters at run-time.
+ *
+ * <p>Extends {@link Serializable} so fields typed as this interface (or sub-interfaces such as
+ * {@link IPSBackEndMapping}) are valid under {@code -Xlint:serial} serial-field checks when held by
+ * serializable objectstore types. Product implementors are already serializable via {@link
+ * PSComponent} (or declare {@code serialVersionUID} where applicable). Wire/XML behavior is
+ * unchanged.
  *
  * @author Tas Giakouminakis
  * @version 1.0
  * @since 1.0
  */
-public interface IPSReplacementValue extends Cloneable {
+public interface IPSReplacementValue extends Cloneable, Serializable {
   /** Get the type of replacement value this object represents. */
   public String getValueType();
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalView.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalView.java
@@ -22,6 +22,10 @@ import java.util.Iterator;
 
 /** This class represents a view that may be selected based on a condition as well as the name. */
 public class PSConditionalView extends PSView {
+
+  /** Serialization id for {@link java.io.Serializable} (inherited via {@link PSView}). */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates a conditional view with the supplied conditions. See {@link PSView base class} for more
    * info.

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
@@ -26,7 +26,6 @@ import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.ResultSet;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -1075,9 +1074,11 @@ public class PSContentEditor extends PSDataSet {
   /**
    * A set of PSCustomActionGroup objects. Never <code>null</code>, may be empty. A custom action
    * group allows the designer to add to or replace actions in various parts of the editors
-   * (example: the main form button could be replaced with the designer specific action).
+   * (example: the main form button could be replaced with the designer specific action). Declared
+   * as {@link ArrayList} (not {@link Collection}) so the field type is {@link
+   * java.io.Serializable} under {@code -Xlint:serial}.
    */
-  private Collection m_customActionGroups = new ArrayList();
+  private ArrayList m_customActionGroups = new ArrayList();
 
   /**
    * This content editor's viewset, contains the set of views used to filter which fields will be

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlDependencyMap.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlDependencyMap.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -42,8 +43,15 @@ import org.apache.commons.lang3.StringUtils;
  * save, call {@link #clearControlDependencies()} followed by {@link
  * #setControlDependencies(PSDisplayMapping, List)} for each existing mapping that was not removed
  * as well for for any new mappings.
+ *
+ * <p>Implements {@link Serializable} so it may be held on {@link PSContentEditorPipe} under {@code
+ * -Xlint:serial}.
  */
-public class PSControlDependencyMap {
+public class PSControlDependencyMap implements Serializable {
+
+  /** Serialization id for {@link Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /** Construct a new, empty dependency map */
   public PSControlDependencyMap() {}
 
@@ -388,29 +396,36 @@ public class PSControlDependencyMap {
 
   /**
    * Map of dependencies for each control, never <code>null</code> after contruction, may be empty,
-   * key is the control id, value is the dependency id.
+   * key is the control id, value is the dependency id. Declared as {@link HashMap} (not {@link
+   * Map}) so the field type is {@link Serializable} under {@code -Xlint:serial}.
    */
-  private Map<Integer, List<Integer>> m_controlDependencies = new HashMap<>();
+  private HashMap<Integer, List<Integer>> m_controlDependencies = new HashMap<>();
 
   /**
    * Map of extension component id to exit, never <code>null</code> after construction, contains
    * extensions specified by control dependencies with parameters that do not specify macros.
+   * Declared as {@link HashMap} (not {@link Map}) so the field type is {@link Serializable} under
+   * {@code -Xlint:serial}.
    */
-  private Map<Integer, PSExtensionCall> m_ceInputDataExits = new HashMap<>();
+  private HashMap<Integer, PSExtensionCall> m_ceInputDataExits = new HashMap<>();
 
   /**
    * Map of extension component id to exit, never <code>null</code> after construction, contains
-   * extensions specified by control dependencies with parameters that specify macros.
+   * extensions specified by control dependencies with parameters that specify macros. Declared as
+   * {@link HashMap} (not {@link Map}) so the field type is {@link Serializable} under {@code
+   * -Xlint:serial}.
    */
-  private Map<Integer, PSExtensionCall> m_controlDepExits = new HashMap<>();
+  private HashMap<Integer, PSExtensionCall> m_controlDepExits = new HashMap<>();
 
   /**
    * Map of extensions known to be specified by a control as "single occurrence" (see {@link
    * PSDependency#SINGLE_OCCURRENCE}. Never <code>null</code>, may be empty, does not necessarily
    * contain all such dependencies, only those that have been checked. Key is the extension name.
-   * Used to return the same extension call instance for such dependencies.
+   * Used to return the same extension call instance for such dependencies. Declared as {@link
+   * HashMap} (not {@link Map}) so the field type is {@link Serializable} under {@code
+   * -Xlint:serial}.
    */
-  private Map<String, PSExtensionCall> m_singleDepExits = new HashMap<>();
+  private HashMap<String, PSExtensionCall> m_singleDepExits = new HashMap<>();
 
   /** Constant for the property name suffix when specifying control dependency ids. */
   private final String DEP_IDS = "_DependencyIds";

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
@@ -424,19 +424,23 @@ public class PSControlMeta extends PSComponent {
 
   /**
    * Contains any parameters this control supports as <code>PSControlParameter</code> objects. May
-   * be empty.
+   * be empty. Declared as {@link ArrayList} (not {@link List}) so the field type is {@link
+   * java.io.Serializable} under {@code -Xlint:serial}.
    */
-  private List m_params = new ArrayList();
+  private ArrayList m_params = new ArrayList();
 
   /**
    * Contains any dependencies defined for this control, as <code>
-   * PSDependency</code> objects. May be empty.
+   * PSDependency</code> objects. May be empty. Declared as {@link ArrayList} (not {@link List}) so
+   * the field type is {@link java.io.Serializable} under {@code -Xlint:serial}.
    */
-  private List m_dependencies = new ArrayList();
+  private ArrayList m_dependencies = new ArrayList();
 
   /**
    * Contains any associated files defined for this control, as <code>
-   * PSFileDescriptor</code> objects. Never <code>null</code>, may be empty.
+   * PSFileDescriptor</code> objects. Never <code>null</code>, may be empty. Declared as {@link
+   * ArrayList} (not {@link List}) so the field type is {@link java.io.Serializable} under {@code
+   * -Xlint:serial}.
    */
-  private List m_files = new ArrayList();
+  private ArrayList m_files = new ArrayList();
 }

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
@@ -217,7 +217,13 @@ public class PSControlParameter extends PSComponent {
    * @param choiceList List of Entry objects, or <code>null</code> to clear the list.
    */
   public void setChoiceList(List choiceList) {
-    m_choiceList = choiceList;
+    if (choiceList == null) {
+      m_choiceList = null;
+    } else if (choiceList instanceof ArrayList) {
+      m_choiceList = (ArrayList) choiceList;
+    } else {
+      m_choiceList = new ArrayList(choiceList);
+    }
   }
 
   /**
@@ -309,9 +315,10 @@ public class PSControlParameter extends PSComponent {
 
   /**
    * Holds the entries that make up the choice list for this parameter. Will be <code>null</code> if
-   * this parameter has not defined a choice list.
+   * this parameter has not defined a choice list. Declared as {@link ArrayList} (not {@link List})
+   * so the field type is {@link java.io.Serializable} under {@code -Xlint:serial}.
    */
-  private List m_choiceList = null;
+  private ArrayList m_choiceList = null;
 
   /** A single entry in the choice list */
   public class Entry {

--- a/system/src/main/java/com/percussion/design/objectstore/PSField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSField.java
@@ -2651,8 +2651,10 @@ public class PSField extends PSComponent {
    * Map of occurrence settings. The key is the transition id as an Integer, and the value is a
    * PSOccurrenceSetting object. Never <code>null</code> once this field is constructed. A default
    * occurrence settings (no transition id) may be in the map with a <code>null</code> key.
+   * Declared as {@link HashMap} (not {@link Map}) so the field type is {@link Serializable} under
+   * {@code -Xlint:serial}.
    */
-  private Map m_occurrenceSettings = new HashMap();
+  private HashMap m_occurrenceSettings = new HashMap();
 
   /**
    * Optional set of choices to use for this field. Modified only by a call to {@link
@@ -2662,9 +2664,10 @@ public class PSField extends PSComponent {
 
   /**
    * A map of field properties, initialized while constructed. Never <code>null</code>, may be empty
-   * after that.
+   * after that. Declared as {@link HashMap} (not {@link Map}) so the field type is {@link
+   * Serializable} under {@code -Xlint:serial}.
    */
-  private Map m_properties = new HashMap();
+  private HashMap m_properties = new HashMap();
 
   /**
    * Groups all search related attributes. Valid except during <code>fromXml

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
@@ -1285,9 +1285,10 @@ public class PSFieldSet extends PSComponent {
 
   /**
    * An ordered map storing PSField and/or PSFieldSet objects, ordered and keyed by their name.
-   * Never <code>null</code>, might be empty.
+   * Never <code>null</code>, might be empty. Declared as {@link TreeMap} (not {@link Map}) so the
+   * field type is {@link java.io.Serializable} under {@code -Xlint:serial}.
    */
-  private Map<String, PSComponent> m_fields = new TreeMap<>();
+  private TreeMap<String, PSComponent> m_fields = new TreeMap<>();
 
   /** The fieldset source type. */
   private int m_sourceType = PSField.TYPE_LOCAL;

--- a/system/src/main/java/com/percussion/design/objectstore/PSView.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSView.java
@@ -17,12 +17,21 @@
 
 package com.percussion.design.objectstore;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-/** Specifies a list of fields that are included in a particular content editor view. */
-public class PSView {
+/**
+ * Specifies a list of fields that are included in a particular content editor view.
+ *
+ * <p>Implements {@link Serializable} so it may be held on serializable content-editor types (e.g.
+ * {@link PSViewSet} / {@link PSContentEditor}) under {@code -Xlint:serial}.
+ */
+public class PSView implements Serializable {
+
+  /** Serialization id for {@link Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Constructs a view with the specified name and list of fields.
    *
@@ -105,7 +114,8 @@ public class PSView {
 
   /**
    * The names of the fields as Strings that are included in this view, never <code>null</code> or
-   * modified after construction, may be empty.
+   * modified after construction, may be empty. Declared as {@link ArrayList} (not {@link List}) so
+   * the field type is {@link Serializable} under {@code -Xlint:serial}.
    */
-  private List m_fields;
+  private ArrayList m_fields;
 }

--- a/system/src/main/java/com/percussion/design/objectstore/PSViewSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSViewSet.java
@@ -17,14 +17,23 @@
 
 package com.percussion.design.objectstore;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-/** Container for a set of {@link PSView} objects. */
-public class PSViewSet {
+/**
+ * Container for a set of {@link PSView} objects.
+ *
+ * <p>Implements {@link Serializable} so it may be held on {@link PSContentEditor} under {@code
+ * -Xlint:serial}.
+ */
+public class PSViewSet implements Serializable {
+
+  /** Serialization id for {@link Serializable}. */
+  private static final long serialVersionUID = 1L;
   /**
    * Adds a view to this view set. Only one PSView may be added for each view name, but multiple
    * conditional views may be added with the same name. See {@link
@@ -118,14 +127,17 @@ public class PSViewSet {
   /**
    * Map of views by name. Key is the view name lowercased and stored as a String. Value is the
    * PSView object, never <code>null</code>. Map is instantiated at construction and never <code>
-   * null</code> after that.
+   * null</code> after that. Declared as {@link HashMap} (not {@link Map}) so the field type is
+   * {@link Serializable} under {@code -Xlint:serial}.
    */
-  private Map m_views = new HashMap();
+  private HashMap m_views = new HashMap();
 
   /**
    * Map of <code>PSConditionalView</code> objects. The key is the view name as a lowercase String,
    * and the value is a List of <code>PSConditionalView</code> objects, never <code>null</code>. Map
-   * is instantiated at runtime, never <code>null</code> after that, may be empty.
+   * is instantiated at runtime, never <code>null</code> after that, may be empty. Declared as
+   * {@link HashMap} (not {@link Map}) so the field type is {@link Serializable} under {@code
+   * -Xlint:serial}.
    */
-  private Map m_conditionalViews = new HashMap();
+  private HashMap m_conditionalViews = new HashMap();
 }

--- a/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialFieldEditorsTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialFieldEditorsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Java serialization surface checks for design.objectstore serial-field cleanup on hottest content
+ * editor types (#2405 / parent #2022). Field declared types use concrete {@link Serializable}
+ * collections/maps; companion holders implement {@link Serializable}.
+ */
+public class PSObjectStoreSerialFieldEditorsTest {
+
+  @Test
+  public void testReplacementValueInterfaceIsSerializable() {
+    assertTrue(
+        Serializable.class.isAssignableFrom(IPSReplacementValue.class),
+        "IPSReplacementValue must extend Serializable so IPSBackEndMapping/locator fields clear serial-field");
+    assertTrue(Serializable.class.isAssignableFrom(IPSBackEndMapping.class));
+  }
+
+  @Test
+  public void testViewAndViewSetJavaSerialization() throws Exception {
+    PSView view = new PSView("sys_All", Collections.singletonList("sys_title").iterator());
+    PSViewSet viewSet = new PSViewSet();
+    viewSet.addView(view);
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(view);
+      oos.writeObject(viewSet);
+      bytes = bos.toByteArray();
+    }
+
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      PSView serView = (PSView) ois.readObject();
+      PSViewSet serSet = (PSViewSet) ois.readObject();
+
+      assertEquals(view, serView);
+      assertEquals("sys_All", serView.getName());
+      assertEquals(view, serSet.getView("sys_All"));
+      assertEquals(view, serSet.getView("SYS_ALL"));
+    }
+  }
+
+  @Test
+  public void testControlDependencyMapEmptyRoundTrip() throws Exception {
+    PSControlDependencyMap map = new PSControlDependencyMap();
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(map);
+      bytes = bos.toByteArray();
+    }
+
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      PSControlDependencyMap ser = (PSControlDependencyMap) ois.readObject();
+      assertNotNull(ser);
+      assertNotNull(ser.getInputDataExtensions());
+      assertTrue(ser.getInputDataExtensions().isEmpty());
+    }
+  }
+
+  @Test
+  public void testConcreteFieldTypesOnHottestEditors() throws Exception {
+    // Reflect declared field types so regressions to Map/List/Collection interfaces fail the suite.
+    assertEquals(
+        ArrayList.class,
+        PSContentEditor.class.getDeclaredField("m_customActionGroups").getType());
+    assertEquals(HashMap.class, PSField.class.getDeclaredField("m_occurrenceSettings").getType());
+    assertEquals(HashMap.class, PSField.class.getDeclaredField("m_properties").getType());
+    assertEquals(TreeMap.class, PSFieldSet.class.getDeclaredField("m_fields").getType());
+    assertEquals(ArrayList.class, PSControlMeta.class.getDeclaredField("m_params").getType());
+    assertEquals(ArrayList.class, PSControlMeta.class.getDeclaredField("m_dependencies").getType());
+    assertEquals(ArrayList.class, PSControlMeta.class.getDeclaredField("m_files").getType());
+    assertEquals(ArrayList.class, PSControlParameter.class.getDeclaredField("m_choiceList").getType());
+    assertEquals(ArrayList.class, PSView.class.getDeclaredField("m_fields").getType());
+    assertEquals(HashMap.class, PSViewSet.class.getDeclaredField("m_views").getType());
+    assertEquals(HashMap.class, PSViewSet.class.getDeclaredField("m_conditionalViews").getType());
+    assertEquals(
+        HashMap.class,
+        PSControlDependencyMap.class.getDeclaredField("m_controlDependencies").getType());
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized batch for **#2405** (parent **#2022** / grandparent **#2200**): reduce `-Xlint:serial` **serial-field** on hottest `design.objectstore` content-editor types after serialVersionUID work (#2366).

No wire/XML behavior change — only Java serialization surface / field declared types.

### Changes
| Area | Fix |
| --- | --- |
| `PSContentEditor` | `Collection` → `ArrayList` for `m_customActionGroups` |
| `PSField` | `Map` → `HashMap` for occurrence settings + properties |
| `PSFieldSet` | `Map` → `TreeMap` for ordered `m_fields` |
| `PSControlMeta` / `PSControlParameter` | `List` → `ArrayList` |
| `IPSReplacementValue` | extends `Serializable` (clears `m_locator` / `m_default` and similar interface-typed fields) |
| `PSView` / `PSViewSet` / `PSControlDependencyMap` | implement `Serializable` + concrete map/list fields |
| `PSConditionalView` | `serialVersionUID` companion after `PSView` became `Serializable` |

### Metrics (`design.objectstore`, `-Xlint:serial -Xmaxwarns 10000`)
| Kind | Before | After (this PR) | Δ |
| --- | ---: | ---: | ---: |
| serial-field | ~119 | ~99 | **−20** |

### Residual (not in this PR)
- **PSCollection / PSCollectionComponent / PSConcurrentList hierarchy** still non-Serializable → remaining fields typed as `PSCollection`, `PSValidationRules`, `PSInputTranslations`, etc. on `PSContentEditor` and mappers.
- Broader package serial-field holders outside hottest editors (`PSRelationshipConfig`, `PSSearchConfig`, …).

Residual child issues filed from this pass (see parent progress table).

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1278**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] New `PSObjectStoreSerialFieldEditorsTest` — 4 tests, 0 failures (View/ViewSet round-trip, empty ControlDependencyMap, concrete field types, IPSReplacementValue Serializable)

## Gates evidence
- Erlang-style self-review: no bugs; portable paths N/A; change-class companions (test + residual issues) included
- Per-module standalone clean install: pass (system only)
- No monorepo-wide reformat

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2405 (hottest editors batch; residual serial-field remains)  
Refs #2022 #2200 #2366

> Co-Authored by Grok Build using grok-4.5 with agent main.