### PR TITLE
fix(perc-system): type security role catalogers rawtypes batch (#2386)

### DIFF
--- a/system/src/main/java/com/percussion/security/IPSInternalRoleCataloger.java
+++ b/system/src/main/java/com/percussion/security/IPSInternalRoleCataloger.java
@@ -17,6 +17,7 @@
 package com.percussion.security;
 
 import com.percussion.design.objectstore.PSRoleProvider;
+import com.percussion.design.objectstore.PSSubject;
 import java.util.List;
 import java.util.Set;
 
@@ -38,10 +39,10 @@ public interface IPSInternalRoleCataloger {
    * @return a valid list of 0 or more Strings, each naming a role. The list will not contain
    *     duplicates.
    */
-  public List getRoles(String subjectName, int subjectType);
+  List<String> getRoles(String subjectName, int subjectType);
 
   /** Convenience method which calls {@link #getSubjects(String, String, int, String, boolean)}. */
-  public Set getSubjects(String roleName, String subjectNameFilter);
+  Set<PSSubject> getSubjects(String roleName, String subjectNameFilter);
 
   /**
    * Gets a filtered set of subjects associated with a specific role.
@@ -62,7 +63,7 @@ public interface IPSInternalRoleCataloger {
    *     set contents. The subjects are ordered in ascending alpha order by their name.
    * @throws PSSecurityException If any problems occur while trying to get the requested data.
    */
-  public Set getSubjects(
+  Set<PSSubject> getSubjects(
       String roleName,
       String subjectNameFilter,
       int subjectType,
@@ -74,5 +75,5 @@ public interface IPSInternalRoleCataloger {
    *
    * @return the role provider definition, never <code>null</code>.
    */
-  public PSRoleProvider getProvider();
+  PSRoleProvider getProvider();
 }

--- a/system/src/main/java/com/percussion/security/PSBackEndDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndDirectoryCataloger.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -92,8 +93,7 @@ public class PSBackEndDirectoryCataloger extends PSDirectoryCataloger {
     Collection users = new HashSet();
     if (criteria == null || criteria.length == 0) criteria = new PSConditional[] {null};
     for (int i = 0; i < criteria.length; i++) {
-      users.addAll(
-          PSBackendCataloger.getSubjects((HashMap) createFilter(criteria[i]), attributeNames));
+      users.addAll(PSBackendCataloger.getSubjects(createFilter(criteria[i]), attributeNames));
     }
 
     return users;
@@ -123,11 +123,11 @@ public class PSBackEndDirectoryCataloger extends PSDirectoryCataloger {
    * @return The subject, or <code>null</code> if not found.
    */
   private PSSubject getMatchingSubject(String name, Collection attributeNames) {
-    HashMap<String, String> filters = new HashMap<>();
+    Map<String, String> filters = new HashMap<>();
     filters.put(PSBackendCataloger.FILTER_SUBJECT_NAME, name);
-    Set subjects = PSBackendCataloger.getSubjects(filters, attributeNames);
+    Set<PSSubject> subjects = PSBackendCataloger.getSubjects(filters, attributeNames);
     if (subjects.isEmpty()) return null;
-    else return (PSSubject) subjects.iterator().next();
+    else return subjects.iterator().next();
   }
 
   /** Constant for the default name of this cataloger */

--- a/system/src/main/java/com/percussion/security/PSBackendCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackendCataloger.java
@@ -31,6 +31,7 @@ import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -45,7 +46,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Base class which holds common backend catalog functionality used in security classes. */
-@SuppressWarnings(value = {"unchecked"})
 public class PSBackendCataloger {
 
   private static final Logger log = LogManager.getLogger(PSBackendCataloger.class);
@@ -54,7 +54,7 @@ public class PSBackendCataloger {
    * Convenience method that call {@link #getRoleAttributes(String, String)
    * getRoleAttributes(String, null)}.
    */
-  public static List getRoleAttributes(String roleName) {
+  public static List<PSAttribute> getRoleAttributes(String roleName) {
     if (roleName == null) throw new IllegalArgumentException("roleName cannot be null");
 
     roleName = roleName.trim();
@@ -87,15 +87,15 @@ public class PSBackendCataloger {
    *     includeEmptySubjects is <code>true</code>), ordered in ascending alpha order by subject
    *     name. The caller takes ownership of the list.
    */
-  public static List getSubjectGlobalAttributes(
+  public static List<PSSubject> getSubjectGlobalAttributes(
       String subjectNameFilter,
       int subjectType,
       String roleName,
       String attributeNameFilter,
       boolean includeEmptySubjects) {
-    Set subjects = new HashSet();
+    Set<PSSubject> subjects = new HashSet<>();
 
-    HashMap filters = new HashMap();
+    HashMap<String, String> filters = new HashMap<>();
     if (null != subjectNameFilter && subjectNameFilter.trim().length() > 0)
       filters.put(FILTER_SUBJECT_NAME, subjectNameFilter);
 
@@ -115,12 +115,12 @@ public class PSBackendCataloger {
       requestPage = "sys_catalogSubjectAttributes";
 
     Document doc = getCatalogDocument(requestPage, filters);
-    List results = processSubjectAttributes(doc, includeEmptySubjects);
+    List<PSSubject> results = processSubjectAttributes(doc, includeEmptySubjects);
 
     // add all subjects to the result
     subjects.addAll(results);
 
-    return new ArrayList(subjects);
+    return new ArrayList<>(subjects);
   }
 
   /**
@@ -140,14 +140,14 @@ public class PSBackendCataloger {
    * @return the subject specific role attributes in a list of <code>PSSubject</code> objects, never
    *     <code>null</code>, may be empty.
    */
-  public static List getSubjectRoleAttributes(
+  public static List<PSSubject> getSubjectRoleAttributes(
       String subjectNameFilter, int subjectType, String roleName, String attributeNameFilter) {
     if (roleName == null) throw new IllegalArgumentException("roleName cannot be null");
 
     roleName = roleName.trim();
     if (roleName.length() == 0) throw new IllegalArgumentException("roleName cannot be empty");
 
-    HashMap filters = new HashMap();
+    HashMap<String, String> filters = new HashMap<>();
     if (null != subjectNameFilter && subjectNameFilter.trim().length() > 0)
       filters.put(FILTER_SUBJECT_NAME, subjectNameFilter);
 
@@ -163,8 +163,8 @@ public class PSBackendCataloger {
     }
 
     Document doc = getCatalogDocument("sys_catalogRoleSubjectAttributes", filters);
-    List subjects = processSubjectAttributes(doc, false);
-    if (null == subjects) subjects = new ArrayList();
+    List<PSSubject> subjects = processSubjectAttributes(doc, false);
+    if (null == subjects) subjects = new ArrayList<>();
 
     return subjects;
   }
@@ -180,11 +180,11 @@ public class PSBackendCataloger {
    * @return a valid list of 0 or more <code>PSAttribute</code> objects. They are ordered in
    *     ascending alpha order by attribute name. The caller takes ownership of the list.
    */
-  protected static List getRoleAttributes(String roleName, String attributeNameFilter) {
+  protected static List<PSAttribute> getRoleAttributes(String roleName, String attributeNameFilter) {
     if (roleName == null || roleName.trim().length() == 0)
       throw new IllegalArgumentException("roleName cannot be null or empty");
 
-    HashMap filters = new HashMap();
+    HashMap<String, String> filters = new HashMap<>();
     filters.put(FILTER_ROLE_NAME, roleName);
 
     if (null != attributeNameFilter && attributeNameFilter.trim().length() > 0)
@@ -194,7 +194,7 @@ public class PSBackendCataloger {
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
 
-    List results = new ArrayList();
+    List<PSAttribute> results = new ArrayList<>();
     if (null == tree.getCurrent()) return results;
 
     // we only expect a single role back, so no for loop
@@ -205,7 +205,8 @@ public class PSBackendCataloger {
     }
 
     PSAttributeList attribs = getAttributes(el);
-    Iterator iter = attribs.iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<PSAttribute> iter = attribs.iterator();
     while (iter.hasNext()) results.add(iter.next());
 
     return results;
@@ -242,7 +243,7 @@ public class PSBackendCataloger {
         continue;
       }
 
-      List values = getValues(el);
+      List<String> values = getValues(el);
       results.setAttribute(name, values);
     }
 
@@ -258,17 +259,17 @@ public class PSBackendCataloger {
    *     no values are found, <code>null</code> is returned. The entries may be <code>null</code> or
    *     empty.
    */
-  protected static List getValues(Element parent) {
+  protected static List<String> getValues(Element parent) {
     if (parent == null) throw new IllegalArgumentException("parent cannot be null");
 
-    List results = null;
+    List<String> results = null;
     PSXmlTreeWalker tree = new PSXmlTreeWalker(parent);
 
     Element el = tree.getNextElement("Value", ms_firstFlags);
 
     if (null == el) return results;
 
-    results = new ArrayList();
+    results = new ArrayList<>();
     for (; null != el; el = tree.getNextElement("Value", ms_nextFlags)) {
       String value = PSXmlTreeWalker.getElementData(el);
       results.add(value);
@@ -294,14 +295,19 @@ public class PSBackendCataloger {
    *     not a query resource, security on the app failed (the app is corrupted) or the actual
    *     request failed.
    */
-  protected static Document getCatalogDocument(String datasetName, HashMap filters) {
+  protected static Document getCatalogDocument(String datasetName, Map<String, String> filters) {
     if (datasetName == null || datasetName.trim().length() == 0)
       throw new IllegalArgumentException("datasetName cannot be null or empty");
 
     try {
       String path = CATALOGER_APPNAME + "/" + datasetName;
+      // PSRequest html params require a HashMap; copy when a non-HashMap map is supplied.
+      HashMap<String, String> paramMap =
+          filters instanceof HashMap
+              ? (HashMap<String, String>) filters
+              : filters == null ? null : new HashMap<>(filters);
       PSInternalRequest ir =
-          PSServer.getInternalRequest(path, PSRequest.getContextForRequest(), filters, false);
+          PSServer.getInternalRequest(path, PSRequest.getContextForRequest(), paramMap, false);
 
       return ir.getResultDoc();
     } catch (PSInternalRequestCallException e) {
@@ -320,14 +326,14 @@ public class PSBackendCataloger {
    * @return a valid list of 0 or more <code>Strings</code>, each naming a role. The list will not
    *     contain duplicates.
    */
-  public static List getRhythmyxRoles(String subjectName, int subjectType) {
+  public static List<String> getRhythmyxRoles(String subjectName, int subjectType) {
     // use a set to remove duplicates
     Set<String> resultSet = new HashSet<>();
     resultSet.addAll(
         PSRoleMgrLocator.getBackEndRoleManager().getRhythmyxRoles(subjectName, subjectType));
 
     // make sure we return an alpha ordered list
-    List resultList = new ArrayList(resultSet);
+    List<String> resultList = new ArrayList<>(resultSet);
     Collections.sort(
         resultList, new PSStringComparator(PSStringComparator.SORT_CASE_INSENSITIVE_ASC));
 
@@ -346,18 +352,19 @@ public class PSBackendCataloger {
    * @return A valid list with 0 or more PSSubjects, each containing any attributes they have.
    * @throws PSSecurityException If the document is improperly formed.
    */
-  protected static List processSubjectAttributes(Document doc, boolean includeEmptySubjects) {
+  protected static List<PSSubject> processSubjectAttributes(
+      Document doc, boolean includeEmptySubjects) {
     if (doc == null) throw new IllegalArgumentException("doc cannot be null");
 
     Element el = doc.getDocumentElement();
-    if (null == el) return new ArrayList();
+    if (null == el) return new ArrayList<>();
 
     if (!el.getTagName().equals("Subjects")) {
       Object[] args = {"Subjects", el.getTagName()};
       throw new PSSecurityException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
     }
 
-    return new ArrayList(processCatalogedSubjects(el, includeEmptySubjects));
+    return new ArrayList<>(processCatalogedSubjects(el, includeEmptySubjects));
   }
 
   /**
@@ -378,11 +385,15 @@ public class PSBackendCataloger {
    *    </code>.
    * @throws PSSecurityException If any of a Subject's attributes are not valid.
    */
-  protected static Set processCatalogedSubjects(Element parent, boolean includeEmptySubjects) {
+  @SuppressWarnings("unchecked")
+  protected static Set<PSSubject> processCatalogedSubjects(
+      Element parent, boolean includeEmptySubjects) {
     if (parent == null) throw new IllegalArgumentException("parent cannot be null");
 
     // use set to remove dups introduced with the fix for Rx-01-10-0104
-    TreeSet results = new TreeSet(PSSubject.getSubjectIdentifierComparator());
+    Comparator<PSSubject> subjectComparator =
+        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
+    TreeSet<PSSubject> results = new TreeSet<>(subjectComparator);
 
     Map<String, PSSubject> subjectMap = new LinkedHashMap<>();
 
@@ -449,32 +460,41 @@ public class PSBackendCataloger {
    *     empty to get all attributes.
    * @return a set of <code>PSSubject</code> objects with the requested attributes.
    */
-  protected static Set getSubjects(HashMap filters, Collection attributeNames) {
+  @SuppressWarnings("unchecked")
+  protected static Set<PSSubject> getSubjects(
+      Map<String, String> filters, Collection<?> attributeNames) {
     if (filters == null) throw new IllegalArgumentException("filters cannot be null");
 
     // use treeset to prevent duplicates and enforce ordering
-    TreeSet sortedSet = new TreeSet(PSSubject.getSubjectIdentifierComparator());
+    Comparator<PSSubject> subjectComparator =
+        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
+    TreeSet<PSSubject> sortedSet = new TreeSet<>(subjectComparator);
 
-    Document doc = doc = getCatalogDocument("sys_catalogOuterJoinSubjectAttributes", filters);
+    Document doc = getCatalogDocument("sys_catalogOuterJoinSubjectAttributes", filters);
     sortedSet.addAll(processSubjectAttributes(doc, true));
 
-    if (attributeNames != null && attributeNames.size() > 0) {
-      Iterator subjects = sortedSet.iterator();
-      while (subjects.hasNext()) {
-        PSSubject subject = (PSSubject) subjects.next();
+    if (attributeNames != null && !attributeNames.isEmpty()) {
+      Set<String> requestedNames = new HashSet<>();
+      for (Object nameObj : attributeNames) {
+        if (nameObj != null) requestedNames.add(nameObj.toString());
+      }
+
+      for (PSSubject subject : sortedSet) {
         PSAttributeList attributes = subject.getAttributes();
 
         // remove not requested attributes
-        Iterator attrs = attributes.iterator();
+        List<PSAttribute> toRemove = new ArrayList<>();
+        Iterator<?> attrs = attributes.iterator();
         while (attrs.hasNext()) {
           PSAttribute attribute = (PSAttribute) attrs.next();
-          if (!attributeNames.contains(attribute.getName())) attributes.remove(attribute);
+          if (!requestedNames.contains(attribute.getName())) toRemove.add(attribute);
+        }
+        for (PSAttribute attribute : toRemove) {
+          attributes.remove(attribute);
         }
 
         // add missing attributes
-        Iterator names = attributeNames.iterator();
-        while (names.hasNext()) {
-          String name = (String) names.next();
+        for (String name : requestedNames) {
           PSAttribute attribute = attributes.getAttribute(name);
           if (attribute == null) attributes.setAttribute(name, null);
         }

--- a/system/src/main/java/com/percussion/security/PSBackendRoleCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackendRoleCataloger.java
@@ -18,7 +18,7 @@ package com.percussion.security;
 
 import com.percussion.design.objectstore.PSRoleProvider;
 import com.percussion.design.objectstore.PSServerConfiguration;
-import java.util.ArrayList;
+import com.percussion.design.objectstore.PSSubject;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,13 +57,15 @@ public class PSBackendRoleCataloger extends PSBackendCataloger implements IPSInt
   /**
    * @see IPSInternalRoleCataloger
    */
-  public List getRoles(String subjectName, int subjectType) {
+  @Override
+  public List<String> getRoles(String subjectName, int subjectType) {
     return getRhythmyxRoles(subjectName, subjectType);
   }
 
   /**
    * @see IPSInternalRoleCataloger
    */
+  @Override
   public PSRoleProvider getProvider() {
     return new PSRoleProvider(
         "sys_backendrolecataloger", PSRoleProvider.TYPE_BACKEND, (String) null);
@@ -72,20 +74,22 @@ public class PSBackendRoleCataloger extends PSBackendCataloger implements IPSInt
   /**
    * @see IPSInternalRoleCataloger
    */
-  public Set getSubjects(String roleName, String subjectNameFilter) {
+  @Override
+  public Set<PSSubject> getSubjects(String roleName, String subjectNameFilter) {
     return getSubjects(roleName, subjectNameFilter, 0, null, true);
   }
 
   /**
    * @see IPSInternalRoleCataloger
    */
-  public Set getSubjects(
+  @Override
+  public Set<PSSubject> getSubjects(
       String roleName,
       String subjectNameFilter,
       int subjectType,
       String attributeNameFilter,
       boolean includeEmpty) {
-    HashMap filters = new HashMap();
+    HashMap<String, String> filters = new HashMap<>();
 
     if (null != roleName && roleName.trim().length() > 0) filters.put(FILTER_ROLE_NAME, roleName);
 
@@ -97,10 +101,7 @@ public class PSBackendRoleCataloger extends PSBackendCataloger implements IPSInt
 
     if (subjectType != 0) filters.put("sys_subjectType", String.valueOf(subjectType));
 
-    List results = new ArrayList();
-    results.addAll(getSubjects(filters, null));
-
-    return new HashSet(results);
+    return new HashSet<>(getSubjects(filters, null));
   }
 
   /** Role cataloger configuration properties supplied at construction time. Currently not used. */

--- a/system/src/main/java/com/percussion/security/PSCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSCataloger.java
@@ -48,7 +48,6 @@ import javax.naming.directory.SearchResult;
 import org.apache.commons.lang3.StringUtils;
 
 /** An abstract base class which holds all common functionality to all catalogers. */
-@SuppressWarnings(value = {"unchecked"})
 public abstract class PSCataloger {
   /**
    * Convenience constructor that calls {@link #PSCataloger(Properties, PSServerConfiguration)} with
@@ -125,7 +124,7 @@ public abstract class PSCataloger {
    *     <code>String</code>. Initialized in constructor, never <code>null</code> or changed after
    *     that.
    */
-  protected Map getDirectories() {
+  protected Map<String, PSDirectoryDefinition> getDirectories() {
     return m_directories;
   }
 
@@ -153,9 +152,10 @@ public abstract class PSCataloger {
     }
 
     // load and validate all referenced directories/authentications
-    Iterator directoryRefs = m_directorySet.iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<PSReference> directoryRefs = m_directorySet.iterator();
     while (directoryRefs.hasNext()) {
-      PSReference directoryRef = (PSReference) directoryRefs.next();
+      PSReference directoryRef = directoryRefs.next();
       PSDirectory directory = config.getDirectory(directoryRef.getName());
       if (directory == null) {
         Object[] args = {directoryRef.getName()};
@@ -278,18 +278,18 @@ public abstract class PSCataloger {
     String uid = objectAttribute.get(0).toString();
 
     PSAttributeList attributes = new PSAttributeList();
-    NamingEnumeration attrs = null;
-    NamingEnumeration attrValues = null;
+    NamingEnumeration<? extends Attribute> attrs = null;
+    NamingEnumeration<?> attrValues = null;
     try {
       attrs = subject.getAttributes().getAll();
       while (attrs.hasMore()) {
-        Attribute attr = (Attribute) attrs.next();
+        Attribute attr = attrs.next();
 
         String attrName = attr.getID();
         if (!requestedReturns.contains(attrName)) continue;
         PSAttribute attribute = new PSAttribute(attrName);
 
-        List attributeValues = new ArrayList();
+        List<Object> attributeValues = new ArrayList<>();
         attrValues = attr.getAll();
         while (attrValues.hasMore()) {
           attributeValues.add(attrValues.next());
@@ -329,11 +329,11 @@ public abstract class PSCataloger {
    * @return a by subject type filtered set of <code>PSSubject</code> objects, never <code>null
    *     </code>, may be empty.
    */
-  protected Set filterByType(Set subjects, int type, boolean includeEmpty) {
+  protected Set<PSSubject> filterByType(Set<PSSubject> subjects, int type, boolean includeEmpty) {
     if (type != 0 || !includeEmpty) {
-      List subjectList = new ArrayList(subjects);
+      List<PSSubject> subjectList = new ArrayList<>(subjects);
       for (int i = 0; i < subjectList.size(); i++) {
-        PSSubject subject = (PSSubject) subjectList.get(i);
+        PSSubject subject = subjectList.get(i);
         if ((type != 0 && subject.getType() != type)
             || (!includeEmpty && subject.getAttributes().size() == 0)) subjects.remove(subject);
       }
@@ -376,9 +376,10 @@ public abstract class PSCataloger {
   private static Map<String, IPSGroupProviderInstance> getGroupProviderInstances(
       PSServerConfiguration config) {
     Map<String, IPSGroupProviderInstance> result = new HashMap<>();
-    Iterator i = config.getGroupProviderInstances().iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<IPSGroupProviderInstance> i = config.getGroupProviderInstances().iterator();
     while (i.hasNext()) {
-      IPSGroupProviderInstance inst = (IPSGroupProviderInstance) i.next();
+      IPSGroupProviderInstance inst = i.next();
       result.put(inst.getName(), inst);
     }
 
@@ -397,18 +398,23 @@ public abstract class PSCataloger {
    * @return a collection with <code>PSSubject</code> objects, each subject with the requested
    *     attributes. Never <code>null</code>, may be empty.
    */
-  protected Collection getSubjects(
-      PSDirectoryDefinition directory, Map filter, Collection attributeNames) {
-    Collection resultList = new ArrayList();
+  @SuppressWarnings("unchecked")
+  protected Collection<PSSubject> getSubjects(
+      PSDirectoryDefinition directory, Map<String, ?> filter, Collection<?> attributeNames) {
+    Collection<PSSubject> resultList = new ArrayList<>();
 
     DirContext context = null;
-    NamingEnumeration results = null;
+    NamingEnumeration<SearchResult> results = null;
 
     try {
       context = createContext(directory);
 
-      Set additionals = new HashSet();
-      if (attributeNames != null) additionals.addAll(attributeNames);
+      Set<String> additionals = new HashSet<>();
+      if (attributeNames != null) {
+        for (Object attrName : attributeNames) {
+          if (attrName != null) additionals.add(attrName.toString());
+        }
+      }
       Set<String> requestedReturns = directory.getReturnAttributeNames(additionals);
       Set<String> returns = new HashSet<>(requestedReturns);
       returns.add(getObjectAttributeName());
@@ -416,13 +422,13 @@ public abstract class PSCataloger {
 
       SearchControls searchControls = createSearchControls(directory.getDirectory(), returnAttrs);
 
-      Map values = new HashMap();
+      Map<String, Object> values = new HashMap<>();
       values.put(PSJndiProvider.OBJECT_CLASS_ATTR, PSJndiProvider.OBJECT_CLASS_PERSON_VAL);
       values.putAll(filter);
 
       results = context.search("", PSJndiUtils.buildFilter(values), searchControls);
       while (results.hasMore()) {
-        resultList.add(createSubject((SearchResult) results.next(), requestedReturns));
+        resultList.add(createSubject(results.next(), requestedReturns));
       }
 
       return resultList;
@@ -456,7 +462,7 @@ public abstract class PSCataloger {
    * A map of <code>PSDirectoryDefinition</code> objects. The key is the directory name as <code>
    * String</code>. Initialized in constructor, never <code>null</code> or changed after that.
    */
-  protected Map m_directories = new HashMap();
+  protected Map<String, PSDirectoryDefinition> m_directories = new HashMap<>();
 
   /**
    * List of IPSGroupProvider objects used by this security provider, never <code>null</code> after

--- a/system/src/main/java/com/percussion/security/PSRoleCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSRoleCataloger.java
@@ -25,6 +25,7 @@ import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSServer;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -45,10 +46,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /** A role cataloger using a directory server as source. */
-@SuppressWarnings(value = {"unchecked"})
 public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCataloger {
   /** Logger to use, never <code>null</code>. */
-  private static Logger log = LogManager.getLogger(PSRoleCataloger.class);
+  private static final Logger log = LogManager.getLogger(PSRoleCataloger.class);
 
   /**
    * Convenience constructor that calls {@link #PSRoleCataloger(Properties, PSServerConfiguration)}
@@ -95,9 +95,10 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
   /**
    * @see IPSInternalRoleCataloger
    */
-  public List getRoles(String subjectName, int subjectType) {
-    List roleList = new ArrayList();
-    Set roleSet = new HashSet();
+  @Override
+  public List<String> getRoles(String subjectName, int subjectType) {
+    List<String> roleList = new ArrayList<>();
+    Set<String> roleSet = new HashSet<>();
 
     // groups not supported
     if (subjectType == PSSubject.SUBJECT_TYPE_GROUP) return roleList;
@@ -106,9 +107,9 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
 
     if (provider.isDirectoryRoleProvider() || provider.isBothProvider()) {
       DirContext context = null;
-      NamingEnumeration results = null;
-      NamingEnumeration attrs = null;
-      NamingEnumeration values = null;
+      NamingEnumeration<SearchResult> results = null;
+      NamingEnumeration<? extends Attribute> attrs = null;
+      NamingEnumeration<?> values = null;
 
       try {
         String objectAttributeName =
@@ -116,7 +117,7 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
         String roleAttrName =
             getDirectorySet().getRequiredAttributeName(PSDirectorySet.ROLE_ATTRIBUTE_KEY);
 
-        Map filterValues = new HashMap();
+        Map<String, Object> filterValues = new HashMap<>();
         if (subjectName != null) {
           if (subjectName.trim().length() == 0)
             filterValues.put(objectAttributeName, PSJndiUtils.WILDCARD_SEARCH);
@@ -126,21 +127,19 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
 
         String[] returnAttributes = {roleAttrName};
 
-        Iterator directories = getDirectories().values().iterator();
-        while (directories.hasNext()) {
+        for (PSDirectoryDefinition directory : getDirectories().values()) {
           String dirName = "";
           try {
-            PSDirectoryDefinition directory = (PSDirectoryDefinition) directories.next();
             dirName = directory.getDirectory().getName();
             context = createContext(directory);
             results = getAttributes(context, directory, filterValues, returnAttributes);
             while (results != null && results.hasMore()) {
-              SearchResult result = (SearchResult) results.next();
+              SearchResult result = results.next();
               Attributes attributes = result.getAttributes();
               if (attributes != null) {
                 attrs = attributes.getAll();
                 while (attrs != null && attrs.hasMore()) {
-                  Attribute attribute = (Attribute) attrs.next();
+                  Attribute attribute = attrs.next();
                   if (attribute.getID().equals(roleAttrName)) {
                     if (!m_roleProvider.isDelimited())
                       roleSet.addAll(getMultiValuedRoles(attribute));
@@ -159,10 +158,14 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
                 dirName,
                 PSExceptionUtils.getMessageForLog(e));
           }
-          results.close();
-          results = null;
-          context.close();
-          context = null;
+          if (results != null) {
+            results.close();
+            results = null;
+          }
+          if (context != null) {
+            context.close();
+            context = null;
+          }
         }
       } catch (NamingException e) {
         // print the error to the console and return an empty list
@@ -191,7 +194,6 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
           } catch (NamingException e) {
             /* noop */
           }
-        ;
       }
     }
 
@@ -203,16 +205,16 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
    * Extract roles from a role attribute that stores values as a multi valued attribute
    *
    * @param attribute the attribute, assumed not <code>null</code>
-   * @return a set of role values that can be merged into a larger role set
    * @param delimiter the delimiter string used to split the values in attribute, assumed not <code>
    *     null</code>
+   * @return a set of role values that can be merged into a larger role set
    * @throws NamingException
    */
-  private Set getDelimitedValuedRoles(Attribute attribute, String delimiter)
+  private Set<String> getDelimitedValuedRoles(Attribute attribute, String delimiter)
       throws NamingException {
     String value = (String) attribute.get();
     String roles[] = value.split(delimiter);
-    Set rval = new HashSet();
+    Set<String> rval = new HashSet<>();
     for (int i = 0; i < roles.length; i++) {
       rval.add(roles[i]);
     }
@@ -226,40 +228,43 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
    * @return a set of role values that can be merged into a larger role set
    * @throws NamingException
    */
-  private Set getMultiValuedRoles(Attribute attribute) throws NamingException {
-    NamingEnumeration values;
-    values = attribute.getAll();
-    Set rval = new HashSet();
+  private Set<String> getMultiValuedRoles(Attribute attribute) throws NamingException {
+    NamingEnumeration<?> values = attribute.getAll();
+    Set<String> rval = new HashSet<>();
     while (values != null && values.hasMore()) {
       String role = (String) values.next();
       if (role != null) rval.add(role);
     }
     values.close();
-    values = null;
     return rval;
   }
 
   /**
    * @see IPSInternalRoleCataloger
    */
-  public Set getSubjects(String roleName, String subjectNameFilter) {
+  @Override
+  public Set<PSSubject> getSubjects(String roleName, String subjectNameFilter) {
     return getSubjects(roleName, subjectNameFilter, 0, null, true);
   }
 
   /**
    * @see IPSInternalRoleCataloger
    */
-  public Set getSubjects(
+  @Override
+  @SuppressWarnings("unchecked")
+  public Set<PSSubject> getSubjects(
       String roleName,
       String subjectNameFilter,
       int subjectType,
       String attributeNameFilter,
       boolean includeEmpty) {
     // groups not supported
-    if (subjectType == PSSubject.SUBJECT_TYPE_GROUP) return new HashSet();
+    if (subjectType == PSSubject.SUBJECT_TYPE_GROUP) return new HashSet<>();
 
     // use treeset to prevent duplicates and enforce ordering
-    Set results = new TreeSet(PSSubject.getSubjectIdentifierComparator());
+    Comparator<PSSubject> subjectComparator =
+        (Comparator<PSSubject>) PSSubject.getSubjectIdentifierComparator();
+    Set<PSSubject> results = new TreeSet<>(subjectComparator);
     String plainRoleName = roleName;
     if (roleName != null && m_roleProvider.isDelimited()) {
       roleName = "*" + roleName + "*";
@@ -269,7 +274,7 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
     // handles all directory connection security providers
     if (provider.isDirectoryRoleProvider() || provider.isBothProvider()) {
       PSDirectorySet directorySet = getDirectorySet();
-      Map filterValues = new HashMap();
+      Map<String, Object> filterValues = new HashMap<>();
       if (!StringUtils.isBlank(roleName)) {
         String roleAttrName =
             directorySet.getRequiredAttributeName(PSDirectorySet.ROLE_ATTRIBUTE_KEY);
@@ -281,18 +286,16 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
             getObjectAttributeName(), PSJndiUtils.translateSQLFilter(subjectNameFilter));
       }
 
-      Set additionals = null;
+      Set<String> additionals = null;
       if (attributeNameFilter != null && attributeNameFilter.trim().length() > 0) {
         filterValues.put(attributeNameFilter, PSJndiUtils.WILDCARD_SEARCH);
-        additionals = new HashSet();
+        additionals = new HashSet<>();
         additionals.add(attributeNameFilter);
       }
 
-      Iterator directories = getDirectories().values().iterator();
-      while (directories.hasNext()) {
+      for (PSDirectoryDefinition directory : getDirectories().values()) {
         String dirName = "";
         try {
-          PSDirectoryDefinition directory = (PSDirectoryDefinition) directories.next();
           dirName = directory.getDirectory().getName();
 
           if (provider.isDirectoryRoleProvider() || provider.isBothProvider())
@@ -323,12 +326,10 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
    * @param results the original results, assumed not <code>null</code>
    * @return the new results
    */
-  private Set filterResultsByRoleAttribute(String roleName, Set results) {
-    Set rval = new HashSet();
-    Iterator iter = results.iterator();
-    while (iter.hasNext()) {
-      PSGlobalSubject user = (PSGlobalSubject) iter.next();
-      List roles = getRoles(user.getName(), 0);
+  private Set<PSSubject> filterResultsByRoleAttribute(String roleName, Set<PSSubject> results) {
+    Set<PSSubject> rval = new HashSet<>();
+    for (PSSubject user : results) {
+      List<String> roles = getRoles(user.getName(), 0);
       if (roles.contains(roleName)) rval.add(user);
     }
     return rval;
@@ -337,6 +338,7 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
   /**
    * @see IPSInternalRoleCataloger
    */
+  @Override
   public PSRoleProvider getProvider() {
     return m_roleProvider;
   }
@@ -351,7 +353,10 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
    *     <code>null</code>.
    */
   protected void getSubjects(
-      PSDirectoryDefinition directory, Map filterValues, Set results, Set additionals) {
+      PSDirectoryDefinition directory,
+      Map<String, ?> filterValues,
+      Set<PSSubject> results,
+      Set<String> additionals) {
     results.addAll(getSubjects(directory, filterValues, additionals));
   }
 
@@ -370,8 +375,11 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
    * @throws NamingException for any JNDI lookup error.
    */
   // TODO: Remove me @SuppressFBWarnings("LDAP_INJECTION") //Mitigated in PSJndiUtils.buildFilter
-  private NamingEnumeration getAttributes(
-      DirContext context, PSDirectoryDefinition directory, Map filterValues, String[] returnAttrs)
+  private NamingEnumeration<SearchResult> getAttributes(
+      DirContext context,
+      PSDirectoryDefinition directory,
+      Map<String, Object> filterValues,
+      String[] returnAttrs)
       throws NamingException {
     context = createContext(directory);
     SearchControls searchControls = createSearchControls(directory.getDirectory(), returnAttrs);

--- a/system/src/test/java/com/percussion/security/PSBackendCatalogerAttributesTest.java
+++ b/system/src/test/java/com/percussion/security/PSBackendCatalogerAttributesTest.java
@@ -19,19 +19,32 @@ package com.percussion.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSAttributeList;
+import com.percussion.design.objectstore.PSSubject;
 import java.io.StringReader;
+import java.util.List;
+import java.util.Set;
 import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 
 /**
- * Regression: empty Attribute shells from outer-join subject catalogs must not fail findUsers
- * (PSRoleMgr log spam: Attribute @name null).
+ * Behavioral tests for typed backend cataloger attribute/subject parsing (issue #2386 residual
+ * security cataloger rawtypes batch after #2299 / PR #2387).
+ *
+ * <p>Also covers regression: empty Attribute shells from outer-join subject catalogs must not fail
+ * findUsers (PSRoleMgr log spam: Attribute @name null).
  */
+@Tag("UnitTest")
 public class PSBackendCatalogerAttributesTest {
 
   @Test
@@ -72,5 +85,143 @@ public class PSBackendCatalogerAttributesTest {
 
     PSAttributeList attrs = PSBackendCataloger.getAttributes(doc.getDocumentElement());
     assertEquals(0, attrs.size());
+  }
+
+  @Test
+  void getValuesReturnsTypedStringList() throws Exception {
+    String xml =
+        """
+        <Attribute name="sys_defaultCommunity">
+          <Value>Default</Value>
+          <Value>Engineering</Value>
+        </Attribute>
+        """;
+    Document doc =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+
+    List<String> values = PSBackendCataloger.getValues(doc.getDocumentElement());
+    assertNotNull(values);
+    assertEquals(List.of("Default", "Engineering"), values);
+  }
+
+  @Test
+  void getValuesReturnsNullWhenNoValueNodes() throws Exception {
+    String xml = """
+        <Attribute name="sys_defaultCommunity"/>
+        """;
+    Document doc =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+
+    assertNull(PSBackendCataloger.getValues(doc.getDocumentElement()));
+  }
+
+  @Test
+  void processCatalogedSubjectsMergesDuplicateSubjectsAndAttributes() throws Exception {
+    String xml =
+        """
+        <Subjects>
+          <Subject name="Admin" type="1">
+            <Attribute name="sys_defaultCommunity">
+              <Value>Default</Value>
+            </Attribute>
+          </Subject>
+          <Subject name="Admin" type="1">
+            <Attribute name="sys_email">
+              <Value>admin@example.com</Value>
+            </Attribute>
+          </Subject>
+          <Subject name="Editor" type="1">
+            <Attribute name="sys_defaultCommunity">
+              <Value>Engineering</Value>
+            </Attribute>
+          </Subject>
+        </Subjects>
+        """;
+    Document doc =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+
+    Set<PSSubject> subjects =
+        PSBackendCataloger.processCatalogedSubjects(doc.getDocumentElement(), false);
+
+    assertEquals(2, subjects.size());
+
+    PSSubject admin = findByName(subjects, "Admin");
+    assertNotNull(admin);
+    assertEquals(PSSubject.SUBJECT_TYPE_USER, admin.getType());
+    PSAttribute community = admin.getAttributes().getAttribute("sys_defaultCommunity");
+    assertNotNull(community);
+    assertEquals("Default", community.getValues().get(0));
+    PSAttribute email = admin.getAttributes().getAttribute("sys_email");
+    assertNotNull(email);
+    assertEquals("admin@example.com", email.getValues().get(0));
+
+    PSSubject editor = findByName(subjects, "Editor");
+    assertNotNull(editor);
+    assertEquals(
+        "Engineering",
+        editor.getAttributes().getAttribute("sys_defaultCommunity").getValues().get(0));
+  }
+
+  @Test
+  void processCatalogedSubjectsCanIncludeEmptyAttributeSubjects() throws Exception {
+    String xml =
+        """
+        <Subjects>
+          <Subject name="EmptyUser" type="1">
+            <Attribute context="global"/>
+          </Subject>
+        </Subjects>
+        """;
+    Document doc =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+
+    Set<PSSubject> withEmpty =
+        PSBackendCataloger.processCatalogedSubjects(doc.getDocumentElement(), true);
+    assertEquals(1, withEmpty.size());
+    assertEquals(0, withEmpty.iterator().next().getAttributes().size());
+
+    Set<PSSubject> withoutEmpty =
+        PSBackendCataloger.processCatalogedSubjects(doc.getDocumentElement(), false);
+    assertTrue(withoutEmpty.isEmpty());
+  }
+
+  @Test
+  void processSubjectAttributesRejectsWrongRootElement() throws Exception {
+    String xml = """
+        <Roles/>
+        """;
+    Document doc =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+
+    assertThrows(
+        PSSecurityException.class,
+        () -> PSBackendCataloger.processSubjectAttributes(doc, true));
+  }
+
+  @Test
+  void processSubjectAttributesEmptyDocumentReturnsEmptyList() throws Exception {
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    List<PSSubject> subjects = PSBackendCataloger.processSubjectAttributes(doc, true);
+    assertNotNull(subjects);
+    assertTrue(subjects.isEmpty());
+  }
+
+  private static PSSubject findByName(Set<PSSubject> subjects, String name) {
+    for (PSSubject subject : subjects) {
+      if (name.equals(subject.getName())) {
+        return subject;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
Partial fix for **#2386** (parent epic **#2022**, residual of **#2299** / PR #2387, grandparent **#2200**).

PR-sized **security residual** batch: real generics on the role/backend cataloger stack (not HTTPClient — re-filed as residual).

### Changed
- `IPSInternalRoleCataloger` — `List<String>` / `Set<PSSubject>`
- `PSBackendCataloger` — typed attributes/subjects/filters; removed class-level `@SuppressWarnings`
- `PSBackendRoleCataloger` / `PSRoleCataloger` — implement typed interface
- `PSCataloger` — typed directory map, subject collection, filter helpers
- `PSBackEndDirectoryCataloger` — call-site alignment with typed `getSubjects`

Targeted residual `@SuppressWarnings` only at raw `Comparator` / `PSCollection.iterator()` boundaries from objectstore.

### Out of scope (residuals)
- `PSRoleManager` remaining rawtypes / class-level suppress
- `PSJndiGroupProvider` residual internals
- `HTTPClient` package rawtypes cluster
- design/cms objectstore and data.jdbc (owned by other slices)

## Test plan
- [x] `cd system && ../mvnw.cmd clean test -Dtest=PSBackendCatalogerAttributesTest` → **Tests run: 8, Failures: 0**
- [x] `cd system && ../mvnw.cmd clean install` (tests phase) → **Tests run: 1280, Failures: 0, Errors: 0, Skipped: 240**
- [x] `cd system && ../mvnw.cmd install -DskipTests` completed package/install after green test run (**BUILD SUCCESS**)
- [x] No new warnings attributable to this change on the edited security files

## Gates
- Erlang-style self-review: real generics, portable (no path I/O), companions = unit tests on parse/typing behavior
- Pre-PR Maven: standalone `system` clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

## Links
- Fixes partially: #2386
- Parent tracker: #2022
- Related: #2299 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.