### PR TITLE
fix(perc-content-explorer): clear PSFolderDialog residual Xlint (#2441)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2441-psfolderdialog-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2441-psfolderdialog-xlint-erlang.md
@@ -1,0 +1,57 @@
+# Erlang review — #2441 PSFolderDialog residual Xlint
+
+## Summary
+
+Real fixes for the five residual `-Xlint` diagnostics on
+`com.percussion.cx.PSFolderDialog` (parent #2045 / monorepo #2200 / residual of
+#2380):
+
+| Kind | Fix |
+|------|-----|
+| `this-escape` | Class made `final` (no subclasses); early `setResizable(true)` removed (still applied in `initDialog()`) |
+| `serial` (×4) | `m_parentFolderNode`, `m_folderNode`, `m_folderMgr`, `m_userInfo` marked `transient`; `m_applet` also transient for consistency |
+| serialVersionUID | Already present; comment cleaned |
+
+No product behavior change. No class-level `@SuppressWarnings`. Structural unit
+tests in `PSFolderDialogTest` (final + serialVersionUID + transient fields).
+
+## Scope
+
+- Branch: `fix/issue-2441-psfolderdialog-xlint`
+- Base: `origin/main`
+- Module: `modules/DesktopContentExplorer` only
+- Cross-platform path review: N/A (no path/file I/O changes)
+- Out of scope: `PSFolderAclEditorDialog` (#2439)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None (bug / missing tests / non-portable paths).
+
+### Notes
+
+- Pre-change inventory under standalone `javac -Xmaxwarns 5000`: **5** warnings
+  on `PSFolderDialog.java` only; post-change: **0**.
+- Default Maven warning cap (100) hides this file in full-module compiles; inventory
+  used direct `javac` on the single source file.
+- Dialogs are never serialized in product paths; `transient` on session
+  collaborators is the standard real serial fix (same pattern as
+  `PSContentExplorerApplet` / `PSNavigationTree`).
+
+## Verification
+
+- `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` →
+  **BUILD SUCCESS**
+- Tests run: **54**, Failures: **0**, Errors: **0**, Skipped: **0**
+  (includes `PSFolderDialogTest` ×3)
+- No new compiler warnings attributable to this change (baseline shade /
+  dependency-analyze only)
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderDialog.java
@@ -42,8 +42,15 @@ import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 
-/** The dialog to create and modify Folder options. */
-public class PSFolderDialog extends PSDialog {
+/**
+ * The dialog to create and modify Folder options.
+ *
+ * <p>Declared {@code final} so Swing/UI initialization from the constructor cannot observe a
+ * partially constructed subclass (javac {@code this-escape}). Session-only collaborator fields that
+ * are not {@link java.io.Serializable} are {@code transient} (dialogs are never serialized in
+ * practice).
+ */
+public final class PSFolderDialog extends PSDialog {
 
   /**
    * Constructs the dialog with supplied options.
@@ -76,7 +83,8 @@ public class PSFolderDialog extends PSDialog {
             .getResourceString(
                 PSFolderDialog.class, folderNode == null ? "Create folder" : "Edit folder"));
 
-    setResizable(true);
+    // Resizable is applied after full field init in {@link #initDialog()} (avoids early
+    // this-escape via overridable JDialog#setResizable before collaborators are set).
 
     if (userInfo == null) throw new IllegalArgumentException("userInfo may not be null.");
 
@@ -319,25 +327,25 @@ public class PSFolderDialog extends PSDialog {
    * is invoked to create a new folder and never modified after that. <code>null</code> if the
    * dialog is invoked to edit the folder.
    */
-  private PSNode m_parentFolderNode;
+  private transient PSNode m_parentFolderNode;
 
   /**
    * The folder node of the folder being modified, initialized in the ctor and never modified after
    * that. <code>null</code> if the dialog is invoked to create the folder.
    */
-  private PSNode m_folderNode;
+  private transient PSNode m_folderNode;
 
   /**
    * The manager that handles the creating or updating folders, initialized in the ctor and never
    * <code>null</code> or modified after that.
    */
-  private PSFolderActionManager m_folderMgr;
+  private transient PSFolderActionManager m_folderMgr;
 
   /**
    * The info of the user editing or creating the folder, initialized in the ctor and never <code>
    * null</code> or modified after that.
    */
-  private PSUserInfo m_userInfo;
+  private transient PSUserInfo m_userInfo;
 
   /**
    * The flag that specifies whether folder is being created or edited, <code>
@@ -361,9 +369,9 @@ public class PSFolderDialog extends PSDialog {
    */
   private boolean m_publishFolderFlagInitialState;
 
-  /** default serail# avoid warning */
+  /** Default serialVersionUID to satisfy {@code -Xlint:serial}. */
   private static final long serialVersionUID = 1L;
 
   /** A reference back to the applet that initiated the action manager. */
-  private PSContentExplorerApplet m_applet;
+  private transient PSContentExplorerApplet m_applet;
 }

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSFolderDialogTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSFolderDialogTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural coverage for {@link PSFolderDialog} after residual Xlint cleanup (#2441): class is
+ * {@code final} (this-escape) and non-serializable session collaborators are {@code transient}.
+ */
+public class PSFolderDialogTest {
+
+  /** Fields that hold non-serializable session collaborators (must be transient). */
+  private static final Set<String> TRANSIENT_COLLABORATOR_FIELDS =
+      Set.of("m_parentFolderNode", "m_folderNode", "m_folderMgr", "m_userInfo", "m_applet");
+
+  @Test
+  public void dialogClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSFolderDialog.class.getModifiers()),
+        "PSFolderDialog must be final to avoid this-escape in the ctor");
+  }
+
+  @Test
+  public void dialogDeclaresSerialVersionUid() throws Exception {
+    Field uid = PSFolderDialog.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(uid.getModifiers()));
+    assertTrue(Modifier.isFinal(uid.getModifiers()));
+    assertNotNull(uid);
+  }
+
+  @Test
+  public void nonSerializableCollaboratorsAreTransient() throws Exception {
+    for (String name : TRANSIENT_COLLABORATOR_FIELDS) {
+      Field f = PSFolderDialog.class.getDeclaredField(name);
+      assertTrue(
+          Modifier.isTransient(f.getModifiers()),
+          () -> name + " must be transient (non-serializable collaborator)");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Clears the **5 residual** `-Xlint` diagnostics on `PSFolderDialog` left after the #2380 panel rawtypes PR (#2438).

| Diagnostic | Fix |
|------------|-----|
| `this-escape` | Class made `final` (no subclasses); early `setResizable(true)` removed — still applied in `initDialog()` after full field init |
| `serial` (×4 non-serializable collaborators) | `m_parentFolderNode`, `m_folderNode`, `m_folderMgr`, `m_userInfo` marked `transient`; `m_applet` also transient |
| `serialVersionUID` | Already present |

No product behavior change. Prefer real fixes over class-level suppress. Structural tests in `PSFolderDialogTest`.

## Parent / links
- Fixes #2441
- Parent module tracker: #2045
- Parent monorepo tracker: #2200
- Residual of: #2380 / PR #2438
- Out of scope: `PSFolderAclEditorDialog` (#2439)

## Test plan
- [x] Erlang self-review **approve** — `docs/ai-generated/code-reviews/issue-2441-psfolderdialog-xlint-erlang.md`
- [x] Standalone module clean install:
  `
  cd modules/DesktopContentExplorer
  ../../mvnw.cmd clean install
  `
  **BUILD SUCCESS** — Tests run: **54**, Failures: **0** (includes `PSFolderDialogTest` ×3)
- [x] Direct `javac -Xmaxwarns 5000` on `PSFolderDialog.java`: **5 → 0** warnings
- [x] No new warnings attributable to this change (baseline shade/dependency-analyze only)

## Gates
- Pre-PR Maven verification: standalone `perc-content-explorer` clean install green
- Cross-platform paths: N/A (no path/file I/O)
- Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.