### PR TITLE
fix(qa): folder+recycle REST smoke after folderHelper cycle (#2464)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -370,6 +370,40 @@ npm run test:surface:list -- --tag locale
 
 Does **not** expand Spanish/#961 residual matrix scope (tracked separately).
 
+#### Folder + recycle REST smoke (#2464 / parent #2423)
+
+Surface-filtered regression after the `folderHelper` → `recycleService` Spring
+cycle break. Proves pathmanagement is up (hard fail if Rhythmyx context is dead),
+then create folder under Assets → soft-delete (recycle) → restore by guid when
+available, else purge via empty Recycling. Optional Admin login check when
+context is healthy.
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/folder-recycle-smoke.spec.js` |
+| Tags | `@folder-recycle` `@smoke` |
+| Unit (no CMS) | `npm run test:unit` (includes `folder-recycle-smoke.test.js`) |
+| Helper | `frontend/tests/helpers/folder-recycle-smoke.js` |
+
+```bash
+# After qa-up — path-filtered only (do not run full suite)
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/folder-recycle-smoke.spec.js
+
+# Tag form
+npm run test:surface -- --tag folder-recycle
+
+# List only (no live CMS)
+npm run test:surface:list -- --path tests/folder-recycle-smoke.spec.js
+npm run test:surface:list -- --tag folder-recycle
+```
+
+**Hard fail contract:** if pathmanagement returns connection error / 5xx (or body
+mentions `BeanCurrentlyInCreationException` / `folderHelper`), the smoke fails
+with an explicit message citing #2464 / #2423 — do not treat as soft skip.
+
 **`run-surface` refuses the full suite** unless you pass `--allow-full` (agents must
 not use that by default).
 

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:surface": "node scripts/run-surface.js",

--- a/modules/perc-qa-automation/frontend/tests/folder-recycle-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/folder-recycle-smoke.spec.js
@@ -63,7 +63,8 @@ const {
   contextDownFailureMessage,
 } = require("./helpers/folder-recycle-smoke");
 
-test.describe("folder + recycle REST smoke @folder-recycle @smoke", () => {
+// Tags live on individual test() titles only — Playwright ignores @tags on describe names.
+test.describe("folder + recycle REST smoke", () => {
   test("pathmanagement context is up (hard fail if Rhythmyx dead) @folder-recycle @smoke", async ({
     request,
   }) => {

--- a/modules/perc-qa-automation/frontend/tests/folder-recycle-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/folder-recycle-smoke.spec.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Folder + recycle REST smoke after folderHelper cycle break
+ * (#2464 / parent #2423 residual; related #2437 login/health).
+ *
+ * <p>Proves pathmanagement + recycleService still work end-to-end on a healthy
+ * H2 QA stack: create folder under Assets → recycle (soft-delete) →
+ * restore when guid available else purge via empty Recycling.</p>
+ *
+ * <p><strong>Hard fail</strong> when Rhythmyx context / pathmanagement is down
+ * (the pre-fix class of bug: Jetty connector up, Spring cycle dead). Do not
+ * soft-skip that failure.</p>
+ *
+ * <h3>Unattended surface (QA mode)</h3>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; \
+ *     npm run test:surface -- --path tests/folder-recycle-smoke.spec.js
+ *   # tags:
+ *   npm run test:surface -- --tag folder-recycle
+ *   python docker/scripts/perc-devctl.py qa-down
+ * </pre>
+ *
+ * <p>List only (no live CMS):
+ * {@code npm run test:surface:list -- --path tests/folder-recycle-smoke.spec.js}
+ * or {@code --tag folder-recycle}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const {
+  probePathmanagementContext,
+  createNamedFolder,
+  recycleFolder,
+  restoreFolderByGuid,
+  findInRecycling,
+  findNamedPathItem,
+  listFolderChildren,
+  emptyRecyclingViaApi,
+  emptyApiFailureMessage,
+  extractPathItemGuid,
+  contextDownFailureMessage,
+} = require("./helpers/folder-recycle-smoke");
+
+test.describe("folder + recycle REST smoke @folder-recycle @smoke", () => {
+  test("pathmanagement context is up (hard fail if Rhythmyx dead) @folder-recycle @smoke", async ({
+    request,
+  }) => {
+    test.setTimeout(45_000);
+    const headers = adminBasicAuthHeaders();
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+    expect(probe.status).toBeGreaterThanOrEqual(200);
+  });
+
+  test("REST: create folder, recycle, restore or purge @folder-recycle @smoke", async ({
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const headers = adminBasicAuthHeaders();
+
+    // Hard fail first — never soft-skip a dead context as "folder missing".
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+
+    const created = await createNamedFolder(request, BASE_URL, headers, {
+      parentPath: "Assets",
+    });
+    expect(created.name).toBeTruthy();
+    expect(created.path).toMatch(/Assets/i);
+
+    const underAssets = await listFolderChildren(
+      request,
+      BASE_URL,
+      headers,
+      "Assets",
+    );
+    expect(
+      findNamedPathItem(underAssets, created.name),
+      `expected live folder ${created.name} under Assets after create; got ${JSON.stringify(underAssets).slice(0, 400)}`,
+    ).toBeTruthy();
+
+    await recycleFolder(request, BASE_URL, headers, {
+      path: created.path,
+      guid: created.guid,
+    });
+
+    // Live tree should no longer list the folder (soft-deleted into Recycling).
+    const assetsAfter = await listFolderChildren(
+      request,
+      BASE_URL,
+      headers,
+      "Assets",
+    );
+    expect(
+      findNamedPathItem(assetsAfter, created.name),
+      `folder ${created.name} should leave Assets after recycle`,
+    ).toBeNull();
+
+    const recycled = await findInRecycling(
+      request,
+      BASE_URL,
+      headers,
+      created.name,
+    );
+    expect(
+      recycled.found,
+      `expected ${created.name} under Recycling after soft-delete; location scan failed`,
+    ).toBe(true);
+
+    // Prefer restore when we have a guid (recycleService.restoreFolder path).
+    const restoreGuid =
+      extractPathItemGuid(recycled.item) || created.guid || "";
+    if (restoreGuid) {
+      const restored = await restoreFolderByGuid(
+        request,
+        BASE_URL,
+        headers,
+        restoreGuid,
+      );
+      expect(
+        restored.status >= 200 && restored.status < 300,
+        `restoreFolder failed HTTP ${restored.status}: ${(restored.text || "").slice(0, 300)}`,
+      ).toBe(true);
+
+      // After restore, folder should leave Recycling (may reappear under Assets).
+      const stillInBin = await findInRecycling(
+        request,
+        BASE_URL,
+        headers,
+        created.name,
+      );
+      // Best-effort: if restore succeeded, recycle listing should not keep it.
+      // Some installs rename on restore conflict — accept either not-in-bin
+      // or present-under-Assets under original or restored name.
+      const assetsRestored = await listFolderChildren(
+        request,
+        BASE_URL,
+        headers,
+        "Assets",
+      );
+      const liveAgain =
+        findNamedPathItem(assetsRestored, created.name) ||
+        stillInBin.found === false;
+      expect(
+        liveAgain,
+        `after restore guid=${restoreGuid}: expected not-in-Recycling or under Assets; stillInBin=${stillInBin.found}`,
+      ).toBeTruthy();
+
+      // Cleanup: soft-delete again then empty so we do not leave fixtures.
+      const liveItem = findNamedPathItem(assetsRestored, created.name);
+      if (liveItem) {
+        await recycleFolder(request, BASE_URL, headers, {
+          path: String(liveItem.path || created.path),
+          guid: extractPathItemGuid(liveItem),
+        }).catch(() => {});
+      }
+      const emptied = await emptyRecyclingViaApi(request, BASE_URL, headers);
+      expect(
+        emptied.status >= 200 && emptied.status < 300,
+        emptyApiFailureMessage(emptied),
+      ).toBe(true);
+    } else {
+      // No guid available — product still allows purge via empty Recycling.
+      const emptied = await emptyRecyclingViaApi(request, BASE_URL, headers);
+      expect(
+        emptied.status >= 200 && emptied.status < 300,
+        emptyApiFailureMessage(emptied),
+      ).toBe(true);
+      const afterPurge = await findInRecycling(
+        request,
+        BASE_URL,
+        headers,
+        created.name,
+      );
+      expect(
+        afterPurge.found,
+        `seed ${created.name} should be gone after empty purge`,
+      ).toBe(false);
+    }
+  });
+
+  test("Admin login still works when context is healthy @folder-recycle @smoke", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(90_000);
+    const headers = adminBasicAuthHeaders();
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+
+    await loginAsAdmin(page);
+    const url = page.url();
+    expect(url).not.toMatch(/\/Rhythmyx\/login(\?|$)/);
+    expect(url).toMatch(/\/Rhythmyx\/|\/cm\//);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
@@ -14,7 +14,6 @@
 
 const {
   cmsUrl,
-  normalizePathItems,
   uniqueSeedFolderName,
   listFolderChildren,
   recyclingHasName,
@@ -222,12 +221,13 @@ async function createNamedFolder(request, baseUrl, headers, opts = {}) {
     baseUrl,
     `${PATH_ADD_NEW_FOLDER}/${parent}?name=${encodeURIComponent(name)}`,
   );
+  const fallbackUrl = cmsUrl(baseUrl, `${PATH_ADD_NEW_FOLDER}/${parent}`);
+  // Track the URL of the request that actually failed (named first, then fallback).
+  let attemptedUrl = addUrl;
   let addRes = await request.get(addUrl, { headers });
   if (!addRes.ok()) {
-    addRes = await request.get(
-      cmsUrl(baseUrl, `${PATH_ADD_NEW_FOLDER}/${parent}`),
-      { headers },
-    );
+    attemptedUrl = fallbackUrl;
+    addRes = await request.get(fallbackUrl, { headers });
   }
   if (!addRes.ok()) {
     const text = await addRes.text().catch(() => "");
@@ -236,13 +236,13 @@ async function createNamedFolder(request, baseUrl, headers, opts = {}) {
       throw new Error(
         contextDownFailureMessage({
           status: addRes.status(),
-          url: addUrl,
+          url: attemptedUrl,
           bodySnippet: text,
         }),
       );
     }
     throw new Error(
-      `addNewFolder under ${parent} failed status=${addRes.status()} body=${text.slice(0, 300)}`,
+      `addNewFolder under ${parent} failed status=${addRes.status()} url=${attemptedUrl} body=${text.slice(0, 300)}`,
     );
   }
   const created = await addRes.json().catch(() => ({}));
@@ -374,9 +374,19 @@ async function restoreFolderByGuid(request, baseUrl, headers, guid) {
 async function findInRecycling(request, baseUrl, headers, name) {
   const roots = ["Recycling", "Recycling/Assets", "Recycling/Sites"];
   for (const root of roots) {
-    const items = await listFolderChildren(request, baseUrl, headers, root).catch(
-      () => [],
-    );
+    let items;
+    try {
+      items = await listFolderChildren(request, baseUrl, headers, root);
+    } catch (err) {
+      const msg = err && err.message ? String(err.message) : String(err);
+      // Optional structural children (e.g. Recycling/Sites) may 404 when empty
+      // or absent. Network / 5xx / auth / context-down must not become
+      // "not in Recycling" — rethrow so the smoke fails honestly.
+      if (/\bfailed status=404\b/i.test(msg)) {
+        continue;
+      }
+      throw err;
+    }
     const hit = findNamedPathItem(items, name);
     if (hit) {
       return { found: true, item: hit, location: root };

--- a/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
@@ -1,0 +1,419 @@
+/**
+ * Folder + recycle REST smoke helpers (#2464 / parent #2423 residual).
+ *
+ * <p>Exercises the pathmanagement + recycleService chain that failed Spring
+ * context startup with the folderHelper circular dependency. Pure helpers are
+ * unit-tested without a live CMS; live API helpers reuse empty-recycling
+ * patterns (addNewFolder / deleteFolder / empty / list).</p>
+ *
+ * <p>No machine hard-coded install paths. Base URL and credentials come from
+ * auth / resolve-cms-env ({@code TEST_CMS_URL} or {@code DEV_PERCUSSION_*}).</p>
+ */
+
+"use strict";
+
+const {
+  cmsUrl,
+  normalizePathItems,
+  uniqueSeedFolderName,
+  listFolderChildren,
+  recyclingHasName,
+  emptyRecyclingViaApi,
+  emptyApiFailureMessage,
+  PATH_FOLDER,
+  PATH_ADD_NEW_FOLDER,
+  PATH_DELETE_FOLDER,
+  RECYCLE_EMPTY_PATH,
+} = require("./empty-recycling");
+
+/** Pathmanagement restore endpoint (sitemanage PSPathService). */
+const PATH_RESTORE_FOLDER = "/Rhythmyx/services/pathmanagement/path/restoreFolder";
+
+/**
+ * True when an HTTP status means Rhythmyx / pathmanagement is answering.
+ * 401/403 still prove the webapp is up (auth required); 5xx / connection
+ * failures indicate the pre-#2423 "connector up, context dead" class of bug.
+ *
+ * @param {number | null | undefined} status
+ * @returns {boolean}
+ */
+function isContextHealthyStatus(status) {
+  if (status == null || !Number.isFinite(Number(status))) {
+    return false;
+  }
+  const s = Number(status);
+  // 2xx success, 3xx redirect, 401/403 auth — all prove the webapp is live.
+  if (s >= 200 && s < 400) {
+    return true;
+  }
+  if (s === 401 || s === 403) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Operator-facing message when Rhythmyx context is down (cycle / startup fail).
+ *
+ * @param {{ status?: number, url?: string, bodySnippet?: string, cause?: string }} [detail]
+ * @returns {string}
+ */
+function contextDownFailureMessage(detail = {}) {
+  const status = detail.status != null ? String(detail.status) : "n/a";
+  const url = detail.url || "pathmanagement";
+  const body = detail.bodySnippet
+    ? String(detail.bodySnippet).replace(/\s+/g, " ").slice(0, 240)
+    : "";
+  const cause = detail.cause ? ` cause=${detail.cause}` : "";
+  return (
+    `Rhythmyx / pathmanagement context appears DOWN (HTTP ${status} for ${url}).` +
+    ` This is a hard fail for folder+recycle smoke (#2464 / parent #2423):` +
+    ` Jetty connector can bind while Spring fails (folderHelper→recycleService cycle).` +
+    ` Check container logs for BeanCurrentlyInCreationException / folderHelper.` +
+    (body ? ` body=${body}` : "") +
+    cause
+  );
+}
+
+/**
+ * Extract a stable path item from common Jackson wrappers.
+ * @param {unknown} body
+ * @returns {Record<string, unknown>}
+ */
+function extractPathItem(body) {
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+  const o = /** @type {Record<string, unknown>} */ (body);
+  if (o.PathItem && typeof o.PathItem === "object" && !Array.isArray(o.PathItem)) {
+    return /** @type {Record<string, unknown>} */ (o.PathItem);
+  }
+  if (o.pathItem && typeof o.pathItem === "object" && !Array.isArray(o.pathItem)) {
+    return /** @type {Record<string, unknown>} */ (o.pathItem);
+  }
+  return o;
+}
+
+/**
+ * Prefer id / guid string from a PathItem-like object.
+ * @param {unknown} item
+ * @returns {string}
+ */
+function extractPathItemGuid(item) {
+  if (!item || typeof item !== "object") {
+    return "";
+  }
+  const o = /** @type {Record<string, unknown>} */ (item);
+  const raw = o.id ?? o.guid ?? o.Id ?? o.Guid ?? "";
+  return raw != null ? String(raw).trim() : "";
+}
+
+/**
+ * Find a child PathItem by exact name (or path basename).
+ * @param {object[]} items
+ * @param {string} name
+ * @returns {object | null}
+ */
+function findNamedPathItem(items, name) {
+  const target = String(name || "");
+  if (!target) {
+    return null;
+  }
+  for (const it of items || []) {
+    if (!it || typeof it !== "object") {
+      continue;
+    }
+    if (it.name != null && String(it.name) === target) {
+      return it;
+    }
+    if (it.path != null) {
+      const p = String(it.path);
+      if (p === target) {
+        return it;
+      }
+      const base = p.split("/").filter(Boolean).pop() || "";
+      if (base === target) {
+        return it;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Build restoreFolder absolute URL for a guid.
+ * @param {string} baseUrl
+ * @param {string} guid
+ * @returns {string}
+ */
+function restoreFolderUrl(baseUrl, guid) {
+  const id = encodeURIComponent(String(guid || "").trim());
+  return cmsUrl(baseUrl, `${PATH_RESTORE_FOLDER}/${id}`);
+}
+
+/**
+ * Probe pathmanagement so a dead Rhythmyx context fails hard (not soft skip).
+ *
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @param {string} baseUrl
+ * @param {Record<string, string>} headers
+ * @returns {Promise<{ ok: true, status: number } | { ok: false, status: number, message: string }>}
+ */
+async function probePathmanagementContext(request, baseUrl, headers) {
+  const url = cmsUrl(baseUrl, `${PATH_FOLDER}/`);
+  let status = 0;
+  let bodySnippet = "";
+  try {
+    const res = await request.get(url, {
+      headers: {
+        ...headers,
+        Accept: "application/json",
+      },
+      // Fail fast when Jetty is up but webapp is dead / hanging.
+      timeout: 20_000,
+    });
+    status = res.status();
+    bodySnippet = (await res.text().catch(() => "")).slice(0, 300);
+  } catch (err) {
+    const cause = err && err.message ? String(err.message) : String(err);
+    return {
+      ok: false,
+      status: 0,
+      message: contextDownFailureMessage({ status: 0, url, cause }),
+    };
+  }
+
+  if (!isContextHealthyStatus(status)) {
+    return {
+      ok: false,
+      status,
+      message: contextDownFailureMessage({ status, url, bodySnippet }),
+    };
+  }
+  // 5xx bodies that mention the cycle should still hard-fail even if we
+  // somehow classified status wrong — belt-and-suspenders for log text.
+  if (
+    /BeanCurrentlyInCreationException|folderHelper|circular reference/i.test(
+      bodySnippet,
+    )
+  ) {
+    return {
+      ok: false,
+      status,
+      message: contextDownFailureMessage({ status, url, bodySnippet }),
+    };
+  }
+  return { ok: true, status };
+}
+
+/**
+ * Create a uniquely named folder under a parent (default Assets).
+ *
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @param {string} baseUrl
+ * @param {Record<string, string>} headers
+ * @param {{ parentPath?: string, name?: string }} [opts]
+ * @returns {Promise<{ name: string, path: string, guid: string, raw: object }>}
+ */
+async function createNamedFolder(request, baseUrl, headers, opts = {}) {
+  const parent = String(opts.parentPath || "Assets").replace(/^\/+|\/+$/g, "");
+  const name = opts.name || uniqueSeedFolderName("qa-folder-recycle");
+  const addUrl = cmsUrl(
+    baseUrl,
+    `${PATH_ADD_NEW_FOLDER}/${parent}?name=${encodeURIComponent(name)}`,
+  );
+  let addRes = await request.get(addUrl, { headers });
+  if (!addRes.ok()) {
+    addRes = await request.get(
+      cmsUrl(baseUrl, `${PATH_ADD_NEW_FOLDER}/${parent}`),
+      { headers },
+    );
+  }
+  if (!addRes.ok()) {
+    const text = await addRes.text().catch(() => "");
+    // Surface context-down class failures with the hard-fail message.
+    if (!isContextHealthyStatus(addRes.status())) {
+      throw new Error(
+        contextDownFailureMessage({
+          status: addRes.status(),
+          url: addUrl,
+          bodySnippet: text,
+        }),
+      );
+    }
+    throw new Error(
+      `addNewFolder under ${parent} failed status=${addRes.status()} body=${text.slice(0, 300)}`,
+    );
+  }
+  const created = await addRes.json().catch(() => ({}));
+  const createdItem = extractPathItem(created);
+  let finalName = String(createdItem.name || "New Folder");
+  let livePath = String(createdItem.path || `/${parent}/${finalName}`);
+  let guid = extractPathItemGuid(createdItem);
+
+  // Rename when server ignored ?name= and used default "New Folder".
+  if (finalName !== name) {
+    const renameBody = {
+      path: livePath.endsWith("/") ? livePath : `${livePath}/`,
+      name,
+    };
+    const renameRes = await request.post(
+      cmsUrl(baseUrl, "/Rhythmyx/services/pathmanagement/path/renameFolder"),
+      {
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        data: renameBody,
+      },
+    );
+    if (renameRes.ok()) {
+      const renamed = await renameRes.json().catch(() => ({}));
+      const item = extractPathItem(renamed);
+      finalName = String(item.name || name);
+      livePath = String(item.path || `/${parent}/${finalName}`);
+      guid = extractPathItemGuid(item) || guid;
+    }
+  }
+
+  return {
+    name: finalName,
+    path: livePath.startsWith("/") ? livePath : `/${livePath}`,
+    guid,
+    raw: createdItem,
+  };
+}
+
+/**
+ * Soft-delete (recycle) a folder via deleteFolder shouldPurge=false.
+ *
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @param {string} baseUrl
+ * @param {Record<string, string>} headers
+ * @param {{ path: string, guid?: string }} folder
+ * @returns {Promise<void>}
+ */
+async function recycleFolder(request, baseUrl, headers, folder) {
+  const deletePath = String(folder.path || "").startsWith("/")
+    ? String(folder.path)
+    : `/${folder.path}`;
+  const pathForDelete = deletePath.endsWith("/") ? deletePath : `${deletePath}/`;
+  const delRes = await request.post(cmsUrl(baseUrl, PATH_DELETE_FOLDER), {
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    data: {
+      DeleteFolderCriteria: {
+        path: pathForDelete,
+        shouldPurge: false,
+        skipItems: "YES",
+        guid: folder.guid || "",
+      },
+    },
+  });
+  if (!delRes.ok()) {
+    const text = await delRes.text().catch(() => "");
+    if (!isContextHealthyStatus(delRes.status())) {
+      throw new Error(
+        contextDownFailureMessage({
+          status: delRes.status(),
+          url: PATH_DELETE_FOLDER,
+          bodySnippet: text,
+        }),
+      );
+    }
+    throw new Error(
+      `deleteFolder (recycle) ${pathForDelete} failed status=${delRes.status()} body=${text.slice(0, 400)}`,
+    );
+  }
+}
+
+/**
+ * Restore a recycled folder by guid (PUT restoreFolder/{id}).
+ *
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @param {string} baseUrl
+ * @param {Record<string, string>} headers
+ * @param {string} guid
+ * @returns {Promise<{ status: number, body: unknown, text: string }>}
+ */
+async function restoreFolderByGuid(request, baseUrl, headers, guid) {
+  if (!guid) {
+    throw new Error("restoreFolderByGuid requires a non-empty guid");
+  }
+  const url = restoreFolderUrl(baseUrl, guid);
+  const res = await request.fetch(url, {
+    method: "PUT",
+    headers: {
+      ...headers,
+      Accept: "application/json",
+    },
+  });
+  const text = await res.text().catch(() => "");
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { status: res.status(), body, text };
+}
+
+/**
+ * Search Recycling (and structural Assets/Sites children) for a folder name.
+ *
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @param {string} baseUrl
+ * @param {Record<string, string>} headers
+ * @param {string} name
+ * @returns {Promise<{ found: boolean, item: object | null, location: string }>}
+ */
+async function findInRecycling(request, baseUrl, headers, name) {
+  const roots = ["Recycling", "Recycling/Assets", "Recycling/Sites"];
+  for (const root of roots) {
+    const items = await listFolderChildren(request, baseUrl, headers, root).catch(
+      () => [],
+    );
+    const hit = findNamedPathItem(items, name);
+    if (hit) {
+      return { found: true, item: hit, location: root };
+    }
+    // Also accept recyclingHasName for basename-only list shapes.
+    if (recyclingHasName(items, name)) {
+      return {
+        found: true,
+        item: findNamedPathItem(items, name),
+        location: root,
+      };
+    }
+  }
+  return { found: false, item: null, location: "" };
+}
+
+module.exports = {
+  PATH_RESTORE_FOLDER,
+  PATH_FOLDER,
+  PATH_ADD_NEW_FOLDER,
+  PATH_DELETE_FOLDER,
+  RECYCLE_EMPTY_PATH,
+  isContextHealthyStatus,
+  contextDownFailureMessage,
+  extractPathItem,
+  extractPathItemGuid,
+  findNamedPathItem,
+  restoreFolderUrl,
+  probePathmanagementContext,
+  createNamedFolder,
+  recycleFolder,
+  restoreFolderByGuid,
+  findInRecycling,
+  listFolderChildren,
+  emptyRecyclingViaApi,
+  emptyApiFailureMessage,
+  uniqueSeedFolderName,
+  cmsUrl,
+  recyclingHasName,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/folder-recycle-smoke.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/folder-recycle-smoke.test.js
@@ -15,6 +15,7 @@ const {
   extractPathItem,
   extractPathItemGuid,
   findNamedPathItem,
+  findInRecycling,
   restoreFolderUrl,
   PATH_RESTORE_FOLDER,
 } = require("../helpers/folder-recycle-smoke");
@@ -80,5 +81,67 @@ describe("folder-recycle-smoke helpers", () => {
       restoreFolderUrl("http://127.0.0.1:9993/", "jcr:guid-1"),
       "http://127.0.0.1:9993/Rhythmyx/services/pathmanagement/path/restoreFolder/jcr%3Aguid-1",
     );
+  });
+
+  it("findInRecycling rethrows non-404 listFolderChildren failures", async () => {
+    const request = {
+      get: async () => ({
+        ok: () => false,
+        status: () => 503,
+        text: async () => "BeanCurrentlyInCreationException folderHelper",
+      }),
+    };
+    await assert.rejects(
+      () => findInRecycling(request, "http://127.0.0.1:9993", {}, "seed"),
+      /failed status=503/,
+    );
+  });
+
+  it("findInRecycling treats 404 roots as empty and returns not found", async () => {
+    const request = {
+      get: async () => ({
+        ok: () => false,
+        status: () => 404,
+        text: async () => "missing",
+      }),
+    };
+    const result = await findInRecycling(
+      request,
+      "http://127.0.0.1:9993",
+      {},
+      "seed",
+    );
+    assert.equal(result.found, false);
+    assert.equal(result.item, null);
+  });
+
+  it("findInRecycling returns hit when list contains name", async () => {
+    const request = {
+      get: async (url) => {
+        const path = String(url || "");
+        if (path.includes("/folder/Recycling") && !path.includes("Recycling/")) {
+          return {
+            ok: () => true,
+            status: () => 200,
+            json: async () => [{ name: "seed-a", path: "/Recycling/Assets/seed-a" }],
+            text: async () => "[]",
+          };
+        }
+        return {
+          ok: () => false,
+          status: () => 404,
+          text: async () => "missing",
+        };
+      },
+    };
+    const result = await findInRecycling(
+      request,
+      "http://127.0.0.1:9993",
+      {},
+      "seed-a",
+    );
+    assert.equal(result.found, true);
+    assert.equal(result.location, "Recycling");
+    assert.equal(result.item.name, "seed-a");
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/folder-recycle-smoke.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/folder-recycle-smoke.test.js
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for folder + recycle smoke pure helpers (no live CMS).
+ *
+ * Run from modules/perc-qa-automation/frontend:
+ *   npm run test:unit
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  isContextHealthyStatus,
+  contextDownFailureMessage,
+  extractPathItem,
+  extractPathItemGuid,
+  findNamedPathItem,
+  restoreFolderUrl,
+  PATH_RESTORE_FOLDER,
+} = require("../helpers/folder-recycle-smoke");
+
+describe("folder-recycle-smoke helpers", () => {
+  it("isContextHealthyStatus treats 2xx/3xx/401/403 as live context", () => {
+    assert.equal(isContextHealthyStatus(200), true);
+    assert.equal(isContextHealthyStatus(204), true);
+    assert.equal(isContextHealthyStatus(302), true);
+    assert.equal(isContextHealthyStatus(401), true);
+    assert.equal(isContextHealthyStatus(403), true);
+    assert.equal(isContextHealthyStatus(404), false);
+    assert.equal(isContextHealthyStatus(500), false);
+    assert.equal(isContextHealthyStatus(503), false);
+    assert.equal(isContextHealthyStatus(0), false);
+    assert.equal(isContextHealthyStatus(null), false);
+    assert.equal(isContextHealthyStatus(undefined), false);
+  });
+
+  it("contextDownFailureMessage cites #2464/#2423 and folderHelper cycle", () => {
+    const msg = contextDownFailureMessage({
+      status: 503,
+      url: "http://127.0.0.1:9993/Rhythmyx/services/pathmanagement/path/folder/",
+      bodySnippet: "BeanCurrentlyInCreationException folderHelper",
+    });
+    assert.match(msg, /#2464/);
+    assert.match(msg, /#2423/);
+    assert.match(msg, /folderHelper/);
+    assert.match(msg, /hard fail/i);
+    assert.match(msg, /503/);
+  });
+
+  it("extractPathItem unwraps PathItem / pathItem wrappers", () => {
+    assert.deepEqual(extractPathItem(null), {});
+    assert.equal(extractPathItem({ PathItem: { name: "a" } }).name, "a");
+    assert.equal(extractPathItem({ pathItem: { name: "b" } }).name, "b");
+    assert.equal(extractPathItem({ name: "c" }).name, "c");
+  });
+
+  it("extractPathItemGuid reads id/guid variants", () => {
+    assert.equal(extractPathItemGuid(null), "");
+    assert.equal(extractPathItemGuid({ id: "1-2-3" }), "1-2-3");
+    assert.equal(extractPathItemGuid({ guid: "g-1" }), "g-1");
+    assert.equal(extractPathItemGuid({ Id: "X" }), "X");
+    assert.equal(extractPathItemGuid({ name: "only" }), "");
+  });
+
+  it("findNamedPathItem matches name and path basename exactly", () => {
+    const items = [
+      { name: "qa-folder-1", path: "/Assets/qa-folder-1" },
+      { path: "/Recycling/Assets/other" },
+    ];
+    assert.equal(findNamedPathItem(items, "qa-folder-1").name, "qa-folder-1");
+    assert.equal(findNamedPathItem(items, "other").path, "/Recycling/Assets/other");
+    assert.equal(findNamedPathItem(items, "missing"), null);
+    // Substring must not count.
+    assert.equal(findNamedPathItem([{ name: "qa-folder-10" }], "qa-folder-1"), null);
+  });
+
+  it("restoreFolderUrl builds pathmanagement restore URL", () => {
+    assert.match(PATH_RESTORE_FOLDER, /\/pathmanagement\/path\/restoreFolder$/);
+    assert.equal(
+      restoreFolderUrl("http://127.0.0.1:9993/", "jcr:guid-1"),
+      "http://127.0.0.1:9993/Rhythmyx/services/pathmanagement/path/restoreFolder/jcr%3Aguid-1",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Parent tracker: **#2423** (folderHelper Spring cycle). This slice **#2464** adds surface-filtered Playwright **REST smoke** for folder + recycle after the cycle break.

- Probe pathmanagement first — **hard fail** if Rhythmyx context is down (Jetty connector up / Spring dead class)
- Create folder under Assets → soft-delete (recycle) → restore by guid when available, else purge via empty Recycling
- Admin login check when context is healthy
- Pure helpers + `npm run test:unit` coverage (no live CMS required for unit)
- Documented surface path/tag for unattended runs

### Surface (unattended)

```bash
# After perc-devctl qa-up
cd modules/perc-qa-automation/frontend
TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
  npm run test:surface -- --path tests/folder-recycle-smoke.spec.js
# or: npm run test:surface -- --tag folder-recycle
```

| Item | Value |
|------|--------|
| Spec | `modules/perc-qa-automation/frontend/tests/folder-recycle-smoke.spec.js` |
| Tags | `@folder-recycle` `@smoke` |
| Helper | `tests/helpers/folder-recycle-smoke.js` |
| Unit | `tests/unit/folder-recycle-smoke.test.js` |

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd modules/perc-qa-automation/frontend && npm run test:unit` — **133 pass** (includes 6 new folder-recycle helper tests)
- [x] `npm run test:surface:list -- --path tests/folder-recycle-smoke.spec.js` — 3 tests listed
- [x] `npm run test:surface:list -- --tag folder-recycle` — same 3 tests
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (no Java sources; packaging only)
- [ ] Live H2 `perc-devctl qa-up` + surface run (residual — overnight stack not always available)

## Gates

- Erlang-style self-review: portable URL join (`cmsUrl`), no OS path hardcodes, hard-fail contract for dead context
- No Java production change; companions: helper + unit + README surface docs + Playwright spec
- Spotless not required (process gate dropped)
- Does **not** merge AGENTS.md rule edits (human-review gate for agent rules)

## Partial / residuals

Fixes implementation of smoke + docs for **#2464**. Live qa-up green run + optional UI Finder companion filed as residuals under **#2423**.

Closes / Fixes: Partial for #2464 (code delivered; live stack residual)

> Co-Authored by Grok Build using grok-4.5 with agent main.