### PR TITLE
fix(sitemanage): injection-cycle inventory + assetService/pageService near-cycle protection (#2463)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -1,0 +1,109 @@
+# Sitemanage Spring constructor-injection cycle inventory
+
+**Issue:** #2463 (residual of #2423)  
+**Module:** `projects/sitemanage`  
+**Date:** 2026-08-08  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `FolderHelperCycleContextTest` (#2436).
+
+This is an analysis note for humans/agents — **not** an agent rule file.
+
+## Known cycle (fixed)
+
+```text
+folderHelper
+  → recycleService
+    → widgetAssetRelationshipService
+      → assetDao
+        → contentItemDao
+          → folderHelper   ← back-edge broken with @Lazy on PSContentItemDao ctor param
+```
+
+| Edge | Type | Breaker |
+|------|------|---------|
+| `PSFolderHelper` → `IPSRecycleService` | ctor | none (forward) |
+| `PSRecycleService` → `IPSWidgetAssetRelationshipService` | ctor | none (forward) |
+| `PSWidgetAssetRelationshipService` → `IPSAssetDao` | ctor | none (forward) |
+| `PSAssetDao` → `IPSContentItemDao` | ctor | none (forward) |
+| `PSContentItemDao` → `IPSFolderHelper` | ctor | **`@Lazy`** (#2435) |
+
+Class-level `@Lazy` is present on `folderHelper` and `recycleService` but is **not** sufficient alone: an eager consumer (e.g. field inject on `pSRedirectService`) still forces full construction and re-enters the cycle without a parameter-level `@Lazy` proxy.
+
+## Inventory result: other constructor cycles
+
+Among the mapped interest set (folder/recycle/asset/content/page/item/template/workflow/site hubs), the **only constructor cycle of length 2–6** is the known folderHelper chain above.
+
+No second closed constructor cycle was found in the current tree.
+
+Field injection adds a few edges (e.g. `PSItemService` → `IPSRecycleService` field; `PSSiteDataService` → `IPSPageService` / path service field) but does not form an additional closed cycle in the combo graph under the same mapping.
+
+## High-risk hubs (near-miss / future cycle fuel)
+
+These beans have high constructor fan-in and sit on or next to the known cycle peers. They are **not** currently cyclic, but a single reverse ctor edge would re-create `BeanCurrentlyInCreationException`.
+
+| Rank | Bean | Approx. ctor out / in (interest graph) | Notes |
+|------|------|----------------------------------------|-------|
+| 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. |
+| 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset`. Class `@Lazy`. |
+| 3 | `PSTemplateService` | out ~6 / in ~20 | **Not** class `@Lazy`. Injects `widgetAsset`, page/template DAOs. |
+| 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
+| 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` (and folder/asset/widget/item). Class `@Lazy`. |
+| 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
+
+### Next hottest unprotected edge
+
+**`PSAssetService` → `IPSPageService` (constructor, not `@Lazy`)** with **no reverse** `PSPageService` → `IPSAssetService`.
+
+If a future change adds `IPSAssetService` to `PSPageService`'s constructor (or an eager non-`@Lazy` field), Spring will hit a creation cycle involving two of the busiest product services, independent of the folderHelper fix.
+
+Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + no reverse).
+
+### Other one-way edges to keep one-way (known cycle intermediate)
+
+These must not gain reverse constructor dependencies:
+
+| From | To | Reverse would mean |
+|------|----|--------------------|
+| `PSAssetDao` | `IPSContentItemDao` | contentItemDao → assetDao closes dao sub-cycle |
+| `PSWidgetAssetRelationshipService` | `IPSAssetDao` | assetDao → widgetAsset skips contentItemDao break |
+| `PSRecycleService` | `IPSWidgetAssetRelationshipService` | widgetAsset → recycle closes mid-chain |
+| `PSFolderHelper` | `IPSRecycleService` | recycle → folderHelper bypasses contentItemDao `@Lazy` |
+
+`FolderHelperCycleContextTest` (#2436) + `PSContentItemDaoCycleLazyWiringTest` (#2435) cover the `@Lazy` break; intermediate reverse edges are residual hardening candidates.
+
+## Constructor `@Lazy` parameter edges found (sitemanage)
+
+Outside the known fix, constructor-parameter `@Lazy` is rare in this module. Scan snapshot:
+
+- `PSContentItemDao` → `IPSFolderHelper` (`@Lazy`) — cycle break
+- `PSRecentRestService` → `IPSRecentService` (`@Lazy`) — rest convenience, not cycle-related
+
+Class-level `@Lazy` is common on REST facades and many services; treat it as lazy *init*, not a cycle breaker.
+
+## Who constructs `IPSFolderHelper` (no param `@Lazy`)
+
+Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g. `PSPageService`, `PSItemService`, `PSItemWorkflowService`, `PSSiteDataService`, path item services). That is OK **only while** the back-edge `contentItemDao → folderHelper` remains `@Lazy` (or another edge on the same cycle is broken).
+
+## Disposition for #2463
+
+| Acceptance item | Status |
+|-----------------|--------|
+| Inventory of high-risk edges | This note + issue comment |
+| Additional regression/protection test for next hottest edge | `PSAssetServicePageServiceNearCycleWiringTest` |
+| Explicit disposition if no second full cycle | **No second closed constructor cycle found**; residual work is reverse-edge hardening + Docker smoke (#2437) |
+| Module clean install | Required on PR |
+
+## Residual recommendations (file as GitHub issues under #2423)
+
+1. Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way).
+2. Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param as belt-and-braces (behavior review needed).
+3. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
+4. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+
+## Related
+
+- Parent #2423 — startup cycle epic  
+- #2435 — `@Lazy` break (merged)  
+- #2436 — `FolderHelperCycleContextTest` graph witness  
+- #2437 — Docker qa-up health/login smoke  
+- #2463 — this residual inventory  
+- #2457 / PR #2469 — JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/PSFolderPermissionUtils.java
@@ -83,8 +83,9 @@ public class PSFolderPermissionUtils {
     var readPrincipals = new ArrayList<Principal>();
     var writePrincipals = new ArrayList<Principal>();
 
-    for (var entryObj : (Iterable<?>) () -> acl.iterator()) {
-      var entry = (PSObjectAclEntry) entryObj;
+    var iter = acl.iterator();
+    while (iter.hasNext()) {
+      var entry = (PSObjectAclEntry) iter.next();
       if (entry.isUser()) {
         var p = new Principal();
         p.setName(entry.getName());
@@ -401,8 +402,9 @@ public class PSFolderPermissionUtils {
    */
   private static PSObjectAclEntry getAclEntry(PSObjectAcl acl, int type, String name) {
     if (acl == null) return null;
-    for (var entryObj : (Iterable<?>) () -> acl.iterator()) {
-      var entry = (PSObjectAclEntry) entryObj;
+    var iter = acl.iterator();
+    while (iter.hasNext()) {
+      var entry = (PSObjectAclEntry) iter.next();
       if (entry.getType() == type && (name == null || entry.getName().equalsIgnoreCase(name))) {
         return entry;
       }
@@ -418,8 +420,9 @@ public class PSFolderPermissionUtils {
   private static void removeNonVirtualAclEntries(PSObjectAcl acl) {
     if (acl == null) return;
     var entries = new ArrayList<PSObjectAclEntry>();
-    for (var entryObj : (Iterable<?>) () -> acl.iterator()) {
-      var entry = (PSObjectAclEntry) entryObj;
+    var iter = acl.iterator();
+    while (iter.hasNext()) {
+      var entry = (PSObjectAclEntry) iter.next();
       if (!entry.isVirtual()) entries.add(entry);
     }
     entries.forEach(acl::remove);

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSAssetServicePageServiceNearCycleWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSAssetServicePageServiceNearCycleWiringTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.service.IPSAssetService;
+import com.percussion.assetmanagement.service.impl.PSAssetService;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pagemanagement.service.impl.PSPageService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Protection for the next-hottest sitemanage injection edge after the folderHelper cycle (#2423).
+ *
+ * <p>Static inventory (#2463) found only one closed constructor cycle in sitemanage — the known
+ * {@code folderHelper → … → contentItemDao → folderHelper} chain broken by {@code @Lazy} on {@link
+ * PSContentItemDao}. The next hottest <em>near-cycle</em> is a one-way hub edge:
+ *
+ * <pre>
+ * assetService  →  pageService   (constructor, not @Lazy)
+ * pageService   ↛  assetService  (must remain true)
+ * </pre>
+ *
+ * <p>{@link PSAssetService} is a high fan-in product service that construct-requires {@link
+ * IPSPageService}. {@link PSPageService} already construct-requires cycle peers ({@code
+ * contentItemDao}, {@code folderHelper}, {@code recycleService}, {@code
+ * widgetAssetRelationshipService}). Adding {@link IPSAssetService} to {@code PSPageService}'s
+ * constructor (or an eager non-{@code @Lazy} field) would form a new {@code
+ * BeanCurrentlyInCreationException} path independent of the folderHelper fix.
+ *
+ * <p>Peers: {@link PSContentItemDaoCycleLazyWiringTest}, {@code FolderHelperCycleContextTest}
+ * (#2436). Full inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSAssetServicePageServiceNearCycleWiringTest {
+
+  @Test
+  public void assetServiceConstructorTakesPageService() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSAssetService.class);
+    Parameter pageParam = findParamOfType(ctor, IPSPageService.class);
+    assertNotNull(
+        pageParam,
+        "PSAssetService must still construct-require IPSPageService — inventory #2463 assumed this"
+            + " one-way hub edge; if the edge was removed, update the inventory and this test");
+  }
+
+  @Test
+  public void pageServiceConstructorMustNotTakeAssetService() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSPageService.class);
+    Parameter assetParam = findParamOfType(ctor, IPSAssetService.class);
+    assertTrue(
+        assetParam == null,
+        "PSPageService must not construct-require IPSAssetService: that would close a"
+            + " pageService↔assetService cycle (next hottest edge after folderHelper; see #2463)."
+            + " Prefer method-level lookup, setter injection, or @Lazy on the injection point.");
+  }
+
+  /**
+   * Intermediate known-cycle edges must stay one-way so a reverse ctor dep cannot bypass the
+   * contentItemDao {@code @Lazy} break.
+   */
+  @Test
+  public void knownCycleIntermediateBeansHaveNoReverseConstructorEdges()
+      throws NoSuchMethodException {
+    // assetDao must not construct-require cycle peers other than contentItemDao (forward)
+    assertNoCtorParam(
+        com.percussion.assetmanagement.dao.impl.PSAssetDao.class,
+        com.percussion.share.dao.IPSFolderHelper.class,
+        "PSAssetDao → folderHelper would reverse-bypass contentItemDao @Lazy");
+    assertNoCtorParam(
+        com.percussion.assetmanagement.dao.impl.PSAssetDao.class,
+        com.percussion.recycle.service.IPSRecycleService.class,
+        "PSAssetDao → recycleService would form a new mid-cycle");
+    assertNoCtorParam(
+        com.percussion.assetmanagement.dao.impl.PSAssetDao.class,
+        com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService.class,
+        "PSAssetDao → widgetAsset would reverse the widgetAsset→assetDao edge");
+
+    // widgetAsset must not construct-require recycle / folderHelper / contentItemDao
+    assertNoCtorParam(
+        com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService.class,
+        com.percussion.recycle.service.IPSRecycleService.class,
+        "widgetAsset → recycleService would reverse recycle→widgetAsset");
+    assertNoCtorParam(
+        com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService.class,
+        com.percussion.share.dao.IPSFolderHelper.class,
+        "widgetAsset → folderHelper would short-circuit the known cycle");
+    assertNoCtorParam(
+        com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService.class,
+        com.percussion.share.dao.IPSContentItemDao.class,
+        "widgetAsset → contentItemDao would skip assetDao and re-cycle via folderHelper");
+
+    // recycleService must not construct-require folderHelper / contentItemDao / assetDao
+    assertNoCtorParam(
+        com.percussion.recycle.service.impl.PSRecycleService.class,
+        com.percussion.share.dao.IPSFolderHelper.class,
+        "recycleService → folderHelper would reverse folderHelper→recycleService");
+    assertNoCtorParam(
+        com.percussion.recycle.service.impl.PSRecycleService.class,
+        com.percussion.share.dao.IPSContentItemDao.class,
+        "recycleService → contentItemDao would form a parallel cycle path");
+    assertNoCtorParam(
+        com.percussion.recycle.service.impl.PSRecycleService.class,
+        com.percussion.assetmanagement.dao.IPSAssetDao.class,
+        "recycleService → assetDao would skip widgetAsset");
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  private static void assertNoCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    assertTrue(
+        p == null,
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + ": "
+            + why);
+  }
+}


### PR DESCRIPTION
## Summary

Parent tracker: #2423. Residual slice #2463.

Inventories sitemanage constructor/injection edges beyond the known `folderHelper` cycle and adds a regression peer for the **next hottest near-cycle edge**.

### Findings
- **Only one closed constructor cycle** in the mapped high-fan-in graph: the known `folderHelper → recycleService → widgetAssetRelationshipService → assetDao → contentItemDao → folderHelper` chain (already broken by `@Lazy` on `PSContentItemDao` / #2435).
- **Next hottest unprotected edge:** one-way `PSAssetService → IPSPageService` with no reverse. Closing that reverse would create a new `BeanCurrentlyInCreationException` path independent of the folderHelper fix.
- High-risk hubs (not currently cyclic): `pageService`, `itemWorkflowService`, `templateService` (not class `@Lazy`), `widgetAssetRelationshipService`, `assetService`, `siteDataService`.

### Changes
- `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md` — inventory note (not agent rules).
- `PSAssetServicePageServiceNearCycleWiringTest` — reflection gate:
  - assetService still construct-requires pageService
  - pageService must **not** construct-require assetService
  - known-cycle intermediate beans must not gain reverse ctor edges that bypass contentItemDao `@Lazy`
- Cherry-pick of #2457 / PR #2469 (`PSFolderPermissionUtils` iterator fix) so sitemanage compiles on JDK 21 (same as #2436 PR).

### Related
- Fixes #2463
- Parent #2423
- Peers: #2435 (merged), #2436 (FolderHelperCycleContextTest), #2437 (Docker smoke)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw.cmd test -Dtest=PSAssetServicePageServiceNearCycleWiringTest,PSContentItemDaoCycleLazyWiringTest`
  - Tests run: 4, Failures: 0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install`
  - **BUILD SUCCESS**
  - Tests run: 794, Failures: 0, Errors: 0, Skipped: 128
  - No new warnings attributable to this change (reflection UnitTest only + inventory doc + cherry-picked compile fix)

## Gates
- Erlang self-review: no bugs; portable (reflection-only); change-class companions (inventory + protection test peers of CycleLazyWiringTest).
- Pre-PR Maven: standalone sitemanage clean install green.
- No agent rule file commits.

> Co-Authored by Grok Build using grok-4.5 with agent main.