### PR TITLE
fix(sitemanage): @Lazy on assetService→pageService ctor edge (#2476)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -46,16 +46,21 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset`. Class `@Lazy`. |
 | 3 | `PSTemplateService` | out ~6 / in ~20 | **Not** class `@Lazy`. Injects `widgetAsset`, page/template DAOs. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
-| 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` (and folder/asset/widget/item). Class `@Lazy`. |
+| 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
 | 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
 
-### Next hottest unprotected edge
+### Next hottest near-cycle edge (protected — #2476)
 
-**`PSAssetService` → `IPSPageService` (constructor, not `@Lazy`)** with **no reverse** `PSPageService` → `IPSAssetService`.
+**`PSAssetService` → `IPSPageService` (constructor, param `@Lazy` as of #2476)** with **no reverse** `PSPageService` → `IPSAssetService`.
 
-If a future change adds `IPSAssetService` to `PSPageService`'s constructor (or an eager non-`@Lazy` field), Spring will hit a creation cycle involving two of the busiest product services, independent of the folderHelper fix.
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on both beans | Present but **not** a cycle breaker when an eager consumer forces construction |
+| Param `@Lazy` on forward edge | **Added (#2476)** — Spring injects a pageService proxy; safe because `PSAssetService` only calls `pageService` post-construction (`load` / `notifyPageChange` / `isPageItem` / etc.), never during the ctor body beyond a non-null check (proxy is non-null) |
+| Reverse edge ban | Kept — `PSPageService` must not construct-require `IPSAssetService` |
+| Why not skip param `@Lazy` | Inventory residual after #2463: without it, a future reverse edge or multi-hop eager path would form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
 
-Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + no reverse).
+Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + param `@Lazy` + no reverse).
 
 ### Other one-way edges to keep one-way (known cycle intermediate)
 
@@ -72,9 +77,10 @@ These must not gain reverse constructor dependencies:
 
 ## Constructor `@Lazy` parameter edges found (sitemanage)
 
-Outside the known fix, constructor-parameter `@Lazy` is rare in this module. Scan snapshot:
+Constructor-parameter `@Lazy` remains rare in this module. Scan snapshot (after #2476):
 
-- `PSContentItemDao` → `IPSFolderHelper` (`@Lazy`) — cycle break
+- `PSContentItemDao` → `IPSFolderHelper` (`@Lazy`) — known cycle break (#2435)
+- `PSAssetService` → `IPSPageService` (`@Lazy`) — near-cycle belt-and-braces (#2476)
 - `PSRecentRestService` → `IPSRecentService` (`@Lazy`) — rest convenience, not cycle-related
 
 Class-level `@Lazy` is common on REST facades and many services; treat it as lazy *init*, not a cycle breaker.
@@ -94,10 +100,11 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 
 ## Residual recommendations (file as GitHub issues under #2423)
 
-1. Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way).
-2. Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param as belt-and-braces (behavior review needed).
+1. Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way) — **covered in** `PSAssetServicePageServiceNearCycleWiringTest.knownCycleIntermediateBeansHaveNoReverseConstructorEdges` (#2463).
+2. ~~Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param~~ — **done (#2476)**.
 3. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 4. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+5. Hub hardening still open as separate residuals: templateService (#2477), itemWorkflow reverse-edge tests (#2478).
 
 ## Related
 
@@ -106,4 +113,5 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 - #2436 — `FolderHelperCycleContextTest` graph witness  
 - #2437 — Docker qa-up health/login smoke  
 - #2463 — this residual inventory  
+- #2476 — param `@Lazy` on assetService→pageService  
 - #2457 / PR #2469 — JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
@@ -164,7 +164,11 @@ public class PSAssetService extends PSAbstractFullDataService<PSAsset, PSAssetSu
   @Autowired
   public PSAssetService(
       IPSIdMapper idMapper,
-      IPSPageService pageService,
+      // Belt-and-braces: class-level @Lazy on both beans does not break constructor edges.
+      // Param @Lazy injects a pageService proxy so a future reverse edge (or eager multi-hop
+      // creation through shared cycle peers) cannot form BeanCurrentlyInCreationException on
+      // assetService↔pageService. pageService is only used post-construction (see #2476 / #2463).
+      @Lazy IPSPageService pageService,
       @Qualifier("sys_templateService") IPSTemplateService templateService,
       IPSWidgetService widgetService,
       IPSContentDesignWs contentDs,

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSAssetServicePageServiceNearCycleWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSAssetServicePageServiceNearCycleWiringTest.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Parameter;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * Protection for the next-hottest sitemanage injection edge after the folderHelper cycle (#2423).
@@ -37,16 +38,18 @@ import org.junit.jupiter.api.Test;
  * PSContentItemDao}. The next hottest <em>near-cycle</em> is a one-way hub edge:
  *
  * <pre>
- * assetService  →  pageService   (constructor, not @Lazy)
+ * assetService  →  pageService   (constructor, param @Lazy — #2476)
  * pageService   ↛  assetService  (must remain true)
  * </pre>
  *
  * <p>{@link PSAssetService} is a high fan-in product service that construct-requires {@link
- * IPSPageService}. {@link PSPageService} already construct-requires cycle peers ({@code
- * contentItemDao}, {@code folderHelper}, {@code recycleService}, {@code
- * widgetAssetRelationshipService}). Adding {@link IPSAssetService} to {@code PSPageService}'s
- * constructor (or an eager non-{@code @Lazy} field) would form a new {@code
- * BeanCurrentlyInCreationException} path independent of the folderHelper fix.
+ * IPSPageService}. Class-level {@code @Lazy} on both beans does <em>not</em> break constructor
+ * dependency edges when an eager consumer forces creation; parameter {@code @Lazy} injects a proxy
+ * (peer of {@link PSContentItemDaoCycleLazyWiringTest}). {@link PSPageService} already
+ * construct-requires cycle peers ({@code contentItemDao}, {@code folderHelper}, {@code
+ * recycleService}, {@code widgetAssetRelationshipService}). Adding {@link IPSAssetService} to
+ * {@code PSPageService}'s constructor without a matching lazy break would still be a wiring hazard;
+ * the reverse edge remains banned here and the forward edge carries param {@code @Lazy}.
  *
  * <p>Peers: {@link PSContentItemDaoCycleLazyWiringTest}, {@code FolderHelperCycleContextTest}
  * (#2436). Full inventory: {@code
@@ -63,6 +66,23 @@ public class PSAssetServicePageServiceNearCycleWiringTest {
         pageParam,
         "PSAssetService must still construct-require IPSPageService — inventory #2463 assumed this"
             + " one-way hub edge; if the edge was removed, update the inventory and this test");
+  }
+
+  /**
+   * Belt-and-braces: param {@code @Lazy} on the forward edge so Spring injects a pageService proxy
+   * (#2476). Class-level {@code @Lazy} alone is insufficient when both beans are forced during
+   * startup (see inventory note on class vs param {@code @Lazy}).
+   */
+  @Test
+  public void assetServicePageServiceConstructorParameterIsLazy() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSAssetService.class);
+    Parameter pageParam = findParamOfType(ctor, IPSPageService.class);
+    assertNotNull(pageParam, "Expected an IPSPageService constructor parameter on PSAssetService");
+    assertTrue(
+        pageParam.isAnnotationPresent(Lazy.class),
+        "IPSPageService constructor parameter on PSAssetService must be @Lazy (belt-and-braces"
+            + " near-cycle protection for assetService→pageService; see #2476 / #2463)."
+            + " pageService is only used post-construction so the proxy is safe.");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Parent tracker: #2423. Residual slice #2476 (after inventory #2463 / PR #2475).

**Disposition:** param `@Lazy` on `PSAssetService(…, IPSPageService pageService, …)` is **safe and implemented**.

### Design note
- Both beans already have **class-level** `@Lazy`, but class-level lazy init is **not** a constructor-edge cycle breaker when an eager consumer forces full construction (same lesson as folderHelper / #2435).
- `PSAssetService` only uses `pageService` **post-construction** (`load`, `notifyPageChange`, `isPageItem`, `updateTemplateMigrationVersion`, `find`). The ctor only stores the reference and runs `notNull` (Spring lazy proxy is non-null).
- Param `@Lazy` injects an interface proxy (peer of `PSContentItemDao` → `IPSFolderHelper` @Lazy). Belt-and-braces if a future reverse edge or multi-hop eager path appears.
- **Reverse edge remains banned** by reflection test (`PSPageService` must not construct-require `IPSAssetService`).

### Changes
- `PSAssetService` — `@Lazy` on `IPSPageService` ctor parameter
- `PSAssetServicePageServiceNearCycleWiringTest` — assert param `@Lazy`; keep reverse-edge + intermediate reverse-edge gates
- Inventory note updated with #2476 disposition

### Related
- Fixes #2476
- Parent #2423
- Peers: #2463 / PR #2475, #2435 (`PSContentItemDaoCycleLazyWiringTest`)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw.cmd test -Dtest=PSAssetServicePageServiceNearCycleWiringTest,PSContentItemDaoCycleLazyWiringTest`
  - Tests run: 5, Failures: 0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install`
  - **BUILD SUCCESS**
  - Tests run: 797, Failures: 0, Errors: 0, Skipped: 128
  - No new warnings attributable to this change (param annotation + reflection assert + inventory doc only)

## Gates
- Erlang self-review: no bugs; portable (annotation + reflection); change-class companions (wiring test peer of CycleLazyWiringTest + inventory disposition).
- Pre-PR Maven: standalone sitemanage clean install green.
- No agent rule file commits.
- No human QA (pure Spring wiring / unit reflection; no UI/install).

> Co-Authored by Grok Build using grok-4.5 with agent main.
