### PR TITLE
fix(docker): matrix/cms HEALTHCHECK for dead Rhythmyx context (#2481)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,16 @@ services:
     volumes:
       - ${PROJECT_ROOT:-.}:/workspace:ro
       - /opt/Percussion:/opt/Percussion
+    # #2481: HTTP ready codes + in-container Jetty log scan for dead Rhythmyx
+    # ApplicationContext (same markers as docker/scripts/rhythmyx_ready.py).
+    # Operators: docker inspect -f "{{.State.Health.Status}}" percussion-cms-dts
+    #   healthy   = login/probe ready and no context-failure markers in logs
+    #   unhealthy = context failed and/or login not ready (do not run Playwright)
+    #   starting  = within start_period (first boot)
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          'cms=$$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9992/Rhythmyx/login || true); ([ "$$cms" = "200" ] || [ "$$cms" = "302" ])',
-        ]
+      test: ["CMD", "python3", "/usr/local/bin/rhythmyx_healthcheck.py"]
       interval: 20s
-      timeout: 5s
+      timeout: 10s
       retries: ${PERC_HEALTHCHECK_RETRIES:-60}
       start_period: ${PERC_HEALTHCHECK_START_PERIOD:-30s}
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -243,8 +243,20 @@ Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `
 | `RESULT:FAIL … DETAIL:timeout after Ns (last_http=…)` | `qa-health` | Probe never became ready; if logs later show context fail, re-run `qa-health` or `docker logs perc-matrix-cms-h2` |
 | `RESULT:FAIL … DETAIL:timeout after Ns (cms_http=… dts_http=… health=…)` | `verify` | Stack never became ready; scan `docker logs percussion-cms-dts` for context markers |
 | Matrix `status=fail` + `detail` containing `rhythmyx_context_failed` | `matrix-install-smoke.py` CMS cells | Same fail-fast during cell HTTP wait (container log scan) |
+| Docker `Health.Status=healthy` | matrix cell / cms-dts image HEALTHCHECK (#2481) | In-container login probe ready **and** local Jetty logs have **no** context-failure markers |
+| Docker `Health.Status=unhealthy` | same | Context failed and/or login not ready — **do not** attach Playwright; inspect health log + `docker logs` |
+| Docker `Health.Status=starting` | same | Still inside HEALTHCHECK `start_period` (matrix cells: long install window) |
 
 Markers (shared helper `docker/scripts/rhythmyx_ready.py`): `Failed startup of context`, `BeanCurrentlyInCreationException`, `Requested bean is currently in creation`, `Is there an unresolvable circular reference`.
+
+##### Docker `Health.Status` (in-image HEALTHCHECK, #2481)
+
+Matrix cells (`percussion-matrix-cell:local`) and the cms-dts image bake `docker/scripts/rhythmyx_healthcheck.py`, which reuses `rhythmyx_ready` markers:
+
+| Container | Inspect | When **unhealthy** means |
+|-----------|---------|---------------------------|
+| `perc-matrix-cms-h2` (qa-up / matrix `--keep`) | `docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2` | Dead Rhythmyx context and/or `/Rhythmyx/login` not ready **inside** the cell |
+| `percussion-cms-dts` (compose) | `docker inspect -f "{{.State.Health.Status}}" percussion-cms-dts` | Same for bind-mounted host install |
 
 ```bash
 # After qa-up (or matrix --keep), re-check readiness with log scan:
@@ -254,15 +266,24 @@ python docker/scripts/perc-devctl.py qa-health
 docker logs perc-matrix-cms-h2 2>&1 | findstr /i "Failed startup BeanCurrently circular folderHelper"
 # Unix: docker logs perc-matrix-cms-h2 2>&1 | grep -E 'Failed startup|BeanCurrently|circular'
 
+# Docker HEALTHCHECK (orchestrators / docker ps HEALTH column) — #2481:
+docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2
+# healthy | unhealthy | starting
+docker inspect -f "{{json .State.Health}}" perc-matrix-cms-h2
+# Last health log lines include assessor detail (e.g. rhythmyx_context_failed …)
+
 # After compose up, verify also scans cms-dts logs (#2480):
 python docker/scripts/perc-devctl.py verify
 # FAIL example:
 # RESULT:FAIL STEP:verify DETAIL:rhythmyx_context_failed MATCH:Failed startup of context …
 docker logs percussion-cms-dts 2>&1 | findstr /i "Failed startup BeanCurrently circular folderHelper"
 # Unix: docker logs percussion-cms-dts 2>&1 | grep -E 'Failed startup|BeanCurrently|circular'
+docker inspect -f "{{.State.Health.Status}}" percussion-cms-dts
 ```
 
-Unit tests: `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q`.
+**Rebuild note:** matrix image build context is `docker/` (not `docker/matrix/` alone) so HEALTHCHECK scripts are copied in. After pulling this change, rebuild with `matrix-install-smoke.py` (default) or `docker build -t percussion-matrix-cell:local -f docker/matrix/Dockerfile docker/`. Compose cms-dts: `docker compose build cms-dts`.
+
+Unit tests: `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_rhythmyx_healthcheck.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q`.
 
 ### `docker/scripts/freeport-concurrent-smoke.py`
 

--- a/docker/cms/Dockerfile
+++ b/docker/cms/Dockerfile
@@ -1,3 +1,7 @@
+# Dev cms-dts image: JRE 21 + curl + Rhythmyx HEALTHCHECK (#2481).
+# Host install is bind-mounted; entrypoint only starts services.
+#
+# Build context is the repo root (see docker-compose.yml cms-dts service).
 FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update \
@@ -7,6 +11,13 @@ RUN apt-get update \
 WORKDIR /opt/Percussion
 
 COPY docker/entrypoint/install-update.py /usr/local/bin/install-update.py
-RUN chmod +x /usr/local/bin/install-update.py
+COPY docker/scripts/rhythmyx_ready.py /usr/local/lib/perc/rhythmyx_ready.py
+COPY docker/scripts/rhythmyx_healthcheck.py /usr/local/bin/rhythmyx_healthcheck.py
+RUN chmod +x /usr/local/bin/install-update.py /usr/local/bin/rhythmyx_healthcheck.py
 
-ENTRYPOINT ["/usr/local/bin/python3", "/usr/local/bin/install-update.py"]
+# Prefer image HEALTHCHECK; compose may also set healthcheck (same script).
+# Shorter start_period: host install is already present (service-only mode).
+HEALTHCHECK --interval=20s --timeout=10s --start-period=60s --retries=15 \
+    CMD ["/usr/bin/python3", "/usr/local/bin/rhythmyx_healthcheck.py"]
+
+ENTRYPOINT ["/usr/bin/python3", "/usr/local/bin/install-update.py"]

--- a/docker/matrix/Dockerfile
+++ b/docker/matrix/Dockerfile
@@ -1,5 +1,8 @@
-# Matrix install-smoke image: JRE 21 + curl for health probes.
+# Matrix install-smoke image: JRE 21 + curl + Rhythmyx HEALTHCHECK (#2481).
 # Installer jars are bind-mounted at runtime (not baked in).
+#
+# Build context is docker/ (see matrix-install-smoke.py build_matrix_image):
+#   docker build -t percussion-matrix-cell:local -f docker/matrix/Dockerfile docker/
 FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update \
@@ -14,9 +17,18 @@ RUN apt-get update \
 
 WORKDIR /opt/matrix
 
-# Build context is docker/matrix/ (see matrix-install-smoke.py docker build -f/-path).
-COPY cell-entrypoint.py /usr/local/bin/cell-entrypoint.py
-RUN chmod +x /usr/local/bin/cell-entrypoint.py
+# Cell entrypoint + shared readiness helpers (HTTP + ApplicationContext markers).
+COPY matrix/cell-entrypoint.py /usr/local/bin/cell-entrypoint.py
+COPY scripts/rhythmyx_ready.py /usr/local/lib/perc/rhythmyx_ready.py
+COPY scripts/rhythmyx_healthcheck.py /usr/local/bin/rhythmyx_healthcheck.py
+RUN chmod +x /usr/local/bin/cell-entrypoint.py /usr/local/bin/rhythmyx_healthcheck.py
+
+# In-image health: fail when /Rhythmyx/login is not ready OR Jetty logs show a
+# dead Rhythmyx ApplicationContext (same markers as docker/scripts/rhythmyx_ready.py).
+# start_period covers silent install + first Jetty start inside matrix cells.
+# Operators: docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2
+HEALTHCHECK --interval=30s --timeout=15s --start-period=600s --retries=5 \
+    CMD ["/usr/bin/python3", "/usr/local/bin/rhythmyx_healthcheck.py"]
 
 # Default: run one matrix cell (install + start + wait for signal).
 ENTRYPOINT ["/usr/bin/python3", "/usr/local/bin/cell-entrypoint.py"]

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -666,9 +666,14 @@ def ensure_network(network: str, *, dry_run: bool) -> None:
 
 
 def build_matrix_image(repo_root: Path, *, dry_run: bool) -> None:
-    """Build from ``docker/matrix/`` context only (small; not the monorepo root)."""
-    matrix_dir = repo_root / "docker" / "matrix"
-    dockerfile = matrix_dir / "Dockerfile"
+    """Build matrix cell image with context ``docker/`` (matrix + scripts).
+
+    Context is the ``docker/`` tree (not monorepo root, not ``docker/matrix/``
+    alone) so the image can COPY ``scripts/rhythmyx_ready.py`` and
+    ``scripts/rhythmyx_healthcheck.py`` for the in-image HEALTHCHECK (#2481).
+    """
+    docker_dir = repo_root / "docker"
+    dockerfile = docker_dir / "matrix" / "Dockerfile"
     _run(
         [
             "docker",
@@ -677,7 +682,7 @@ def build_matrix_image(repo_root: Path, *, dry_run: bool) -> None:
             MATRIX_IMAGE_TAG,
             "-f",
             str(dockerfile),
-            str(matrix_dir),
+            str(docker_dir),
         ],
         dry_run=dry_run,
         check=not dry_run,

--- a/docker/scripts/rhythmyx_healthcheck.py
+++ b/docker/scripts/rhythmyx_healthcheck.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""In-container Docker HEALTHCHECK for Rhythmyx readiness (#2481 / #2423).
+
+Jetty can bind HTTP while the ROOT/Rhythmyx Spring ``ApplicationContext``
+failed. Host-side probes (``qa-health``, matrix ``wait_for_http``) already
+scan logs via :mod:`rhythmyx_ready`. This CLI is the **in-image** counterpart
+so ``docker inspect … Health.Status`` reports **unhealthy** for orchestrators
+that only watch Docker health.
+
+Exit codes (Docker HEALTHCHECK contract)
+----------------------------------------
+* ``0`` — healthy (login HTTP ready **and** no context-failure markers in
+  local Jetty logs)
+* ``1`` — unhealthy (HTTP not ready and/or context failed)
+* ``2`` — usage / configuration error (also treated as unhealthy)
+
+Environment
+-----------
+* ``PRODUCT`` — ``cms`` (default) or ``dts``
+* ``INSTALL_ROOT`` / ``PERC_INSTALL_ROOT`` — CMS install root (default
+  ``/opt/Percussion``)
+* ``CMS_PORT`` — CMS listen port inside the container (default ``9992``)
+* ``DTS_PORT`` — DTS listen port (default ``9980``)
+* ``RHYTHMYX_HEALTH_PATH`` — CMS probe path (default ``/Rhythmyx/login``)
+* ``RHYTHMYX_HEALTH_URL`` — full override URL for the HTTP probe
+* ``RHYTHMYX_LOG_TAIL_BYTES`` — max bytes read per log file (default 262144)
+
+No secrets. Stdlib only. Pure helpers are unit-tested without Docker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Import shared markers / assessor (same tree on host tests; image layout
+# under /usr/local/lib/perc when baked into matrix/cms images).
+# ---------------------------------------------------------------------------
+
+
+def _ensure_rhythmyx_ready_on_path() -> None:
+    candidates = (
+        Path(__file__).resolve().parent,
+        Path("/usr/local/lib/perc"),
+        Path("/usr/local/lib"),
+    )
+    for candidate in candidates:
+        ready = candidate / "rhythmyx_ready.py"
+        if ready.is_file():
+            path_str = str(candidate)
+            if path_str not in sys.path:
+                sys.path.insert(0, path_str)
+            return
+
+
+_ensure_rhythmyx_ready_on_path()
+
+from rhythmyx_ready import (  # noqa: E402
+    DETAIL_CONTEXT_FAILED,
+    assess_rhythmyx_ready,
+    is_http_ready_code,
+)
+
+DEFAULT_INSTALL_ROOT = "/opt/Percussion"
+DEFAULT_CMS_PORT = "9992"
+DEFAULT_DTS_PORT = "9980"
+DEFAULT_CMS_PATH = "/Rhythmyx/login"
+DEFAULT_LOG_TAIL_BYTES = 256 * 1024
+
+EXIT_HEALTHY = 0
+EXIT_UNHEALTHY = 1
+EXIT_USAGE = 2
+
+
+def discover_jetty_log_paths(install_root: Path) -> List[Path]:
+    """Return existing Jetty/server log files under ``install_root``.
+
+    Paths use ``Path`` join (portable). Missing dirs yield an empty list —
+    common before install finishes inside a matrix cell.
+    """
+    root = Path(install_root)
+    dirs = (
+        root / "jetty" / "base" / "logs",
+        root / "Deployment" / "Server" / "logs",
+    )
+    found: List[Path] = []
+    for log_dir in dirs:
+        if not log_dir.is_dir():
+            continue
+        for path in sorted(log_dir.glob("*.log")):
+            if path.is_file():
+                found.append(path)
+    return found
+
+
+def read_log_tail(path: Path, max_bytes: int = DEFAULT_LOG_TAIL_BYTES) -> str:
+    """Read the last ``max_bytes`` of a log file as text (lossy-safe)."""
+    if max_bytes <= 0:
+        return ""
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return ""
+    try:
+        with path.open("rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+            data = fh.read(max_bytes)
+    except OSError:
+        return ""
+    # Jetty logs are mostly ASCII/UTF-8; replace undecodable bytes.
+    return data.decode("utf-8", errors="replace")
+
+
+def collect_log_text(
+    install_root: Path,
+    *,
+    max_bytes_per_file: int = DEFAULT_LOG_TAIL_BYTES,
+    log_paths: Optional[Sequence[Path]] = None,
+) -> str:
+    """Concatenate tails of Jetty logs for context-failure scanning."""
+    paths: Iterable[Path]
+    if log_paths is not None:
+        paths = log_paths
+    else:
+        paths = discover_jetty_log_paths(install_root)
+    chunks: List[str] = []
+    for path in paths:
+        text = read_log_tail(Path(path), max_bytes=max_bytes_per_file)
+        if text:
+            chunks.append(text)
+    return "\n".join(chunks)
+
+
+def http_probe_status(url: str, *, timeout: float = 5.0) -> int:
+    """Return HTTP status code, or ``0`` when the endpoint is unreachable."""
+    if not url:
+        return 0
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return int(resp.getcode())
+    except urllib.error.HTTPError as exc:
+        # 401/403/etc. still prove the endpoint answered.
+        try:
+            return int(exc.code)
+        except (TypeError, ValueError):
+            return 0
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return 0
+
+
+def build_probe_url(
+    *,
+    product: str,
+    cms_port: str = DEFAULT_CMS_PORT,
+    dts_port: str = DEFAULT_DTS_PORT,
+    cms_path: str = DEFAULT_CMS_PATH,
+    url_override: str = "",
+) -> str:
+    """Build the in-container probe URL (pure; unit-tested)."""
+    if url_override and url_override.strip():
+        return url_override.strip()
+    product = (product or "cms").strip().lower()
+    if product == "dts":
+        port = (dts_port or DEFAULT_DTS_PORT).strip() or DEFAULT_DTS_PORT
+        return f"http://127.0.0.1:{port}/"
+    port = (cms_port or DEFAULT_CMS_PORT).strip() or DEFAULT_CMS_PORT
+    path = cms_path if cms_path.startswith("/") else f"/{cms_path}"
+    return f"http://127.0.0.1:{port}{path}"
+
+
+def assess_container_health(
+    *,
+    product: str,
+    http_code: int,
+    log_text: str = "",
+) -> Tuple[bool, str]:
+    """Return ``(healthy, detail)`` for HEALTHCHECK exit mapping.
+
+    * **cms** — :func:`assess_rhythmyx_ready` (HTTP ready codes + context
+      markers). Context failure always wins (unhealthy).
+    * **dts** — HTTP answered with any positive status (Tomcat up). No
+      Rhythmyx context scan (DTS has no ROOT/Rhythmyx Spring app).
+    """
+    product = (product or "cms").strip().lower()
+    if product == "dts":
+        if int(http_code) > 0:
+            return True, f"ok dts_http={http_code}"
+        return False, f"dts_http_not_ready http={http_code}"
+    return assess_rhythmyx_ready(http_code, log_text, require_http=True)
+
+
+def run_healthcheck(
+    *,
+    product: str = "cms",
+    install_root: Path = Path(DEFAULT_INSTALL_ROOT),
+    probe_url: str = "",
+    cms_port: str = DEFAULT_CMS_PORT,
+    dts_port: str = DEFAULT_DTS_PORT,
+    cms_path: str = DEFAULT_CMS_PATH,
+    log_tail_bytes: int = DEFAULT_LOG_TAIL_BYTES,
+    http_timeout: float = 5.0,
+    log_text_override: Optional[str] = None,
+    http_code_override: Optional[int] = None,
+) -> Tuple[int, str]:
+    """Execute one health assessment; return ``(exit_code, detail)``.
+
+    Overrides are for unit tests (no network / no real install tree).
+    """
+    url = probe_url or build_probe_url(
+        product=product,
+        cms_port=cms_port,
+        dts_port=dts_port,
+        cms_path=cms_path,
+    )
+    if http_code_override is not None:
+        http_code = int(http_code_override)
+    else:
+        http_code = http_probe_status(url, timeout=http_timeout)
+
+    if log_text_override is not None:
+        log_text = log_text_override
+    elif (product or "cms").strip().lower() == "dts":
+        log_text = ""
+    else:
+        log_text = collect_log_text(
+            Path(install_root),
+            max_bytes_per_file=log_tail_bytes,
+        )
+
+    healthy, detail = assess_container_health(
+        product=product,
+        http_code=http_code,
+        log_text=log_text,
+    )
+    if healthy:
+        return EXIT_HEALTHY, detail
+    return EXIT_UNHEALTHY, detail
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "")
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return int(str(raw).strip())
+    except ValueError:
+        return default
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Docker HEALTHCHECK for Percussion CMS/DTS containers "
+            "(#2481). Exit 0=healthy, 1=unhealthy."
+        )
+    )
+    p.add_argument(
+        "--product",
+        default=os.environ.get("PRODUCT", "cms"),
+        help="cms (default) or dts",
+    )
+    p.add_argument(
+        "--install-root",
+        default=(
+            os.environ.get("INSTALL_ROOT")
+            or os.environ.get("PERC_INSTALL_ROOT")
+            or DEFAULT_INSTALL_ROOT
+        ),
+    )
+    p.add_argument(
+        "--url",
+        default=os.environ.get("RHYTHMYX_HEALTH_URL", ""),
+        help="Full probe URL override",
+    )
+    p.add_argument(
+        "--cms-port",
+        default=os.environ.get("CMS_PORT", DEFAULT_CMS_PORT),
+    )
+    p.add_argument(
+        "--dts-port",
+        default=os.environ.get("DTS_PORT", DEFAULT_DTS_PORT),
+    )
+    p.add_argument(
+        "--cms-path",
+        default=os.environ.get("RHYTHMYX_HEALTH_PATH", DEFAULT_CMS_PATH),
+    )
+    p.add_argument(
+        "--log-tail-bytes",
+        type=int,
+        default=_env_int("RHYTHMYX_LOG_TAIL_BYTES", DEFAULT_LOG_TAIL_BYTES),
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="HTTP probe timeout seconds",
+    )
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        exit_code, detail = run_healthcheck(
+            product=args.product,
+            install_root=Path(args.install_root),
+            probe_url=args.url or "",
+            cms_port=args.cms_port,
+            dts_port=args.dts_port,
+            cms_path=args.cms_path,
+            log_tail_bytes=int(args.log_tail_bytes),
+            http_timeout=float(args.timeout),
+        )
+    except (OSError, ValueError, TypeError) as exc:
+        print(f"healthcheck_error: {exc}", file=sys.stderr, flush=True)
+        return EXIT_USAGE
+
+    # Docker captures HEALTHCHECK stdout/stderr in inspect State.Health.Log.
+    # Keep one machine-friendly line for operators.
+    print(detail, flush=True)
+    if DETAIL_CONTEXT_FAILED in detail:
+        # Explicit marker for log scrapers / humans reading health log.
+        print(f"RESULT:FAIL DETAIL:{DETAIL_CONTEXT_FAILED}", flush=True)
+    return int(exit_code)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/scripts/rhythmyx_ready.py
+++ b/docker/scripts/rhythmyx_ready.py
@@ -14,7 +14,8 @@ This module provides pure, stdlib-only helpers:
 * A small assessor that combines HTTP + log scan for fail-fast
 
 Callers: ``perc-devctl.py`` (``qa-health``, compose ``verify`` /
-``_verify_inline``), ``matrix-install-smoke.py`` (``wait_for_http``).
+``_verify_inline``), ``matrix-install-smoke.py`` (``wait_for_http``),
+and in-image ``rhythmyx_healthcheck.py`` (Docker HEALTHCHECK / #2481).
 No secrets; no network I/O here.
 """
 

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -277,6 +277,35 @@ class DockerRunArgvTests(unittest.TestCase):
             )
         )
 
+    def test_build_matrix_image_uses_docker_dir_context(self):
+        """#2481: build context is docker/ so HEALTHCHECK scripts can COPY in."""
+        captured: list = []
+
+        def fake_run(argv, *, dry_run, check=False, capture=False, timeout=None):
+            captured.append(list(argv))
+            return __import__("subprocess").CompletedProcess(argv, 0, "", "")
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "docker" / "matrix").mkdir(parents=True)
+            (root / "docker" / "matrix" / "Dockerfile").write_text(
+                "FROM scratch\n", encoding="utf-8"
+            )
+            (root / "docker" / "scripts").mkdir(parents=True)
+            orig = smoke._run
+            smoke._run = fake_run  # type: ignore[assignment]
+            try:
+                smoke.build_matrix_image(root, dry_run=False)
+            finally:
+                smoke._run = orig  # type: ignore[assignment]
+        self.assertEqual(len(captured), 1)
+        argv = captured[0]
+        self.assertEqual(argv[0:3], ["docker", "build", "-t"])
+        self.assertIn(smoke.MATRIX_IMAGE_TAG, argv)
+        # Context path is …/docker (parent of matrix/), not …/docker/matrix alone.
+        self.assertEqual(Path(argv[-1]), root / "docker")
+        self.assertEqual(Path(argv[argv.index("-f") + 1]), root / "docker" / "matrix" / "Dockerfile")
+
 
 class WaitForHttpContextFailTests(unittest.TestCase):
     """#2462: matrix probe must fail-fast on Rhythmyx context death."""

--- a/docker/scripts/test_rhythmyx_healthcheck.py
+++ b/docker/scripts/test_rhythmyx_healthcheck.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for rhythmyx_healthcheck.py (#2481)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def _load():
+    # Ensure sibling rhythmyx_ready is importable the same way the CLI does.
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    path = SCRIPTS / "rhythmyx_healthcheck.py"
+    name = "rhythmyx_healthcheck"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hc = _load()
+
+
+class BuildProbeUrlTests(unittest.TestCase):
+    def test_cms_default(self):
+        self.assertEqual(
+            hc.build_probe_url(product="cms"),
+            "http://127.0.0.1:9992/Rhythmyx/login",
+        )
+
+    def test_cms_custom_port_path(self):
+        self.assertEqual(
+            hc.build_probe_url(
+                product="cms",
+                cms_port="19111",
+                cms_path="/Rhythmyx/rest/ping",
+            ),
+            "http://127.0.0.1:19111/Rhythmyx/rest/ping",
+        )
+
+    def test_dts_root(self):
+        self.assertEqual(
+            hc.build_probe_url(product="dts", dts_port="9980"),
+            "http://127.0.0.1:9980/",
+        )
+
+    def test_url_override_wins(self):
+        self.assertEqual(
+            hc.build_probe_url(
+                product="cms",
+                url_override="http://127.0.0.1:9/x",
+            ),
+            "http://127.0.0.1:9/x",
+        )
+
+
+class DiscoverAndReadLogsTests(unittest.TestCase):
+    def test_missing_install_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "missing"
+            self.assertEqual(hc.discover_jetty_log_paths(root), [])
+            self.assertEqual(hc.collect_log_text(root), "")
+
+    def test_reads_jetty_log_tail(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            log_dir = root / "jetty" / "base" / "logs"
+            log_dir.mkdir(parents=True)
+            log_path = log_dir / "jetty.log"
+            body = "INFO Server Started\nWARN Failed startup of context Rhythmyx\n"
+            log_path.write_text(body, encoding="utf-8")
+            paths = hc.discover_jetty_log_paths(root)
+            self.assertEqual(paths, [log_path])
+            text = hc.collect_log_text(root)
+            self.assertIn("Failed startup of context", text)
+
+    def test_read_log_tail_truncates(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "big.log"
+            path.write_bytes(b"A" * 1000 + b"MARKER")
+            text = hc.read_log_tail(path, max_bytes=10)
+            self.assertTrue(text.endswith("MARKER") or "MARKER" in text)
+            self.assertLessEqual(len(text.encode("utf-8")), 10)
+
+
+class AssessContainerHealthTests(unittest.TestCase):
+    def test_cms_http_ready_clean_logs(self):
+        ok, detail = hc.assess_container_health(
+            product="cms",
+            http_code=200,
+            log_text="INFO [Server] Started",
+        )
+        self.assertTrue(ok)
+        self.assertEqual(detail, "ok")
+
+    def test_cms_http_ready_but_context_failed(self):
+        ok, detail = hc.assess_container_health(
+            product="cms",
+            http_code=200,
+            log_text="WARN [WebAppContext] Failed startup of context Rhythmyx",
+        )
+        self.assertFalse(ok)
+        self.assertIn(hc.DETAIL_CONTEXT_FAILED, detail)
+
+    def test_cms_http_not_ready(self):
+        ok, detail = hc.assess_container_health(
+            product="cms",
+            http_code=0,
+            log_text="",
+        )
+        self.assertFalse(ok)
+        self.assertIn("http_not_ready", detail)
+
+    def test_cms_circular_marker(self):
+        ok, detail = hc.assess_container_health(
+            product="cms",
+            http_code=302,
+            log_text="BeanCurrentlyInCreationException: folderHelper",
+        )
+        self.assertFalse(ok)
+        self.assertIn(hc.DETAIL_CONTEXT_FAILED, detail)
+
+    def test_dts_any_http_ok(self):
+        ok, detail = hc.assess_container_health(
+            product="dts",
+            http_code=404,
+            log_text="BeanCurrentlyInCreationException",  # ignored for dts
+        )
+        self.assertTrue(ok)
+        self.assertIn("dts_http", detail)
+
+    def test_dts_unreachable(self):
+        ok, detail = hc.assess_container_health(
+            product="dts",
+            http_code=0,
+            log_text="",
+        )
+        self.assertFalse(ok)
+        self.assertIn("dts_http_not_ready", detail)
+
+
+class RunHealthcheckTests(unittest.TestCase):
+    def test_healthy_exit_with_overrides(self):
+        code, detail = hc.run_healthcheck(
+            product="cms",
+            http_code_override=200,
+            log_text_override="Server Started cleanly",
+        )
+        self.assertEqual(code, hc.EXIT_HEALTHY)
+        self.assertEqual(detail, "ok")
+
+    def test_unhealthy_on_context_fail_even_if_http_ok(self):
+        code, detail = hc.run_healthcheck(
+            product="cms",
+            http_code_override=200,
+            log_text_override=(
+                "WARN [WebAppContext] Failed startup of context oeje11w"
+            ),
+        )
+        self.assertEqual(code, hc.EXIT_UNHEALTHY)
+        self.assertIn(hc.DETAIL_CONTEXT_FAILED, detail)
+
+    def test_unhealthy_http_not_ready(self):
+        code, detail = hc.run_healthcheck(
+            product="cms",
+            http_code_override=0,
+            log_text_override="",
+        )
+        self.assertEqual(code, hc.EXIT_UNHEALTHY)
+        self.assertIn("http_not_ready", detail)
+
+    def test_reads_real_log_files_with_http_override(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            log_dir = root / "jetty" / "base" / "logs"
+            log_dir.mkdir(parents=True)
+            (log_dir / "server.log").write_text(
+                "Caused by: org.springframework.beans.factory."
+                "BeanCurrentlyInCreationException: folderHelper\n",
+                encoding="utf-8",
+            )
+            code, detail = hc.run_healthcheck(
+                product="cms",
+                install_root=root,
+                http_code_override=302,
+            )
+            self.assertEqual(code, hc.EXIT_UNHEALTHY)
+            self.assertIn(hc.DETAIL_CONTEXT_FAILED, detail)
+            self.assertIn("BeanCurrentlyInCreationException", detail)
+
+    def test_main_prints_detail_and_exits_unhealthy(self):
+        # main() with env-free argv using only pure overrides via run path:
+        # exercise main CLI lightly with --product dts and unreachable port.
+        rc = hc.main(
+            [
+                "--product",
+                "dts",
+                "--dts-port",
+                "1",
+                "--timeout",
+                "0.2",
+            ]
+        )
+        self.assertEqual(rc, hc.EXIT_UNHEALTHY)
+
+    def test_is_http_ready_reexport_path(self):
+        # Sanity: healthcheck module exposes shared constant used in docs.
+        self.assertTrue(hc.is_http_ready_code(200))
+        self.assertFalse(hc.is_http_ready_code(503))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -141,6 +141,11 @@ python docker/scripts/perc-devctl.py qa-up
 python docker/scripts/perc-devctl.py qa-health
 # optional: --timeout-seconds 120  --interval-seconds 5
 # DETAIL:rhythmyx_context_failed → cell unusable; inspect docker logs; do not run Playwright
+# Docker Health.Status (in-image HEALTHCHECK, #2481) — orchestrators / docker ps:
+#   docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2
+#   healthy = login ready + no context-failure markers in cell Jetty logs
+#   unhealthy = context failed and/or login not ready (same signal as qa-health fail-fast)
+#   starting = still within HEALTHCHECK start_period (matrix install window)
 
 # 3) Playwright against the stack only — no DEV_PERCUSSION_INSTALL
 #    (#2064 env + #2065 golden smoke + #1929 surface filter)
@@ -174,6 +179,7 @@ python docker/scripts/perc-devctl.py qa-down
 | Admin user           | `Admin` (password from install generated passwords)                      |
 | RESULT line contract | `RESULT:OK\|FAIL STEP:qa-up\|qa-health\|qa-down LOG:…`                   |
 | Context fail-fast    | `DETAIL:rhythmyx_context_failed MATCH:…` when Jetty logs show dead Rhythmyx Spring context (#2462); helper `docker/scripts/rhythmyx_ready.py` |
+| Docker Health.Status | `healthy` / `unhealthy` / `starting` via in-image `rhythmyx_healthcheck.py` (#2481); same markers as `rhythmyx_ready` |
 
 **Tear-down policy:** `qa-down` runs `docker rm -f` on the QA cell. The install lives **inside** the container (no named multi-GB volume by default), so removing the container frees ports and disk. Prefer `qa-down` after every agent session; do not leave `perc-matrix-cms-h2` running overnight unless debugging.
 


### PR DESCRIPTION
## Summary

**Fixes #2481** (residual of parent **#2423**, related **#2462** / PR #2479): matrix CMS cells and the cms-dts image expose a Docker **HEALTHCHECK** that fails when the ROOT/Rhythmyx Spring `ApplicationContext` died or login is not ready — so `docker inspect` `Health.Status` is **unhealthy** for orchestrators that only watch Docker health.

Host-side probes already fail-fast via `rhythmyx_ready` (#2462 / #2480). This slice adds the **in-image** counterpart.

### Changes
- New `docker/scripts/rhythmyx_healthcheck.py` — reuses `rhythmyx_ready` markers + HTTP ready codes; scans local Jetty log tails under `INSTALL_ROOT`
- Matrix image: bake scripts + `HEALTHCHECK`; build context is now `docker/` (not `docker/matrix/` alone)
- cms-dts image + `docker-compose.yml` healthcheck: same CLI (replaces HTTP-only curl)
- Operator docs: `Health.Status` table in `docker/README.md` + workbench QA modes
- Unit tests: pure assessor / log-tail / build-context (no live Docker required)

### Operator signal
| Health.Status | Meaning |
|---------------|---------|
| `healthy` | Login probe ready **and** no context-failure markers in local Jetty logs |
| `unhealthy` | Context failed and/or login not ready — do not run Playwright |
| `starting` | Within HEALTHCHECK `start_period` (matrix: long install window) |

`ash
docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2
docker inspect -f "{{.State.Health.Status}}" percussion-cms-dts
`

**Parent tracker:** #2423

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_rhythmyx_healthcheck.py docker/scripts/test_matrix_install_smoke.py docker/scripts/test_perc_devctl.py -q` → **145 passed**
- [x] Unit cases: HTTP 200 + clean logs → healthy; HTTP 200 + `Failed startup of context` → unhealthy; log file scan with `BeanCurrentlyInCreationException`; matrix build context = `docker/`
- [x] No Maven modules changed (docker scripts / Dockerfiles / docs only) — Pre-PR Maven clean install **N/A**

## Gates
- Erlang self-review: portable `Path` joins; no hardcoded FS separators; stdlib only; no secrets
- Change-class: in-image healthcheck + Dockerfiles + compose + harness build context + unit tests + operator docs

## Residuals (filed under parent #2423)
- Matrix harness wait on CMS cell `Health.Status` (complement to host HTTP)
- Live inject-marker proof that inspect reports unhealthy
- perc-devctl RESULT surfaces inspect Health for matrix cells

> Co-Authored by Grok Build using grok-4.5 with agent main.
