### PR TITLE
fix(sitemanage): templateService hub class @Lazy + reverse-edge protection (#2477)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -44,7 +44,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 |------|------|----------------------------------------|-------|
 | 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. |
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset`. Class `@Lazy`. |
-| 3 | `PSTemplateService` | out ~6 / in ~20 | **Not** class `@Lazy`. Injects `widgetAsset`, page/template DAOs. |
+| 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` as of #2477. Injects `widgetAsset`, page/template DAOs. Reverse-edge bans: widgetAsset / pageDao / pageDaoHelper / templateDao ↛ templateService. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
 | 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
@@ -62,6 +62,20 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 
 Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + param `@Lazy` + no reverse).
 
+### TemplateService hub hardening (#2477)
+
+**`PSTemplateService` → `widgetAsset` / page+template DAOs (constructor)** with **no reverse** from those peers → `IPSTemplateService`.
+
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on hub | **Added (#2477)** — aligns with `pageService` / `assetService`; lazy *init* only, not a constructor-edge cycle breaker |
+| Param `@Lazy` on forward edges | Not added — ctor only stores peer refs and uses them post-construction; reverse-edge freezes are the primary gate (same class as #2478 itemWorkflow) |
+| Reverse edge ban | **Required** — `PSWidgetAssetRelationshipService`, `PSPageDao`, `PSPageDaoHelper`, `PSTemplateDao` must not construct-require (or eagerly field-inject) `IPSTemplateService` without `@Lazy` |
+
+Scan (2026-08-08 / #2477): none of the four peers inject `IPSTemplateService` (ctor or field).
+
+Protection test: `PSTemplateServiceHubNearCycleWiringTest` — freezes forward hub edges; asserts class `@Lazy`; forbids reverse ctor edges unless parameter `@Lazy`; forbids non-`@Lazy` field inject of `IPSTemplateService` on the four peers.
+
 ### Other one-way edges to keep one-way (known cycle intermediate)
 
 These must not gain reverse constructor dependencies:
@@ -72,8 +86,9 @@ These must not gain reverse constructor dependencies:
 | `PSWidgetAssetRelationshipService` | `IPSAssetDao` | assetDao → widgetAsset skips contentItemDao break |
 | `PSRecycleService` | `IPSWidgetAssetRelationshipService` | widgetAsset → recycle closes mid-chain |
 | `PSFolderHelper` | `IPSRecycleService` | recycle → folderHelper bypasses contentItemDao `@Lazy` |
+| `PSTemplateService` | `IPSWidgetAssetRelationshipService` / `IPSPageDao` / `IPSPageDaoHelper` / `IPSTemplateDao` | peer → templateService closes hub reverse cycle (#2477) |
 
-`FolderHelperCycleContextTest` (#2436) + `PSContentItemDaoCycleLazyWiringTest` (#2435) cover the `@Lazy` break; intermediate reverse edges are residual hardening candidates.
+`FolderHelperCycleContextTest` (#2436) + `PSContentItemDaoCycleLazyWiringTest` (#2435) cover the `@Lazy` break; intermediate reverse edges: `PSAssetServicePageServiceNearCycleWiringTest` + `PSTemplateServiceHubNearCycleWiringTest` (#2477).
 
 ## Constructor `@Lazy` parameter edges found (sitemanage)
 
@@ -100,11 +115,12 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 
 ## Residual recommendations (file as GitHub issues under #2423)
 
-1. Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way) — **covered in** `PSAssetServicePageServiceNearCycleWiringTest.knownCycleIntermediateBeansHaveNoReverseConstructorEdges` (#2463).
+1. ~~Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way).~~ Covered in `PSAssetServicePageServiceNearCycleWiringTest.knownCycleIntermediateBeansHaveNoReverseConstructorEdges` (#2463).
 2. ~~Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param~~ — **done (#2476)**.
-3. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
-4. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-5. Hub hardening still open as separate residuals: templateService (#2477), itemWorkflow reverse-edge tests (#2478).
+3. ~~TemplateService hub class `@Lazy` + reverse-edge freezes.~~ **Done (#2477)** — `PSTemplateServiceHubNearCycleWiringTest`.
+4. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
+5. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+6. Optional next hubs (same reverse-edge pattern): `PSPageService` (rank 1 / #2514), `PSItemWorkflowService` (#2478), `PSSiteDataService` (rank 6 / #2516).
 
 ## Related
 
@@ -114,4 +130,5 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 - #2437 — Docker qa-up health/login smoke  
 - #2463 — this residual inventory  
 - #2476 — param `@Lazy` on assetService→pageService  
+- #2477 — templateService hub hardening (`PSTemplateServiceHubNearCycleWiringTest` + class `@Lazy`)  
 - #2457 / PR #2469 — JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
@@ -85,16 +85,23 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Will CRUD templates using the {@link IPSTemplateDao}.
  *
+ * <p>Class-level {@link Lazy @Lazy} aligns this high fan-in hub with {@code pageService} / {@code
+ * assetService} peers (#2477 / #2463). Class {@code @Lazy} is lazy <em>init</em>, not a constructor
+ * cycle breaker — reverse-edge bans on widgetAsset / pageDao peers are covered by {@code
+ * PSTemplateServiceHubNearCycleWiringTest}.
+ *
  * @author YuBingChen
  * @author adamgent
  */
 @Component("sys_templateService")
+@Lazy
 @Transactional(noRollbackFor = Exception.class)
 public class PSTemplateService implements IPSTemplateService {
 

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSTemplateServiceHubNearCycleWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSTemplateServiceHubNearCycleWiringTest.java
@@ -134,26 +134,31 @@ public class PSTemplateServiceHubNearCycleWiringTest {
   public void hubPeersMustNotEagerFieldInjectTemplateService() {
     List<String> violations = new ArrayList<>();
     for (Class<?> peer : HUB_PEERS) {
-      for (Field field : peer.getDeclaredFields()) {
-        if (!IPSTemplateService.class.isAssignableFrom(field.getType())) {
-          continue;
+      // Walk hierarchy: getDeclaredFields() alone misses inherited reverse edges.
+      for (Class<?> type = peer; type != null && type != Object.class; type = type.getSuperclass()) {
+        for (Field field : type.getDeclaredFields()) {
+          if (!IPSTemplateService.class.isAssignableFrom(field.getType())) {
+            continue;
+          }
+          if (field.isAnnotationPresent(Lazy.class)) {
+            continue; // documented intentional reverse edge
+          }
+          boolean autowired = field.isAnnotationPresent(Autowired.class);
+          String owner =
+              type.equals(peer) ? peer.getSimpleName() : peer.getSimpleName() + ":" + type.getSimpleName();
+          violations.add(
+              owner
+                  + "."
+                  + field.getName()
+                  + (autowired ? " (@Autowired)" : " (field type)")
+                  + " — reverse field edge without @Lazy");
         }
-        if (field.isAnnotationPresent(Lazy.class)) {
-          continue; // documented intentional reverse edge
-        }
-        boolean autowired = field.isAnnotationPresent(Autowired.class);
-        violations.add(
-            peer.getSimpleName()
-                + "."
-                + field.getName()
-                + (autowired ? " (@Autowired)" : " (field type)")
-                + " — reverse field edge without @Lazy");
       }
     }
     assertTrue(
         violations.isEmpty(),
         "Hub peers must not eagerly field-inject IPSTemplateService (use @Lazy or remove the"
-            + " edge). Violations: "
+            + " edge; includes inherited fields). Violations: "
             + String.join("; ", violations));
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSTemplateServiceHubNearCycleWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSTemplateServiceHubNearCycleWiringTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
+import com.percussion.pagemanagement.dao.IPSPageDao;
+import com.percussion.pagemanagement.dao.IPSPageDaoHelper;
+import com.percussion.pagemanagement.dao.IPSTemplateDao;
+import com.percussion.pagemanagement.dao.impl.PSPageDao;
+import com.percussion.pagemanagement.dao.impl.PSPageDaoHelper;
+import com.percussion.pagemanagement.dao.impl.PSTemplateDao;
+import com.percussion.pagemanagement.service.IPSTemplateService;
+import com.percussion.pagemanagement.service.impl.PSTemplateService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Protection for the {@link PSTemplateService} high fan-in hub (#2423 residual #2477).
+ *
+ * <p>Static inventory (#2463) ranked {@code PSTemplateService} as the third-hottest sitemanage hub
+ * (ctor out ~6 / in ~20). Unlike {@code pageService} / {@code assetService}, it historically lacked
+ * class-level {@code @Lazy}. It construct-requires peers that sit next to the known folderHelper
+ * cycle path:
+ *
+ * <pre>
+ * templateService  →  widgetAssetRelationshipService
+ * templateService  →  pageDao / pageDaoHelper / templateDao
+ * </pre>
+ *
+ * <p>No closed cycle exists today, but a reverse constructor (or eager field) edge from any of those
+ * peers back to {@link IPSTemplateService} would form a new {@code BeanCurrentlyInCreationException}
+ * path independent of the contentItemDao {@code @Lazy} break.
+ *
+ * <p><strong>Disposition (#2477):</strong> class-level {@code @Lazy} on {@link PSTemplateService}
+ * (consistent with page/asset hubs) <em>plus</em> reverse-edge bans. Class {@code @Lazy} is lazy
+ * init, not a constructor-edge cycle breaker when an eager consumer forces full construction —
+ * reverse-edge freezes are the real protection for peers that inject the hub.
+ *
+ * <p>Peers: {@link PSAssetServicePageServiceNearCycleWiringTest}, {@code
+ * PSItemWorkflowServiceHubReverseEdgeWiringTest} (#2478), {@link
+ * PSContentItemDaoCycleLazyWiringTest}. Inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSTemplateServiceHubNearCycleWiringTest {
+
+  /** Peers that templateService construct-requires and must not reverse-require it. */
+  private static final Class<?>[] HUB_PEERS = {
+    PSWidgetAssetRelationshipService.class,
+    PSPageDao.class,
+    PSPageDaoHelper.class,
+    PSTemplateDao.class
+  };
+
+  @Test
+  public void templateServiceIsClassLazy() {
+    assertTrue(
+        PSTemplateService.class.isAnnotationPresent(Lazy.class),
+        "PSTemplateService must carry class-level @Lazy (hub alignment with pageService/assetService;"
+            + " disposition #2477). Class @Lazy is not a cycle breaker alone — reverse-edge bans"
+            + " below remain required.");
+  }
+
+  @Test
+  public void templateServiceConstructRequiresWidgetAssetAndPageDaoPeers()
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSTemplateService.class);
+
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSTemplateService must still construct-require IPSWidgetAssetRelationshipService —"
+            + " inventory #2463 / #2477 hub model; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSPageDao.class),
+        "PSTemplateService must still construct-require IPSPageDao");
+    assertNotNull(
+        findParamOfType(ctor, IPSPageDaoHelper.class),
+        "PSTemplateService must still construct-require IPSPageDaoHelper");
+    assertNotNull(
+        findParamOfType(ctor, IPSTemplateDao.class),
+        "PSTemplateService must still construct-require IPSTemplateDao");
+  }
+
+  @Test
+  public void hubPeersMustNotConstructRequireTemplateService() throws NoSuchMethodException {
+    for (Class<?> peer : HUB_PEERS) {
+      Constructor<?> ctor = singlePublicConstructor(peer);
+      Parameter template = findParamOfType(ctor, IPSTemplateService.class);
+      if (template == null) {
+        continue; // desired: no reverse ctor edge
+      }
+      assertTrue(
+          template.isAnnotationPresent(Lazy.class),
+          peer.getSimpleName()
+              + " construct-requires IPSTemplateService without @Lazy — that closes a"
+              + " reverse cycle with the templateService hub (see #2477). Prefer method-level"
+              + " lookup, setter injection, or @Lazy on the injection point; document intentional"
+              + " @Lazy reverse edges in sitemanage-injection-cycle-inventory.md.");
+    }
+  }
+
+  /**
+   * Eager {@code @Autowired} field inject of {@link IPSTemplateService} on a hub peer is the same
+   * class of reverse edge as a constructor param (class-level {@code @Lazy} on either bean does not
+   * break an eager field edge from a bean already under construction).
+   */
+  @Test
+  public void hubPeersMustNotEagerFieldInjectTemplateService() {
+    List<String> violations = new ArrayList<>();
+    for (Class<?> peer : HUB_PEERS) {
+      for (Field field : peer.getDeclaredFields()) {
+        if (!IPSTemplateService.class.isAssignableFrom(field.getType())) {
+          continue;
+        }
+        if (field.isAnnotationPresent(Lazy.class)) {
+          continue; // documented intentional reverse edge
+        }
+        boolean autowired = field.isAnnotationPresent(Autowired.class);
+        violations.add(
+            peer.getSimpleName()
+                + "."
+                + field.getName()
+                + (autowired ? " (@Autowired)" : " (field type)")
+                + " — reverse field edge without @Lazy");
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Hub peers must not eagerly field-inject IPSTemplateService (use @Lazy or remove the"
+            + " edge). Violations: "
+            + String.join("; ", violations));
+  }
+
+  /** Named assertion for the primary near-cycle pair called out in #2477 acceptance. */
+  @Test
+  public void widgetAssetMustNotConstructRequireTemplateService() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSWidgetAssetRelationshipService.class,
+        IPSTemplateService.class,
+        "widgetAsset → templateService would reverse templateService→widgetAsset (#2477)");
+  }
+
+  /** Named assertion for the primary near-cycle pair called out in #2477 acceptance. */
+  @Test
+  public void pageDaoMustNotConstructRequireTemplateService() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSPageDao.class,
+        IPSTemplateService.class,
+        "pageDao → templateService would reverse templateService→pageDao (#2477)");
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    if (p == null) {
+      return;
+    }
+    assertTrue(
+        p.isAnnotationPresent(Lazy.class),
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + " without @Lazy: "
+            + why);
+  }
+}


### PR DESCRIPTION
## Summary

Parent tracker: #2423. Residual slice **#2477** (after inventory #2463 / PR #2475).

**Disposition:** class-level `@Lazy` on `PSTemplateService` **plus** reverse-edge bans (not reverse-edge-only).

### Design note
- Inventory rank-3 hub (`PSTemplateService`) historically lacked class `@Lazy` while peers `pageService` / `assetService` already had it.
- Class `@Lazy` is lazy *init* only — **not** a constructor-edge cycle breaker when an eager consumer forces full construction (same lesson as folderHelper / #2435).
- Hub construct-requires `IPSWidgetAssetRelationshipService`, `IPSPageDao`, `IPSPageDaoHelper`, `IPSTemplateDao`. No closed cycle today; a reverse ctor/eager-field edge would form a new `BeanCurrentlyInCreationException` independent of the contentItemDao `@Lazy` break.
- Param `@Lazy` on forward edges **not** added here (ctor only stores peers; reverse freezes are the primary gate — same class as #2478 itemWorkflow). Optional belt-and-braces param `@Lazy` residual filed separately.

### Changes
- `PSTemplateService` — class `@Lazy` + javadoc disposition
- New: `PSTemplateServiceHubNearCycleWiringTest` (`@Tag("UnitTest")`)
  - Asserts class `@Lazy`
  - Freezes forward hub edges (widgetAsset / pageDao / pageDaoHelper / templateDao)
  - Forbids reverse ctor edges unless param `@Lazy`
  - Forbids non-`@Lazy` field inject of `IPSTemplateService` on the four peers
  - Named assertions for template↔widgetAsset and template↔pageDao
- Inventory note updated with #2477 disposition

### Related
- Fixes #2477
- Parent #2423
- Peers: #2463 / PR #2475, #2476 (asset→page param `@Lazy`), #2478 (itemWorkflow reverse-edge)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw.cmd test -Dtest=PSTemplateServiceHubNearCycleWiringTest,PSAssetServicePageServiceNearCycleWiringTest`
  - Tests run: 9, Failures: 0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install`
  - **BUILD SUCCESS**
  - Tests run: 804, Failures: 0, Errors: 0, Skipped: 128
  - No new warnings attributable to this change (class annotation + reflection UnitTest + inventory doc only; baseline javadoc/dependency-analyze warnings unchanged)

## Gates
| Gate | Result |
|------|--------|
| Erlang-style self-review | Pass — no bugs; portable (annotation + reflection); companions match near-cycle peer tests + inventory disposition |
| Standalone module clean install | `cd projects/sitemanage; ../../mvnw.cmd clean install` BUILD SUCCESS |
| Product UI / installer | N/A — pure Spring wiring hardening / unit reflection |
| Human QA | Not required (no UI/install behavior) |

> Co-Authored by Grok Build using grok-4.5 with agent main.
