### PR TITLE
test(sitemanage): itemWorkflow hub reverse-edge protection (#2478)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -62,6 +62,24 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 
 Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + param `@Lazy` + no reverse).
 
+### ItemWorkflow hub reverse-edge protection (#2478)
+
+**`PSItemWorkflowService` → cycle peers (constructor)** with **no reverse** from those peers → `IPSItemWorkflowService`.
+
+Scan (2026-08-08 / #2478): among known-cycle peers (`PSAssetDao`, `PSContentItemDao`, `PSWidgetAssetRelationshipService`, `PSRecycleService`, `PSFolderHelper`):
+
+| Peer | ctor → `IPSItemWorkflowService`? | field → `IPSItemWorkflowService`? | Notes |
+|------|----------------------------------|-----------------------------------|-------|
+| `PSAssetDao` | no | no | Forward only: itemWorkflow → assetDao |
+| `PSContentItemDao` | no | no | Cycle-break peer; must stay free of hub reverse |
+| `PSWidgetAssetRelationshipService` | no | no | Forward only |
+| `PSRecycleService` | no | no | Imports transition **constants** only (`TRANSITION_TRIGGER_*`), not the bean |
+| `PSFolderHelper` | no | no | Forward only |
+
+`PSItemWorkflowService` itself construct-requires `IPSAssetDao`, `IPSFolderHelper`, `IPSRecycleService`, `IPSWidgetAssetRelationshipService` (class `@Lazy` on the hub is not a reverse-edge breaker for peers that inject it eagerly).
+
+Protection test: `PSItemWorkflowServiceHubReverseEdgeWiringTest` — freezes forward hub edges; forbids reverse ctor edges unless parameter `@Lazy`; forbids non-`@Lazy` field inject of `IPSItemWorkflowService` on the five peers. Intentional `@Lazy` reverse edges (if ever added) must be documented in this table.
+
 ### Other one-way edges to keep one-way (known cycle intermediate)
 
 These must not gain reverse constructor dependencies:
@@ -72,8 +90,9 @@ These must not gain reverse constructor dependencies:
 | `PSWidgetAssetRelationshipService` | `IPSAssetDao` | assetDao → widgetAsset skips contentItemDao break |
 | `PSRecycleService` | `IPSWidgetAssetRelationshipService` | widgetAsset → recycle closes mid-chain |
 | `PSFolderHelper` | `IPSRecycleService` | recycle → folderHelper bypasses contentItemDao `@Lazy` |
+| `PSItemWorkflowService` | `IPSAssetDao` / `IPSFolderHelper` / `IPSRecycleService` / `IPSWidgetAssetRelationshipService` | peer → itemWorkflow closes hub reverse cycle (#2478) |
 
-`FolderHelperCycleContextTest` (#2436) + `PSContentItemDaoCycleLazyWiringTest` (#2435) cover the `@Lazy` break; intermediate reverse edges are residual hardening candidates.
+`FolderHelperCycleContextTest` (#2436) + `PSContentItemDaoCycleLazyWiringTest` (#2435) cover the `@Lazy` break; intermediate reverse edges: `PSAssetServicePageServiceNearCycleWiringTest` + `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478).
 
 ## Constructor `@Lazy` parameter edges found (sitemanage)
 
@@ -100,11 +119,12 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 
 ## Residual recommendations (file as GitHub issues under #2423)
 
-1. Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way) — **covered in** `PSAssetServicePageServiceNearCycleWiringTest.knownCycleIntermediateBeansHaveNoReverseConstructorEdges` (#2463).
-2. ~~Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param~~ — **done (#2476)**.
-3. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
-4. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-5. Hub hardening still open as separate residuals: templateService (#2477), itemWorkflow reverse-edge tests (#2478).
+1. ~~Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way).~~ Done in `PSAssetServicePageServiceNearCycleWiringTest.knownCycleIntermediateBeansHaveNoReverseConstructorEdges` (#2463).
+2. ~~Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param as belt-and-braces.~~ **Done (#2476)**.
+3. ~~ItemWorkflow hub reverse-edge tests.~~ Done: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478).
+4. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
+5. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+6. Optional next hubs (same pattern as #2478): `PSPageService` (rank 1) and `PSTemplateService` (rank 3 / #2477) reverse-edge freezes.
 
 ## Related
 
@@ -114,4 +134,6 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 - #2437 — Docker qa-up health/login smoke  
 - #2463 — this residual inventory  
 - #2476 — param `@Lazy` on assetService→pageService  
+- #2478 — itemWorkflow hub reverse-edge protection (`PSItemWorkflowServiceHubReverseEdgeWiringTest`)  
+- #2477 — templateService hub hardening residual  
 - #2457 / PR #2469 — JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemWorkflowServiceHubReverseEdgeWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemWorkflowServiceHubReverseEdgeWiringTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.dao.impl.PSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.impl.PSItemWorkflowService;
+import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.recycle.service.impl.PSRecycleService;
+import com.percussion.share.dao.IPSContentItemDao;
+import com.percussion.share.dao.IPSFolderHelper;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Protection for the {@link PSItemWorkflowService} high fan-in hub (#2423 residual #2478).
+ *
+ * <p>Static inventory (#2463) ranked {@code PSItemWorkflowService} as the second-hottest sitemanage
+ * hub (ctor out ~7 / in ~23). It construct-requires known-cycle peers:
+ *
+ * <pre>
+ * itemWorkflowService
+ *   → assetDao
+ *   → folderHelper
+ *   → recycleService
+ *   → widgetAssetRelationshipService
+ * </pre>
+ *
+ * <p>Those peers sit on the known {@code folderHelper → … → contentItemDao → folderHelper} chain
+ * (broken by {@code @Lazy} on {@link PSContentItemDao}). A reverse constructor (or eager field)
+ * edge from any of those peers back to {@link IPSItemWorkflowService} would form a new creation
+ * cycle independent of the contentItemDao {@code @Lazy} break:
+ *
+ * <pre>
+ * folderHelper → recycle → widgetAsset → assetDao → contentItemDao → folderHelper
+ *       ↑________________________________ itemWorkflow ______________________/
+ * </pre>
+ *
+ * <p>This test freezes the one-way hub edges and forbids reverse ctor / non-{@code @Lazy} field
+ * inject of {@code IPSItemWorkflowService} on the cycle peers. Intentional reverse edges must use
+ * parameter/field {@link Lazy @Lazy} and be documented in the inventory note.
+ *
+ * <p>Peers: {@link PSAssetServicePageServiceNearCycleWiringTest}, {@link
+ * PSContentItemDaoCycleLazyWiringTest}, {@code FolderHelperCycleContextTest} (#2436). Inventory:
+ * {@code docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSItemWorkflowServiceHubReverseEdgeWiringTest {
+
+  /** Cycle peers that itemWorkflow construct-requires (and must not reverse-require it). */
+  private static final Class<?>[] CYCLE_PEERS = {
+    PSAssetDao.class,
+    PSContentItemDao.class,
+    PSWidgetAssetRelationshipService.class,
+    PSRecycleService.class,
+    PSFolderHelper.class
+  };
+
+  @Test
+  public void itemWorkflowServiceConstructRequiresCyclePeers() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSItemWorkflowService.class);
+
+    assertNotNull(
+        findParamOfType(ctor, IPSAssetDao.class),
+        "PSItemWorkflowService must still construct-require IPSAssetDao — inventory #2463 / #2478"
+            + " hub model; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSFolderHelper.class),
+        "PSItemWorkflowService must still construct-require IPSFolderHelper");
+    assertNotNull(
+        findParamOfType(ctor, IPSRecycleService.class),
+        "PSItemWorkflowService must still construct-require IPSRecycleService");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSItemWorkflowService must still construct-require IPSWidgetAssetRelationshipService");
+  }
+
+  @Test
+  public void cyclePeersMustNotConstructRequireItemWorkflowService() throws NoSuchMethodException {
+    for (Class<?> peer : CYCLE_PEERS) {
+      Constructor<?> ctor = singlePublicConstructor(peer);
+      Parameter itemWf = findParamOfType(ctor, IPSItemWorkflowService.class);
+      if (itemWf == null) {
+        continue; // desired: no reverse ctor edge
+      }
+      // Intentional exception path: only allowed with parameter @Lazy
+      assertTrue(
+          itemWf.isAnnotationPresent(Lazy.class),
+          peer.getSimpleName()
+              + " construct-requires IPSItemWorkflowService without @Lazy — that closes a"
+              + " reverse cycle with the itemWorkflow hub (see #2478). Prefer method-level lookup,"
+              + " setter injection, or @Lazy on the injection point; document intentional @Lazy"
+              + " reverse edges in sitemanage-injection-cycle-inventory.md.");
+    }
+  }
+
+  /**
+   * Eager {@code @Autowired} field inject of {@link IPSItemWorkflowService} on a cycle peer is the
+   * same class of reverse edge as a constructor param (class-level {@code @Lazy} on the peer does
+   * not break an eager field edge from a bean already under construction).
+   *
+   * <p>Also flags unannotated fields of that type (legacy XML/setter surfaces) unless marked
+   * {@code @Lazy}.
+   */
+  @Test
+  public void cyclePeersMustNotEagerFieldInjectItemWorkflowService() {
+    List<String> violations = new ArrayList<>();
+    for (Class<?> peer : CYCLE_PEERS) {
+      for (Field field : peer.getDeclaredFields()) {
+        if (!IPSItemWorkflowService.class.isAssignableFrom(field.getType())) {
+          continue;
+        }
+        if (field.isAnnotationPresent(Lazy.class)) {
+          continue; // documented intentional reverse edge
+        }
+        boolean autowired = field.isAnnotationPresent(Autowired.class);
+        violations.add(
+            peer.getSimpleName()
+                + "."
+                + field.getName()
+                + (autowired ? " (@Autowired)" : " (field type)")
+                + " — reverse field edge without @Lazy");
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Cycle peers must not eagerly field-inject IPSItemWorkflowService (use @Lazy or remove"
+            + " the edge). Violations: "
+            + String.join("; ", violations));
+  }
+
+  @Test
+  public void contentItemDaoStillHasNoItemWorkflowConstructorEdge() throws NoSuchMethodException {
+    // Explicit named assertion for the known-cycle break peer (contentItemDao is the @Lazy site)
+    assertNoEagerCtorParam(
+        PSContentItemDao.class,
+        IPSItemWorkflowService.class,
+        "contentItemDao → itemWorkflow would couple the cycle-break peer to the hub");
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    if (p == null) {
+      return;
+    }
+    assertTrue(
+        p.isAnnotationPresent(Lazy.class),
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + " without @Lazy: "
+            + why);
+  }
+}


### PR DESCRIPTION
## Summary

Adds reflection-based UnitTest protection for the **PSItemWorkflowService** high fan-in hub (rank 2 in the #2463 inventory). The hub construct-requires known-cycle peers (ssetDao, olderHelper, ecycleService, widgetAssetRelationshipService). This PR freezes those one-way edges and forbids reverse constructor (or non-@Lazy field) inject of IPSItemWorkflowService from those peers — the same class of startup risk as the folderHelper cycle (#2423).

**No product behavior change** — tests + inventory note only.

- Parent epic: #2423
- Fixes #2478
- Related inventory: #2463 / PR #2475
- Peer pattern: PSAssetServicePageServiceNearCycleWiringTest

### Changes
- New: PSItemWorkflowServiceHubReverseEdgeWiringTest (@Tag("UnitTest"))
  - Asserts hub still construct-requires the four cycle peers
  - Forbids reverse ctor edges on assetDao / contentItemDao / widgetAsset / recycle / folderHelper unless param @Lazy
  - Forbids non-@Lazy field inject of IPSItemWorkflowService on those peers
- Updates docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md with scan results

### Scan result (current tree)
None of the five cycle peers inject IPSItemWorkflowService (ctor or field). PSRecycleService only references transition **constants** on the interface.

## Test plan
- [x] cd projects/sitemanage && ../../mvnw clean install → **BUILD SUCCESS**
- [x] New class: Tests run: 4, Failures: 0
- [x] Module suite: Tests run: 800, Failures: 0, Errors: 0, Skipped: 128
- [x] No new warnings attributable to this change (baseline javadoc/dependency-analyze only)

## Gates evidence
| Gate | Result |
|------|--------|
| Erlang-style self-review | Pass — unit tests only, portable, no path I/O, companions match peer near-cycle test |
| Standalone module clean install | cd projects/sitemanage; ../../mvnw.cmd clean install BUILD SUCCESS |
| Product UI / installer | N/A — pure wiring regression test |

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.