### PR TITLE
fix(workflows): residual size anti-padding + issue lifecycle (QA or close)

### DIFF
--- a/.grok/workflows/README.md
+++ b/.grok/workflows/README.md
@@ -104,6 +104,17 @@ When Work finishes a change that is **ready for human QA** (product UI, installe
 
 Human QA issues are **not** unassigned residuals and usually **do not** count toward residual quota.
 
+### Issue lifecycle / close rules (no empty trackers)
+
+| Situation | Required action |
+|-----------|-----------------|
+| Work complete, **no** open children / residuals / QA issues, **no** remaining steps | **Close** the issue (comment + reason + PR/child links). Do **not** leave it open “for tracking.” |
+| Blocked on **human QA** and no open QA issue | **Create** QA issue with test plan, assign `qa_assignee`, link Parent + PR; parent may stay open while QA is open |
+| Remaining agent work | File **PR-sized** residual/child issues; parent stays open while children exist |
+| Open children or open QA or active linked PRs | **Do not close** the parent |
+
+Hard ban: epic/tracker issues open with **zero** related open child/QA issues and no next step.
+
 ### Residual quota + circuit breaker
 
 Live runs must **grow backlog under existing high-priority parents**, not invent low-priority noise.

--- a/.grok/workflows/README.md
+++ b/.grok/workflows/README.md
@@ -113,9 +113,10 @@ Live runs must **grow backlog under existing high-priority parents**, not invent
 | **Quota** | At least `min_residual_issues` (default **3**) **new** residual/child issues this pass |
 | **Parent filter** | Parent issue must **already** be labeled **p1, p2, p3, or p4**. Residuals of Unset/p5–p8 parents **do not count** |
 | **Priority on residual** | **Copy parent pN exactly** onto the residual. Do **not** invent a higher priority. Do **not** pad with p8 residuals |
-| **What counts** | `residual_issue_urls` + `child_issue_urls` from Work (+ PR follow-up residuals): open, real body, filed this pass, parent p1–p4, residual pN matches parent |
-| **Backfill** | If short, one residual-quota agent files more real slices **only under existing p1–p4 parents**, inheriting that pN. **No fake padding; no priority upgrades.** |
-| **Circuit breaker** | If still short: **stop** overnight post-processing (skip PR cluster + security audit), write Report, complete with `residual_circuit_breaker: true` |
+| **Size (anti-padding)** | Each residual must be a **full PR-sized** unit (coherent acceptance, typically 1–3 modules + tests). **Prefer under-quota / circuit breaker over micro-slices** invented to hit the number |
+| **What counts** | `residual_issue_urls` + `child_issue_urls` from Work (+ PR follow-up residuals): open, **PR-sized** real body, filed this pass, parent p1–p4, residual pN matches parent |
+| **Backfill** | If short, one residual-quota agent files more **PR-sized** slices **only under existing p1–p4 parents**, inheriting that pN. **No fake padding, no micro-split, no priority upgrades.** |
+| **Circuit breaker** | If still short of real PR-sized residuals: **stop** overnight post-processing (skip PR cluster + security audit), write Report, complete with `residual_circuit_breaker: true` |
 | **Disable** | `require_residual_quota: false` (not recommended for overnight) |
 
 ### Security audit Fix Pass (post-processing)

--- a/.grok/workflows/night-issue-prs.rhai
+++ b/.grok/workflows/night-issue-prs.rhai
@@ -31,10 +31,12 @@
 //                                ONLY residuals whose PARENT issue is already p1–p4 count.
 //                                Residual priority MUST be copied from the parent (same pN) — never invent
 //                                a higher priority and never pad the quota with p5–p8 (or parent-p8) residuals.
+//                                Each residual must be a REAL PR-sized unit (see SIZE RULES) — never split
+//                                one PR of work into three tiny issues just to hit the quota.
 //                                Counts residual_issue_urls + child_issue_urls from Work and PR follow-up.
 //                                After Work+PR-POST: if under quota, one residual-backfill agent may file more
-//                                REAL residuals under existing p1–p4 parents only. If still under quota →
-//                                CIRCUIT BREAKER (stop run).
+//                                REAL PR-sized residuals under existing p1–p4 parents only. If still under
+//                                quota → CIRCUIT BREAKER (stop run) — prefer circuit breaker over micro-slices.
 //   require_residual_quota bool - enforce min_residual_issues gate (default true). dry_run skips the gate.
 //   include_human_qa    bool   - when Work item is ready for human QA, create QA issue with test plan
 //                                and assign designated QA resource (default true).
@@ -414,6 +416,8 @@ triage_prompt += "- One PR should touch a small module set (ideally 1-3 Maven mo
 triage_prompt += "- Javadoc-only module cleanup is implement.\n";
 triage_prompt += "- Multi-module product features without a narrow first slice are split.\n";
 triage_prompt += "- If implement is a slice of a large issue, set slice_title + put the rest in split_plan.\n";
+triage_prompt += "- Do NOT over-split: each child/slice must be independently PR-sized. Prefer fewer\n";
+triage_prompt += "  larger children over many micro-tasks. Never split just to create residual count.\n";
 triage_prompt += "- Prefer open child/slice issues that already list a Parent #N over inventing new\n";
 triage_prompt += "  markdown task trackers. Multi-phase status lives on the PARENT GitHub issue.\n\n";
 triage_prompt += "Use tools (gh issue view, codebase grep/read) to refine scope before deciding.\n";
@@ -776,8 +780,18 @@ for item in queue {
     work_prompt += "Residual priority MUST equal the parent's priority label (copy pN exactly).\n";
     work_prompt += "Do NOT invent a higher priority. Do NOT pad the quota with p5–p8 residuals or with\n";
     work_prompt += "residuals of Unset/p5–p8 parents. Those may exist outside quota but do not count.\n";
+    work_prompt += "SIZE / ANTI-PADDING (HARD — more important than hitting the number):\n";
+    work_prompt += "  - Each residual/child MUST be a full PR-sized unit (ideally 1–3 Maven modules,\n";
+    work_prompt += "    shippable tests, coherent acceptance) — same SIZE RULES as triage implement.\n";
+    work_prompt += "  - Prefer ONE solid residual over THREE micro-issues that could be one PR.\n";
+    work_prompt += "  - FORBIDDEN: splitting one unfinished feature into tiny label-only or single-file\n";
+    work_prompt += "    residuals just to hit the run quota (quota padding).\n";
+    work_prompt += "  - FORBIDDEN: parallel residuals that only differ by wording / the same acceptance.\n";
+    work_prompt += "  - If you only have 1–2 real PR-sized leftovers, file those only — the residual-quota\n";
+    work_prompt += "    phase may circuit-break; that is BETTER than inventing micro-slices.\n";
+    work_prompt += "  - Split children: only when each child is independently implementable and reviewable.\n";
     work_prompt += "Circuit breaker if the pass ends short of " + min_residual_issues.to_string()
-        + " residuals under p1–p4 parents — do your part; no fake issues.\n";
+        + " real PR-sized residuals under p1–p4 parents — no fake/tiny issues.\n";
     work_prompt += "If dry_run=false: create GitHub issues with gh issue create for each residual slice\n";
     work_prompt += "  (title/body link PARENT tracker + this issue #" + inum.to_string() + " and any PR URL;\n";
     work_prompt += "  leave unassigned).\n";
@@ -793,13 +807,14 @@ for item in queue {
     work_prompt += "  Do NOT put In Progress on residual/child issues you only file (not working now).\n";
     work_prompt += "  Then update PARENT ## Agent progress table + comment (P2/P3).\n";
     work_prompt += "REAL/actionable only: PR-sized units with clear acceptance, module hints, Parent: #N.\n";
-    work_prompt += "  Forbidden: placeholder titles, empty bodies, duplicates, priority upgrades, p8 padding.\n";
+    work_prompt += "  Forbidden: placeholder titles, empty bodies, duplicates, priority upgrades, p8 padding,\n";
+    work_prompt += "  micro-slices / quota padding (see SIZE / ANTI-PADDING).\n";
     work_prompt += "Even full pr_opened success: if more work remains on a p1–p4 parent epic, file residual\n";
-    work_prompt += "  children with the parent's pN.\n";
+    work_prompt += "  children with the parent's pN — only when each child is PR-sized.\n";
     work_prompt += "If dry_run=true: list planned residual titles + parent # + inherited pN in summary only.\n";
     work_prompt += "Put created URLs in residual_issue_urls (space-separated). child_issue_urls is for\n";
     work_prompt += "planned split slices; residual_issue_urls is for leftover after a partial implement.\n";
-    work_prompt += "Only residuals of p1–p4 parents (with matching pN) count toward the pass residual quota.\n\n";
+    work_prompt += "Only PR-sized residuals of p1–p4 parents (with matching pN) count toward residual quota.\n\n";
 
     if include_human_qa {
         work_prompt += "HUMAN QA HANDOFF (when ready for human verification):\n";
@@ -1043,9 +1058,18 @@ if require_residual_quota {
         rq_prompt += "Triage notes:\n" + json_encode(triage_notes) + "\n\n";
 
         rq_prompt += "GOAL: Ensure this overnight PASS logged at least min_residual_issues NEW,\n";
-        rq_prompt += "REAL residual/child issues under parents that are ALREADY p1–p4, each residual\n";
-        rq_prompt += "inheriting the parent pN. Important unfinished work on high-priority parents —\n";
-        rq_prompt += "not three new low-priority issues.\n\n";
+        rq_prompt += "REAL **PR-sized** residual/child issues under parents that are ALREADY p1–p4,\n";
+        rq_prompt += "each residual inheriting the parent pN. Important unfinished work — NOT three\n";
+        rq_prompt += "micro-issues invented to pad a number, and NOT three low-priority fillers.\n\n";
+
+        rq_prompt += "SIZE / ANTI-PADDING (HARD — overrides quota pressure):\n";
+        rq_prompt += "  - Count ONLY issues that are independently implementable as one PR (1–3 modules,\n";
+        rq_prompt += "    clear acceptance, own tests). If body is a one-liner, single-file chore, or\n";
+        rq_prompt += "    could merge into a sibling residual in <1 day of work, EXCLUDE from count\n";
+        rq_prompt += "    (and do not create more like them).\n";
+        rq_prompt += "  - Prefer under-quota + circuit_breaker over filing tiny slices.\n";
+        rq_prompt += "  - Prefer consolidating related leftovers into fewer larger residuals.\n";
+        rq_prompt += "  - Never create N near-duplicate residuals that differ only by title wording.\n\n";
 
         rq_prompt += "COUNTING RULES (residual_count):\n";
         rq_prompt += "1) Collect every URL/number from:\n";
@@ -1058,40 +1082,44 @@ if require_residual_quota {
         rq_prompt += "3) Count R only if ALL are true:\n";
         rq_prompt += "   - R is OPEN (or just created this run)\n";
         rq_prompt += "   - R was filed this overnight pass (operator labels OR body links this run)\n";
-        rq_prompt += "   - R is REAL (acceptance or concrete slice goal; no TBD-only / empty)\n";
+        rq_prompt += "   - R is REAL and PR-SIZED (acceptance + modules; not TBD-only / empty / micro)\n";
         rq_prompt += "   - PARENT has label p1 OR p2 OR p3 OR p4 (if multiple pN on parent, highest wins)\n";
         rq_prompt += "   - R has the SAME pN label as the resolved parent priority (exact copy)\n";
         rq_prompt += "4) EXCLUDE if parent is Unset or p5–p8, or residual pN differs from parent pN,\n";
         rq_prompt += "   or residual has no pN while parent is p1–p4 (must fix label to match parent).\n";
-        rq_prompt += "5) Do NOT count parent work issues themselves, closed junk, duplicates, or\n";
+        rq_prompt += "5) EXCLUDE micro-slices / quota padding (see SIZE / ANTI-PADDING).\n";
+        rq_prompt += "6) Do NOT count parent work issues themselves, closed junk, duplicates, or\n";
         rq_prompt += "   pre-existing backlog not filed this pass.\n\n";
 
         rq_prompt += "IF residual_count >= min_residual_issues:\n";
         rq_prompt += "  status=quota_met, quota_met=true, circuit_breaker=false, list URLs/numbers.\n";
-        rq_prompt += "  Do not create extra issues for quota.\n\n";
+        rq_prompt += "  Do not create extra issues for quota. Do not split large residuals further.\n\n";
 
         rq_prompt += "IF residual_count < min_residual_issues:\n";
-        rq_prompt += "  BACKFILL only under existing p1–p4 parents (need shortfall more issues):\n";
+        rq_prompt += "  BACKFILL only under existing p1–p4 parents — PR-sized only:\n";
         rq_prompt += "  Sources (must attach to a p1–p4 Parent):\n";
-        rq_prompt += "  A) Partial implement leftovers on p1–p4 parents worked this run\n";
-        rq_prompt += "  B) Split plans on p1–p4 epics not yet filed as children\n";
+        rq_prompt += "  A) Partial implement leftovers on p1–p4 parents worked this run (one PR each)\n";
+        rq_prompt += "  B) Split plans on p1–p4 epics not yet filed as children (each child = one PR)\n";
         rq_prompt += "  C) PR follow-up deferred product work that links to a p1–p4 parent issue\n";
-        rq_prompt += "  D) Open p1–p4 issues/epics from triage with clear next slices not yet filed\n";
+        rq_prompt += "  D) Open p1–p4 issues/epics from triage with clear next PR-sized slices\n";
         rq_prompt += "  For each backfill issue:\n";
         rq_prompt += "    - Parent MUST already be p1–p4 (verify labels before create)\n";
         rq_prompt += "    - Copy parent's pN onto the residual (same label; do not change severity)\n";
+        rq_prompt += "    - Scope must need a dedicated PR (not a one-line follow-up)\n";
         rq_prompt += "    gh issue create --repo " + repo + " with:\n";
         rq_prompt += "    - Title: concrete, PR-sized (e.g. issue N residual: <action>)\n";
         rq_prompt += "    - Body: Parent: #N, goal, acceptance, modules, out of scope\n";
         rq_prompt += "    - Labels: operator:grok, operator:night-issue-prs, model:grok-4.5, <parent pN>\n";
         rq_prompt += "    - Leave unassigned. No In Progress.\n";
         rq_prompt += "    - Comment on Parent.\n";
-        rq_prompt += "  HARD BAN: fake padding; new residuals under p5–p8 parents for quota; inventing\n";
-        rq_prompt += "  p1–p4; upgrading parent priority; empty 'misc cleanup' issues.\n";
-        rq_prompt += "  If not enough REAL leftover work under p1–p4 parents, do NOT invent fakes.\n\n";
+        rq_prompt += "  HARD BAN: fake padding; micro-slices; new residuals under p5–p8 parents for quota;\n";
+        rq_prompt += "  inventing p1–p4; upgrading parent priority; empty 'misc cleanup' issues;\n";
+        rq_prompt += "  splitting one leftover into three issues to hit min_residual_issues.\n";
+        rq_prompt += "  If not enough REAL PR-sized leftover work under p1–p4 parents, do NOT invent\n";
+        rq_prompt += "  fakes or shrink scope — leave under-quota and circuit-break.\n\n";
 
         rq_prompt += "AFTER BACKFILL (or if none possible):\n";
-        rq_prompt += "  Re-count with parent p1–p4 + matching pN rules only.\n";
+        rq_prompt += "  Re-count with parent p1–p4 + matching pN + PR-sized rules only.\n";
         rq_prompt += "  Set residual_count, residual_issue_urls, residual_issue_numbers.\n";
         rq_prompt += "  backfill_created = number newly created this step that meet counting rules.\n";
         rq_prompt += "  If residual_count >= min_residual_issues:\n";
@@ -1099,7 +1127,7 @@ if require_residual_quota {
         rq_prompt += "  Else:\n";
         rq_prompt += "    status=circuit_breaker, quota_met=false, circuit_breaker=true\n";
         rq_prompt += "    summary MUST explain shortfall (e.g. only p8 parents worked; not enough\n";
-        rq_prompt += "    residual scope under p1–p4 parents).\n";
+        rq_prompt += "    PR-sized residual scope under p1–p4 parents; refused micro-padding).\n";
         rq_prompt += "    blocked=residual_quota\n\n";
 
         rq_prompt += "Return structured fields. circuit_breaker true STOPS the overnight run\n";

--- a/.grok/workflows/night-issue-prs.rhai
+++ b/.grok/workflows/night-issue-prs.rhai
@@ -301,7 +301,8 @@ discover_prompt += "HARD RULES:\n";
 discover_prompt += "1) Before any gh command: run `gh auth status` and ensure the active account\n";
 discover_prompt += "   can access " + repo + " (prefer natechadwick-intsof if listed).\n";
 discover_prompt += "2) Do NOT invent issue numbers. Only report issues returned by gh.\n";
-discover_prompt += "3) Do NOT close issues, merge PRs, or force-push.\n\n";
+discover_prompt += "3) Do NOT merge PRs or force-push. Discover does not close issues (Work agents may\n";
+discover_prompt += "   close issues only under ISSUE LIFECYCLE rules when no remaining work).\n\n";
 discover_prompt += "TASK:\n";
 discover_prompt += "List open issues for " + repo + ".\n";
 discover_prompt += "unassigned_only=" + unassigned_only.to_string() + "\n";
@@ -856,6 +857,30 @@ for item in queue {
         work_prompt += "HUMAN QA HANDOFF: include_human_qa=false — do not create QA issues this run.\n\n";
     }
 
+    work_prompt += "ISSUE LIFECYCLE / CLOSE RULES (HARD — no empty trackers):\n";
+    work_prompt += "No open issue may be left open as a pure tracker with zero related open child /\n";
+    work_prompt += "residual / QA issues AND no remaining implementable steps.\n";
+    work_prompt += "Apply to the issue you worked (#" + inum.to_string() + ") and to PARENT_TRACKER when you own the lifecycle:\n";
+    work_prompt += "L1) Inventory open related issues: children/residuals with Parent: #N, QA (#N) issues,\n";
+    work_prompt += "    and open PRs still linked to this issue. Use gh issue list / search + body links.\n";
+    work_prompt += "L2) If the issue is BLOCKED ON HUMAN QA (or ready for human QA) and no open QA issue\n";
+    work_prompt += "    exists for it: CREATE the QA issue (test plan + assign @" + qa_assignee
+        + " / label \"" + qa_label + "\") — see HUMAN QA HANDOFF.\n";
+    work_prompt += "    Do NOT leave the parent open with only a chat note that QA is needed.\n";
+    work_prompt += "L3) If remaining agent work exists: file PR-sized residual/child issues (not empty\n";
+    work_prompt += "    trackers). Parent may stay open while children exist.\n";
+    work_prompt += "L4) If NO remaining steps AND NO open related child/residual/QA issues AND your PR\n";
+    work_prompt += "    (if any) fully covers the issue (or issue was split_only with children only):\n";
+    work_prompt += "    - Comment with final status + PR/child links\n";
+    work_prompt += "    - Remove In Progress\n";
+    work_prompt += "    - gh issue close #" + inum.to_string() + " --repo " + repo
+        + " with a short reason (e.g. work complete; see PR #… / children #…)\n";
+    work_prompt += "L5) HARD BAN: leaving an epic/tracker open with zero open children and no next step\n";
+    work_prompt += "    (\"tracking only\"). Either file real children/QA or close it.\n";
+    work_prompt += "L6) Do NOT close issues that still have open children, open QA tasks, or open PRs\n";
+    work_prompt += "    that have not been superseded. Do NOT close other humans' active work.\n";
+    work_prompt += "L7) dry_run=true: describe close/QA decisions only; do not close or create.\n\n";
+
     if disp == "skip" {
         work_prompt += "ACTION: disposition is skip. Do not change code. Confirm why in summary.\n";
         work_prompt += "status=skipped. Optional: comment on the issue only if dry_run is false and\n";
@@ -882,6 +907,9 @@ for item in queue {
             work_prompt += "   can finish gates tonight; default is split-only.\n";
             work_prompt += "6) If you ship a first-slice PR, update that row to pr_opened + PR link on PARENT,\n";
             work_prompt += "   and file residual issues for remaining slices if not already children.\n";
+            work_prompt += "7) PARENT must not remain open without open children: after filing children, leave\n";
+            work_prompt += "   PARENT open; if you somehow created zero children and have no more steps, CLOSE\n";
+            work_prompt += "   PARENT only after re-checking lifecycle (should not happen on a true split).\n";
             work_prompt += "status=split_only (or pr_opened if you also shipped the first slice).\n";
         }
     } else {
@@ -916,6 +944,9 @@ for item in queue {
             work_prompt += "   (status pr_opened/blocked + PR URL + notes) and post a PARENT comment.\n";
             work_prompt += "K) Do not resolve review threads on OTHER people PRs in this step.\n";
             work_prompt += "L) Do not write multi-phase progress into docs/ai-generated markdown trackers.\n";
+            work_prompt += "M) Apply ISSUE LIFECYCLE / CLOSE RULES: QA issue if blocked on human QA; residual\n";
+            work_prompt += "   children if more agent work remains; otherwise close #" + inum.to_string()
+                + " when no open children/QA remain.\n";
             work_prompt += "status=pr_opened on success, status=failed with summary of blockers on failure.\n";
         }
     }
@@ -1060,7 +1091,10 @@ if require_residual_quota {
         rq_prompt += "GOAL: Ensure this overnight PASS logged at least min_residual_issues NEW,\n";
         rq_prompt += "REAL **PR-sized** residual/child issues under parents that are ALREADY p1–p4,\n";
         rq_prompt += "each residual inheriting the parent pN. Important unfinished work — NOT three\n";
-        rq_prompt += "micro-issues invented to pad a number, and NOT three low-priority fillers.\n\n";
+        rq_prompt += "micro-issues invented to pad a number, and NOT three low-priority fillers.\n";
+        rq_prompt += "Parents must not sit open as empty trackers: if a p1–p4 parent has remaining work,\n";
+        rq_prompt += "it needs open children/QA; if blocked on human QA with no QA issue, file QA (@"
+            + qa_assignee + "). Empty trackers with zero children/QA should be closed by Work agents.\n\n";
 
         rq_prompt += "SIZE / ANTI-PADDING (HARD — overrides quota pressure):\n";
         rq_prompt += "  - Count ONLY issues that are independently implementable as one PR (1–3 modules,\n";


### PR DESCRIPTION
## Summary

Agents were filing **too-small residual/child issues** to satisfy `min_residual_issues` (3) under p1–p4 parents. That pads the backlog without real PR-sized work.

### Change
- **SIZE / ANTI-PADDING (HARD)** in Work residual instructions and residual-quota agent:
  - Each residual must be an **independent PR-sized** unit (1–3 modules, tests, coherent acceptance)
  - Prefer **one solid residual** over three micro-issues
  - Prefer **under-quota + circuit breaker** over inventing tiny slices
  - Exclude micro-slices from residual_count
- Triage SIZE RULES: do not over-split just to create residual count

Parent p1–p4 + inherit parent pN rules are unchanged.

### Test plan
- [x] Local prompt/text review of residual + triage sections
- [ ] Next overnight launch uses updated script (after merge, or local/user-global copy)

> Co-Authored by Grok Build using grok-4.5 with agent main.
