### PR TITLE
fix(docker): compose verify Rhythmyx context fail-fast (#2480)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -231,15 +231,17 @@ python docker/scripts/perc-devctl.py down
 
 Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for the resolved probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`), prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section. Concurrent freeport checklist: **Two-worktree concurrent freeport smoke** above.
 
-##### Rhythmyx ApplicationContext fail-fast (#2462 / #2423)
+##### Rhythmyx ApplicationContext fail-fast (#2462 / #2480 / #2423)
 
-Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `ApplicationContext` failed (e.g. `BeanCurrentlyInCreationException` / circular `folderHelper` wiring). A port-up or HTTP-only probe is **not** sufficient.
+Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `ApplicationContext` failed (e.g. `BeanCurrentlyInCreationException` / circular `folderHelper` wiring). A port-up or HTTP-only probe is **not** sufficient. The same markers apply to **QA matrix cells** and the **cms-dts compose stack**.
 
 | Signal | Where | Operator meaning |
 |--------|--------|------------------|
 | `RESULT:OK STEP:qa-health HTTP:…` | `perc-devctl.py qa-health` | Probe URL ready **and** recent `docker logs` have **no** Rhythmyx context-failure markers |
-| `RESULT:FAIL … DETAIL:rhythmyx_context_failed MATCH:…` | `qa-health` or matrix cell `detail` | **Fail-fast**: Spring/Jetty context death detected in logs; treat cell as unusable even if HTTP answered |
+| `RESULT:OK STEP:verify CMS_HTTP:… DTS_HTTP:… HEALTH:healthy` | `perc-devctl.py verify` (and `verify-fix` / `deploy-jar --verify`) | CMS+DTS HTTP ready, docker health healthy, **and** cms-dts logs have **no** Rhythmyx context-failure markers |
+| `RESULT:FAIL … DETAIL:rhythmyx_context_failed MATCH:…` | `qa-health`, compose `verify` / `_verify_inline`, or matrix cell `detail` | **Fail-fast**: Spring/Jetty context death detected in logs; treat stack as unusable even if HTTP / docker health answered green |
 | `RESULT:FAIL … DETAIL:timeout after Ns (last_http=…)` | `qa-health` | Probe never became ready; if logs later show context fail, re-run `qa-health` or `docker logs perc-matrix-cms-h2` |
+| `RESULT:FAIL … DETAIL:timeout after Ns (cms_http=… dts_http=… health=…)` | `verify` | Stack never became ready; scan `docker logs percussion-cms-dts` for context markers |
 | Matrix `status=fail` + `detail` containing `rhythmyx_context_failed` | `matrix-install-smoke.py` CMS cells | Same fail-fast during cell HTTP wait (container log scan) |
 
 Markers (shared helper `docker/scripts/rhythmyx_ready.py`): `Failed startup of context`, `BeanCurrentlyInCreationException`, `Requested bean is currently in creation`, `Is there an unresolvable circular reference`.
@@ -251,6 +253,13 @@ python docker/scripts/perc-devctl.py qa-health
 # RESULT:FAIL STEP:qa-health DETAIL:rhythmyx_context_failed MATCH:Failed startup of context …
 docker logs perc-matrix-cms-h2 2>&1 | findstr /i "Failed startup BeanCurrently circular folderHelper"
 # Unix: docker logs perc-matrix-cms-h2 2>&1 | grep -E 'Failed startup|BeanCurrently|circular'
+
+# After compose up, verify also scans cms-dts logs (#2480):
+python docker/scripts/perc-devctl.py verify
+# FAIL example:
+# RESULT:FAIL STEP:verify DETAIL:rhythmyx_context_failed MATCH:Failed startup of context …
+docker logs percussion-cms-dts 2>&1 | findstr /i "Failed startup BeanCurrently circular folderHelper"
+# Unix: docker logs percussion-cms-dts 2>&1 | grep -E 'Failed startup|BeanCurrently|circular'
 ```
 
 Unit tests: `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q`.

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -18,6 +18,10 @@ QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
   even if HTTP still answers (#2462 / #2423)
 * ``qa-down`` — destroy the QA cell (frees ports; no multi-GB orphans)
 
+Compose ``verify`` / ``verify-fix`` / ``deploy-jar --verify`` apply the same
+Rhythmyx context log scan against the cms-dts container (#2480 companion to
+#2462): HTTP + docker health alone is not enough when Spring context is dead.
+
 Each subcommand logs its full output to a timestamped file under
 ``docker/logs/`` and emits a single ``RESULT:OK STEP:<step> LOG:<path>``
 or ``RESULT:FAIL STEP:<step> LOG:<path>`` line on stdout so agent
@@ -642,8 +646,9 @@ def _docker_logs_tail(
 ) -> str:
     """Return recent ``docker logs`` text for ``container_name``, or empty.
 
-    Used by ``qa-health`` to fail-fast when Jetty reports Rhythmyx context
-    startup failure while the HTTP port may still answer (#2462).
+    Used by ``qa-health`` and compose ``verify`` / ``_verify_inline`` to
+    fail-fast when Jetty reports Rhythmyx context startup failure while the
+    HTTP port may still answer (#2462 / #2480).
     """
     if not container_name:
         return ""
@@ -675,6 +680,16 @@ def _docker_logs_tail(
 
 
 def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
+    """Poll CMS/DTS HTTP + docker health until ready or timeout / context fail.
+
+    Ready means CMS and DTS probe HTTP codes are in the verify set, the
+    cms-dts container health is ``healthy``, **and** recent ``docker logs``
+    for that container do **not** contain Rhythmyx ApplicationContext
+    failure markers (see :mod:`rhythmyx_ready`).
+
+    Context-failure markers cause **immediate** FAIL even when HTTP answers
+    and docker reports healthy (Jetty up, Spring webapp dead — #2480 / #2462).
+    """
     repo_root, env_file, compose_file = paths
     log_dir = _log_dir(repo_root)
     timeout = args.timeout_seconds
@@ -683,47 +698,105 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     log_file = _new_log_file(log_dir, "verify")
     cms_url = resolve_verify_cms_url()
     dts_url = resolve_verify_dts_url()
+    container = DEFAULT_CONTAINER
 
     if args.dry_run:
         LOG.info(
-            "DRY-RUN: verify plan: %d checks x %ds interval against %s + %s",
-            max_checks, interval, cms_url, dts_url,
+            "DRY-RUN: verify plan: %d checks x %ds interval against %s + %s "
+            "(+ Rhythmyx context log scan on %s)",
+            max_checks, interval, cms_url, dts_url, container,
         )
         with log_file.open("w", encoding="utf-8") as f:
             f.write(
                 f"DRY-RUN: verify max_checks={max_checks} interval={interval}\n"
                 f"endpoints={cms_url} {dts_url}\n"
+                f"container={container}\n"
+                f"log_scan=rhythmyx_context_fail_markers\n"
             )
         print(f"RESULT:OK STEP:verify CMS_HTTP:200 DTS_HTTP:200 HEALTH:healthy LOG:{log_file}")
         return EXIT_OK
 
+    last_cms = 0
+    last_dts = 0
+    last_health = "unknown"
+    last_detail = "not_checked"
     for check in range(1, max_checks + 1):
-        cms_code = _curl_status(cms_url, timeout=5.0)
-        dts_code = _curl_status(dts_url, timeout=5.0)
-        health = _docker_health(DEFAULT_CONTAINER)
+        last_cms = _curl_status(cms_url, timeout=5.0)
+        last_dts = _curl_status(dts_url, timeout=5.0)
+        last_health = _docker_health(container)
+        logs = _docker_logs_tail(container)
+        # require_http=False: HTTP readiness is still gated by the verify
+        # code set below; this assessor is for context-fail markers only.
+        _ready_ctx, last_detail = assess_rhythmyx_ready(
+            last_cms, logs, require_http=False,
+        )
+
+        # Fail-fast when Spring/Jetty already reported a dead Rhythmyx context.
+        if DETAIL_CONTEXT_FAILED in last_detail:
+            match = find_rhythmyx_context_failure(logs) or "unknown"
+            with log_file.open("w", encoding="utf-8") as f:
+                f.write("verify failed\n")
+                f.write(f"cms_http={last_cms}\n")
+                f.write(f"dts_http={last_dts}\n")
+                f.write(f"container_health={last_health}\n")
+                f.write(f"check={check}\n")
+                f.write(f"container={container}\n")
+                f.write(f"detail={last_detail}\n")
+                f.write(f"match={match}\n")
+                f.write(f"cms_url={cms_url}\n")
+                f.write(f"dts_url={dts_url}\n")
+                f.write(
+                    "hint: Rhythmyx ApplicationContext failed; Jetty HTTP / "
+                    "docker health may still look green. Inspect docker logs "
+                    "for Spring cycle / bean errors (parent #2423 / #2480). "
+                    "Do not treat port-up as ready.\n"
+                )
+            print(
+                f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
+                f"MATCH:{match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+                f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
+            )
+            return EXIT_SUBPROCESS_FAILED
+
         if (
-            cms_code in (200, 401, 403)
-            and dts_code in (200, 401, 403)
-            and health == "healthy"
+            last_cms in (200, 401, 403)
+            and last_dts in (200, 401, 403)
+            and last_health == "healthy"
         ):
             with log_file.open("w", encoding="utf-8") as f:
                 f.write("verify success\n")
-                f.write(f"cms_http={cms_code}\n")
-                f.write(f"dts_http={dts_code}\n")
-                f.write(f"container_health={health}\n")
+                f.write(f"cms_http={last_cms}\n")
+                f.write(f"dts_http={last_dts}\n")
+                f.write(f"container_health={last_health}\n")
                 f.write(f"cms_url={cms_url}\n")
                 f.write(f"dts_url={dts_url}\n")
+                f.write("rhythmyx_context=ok\n")
             print(
-                f"RESULT:OK STEP:verify CMS_HTTP:{cms_code} DTS_HTTP:{dts_code} "
-                f"HEALTH:{health} LOG:{log_file}"
+                f"RESULT:OK STEP:verify CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+                f"HEALTH:{last_health} LOG:{log_file}"
             )
             return EXIT_OK
         time.sleep(interval)
 
+    # Timeout path: re-scan logs once more so DETAIL prefers context failure.
+    final_logs = _docker_logs_tail(container)
+    final_match = find_rhythmyx_context_failure(final_logs)
     with log_file.open("w", encoding="utf-8") as f:
         f.write("verify failed\n")
         f.write(f"timeout_seconds={timeout}\n")
         f.write(f"interval_seconds={interval}\n")
+        f.write(f"cms_http={last_cms}\n")
+        f.write(f"dts_http={last_dts}\n")
+        f.write(f"container_health={last_health}\n")
+        f.write(f"container={container}\n")
+        f.write(f"last_detail={last_detail}\n")
+        if final_match:
+            f.write(f"match={final_match}\n")
+            f.write(
+                "hint: Rhythmyx context failure markers found in docker logs; "
+                "see parent #2423 / #2480. HTTP-only / health-only ready is "
+                "insufficient.\n"
+            )
         f.write("--- compose ps\n")
         # capture compose ps in a child log to avoid clobbering
         compose_ps_log = _new_log_file(log_dir, "verify-compose-ps")
@@ -736,7 +809,18 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
                 stderr=subprocess.STDOUT,
             )
         f.write(f"see {compose_ps_log}\n")
-    print(f"RESULT:FAIL STEP:verify LOG:{log_file}")
+    if final_match:
+        print(
+            f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
+            f"MATCH:{final_match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+            f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
+        )
+    else:
+        print(
+            f"RESULT:FAIL STEP:verify DETAIL:timeout after {timeout}s "
+            f"(cms_http={last_cms} dts_http={last_dts} health={last_health}) "
+            f"LOG:{log_file}"
+        )
     return EXIT_SUBPROCESS_FAILED
 
 
@@ -843,49 +927,95 @@ def _verify_inline(
     dry_run: bool,
 ) -> tuple[int, Path]:
     """Inline verify used by ``deploy-jar --verify`` and ``verify-fix``.
-    Mirrors ``cmd_verify`` but bypasses the wrapped ``verify`` parser
-    argument. Returns ``(exit_code, log_file_path)`` so callers
-    (e.g. ``cmd_verify_fix``) can include the log path in their own
-    ``RESULT:FAIL`` lines.
+
+    Mirrors ``cmd_verify`` (including Rhythmyx context log fail-fast —
+    #2480) but bypasses the wrapped ``verify`` parser argument. Returns
+    ``(exit_code, log_file_path)`` so callers (e.g. ``cmd_verify_fix``)
+    can include the log path in their own ``RESULT:FAIL`` lines.
     """
     max_checks = max(1, timeout_seconds // interval_seconds) if interval_seconds > 0 else 1
     log_file = _new_log_file(log_dir, "verify")
 
     cms_url = resolve_verify_cms_url()
     dts_url = resolve_verify_dts_url()
+    container = DEFAULT_CONTAINER
 
     if dry_run:
         with log_file.open("w", encoding="utf-8") as f:
             f.write(
                 f"DRY-RUN: verify-inline max_checks={max_checks} interval={interval_seconds}\n"
                 f"endpoints={cms_url} {dts_url}\n"
+                f"container={container}\n"
+                f"log_scan=rhythmyx_context_fail_markers\n"
             )
         return EXIT_OK, log_file
 
+    last_cms = 0
+    last_dts = 0
+    last_health = "unknown"
     for _ in range(1, max_checks + 1):
-        cms_code = _curl_status(cms_url, timeout=5.0)
-        dts_code = _curl_status(dts_url, timeout=5.0)
-        health = _docker_health(DEFAULT_CONTAINER)
+        last_cms = _curl_status(cms_url, timeout=5.0)
+        last_dts = _curl_status(dts_url, timeout=5.0)
+        last_health = _docker_health(container)
+        logs = _docker_logs_tail(container)
+        _ready_ctx, detail = assess_rhythmyx_ready(
+            last_cms, logs, require_http=False,
+        )
+        if DETAIL_CONTEXT_FAILED in detail:
+            match = find_rhythmyx_context_failure(logs) or "unknown"
+            with log_file.open("w", encoding="utf-8") as f:
+                f.write("verify failed\n")
+                f.write(f"cms_http={last_cms}\n")
+                f.write(f"dts_http={last_dts}\n")
+                f.write(f"container_health={last_health}\n")
+                f.write(f"container={container}\n")
+                f.write(f"detail={detail}\n")
+                f.write(f"match={match}\n")
+                f.write(
+                    "hint: Rhythmyx ApplicationContext failed during "
+                    "verify-inline (#2480 / #2423).\n"
+                )
+            print(
+                f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
+                f"MATCH:{match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+                f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
+            )
+            return EXIT_SUBPROCESS_FAILED, log_file
         if (
-            cms_code in (200, 401, 403)
-            and dts_code in (200, 401, 403)
-            and health == "healthy"
+            last_cms in (200, 401, 403)
+            and last_dts in (200, 401, 403)
+            and last_health == "healthy"
         ):
             with log_file.open("w", encoding="utf-8") as f:
                 f.write("verify success\n")
-                f.write(f"cms_http={cms_code}\n")
-                f.write(f"dts_http={dts_code}\n")
-                f.write(f"container_health={health}\n")
+                f.write(f"cms_http={last_cms}\n")
+                f.write(f"dts_http={last_dts}\n")
+                f.write(f"container_health={last_health}\n")
+                f.write("rhythmyx_context=ok\n")
             print(
-                f"RESULT:OK STEP:verify CMS_HTTP:{cms_code} DTS_HTTP:{dts_code} "
-                f"HEALTH:{health} LOG:{log_file}"
+                f"RESULT:OK STEP:verify CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+                f"HEALTH:{last_health} LOG:{log_file}"
             )
             return EXIT_OK, log_file
         time.sleep(interval_seconds)
 
+    final_logs = _docker_logs_tail(container)
+    final_match = find_rhythmyx_context_failure(final_logs)
     with log_file.open("w", encoding="utf-8") as f:
         f.write("verify failed\n")
-    print(f"RESULT:FAIL STEP:verify LOG:{log_file}")
+        f.write(f"cms_http={last_cms}\n")
+        f.write(f"dts_http={last_dts}\n")
+        f.write(f"container_health={last_health}\n")
+        if final_match:
+            f.write(f"match={final_match}\n")
+    if final_match:
+        print(
+            f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
+            f"MATCH:{final_match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+            f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
+        )
+    else:
+        print(f"RESULT:FAIL STEP:verify LOG:{log_file}")
     return EXIT_SUBPROCESS_FAILED, log_file
 
 

--- a/docker/scripts/rhythmyx_ready.py
+++ b/docker/scripts/rhythmyx_ready.py
@@ -13,8 +13,9 @@ This module provides pure, stdlib-only helpers:
 * Log-text markers that mean the Rhythmyx webapp context failed
 * A small assessor that combines HTTP + log scan for fail-fast
 
-Callers: ``perc-devctl.py`` (``qa-health``), ``matrix-install-smoke.py``
-(``wait_for_http``). No secrets; no network I/O here.
+Callers: ``perc-devctl.py`` (``qa-health``, compose ``verify`` /
+``_verify_inline``), ``matrix-install-smoke.py`` (``wait_for_http``).
+No secrets; no network I/O here.
 """
 
 from __future__ import annotations

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -290,14 +290,16 @@ class TestVerifyRealMode(unittest.TestCase):
         self.runner = _CliRunner(self.repo_root)
 
     def test_verify_first_check_succeeds(self):
-        """When curl + docker inspect all return success values, the
-        verify loop exits on the first check with RESULT:OK.
+        """When curl + docker inspect + clean logs all return success values,
+        the verify loop exits on the first check with RESULT:OK.
         """
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
              unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
              unittest.mock.patch.object(pdc.time, "sleep"):
             mock_curl.side_effect = lambda url, **kw: 200
             mock_health.return_value = "healthy"
+            mock_logs.return_value = "INFO [Server] Started @7879ms\n"
             import io
             from contextlib import redirect_stdout
             buf = io.StringIO()
@@ -311,6 +313,72 @@ class TestVerifyRealMode(unittest.TestCase):
         self.assertIn("RESULT:OK STEP:verify", out)
         self.assertIn("CMS_HTTP:200", out)
         self.assertIn("HEALTH:healthy", out)
+        mock_logs.assert_called()
+
+    def test_verify_fails_when_http_ok_but_context_failed(self):
+        """#2480: CMS/DTS HTTP ready + docker healthy + dead Rhythmyx context
+        must FAIL (not OK), and fail-fast without burning the poll budget.
+        """
+        dead_ctx = (
+            "WARN  [WebAppContext] Failed startup of context "
+            "oeje11w.WebAppContext Rhythmyx\n"
+            "BeanCurrentlyInCreationException: folderHelper\n"
+            "INFO  [AbstractConnector] Started {HTTP/1.1}{0.0.0.0:9992}\n"
+        )
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
+             unittest.mock.patch.object(pdc.time, "sleep") as mock_sleep:
+            mock_curl.return_value = 200
+            mock_health.return_value = "healthy"
+            mock_logs.return_value = dead_ctx
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "verify",
+                    "--timeout-seconds", "30",
+                    "--interval-seconds", "5",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
+        self.assertIn("RESULT:FAIL STEP:verify", out)
+        self.assertIn("rhythmyx_context_failed", out)
+        self.assertIn("Failed startup of context", out)
+        self.assertIn(pdc.DEFAULT_CONTAINER, out)
+        mock_sleep.assert_not_called()
+
+    def test_verify_timeout_prefers_context_failure_detail(self):
+        """When HTTP/health never ready but logs show context fail, DETAIL uses that."""
+        dead_ctx = "Failed startup of context Rhythmyx\n"
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
+             unittest.mock.patch.object(pdc.subprocess, "run") as mock_run, \
+             unittest.mock.patch.object(pdc.time, "sleep"):
+            mock_curl.return_value = 0
+            mock_health.return_value = "starting"
+            # max_checks=1 (5//5): one in-loop scan (empty) + one final scan (fail).
+            mock_logs.side_effect = ["", dead_ctx]
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "verify",
+                    "--timeout-seconds", "5",
+                    "--interval-seconds", "5",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
+        self.assertIn("rhythmyx_context_failed", out)
+        self.assertIn("Failed startup of context", out)
 
 
 class TestVerifyFixRealMode(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Wire compose-stack `perc-devctl.py verify` (and `_verify_inline` used by `verify-fix` / `deploy-jar --verify`) to scan cms-dts `docker logs` via `assess_rhythmyx_ready` / `rhythmyx_ready` markers.
- Fail-fast with `RESULT:FAIL STEP:verify DETAIL:rhythmyx_context_failed MATCH:…` when Jetty/Spring context is dead, even if CMS/DTS HTTP and docker health look green.
- Timeout path prefers context-failure DETAIL when markers appear on final log scan.
- Document operator signals next to the existing qa-health fail-fast table in `docker/README.md`.

Parent tracker: #2423 (slice I). Companion to #2462 / PR #2479.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `python -m pytest docker/scripts/test_perc_devctl.py docker/scripts/test_rhythmyx_ready.py -q` → **59 passed**
- [x] New tests: success with clean logs; HTTP+healthy+dead context fail-fast (no sleep); timeout prefers context DETAIL
- [x] No production secrets; no Maven modules changed (scripts/docs only — no `mvnw clean install` required)

## Gates
- Erlang-style self-review: portable paths (existing `Path` / docker argv), no secrets, change-class companions (tests + README) present
- Pre-PR Maven: N/A (no Java module sources/tests/pom changes)

Fixes #2480