### PR TITLE
fix(docker): sitemanage→WebUI→dist rebuild preflight before qa-up (#2486)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -222,14 +222,38 @@ python docker/scripts/perc-devctl.py down
 |                   Artifact                    |                                            Role                                            |
 |-----------------------------------------------|--------------------------------------------------------------------------------------------|
 | `docker/scripts/perc_host_ports.py`           | `find_free_port` / `is_port_free` / `resolve_host_port`                                    |
-| `docker/scripts/perc-devctl.py`               | `up` / `verify` / `qa-up` pin + print ports                                                |
+| `docker/scripts/perc-devctl.py`               | `up` / `verify` / `qa-up` / `qa-preflight` pin + print ports                               |
+| `docker/scripts/qa_preflight.py`              | Rebuild-chain freshness (m2 sitemanage vs WebUI WAR vs dist) (#2486)                       |
 | `docker/scripts/matrix-install-smoke.py`      | Matrix CMS/DTS freeport publish + probe                                                    |
 | `docker/scripts/freeport-concurrent-smoke.py` | Tier 0 allocation smoke (#2006)                                                            |
-| Unit tests                                    | `test_perc_devctl.py`, `test_matrix_install_smoke.py`, `test_freeport_concurrent_smoke.py` |
+| Unit tests                                    | `test_perc_devctl.py`, `test_qa_preflight.py`, `test_matrix_install_smoke.py`, `test_freeport_concurrent_smoke.py` |
 
-#### QA mode (`qa-up` / `qa-health` / `qa-down`)
+#### QA mode (`qa-up` / `qa-preflight` / `qa-health` / `qa-down`)
 
 Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for the resolved probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`), prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section. Concurrent freeport checklist: **Two-worktree concurrent freeport smoke** above.
+
+##### QA rebuild preflight (#2486)
+
+`perc-distribution-tree` unpacks `WebUI/target/perc-web-ui-*.war` into Rhythmyx `WEB-INF/lib` (including `sitemanage-*.jar`). Installing only `sitemanage` into m2 **without** repackaging WebUI + dist leaves a **stale** jar in the image path — Docker then proves the old wiring even when m2 has the fix.
+
+| Command | Role |
+|---------|------|
+| `python docker/scripts/perc-devctl.py qa-preflight` | Fail-loud (exit 2) when WebUI WAR or dist is older than m2 sitemanage, or missing |
+| `python docker/scripts/qa_preflight.py --repo-root .` | Same check without perc-devctl RESULT wrapper |
+| `qa-up` (default) | Runs preflight first; blocks on STALE |
+| `qa-up --skip-preflight` | Bypass (e.g. intentional use of prebuilt dist only) |
+| `qa-up --preflight-warn-only` | Print STALE but continue |
+
+Required rebuild order when `STALE:`:
+
+```bash
+cd projects/sitemanage && ../../mvnw clean install
+cd ../../WebUI && ../mvnw package -DskipTests
+cd ../modules/perc-distribution-tree && ../../mvnw clean package -DskipTests
+python docker/scripts/perc-devctl.py qa-up
+```
+
+Unit tests: `python docker/scripts/test_qa_preflight.py` (also covered from `test_perc_devctl.py` dry-run paths). Details: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **Rebuild preflight**.
 
 ##### Rhythmyx ApplicationContext fail-fast (#2462 / #2480 / #2423)
 

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -11,7 +11,10 @@ docker compose stack and exposes every subcommand the original
 
 QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
 
-* ``qa-up`` — one-shot CMS on H2 via matrix cell (``--keep``), health wait
+* ``qa-up`` — one-shot CMS on H2 via matrix cell (``--keep``), health wait;
+  runs rebuild-chain preflight first unless ``--skip-preflight`` (#2486)
+* ``qa-preflight`` — fail-loud check that WebUI WAR + dist are not older
+  than m2 sitemanage SNAPSHOT (sitemanage → WebUI → dist → qa-up)
 * ``qa-health`` — poll published CMS URL until ready (clear timeout);
   fail-fast when Jetty logs show Rhythmyx ApplicationContext failure
   (``Failed startup of context`` / ``BeanCurrentlyInCreationException``)
@@ -378,7 +381,44 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Pass --skip-image-build to matrix-install-smoke (reuse local image).",
     )
+    pqu.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help=(
+            "Skip sitemanage→WebUI→dist rebuild preflight before qa-up (#2486). "
+            "Default is fail-loud when WAR/dist is older than m2 sitemanage."
+        ),
+    )
+    pqu.add_argument(
+        "--preflight-warn-only",
+        action="store_true",
+        help=(
+            "Run rebuild preflight but do not block qa-up on STALE "
+            "(prints STALE: / RESULT:OK for preflight)."
+        ),
+    )
     pqu.add_argument("--dry-run", action="store_true")
+
+    # --- Rebuild-chain preflight — #2486 ---
+    pqp = sub.add_parser(
+        "qa-preflight",
+        help=(
+            "Detect stale WebUI WAR / dist vs m2 sitemanage before qa-up "
+            "(#2486). Default fail-loud (exit 2) when stale."
+        ),
+    )
+    pqp.add_argument(
+        "--no-strict",
+        action="store_true",
+        help="Print STALE: but exit 0 (warn-only).",
+    )
+    pqp.add_argument(
+        "--m2-root",
+        type=Path,
+        default=None,
+        help="Maven local repository root (default: ~/.m2/repository).",
+    )
+    pqp.add_argument("--dry-run", action="store_true")
 
     pqh = sub.add_parser(
         "qa-health",
@@ -1196,6 +1236,65 @@ def _qa_fetch_admin_password(container_name: str) -> Optional[str]:
     return None
 
 
+def _run_qa_preflight(
+    repo_root: Path,
+    *,
+    strict: bool,
+    dry_run: bool,
+    m2_root: Optional[Path] = None,
+) -> int:
+    """Run rebuild-chain preflight and emit RESULT:OK/FAIL STEP:qa-preflight.
+
+    Returns exit code from :mod:`qa_preflight` (0 fresh/skip/non-strict,
+    2 stale under strict). Dry-run skips filesystem checks.
+    """
+    # Local import keeps perc-devctl loadable when qa_preflight is absent
+    # in partial checkouts; scripts dir is already on sys.path.
+    import qa_preflight  # type: ignore
+
+    log_dir = _log_dir(repo_root)
+    log_file = _new_log_file(log_dir, "qa-preflight")
+    if dry_run:
+        print(f"RESULT:OK STEP:qa-preflight LOG:{log_file}")
+        print("PREFLIGHT: dry-run — skipping filesystem checks")
+        return EXIT_OK
+
+    argv: List[str] = [
+        "--repo-root",
+        str(repo_root),
+        "--log-file",
+        str(log_file),
+    ]
+    if strict:
+        argv.append("--strict")
+    else:
+        argv.append("--no-strict")
+    if m2_root is not None:
+        argv.extend(["--m2-root", str(m2_root)])
+
+    rc = int(qa_preflight.main(argv))
+    if rc == 0:
+        print(f"RESULT:OK STEP:qa-preflight LOG:{log_file}")
+    else:
+        print(f"RESULT:FAIL STEP:qa-preflight LOG:{log_file}")
+    return rc
+
+
+def cmd_qa_preflight(
+    args: argparse.Namespace, paths: tuple[Path, Path, Path]
+) -> int:
+    """Operator entry for rebuild-chain preflight (#2486)."""
+    repo_root, _env_file, _compose_file = paths
+    strict = not bool(getattr(args, "no_strict", False))
+    m2_root = getattr(args, "m2_root", None)
+    return _run_qa_preflight(
+        repo_root,
+        strict=strict,
+        dry_run=bool(args.dry_run),
+        m2_root=m2_root,
+    )
+
+
 def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     """Bring up CMS on H2 in Docker and wait until the probe URL is ready.
 
@@ -1206,6 +1305,10 @@ def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     Host port is resolved via :func:`ensure_qa_cms_host_port` (env override
     or freeport) and exported as ``QA_CMS_HOST_PORT`` / ``CMS_HOST_PORT`` so
     matrix-install-smoke docker ``-p`` and operators / Playwright agree (#2005).
+
+    By default runs rebuild-chain preflight first (#2486) so a stale WebUI
+    WAR / dist cannot silently ship an old sitemanage SNAPSHOT. Use
+    ``--skip-preflight`` or ``--preflight-warn-only`` to override.
     """
     repo_root, _env_file, _compose_file = paths
     log_dir = _log_dir(repo_root)
@@ -1213,6 +1316,18 @@ def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     probe_timeout = int(args.timeout_seconds)
     skip_image_build = bool(args.skip_image_build)
     host_port = ensure_qa_cms_host_port()
+
+    if not bool(getattr(args, "skip_preflight", False)):
+        strict = not bool(getattr(args, "preflight_warn_only", False))
+        pf_rc = _run_qa_preflight(repo_root, strict=strict, dry_run=dry_run)
+        if pf_rc != EXIT_OK:
+            print(
+                "QA_DETAIL:rebuild preflight failed — "
+                "sitemanage → WebUI package → dist package → qa-up "
+                f"(see PREFLIGHT: lines; --skip-preflight to bypass) "
+                f"QA_CMS_HOST_PORT={host_port}"
+            )
+            return pf_rc
 
     matrix_argv = _qa_matrix_up_argv(
         repo_root,
@@ -1417,6 +1532,7 @@ _DISPATCH = {
     "inspect-install": cmd_inspect_install,
     "show-generated-passwords": cmd_show_generated_passwords,
     "qa-up": cmd_qa_up,
+    "qa-preflight": cmd_qa_preflight,
     "qa-health": cmd_qa_health,
     "qa-down": cmd_qa_down,
 }

--- a/docker/scripts/qa_preflight.py
+++ b/docker/scripts/qa_preflight.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""QA rebuild-chain preflight: sitemanage → WebUI WAR → dist (#2486).
+
+``perc-distribution-tree`` unpacks ``WebUI/target/perc-web-ui-*.war`` into
+Rhythmyx ``WEB-INF/lib`` (including ``sitemanage-*.jar``). Packaging only
+the dist module after a sitemanage-only install leaves a **stale**
+sitemanage jar inside the WAR — Docker then proves the old cycle even
+when ``~/.m2`` has the fix.
+
+This preflight is filesystem-only (no docker, curl, or maven). It
+compares modification times of:
+
+1. ``~/.m2/repository/com/percussion/sitemanage/<ver>/sitemanage-*.jar``
+   (newest non-classifier jar after ``mvn install`` on sitemanage)
+2. ``WebUI/target/perc-web-ui-*.war`` (must be rebuilt after sitemanage)
+3. ``modules/perc-distribution-tree/target/perc-distribution-tree.jar``
+   (must be repackaged after the WebUI WAR)
+
+Exit codes:
+
+* ``0`` — FRESH (or check skipped when no m2 sitemanage jar), or
+  non-strict mode after printing ``STALE:``
+* ``2`` — STALE under ``--strict`` (default)
+* ``1`` — invocation / unexpected error
+
+Operators:
+
+```text
+python docker/scripts/qa_preflight.py --repo-root .
+python docker/scripts/perc-devctl.py qa-preflight
+# rebuild order when STALE:
+#   sitemanage install → WebUI package → perc-distribution-tree package → qa-up
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+# Maven coordinates for sitemanage (groupId com.percussion, artifactId sitemanage).
+# Layout: ~/.m2/repository/com/percussion/sitemanage/<version>/sitemanage-<ver>.jar
+_M2_GROUP_PATH = Path("com") / "percussion" / "sitemanage"
+_SITEMANAGE_JAR_RE = re.compile(r"^sitemanage-.+\.jar$")
+_CLASSIFIER_SUFFIXES = ("-sources.jar", "-javadoc.jar", "-tests.jar")
+_WEBUI_WAR_RE = re.compile(r"^perc-web-ui-.+\.war$")
+_DIST_JAR_NAMES = ("perc-distribution-tree.jar",)
+
+LOG = logging.getLogger("qa_preflight")
+
+# Exit codes
+EXIT_OK = 0
+EXIT_INVOCATION = 1
+EXIT_STALE = 2
+
+REBUILD_HINT = (
+    "rebuild chain: "
+    "cd projects/sitemanage && ../../mvnw clean install; "
+    "cd ../../WebUI && ../mvnw package -DskipTests; "
+    "cd ../modules/perc-distribution-tree && ../../mvnw clean package -DskipTests; "
+    "then qa-up"
+)
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """One artifact the preflight knows about."""
+
+    label: str
+    path: Optional[Path]
+    mtime: Optional[float]
+
+    def is_present(self) -> bool:
+        return self.path is not None and self.mtime is not None
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """Structured result of a preflight run."""
+
+    rows: List[ArtifactRef]
+    stale: bool
+    reasons: List[str]
+    skipped: bool  # True when no m2 sitemanage — check is a no-op
+
+
+def _mtime(path: Optional[Path]) -> Optional[float]:
+    if path is None or not path.is_file():
+        return None
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _is_main_sitemanage_jar(name: str) -> bool:
+    if not _SITEMANAGE_JAR_RE.match(name):
+        return False
+    return not any(name.endswith(suf) for suf in _CLASSIFIER_SUFFIXES)
+
+
+def find_sitemanage_in_m2(m2_root: Path) -> Optional[Path]:
+    """Newest main ``sitemanage-*.jar`` under the local Maven repo.
+
+    Walks ``com/percussion/sitemanage/<version>/`` (standard Maven layout).
+    Skips sources/javadoc/tests classifiers.
+    """
+    base = Path(m2_root) / _M2_GROUP_PATH
+    if not base.is_dir():
+        return None
+    candidates: List[Path] = []
+    try:
+        for p in base.rglob("sitemanage-*.jar"):
+            if p.is_file() and _is_main_sitemanage_jar(p.name):
+                candidates.append(p)
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def find_webui_war(repo_root: Path) -> Optional[Path]:
+    """Newest ``perc-web-ui-*.war`` under ``WebUI/target``."""
+    target = Path(repo_root) / "WebUI" / "target"
+    if not target.is_dir():
+        return None
+    try:
+        candidates = [
+            p for p in target.iterdir() if p.is_file() and _WEBUI_WAR_RE.match(p.name)
+        ]
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def find_dist_jar(repo_root: Path) -> Optional[Path]:
+    """``perc-distribution-tree.jar`` under the distribution module target."""
+    target = Path(repo_root) / "modules" / "perc-distribution-tree" / "target"
+    if not target.is_dir():
+        return None
+    for name in _DIST_JAR_NAMES:
+        candidate = target / name
+        if candidate.is_file():
+            return candidate
+    # Fallback: any perc-distribution-tree*.jar that is not a plain module SNAPSHOT
+    # sources jar (prefer exact finalName from assembly).
+    try:
+        candidates = [
+            p
+            for p in target.iterdir()
+            if p.is_file()
+            and p.name.startswith("perc-distribution-tree")
+            and p.suffix == ".jar"
+            and not any(p.name.endswith(suf) for suf in _CLASSIFIER_SUFFIXES)
+        ]
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    # Prefer exact finalName if present among candidates.
+    for name in _DIST_JAR_NAMES:
+        for p in candidates:
+            if p.name == name:
+                return p
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def war_bundles_sitemanage(war_path: Optional[Path]) -> bool:
+    """True when the WAR has a ``sitemanage-*.jar`` under ``WEB-INF/lib``."""
+    if war_path is None or not war_path.is_file():
+        return False
+    try:
+        with zipfile.ZipFile(war_path, "r") as zf:
+            for name in zf.namelist():
+                base = name.rsplit("/", 1)[-1]
+                if _is_main_sitemanage_jar(base):
+                    return True
+    except (OSError, zipfile.BadZipFile):
+        return False
+    return False
+
+
+def run_preflight(repo_root: Path, m2_root: Path) -> PreflightReport:
+    """Collect artifact rows and decide STALE vs FRESH vs skipped."""
+    m2_jar = find_sitemanage_in_m2(m2_root)
+    webui_war = find_webui_war(repo_root)
+    dist_jar = find_dist_jar(repo_root)
+    war_has_sm = war_bundles_sitemanage(webui_war)
+
+    rows = [
+        ArtifactRef("m2:sitemanage", m2_jar, _mtime(m2_jar)),
+        ArtifactRef("war:webui", webui_war, _mtime(webui_war)),
+        ArtifactRef(
+            "war:sitemanage",
+            webui_war if war_has_sm else None,
+            _mtime(webui_war) if war_has_sm else None,
+        ),
+        ArtifactRef("dist:tree", dist_jar, _mtime(dist_jar)),
+    ]
+
+    m2 = rows[0]
+    war = rows[1]
+    war_sm = rows[2]
+    dist = rows[3]
+
+    # No m2 jar → operator has not installed sitemanage; do not block (NOTE).
+    if not m2.is_present():
+        return PreflightReport(rows=rows, stale=False, reasons=[], skipped=True)
+
+    reasons: List[str] = []
+    if not war.is_present():
+        reasons.append("WebUI WAR missing (WebUI/target/perc-web-ui-*.war)")
+    else:
+        if not war_sm.is_present():
+            reasons.append(
+                "WebUI WAR does not bundle sitemanage-*.jar under WEB-INF/lib"
+            )
+        elif war.mtime is not None and m2.mtime is not None and war.mtime < m2.mtime:
+            reasons.append(
+                "WebUI WAR older than m2 sitemanage (repackage WebUI after sitemanage)"
+            )
+
+    if not dist.is_present():
+        reasons.append(
+            "dist jar missing (modules/perc-distribution-tree/target/"
+            "perc-distribution-tree.jar)"
+        )
+    else:
+        # Dist must be packaged after the WAR when WAR exists; else after m2.
+        if war.is_present() and dist.mtime is not None and war.mtime is not None:
+            if dist.mtime < war.mtime:
+                reasons.append(
+                    "dist jar older than WebUI WAR (repackage perc-distribution-tree)"
+                )
+        elif dist.mtime is not None and m2.mtime is not None and dist.mtime < m2.mtime:
+            reasons.append(
+                "dist jar older than m2 sitemanage (rebuild WebUI then dist)"
+            )
+
+    return PreflightReport(
+        rows=rows, stale=bool(reasons), reasons=reasons, skipped=False
+    )
+
+
+def format_report(report: PreflightReport, *, strict: bool) -> str:
+    """Render a multi-line agent-friendly report."""
+    by_label = {r.label: r for r in report.rows}
+
+    if report.skipped:
+        note = (
+            "NOTE: no sitemanage jar in m2 — build sitemanage first; check skipped"
+        )
+    elif report.stale:
+        note = "STALE: rebuild chain required before qa-up — " + "; ".join(
+            report.reasons
+        )
+    else:
+        note = "FRESH: m2 sitemanage ≤ WebUI WAR ≤ dist jar"
+
+    lines = [
+        f"PREFLIGHT: {note}",
+        f"  m2:sitemanage   = {_render(by_label.get('m2:sitemanage'))}",
+        f"  war:webui       = {_render(by_label.get('war:webui'))}",
+        f"  war:sitemanage  = {_render(by_label.get('war:sitemanage'))}",
+        f"  dist:tree       = {_render(by_label.get('dist:tree'))}",
+    ]
+    if report.stale:
+        lines.append(f"  HINT: {REBUILD_HINT}")
+        if not strict:
+            lines.append(
+                "  (non-strict mode: returning OK; qa-up will likely use a stale jar)"
+            )
+    return "\n".join(lines)
+
+
+def _render(row: Optional[ArtifactRef]) -> str:
+    if row is None or not row.is_present():
+        return "<missing>"
+    # Portable path display for logs (forward slashes).
+    path_s = str(row.path).replace("\\", "/")
+    return f"{path_s}  mtime={row.mtime:.0f}"
+
+
+def _default_m2_root() -> Path:
+    """Cross-platform default for the Maven local repository root."""
+    home = os.path.expanduser("~")
+    return Path(home) / ".m2" / "repository"
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="qa-preflight",
+        description=(
+            "Detect stale WebUI WAR / dist vs m2 sitemanage before qa-up (#2486)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(os.getcwd()),
+        help="Path to the Percussion CMS checkout root (default: cwd).",
+    )
+    parser.add_argument(
+        "--m2-root",
+        type=Path,
+        default=_default_m2_root(),
+        help="Maven local repository root (default: ~/.m2/repository).",
+    )
+    strict_group = parser.add_mutually_exclusive_group()
+    strict_group.add_argument(
+        "--strict",
+        dest="strict",
+        action="store_true",
+        help="Exit 2 when stale (default).",
+    )
+    strict_group.add_argument(
+        "--no-strict",
+        dest="strict",
+        action="store_false",
+        help="Print STALE: but exit 0 (warn-only).",
+    )
+    parser.set_defaults(strict=True)
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        default=None,
+        help="Optional path to append the report to (agent workflows).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Verbose logging on stderr.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    try:
+        report = run_preflight(Path(args.repo_root), Path(args.m2_root))
+    except Exception as exc:  # pragma: no cover - defensive
+        LOG.exception("preflight failed: %s", exc)
+        print(f"PREFLIGHT: ERROR: {exc}", file=sys.stderr)
+        return EXIT_INVOCATION
+
+    text = format_report(report, strict=bool(args.strict))
+    print(text)
+    if args.log_file is not None:
+        log_path = Path(args.log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+
+    if report.stale and args.strict:
+        return EXIT_STALE
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -214,11 +214,88 @@ class TestSubcommandDryRun(unittest.TestCase):
         self.addCleanup(_clear_port_env)
         rc, out = self.runner.run(["qa-up", "--timeout-seconds", "60"])
         self.assertEqual(rc, pdc.EXIT_OK)
+        # Preflight runs first under dry-run (#2486).
+        self.assertIn("RESULT:OK STEP:qa-preflight", out)
         self.assertIn("RESULT:OK STEP:qa-up", out)
         self.assertIn("TEST_CMS_URL=", out)
         self.assertIn("QA_CMS_HOST_PORT=", out)
         self.assertRegex(out, r"TEST_CMS_URL=http://127\.0\.0\.1:\d+")
         self.assertIn(f"ADMIN_USERNAME={pdc.QA_ADMIN_USERNAME}", out)
+
+    def test_qa_up_skip_preflight_dry_run(self):
+        _clear_port_env()
+        self.addCleanup(_clear_port_env)
+        rc, out = self.runner.run(
+            ["qa-up", "--timeout-seconds", "60", "--skip-preflight"]
+        )
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertNotIn("RESULT:OK STEP:qa-preflight", out)
+        self.assertIn("RESULT:OK STEP:qa-up", out)
+
+    def test_qa_preflight_dry_run(self):
+        rc, out = self.runner.run(["qa-preflight"])
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-preflight", out)
+        self.assertIn("PREFLIGHT: dry-run", out)
+
+    def test_qa_preflight_strict_stale_fails(self):
+        """Non-dry-run: m2 sitemanage newer than missing WAR/dist → FAIL (#2486)."""
+        # Lay out m2 under a temp root and point preflight at it via --m2-root.
+        m2 = Path(self.td.name) / "m2"
+        jar = (
+            m2
+            / "com"
+            / "percussion"
+            / "sitemanage"
+            / "8.2.0-SNAPSHOT"
+            / "sitemanage-8.2.0-SNAPSHOT.jar"
+        )
+        jar.parent.mkdir(parents=True)
+        jar.write_bytes(b"jar")
+        # Repo has no WebUI WAR / dist → STALE when m2 present.
+        rc, out = self.runner.run(
+            ["qa-preflight", "--m2-root", str(m2)],
+            dry_run=False,
+        )
+        self.assertEqual(rc, 2)
+        self.assertIn("RESULT:FAIL STEP:qa-preflight", out)
+        self.assertIn("STALE", out)
+
+    def test_qa_up_blocks_on_stale_preflight(self):
+        """qa-up must not start matrix when rebuild preflight is STALE (#2486)."""
+        m2 = Path(self.td.name) / "m2-up"
+        jar = (
+            m2
+            / "com"
+            / "percussion"
+            / "sitemanage"
+            / "8.2.0-SNAPSHOT"
+            / "sitemanage-8.2.0-SNAPSHOT.jar"
+        )
+        jar.parent.mkdir(parents=True)
+        jar.write_bytes(b"jar")
+
+        # Force preflight to use our m2 by patching qa_preflight default root.
+        import qa_preflight as qpf  # type: ignore
+
+        original = qpf._default_m2_root
+        qpf._default_m2_root = lambda: m2  # type: ignore
+        self.addCleanup(lambda: setattr(qpf, "_default_m2_root", original))
+
+        matrix = self.repo_root / "docker" / "scripts" / "matrix-install-smoke.py"
+        matrix.write_text("# stub\n", encoding="utf-8")
+
+        def boom(*_a, **_k):
+            raise AssertionError("matrix must not run when preflight is stale")
+
+        rc, out = self.runner.run(
+            ["qa-up", "--timeout-seconds", "30"],
+            dry_run=False,
+            fake_run=boom,
+        )
+        self.assertEqual(rc, 2)
+        self.assertIn("RESULT:FAIL STEP:qa-preflight", out)
+        self.assertIn("QA_DETAIL:rebuild preflight failed", out)
 
     def test_qa_health_dry_run(self):
         _clear_port_env()

--- a/docker/scripts/test_qa_preflight.py
+++ b/docker/scripts/test_qa_preflight.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for docker/scripts/qa_preflight.py (#2486).
+
+Filesystem-only: synthetic repo + m2 layout in a tempdir — no docker,
+maven, or curl.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+from contextlib import redirect_stdout
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+_spec = importlib.util.spec_from_file_location(
+    "qa_preflight", SCRIPTS / "qa_preflight.py"
+)
+qa_preflight = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["qa_preflight"] = qa_preflight
+_spec.loader.exec_module(qa_preflight)
+
+
+def _touch(path: Path, mtime: float, content: bytes = b"x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    os.utime(path, (mtime, mtime))
+
+
+def _make_war(
+    war_path: Path, *, sitemanage_jar_name: str = "sitemanage-8.2.0-SNAPSHOT.jar"
+) -> None:
+    war_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(war_path, "w") as zf:
+        zf.writestr("WEB-INF/lib/" + sitemanage_jar_name, b"PK fake")
+
+
+def _m2_sitemanage(m2_root: Path, mtime: float) -> Path:
+    """Standard Maven layout: com/percussion/sitemanage/<ver>/sitemanage-<ver>.jar."""
+    jar = (
+        m2_root
+        / "com"
+        / "percussion"
+        / "sitemanage"
+        / "8.2.0-SNAPSHOT"
+        / "sitemanage-8.2.0-SNAPSHOT.jar"
+    )
+    _touch(jar, mtime)
+    return jar
+
+
+class _Repo:
+    def __init__(self) -> None:
+        self.td = tempfile.TemporaryDirectory()
+        self.root = Path(self.td.name)
+
+    def cleanup(self) -> None:
+        self.td.cleanup()
+
+    def layout_repo(self) -> Path:
+        repo = self.root / "repo"
+        (repo / "WebUI" / "target").mkdir(parents=True)
+        (repo / "modules" / "perc-distribution-tree" / "target").mkdir(parents=True)
+        return repo
+
+    def layout_m2(self) -> Path:
+        return self.root / "m2"
+
+
+class TestFindSitemanageInM2(unittest.TestCase):
+    def setUp(self):
+        self.repo_helper = _Repo()
+        self.addCleanup(self.repo_helper.cleanup)
+        self.m2 = self.repo_helper.layout_m2()
+
+    def test_finds_versioned_layout(self):
+        jar = _m2_sitemanage(self.m2, 100)
+        found = qa_preflight.find_sitemanage_in_m2(self.m2)
+        self.assertEqual(found, jar)
+
+    def test_skips_classifier_jars(self):
+        base = self.m2 / "com" / "percussion" / "sitemanage" / "8.2.0-SNAPSHOT"
+        _touch(base / "sitemanage-8.2.0-SNAPSHOT-javadoc.jar", 500)
+        _touch(base / "sitemanage-8.2.0-SNAPSHOT-sources.jar", 500)
+        main = base / "sitemanage-8.2.0-SNAPSHOT.jar"
+        _touch(main, 100)
+        found = qa_preflight.find_sitemanage_in_m2(self.m2)
+        self.assertEqual(found, main)
+
+    def test_picks_newest_when_multiple_versions(self):
+        old = (
+            self.m2
+            / "com"
+            / "percussion"
+            / "sitemanage"
+            / "8.1.0-SNAPSHOT"
+            / "sitemanage-8.1.0-SNAPSHOT.jar"
+        )
+        new = (
+            self.m2
+            / "com"
+            / "percussion"
+            / "sitemanage"
+            / "8.2.0-SNAPSHOT"
+            / "sitemanage-8.2.0-SNAPSHOT.jar"
+        )
+        _touch(old, 100)
+        _touch(new, 300)
+        self.assertEqual(qa_preflight.find_sitemanage_in_m2(self.m2), new)
+
+
+class TestPreflightFresh(unittest.TestCase):
+    def setUp(self):
+        self.repo_helper = _Repo()
+        self.addCleanup(self.repo_helper.cleanup)
+        self.repo = self.repo_helper.layout_repo()
+        self.m2 = self.repo_helper.layout_m2()
+
+    def _fresh_chain(self, m2_t=100, war_t=200, dist_t=300):
+        _m2_sitemanage(self.m2, m2_t)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        os.utime(war_path, (war_t, war_t))
+        dist = (
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "perc-distribution-tree.jar"
+        )
+        _touch(dist, dist_t, b"dist")
+        return war_path, dist
+
+    def test_fresh_when_chain_ordered(self):
+        self._fresh_chain()
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertFalse(report.stale)
+        self.assertFalse(report.skipped)
+        text = qa_preflight.format_report(report, strict=True)
+        self.assertIn("FRESH", text)
+
+    def test_fresh_when_equal_mtimes(self):
+        self._fresh_chain(m2_t=200, war_t=200, dist_t=200)
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertFalse(report.stale)
+
+    def test_strict_main_returns_zero_when_fresh(self):
+        self._fresh_chain()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_preflight.main(
+                [
+                    "--repo-root",
+                    str(self.repo),
+                    "--m2-root",
+                    str(self.m2),
+                    "--strict",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("FRESH", buf.getvalue())
+
+
+class TestPreflightStale(unittest.TestCase):
+    def setUp(self):
+        self.repo_helper = _Repo()
+        self.addCleanup(self.repo_helper.cleanup)
+        self.repo = self.repo_helper.layout_repo()
+        self.m2 = self.repo_helper.layout_m2()
+
+    def test_stale_when_war_built_before_m2(self):
+        _m2_sitemanage(self.m2, 300)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        os.utime(war_path, (250, 250))
+        dist = (
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "perc-distribution-tree.jar"
+        )
+        _touch(dist, 260, b"dist")
+
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertTrue(report.stale)
+        text = qa_preflight.format_report(report, strict=True)
+        self.assertIn("STALE", text)
+        self.assertTrue(any("WebUI WAR older" in r for r in report.reasons))
+
+    def test_stale_when_dist_older_than_war(self):
+        _m2_sitemanage(self.m2, 100)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        os.utime(war_path, (300, 300))
+        dist = (
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "perc-distribution-tree.jar"
+        )
+        _touch(dist, 200, b"dist")
+
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertTrue(report.stale)
+        self.assertTrue(any("dist jar older" in r for r in report.reasons))
+
+    def test_strict_returns_nonzero_when_stale(self):
+        _m2_sitemanage(self.m2, 300)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        os.utime(war_path, (250, 250))
+        _touch(
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "perc-distribution-tree.jar",
+            260,
+            b"dist",
+        )
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_preflight.main(
+                [
+                    "--repo-root",
+                    str(self.repo),
+                    "--m2-root",
+                    str(self.m2),
+                    "--strict",
+                ]
+            )
+        self.assertEqual(rc, qa_preflight.EXIT_STALE)
+        self.assertIn("STALE", buf.getvalue())
+        self.assertIn("HINT:", buf.getvalue())
+
+    def test_no_strict_returns_zero_when_stale(self):
+        _m2_sitemanage(self.m2, 300)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        os.utime(war_path, (250, 250))
+        _touch(
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "perc-distribution-tree.jar",
+            260,
+            b"dist",
+        )
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_preflight.main(
+                [
+                    "--repo-root",
+                    str(self.repo),
+                    "--m2-root",
+                    str(self.m2),
+                    "--no-strict",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("STALE", buf.getvalue())
+        self.assertIn("non-strict", buf.getvalue())
+
+    def test_stale_when_war_missing(self):
+        _m2_sitemanage(self.m2, 300)
+        _touch(
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "perc-distribution-tree.jar",
+            100,
+            b"dist",
+        )
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertTrue(report.stale)
+        self.assertTrue(any("WAR missing" in r for r in report.reasons))
+
+    def test_stale_when_dist_missing(self):
+        _m2_sitemanage(self.m2, 100)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        os.utime(war_path, (200, 200))
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertTrue(report.stale)
+        self.assertTrue(any("dist jar missing" in r for r in report.reasons))
+
+    def test_stale_when_war_does_not_bundle_sitemanage(self):
+        _m2_sitemanage(self.m2, 300)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        with zipfile.ZipFile(war_path, "w") as zf:
+            zf.writestr("WEB-INF/lib/some-other.jar", b"PK fake")
+        os.utime(war_path, (400, 400))
+        _touch(
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "perc-distribution-tree.jar",
+            500,
+            b"dist",
+        )
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertTrue(report.stale)
+        self.assertTrue(any("does not bundle" in r for r in report.reasons))
+
+
+class TestPreflightNoOp(unittest.TestCase):
+    def setUp(self):
+        self.repo_helper = _Repo()
+        self.addCleanup(self.repo_helper.cleanup)
+        self.repo = self.repo_helper.layout_repo()
+        self.m2 = self.repo_helper.layout_m2()
+
+    def test_no_m2_jar_means_noop(self):
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        os.utime(war_path, (250, 250))
+        report = qa_preflight.run_preflight(self.repo, self.m2)
+        self.assertFalse(report.stale)
+        self.assertTrue(report.skipped)
+        text = qa_preflight.format_report(report, strict=True)
+        self.assertIn("NOTE", text)
+
+    def test_default_m2_root_is_home_m2(self):
+        resolved = qa_preflight._default_m2_root()
+        self.assertTrue(str(resolved).replace("\\", "/").endswith(".m2/repository"))
+
+    def test_handles_missing_repo_layout(self):
+        empty = self.repo_helper.root / "empty"
+        empty.mkdir()
+        report = qa_preflight.run_preflight(empty, self.m2)
+        self.assertFalse(report.stale)
+        self.assertTrue(report.skipped)
+
+    def test_handles_missing_m2_root(self):
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path)
+        report = qa_preflight.run_preflight(self.repo, self.repo_helper.root / "no-m2")
+        self.assertFalse(report.stale)
+        self.assertTrue(report.skipped)
+
+
+class TestWarBundlesSitemanage(unittest.TestCase):
+    def setUp(self):
+        self.repo_helper = _Repo()
+        self.addCleanup(self.repo_helper.cleanup)
+        self.repo = self.repo_helper.layout_repo()
+
+    def test_war_bundles_sitemanage_true(self):
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path, sitemanage_jar_name="sitemanage-8.2.0-SNAPSHOT.jar")
+        self.assertTrue(qa_preflight.war_bundles_sitemanage(war_path))
+
+    def test_war_bundles_sitemanage_false_when_only_other_jars(self):
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        with zipfile.ZipFile(war_path, "w") as zf:
+            zf.writestr("WEB-INF/lib/some-other.jar", b"PK fake")
+        self.assertFalse(qa_preflight.war_bundles_sitemanage(war_path))
+
+    def test_war_bundles_sitemanage_false_for_missing_war(self):
+        self.assertFalse(
+            qa_preflight.war_bundles_sitemanage(
+                self.repo / "WebUI" / "target" / "missing.war"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -123,14 +123,32 @@ cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
 # Windows: cd modules\perc-distribution-tree && ..\..\mvnw.cmd package -DskipTests
 ```
 
+**Rebuild preflight (#2486):** fail-loud if the WebUI WAR or dist jar is older than the m2 sitemanage SNAPSHOT (or missing) before qa-up. See also [docker/README.md](../../docker/README.md) → **QA rebuild preflight**.
+
+`ash
+# Standalone (default: exit 2 when STALE):
+python docker/scripts/perc-devctl.py qa-preflight
+# or: python docker/scripts/qa_preflight.py --repo-root .
+# Unit tests: python docker/scripts/test_qa_preflight.py
+
+# qa-up runs preflight first by default:
+python docker/scripts/perc-devctl.py qa-up
+# overrides: --skip-preflight | --preflight-warn-only
+`
+
+When preflight prints STALE:, re-run the full chain above (sitemanage → WebUI → dist) before retrying qa-up.
+
 **Post-cycle-fix smoke (#2423 / #2437):** after the rebuild chain, `qa-up` logs must show `ServletContextHandler] Started` for ROOT/Rhythmyx and **must not** contain `BeanCurrentlyInCreationException` / `Failed startup of context`. `qa-health` → login page HTTP 200/302 is the operator gate before Playwright.
 
 **Lifecycle (always use this order for unattended QA):**
 
 ```bash
+# 0) PREFLIGHT — optional explicit check (also runs inside qa-up by default)
+python docker/scripts/perc-devctl.py qa-preflight
+
 # 1) UP — silent install + start CMS on H2; waits until /Rhythmyx/login is ready
 python docker/scripts/perc-devctl.py qa-up
-# optional: --timeout-seconds 900  --skip-image-build
+# optional: --timeout-seconds 900  --skip-image-build  --skip-preflight
 # Host port: QA_CMS_HOST_PORT / CMS_HOST_PORT env, else preferred 9993 when free, else freeport.
 # qa-up prints QA_CMS_HOST_PORT=… and TEST_CMS_URL=http://127.0.0.1:<port>
 


### PR DESCRIPTION
## Summary

Parent epic: **#2423**. Residual of **#2437** / PR #2483.

Implements a **fail-loud rebuild-chain preflight** so agents/CI do not run matrix qa-up against a dist tree whose WebUI WAR still embeds a **stale** sitemanage-*.jar after a sitemanage-only m2 install.

- New `docker/scripts/qa_preflight.py`: compares mtimes of
  1. `~/.m2/.../sitemanage-*.jar`
  2. `WebUI/target/perc-web-ui-*.war` (must bundle sitemanage under WEB-INF/lib)
  3. `modules/perc-distribution-tree/target/perc-distribution-tree.jar`
- `perc-devctl.py qa-preflight` (strict / exit 2 by default)
- `qa-up` runs preflight first; `--skip-preflight` / `--preflight-warn-only`
- Unit tests: `test_qa_preflight.py` + perc-devctl wiring (including block-on-stale)
- Docs: `docker/README.md` and `docs/developer-module/workbench-rest-and-qa-modes.md`

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2486

## Test plan

1. `python docker/scripts/test_qa_preflight.py` — 20 tests green
2. `python docker/scripts/test_perc_devctl.py` — 51 tests green (includes qa-preflight dry-run, strict stale fail, qa-up blocks on stale)
3. Manual: `python docker/scripts/perc-devctl.py qa-preflight` on a tree with/without artifacts
4. No Maven module sources changed — no `mvnw clean install` required (docker/scripts + docs only)

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | Pass (`test_qa_preflight.py` 20, `test_perc_devctl.py` 51) |
| Maven clean install | N/A — no Java module changes |
| Cross-platform paths | `pathlib.Path`, `os.path.expanduser`, no hardcoded OS separators for FS joins |
| Erlang self-review | No bugs found in preflight logic; m2 layout uses real `com/percussion/sitemanage/<ver>/` |

## Follow-ups (residuals under #2423)

Planned residual issues (not in this PR):

- Wire preflight into `matrix-install-smoke` / GHA matrix jobs that skip `perc-devctl qa-up`
- SHA-256 content compare of WAR-embedded sitemanage vs m2 (mtime-resistant)
- Optional `perc-devctl` one-shot rebuild-chain driver (mvn install/package order)

> Co-Authored by Grok Build using grok-4.5 with agent main.