### PR TITLE
fix(sitemanage): residual folderHelper cycles + Docker QA smoke (#2437)

### DIFF
--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -106,12 +106,24 @@ Two supported modes. Agents must know which they are in. **Developers/agents do 
 
 Productized entrypoint on `docker/scripts/perc-devctl.py` (cross-platform Python; no shell required). Implements **#1827** slice 1 / **#1927**: CMS on **H2 in Docker**, published URL, no host install.
 
-**Prereq (once per machine / after installer changes):** package the customer CMS installer assembly:
+**Prereq (once per machine / after installer or sitemanage/WebUI SNAPSHOT changes):** rebuild the chain that feeds the installer. The matrix cell **bind-mounts** `modules/perc-distribution-tree/target/perc-distribution-tree.jar`; that jar unpacks **`WebUI/target/perc-web-ui-*.war`** into `Rhythmyx/WEB-INF/lib` (including `sitemanage-*.jar`). Packaging only `perc-distribution-tree` after a sitemanage-only install **does not** pick up a new sitemanage if the WebUI WAR is stale.
+
+```bash
+# After sitemanage (or other Rhythmyx WEB-INF/lib) changes — full QA rebuild chain:
+cd projects/sitemanage && ../../mvnw clean install   # or package if tests already green
+cd ../../WebUI && ../mvnw package -DskipTests
+cd ../modules/perc-distribution-tree && ../../mvnw clean package -DskipTests
+# Windows: use mvnw.cmd and the same module order
+```
+
+If only installer packaging scripts/resources changed (no Java SNAPSHOT under the WAR):
 
 ```bash
 cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
 # Windows: cd modules\perc-distribution-tree && ..\..\mvnw.cmd package -DskipTests
 ```
+
+**Post-cycle-fix smoke (#2423 / #2437):** after the rebuild chain, `qa-up` logs must show `ServletContextHandler] Started` for ROOT/Rhythmyx and **must not** contain `BeanCurrentlyInCreationException` / `Failed startup of context`. `qa-health` → login page HTTP 200/302 is the operator gate before Playwright.
 
 **Lifecycle (always use this order for unattended QA):**
 

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSPageDaoHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSPageDaoHelper.java
@@ -74,7 +74,12 @@ public class PSPageDaoHelper implements IPSPageDaoHelper {
 
   @Autowired
   public PSPageDaoHelper(
-      IPSContentWs contentWs, IPSFolderHelper folderHelper, IPSIdMapper idMapper) {
+      IPSContentWs contentWs,
+      // @Lazy breaks reverse edge: folderHelper creation → … → pageDaoHelper → folderHelper.
+      // Class-level @Lazy on this bean only defers first request; ctor deps still resolve eagerly.
+      // Observed on Docker CMS after contentItemDao @Lazy (#2435): #2423 / #2437.
+      @Lazy IPSFolderHelper folderHelper,
+      IPSIdMapper idMapper) {
     this.contentWs = contentWs;
     this.folderHelper = folderHelper;
     this.idMapper = idMapper;

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
@@ -166,7 +166,11 @@ public class PSFolderHelper implements IPSFolderHelper {
       IPSNotificationService notificationService,
       IPSSiteManager siteMgr,
       IPSWorkflowService workflowService,
-      IPSRecycleService recycleService) {
+      // @Lazy breaks constructor cycles that re-enter folderHelper via recycle →
+      // widgetAssetRelationshipService → pageIndexService → pageDaoHelper (and via
+      // assetDao → contentItemDao). Class-level @Lazy alone does not break ctor edges.
+      // See #2423 / #2437 Docker Rhythmyx startup.
+      @Lazy IPSRecycleService recycleService) {
     this.contentWs = contentWs;
     this.dataItemSummaryService = dataItemSummaryService;
     this.idMapper = idMapper;

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/dao/impl/PSPageDaoHelperCycleLazyWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/dao/impl/PSPageDaoHelperCycleLazyWiringTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.share.dao.IPSFolderHelper;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Regression test for the Spring constructor-injection cycle observed on Docker CMS after
+ * contentItemDao {@code @Lazy} (#2435):
+ *
+ * <pre>
+ * folderHelper -&gt; recycleService -&gt; widgetAssetRelationshipService
+ *   -&gt; pageIndexService -&gt; pageDaoHelper -&gt; folderHelper
+ * </pre>
+ *
+ * <p>Class-level {@code @Lazy} on {@link PSPageDaoHelper} only defers first request; constructor
+ * dependencies still resolve eagerly. The {@code IPSFolderHelper} constructor parameter must be
+ * {@link Lazy @Lazy} so Spring injects a proxy and does not re-enter {@code folderHelper} while
+ * it is still being created (#2423 / #2437).
+ */
+@Tag("UnitTest")
+public class PSPageDaoHelperCycleLazyWiringTest {
+
+  @Test
+  public void folderHelperConstructorParameterIsLazy() throws NoSuchMethodException {
+    Constructor<PSPageDaoHelper> ctor =
+        PSPageDaoHelper.class.getDeclaredConstructor(
+            com.percussion.webservices.content.IPSContentWs.class,
+            IPSFolderHelper.class,
+            com.percussion.share.service.IPSIdMapper.class);
+
+    assertNotNull(ctor, "PSPageDaoHelper constructor signature must match");
+
+    Parameter folderHelperParam = null;
+    for (Parameter p : ctor.getParameters()) {
+      if (IPSFolderHelper.class.isAssignableFrom(p.getType())) {
+        folderHelperParam = p;
+        break;
+      }
+    }
+
+    assertNotNull(folderHelperParam, "Expected an IPSFolderHelper constructor parameter");
+    assertTrue(
+        folderHelperParam.isAnnotationPresent(Lazy.class),
+        "IPSFolderHelper constructor parameter must be @Lazy to break the "
+            + "folderHelper↔pageDaoHelper Spring cycle (see #2423 / #2437)");
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperRecycleLazyWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperRecycleLazyWiringTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.recycle.service.IPSRecycleService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Regression test for Spring constructor-injection cycles rooted at {@code folderHelper}'s
+ * {@code recycleService} dependency (#2423 / #2437).
+ *
+ * <pre>
+ * folderHelper -&gt; recycleService -&gt; widgetAssetRelationshipService
+ *   -&gt; pageIndexService -&gt; pageDaoHelper -&gt; folderHelper
+ * folderHelper -&gt; recycleService -&gt; … -&gt; contentItemDao -&gt; folderHelper
+ * </pre>
+ *
+ * <p>Class-level {@code @Lazy} on {@link PSFolderHelper} does not break constructor edges. The
+ * {@code IPSRecycleService} constructor parameter must be {@link Lazy @Lazy} so Spring injects a
+ * proxy and finishes {@code folderHelper} construction before resolving the recycle subgraph.
+ */
+@Tag("UnitTest")
+public class PSFolderHelperRecycleLazyWiringTest {
+
+  @Test
+  public void recycleServiceConstructorParameterIsLazy() throws NoSuchMethodException {
+    Constructor<PSFolderHelper> ctor =
+        PSFolderHelper.class.getDeclaredConstructor(
+            com.percussion.webservices.content.IPSContentWs.class,
+            com.percussion.share.service.IPSDataItemSummaryService.class,
+            com.percussion.webservices.content.IPSContentDesignWs.class,
+            com.percussion.share.service.IPSIdMapper.class,
+            com.percussion.services.publisher.IPSPublisherService.class,
+            com.percussion.services.system.IPSSystemService.class,
+            com.percussion.services.notification.IPSNotificationService.class,
+            com.percussion.services.sitemgr.IPSSiteManager.class,
+            com.percussion.services.workflow.IPSWorkflowService.class,
+            IPSRecycleService.class);
+
+    assertNotNull(ctor, "PSFolderHelper constructor signature must match");
+
+    Parameter recycleParam = null;
+    for (Parameter p : ctor.getParameters()) {
+      if (IPSRecycleService.class.isAssignableFrom(p.getType())) {
+        recycleParam = p;
+        break;
+      }
+    }
+
+    assertNotNull(recycleParam, "Expected an IPSRecycleService constructor parameter");
+    assertTrue(
+        recycleParam.isAnnotationPresent(Lazy.class),
+        "IPSRecycleService constructor parameter must be @Lazy to break "
+            + "folderHelper→recycleService constructor cycles (see #2423 / #2437)");
+  }
+}


### PR DESCRIPTION
## Summary

**Fixes #2437** (slice C of parent **#2423**): prove Docker CMS H2 (`perc-devctl qa-up`) starts Rhythmyx after the folderHelper cycle work — and fix the **residual** constructor cycle that still blocked startup after #2435.

### Discovery during smoke
#2435 `@Lazy` on `contentItemDao → folderHelper` is present and correct, but Docker still failed with:

```text
folderHelper → recycleService → widgetAssetRelationshipService
  → pageIndexService → pageDaoHelper → folderHelper
  BeanCurrentlyInCreationException: folderHelper
```

Class-level `@Lazy` on `PSFolderHelper` / `PSPageDaoHelper` does **not** break constructor dependency edges.

### Fix
| Edge | Change |
|------|--------|
| `folderHelper → recycleService` | `@Lazy` on `PSFolderHelper` ctor `IPSRecycleService` |
| `pageDaoHelper → folderHelper` | `@Lazy` on `PSPageDaoHelper` ctor `IPSFolderHelper` |

### Tests
- `PSFolderHelperRecycleLazyWiringTest`
- `PSPageDaoHelperCycleLazyWiringTest`
- (existing) `PSContentItemDaoCycleLazyWiringTest`

### Docs
`docs/developer-module/workbench-rest-and-qa-modes.md` — rebuild chain for QA:

`sitemanage install → WebUI package → perc-distribution-tree package → qa-up`

(Stale WebUI WAR was a real false-negative: packaging only dist after sitemanage install leaves old `sitemanage` inside the WAR.)

### Also on branch
Cherry-pick of **#2457** JDK 21 Iterable cast fix (open PR **#2469**) so `projects/sitemanage` clean-installs on the JDK 21 toolchain. If #2469 merges first, rebase drops the duplicate.

**Parent tracker:** #2423  
**Operator:** Grok: night-issue-prs (model grok-4.5)

## Live evidence (this session)

```text
RESULT:OK STEP:qa-up
RESULT:OK STEP:qa-health HTTP:200 URL:http://127.0.0.1:9993/Rhythmyx/login
LOGIN_PAGE_HTTP=200
LOGIN_POST_HTTP=302
CYCLE_MATCH_COUNT=0   # BeanCurrentlyInCreation / Failed startup of context
ServletContextHandler] Started … Rhythmyx
Server] Started … @45123ms
```

Commands (after rebuild chain):

```bat
cd projects\sitemanage && ..\..\mvnw.cmd clean install
cd ..\..\WebUI && ..\mvnw.cmd package -DskipTests
cd ..\modules\perc-distribution-tree && ..\..\mvnw.cmd clean package -DskipTests
python docker\scripts\perc-devctl.py qa-up --timeout-seconds 900
python docker\scripts\perc-devctl.py qa-health
docker logs perc-matrix-cms-h2 2>&1 | findstr /i "BeanCurrentlyInCreation Failed startup"
python docker\scripts\perc-devctl.py qa-down
```

## Test plan / gates

- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] New Lazy wiring unit tests green
- [x] WebUI package + perc-distribution-tree clean package (for live smoke only; not committed artifacts)
- [x] `qa-up` / `qa-health` RESULT:OK; cycle log scan empty; login 200/302
- [x] Erlang self-review: portable (no path I/O); constructor-param `@Lazy` only; tests assert annotations
- [x] Pre-PR Maven: sitemanage standalone clean install

## Residuals (to file under #2423)
- Golden Playwright surface smoke as CI-default after cycle fix
- Remaining constructor reverse-edges to `folderHelper` inventory beyond recycle/pageDaoHelper
- Optional CI cache/order note so matrix never mounts a stale WebUI WAR

> Co-Authored by Grok Build using grok-4.5 with agent main.