### PR TITLE
fix(perc-system): cms.objectstore rawtypes batch 2e — CoreItem/DisplayFormat/Folder (#2401)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2401-cms-objectstore-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2401-cms-objectstore-rawtypes-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review — issue #2401 (cms.objectstore rawtypes batch 2e)
+
+**Disposition:** approve  
+**Scope:** residual rawtypes/unchecked in `com.percussion.cms.objectstore` after #2376 / PR #2402  
+**Reviewer persona:** Erlang (pre-commit gate)
+
+## Change class
+
+PR-sized generics parameterization of public iterators and tightly coupled consumers — not interface redesign of `IPSComponent.parentComponents` (deferred).
+
+## Findings
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| none | No behavioral bugs in typed iterator conversion | — |
+| note | `getColumns()` / folder property iterators still bridge `PSDbComponentList` via localized suppress + cast | Acceptable; list container remains `Iterator<IPSDbComponent>` |
+| residual | `IPSComponent` raw `List parentComponents` | Documented for design.objectstore interface work |
+| residual | Server handlers (`PSLocalCataloger`, `PSItemDefManager`, etc.) | Follow-up residual issues |
+| residual | Raw `PSDbComponentSet` subclasses (`PSSlotTypeSet`, etc.) | Follow-up residual |
+
+## Tests
+
+- `PSDisplayFormatGenericsTest` (3)
+- `PSItemRelatedItemGenericsTest` (1)
+- `PSFolderTest.testTypedPropertyIterator` (+ existing folder suite)
+- Module: `cd system && ../mvnw clean install`
+
+## Cross-platform
+
+No path/file I/O changes.
+
+## Verdict
+
+Approve for commit/PR.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentDefProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentDefProcessorProxy.java
@@ -76,9 +76,9 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
 
         Element[] elems = proxy.load("PSContentTypeVariantSet", keys);
 
-        PSDbComponentSet vs = new PSContentTypeVariantSet(elems);
+        PSDbComponentSet<?> vs = new PSContentTypeVariantSet(elems);
 
-        Iterator it = vs.iterator();
+        Iterator<?> it = vs.iterator();
         while (it.hasNext()) {
           PSContentTypeTemplate v = (PSContentTypeTemplate) it.next();
 
@@ -95,9 +95,9 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
 
         Element[] elems = proxy.load("PSSlotTypeSet", keys);
 
-        PSDbComponentSet slots = new PSSlotTypeSet(elems);
+        PSDbComponentSet<?> slots = new PSSlotTypeSet(elems);
 
-        Iterator it = slots.iterator();
+        Iterator<?> it = slots.iterator();
         while (it.hasNext()) {
           PSSlotType s = (PSSlotType) it.next();
 
@@ -113,9 +113,9 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
         PSKey[] keys = PSContentType.createKeys(ctIds);
         Element[] elems = proxy.load("PSContentTypeSet", keys);
 
-        PSDbComponentSet cts = new PSContentTypeSet(elems);
+        PSDbComponentSet<?> cts = new PSContentTypeSet(elems);
 
-        Iterator it = cts.iterator();
+        Iterator<?> it = cts.iterator();
         while (it.hasNext()) {
           PSContentType ct = (PSContentType) it.next();
         }
@@ -127,13 +127,13 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
   }
 
   private static void checkContentVariant(PSContentTypeTemplate v) {
-    PSDbComponentSet slots = v.getVariantSlots();
+    PSDbComponentSet<?> slots = v.getVariantSlots();
 
     if (slots == null) {
       System.out.println("No slots for the variant");
     }
 
-    Iterator it1 = slots.iterator();
+    Iterator<?> it1 = slots.iterator();
 
     while (it1.hasNext()) {
       PSVariantSlotType slot = (PSVariantSlotType) it1.next();
@@ -150,9 +150,9 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
     int systemSlot = s.getSystemSlot();
     int slotType = s.getSlotType();
 
-    PSDbComponentSet slotV = s.getSlotVariants();
+    PSDbComponentSet<?> slotV = s.getSlotVariants();
 
-    Iterator it1 = slotV.iterator();
+    Iterator<?> it1 = slotV.iterator();
 
     while (it1.hasNext()) {
       PSSlotTypeContentTypeVariant vslot = (PSSlotTypeContentTypeVariant) it1.next();

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCoreItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCoreItem.java
@@ -254,18 +254,14 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
     copy.init();
 
     // clone fields:
-    Iterator i = m_fieldNameFieldMap.keySet().iterator();
-    while (i.hasNext()) {
-      Object key = i.next();
-      PSItemField val = (PSItemField) m_fieldNameFieldMap.get(key);
+    for (String key : m_fieldNameFieldMap.keySet()) {
+      PSItemField val = m_fieldNameFieldMap.get(key);
       copy.addField((PSItemField) val.clone());
     }
 
     // clone children:
-    Iterator k = m_childNameChildMap.keySet().iterator();
-    while (k.hasNext()) {
-      Object key = k.next();
-      PSItemChild val = (PSItemChild) m_childNameChildMap.get(key);
+    for (String key : m_childNameChildMap.keySet()) {
+      PSItemChild val = m_childNameChildMap.get(key);
       copy.addChild((PSItemChild) val.clone());
     }
 
@@ -277,10 +273,8 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
     if (m_itemDefinition != null) copy.m_itemDefinition = m_itemDefinition;
 
     if (m_relatedItemsMap != null) {
-      Iterator l = m_relatedItemsMap.keySet().iterator();
-      while (l.hasNext()) {
-        String key = (String) l.next();
-        PSItemRelatedItem val = (PSItemRelatedItem) m_relatedItemsMap.get(key);
+      for (String key : m_relatedItemsMap.keySet()) {
+        PSItemRelatedItem val = m_relatedItemsMap.get(key);
         copy.m_relatedItemsMap.put(key, (PSItemRelatedItem) val.clone());
       }
     }
@@ -548,14 +542,14 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
         serverItem.setAction(relItem.getAction());
         serverItem.setDependentId(relItem.getDependentId());
         serverItem.setRelatedItemData(relItem.getRelatedItemData());
-        Iterator propsIter = relItem.getAllProperties();
+        Iterator<String> propsIter = relItem.getAllProperties();
         while (propsIter.hasNext()) {
-          String prop = (String) propsIter.next();
+          String prop = propsIter.next();
           serverItem.addProperty(prop, relItem.getProperty(prop));
         }
-        Iterator keyFieldsIter = relItem.getAllKeyFields();
+        Iterator<String> keyFieldsIter = relItem.getAllKeyFields();
         while (keyFieldsIter.hasNext()) {
-          String keyField = (String) keyFieldsIter.next();
+          String keyField = keyFieldsIter.next();
           serverItem.addKeyField(keyField, relItem.getKeyField(keyField));
         }
       }
@@ -583,7 +577,7 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
     if (fieldName == null || fieldName.trim().length() == 0)
       throw new IllegalArgumentException("fieldname must not be null or empty");
 
-    return (PSItemField) m_fieldNameFieldMap.get(fieldName);
+    return m_fieldNameFieldMap.get(fieldName);
   }
 
   /**
@@ -701,7 +695,7 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
     if (childName == null || childName.length() == 0)
       throw new IllegalArgumentException("childName must not be null or empty");
 
-    return (PSItemChild) m_childNameChildMap.get(childName);
+    return m_childNameChildMap.get(childName);
   }
 
   /**
@@ -713,9 +707,9 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
   public PSItemChild getChildById(int childId) {
     PSItemChild child = null;
 
-    Iterator children = getAllChildren();
+    Iterator<PSItemChild> children = getAllChildren();
     while (children.hasNext() && child == null) {
-      PSItemChild test = (PSItemChild) children.next();
+      PSItemChild test = children.next();
       if (test.getChildId() == childId) child = test;
     }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
@@ -117,9 +117,9 @@ public class PSDisplayFormat extends PSVersionableDbComponent
     boolean ctTypeExists = false;
     boolean variantExists = false;
 
-    Iterator columns = getColumns();
+    Iterator<PSDisplayColumn> columns = getColumns();
     while (columns.hasNext() && (!ctTypeExists || !variantExists)) {
-      PSDisplayColumn column = (PSDisplayColumn) columns.next();
+      PSDisplayColumn column = columns.next();
       if (!ctTypeExists
           && (column.getSource().equals(COL_CONTENTTYPEID)
               || column.getSource().equals(COL_CONTENTTYPENAME))) ctTypeExists = true;
@@ -202,11 +202,11 @@ public class PSDisplayFormat extends PSVersionableDbComponent
       throw new IllegalArgumentException(
           "property name must not exceed " + PSDFProperty.NAME_LENGTH + " characters");
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSDFMultiProperty> iter = m_properties.iterator();
     boolean bFound = false;
 
     while (iter.hasNext()) {
-      PSDFMultiProperty prop = (PSDFMultiProperty) iter.next();
+      PSDFMultiProperty prop = iter.next();
 
       if (prop.getName().equalsIgnoreCase(strName)) {
         // Threshold - if prop already contains this value
@@ -219,10 +219,10 @@ public class PSDisplayFormat extends PSVersionableDbComponent
           // Remove the values of the old property
           // add the new one and clone it to bring over
           // any other attributes (e.g. description ...)
-          Iterator values = prop.iterator(); // cms property(s)
+          Iterator<String> values = prop.iterator(); // cms property(s)
           while (values.hasNext()) {
             // remove each entry and add
-            prop.remove((String) values.next());
+            prop.remove(values.next());
           }
 
           // Single value
@@ -262,10 +262,10 @@ public class PSDisplayFormat extends PSVersionableDbComponent
     if (strName == null || strName.trim().length() == 0)
       throw new IllegalArgumentException("strName must not be null or empty");
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSDFMultiProperty> iter = m_properties.iterator();
 
     while (iter.hasNext()) {
-      PSDFMultiProperty prop = (PSDFMultiProperty) iter.next();
+      PSDFMultiProperty prop = iter.next();
 
       if (prop.getName().equalsIgnoreCase(strName)) return true;
     }
@@ -296,10 +296,10 @@ public class PSDisplayFormat extends PSVersionableDbComponent
     // Threshold
     if (m_properties.size() < 1) return;
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSDFMultiProperty> iter = m_properties.iterator();
     boolean bFound = false;
     while (!bFound && iter.hasNext()) {
-      PSDFMultiProperty prop = (PSDFMultiProperty) iter.next();
+      PSDFMultiProperty prop = iter.next();
       if (prop.getName().equalsIgnoreCase(strName)) {
         if (bMulti) {
           if (strValue == null)
@@ -342,9 +342,9 @@ public class PSDisplayFormat extends PSVersionableDbComponent
   public boolean isValidForFolder() {
     boolean valid = !isValidForRelatedContent();
 
-    Iterator columns = getColumns();
+    Iterator<PSDisplayColumn> columns = getColumns();
     while (columns.hasNext() && valid) {
-      PSDisplayColumn column = (PSDisplayColumn) columns.next();
+      PSDisplayColumn column = columns.next();
       if (column.isCategorized()) valid = false;
 
       for (String name : ms_invalidFolderFields) {
@@ -378,9 +378,9 @@ public class PSDisplayFormat extends PSVersionableDbComponent
   public void removeInvalidFolderColums() {
     List<IPSDbComponent> deletes = new ArrayList<>();
 
-    Iterator columns = getColumns();
+    Iterator<PSDisplayColumn> columns = getColumns();
     while (columns.hasNext()) {
-      PSDisplayColumn column = (PSDisplayColumn) columns.next();
+      PSDisplayColumn column = columns.next();
       for (String name : ms_invalidFolderFields) {
         if (column.getSource().equals(name)) {
           deletes.add(column);
@@ -418,10 +418,10 @@ public class PSDisplayFormat extends PSVersionableDbComponent
     // Threshold
     if (m_properties.size() < 1) return false;
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSDFMultiProperty> iter = m_properties.iterator();
 
     while (iter.hasNext()) {
-      PSDFMultiProperty prop = (PSDFMultiProperty) iter.next();
+      PSDFMultiProperty prop = iter.next();
 
       if (prop.getName().equalsIgnoreCase(name) && prop.contains(value)) return true;
     }
@@ -444,11 +444,12 @@ public class PSDisplayFormat extends PSVersionableDbComponent
 
     String val = null;
 
-    Iterator iter = m_properties.iterator();
+    Iterator<PSDFMultiProperty> iter = m_properties.iterator();
     while (iter.hasNext() && val == null) {
-      PSDFMultiProperty prop = (PSDFMultiProperty) iter.next();
+      PSDFMultiProperty prop = iter.next();
       if (prop.getName().equalsIgnoreCase(name)) {
-        if (prop.iterator().hasNext()) val = (String) prop.iterator().next();
+        Iterator<String> values = prop.iterator();
+        if (values.hasNext()) val = values.next();
       }
     }
 
@@ -573,7 +574,7 @@ public class PSDisplayFormat extends PSVersionableDbComponent
    *
    * @return list never <code>null</code> or empty.
    */
-  public Iterator getProperties() {
+  public Iterator<PSDFMultiProperty> getProperties() {
     return m_properties.iterator();
   }
 
@@ -603,8 +604,11 @@ public class PSDisplayFormat extends PSVersionableDbComponent
    *
    * @return list never <code>null</code> or empty.
    */
-  public Iterator getColumns() {
-    return m_columns.iterator();
+  public Iterator<PSDisplayColumn> getColumns() {
+    // PSDFColumns is a typed list of PSDisplayColumn
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayColumn> cols = (Iterator<PSDisplayColumn>) (Iterator<?>) m_columns.iterator();
+    return cols;
   }
 
   /**
@@ -619,7 +623,9 @@ public class PSDisplayFormat extends PSVersionableDbComponent
 
     int index = -1;
     for (int i = 0; i < m_columns.size(); i++) {
-      if (((PSDisplayColumn) m_columns.get(i)).getSource().equals(columnName)) {
+      IPSDbComponent component = m_columns.get(i);
+      if (component instanceof PSDisplayColumn
+          && ((PSDisplayColumn) component).getSource().equals(columnName)) {
         index = i;
         break;
       }
@@ -786,10 +792,12 @@ public class PSDisplayFormat extends PSVersionableDbComponent
    */
   private void addSystemTitle(PSDFColumns columns) {
     boolean found = false;
-    Iterator walker = columns.iterator();
+    Iterator<IPSDbComponent> walker = columns.iterator();
     while (!found && walker.hasNext()) {
-      PSDisplayColumn column = (PSDisplayColumn) walker.next();
-      found = column.getSource().equalsIgnoreCase(SYS_TITLE);
+      IPSDbComponent component = walker.next();
+      if (component instanceof PSDisplayColumn) {
+        found = ((PSDisplayColumn) component).getSource().equalsIgnoreCase(SYS_TITLE);
+      }
     }
 
     if (!found) {
@@ -1004,14 +1012,16 @@ public class PSDisplayFormat extends PSVersionableDbComponent
   public Object tuneClone(long newId) {
     PSKey newKey = createKey(new String[] {newId + ""});
     setKey(newKey);
-    Iterator cols = m_columns.iterator();
+    Iterator<IPSDbComponent> cols = m_columns.iterator();
     while (cols.hasNext()) {
-      PSDisplayColumn col = (PSDisplayColumn) cols.next();
-      col.setKey(newKey);
+      IPSDbComponent component = cols.next();
+      if (component instanceof PSDisplayColumn) {
+        ((PSDisplayColumn) component).setKey(newKey);
+      }
     }
-    Iterator props = m_properties.iterator();
+    Iterator<PSDFMultiProperty> props = m_properties.iterator();
     while (props.hasNext()) {
-      PSDFMultiProperty prop = (PSDFMultiProperty) props.next();
+      PSDFMultiProperty prop = props.next();
       prop.setKey(newKey);
     }
     return this;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolder.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolder.java
@@ -703,9 +703,9 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
     PSObjectAclEntry entry, srcEntry, tgtEntry;
 
     // Base on the current ACL, handles the modified and deleted ACLs
-    Iterator entries = origAcl.iterator();
+    Iterator<PSObjectAclEntry> entries = origAcl.iterator();
     while (entries.hasNext()) {
-      entry = (PSObjectAclEntry) entries.next();
+      entry = entries.next();
       tgtEntry = m_acl.getAclEntry(entry.getName(), entry.getType());
 
       srcEntry = srcAclClone.getAclEntry(entry.getName(), entry.getType());
@@ -718,7 +718,7 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
     // Base on the source ACLs, handles the new ACLs
     entries = srcAclClone.iterator();
     while (entries.hasNext()) {
-      srcEntry = (PSObjectAclEntry) entries.next();
+      srcEntry = entries.next();
       if (srcEntry.isPersisted())
         throw new IllegalStateException(
             "The new ACL entry, ("
@@ -739,9 +739,13 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
 
     // handles the modified and deleted properties, based on current object.
     PSDbComponentList origProps = (PSDbComponentList) m_properties.cloneFull();
-    Iterator props = origProps.iterator();
+    Iterator<IPSDbComponent> props = origProps.iterator();
     while (props.hasNext()) {
-      prop = (PSFolderProperty) props.next();
+      IPSDbComponent component = props.next();
+      if (!(component instanceof PSFolderProperty)) {
+        continue;
+      }
+      prop = (PSFolderProperty) component;
       String pname = prop.getName();
       srcProp = getProperty(pname, srcProps);
       if (srcProp != null) {
@@ -759,7 +763,11 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
     // (or new) properties.
     props = srcProps.iterator();
     while (props.hasNext()) {
-      prop = (PSFolderProperty) props.next();
+      IPSDbComponent component = props.next();
+      if (!(component instanceof PSFolderProperty)) {
+        continue;
+      }
+      prop = (PSFolderProperty) component;
       if (getProperty(prop.getName()) == null) {
         if (prop.isPersisted())
           throw new IllegalStateException(
@@ -842,8 +850,11 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
    * @return An iterator with zero or more <code>PSFolderProperty</code> object. Never <code>null
    *     </code>, but may be empty.
    */
-  public Iterator getProperties() {
-    return m_properties.iterator();
+  public Iterator<PSFolderProperty> getProperties() {
+    @SuppressWarnings("unchecked")
+    Iterator<PSFolderProperty> props =
+        (Iterator<PSFolderProperty>) (Iterator<?>) m_properties.iterator();
+    return props;
   }
 
   /**
@@ -852,8 +863,11 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
    * @return An iterator with zero or more <code>PSFolderProperty</code> object. Never <code>null
    *     </code>, but may be empty.
    */
-  public Iterator getDeletedProperties() {
-    return m_properties.getDeleteCollection().iterator();
+  public Iterator<PSFolderProperty> getDeletedProperties() {
+    @SuppressWarnings("unchecked")
+    Iterator<PSFolderProperty> props =
+        (Iterator<PSFolderProperty>) (Iterator<?>) m_properties.getDeleteCollection().iterator();
+    return props;
   }
 
   /**
@@ -976,10 +990,13 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
    *     exist in the specified property list.
    */
   private PSFolderProperty getProperty(String name, PSDbComponentList props) {
-    Iterator entries = props.iterator();
+    Iterator<IPSDbComponent> entries = props.iterator();
     while (entries.hasNext()) {
-      PSFolderProperty prop = (PSFolderProperty) entries.next();
-      if (name.equalsIgnoreCase(prop.getName())) return prop;
+      IPSDbComponent component = entries.next();
+      if (component instanceof PSFolderProperty) {
+        PSFolderProperty prop = (PSFolderProperty) component;
+        if (name.equalsIgnoreCase(prop.getName())) return prop;
+      }
     }
 
     return null;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemRelatedItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemRelatedItem.java
@@ -158,7 +158,7 @@ public class PSItemRelatedItem extends PSItemComponent {
    * @return unmodifiable <code>Iterator</code> of all of the <code>key</code> names as <code>
    *     Strings</code>. May be empty but not <code>null</code>.
    */
-  public Iterator getAllProperties() {
+  public Iterator<String> getAllProperties() {
     return Collections.unmodifiableCollection(m_propertyMap.keySet()).iterator();
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSObjectAcl.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSObjectAcl.java
@@ -38,7 +38,7 @@ import org.w3c.dom.Element;
  * used while serializing it to the database (in the <code>PSServerFolderProcessor</code> class).
  * Each ACL entry in this collection should be in one of the DBSTATE_xxx state.
  */
-public class PSObjectAcl extends PSDbComponentSet {
+public class PSObjectAcl extends PSDbComponentSet<PSObjectAclEntry> {
   /** The default constructor to create an empty ACL. */
   public PSObjectAcl() {
     super(PSObjectAclEntry.class);
@@ -78,10 +78,9 @@ public class PSObjectAcl extends PSDbComponentSet {
    *     not exist.
    */
   public PSObjectAclEntry getAclEntry(String name, int type) {
-    Iterator entries = iterator();
-    PSObjectAclEntry entry;
+    Iterator<PSObjectAclEntry> entries = iterator();
     while (entries.hasNext()) {
-      entry = (PSObjectAclEntry) entries.next();
+      PSObjectAclEntry entry = entries.next();
       if (entry.getName().equalsIgnoreCase(name) && entry.getType() == type) {
         return entry;
       }

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSServerItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSServerItem.java
@@ -1220,9 +1220,9 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
       relatedParams.put(IPSHtmlParameters.SYS_RELATIONSHIPTYPE, related.getRelatedType());
 
       // put all the properties into the param map
-      Iterator propIter = related.getAllProperties();
+      Iterator<String> propIter = related.getAllProperties();
       while (propIter.hasNext()) {
-        String key = (String) propIter.next();
+        String key = propIter.next();
         String val = related.getProperty(key);
 
         relatedParams.put(key, val);

--- a/system/src/main/java/com/percussion/search/PSGenerateSearchResultsExit.java
+++ b/system/src/main/java/com/percussion/search/PSGenerateSearchResultsExit.java
@@ -190,8 +190,8 @@ public class PSGenerateSearchResultsExit extends PSDefaultExtension
       }
 
       List resultColumns = new ArrayList();
-      Iterator columns = displayFormat.getColumns();
-      while (columns.hasNext()) resultColumns.add(((PSDisplayColumn) columns.next()).getSource());
+      Iterator<PSDisplayColumn> columns = displayFormat.getColumns();
+      while (columns.hasNext()) resultColumns.add(columns.next().getSource());
 
       PSRequest req = new PSRequest(request.getSecurityToken());
       req.setParameters(request.getParametersIterator());
@@ -378,8 +378,8 @@ public class PSGenerateSearchResultsExit extends PSDefaultExtension
      * level, then all other columns.
      */
     List displayedColumns = new ArrayList();
-    Iterator columns = displayFormat.getColumns();
-    while (columns.hasNext()) addColumn(displayedColumns, (PSDisplayColumn) columns.next());
+    Iterator<PSDisplayColumn> columns = displayFormat.getColumns();
+    while (columns.hasNext()) addColumn(displayedColumns, columns.next());
 
     // create the header element
     Element header = PSXmlDocumentBuilder.addEmptyElement(doc, root, HEADER_ELEM);

--- a/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
@@ -315,9 +315,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
       throw new PSCmsException(IPSCmsErrors.INVALID_FOLDER_NAME, args);
     }
 
-    Iterator props = folder.getProperties();
+    Iterator<PSFolderProperty> props = folder.getProperties();
     while (props.hasNext()) {
-      PSFolderProperty prop = (PSFolderProperty) props.next();
+      PSFolderProperty prop = props.next();
 
       if (prop.getName().length() > PROP_NAME_MAX)
         throwInvalidException("property name", prop.getName().length(), PROP_NAME_MAX);
@@ -642,9 +642,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     PSItemChild child = fItem.getChildByName(CHILD_NAME_PROPERTIES);
 
     // set the inserted and modified properties
-    Iterator childs = folder.getProperties();
+    Iterator<PSFolderProperty> childs = folder.getProperties();
     while (childs.hasNext()) {
-      PSFolderProperty prop = (PSFolderProperty) childs.next();
+      PSFolderProperty prop = childs.next();
 
       if (prop.getState() == IPSDbComponent.DBSTATE_UNMODIFIED) continue;
 
@@ -676,7 +676,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     // take care the deleted properties
     childs = folder.getDeletedProperties();
     while (childs.hasNext()) {
-      PSFolderProperty prop = (PSFolderProperty) childs.next();
+      PSFolderProperty prop = childs.next();
 
       PSItemChildEntry childEntry = child.createChildEntry();
       childEntry.setAction(PSItemChildEntry.CHILD_ACTION_DELETE);

--- a/system/src/test/java/com/percussion/cms/objectstore/PSDisplayFormatGenericsTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSDisplayFormatGenericsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.cms.PSCmsException;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed property/column iterators on {@link PSDisplayFormat} (issue #2401
+ * cms.objectstore rawtypes batch 2e).
+ */
+public class PSDisplayFormatGenericsTest {
+
+  @Test
+  public void testTypedPropertyApis() throws PSCmsException {
+    PSDisplayFormat format = new PSDisplayFormat();
+    format.setProperty("customProp", "alpha");
+    format.setProperty("customProp", "beta", true);
+
+    assertTrue(format.hasProperty("customProp"));
+    assertTrue(format.doesPropertyHaveValue("customProp", "alpha"));
+    assertTrue(format.doesPropertyHaveValue("customProp", "beta"));
+    assertEquals("alpha", format.getPropertyValue("customProp"));
+
+    Iterator<PSDFMultiProperty> props = format.getProperties();
+    assertNotNull(props);
+    boolean found = false;
+    while (props.hasNext()) {
+      PSDFMultiProperty prop = props.next();
+      assertNotNull(prop.getName());
+      if ("customProp".equalsIgnoreCase(prop.getName())) {
+        found = true;
+        assertTrue(prop.contains("alpha"));
+        assertTrue(prop.contains("beta"));
+      }
+    }
+    assertTrue(found, "customProp multiproperty must be present");
+
+    format.removeProperty("customProp", "beta", true);
+    assertFalse(format.doesPropertyHaveValue("customProp", "beta"));
+    assertTrue(format.doesPropertyHaveValue("customProp", "alpha"));
+  }
+
+  @Test
+  public void testTypedColumnIteratorIncludesSystemTitle() throws PSCmsException {
+    PSDisplayFormat format = new PSDisplayFormat();
+
+    Iterator<PSDisplayColumn> columns = format.getColumns();
+    assertNotNull(columns);
+    assertTrue(columns.hasNext(), "default format must include sys_title column");
+
+    boolean foundTitle = false;
+    while (columns.hasNext()) {
+      PSDisplayColumn column = columns.next();
+      assertNotNull(column.getSource());
+      if ("sys_title".equalsIgnoreCase(column.getSource())) {
+        foundTitle = true;
+      }
+    }
+    assertTrue(foundTitle);
+
+    int titleIndex = format.getColumnIndex("sys_title");
+    assertTrue(titleIndex >= 0);
+  }
+
+  @Test
+  public void testValidForFolderWithDefaultColumns() throws PSCmsException {
+    PSDisplayFormat format = new PSDisplayFormat();
+    // default has only sys_title → valid for folders and not for related content
+    assertTrue(format.isValidForFolder());
+    assertFalse(format.isValidForRelatedContent());
+    assertTrue(format.isValidForViewsAndSearches());
+  }
+}

--- a/system/src/test/java/com/percussion/cms/objectstore/PSFolderTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSFolderTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -237,6 +238,37 @@ public class PSFolderTest {
     folderSet.add(folder3);
 
     assertTrue(folderSet.size() == 2);
+  }
+
+  /**
+   * Typed property iterator coverage for generics parameterization (issue #2401).
+   *
+   * @throws Exception on error
+   */
+  @Test
+  public void testTypedPropertyIterator() throws Exception {
+    PSFolder folder = new PSFolder("f1", 10, -1, PSObjectPermissions.ACCESS_ADMIN, "description");
+    folder.setProperty("p1", "value1");
+    folder.setProperty("p2", "value2", "desc2");
+
+    Iterator<PSFolderProperty> props = folder.getProperties();
+    Set<String> names = new HashSet<>();
+    while (props.hasNext()) {
+      PSFolderProperty prop = props.next();
+      assertNotNull(prop.getName());
+      names.add(prop.getName());
+    }
+    assertTrue(names.contains("p1"));
+    assertTrue(names.contains("p2"));
+    assertEquals(2, folder.getPropertySize());
+
+    PSObjectAcl acl = new PSObjectAcl();
+    PSObjectAclEntry entry =
+        new PSObjectAclEntry(
+            PSObjectAclEntry.ACL_ENTRY_TYPE_USER, "qa1", PSObjectAclEntry.ACCESS_READ);
+    acl.add(entry);
+    assertNotNull(acl.getAclEntry("qa1", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+    assertNull(acl.getAclEntry("missing", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
   }
 
   /**

--- a/system/src/test/java/com/percussion/cms/objectstore/PSItemRelatedItemGenericsTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSItemRelatedItemGenericsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed property/key-field iterators on {@link PSItemRelatedItem} (issue
+ * #2401 cms.objectstore rawtypes batch 2e).
+ */
+public class PSItemRelatedItemGenericsTest {
+
+  @Test
+  public void testTypedPropertyAndKeyFieldIterators() {
+    PSItemRelatedItem related = new PSItemRelatedItem();
+    related.setRelationshipId(42);
+    related.addProperty("sys_slotid", "301");
+    related.addProperty("sys_variantid", "501");
+
+    org.w3c.dom.Document doc = com.percussion.xml.PSXmlDocumentBuilder.createXmlDocument();
+    org.w3c.dom.Element keyEl = doc.createElement("KeyField");
+    keyEl.setAttribute("name", "sys_title");
+    keyEl.appendChild(doc.createTextNode("Hello"));
+    related.addKeyField("sys_title", keyEl);
+
+    Iterator<String> props = related.getAllProperties();
+    Set<String> propNames = new HashSet<>();
+    while (props.hasNext()) {
+      String name = props.next();
+      assertNotNull(name);
+      propNames.add(name);
+      assertNotNull(related.getProperty(name));
+    }
+    assertTrue(propNames.contains("sys_slotid"));
+    assertTrue(propNames.contains("sys_variantid"));
+    assertEquals("301", related.getProperty("sys_slotid"));
+
+    Iterator<String> keys = related.getAllKeyFields();
+    Set<String> keyNames = new HashSet<>();
+    while (keys.hasNext()) {
+      String name = keys.next();
+      assertNotNull(name);
+      keyNames.add(name);
+    }
+    assertTrue(keyNames.contains("sys_title"));
+    assertNotNull(related.getKeyField("sys_title"));
+  }
+}


### PR DESCRIPTION
## Summary

Slice **2e** of parent **#2022** (grandparent **#2200**): real generics for residual rawtypes/unchecked in `com.percussion.cms.objectstore` after #2376 / PR #2402.

### Changes
- **`PSCoreItem`** — typed field/child/related clone loops; typed merge property/key-field iterators; removed redundant map casts
- **`PSItemRelatedItem`** — `getAllProperties()` → `Iterator<String>`
- **`PSDisplayFormat`** — `getProperties()` / `getColumns()` typed; all property/column local iterators parameterized
- **`PSFolder`** — `getProperties()` / `getDeletedProperties()` → `Iterator<PSFolderProperty>`; typed merge ACL/property walks
- **`PSObjectAcl`** — `extends PSDbComponentSet<PSObjectAclEntry>`; typed `getAclEntry`
- **Companions** — `PSServerFolderProcessor`, `PSServerItem`, `PSGenerateSearchResultsExit`, `PSComponentDefProcessorProxy` harness
- **Tests** — `PSDisplayFormatGenericsTest` (3), `PSItemRelatedItemGenericsTest` (1), `PSFolderTest.testTypedPropertyIterator`
- **Erlang** — approve (`docs/ai-generated/code-reviews/issue-2401-cms-objectstore-rawtypes-erlang.md`)

### Residual (filed)
- #2453 — server handlers residual (`PSLocalCataloger`, `PSItemDefManager`, …)
- #2454 — residual raw `PSDbComponentSet` subclasses
- #2455 — `IPSComponent` `parentComponents` List typing (design.objectstore interface; deferred by design)

### Out of scope (per #2401)
- design.objectstore mega-interface refactor
- data/data.jdbc (#2398/#2399)
- this-escape/serial (#2403 line)

## Test plan
- [x] `cd system` → `../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Module tests: **1279** run, **0** failures, **0** errors (240 skipped pre-existing)
- [x] Focused: PSDisplayFormatGenericsTest + PSItemRelatedItemGenericsTest + PSFolderTest → **11** green
- [x] Erlang self-review: approve

## Gates evidence
| Gate | Result |
| --- | --- |
| Standalone module clean install (`cd system`) | BUILD SUCCESS |
| Behavioral unit tests | 11 green (focused); full suite 1279 |
| Scope confined to cms.objectstore batch + tight companions | yes |
| Erlang | approve |

Parent tracker: #2022  
Grandparent: #2200  
Residuals: #2453 #2454 #2455  

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2401  
Refs #2022 #2200 #2376

> Co-Authored by Grok Build using grok-4.5 with agent main.