### PR TITLE
feat(sitemanage): #2477 templateService hub @Lazy hardening

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -44,7 +44,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 |------|------|----------------------------------------|-------|
 | 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. |
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset`. Class `@Lazy`. |
-| 3 | `PSTemplateService` | out ~6 / in ~20 | **Not** class `@Lazy`. Injects `widgetAsset`, page/template DAOs. |
+| 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
 | 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
@@ -104,7 +104,7 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 2. ~~Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param~~ — **done (#2476)**.
 3. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 4. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-5. Hub hardening still open as separate residuals: templateService (#2477), itemWorkflow reverse-edge tests (#2478).
+5. Hub hardening: `PSTemplateService` class `@Lazy` + reverse-edge tests landed (#2477, 2026-08-08). Residual: `itemWorkflow` reverse-edge tests (#2478).
 
 ## Related
 

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
@@ -85,6 +85,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,6 +96,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author adamgent
  */
 @Component("sys_templateService")
+@Lazy
 @Transactional(noRollbackFor = Exception.class)
 public class PSTemplateService implements IPSTemplateService {
 

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSTemplateServiceCycleWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSTemplateServiceCycleWiringTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.service.IPSAssetService;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.share.dao.IPSContentItemDao;
+import com.percussion.share.dao.IPSFolderHelper;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Cycle-risk protection for {@link PSTemplateService} (#2423 residual #2477).
+ *
+ * <p>Per the static inventory in {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md},
+ * {@code PSTemplateService} is a high fan-in hub that construct-requires {@code
+ * IPSWidgetAssetRelationshipService} and the page / template DAOs. The known {@code folderHelper}
+ * cycle is broken by {@code @Lazy}; {@code PSTemplateService} itself has no closed cycle today but
+ * sits close enough to several cycle peers that a future reverse ctor dep on it would close one.
+ * Belt-and-braces: class-level {@code @Lazy} on {@link PSTemplateService} defers the bean until
+ * first use (cheaper during startup and stops an eager consumer from forcing the cycle path), and
+ * the assertions below forbid the reverse edges that would close new cycles via the template
+ * service.</p>
+ *
+ * <p>Peers: {@code PSAssetServicePageServiceNearCycleWiringTest} ({@code
+ * PSAssetService} ↔ {@code PSPageService}), {@code PSContentItemDaoCycleLazyWiringTest} (folderHelper
+ * cycle break).</p>
+ */
+@Tag("UnitTest")
+public class PSTemplateServiceCycleWiringTest {
+
+  @Test
+  public void templateServiceIsClassLevelLazy() {
+    assertTrue(
+        PSTemplateService.class.isAnnotationPresent(Lazy.class),
+        "PSTemplateService must carry class-level @Lazy to harden against cycle formation"
+            + " (#2423 residual #2477). Class @Lazy defers the bean until first use, breaking any"
+            + " eager consumer path that could close a cycle through templateService.");
+  }
+
+  @Test
+  public void templateServiceMustNotConstructRequireCyclePeers() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSTemplateService.class);
+    assertNoCtorParam(
+        ctor, IPSFolderHelper.class, "templateService → folderHelper would close a cycle if a"
+            + " peer later gains a reverse ctor edge into templateService");
+    assertNoCtorParam(
+        ctor, IPSContentItemDao.class, "templateService → contentItemDao would skip the"
+            + " contentItemDao cycle break and re-cycle via folderHelper");
+    assertNoCtorParam(
+        ctor, IPSRecycleService.class, "templateService → recycleService would form a new"
+            + " mid-cycle branch");
+    assertNoCtorParam(
+        ctor, IPSAssetService.class, "templateService → assetService would skip the pageService"
+            + " near-cycle guard");
+    assertNoCtorParam(
+        ctor, IPSPageService.class, "templateService → pageService would form a parallel cycle"
+            + " path with pageService already requiring recycleService / folderHelper");
+    // Note: PSTemplateService does construct-require IPSWidgetAssetRelationshipService today
+    // (inventory #2463). That edge is mitigated by class-level @Lazy on PSTemplateService above;
+    // forbidding it here would require removing a real product dependency, which is out of scope
+    // for the cycle-risk hardening slice (#2477). Belt-and-braces coverage: the @Lazy assertion
+    // plus the reverse-edge ban in cyclePeersMustNotConstructRequireTemplateService below.
+  }
+
+  /**
+   * Known cycle peers must not construct-require {@link PSTemplateService} either. Belt-and-braces
+   * against a future reverse edge into the template hub.
+   */
+  @Test
+  public void cyclePeersMustNotConstructRequireTemplateService() throws NoSuchMethodException {
+    assertNoCtorParam(
+        singlePublicConstructor(com.percussion.share.dao.impl.PSFolderHelper.class),
+        PSTemplateService.class,
+        "folderHelper → templateService would add a reverse edge into the high fan-in hub");
+    assertNoCtorParam(
+        singlePublicConstructor(com.percussion.recycle.service.impl.PSRecycleService.class),
+        PSTemplateService.class,
+        "recycleService → templateService would close a new cycle branch");
+    assertNoCtorParam(
+        singlePublicConstructor(com.percussion.pagemanagement.service.impl.PSPageService.class),
+        PSTemplateService.class,
+        "pageService → templateService would close a pageService↔templateService cycle branch");
+    assertNoCtorParam(
+        singlePublicConstructor(com.percussion.assetmanagement.service.impl.PSAssetService.class),
+        PSTemplateService.class,
+        "assetService → templateService would form a parallel cycle path");
+  }
+
+  @Test
+  public void templateServiceConstructorExists() throws NoSuchMethodException {
+    // Sanity guard: if PSTemplateService ever loses its single public constructor, the assertions
+    // above stop being meaningful. The reflection lookups in this class all assume one ctor.
+    Constructor<?> ctor = singlePublicConstructor(PSTemplateService.class);
+    assertNotNull(ctor, "PSTemplateService must declare exactly one public constructor for Spring"
+        + " wiring inspection; this test enforces the assumption");
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static void assertNoCtorParam(
+      Constructor<?> ctor, Class<?> forbidden, String why) {
+    for (Parameter p : ctor.getParameters()) {
+      if (forbidden.isAssignableFrom(p.getType())) {
+        fail(
+            ctor.getDeclaringClass().getSimpleName()
+                + " must not construct-require "
+                + forbidden.getSimpleName()
+                + ": "
+                + why);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## feat(sitemanage): #2477 templateService hub @Lazy hardening

Resolves #2423 residual #2477 — class-level `@Lazy` on `PSTemplateService` plus reflection-based reverse-edge freeze, matching the peer pattern (`PSPageService`, `PSAssetService`, `PSItemWorkflowService`).

### Production change

- `PSTemplateService` (`projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java`): add `@Lazy` at class level. The service is a high fan-in hub (out ~6 / in ~20 per the `#2463` inventory) that construct-requires `IPSWidgetAssetRelationshipService` and the page / template DAOs. No closed cycle today, but the hub is close enough to several cycle peers that a future reverse ctor dep on it would close one. Class `@Lazy` defers the bean until first use, breaking any eager consumer path that could close a cycle through `templateService`.

### Test (new)

`PSTemplateServiceCycleWiringTest` — 4 reflection tests:

1. `templateServiceIsClassLevelLazy` — class `@Lazy` present
2. `templateServiceMustNotConstructRequireCyclePeers` — no ctor params of `IPSFolderHelper` / `IPSContentItemDao` / `IPSRecycleService` / `IPSAssetService` / `IPSPageService` on `templateService`
3. `cyclePeersMustNotConstructRequireTemplateService` — no reverse ctor edges from `folderHelper` / `recycleService` / `pageService` / `assetService` into `templateService`
4. `templateServiceConstructorExists` — single-public-ctor sanity guard

The existing `widgetAsset` ctor edge is **not** banned here — it is documented in `#2463` inventory and mitigated by the class `@Lazy` above. Removing that edge would require a product refactor outside this hardening slice.

### Docs

`sitemanage-injection-cycle-inventory.md` — row for `PSTemplateService` updated to "Class `@Lazy` (2026-08-08, #2477)" with belt-and-braces reverse-edge ban called out; the open residuals note reworded to reflect that `templateService` is now closed (only `#2478` `itemWorkflow` remains).

### Verification

- `cd projects/sitemanage && ../../mvnw.cmd test -Dtest=PSTemplateServiceCycleWiringTest` → **4/4 pass**
- `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**

> Co-Authored by Kilo Code 0.16.3 using minimax-coding-plan/MiniMax-M3 with agent main.
