### PR TITLE
test(qa): green profile-shell Playwright on H2 QA + non-admin (#2425)

### DIFF
--- a/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
@@ -15,16 +15,25 @@
  */
 
 /**
- * Profile hub shell smoke (#2393 / parent #2374 slice 1).
+ * Profile hub shell smoke (#2393 / #2425 / parent #2374 slice 1 residual).
  *
  * Surface-filtered only — not full suite:
  *   npm run test:surface -- --path tests/profile-shell.spec.js
  *
- * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* / EDITOR_* / CONTRIBUTOR_*
+ * → test:surface → qa-down.
+ *
+ * Covers Admin deep link + UserMenu entry, plus non-admin (Editor, Contributor)
+ * deep-link access so profile is not admin-only (#2374 acceptance).
  */
 
 const { test, expect } = require("@playwright/test");
-const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  loginAsAdmin,
+  loginAsEditor,
+  loginAsContributor,
+  BASE_URL,
+} = require("./helpers/auth");
 
 function profileDeepLink() {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
@@ -32,6 +41,31 @@ function profileDeepLink() {
 
 function homeUrl() {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+}
+
+/**
+ * Assert profile hub shell landmarks after navigation to the profile entry.
+ * @param {import('@playwright/test').Page} page
+ */
+async function expectProfileShellLandmarks(page) {
+  await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-profile-title")).toContainText(
+    /my profile/i,
+  );
+  await expect(page.getByTestId("perc-profile-section-account")).toBeVisible();
+  await expect(page.getByTestId("perc-profile-section-security")).toBeVisible();
+  await expect(
+    page.getByTestId("perc-profile-section-preferences"),
+  ).toBeVisible();
+  await expect(page.getByTestId("perc-profile-section-avatar")).toBeVisible();
+
+  // Client path after entry handoff (or still query — accept either)
+  await expect(page).toHaveURL(/profile/i, { timeout: 15_000 });
 }
 
 test.describe("Profile shell @profile @smoke", () => {
@@ -42,25 +76,7 @@ test.describe("Profile shell @profile @smoke", () => {
     await loginAsAdmin(page);
 
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
-
-    await expect(page.getByTestId("perc-spa-app")).toBeVisible({
-      timeout: 30_000,
-    });
-    await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
-      timeout: 30_000,
-    });
-    await expect(page.getByTestId("perc-profile-title")).toContainText(
-      /my profile/i,
-    );
-    await expect(page.getByTestId("perc-profile-section-account")).toBeVisible();
-    await expect(page.getByTestId("perc-profile-section-security")).toBeVisible();
-    await expect(
-      page.getByTestId("perc-profile-section-preferences"),
-    ).toBeVisible();
-    await expect(page.getByTestId("perc-profile-section-avatar")).toBeVisible();
-
-    // Client path after entry handoff (or still query — accept either)
-    await expect(page).toHaveURL(/profile/i, { timeout: 15_000 });
+    await expectProfileShellLandmarks(page);
   });
 
   test("My profile menu entry navigates to profile shell", async ({ page }) => {
@@ -84,5 +100,23 @@ test.describe("Profile shell @profile @smoke", () => {
       /my profile/i,
     );
     await expect(page).toHaveURL(/profile/i, { timeout: 15_000 });
+  });
+
+  test("Editor deep link opens profile shell (non-admin)", async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsEditor(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectProfileShellLandmarks(page);
+  });
+
+  test("Contributor deep link opens profile shell (non-admin)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsContributor(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectProfileShellLandmarks(page);
   });
 });


### PR DESCRIPTION
## Summary

**Fixes #2425** (residual of #2393 / [PR #2424](https://github.com/intersoftdatalabs-in/percussioncms/pull/2424); parent epic **#2374**).

Slice 1 landed `profile-shell.spec.js` but overnight could not prove green because QA H2 failed to boot (Spring `folderHelper` cycle / empty packages). With cycle fixes on `main` and a healthy `perc-devctl qa-up` stack:

1. **Admin deep link** + **UserMenu → My profile** already pass.
2. This PR adds **Editor** and **Contributor** deep-link coverage so profile is not Admin-only (#2374 acceptance).
3. Shared `expectProfileShellLandmarks` helper to keep asserts DRY.

No selector/testid flakiness was observed; no WebUI changes required.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `python docker/scripts/perc-devctl.py qa-up` → `RESULT:OK`, `TEST_CMS_URL=http://127.0.0.1:9993`
- [x] Login page HTTP 200
- [x] From `modules/perc-qa-automation/frontend`:
  `
  TEST_CMS_URL=http://127.0.0.1:9993 ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
    EDITOR_USERNAME=Editor EDITOR_PASSWORD=<from-qa-up> \
    CONTRIBUTOR_USERNAME=Contributor CONTRIBUTOR_PASSWORD=<from-qa-up> \
    npm run test:surface -- --path tests/profile-shell.spec.js
  `
  → **4 passed** (Admin deep link, Admin menu, Editor deep link, Contributor deep link)
- [x] `npm run test:unit` → 127 passed
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] `qa-down` after evidence (session teardown)

## Gates

| Gate | Evidence |
|------|----------|
| Erlang-style self-review | Test-only; portable auth helpers; no path I/O; companions = surface spec only |
| Pre-PR Maven | standalone `perc-qa-automation` clean install SUCCESS |
| Surface filter | path-only; not full Playwright suite |
| No secrets committed | passwords from docker passwords file / qa-up stdout only |

## Related

- Parent epic: #2374
- Original shell PR: #2424 / #2393
- Axe residual remains: #2427
- Residual follow-ups filed from this session (non-admin menu click, golden include, locale title assert) — see issue comments.

> Co-Authored by Grok Build using grok-4.5 with agent main.