### PR TITLE
fix(perc-system): design.objectstore this-escape real-fix batch (#2404)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2404-design-objectstore-this-escape-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2404-design-objectstore-this-escape-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — #2404 design.objectstore this-escape batch
+
+**Status:** pass (self-review before commit)  
+**Date:** 2026-08-08  
+**Module:** `system` / perc-system
+
+## Change class
+
+Real `-Xlint:this-escape` reduction in `design.objectstore` (+ foundation `PSDbComponent.createKey` path): private non-overridable helpers / final leaf methods called from ctors/fromXml. **No** blanket `@SuppressWarnings("this-escape")`.
+
+## Findings
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| none | Bugs in ctor/fromXml behavior | Covered by existing XML tests + new `PSDesignObjectStoreThisEscapeTest` (9 tests) |
+| none | Non-portable paths | N/A (no file I/O changes) |
+| note | Residual ~200+ this-escape in design.objectstore | File residual child issues (not suppress) |
+| note | `PSDataSet`/`PSBackEndColumn`/`PSEntry`/`PSUrlRequest` keep overridable `fromXml` for subclasses via private `fromXmlBase` | Correct pattern |
+| note | Leaf types use `final` on methods called from ctors | No subclass overrides verified before finalizing |
+
+## Tests
+
+- `cd system && ../mvnw clean install` — BUILD SUCCESS  
+- Tests run: 1287, Failures: 0, Errors: 0  
+- New: `PSDesignObjectStoreThisEscapeTest` 9/9 pass  
+
+## Hard gates
+
+- [x] Behavioral unit tests for ctor/fromXml  
+- [x] No suppress-only this-escape  
+- [x] Cross-platform N/A  
+- [x] Module clean install green  

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
@@ -345,8 +345,11 @@ public abstract class PSDbComponent implements IPSDbComponent {
       nodeName = getNodeName();
     }
 
-    // Must restore key first because it has higher priority than state
-    setLocatorInternal(createKey(PSXMLDomUtil.getFirstElementChild(source)));
+    // Must restore key first because it has higher priority than state.
+    // Element super-ctor path uses non-overridable default createKey to avoid
+    // this-escape; public fromXml (after full construction) still uses virtual createKey.
+    Element keyEl = PSXMLDomUtil.getFirstElementChild(source);
+    setLocatorInternal(checkNodeName ? createKey(keyEl) : createKeyDefault(keyEl));
 
     // Threshold
     String strState = PSXMLDomUtil.checkAttribute(source, XML_ATTR_STATE, false);
@@ -408,6 +411,16 @@ public abstract class PSDbComponent implements IPSDbComponent {
    * @return Never <code>null</code>.
    */
   protected PSKey createKey(Element el) throws PSUnknownNodeTypeException {
+    return createKeyDefault(el);
+  }
+
+  /**
+   * Default key restoration used by {@link #createKey(Element)} and by the Element super-ctor path
+   * in {@link #fromXmlBase(Element, boolean)} (non-virtual, this-escape safe). Subclasses may still
+   * override {@link #createKey(Element)}; that override is honored from public {@link
+   * #fromXml(Element)} after construction.
+   */
+  private PSKey createKeyDefault(Element el) throws PSUnknownNodeTypeException {
     if (el == null) throw new IllegalArgumentException("Source element cannot be null.");
 
     String strNodeName = el.getNodeName();

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
@@ -419,48 +419,64 @@ public abstract class PSDbComponent implements IPSDbComponent {
    * in {@link #fromXmlBase(Element, boolean)} (non-virtual, this-escape safe). Subclasses may still
    * override {@link #createKey(Element)}; that override is honored from public {@link
    * #fromXml(Element)} after construction.
+   *
+   * <p>Resolves the key class from the element node name (PSXFoo → PSFoo) by trying known key
+   * packages in order: {@code com.percussion.cms.objectstore} first (typical {@link PSKey} /
+   * {@link PSSimpleKey}), then {@code com.percussion.design.objectstore} (e.g. {@code PSLocator}).
+   * Virtual {@link #createKey(Element)} overrides remain the path for specialized keys after full
+   * construction.
    */
   private PSKey createKeyDefault(Element el) throws PSUnknownNodeTypeException {
     if (el == null) throw new IllegalArgumentException("Source element cannot be null.");
 
     String strNodeName = el.getNodeName();
-    String strClassName = "com.percussion.cms.objectstore.";
-    if (strNodeName.startsWith("PSX"))
-      strClassName += PSStringOperation.replace(strNodeName, "PSX", "PS");
-    else strClassName += strNodeName;
+    String simpleName =
+        strNodeName.startsWith("PSX")
+            ? PSStringOperation.replace(strNodeName, "PSX", "PS")
+            : strNodeName;
 
-    PSKey key = null;
+    // Non-virtual package search — no subclass createKey during Element super-ctor.
+    final String[] keyPackages = {
+      "com.percussion.cms.objectstore.", "com.percussion.design.objectstore."
+    };
 
-    try {
-
-      Class<? extends PSKey> c = (Class<? extends PSKey>) Class.forName(strClassName);
-      Constructor<? extends PSKey> ctor = c.getConstructor(Element.class);
-      key = ctor.newInstance(el);
-    } catch (ClassNotFoundException cnfe) {
-      String[] args = {strClassName, getComponentType(), cnfe.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
-    } catch (InstantiationException ie) {
-      String[] args = {strClassName, getComponentType(), ie.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
-    } catch (IllegalAccessException iae) {
-      String[] args = {strClassName, getComponentType(), iae.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
-    } catch (InvocationTargetException ite) {
-      Throwable origException = ite.getTargetException();
-      String msg = origException.getLocalizedMessage();
-      String[] args = {
-        strClassName, getComponentType(), origException.getClass().getName() + ": " + msg
-      };
-      throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
-    } catch (NoSuchMethodException nsme) {
-      String[] args = {strClassName, getComponentType(), nsme.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
-    } catch (IllegalArgumentException iae) {
-      // this should never happen because we checked ahead of time
-      throw new RuntimeException("Ctor parameter count changed unexpectedly.");
+    String lastClassName = keyPackages[0] + simpleName;
+    ClassNotFoundException lastCnfe = null;
+    for (String pkg : keyPackages) {
+      String strClassName = pkg + simpleName;
+      lastClassName = strClassName;
+      try {
+        Class<? extends PSKey> c = (Class<? extends PSKey>) Class.forName(strClassName);
+        Constructor<? extends PSKey> ctor = c.getConstructor(Element.class);
+        return ctor.newInstance(el);
+      } catch (ClassNotFoundException cnfe) {
+        lastCnfe = cnfe;
+        // try next package
+      } catch (InstantiationException ie) {
+        String[] args = {strClassName, getComponentType(), ie.getLocalizedMessage()};
+        throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
+      } catch (IllegalAccessException iae) {
+        String[] args = {strClassName, getComponentType(), iae.getLocalizedMessage()};
+        throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
+      } catch (InvocationTargetException ite) {
+        Throwable origException = ite.getTargetException();
+        String msg = origException.getLocalizedMessage();
+        String[] args = {
+          strClassName, getComponentType(), origException.getClass().getName() + ": " + msg
+        };
+        throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
+      } catch (NoSuchMethodException nsme) {
+        String[] args = {strClassName, getComponentType(), nsme.getLocalizedMessage()};
+        throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
+      } catch (IllegalArgumentException iae) {
+        // this should never happen because we checked ahead of time
+        throw new RuntimeException("Ctor parameter count changed unexpectedly.");
+      }
     }
 
-    return key;
+    String cnfeMsg = lastCnfe != null ? lastCnfe.getLocalizedMessage() : "class not found";
+    String[] args = {lastClassName, getComponentType(), cnfeMsg};
+    throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
   }
 
   // see interface for description

--- a/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
@@ -86,7 +86,7 @@ public class PSAcl extends PSComponent {
    * @see PSAclEntry
    * @see #getEntries
    */
-  public void setEntries(com.percussion.util.PSCollection entries) {
+  public final void setEntries(com.percussion.util.PSCollection entries) {
     IllegalArgumentException ex = validateEntries(entries);
     if (ex != null) throw ex;
 
@@ -408,7 +408,7 @@ public class PSAcl extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXAcl
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
@@ -199,7 +199,7 @@ public class PSAclEntry extends PSComponent {
    * @param name the name of the user, group or role to associate with this entry. This is limited
    *     to 255 characters.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     IllegalArgumentException ex = validateName(name);
     if (ex != null) throw ex;
 
@@ -286,7 +286,7 @@ public class PSAclEntry extends PSComponent {
    *     application ACE, specify one or more PSAclEntry.AACE_ flag. Server and application flags
    *     cannot be combined.
    */
-  public void setAccessLevel(int level) {
+  public final void setAccessLevel(int level) {
     boolean isServer = false;
     boolean isApplication = false;
 
@@ -518,7 +518,7 @@ public class PSAclEntry extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXAclEntry
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
@@ -164,7 +164,7 @@ public class PSApplicationFlow extends PSComponent {
    * @throws IllegalArgumentException if the provided command handler name is <code>null</code> or
    *     empty or if the redirect is <code>null</code>.
    */
-  public void setDefaultRedirect(String name, PSUrlRequest redirect) {
+  public final void setDefaultRedirect(String name, PSUrlRequest redirect) {
     validate(name);
     if (redirect == null) throw new IllegalArgumentException("the redirect cannot be null");
 
@@ -209,7 +209,7 @@ public class PSApplicationFlow extends PSComponent {
    * @throws IllegalArgumentException if the provided command handler name is <code>null</code> or
    *     empty or if the redirect collection is <code>null</code>.
    */
-  public void addRedirects(String name, PSCollection redirects) {
+  public final void addRedirects(String name, PSCollection redirects) {
     validate(name);
     validate(redirects);
 
@@ -227,7 +227,7 @@ public class PSApplicationFlow extends PSComponent {
    *     empty or if the redirect collection is <code>null</code> or if no command handler was found
    *     for the provided name.
    */
-  public void addConditionalRedirects(String name, PSCollection redirects) {
+  public final void addConditionalRedirects(String name, PSCollection redirects) {
     validate(name);
     if (redirects == null) throw new IllegalArgumentException("the redirects cannot be null");
 
@@ -289,7 +289,7 @@ public class PSApplicationFlow extends PSComponent {
    *
    * @param c a valid PSApplicationFlow, not <code>null</code>.
    */
-  public void copyFrom(PSApplicationFlow c) {
+  public final void copyFrom(PSApplicationFlow c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
@@ -317,7 +317,7 @@ public class PSApplicationFlow extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
@@ -100,7 +100,7 @@ public class PSAuthentication extends PSComponent {
    *
    * @param name the new name to set, not <code>null</code> or empty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null) throw new IllegalArgumentException("name cannot be null");
 
     name = name.trim();
@@ -346,7 +346,7 @@ public class PSAuthentication extends PSComponent {
    * @see IPSComponent
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
@@ -52,8 +52,8 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
    */
   public PSBackEndColumn(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
-    // allow subclasses to override (don't use "this")
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private path avoids virtual fromXml (e.g. PSSortedColumn) during construction.
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
 
   /**
@@ -106,7 +106,7 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
    *
    * @param table the back-end table containing the column
    */
-  public void setTable(PSBackEndTable table) {
+  public final void setTable(PSBackEndTable table) {
     IllegalArgumentException ex = validateTable(table);
     if (ex != null) throw ex;
 
@@ -133,7 +133,7 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
    *
    * @param name the name of the name of the back-end column
    */
-  public void setColumn(String name) {
+  public final void setColumn(String name) {
     IllegalArgumentException ex = validateColumn(name);
     if (ex != null) throw ex;
 
@@ -441,6 +441,15 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndColumn
    */
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Shared load for {@link #fromXml} and the Element constructor. Avoids virtual fromXml dispatch
+   * (e.g. {@link PSSortedColumn}) before subclass fields are initialized.
+   */
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
@@ -107,7 +107,7 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
    *     is non-unique, an exception will be thrown when the application or server containing this
    *     entry is saved.
    */
-  public void setAlias(java.lang.String alias) {
+  public final void setAlias(java.lang.String alias) {
     IllegalArgumentException ex = validateAlias(alias);
 
     if (ex != null) throw ex;
@@ -125,7 +125,7 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
   /**
    * @param dataSource The dataSource to set.
    */
-  public void setDataSource(String dataSource) {
+  public final void setDataSource(String dataSource) {
     m_dataSource = dataSource;
   }
 
@@ -316,7 +316,7 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
    * @exception PSUnknownNodeTypeException if the XML element node is not of type
    *     PSXBackEndCredential
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
@@ -154,7 +154,7 @@ public class PSBackEndTable extends PSComponent {
    *     used in the data tank. If it is non-unique, an exception will be thrown when the back-end
    *     table is associated with a data tank.
    */
-  public void setAlias(java.lang.String alias) {
+  public final void setAlias(java.lang.String alias) {
     IllegalArgumentException ex = validateAlias(alias);
     if (ex != null) throw ex;
 
@@ -181,7 +181,7 @@ public class PSBackEndTable extends PSComponent {
   /**
    * @param dataSource The dataSource to set.
    */
-  public void setDataSource(String dataSource) {
+  public final void setDataSource(String dataSource) {
     m_dataSource = dataSource;
   }
 
@@ -223,7 +223,7 @@ public class PSBackEndTable extends PSComponent {
    *
    * @param table the name of the back-end table.
    */
-  public void setTable(java.lang.String table) {
+  public final void setTable(java.lang.String table) {
     if (table == null) table = "";
 
     IllegalArgumentException ex = validateTable(table);
@@ -296,7 +296,7 @@ public class PSBackEndTable extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndTable
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
@@ -130,7 +130,7 @@ public class PSChoices extends PSComponent {
    *
    * @param sortOrder the new sort order (ascending | descending | user).
    */
-  public void setSortOrder(int sortOrder) {
+  public final void setSortOrder(int sortOrder) {
     if (sortOrder != SORT_ORDER_ASCENDING
         && sortOrder != SORT_ORDER_DESCENDING
         && sortOrder != SORT_ORDER_USER) throw new IllegalArgumentException("unkown sort order");
@@ -152,7 +152,7 @@ public class PSChoices extends PSComponent {
    *
    * @param global the new global choice table ID.
    */
-  public void setGlobal(int global) {
+  public final void setGlobal(int global) {
     if (global < 0) throw new IllegalArgumentException("invalid global choice ID");
 
     m_global = global;
@@ -173,7 +173,7 @@ public class PSChoices extends PSComponent {
    *
    * @param local a collection of PSEntry objects, not <code>null</code> might be empty.
    */
-  public void setLocal(PSCollection local) {
+  public final void setLocal(PSCollection local) {
     if (local == null) throw new IllegalArgumentException("the collection cannot be null");
 
     if (!local.getMemberClassName().equals(m_local.getMemberClassName()))
@@ -199,7 +199,7 @@ public class PSChoices extends PSComponent {
    * @param lookup the new lookup request, might be <code>null</code>.
    * @param type the lookup type to create, can only be TYPE_LOOKUP or TYPE_INTERNAL_LOOKUP.
    */
-  public void setLookup(PSUrlRequest lookup, int type) {
+  public final void setLookup(PSUrlRequest lookup, int type) {
     if (lookup == null) throw new IllegalArgumentException("lookup cannot be null");
     if (type != TYPE_LOOKUP && type != TYPE_INTERNAL_LOOKUP)
       throw new IllegalArgumentException("type must be TYPE_LOOKUP or TYPE_INTERNAL_LOOKUP");
@@ -222,7 +222,7 @@ public class PSChoices extends PSComponent {
    *
    * @param tableinfo the new PSChoiceTableInfo object.
    */
-  public void setTableInfo(PSChoiceTableInfo tableinfo) {
+  public final void setTableInfo(PSChoiceTableInfo tableinfo) {
     if (tableinfo == null) throw new IllegalArgumentException("tableinfo cannot be null");
 
     m_tableInfo = tableinfo;
@@ -243,7 +243,7 @@ public class PSChoices extends PSComponent {
    *
    * @param nullEntry the new null entry, might be <code>null</code>.
    */
-  public void setNullEntry(PSNullEntry nullEntry) {
+  public final void setNullEntry(PSNullEntry nullEntry) {
     m_nullEntry = nullEntry;
   }
 
@@ -269,7 +269,7 @@ public class PSChoices extends PSComponent {
    *
    * @param choiceFilter may be <code>null</code>.
    */
-  public void setChoiceFilter(PSChoiceFilter choiceFilter) {
+  public final void setChoiceFilter(PSChoiceFilter choiceFilter) {
     m_choiceFilter = choiceFilter;
   }
 
@@ -280,7 +280,7 @@ public class PSChoices extends PSComponent {
    *     empty.
    * @throws IllegalArgumentException if the provided collection is of wrong objects types.
    */
-  public void setDefaultSelected(PSCollection defaultSelected) {
+  public final void setDefaultSelected(PSCollection defaultSelected) {
     if (defaultSelected != null
         && !defaultSelected.getMemberClassName().equals(m_defaultSelected.getMemberClassName()))
       throw new IllegalArgumentException("PSDefaultSelected collection expected");
@@ -348,7 +348,7 @@ public class PSChoices extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
@@ -130,7 +130,7 @@ public class PSCommandHandlerStylesheets extends PSComponent {
    * @throws IllegalArgumentException if the provided command handler name is <code>null</code> or
    *     empty or if the stylesheet is <code>null</code>.
    */
-  public void setDefaultStylesheet(String name, PSStylesheet stylesheet) {
+  public final void setDefaultStylesheet(String name, PSStylesheet stylesheet) {
     validate(name);
     if (stylesheet == null) throw new IllegalArgumentException("the stylesheet cannot be null");
 
@@ -174,7 +174,7 @@ public class PSCommandHandlerStylesheets extends PSComponent {
    * @throws IllegalArgumentException if the provided command handler name is <code>null</code> or
    *     empty or if the stylesheet collection is <code>null</code> or empty.
    */
-  public void addStylesheets(String name, PSCollection stylesheets) {
+  public final void addStylesheets(String name, PSCollection stylesheets) {
     validate(name);
     validate(stylesheets);
 
@@ -192,7 +192,7 @@ public class PSCommandHandlerStylesheets extends PSComponent {
    *     empty or if the stylesheet collection is <code>null</code> or if no command handler was
    *     found for the provided name.
    */
-  public void addConditionalStylesheets(String name, PSCollection stylesheets) {
+  public final void addConditionalStylesheets(String name, PSCollection stylesheets) {
     validate(name);
     if (stylesheets == null) throw new IllegalArgumentException("the stylesheets cannot be null");
 
@@ -254,7 +254,7 @@ public class PSCommandHandlerStylesheets extends PSComponent {
    *
    * @param c a valid PSCommandHandlerStylesheets, not <code>null</code>.
    */
-  public void copyFrom(PSCommandHandlerStylesheets c) {
+  public final void copyFrom(PSCommandHandlerStylesheets c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
@@ -282,7 +282,7 @@ public class PSCommandHandlerStylesheets extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
@@ -171,7 +171,7 @@ public class PSConditionalExit extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
@@ -105,7 +105,7 @@ public class PSConditionalRequest extends PSUrlRequest {
    * @throws IllegalArgumentException if the provided conditions are <code>null</code>, empty or of
    *     a wrong type.
    */
-  public void setConditions(PSCollection conditions) {
+  public final void setConditions(PSCollection conditions) {
     if (conditions == null || conditions.isEmpty())
       throw new IllegalArgumentException("conditions cannot be null or empty");
 
@@ -156,7 +156,7 @@ public class PSConditionalRequest extends PSUrlRequest {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
@@ -130,7 +130,7 @@ public class PSConditionalStylesheet extends PSStylesheet {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
@@ -199,7 +199,7 @@ public class PSContentEditor extends PSDataSet {
    * @param name the content editor name, not <code>null</code> or empty.
    */
   @Override
-  public void setName(String name) {
+  public final void setName(String name) {
     try {
       super.setName(name);
     } catch (IllegalArgumentException e) {
@@ -628,7 +628,7 @@ public class PSContentEditor extends PSDataSet {
    *      com.percussion.design.objectstore.IPSDocument, java.util.ArrayList)
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
@@ -125,7 +125,7 @@ public class PSContentEditorMapper extends PSComponent {
    * @param systemFieldExcludes the new list of system field excludes, may be <code>null</code> or
    *     empty.
    */
-  public void setSystemFieldExcludes(ArrayList systemFieldExcludes) {
+  public final void setSystemFieldExcludes(ArrayList systemFieldExcludes) {
     if (systemFieldExcludes == null) m_systemFieldExcludes = new ArrayList();
     else m_systemFieldExcludes = systemFieldExcludes;
   }
@@ -146,7 +146,7 @@ public class PSContentEditorMapper extends PSComponent {
    * @param sharedFieldIncludes the new list of shared field group names (String) included, may be
    *     <code>null</code> or empty.
    */
-  public void setSharedFieldIncludes(ArrayList sharedFieldIncludes) {
+  public final void setSharedFieldIncludes(ArrayList sharedFieldIncludes) {
     if (sharedFieldIncludes == null) m_sharedFieldIncludes = new ArrayList();
     else m_sharedFieldIncludes = sharedFieldIncludes;
   }
@@ -167,7 +167,7 @@ public class PSContentEditorMapper extends PSComponent {
    * @param sharedFieldExcludes the new list of shared field excludes, may be <code>null</code> or
    *     empty.
    */
-  public void setSharedFieldExcludes(ArrayList sharedFieldExcludes) {
+  public final void setSharedFieldExcludes(ArrayList sharedFieldExcludes) {
     if (sharedFieldExcludes == null) m_sharedFieldExcludes = new ArrayList();
     else m_sharedFieldExcludes = sharedFieldExcludes;
   }
@@ -186,7 +186,7 @@ public class PSContentEditorMapper extends PSComponent {
    *
    * @param fieldSet the new field set, never <code>null</code>.
    */
-  public void setFieldSet(PSFieldSet fieldSet) {
+  public final void setFieldSet(PSFieldSet fieldSet) {
     if (fieldSet == null) throw new IllegalArgumentException("fieldSet cannot be null");
 
     m_fieldSet = fieldSet;
@@ -206,7 +206,7 @@ public class PSContentEditorMapper extends PSComponent {
    *
    * @param uiDefinition the new UI definition, never <code>null</code>.
    */
-  public void setUIDefinition(PSUIDefinition uiDefinition) {
+  public final void setUIDefinition(PSUIDefinition uiDefinition) {
     if (uiDefinition == null) throw new IllegalArgumentException("uiDefinition cannot be null");
 
     m_uiDefinition = uiDefinition;
@@ -218,7 +218,7 @@ public class PSContentEditorMapper extends PSComponent {
    *
    * @param c a valid PSContentEditorMapper, not <code>null</code>.
    */
-  public void copyFrom(PSContentEditorMapper c) {
+  public final void copyFrom(PSContentEditorMapper c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
@@ -262,7 +262,7 @@ public class PSContentEditorMapper extends PSComponent {
    * @see IPSComponent
    */
   // $NON-NLS-1$
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
@@ -80,7 +80,7 @@ public class PSContentEditorPipe extends PSPipe {
    *
    * @param locator the new locator, never <code>null</code>.
    */
-  public void setLocator(PSContainerLocator locator) {
+  public final void setLocator(PSContainerLocator locator) {
     if (locator == null) throw new IllegalArgumentException("locator cannot be null");
 
     m_locator = locator;
@@ -100,7 +100,7 @@ public class PSContentEditorPipe extends PSPipe {
    *
    * @param mapper the new mapper, not <code>null</code>.
    */
-  public void setMapper(PSContentEditorMapper mapper) {
+  public final void setMapper(PSContentEditorMapper mapper) {
     if (mapper == null) throw new IllegalArgumentException("mapper cannot be null");
 
     m_mapper = mapper;
@@ -160,7 +160,7 @@ public class PSContentEditorPipe extends PSPipe {
    *
    * @param c a valid PSContentEditorPipe, not <code>null</code>.
    */
-  public void copyFrom(PSContentEditorPipe c) {
+  public final void copyFrom(PSContentEditorPipe c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
@@ -226,7 +226,7 @@ public class PSContentEditorPipe extends PSPipe {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
@@ -57,7 +57,8 @@ public class PSDataSet extends PSComponent {
   public PSDataSet(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     this();
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private path avoids virtual fromXml (e.g. PSContentEditor) during super construction.
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
 
   /** Constructor for serialization, fromXml, etc. */
@@ -74,7 +75,7 @@ public class PSDataSet extends PSComponent {
    * @see #setName
    */
   public PSDataSet(String name) {
-    setName(name);
+    applyName(name);
   }
 
   /**
@@ -94,6 +95,11 @@ public class PSDataSet extends PSComponent {
    *     server.
    */
   public void setName(String name) {
+    applyName(name);
+  }
+
+  /** Non-overridable name assignment for construction and {@link #setName(String)}. */
+  private void applyName(String name) {
     IllegalArgumentException ex = validateName(name);
     if (ex != null) throw ex;
 
@@ -637,6 +643,15 @@ public class PSDataSet extends PSComponent {
    */
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Shared load for {@link #fromXml} and the Element constructor. Avoids virtual fromXml dispatch
+   * (e.g. {@link PSContentEditor}) before subclass fields are initialized.
+   */
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;
 
@@ -660,7 +675,7 @@ public class PSDataSet extends PSComponent {
       }
 
       try { // private          String          m_name = "";
-        setName(tree.getElementData("name"));
+        applyName(tree.getElementData("name"));
       } catch (IllegalArgumentException e) {
         throw new PSUnknownNodeTypeException(
             ms_NodeType, "name", new PSException(e.getLocalizedMessage()));

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
@@ -97,7 +97,7 @@ public class PSDirectory extends PSComponent {
    *
    * @param name the new name for this directory, not <code>null</code> or empty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null) throw new IllegalArgumentException("name cannot be null");
 
     name = name.trim();
@@ -344,7 +344,7 @@ public class PSDirectory extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
@@ -77,7 +77,7 @@ public class PSDirectorySet extends PSCollectionComponent {
    *
    * @param name the new name for this directory set, not <code>null</code> or empty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null) throw new IllegalArgumentException("name cannot be null");
 
     name = name.trim();
@@ -156,7 +156,7 @@ public class PSDirectorySet extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
@@ -90,7 +90,7 @@ public class PSDisplayMapper extends PSCollectionComponent {
    *
    * @param fieldSetRef the new field set reference name, never <code>null</code> or empty.
    */
-  public void setFieldSetRef(String fieldSetRef) {
+  public final void setFieldSetRef(String fieldSetRef) {
     if (fieldSetRef == null || fieldSetRef.trim().length() == 0)
       throw new IllegalArgumentException("field set reference annot be null or empty");
 
@@ -103,7 +103,7 @@ public class PSDisplayMapper extends PSCollectionComponent {
    *
    * @param c a valid PSDisplayMapper, not <code>null</code>.
    */
-  public void copyFrom(PSDisplayMapper c) {
+  public final void copyFrom(PSDisplayMapper c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
@@ -151,7 +151,7 @@ public class PSDisplayMapper extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
@@ -169,7 +169,7 @@ public class PSDisplayMapping extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayText.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayText.java
@@ -66,7 +66,7 @@ public class PSDisplayText extends PSComponent {
    *
    * @param text the new display text, not <code>null</code>, may be empty.
    */
-  public void setText(String text) {
+  public final void setText(String text) {
     if (text == null) throw new IllegalArgumentException("the text cannot be null");
 
     m_text = text;
@@ -118,7 +118,7 @@ public class PSDisplayText extends PSComponent {
    *  (non-Javadoc)
    * @see com.percussion.design.objectstore.IPSComponent#fromXml(org.w3c.dom.Element, com.percussion.design.objectstore.IPSDocument, java.util.ArrayList)
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSEntry.java
@@ -45,8 +45,9 @@ public class PSEntry extends PSComponent {
    * @param label the label for this entry, not <code>null</code>, may be empty.
    */
   public PSEntry(String value, PSDisplayText label) {
-    setValue(value);
-    setLabel(label);
+    // Private helpers avoid virtual setValue/setLabel during construction (this-escape).
+    applyValue(value);
+    applyLabel(label);
   }
 
   /**
@@ -59,8 +60,8 @@ public class PSEntry extends PSComponent {
    */
   public PSEntry(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
-    // allow subclasses to override (don't use "this")
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private path avoids virtual fromXml dispatch before subclass fields initialize.
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
 
   /** Constructor for XML serialization by subclasses. */
@@ -110,6 +111,11 @@ public class PSEntry extends PSComponent {
    * @throws IllegalArgumentException if the provided value is <code>null</code>.
    */
   public void setValue(String value) {
+    applyValue(value);
+  }
+
+  /** Non-overridable assignment used from constructors and {@link #setValue(String)}. */
+  private void applyValue(String value) {
     if (value == null) throw new IllegalArgumentException("the value cannot be null");
 
     m_value = value;
@@ -161,6 +167,11 @@ public class PSEntry extends PSComponent {
    * @param label the new display text, never <code>null</code>.
    */
   public void setLabel(PSDisplayText label) {
+    applyLabel(label);
+  }
+
+  /** Non-overridable assignment used from constructors and {@link #setLabel(PSDisplayText)}. */
+  private void applyLabel(PSDisplayText label) {
     if (label == null) throw new IllegalArgumentException("the label cannot be null");
 
     m_label = label;
@@ -242,6 +253,16 @@ public class PSEntry extends PSComponent {
    * @see IPSComponent
    */
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Shared load for {@link #fromXml} and the Element constructor. Keeps construction free of
+   * virtual {@code fromXml} dispatch so subclasses (e.g. {@link PSNullEntry}) can initialize
+   * safely.
+   */
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionCall.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionCall.java
@@ -135,7 +135,7 @@ public class PSExtensionCall extends PSComponent
    *
    * @param ext The name of the extension to be called, not <code>null</code>
    */
-  public void setExtensionRef(PSExtensionRef ext) {
+  public final void setExtensionRef(PSExtensionRef ext) {
     IllegalArgumentException ex = validateExtension(ext);
     if (ex != null) throw ex;
 
@@ -177,7 +177,7 @@ public class PSExtensionCall extends PSComponent
    *
    * @param params an array of PSExtensionParamValue objects
    */
-  public void setParamValues(PSExtensionParamValue[] params) {
+  public final void setParamValues(PSExtensionParamValue[] params) {
     if (params == null) {
       setParamValues((Iterator<? extends PSExtensionParamValue>) null);
     } else {
@@ -191,7 +191,7 @@ public class PSExtensionCall extends PSComponent
    * @param params An Iterator over 0 or more PSExtensionParamValue objects. Can be <CODE>null
    *     </CODE>.
    */
-  public void setParamValues(Iterator<? extends PSExtensionParamValue> params) {
+  public final void setParamValues(Iterator<? extends PSExtensionParamValue> params) {
     m_params = new LinkedList<>();
 
     // build column names which need to be mapped
@@ -357,7 +357,7 @@ public class PSExtensionCall extends PSComponent
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXExtensionCall
    */
-  public void fromXml(
+  public final void fromXml(
       Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSField.java
@@ -282,7 +282,7 @@ public class PSField extends PSComponent {
    *
    * @param type the field type to set, must be one of TYPE_SYSTEM | TYPE_SHARED | TYPE_LOCAL.
    */
-  public void setType(int type) {
+  public final void setType(int type) {
     if (type != TYPE_SYSTEM && type != TYPE_SHARED && type != TYPE_LOCAL)
       throw new IllegalArgumentException("unsupported type " + type);
 
@@ -384,7 +384,7 @@ public class PSField extends PSComponent {
    *
    * @param submitName the new name, not <code>null</code> or empty.
    */
-  public void setSubmitName(String submitName) {
+  public final void setSubmitName(String submitName) {
     if (submitName == null || submitName.trim().length() == 0)
       throw new IllegalArgumentException("the name cannot be null or empty");
 
@@ -1206,7 +1206,7 @@ public class PSField extends PSComponent {
    *
    * @param locator the new locator, may be <code>null</code>.
    */
-  public void setLocator(IPSBackEndMapping locator) {
+  public final void setLocator(IPSBackEndMapping locator) {
     m_locator = locator;
   }
 
@@ -1581,7 +1581,7 @@ public class PSField extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
@@ -272,7 +272,7 @@ public class PSFieldSet extends PSComponent {
    *     valid name.
    * @return the previous value if there was one, <code>null</code> otherwise
    */
-  public Object add(PSField field) {
+  public final Object add(PSField field) {
     if (field == null) throw new IllegalArgumentException("the field cannot be null");
 
     String name = field.getSubmitName();
@@ -289,7 +289,7 @@ public class PSFieldSet extends PSComponent {
    *     contain a valid name.
    * @return the previous value if there was one, <code>null</code> otherwise.
    */
-  public Object add(PSFieldSet fieldSet) {
+  public final Object add(PSFieldSet fieldSet) {
     if (fieldSet == null) throw new IllegalArgumentException("the field set cannot be null");
 
     String name = fieldSet.getName();
@@ -342,7 +342,7 @@ public class PSFieldSet extends PSComponent {
    *
    * @param name the new field set name, not <code>null</code> or empty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null || name.trim().length() == 0)
       throw new IllegalArgumentException("name cannot be null or empty");
 
@@ -363,7 +363,7 @@ public class PSFieldSet extends PSComponent {
    *
    * @param type the new field set type.
    */
-  public void setType(int type) {
+  public final void setType(int type) {
     if (!isValidType(type)) throw new IllegalArgumentException("unknown type");
 
     m_type = type;
@@ -661,7 +661,7 @@ public class PSFieldSet extends PSComponent {
    *
    * @param c a valid PSFieldSet, not <code>null</code>.
    */
-  public void copyFrom(PSFieldSet c) {
+  public final void copyFrom(PSFieldSet c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
@@ -723,7 +723,7 @@ public class PSFieldSet extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
@@ -64,7 +64,7 @@ public class PSNullEntry extends PSEntry {
    * @param includeWhen the new include when attribute.
    * @throws IllegalArgumentException if the include when provided is not known.
    */
-  public void setIncludeWhen(int includeWhen) {
+  public final void setIncludeWhen(int includeWhen) {
     if (includeWhen != INCLUDE_WHEN_ALWAYS && includeWhen != INCLUDE_WHEN_ONLY_IF_NULL)
       throw new IllegalArgumentException("unknown inchlude when attribute");
 
@@ -86,7 +86,7 @@ public class PSNullEntry extends PSEntry {
    * @param sortOrder the new sort order.
    * @throws IllegalArgumentException if thw sort order provided is not known.
    */
-  public void setSortOrder(int sortOrder) {
+  public final void setSortOrder(int sortOrder) {
     if (sortOrder != SORT_ORDER_FIRST
         && sortOrder != SORT_ORDER_LAST
         && sortOrder != SORT_ORDER_SORTED)
@@ -138,7 +138,7 @@ public class PSNullEntry extends PSEntry {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSParam.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSParam.java
@@ -76,7 +76,7 @@ public class PSParam extends PSComponent implements IPSParameter {
    *
    * @param name the new parameter name, not <code>null</code> or empty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null || name.trim().length() == 0)
       throw new IllegalArgumentException("name cannot be null or empty");
 
@@ -136,7 +136,7 @@ public class PSParam extends PSComponent implements IPSParameter {
    *
    * @param value the new parameter value, not <code>null</code>.
    */
-  public void setValue(IPSReplacementValue value) {
+  public final void setValue(IPSReplacementValue value) {
     if (value == null) throw new IllegalArgumentException("the value cannot be null");
 
     m_value = value;
@@ -200,7 +200,7 @@ public class PSParam extends PSComponent implements IPSParameter {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
@@ -63,7 +63,7 @@ public class PSProperty extends PSComponent {
    * @param name the name of the property, may not be <code>null</code> or empty.
    * @throws IllegalArgumentException if name is invalid.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null || name.trim().length() == 0)
       throw new IllegalArgumentException("name may not be null or empty.");
 
@@ -76,7 +76,7 @@ public class PSProperty extends PSComponent {
    * @param type data type of the property value, must be one of the TYPE_xxx values
    * @throws IllegalArgumentException if type is invalid.
    */
-  public void setType(int type) {
+  public final void setType(int type) {
     if (type < 0 && type >= TYPE_ENUM.length)
       throw new IllegalArgumentException("type must be between 0 and " + TYPE_ENUM.length);
 
@@ -88,7 +88,7 @@ public class PSProperty extends PSComponent {
    *
    * @param value the value of the property, may be <code>null</code>.
    */
-  public void setValue(Object value) {
+  public final void setValue(Object value) {
     if (value != null) {
       if (m_type == TYPE_BOOLEAN) {
         if (value instanceof String) {
@@ -110,7 +110,7 @@ public class PSProperty extends PSComponent {
    *
    * @param lock supply <code>true</code> to lock the property, otherwise <code>false</code>
    */
-  public void setLock(boolean lock) {
+  public final void setLock(boolean lock) {
     m_lock = lock;
   }
 
@@ -120,7 +120,7 @@ public class PSProperty extends PSComponent {
    * @param description the description of the property, may be <code>null
    * </code> or empty.
    */
-  public void setDescription(String description) {
+  public final void setDescription(String description) {
     m_description = description;
   }
 
@@ -221,7 +221,7 @@ public class PSProperty extends PSComponent {
    * @see IPSComponent
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSReference.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSReference.java
@@ -105,7 +105,7 @@ public class PSReference extends PSComponent {
    * @param name the new name of the object that this should reference, not <code>null</code> or
    *     eempty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null) throw new IllegalArgumentException("name cannot be null");
 
     name = name.trim();
@@ -117,7 +117,7 @@ public class PSReference extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
@@ -153,7 +153,7 @@ public class PSReference extends PSComponent {
   /**
    * @see PSComponent
    */
-  public void copyFrom(PSComponent c) {
+  public final void copyFrom(PSComponent c) {
     super.copyFrom(c);
 
     if (!(c instanceof PSReference))

--- a/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
@@ -86,7 +86,7 @@ public class PSRoleProvider extends PSComponent {
    *
    * @param name the new name for this role provider, not <code>null</code> or empty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (name == null) throw new IllegalArgumentException("name cannot be null");
 
     name = name.trim();
@@ -228,7 +228,7 @@ public class PSRoleProvider extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
@@ -275,7 +275,7 @@ public class PSSearchProperties extends PSComponent {
    * Expects a node that conforms to the dtd specified for PSXSearchProperties in
    * sys_basicObjects.dtd. See base class for description of params.
    */
-  public void fromXml(Element source, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element source, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
@@ -215,7 +215,7 @@ public class PSTableLocator extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
@@ -94,7 +94,7 @@ public class PSTableSet extends PSComponent {
    *
    * @param tableLocation the new table locator, not <code>null</code>.
    */
-  public void setTableLocation(PSTableLocator tableLocation) {
+  public final void setTableLocation(PSTableLocator tableLocation) {
     if (tableLocation == null) throw new IllegalArgumentException("tableLocation cannot be null");
 
     m_tableLocation = tableLocation;
@@ -135,7 +135,7 @@ public class PSTableSet extends PSComponent {
    *
    * @param tableRefs the new table references, not <code>null</code>, not empty.
    */
-  public void setTableRefs(PSCollection tableRefs) {
+  public final void setTableRefs(PSCollection tableRefs) {
     if (tableRefs == null || tableRefs.isEmpty())
       throw new IllegalArgumentException("tableRefs cannot be null or empty");
 
@@ -151,7 +151,7 @@ public class PSTableSet extends PSComponent {
    *
    * @param tableRef the table reference, may not be <code>null</code>
    */
-  public void addTableRef(PSTableRef tableRef) {
+  public final void addTableRef(PSTableRef tableRef) {
     if (tableRef == null) throw new IllegalArgumentException("tableRef cannot be null");
 
     m_tableRefs.add(tableRef);
@@ -175,7 +175,7 @@ public class PSTableSet extends PSComponent {
    *
    * @param c a valid PSTableSet, not <code>null</code>.
    */
-  public void copyFrom(PSTableSet c) {
+  public final void copyFrom(PSTableSet c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
@@ -207,7 +207,7 @@ public class PSTableSet extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
@@ -314,7 +314,7 @@ public class PSUIDefinition extends PSComponent {
   }
 
   // see IPSComponent
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
@@ -39,9 +39,10 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param parameters a collection of PSParam objects, never <code>null</code>, may be empty.
    */
   public PSUrlRequest(String name, String href, PSCollection parameters) {
-    setName(name);
-    setHref(href);
-    setQueryParameters(parameters);
+    // Private helpers avoid virtual setters during construction (this-escape).
+    applyName(name);
+    applyHref(href);
+    applyQueryParameters(parameters);
   }
 
   /**
@@ -52,8 +53,8 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param converter a UDF which returns a URL. Never <code>null</code>.
    */
   public PSUrlRequest(String name, PSExtensionCall converter) {
-    setName(name);
-    setConverter(converter);
+    applyName(name);
+    applyConverter(converter);
   }
 
   /**
@@ -66,8 +67,8 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    */
   public PSUrlRequest(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
-    // allow subclasses to override (don't use "this")
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private path avoids virtual fromXml dispatch before subclass fields initialize.
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
 
   /**
@@ -78,7 +79,8 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
   public PSUrlRequest(PSUrlRequest source) {
     if (source == null) throw new IllegalArgumentException("source cannot be null");
 
-    this.copyFrom(source); // make sure we don't get overridden
+    // Non-virtual load for this-escape safety (same as copyFrom body).
+    copyFromBase(source);
   }
 
   /**
@@ -118,6 +120,10 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param name the name for this request. May be <code>null</code> but not empty.
    */
   public void setName(String name) {
+    applyName(name);
+  }
+
+  private void applyName(String name) {
     if (name != null && name.trim().length() == 0)
       throw new IllegalArgumentException("the name cannot be empty");
 
@@ -172,6 +178,10 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param href the base part of the URL, might be <code>null</code> or empty.
    */
   public void setHref(String href) {
+    applyHref(href);
+  }
+
+  private void applyHref(String href) {
     if (href == null) m_href = "";
     else m_href = href;
   }
@@ -191,6 +201,10 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param queryParameters a collection of PSParam objects. Not <code>null</code>, might be empty.
    */
   public void setQueryParameters(PSCollection queryParameters) {
+    applyQueryParameters(queryParameters);
+  }
+
+  private void applyQueryParameters(PSCollection queryParameters) {
     if (queryParameters == null)
       throw new IllegalArgumentException("queryPramaters cannot be null");
 
@@ -283,12 +297,16 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param converter the new converter extension, not <code>null</code>.
    */
   public void setConverter(PSExtensionCall converter) {
+    applyConverter(converter);
+  }
+
+  private void applyConverter(PSExtensionCall converter) {
     if (converter == null) throw new IllegalArgumentException("converter cannot be null");
 
     m_converter = converter;
 
     // href and query parameters are not used when converter is set
-    setHref("");
+    applyHref("");
     m_queryParameters.clear();
   }
 
@@ -299,12 +317,16 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param c a valid PSUrlRequest, not <code>null</code>.
    */
   public void copyFrom(PSUrlRequest c) {
+    copyFromBase(c);
+  }
+
+  /** Non-overridable copy used from constructors and {@link #copyFrom(PSUrlRequest)}. */
+  private void copyFromBase(PSUrlRequest c) {
     try {
       super.copyFrom(c);
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(e.getLocalizedMessage());
     }
-    ;
 
     m_converter = c.getConverter();
     m_href = c.getHref();
@@ -317,6 +339,15 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @see IPSComponent
    */
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Shared load for {@link #fromXml} and the Element constructor. Avoids virtual fromXml dispatch
+   * during construction for subclasses such as {@link PSConditionalRequest}.
+   */
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
@@ -356,7 +387,7 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
           throw new PSUnknownNodeTypeException(
               IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
         }
-        setHref(PSXmlTreeWalker.getElementData(node));
+        applyHref(PSXmlTreeWalker.getElementData(node));
 
         node = tree.getNextElement(PSParam.XML_NODE_NAME, nextFlags);
         while (node != null) {

--- a/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentThisEscapeTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentThisEscapeTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for {@link PSDbComponent} Element super-ctor / {@code fromXmlBase} + {@code
+ * createKeyDefault} path (#2404 review follow-up). Complements design.objectstore coverage in
+ * {@code PSDesignObjectStoreThisEscapeTest}.
+ *
+ * <p>Uses {@link PSVariantSlotType} because it calls {@code super(source)} then {@code
+ * fromXml(source)} and stores a multi-part {@link PSKey} (not {@link PSSimpleKey}, whose node name
+ * mismatches the PSContentType {@code createKey} override).
+ */
+public class PSDbComponentThisEscapeTest {
+
+  @Test
+  public void variantSlotTypeElementCtorRoundTripUsesCreateKeyDefaultThenFromXml()
+      throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element source = sampleVariantSlotTypeElement(doc, 42, 7);
+
+    // Element ctor: super(source) → createKeyDefault (non-virtual), then subclass fromXml →
+    // virtual createKey (PSKey(Element)).
+    PSVariantSlotType restored = new PSVariantSlotType(source);
+
+    assertEquals(42, restored.getVariantId());
+    assertEquals(7, restored.getSlotId());
+    assertNotNull(restored.getLocator());
+    assertEquals(IPSDbComponent.DBSTATE_UNMODIFIED, restored.getState());
+  }
+
+  @Test
+  public void variantSlotTypePublicFromXmlAfterConstructionStillWorks() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element first = sampleVariantSlotTypeElement(doc, 1, 2);
+    PSVariantSlotType target = new PSVariantSlotType(first);
+
+    Element second = sampleVariantSlotTypeElement(doc, 99, 88);
+    target.fromXml(second);
+
+    assertEquals(99, target.getVariantId());
+    assertEquals(88, target.getSlotId());
+  }
+
+  /**
+   * Builds a minimal {@code PSXVariantSlotType} document matching {@link
+   * PSVariantSlotType#toXml(Document)} / super key serialization.
+   */
+  private static Element sampleVariantSlotTypeElement(Document doc, int variantId, int slotId) {
+    PSKey key =
+        new PSKey(
+            new String[] {"VARIANTID", "SLOTID"},
+            new String[] {String.valueOf(variantId), String.valueOf(slotId)},
+            true);
+    Element root = doc.createElement("PSXVariantSlotType");
+    root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    root.appendChild(key.toXml(doc));
+    return root;
+  }
+}

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectStoreThisEscapeTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectStoreThisEscapeTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.util.PSCollection;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for ctor/fromXml this-escape real-fix batch (#2404): private helpers /
+ * final setters preserve Element restore and value construction.
+ */
+public class PSDesignObjectStoreThisEscapeTest {
+
+  @Test
+  public void choicesGlobalCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSChoices original = new PSChoices(42);
+    Element elem = original.toXml(doc);
+
+    PSChoices restored = new PSChoices(elem, null, null);
+    assertEquals(original, restored);
+    assertEquals(42, restored.getGlobal());
+    assertEquals(PSChoices.TYPE_GLOBAL, restored.getType());
+  }
+
+  @Test
+  public void choicesLocalCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSEntry entry = new PSEntry("v1", new PSDisplayText("label1"));
+    PSCollection local = new PSCollection(PSEntry.class);
+    local.add(entry);
+    PSChoices original = new PSChoices(local);
+    Element elem = original.toXml(doc);
+
+    PSChoices restored = new PSChoices(elem, null, null);
+    assertEquals(original, restored);
+    assertEquals(PSChoices.TYPE_LOCAL, restored.getType());
+  }
+
+  @Test
+  public void fieldValueCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSField original = new PSField("sys_title", null);
+    original.setType(PSField.TYPE_SYSTEM);
+    Element elem = original.toXml(doc);
+
+    PSField restored = new PSField(elem, null, null);
+    assertEquals(original.getSubmitName(), restored.getSubmitName());
+    assertEquals(original.getType(), restored.getType());
+  }
+
+  @Test
+  public void entryValueCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSEntry original = new PSEntry("val", new PSDisplayText("lbl"));
+    Element elem = original.toXml(doc);
+
+    PSEntry restored = new PSEntry(elem, null, null);
+    assertEquals(original.getValue(), restored.getValue());
+    assertEquals(original.getLabel().getText(), restored.getLabel().getText());
+  }
+
+  @Test
+  public void urlRequestCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSCollection params = new PSCollection(PSParam.class);
+    params.add(new PSParam("p1", new PSTextLiteral("one")));
+    PSUrlRequest original = new PSUrlRequest("req", "http://example.intsof/test", params);
+    Element elem = original.toXml(doc);
+
+    PSUrlRequest restored = new PSUrlRequest(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getHref(), restored.getHref());
+  }
+
+  @Test
+  public void aclEntryNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSAclEntry original = new PSAclEntry("admin1", PSAclEntry.ACE_TYPE_USER);
+    Element elem = original.toXml(doc);
+
+    PSAclEntry restored = new PSAclEntry(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertTrue(restored.isUser());
+  }
+
+  @Test
+  public void aclElementRoundTripPreservesEntries() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSAcl original = new PSAcl();
+    PSCollection entries = new PSCollection(PSAclEntry.class);
+    PSAclEntry entry = new PSAclEntry("Editor", PSAclEntry.ACE_TYPE_ROLE);
+    entries.add(entry);
+    original.setEntries(entries);
+    original.setAccessForMultiMembershipMaximum();
+    Element elem = original.toXml(doc);
+
+    PSAcl restored = new PSAcl(elem, null, null);
+    assertNotNull(restored.getEntries());
+    assertEquals(1, restored.getEntries().size());
+    assertEquals("Editor", ((PSAclEntry) restored.getEntries().get(0)).getName());
+    assertTrue(restored.isAccessForMultiMembershipMaximum());
+  }
+
+  @Test
+  public void fieldSetNameCtor() {
+    PSFieldSet set = new PSFieldSet("body");
+    assertEquals("body", set.getName());
+    assertEquals(PSFieldSet.TYPE_PARENT, set.getType());
+  }
+
+  @Test
+  public void propertyNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSProperty original =
+        new PSProperty("dimage", PSProperty.TYPE_STRING, "gif", false, "image type");
+    Element elem = original.toXml(doc);
+
+    PSProperty restored = new PSProperty(elem);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getType(), restored.getType());
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized **slice 3f** for **#2404** (parent **#2022** / grandparent **#2200**): reduce `-Xlint:this-escape` in **design.objectstore** with **real** constructor/`fromXml` fixes — private non-overridable helpers / final leaf methods — **not** blanket `@SuppressWarnings("this-escape")`.

### Real this-escape fixes
- **Leaf types** (~30 files): methods used from ctors/`fromXml` marked `final` where no subclasses (e.g. `PSChoices`, `PSAcl`/`PSAclEntry`, `PSField`/`PSFieldSet`, content-editor mappers/pipes, table set, property/reference, directory/auth/role provider, etc.)
- **Bases with subclasses**: private `fromXmlBase` / `apply*` helpers — `PSEntry`, `PSUrlRequest`, `PSDataSet`, `PSBackEndColumn` (subclass overrides of public `fromXml` preserved)
- **PSDbComponent**: Element super-ctor path uses non-virtual `createKeyDefault`; public `fromXml` still dispatches virtual `createKey` after full construction

### Tests
- New `PSDesignObjectStoreThisEscapeTest` — 9 ctor/fromXml round-trip cases for hottest types

### Metrics (inventory baseline `tmp/issue-2297-this-escape.txt`)
- design.objectstore this-escape was ~260; this batch targets hottest patterns (~40–50+ diagnostic sites across ~35 types)
- Large residual remains → #2465, #2466, #2467

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1287**, Failures: **0**, Errors: **0** (Skipped: 240)
- [x] `PSDesignObjectStoreThisEscapeTest` — 9/9 pass

## Gates evidence
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2404-design-objectstore-this-escape-erlang.md`
- Per-module standalone clean install: pass
- No monorepo-wide reformat; no suppress-only this-escape

## Residual
- #2465 — design.objectstore this-escape residual (editors/app config)
- #2466 — design.objectstore this-escape residual (security/directory/UI leftovers)
- #2467 — cms.objectstore this-escape residual (createKey / Element ctors)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2404  
Refs #2022 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.