### PR TITLE
fix(docker): Rhythmyx ApplicationContext fail-fast in qa-health/matrix probe (#2462)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -231,6 +231,30 @@ python docker/scripts/perc-devctl.py down
 
 Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for the resolved probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`), prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section. Concurrent freeport checklist: **Two-worktree concurrent freeport smoke** above.
 
+##### Rhythmyx ApplicationContext fail-fast (#2462 / #2423)
+
+Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `ApplicationContext` failed (e.g. `BeanCurrentlyInCreationException` / circular `folderHelper` wiring). A port-up or HTTP-only probe is **not** sufficient.
+
+| Signal | Where | Operator meaning |
+|--------|--------|------------------|
+| `RESULT:OK STEP:qa-health HTTP:…` | `perc-devctl.py qa-health` | Probe URL ready **and** recent `docker logs` have **no** Rhythmyx context-failure markers |
+| `RESULT:FAIL … DETAIL:rhythmyx_context_failed MATCH:…` | `qa-health` or matrix cell `detail` | **Fail-fast**: Spring/Jetty context death detected in logs; treat cell as unusable even if HTTP answered |
+| `RESULT:FAIL … DETAIL:timeout after Ns (last_http=…)` | `qa-health` | Probe never became ready; if logs later show context fail, re-run `qa-health` or `docker logs perc-matrix-cms-h2` |
+| Matrix `status=fail` + `detail` containing `rhythmyx_context_failed` | `matrix-install-smoke.py` CMS cells | Same fail-fast during cell HTTP wait (container log scan) |
+
+Markers (shared helper `docker/scripts/rhythmyx_ready.py`): `Failed startup of context`, `BeanCurrentlyInCreationException`, `Requested bean is currently in creation`, `Is there an unresolvable circular reference`.
+
+```bash
+# After qa-up (or matrix --keep), re-check readiness with log scan:
+python docker/scripts/perc-devctl.py qa-health
+# FAIL example (do not attach Playwright):
+# RESULT:FAIL STEP:qa-health DETAIL:rhythmyx_context_failed MATCH:Failed startup of context …
+docker logs perc-matrix-cms-h2 2>&1 | findstr /i "Failed startup BeanCurrently circular folderHelper"
+# Unix: docker logs perc-matrix-cms-h2 2>&1 | grep -E 'Failed startup|BeanCurrently|circular'
+```
+
+Unit tests: `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q`.
+
 ### `docker/scripts/freeport-concurrent-smoke.py`
 
 Allocation-only smoke for multi-worktree freeport (#2006). No Docker and no CMS install — holds preferred ports with stdlib sockets, asserts second-cell freeport and env override, prints `RESULT:OK|FAIL STEP:freeport-concurrent-smoke`. See **Two-worktree concurrent freeport smoke** above. Unit tests: `test_freeport_concurrent_smoke.py`.

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -85,6 +85,11 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 from perc_host_ports import find_free_port, is_port_free, resolve_host_port  # noqa: E402
+from rhythmyx_ready import (  # noqa: E402
+    DETAIL_CONTEXT_FAILED,
+    find_rhythmyx_context_failure,
+    is_http_ready_code,
+)
 
 LOG = logging.getLogger("matrix-install-smoke")
 
@@ -912,33 +917,113 @@ def destroy_container(name: str, *, dry_run: bool) -> None:
     _run(["docker", "rm", "-f", name], dry_run=dry_run, check=False)
 
 
+def _docker_logs_tail(
+    container_name: str,
+    *,
+    tail: int = 800,
+    timeout: float = 30.0,
+) -> str:
+    """Return recent ``docker logs`` for context-failure scanning (#2462)."""
+    if not container_name:
+        return ""
+    try:
+        completed = subprocess.run(
+            [
+                "docker",
+                "logs",
+                "--tail",
+                str(max(1, int(tail))),
+                container_name,
+            ],
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    out = completed.stdout or ""
+    err = completed.stderr or ""
+    if out and err:
+        return out + "\n" + err
+    return out or err
+
+
 def wait_for_http(
     url: str,
     *,
     timeout_seconds: int,
     interval_seconds: float = 5.0,
     dry_run: bool,
+    container_name: Optional[str] = None,
 ) -> Tuple[bool, str]:
+    """Poll ``url`` until HTTP ready codes, or fail-fast on Rhythmyx context death.
+
+    When ``container_name`` is set (CMS cells), each poll also scans recent
+    ``docker logs`` for Spring/Jetty ApplicationContext failure markers.
+    A dead Rhythmyx context fails the probe **immediately** even if Jetty
+    still answers HTTP (#2462 residual of #2423).
+    """
     if dry_run:
         return True, "dry-run"
     deadline = time.time() + timeout_seconds
     last = ""
     while time.time() < deadline:
+        # Fail-fast: Jetty up + Spring context dead must not wait full timeout.
+        if container_name:
+            logs = _docker_logs_tail(container_name)
+            match = find_rhythmyx_context_failure(logs)
+            if match is not None:
+                return (
+                    False,
+                    f"{DETAIL_CONTEXT_FAILED} match={match!r} last={last or 'n/a'}",
+                )
         try:
             req = urllib.request.Request(url, method="GET")
             with urllib.request.urlopen(req, timeout=10) as resp:
                 code = resp.getcode()
-                if code in (200, 302, 401, 403):
+                if is_http_ready_code(code):
+                    # Re-check logs after a "ready" HTTP so false positives fail.
+                    if container_name:
+                        logs = _docker_logs_tail(container_name)
+                        match = find_rhythmyx_context_failure(logs)
+                        if match is not None:
+                            return (
+                                False,
+                                f"{DETAIL_CONTEXT_FAILED} match={match!r} "
+                                f"http={code}",
+                            )
                     return True, f"HTTP {code}"
                 last = f"HTTP {code}"
         except urllib.error.HTTPError as exc:
             # Some login paths return 401/403 before auth — treat as up.
-            if exc.code in (200, 302, 401, 403):
+            if is_http_ready_code(exc.code):
+                if container_name:
+                    logs = _docker_logs_tail(container_name)
+                    match = find_rhythmyx_context_failure(logs)
+                    if match is not None:
+                        return (
+                            False,
+                            f"{DETAIL_CONTEXT_FAILED} match={match!r} "
+                            f"http={exc.code}",
+                        )
                 return True, f"HTTP {exc.code}"
             last = f"HTTPError {exc.code}"
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             last = str(exc)
         time.sleep(interval_seconds)
+    # Final log scan so timeout DETAIL prefers context failure when present.
+    if container_name:
+        logs = _docker_logs_tail(container_name)
+        match = find_rhythmyx_context_failure(logs)
+        if match is not None:
+            return (
+                False,
+                f"{DETAIL_CONTEXT_FAILED} match={match!r} last={last or 'timeout'}",
+            )
     return False, last or "timeout"
 
 
@@ -1044,11 +1129,14 @@ def run_cell(
             log_path=str(cell_log),
         )
 
-    # Capture container logs while waiting
+    # Capture container logs while waiting. CMS cells pass container_name so
+    # a dead Rhythmyx ApplicationContext fails the probe even if Jetty HTTP
+    # still answers (#2462 / #2423).
     ok, detail = wait_for_http(
         probe_url,
         timeout_seconds=probe_timeout,
         dry_run=dry_run,
+        container_name=name if cell.product == "cms" else None,
     )
     if not dry_run:
         logs = _run(

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -12,7 +12,10 @@ docker compose stack and exposes every subcommand the original
 QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
 
 * ``qa-up`` — one-shot CMS on H2 via matrix cell (``--keep``), health wait
-* ``qa-health`` — poll published CMS URL until ready (clear timeout)
+* ``qa-health`` — poll published CMS URL until ready (clear timeout);
+  fail-fast when Jetty logs show Rhythmyx ApplicationContext failure
+  (``Failed startup of context`` / ``BeanCurrentlyInCreationException``)
+  even if HTTP still answers (#2462 / #2423)
 * ``qa-down`` — destroy the QA cell (frees ports; no multi-GB orphans)
 
 Each subcommand logs its full output to a timestamped file under
@@ -73,6 +76,11 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 from perc_host_ports import find_free_port, is_port_free, resolve_host_port  # noqa: E402
+from rhythmyx_ready import (  # noqa: E402
+    DETAIL_CONTEXT_FAILED,
+    assess_rhythmyx_ready,
+    find_rhythmyx_context_failure,
+)
 
 LOG = logging.getLogger("perc-devctl")
 
@@ -119,6 +127,8 @@ QA_PASSWORDS_REL = "var/config/generated/passwords"
 # Matrix silent install can take several minutes on first run.
 QA_PROBE_TIMEOUT_SECONDS_DEFAULT = 900
 QA_PROBE_INTERVAL_SECONDS_DEFAULT = 5
+# Tail size for docker logs when scanning for Rhythmyx context failure (#2462).
+QA_LOG_SCAN_TAIL_LINES = 800
 
 
 # Freeport primitives live in perc_host_ports.py (shared with matrix) — #2001/#2005.
@@ -624,6 +634,46 @@ def _docker_health(container_name: str) -> str:
     return (completed.stdout or "").strip() or "unknown"
 
 
+def _docker_logs_tail(
+    container_name: str,
+    *,
+    tail: int = QA_LOG_SCAN_TAIL_LINES,
+    timeout: float = 30.0,
+) -> str:
+    """Return recent ``docker logs`` text for ``container_name``, or empty.
+
+    Used by ``qa-health`` to fail-fast when Jetty reports Rhythmyx context
+    startup failure while the HTTP port may still answer (#2462).
+    """
+    if not container_name:
+        return ""
+    try:
+        completed = subprocess.run(
+            [
+                "docker",
+                "logs",
+                "--tail",
+                str(max(1, int(tail))),
+                container_name,
+            ],
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    # docker logs may put stream content on stderr depending on version.
+    out = completed.stdout or ""
+    err = completed.stderr or ""
+    if out and err:
+        return out + "\n" + err
+    return out or err
+
+
 def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     repo_root, env_file, compose_file = paths
     log_dir = _log_dir(repo_root)
@@ -1068,68 +1118,129 @@ def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
 
 
 def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
-    """Poll the QA CMS probe URL until ready or a clear timeout error."""
+    """Poll the QA CMS probe URL until ready or a clear timeout / context fail.
+
+    Ready means:
+
+    * HTTP status on the probe URL is in the ready set (200/302/401/403), **and**
+    * Recent ``docker logs`` for the QA cell do **not** contain Rhythmyx
+      ApplicationContext failure markers (see :mod:`rhythmyx_ready`).
+
+    Context-failure markers cause **immediate** FAIL even when HTTP answers
+    (Jetty up, Spring webapp dead — #2462 residual of #2423).
+    """
     repo_root, _env_file, _compose_file = paths
     log_dir = _log_dir(repo_root)
     timeout = int(args.timeout_seconds)
     interval = int(args.interval_seconds)
     host_port = resolve_qa_cms_host_port()
     url = args.url or qa_cms_probe_url(host_port)
+    container = QA_CMS_CONTAINER
     max_checks = max(1, timeout // interval) if interval > 0 else 1
     log_file = _new_log_file(log_dir, "qa-health")
 
     if args.dry_run:
         LOG.info(
-            "DRY-RUN: qa-health plan: %d checks x %ds interval against %s",
+            "DRY-RUN: qa-health plan: %d checks x %ds interval against %s "
+            "(+ Rhythmyx context log scan on %s)",
             max_checks,
             interval,
             url,
+            container,
         )
         with log_file.open("w", encoding="utf-8") as f:
             f.write(
                 f"DRY-RUN: qa-health max_checks={max_checks} interval={interval}\n"
                 f"url={url}\n"
-                f"container={QA_CMS_CONTAINER}\n"
+                f"container={container}\n"
+                f"log_scan=rhythmyx_context_fail_markers\n"
             )
         print(
             f"RESULT:OK STEP:qa-health HTTP:200 URL:{url} "
-            f"CONTAINER:{QA_CMS_CONTAINER} LOG:{log_file}"
+            f"CONTAINER:{container} LOG:{log_file}"
         )
         return EXIT_OK
 
     last_code = 0
+    last_detail = "not_checked"
     for check in range(1, max_checks + 1):
         last_code = _curl_status(url, timeout=5.0)
-        if last_code in (200, 302, 401, 403):
+        logs = _docker_logs_tail(container)
+        ready, last_detail = assess_rhythmyx_ready(last_code, logs)
+        if ready:
             with log_file.open("w", encoding="utf-8") as f:
                 f.write("qa-health success\n")
                 f.write(f"url={url}\n")
                 f.write(f"http={last_code}\n")
                 f.write(f"check={check}\n")
-                f.write(f"container={QA_CMS_CONTAINER}\n")
+                f.write(f"container={container}\n")
+                f.write("rhythmyx_context=ok\n")
             print(
                 f"RESULT:OK STEP:qa-health HTTP:{last_code} URL:{url} "
-                f"CONTAINER:{QA_CMS_CONTAINER} LOG:{log_file}"
+                f"CONTAINER:{container} LOG:{log_file}"
             )
             return EXIT_OK
+
+        # Fail-fast when Spring/Jetty already reported a dead Rhythmyx context.
+        if DETAIL_CONTEXT_FAILED in last_detail:
+            match = find_rhythmyx_context_failure(logs) or "unknown"
+            with log_file.open("w", encoding="utf-8") as f:
+                f.write("qa-health failed\n")
+                f.write(f"url={url}\n")
+                f.write(f"last_http={last_code}\n")
+                f.write(f"check={check}\n")
+                f.write(f"container={container}\n")
+                f.write(f"detail={last_detail}\n")
+                f.write(f"match={match}\n")
+                f.write(
+                    "hint: Rhythmyx ApplicationContext failed; Jetty HTTP may "
+                    "still bind. Inspect docker logs for Spring cycle / bean "
+                    "errors (parent #2423). Do not treat port-up as ready.\n"
+                )
+            print(
+                f"RESULT:FAIL STEP:qa-health DETAIL:{DETAIL_CONTEXT_FAILED} "
+                f"MATCH:{match} HTTP:{last_code} URL:{url} "
+                f"CONTAINER:{container} LOG:{log_file}"
+            )
+            return EXIT_SUBPROCESS_FAILED
+
         time.sleep(interval)
 
+    # Timeout path: re-scan logs once more so DETAIL prefers context failure.
+    final_logs = _docker_logs_tail(container)
+    final_match = find_rhythmyx_context_failure(final_logs)
     with log_file.open("w", encoding="utf-8") as f:
         f.write("qa-health failed\n")
         f.write(f"url={url}\n")
         f.write(f"last_http={last_code}\n")
         f.write(f"timeout_seconds={timeout}\n")
         f.write(f"interval_seconds={interval}\n")
-        f.write(f"container={QA_CMS_CONTAINER}\n")
-        f.write(
-            "hint: run qa-up first; ensure installer jar is built "
-            "(modules/perc-distribution-tree package)\n"
+        f.write(f"container={container}\n")
+        f.write(f"last_detail={last_detail}\n")
+        if final_match:
+            f.write(f"match={final_match}\n")
+            f.write(
+                "hint: Rhythmyx context failure markers found in docker logs; "
+                "see parent #2423. HTTP-only ready is insufficient.\n"
+            )
+        else:
+            f.write(
+                "hint: run qa-up first; ensure installer jar is built "
+                "(modules/perc-distribution-tree package); if Jetty is up but "
+                "login fails, scan docker logs for Failed startup of context\n"
+            )
+    if final_match:
+        print(
+            f"RESULT:FAIL STEP:qa-health DETAIL:{DETAIL_CONTEXT_FAILED} "
+            f"MATCH:{final_match} HTTP:{last_code} URL:{url} "
+            f"CONTAINER:{container} LOG:{log_file}"
         )
-    print(
-        f"RESULT:FAIL STEP:qa-health DETAIL:timeout after {timeout}s "
-        f"(last_http={last_code}) URL:{url} CONTAINER:{QA_CMS_CONTAINER} "
-        f"LOG:{log_file}"
-    )
+    else:
+        print(
+            f"RESULT:FAIL STEP:qa-health DETAIL:timeout after {timeout}s "
+            f"(last_http={last_code}) URL:{url} CONTAINER:{container} "
+            f"LOG:{log_file}"
+        )
     return EXIT_SUBPROCESS_FAILED
 
 

--- a/docker/scripts/rhythmyx_ready.py
+++ b/docker/scripts/rhythmyx_ready.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Rhythmyx / CMS readiness helpers for docker health probes (#2462 / #2423).
+
+Jetty can bind its HTTP connector while the ROOT/Rhythmyx webapp Spring
+``ApplicationContext`` failed to start (circular beans, missing deps, etc.).
+HTTP-only probes then look green (or hang until timeout) while login/REST
+are dead.
+
+This module provides pure, stdlib-only helpers:
+
+* HTTP status codes that count as "something answered" for login/REST
+* Log-text markers that mean the Rhythmyx webapp context failed
+* A small assessor that combines HTTP + log scan for fail-fast
+
+Callers: ``perc-devctl.py`` (``qa-health``), ``matrix-install-smoke.py``
+(``wait_for_http``). No secrets; no network I/O here.
+"""
+
+from __future__ import annotations
+
+from typing import FrozenSet, Optional, Sequence, Tuple
+
+# Login / REST probes treat these as "endpoint is up" (auth may still apply).
+HTTP_READY_CODES: FrozenSet[int] = frozenset({200, 302, 401, 403})
+
+# Substrings from Jetty / Spring logs when ROOT/Rhythmyx context fails.
+# Keep markers specific enough to avoid installer noise (e.g. file names).
+RHYTHMYX_CONTEXT_FAIL_MARKERS: Tuple[str, ...] = (
+    "Failed startup of context",
+    "BeanCurrentlyInCreationException",
+    "Requested bean is currently in creation",
+    "Is there an unresolvable circular reference",
+)
+
+# RESULT / DETAIL token for agent parsers (stable contract).
+DETAIL_CONTEXT_FAILED = "rhythmyx_context_failed"
+
+
+def find_rhythmyx_context_failure(
+    log_text: str,
+    *,
+    markers: Sequence[str] = RHYTHMYX_CONTEXT_FAIL_MARKERS,
+) -> Optional[str]:
+    """Return the first context-failure marker found in ``log_text``, or None.
+
+    Matching is plain substring (case-sensitive, same as Jetty/Spring log
+    phrasing). Empty / None input yields None.
+    """
+    if not log_text:
+        return None
+    for marker in markers:
+        if marker and marker in log_text:
+            return marker
+    return None
+
+
+def is_http_ready_code(code: int) -> bool:
+    """True when ``code`` is an accepted login/REST probe response."""
+    return int(code) in HTTP_READY_CODES
+
+
+def assess_rhythmyx_ready(
+    http_code: int,
+    log_text: str = "",
+    *,
+    require_http: bool = True,
+) -> Tuple[bool, str]:
+    """Combine HTTP probe + log scan into a ready / not-ready verdict.
+
+    Returns ``(ready, detail)`` where ``detail`` is a short machine-friendly
+    reason when not ready, or ``ok`` when ready.
+
+    Rules (issue #2462):
+
+    1. Any context-failure marker in logs → **not ready** (fail-fast), even
+       if HTTP returned a ready code (dead Spring webapp behind Jetty).
+    2. If ``require_http`` and HTTP is not a ready code → not ready.
+    3. Else ready.
+    """
+    match = find_rhythmyx_context_failure(log_text)
+    if match is not None:
+        return False, f"{DETAIL_CONTEXT_FAILED} match={match!r} http={http_code}"
+    if require_http and not is_http_ready_code(http_code):
+        return False, f"http_not_ready http={http_code}"
+    return True, "ok"

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -278,6 +278,102 @@ class DockerRunArgvTests(unittest.TestCase):
         )
 
 
+class WaitForHttpContextFailTests(unittest.TestCase):
+    """#2462: matrix probe must fail-fast on Rhythmyx context death."""
+
+    def test_wait_for_http_dry_run(self):
+        ok, detail = smoke.wait_for_http(
+            "http://127.0.0.1:9993/Rhythmyx/login",
+            timeout_seconds=1,
+            dry_run=True,
+            container_name="perc-matrix-cms-h2",
+        )
+        self.assertTrue(ok)
+        self.assertEqual(detail, "dry-run")
+
+    def test_wait_for_http_context_fail_without_http(self):
+        import unittest.mock
+
+        dead = "WARN [WebAppContext] Failed startup of context Rhythmyx\n"
+        with unittest.mock.patch.object(
+            smoke, "_docker_logs_tail", return_value=dead
+        ), unittest.mock.patch.object(smoke.time, "sleep"):
+            ok, detail = smoke.wait_for_http(
+                "http://127.0.0.1:9993/Rhythmyx/login",
+                timeout_seconds=30,
+                interval_seconds=5,
+                dry_run=False,
+                container_name="perc-matrix-cms-h2",
+            )
+        self.assertFalse(ok)
+        self.assertIn("rhythmyx_context_failed", detail)
+        self.assertIn("Failed startup of context", detail)
+
+    def test_wait_for_http_http_ok_but_context_failed(self):
+        import unittest.mock
+        import urllib.error
+
+        dead = (
+            "Failed startup of context Rhythmyx\n"
+            "BeanCurrentlyInCreationException: folderHelper\n"
+        )
+
+        class _Resp:
+            def getcode(self):
+                return 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        with unittest.mock.patch.object(
+            smoke, "_docker_logs_tail", return_value=dead
+        ), unittest.mock.patch.object(
+            smoke.urllib.request, "urlopen", return_value=_Resp()
+        ), unittest.mock.patch.object(smoke.time, "sleep"):
+            # First loop iteration: log scan runs before HTTP and fails immediately.
+            ok, detail = smoke.wait_for_http(
+                "http://127.0.0.1:9993/Rhythmyx/login",
+                timeout_seconds=30,
+                interval_seconds=5,
+                dry_run=False,
+                container_name="perc-matrix-cms-h2",
+            )
+        self.assertFalse(ok)
+        self.assertIn("rhythmyx_context_failed", detail)
+
+    def test_wait_for_http_no_container_skips_log_scan(self):
+        """DTS / no container: HTTP-only path unchanged."""
+        import unittest.mock
+
+        class _Resp:
+            def getcode(self):
+                return 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        with unittest.mock.patch.object(
+            smoke, "_docker_logs_tail"
+        ) as mock_logs, unittest.mock.patch.object(
+            smoke.urllib.request, "urlopen", return_value=_Resp()
+        ):
+            ok, detail = smoke.wait_for_http(
+                "http://127.0.0.1:9983/",
+                timeout_seconds=5,
+                dry_run=False,
+                container_name=None,
+            )
+        self.assertTrue(ok)
+        self.assertEqual(detail, "HTTP 200")
+        mock_logs.assert_not_called()
+
+
 class InstallArgvTests(unittest.TestCase):
     def test_cms_postgres_silent_argv(self):
         argv = cell.build_install_argv(

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -516,8 +516,10 @@ class TestQaHealthRealMode(unittest.TestCase):
 
     def test_qa_health_success_on_first_check(self):
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
              unittest.mock.patch.object(pdc.time, "sleep"):
             mock_curl.return_value = 200
+            mock_logs.return_value = "INFO [Server] Started @7879ms\n"
             import io
             from contextlib import redirect_stdout
             buf = io.StringIO()
@@ -530,11 +532,14 @@ class TestQaHealthRealMode(unittest.TestCase):
         self.assertEqual(rc, pdc.EXIT_OK)
         self.assertIn("RESULT:OK STEP:qa-health", out)
         self.assertIn("HTTP:200", out)
+        mock_logs.assert_called()
 
     def test_qa_health_timeout_emits_clear_error(self):
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
              unittest.mock.patch.object(pdc.time, "sleep"):
             mock_curl.return_value = 0
+            mock_logs.return_value = ""
             import io
             from contextlib import redirect_stdout
             buf = io.StringIO()
@@ -551,6 +556,61 @@ class TestQaHealthRealMode(unittest.TestCase):
         self.assertIn("timeout", out)
         self.assertIn("LOG:", out)
         self.assertNotIn("LOG:\n", out)
+
+    def test_qa_health_fails_when_http_ok_but_context_failed(self):
+        """#2462: Jetty HTTP ready + dead Rhythmyx context must FAIL (not OK)."""
+        dead_ctx = (
+            "WARN  [WebAppContext] Failed startup of context "
+            "oeje11w.WebAppContext Rhythmyx\n"
+            "BeanCurrentlyInCreationException: folderHelper\n"
+            "INFO  [AbstractConnector] Started {HTTP/1.1}{0.0.0.0:9992}\n"
+        )
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
+             unittest.mock.patch.object(pdc.time, "sleep") as mock_sleep:
+            mock_curl.return_value = 200
+            mock_logs.return_value = dead_ctx
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "qa-health",
+                    "--timeout-seconds", "30",
+                    "--interval-seconds", "5",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
+        self.assertIn("RESULT:FAIL STEP:qa-health", out)
+        self.assertIn("rhythmyx_context_failed", out)
+        self.assertIn("Failed startup of context", out)
+        # Fail-fast: must not burn the full poll budget.
+        mock_sleep.assert_not_called()
+
+    def test_qa_health_timeout_prefers_context_failure_detail(self):
+        """When HTTP never ready but logs show context fail, DETAIL uses that."""
+        dead_ctx = "Failed startup of context Rhythmyx\n"
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
+             unittest.mock.patch.object(pdc.time, "sleep"):
+            mock_curl.return_value = 0
+            # max_checks=1 (5//5): one in-loop scan (empty) + one final scan (fail).
+            mock_logs.side_effect = ["", dead_ctx]
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "qa-health",
+                    "--timeout-seconds", "5",
+                    "--interval-seconds", "5",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
+        self.assertIn("rhythmyx_context_failed", out)
+        self.assertIn("Failed startup of context", out)
 
 
 class TestQaDownRealMode(unittest.TestCase):

--- a/docker/scripts/test_rhythmyx_ready.py
+++ b/docker/scripts/test_rhythmyx_ready.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for rhythmyx_ready.py (#2462)."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def _load():
+    path = SCRIPTS / "rhythmyx_ready.py"
+    name = "rhythmyx_ready"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rr = _load()
+
+
+class FindContextFailureTests(unittest.TestCase):
+    def test_empty_and_clean(self):
+        self.assertIsNone(rr.find_rhythmyx_context_failure(""))
+        self.assertIsNone(rr.find_rhythmyx_context_failure(None))  # type: ignore[arg-type]
+        self.assertIsNone(
+            rr.find_rhythmyx_context_failure(
+                "INFO [Server] Started @7879ms\n"
+                "INFO [AbstractConnector] Started {HTTP/1.1}{0.0.0.0:9992}\n"
+            )
+        )
+
+    def test_failed_startup_of_context(self):
+        text = (
+            "WARN  [WebAppContext] Failed startup of context "
+            "oeje11w.WebAppContext@…{ROOT,/,b=…Rhythmyx}\n"
+            "org.springframework.beans.factory.UnsatisfiedDependencyException\n"
+        )
+        self.assertEqual(
+            rr.find_rhythmyx_context_failure(text),
+            "Failed startup of context",
+        )
+
+    def test_bean_currently_in_creation(self):
+        text = (
+            "Caused by: org.springframework.beans.factory."
+            "BeanCurrentlyInCreationException:\n"
+            "  Error creating bean with name 'folderHelper'\n"
+        )
+        self.assertEqual(
+            rr.find_rhythmyx_context_failure(text),
+            "BeanCurrentlyInCreationException",
+        )
+
+    def test_circular_reference_phrase(self):
+        text = (
+            "Is there an unresolvable circular reference or an "
+            "asynchronous initialization dependency?\n"
+        )
+        self.assertEqual(
+            rr.find_rhythmyx_context_failure(text),
+            "Is there an unresolvable circular reference",
+        )
+
+    def test_installer_folderhelper_filename_not_a_match(self):
+        """Installer unzip lines mention PercFolderHelper.js — not a context fail."""
+        text = (
+            "Unzipping to /tmp/x/jetty/base/webapps/Rhythmyx/cm/plugins/"
+            "PercFolderHelper.js\n"
+            "Creating file /tmp/x/…/PercFolderHelper.js\n"
+        )
+        self.assertIsNone(rr.find_rhythmyx_context_failure(text))
+
+
+class AssessReadyTests(unittest.TestCase):
+    def test_http_ready_clean_logs(self):
+        ok, detail = rr.assess_rhythmyx_ready(200, "Server Started")
+        self.assertTrue(ok)
+        self.assertEqual(detail, "ok")
+
+    def test_http_ready_but_context_failed(self):
+        ok, detail = rr.assess_rhythmyx_ready(
+            200,
+            "WARN [WebAppContext] Failed startup of context Rhythmyx",
+        )
+        self.assertFalse(ok)
+        self.assertIn(rr.DETAIL_CONTEXT_FAILED, detail)
+        self.assertIn("Failed startup of context", detail)
+
+    def test_http_not_ready_clean_logs(self):
+        ok, detail = rr.assess_rhythmyx_ready(0, "")
+        self.assertFalse(ok)
+        self.assertIn("http_not_ready", detail)
+
+    def test_context_fail_wins_over_http(self):
+        ok, detail = rr.assess_rhythmyx_ready(
+            302,
+            "BeanCurrentlyInCreationException: folderHelper",
+        )
+        self.assertFalse(ok)
+        self.assertIn(rr.DETAIL_CONTEXT_FAILED, detail)
+
+    def test_is_http_ready_codes(self):
+        for code in (200, 302, 401, 403):
+            self.assertTrue(rr.is_http_ready_code(code), code)
+        for code in (0, 404, 500, 503):
+            self.assertFalse(rr.is_http_ready_code(code), code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -122,9 +122,13 @@ python docker/scripts/perc-devctl.py qa-up
 # Host port: QA_CMS_HOST_PORT / CMS_HOST_PORT env, else preferred 9993 when free, else freeport.
 # qa-up prints QA_CMS_HOST_PORT=… and TEST_CMS_URL=http://127.0.0.1:<port>
 
-# 2) HEALTH — re-check readiness (clear RESULT:FAIL + timeout if not ready)
+# 2) HEALTH — re-check readiness (clear RESULT:FAIL + timeout if not ready).
+#    Also fail-fast if docker logs show Rhythmyx ApplicationContext death
+#    (Failed startup of context / BeanCurrentlyInCreationException) even when
+#    Jetty HTTP still answers (#2462 / #2423). Do not treat port-up alone as ready.
 python docker/scripts/perc-devctl.py qa-health
 # optional: --timeout-seconds 120  --interval-seconds 5
+# DETAIL:rhythmyx_context_failed → cell unusable; inspect docker logs; do not run Playwright
 
 # 3) Playwright against the stack only — no DEV_PERCUSSION_INSTALL
 #    (#2064 env + #2065 golden smoke + #1929 surface filter)
@@ -157,6 +161,7 @@ python docker/scripts/perc-devctl.py qa-down
 | Container name       | `perc-matrix-cms-h2`                                                     |
 | Admin user           | `Admin` (password from install generated passwords)                      |
 | RESULT line contract | `RESULT:OK\|FAIL STEP:qa-up\|qa-health\|qa-down LOG:…`                   |
+| Context fail-fast    | `DETAIL:rhythmyx_context_failed MATCH:…` when Jetty logs show dead Rhythmyx Spring context (#2462); helper `docker/scripts/rhythmyx_ready.py` |
 
 **Tear-down policy:** `qa-down` runs `docker rm -f` on the QA cell. The install lives **inside** the container (no named multi-GB volume by default), so removing the container frees ports and disk. Prefer `qa-down` after every agent session; do not leave `perc-matrix-cms-h2` running overnight unless debugging.
 


### PR DESCRIPTION
## Summary

**Fixes #2462** (residual of parent **#2423**): CMS/QA health must fail when the ROOT/Rhythmyx Spring `ApplicationContext` did not start — not only when Jetty HTTP binds.

Jetty can report `Started` while Spring fails with `BeanCurrentlyInCreationException` / `Failed startup of context`. Port-up and HTTP-only probes then look green while login/REST/Playwright are dead.

### Changes
- New shared helper `docker/scripts/rhythmyx_ready.py` — ready HTTP codes + context-failure markers + assessor
- `perc-devctl.py qa-health` — each poll scans recent `docker logs`; **fail-fast** with `DETAIL:rhythmyx_context_failed MATCH:…` even if HTTP is 200/302
- `matrix-install-smoke.py` CMS cells — `wait_for_http(..., container_name=…)` same log scan during probe wait
- Operator docs: `docker/README.md`, `docs/developer-module/workbench-rest-and-qa-modes.md`

### Operator signal
| Result | Meaning |
|--------|---------|
| `RESULT:OK STEP:qa-health` | HTTP ready **and** no context-failure markers in logs |
| `RESULT:FAIL … DETAIL:rhythmyx_context_failed` | Dead Rhythmyx context — do not run Playwright |
| `RESULT:FAIL … DETAIL:timeout` | Probe never ready (final log scan may still upgrade DETAIL to context failed) |

**Parent tracker:** #2423

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q` → **123 passed**
- [x] Unit cases: clean logs + HTTP 200 → OK; HTTP 200 + `Failed startup of context` → FAIL fail-fast; matrix wait same
- [x] No Maven modules changed (scripts/docs only) — Pre-PR Maven clean install N/A

## Gates
- Erlang self-review: portable (no hardcoded FS separators); pure stdlib log scan; no secrets; fail-fast does not sleep full timeout on context death
- Change-class: shared helper + perc-devctl + matrix harness + unit tests + operator docs (companions closed for this slice)

## Residuals (to file after merge path)
- Compose `verify` path log scan (cms-dts stack)
- Matrix image HEALTHCHECK using same markers
- Optional product readiness surface beyond log scan

> Co-Authored by Grok Build using grok-4.5 with agent main.