### PR TITLE
fix(system): PSCmsException serialVersionUID (#2434)

### DIFF
--- a/system/src/main/java/com/percussion/cms/PSCmsException.java
+++ b/system/src/main/java/com/percussion/cms/PSCmsException.java
@@ -21,6 +21,10 @@ import java.util.Objects;
 
 /** This class is used when an error occurs during CMS operations. */
 public class PSCmsException extends PSException {
+
+  /** Serialization id for {@link java.io.Serializable} ({@code -Xlint:serial}). */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct an exception for messages taking no arguments.
    *

--- a/system/src/test/java/com/percussion/cms/PSCmsExceptionSerialVersionUidTest.java
+++ b/system/src/test/java/com/percussion/cms/PSCmsExceptionSerialVersionUidTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Serialization checks for {@link PSCmsException} ({@code com.percussion.cms} only — not
+ * objectstore). Locks the {@code serialVersionUID} added for #2434 / #2022 residual.
+ */
+public class PSCmsExceptionSerialVersionUidTest {
+
+  @Test
+  public void testDeclaresSerialVersionUid() throws Exception {
+    assertTrue(Serializable.class.isAssignableFrom(PSCmsException.class));
+    Field f = PSCmsException.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(f.getModifiers()) && Modifier.isFinal(f.getModifiers()));
+    f.setAccessible(true);
+    assertEquals(1L, f.getLong(null));
+  }
+
+  @Test
+  public void testRoundTripPreservesErrorCode() throws Exception {
+    // Parent PSException keeps m_args as transient; code is the durable wire field.
+    PSCmsException original = new PSCmsException(12345, "serial-check");
+    assertEquals(12345, original.getErrorCode());
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(original);
+      bytes = bos.toByteArray();
+    }
+
+    PSCmsException restored;
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      restored = (PSCmsException) ois.readObject();
+    }
+
+    assertNotNull(restored);
+    assertEquals(12345, restored.getErrorCode());
+    assertSame(PSCmsException.class, restored.getClass());
+  }
+}


### PR DESCRIPTION
## Summary
Adds `serialVersionUID = 1L` to `com.percussion.cms.PSCmsException` so `-Xlint:serial` is clear for this class.

- **Parent epic:** #2022 (perc-system javac)
- **Grandparent:** #2200
- **Discovered from:** #2403 inventory (PR #2433) residual
- **Scope:** `system` / `com.percussion.cms.PSCmsException` only (not objectstore; not this-escape)

## Changes
- `PSCmsException`: declare `private static final long serialVersionUID = 1L` (matches peer exceptions under cms.objectstore)
- New `PSCmsExceptionSerialVersionUidTest`: field/modifiers assertion + Java serialization round-trip preserves error code (parent `PSException.m_args` is `transient` by design)

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Module Surefire: **Tests run: 1318, Failures: 0, Errors: 0, Skipped: 240**
- [x] `PSCmsExceptionSerialVersionUidTest`: Tests run: 2, Failures: 0
- [x] No new warnings attributable to this change (baseline module warnings unchanged)

## Gates evidence
- Pre-PR standalone: `cd system` then `../mvnw.cmd clean install`
- Erlang-style self-review: tiny serial constant + focused unit test; portable (no path I/O); no objectstore scope creep

## Fixes
Fixes #2434

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.