### PR TITLE
fix(sitemanage): replace (Iterable<?>) cast-lambda with explicit iterator loop (#2457)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
@@ -83,8 +83,9 @@ public class PSFolderPermissionUtils {
     var readPrincipals = new ArrayList<Principal>();
     var writePrincipals = new ArrayList<Principal>();
 
-    for (var entryObj : (Iterable<?>) () -> acl.iterator()) {
-      var entry = (PSObjectAclEntry) entryObj;
+    var iter = acl.iterator();
+    while (iter.hasNext()) {
+      var entry = (PSObjectAclEntry) iter.next();
       if (entry.isUser()) {
         var p = new Principal();
         p.setName(entry.getName());
@@ -401,8 +402,9 @@ public class PSFolderPermissionUtils {
    */
   private static PSObjectAclEntry getAclEntry(PSObjectAcl acl, int type, String name) {
     if (acl == null) return null;
-    for (var entryObj : (Iterable<?>) () -> acl.iterator()) {
-      var entry = (PSObjectAclEntry) entryObj;
+    var iter = acl.iterator();
+    while (iter.hasNext()) {
+      var entry = (PSObjectAclEntry) iter.next();
       if (entry.getType() == type && (name == null || entry.getName().equalsIgnoreCase(name))) {
         return entry;
       }
@@ -418,8 +420,9 @@ public class PSFolderPermissionUtils {
   private static void removeNonVirtualAclEntries(PSObjectAcl acl) {
     if (acl == null) return;
     var entries = new ArrayList<PSObjectAclEntry>();
-    for (var entryObj : (Iterable<?>) () -> acl.iterator()) {
-      var entry = (PSObjectAclEntry) entryObj;
+    var iter = acl.iterator();
+    while (iter.hasNext()) {
+      var entry = (PSObjectAclEntry) iter.next();
       if (!entry.isVirtual()) entries.add(entry);
     }
     entries.forEach(acl::remove);


### PR DESCRIPTION
## Summary

Fixes the JDK 21 lambda-inference build break that leaves projects/sitemanage main unable to produce a clean install. The existing pattern

\\\java
for (var entryObj : (Iterable<?>) () -> acl.iterator()) {
\\\

at three sites in \PSFolderPermissionUtils.java\ is rejected by \javac --release 21\ because \Iterator<PSObjectAclEntry>\ is not assignable to the cast's target \Iterator<?>\. Same code compiled under JDK 17; breaks on the JDK 21 toolchain the parent POM pins.

## Fix

Replace each cast-lambda for-each with an explicit iterator while-loop:

\\\java
var iter = acl.iterator();
while (iter.hasNext()) {
  var entry = (PSObjectAclEntry) iter.next();
  ...
}
\\\

\PSObjectAcl\ extends \PSDbComponentSet<PSObjectAclEntry>\ which exposes \Iterator<PSObjectAclEntry> iterator()\. Iteration order, cast, and body semantics are preserved.

## Sites changed

- L86 (in \getFolderPermission\)
- L404 (in \getAclEntry\)
- L421 (in \emoveNonVirtualAclEntries\)

## Pre-PR Maven verification

\\\ash
cd projects/sitemanage && ../../mvnw.cmd clean install
\\\

- **BUILD SUCCESS** on a cache-cleared run
- Tests run: 791, Failures: 0, Errors: 0
- 128 Skipped = pre-existing \@Disabled\ placeholders in this module, unchanged by this PR.

No new warnings introduced. Files changed: 1 (production); no new files.

## Cross-platform

No filesystem / path / process code touched.

## Unblocks

- Slice B (#2436) of #2423 — the Spring \ApplicationContext\ regression test for the folderHelper cycle can now land once #2457 is on main.

Fixes #2457.

Operator: Kilo (minimax-coding-plan/MiniMax-M3)