### PR TITLE
chore(kilo): pickup-issue workflow — PR review pass + already-picked-up check

### DIFF
--- a/.kilo/workflows/pickup-issue.md
+++ b/.kilo/workflows/pickup-issue.md
@@ -4,7 +4,7 @@ description: Triage the open GitHub issue backlog and select up to N (default 5)
 
 ## Goal
 
-Produce a **triage dataset** ΓÇö a ranked list of the first `MAX_TASKS`
+Produce a **triage dataset** -- a ranked list of the first `MAX_TASKS`
 (default `5`) open p1..p8 issues that have actionable engineering
 work for a Kilo session. The output is a list, not a single pick,
 so the human (or a follow-up session) can decide which candidate to
@@ -13,7 +13,7 @@ actually drive to a PR.
 - **`MAX_TASKS`** (default `5`): cap on candidates returned per
   workflow run. Workflow stops once the cap is reached.
 - **`MAX_PRIORITY`** (default `p1`): highest priority bucket the
-  walk starts from. Discovery walks `p1` ΓåÆ `p2` ΓåÆ ΓÇª and stops once
+  walk starts from. Discovery walks `p1` -> `p2` -> ... and stops once
   `MAX_TASKS` survivors are accumulated **or** every priority is
   exhausted, whichever comes first.
 
@@ -24,15 +24,15 @@ from the dataset and drives it to a PR.
 
 **Run order for a full session:** (1) Kilo own-PR comment resolution,
 (2) PR review pass for other agents / unlabeled PRs, (3) issue triage.
-Do **not** chain PR review and issue triage in the same run ΓÇö after
+Do **not** chain PR review and issue triage in the same run -- after
 the review pass emits its summary, **stop**; triage runs in a
 subsequent invocation.
 
-## Kilo PR comment resolution ΓÇö clear threads on YOUR OWN open PRs (run BEFORE the PR review pass)
+## Kilo PR comment resolution -- clear threads on YOUR OWN open PRs (run BEFORE the PR review pass)
 
 Before reviewing other agents' PRs, scan **your own** open PRs
 (any PR carrying the `operator:kilo` label) for unresolved review
-threads and resolve them per root `AGENTS.md` ΓåÆ **PR Review
+threads and resolve them per root `AGENTS.md` -> **PR Review
 Comment Resolution**. The PR review pass downstream assumes Kilo's
 own backlog is already clean.
 
@@ -45,11 +45,11 @@ gh pr list --state open --json number,title,labels --limit 200 \
       | .number'
 ```
 
-### Per PR ΓÇö resolve every unresolved thread
+### Per PR -- resolve every unresolved thread
 
 For each open PR with `operator:kilo`:
 
-1. **Fetch the review threads** (GraphQL ΓÇö the REST comments API
+1. **Fetch the review threads** (GraphQL -- the REST comments API
    does not expose thread-level resolution state):
 
    ```bash
@@ -71,11 +71,11 @@ For each open PR with `operator:kilo`:
      -f owner=<owner> -f repo=<repo> -F n=<n>
    ```
 2. For **each unresolved** thread (regardless of who authored the
-   first comment ΓÇö your own, another agent, a human, or the
+   first comment -- your own, another agent, a human, or the
    kilo-code-bot):
    - Read the finding body and the file:line context.
    - Decide the mitigation: code fix in a follow-up commit on the
-     PR's branch, doc fix, or a documented "noted ΓÇö won't fix
+     PR's branch, doc fix, or a documented "noted -- won't fix
      because X".
    - **Reply inline** with the mitigation, citing the commit hash
      (e.g. `f1908b961e`):
@@ -92,10 +92,10 @@ For each open PR with `operator:kilo`:
          resolveReviewThread(input: { threadId: $threadId }) {
            thread { id isResolved }
          }
-       }' -f threadId="<thread-id-PRRT_ΓÇª>"
+       }' -f threadId="<thread-id-PRRT_...>"
      ```
 3. **Outdated threads** (where the diff no longer contains the
-   offending line ΓÇö `isOutdated: true`) still need an inline
+   offending line -- `isOutdated: true`) still need an inline
    reply explaining the mitigation AND a `resolveReviewThread` call.
    `isOutdated: true` is informational; it does **not** auto-resolve.
 4. **Do not** mark a thread as resolved without first replying
@@ -104,7 +104,7 @@ For each open PR with `operator:kilo`:
 
 ### Sequence
 
-Run **before** the PR review pass ΓÇö clear Kilo's own backlog first,
+Run **before** the PR review pass -- clear Kilo's own backlog first,
 then review others. This ensures the PR review pass sees a clean
 review-thread state on Kilo's PRs before applying the same gate to
 incoming reviews.
@@ -114,9 +114,9 @@ incoming reviews.
 When **every** `operator:kilo` open PR has zero unresolved review
 threads, proceed to the PR review pass. Otherwise emit a one-line
 per-PR summary showing remaining unresolved count and continue
-working through the list ΓÇö never skip a thread.
+working through the list -- never skip a thread.
 
-## PR review pass ΓÇö review-and-merge queue (run BEFORE triage)
+## PR review pass -- review-and-merge queue (run BEFORE triage)
 
 Before any new triage picks up engineering work, scan the open PR list
 for PRs authored by **another model** (or by **no model** at all) that
@@ -153,13 +153,13 @@ operator-based:
 | Condition | Meaning |
 |-----------|---------|
 | Not `operator:kilo` | Kilo has not claimed it; an independent review is owed. |
-| Has **any** `model:*` label | Another model wrote it ΓÇö Kilo reviews it. |
+| Has **any** `model:*` label | Another model wrote it -- Kilo reviews it. |
 | Has **no** `model:*` label | Per the user's rule: "if no model is listed then you should select it for review." |
 
 Note: `operator:*` is workflow attribution (which agent produced the
 work), not assignment (who should review it). Per
 `.kilo/rules/operator-pr-labels.md`, it does **not** gate Kilo's
-review pick ΓÇö only the `model:*` label determines whether Kilo
+review pick -- only the `model:*` label determines whether Kilo
 takes the PR.
 
 PRs authored by the human owner (`natechadwick-intsof`) without an
@@ -171,7 +171,7 @@ selected for review unless the human has explicitly delegated them.
 For each candidate PR, in the order returned by
 `gh pr list --sort created --direction asc` (oldest first):
 
-> **All review comments must be inline** ΓÇö per the user's rule
+> **All review comments must be inline** -- per the user's rule
 > (2026-08-08). Use `gh api -X POST .../pulls/<n>/comments` with
 > `path` + `line` + `commit_id` to attach the comment to the
 > specific file:line in the diff. Top-level PR comments via
@@ -194,7 +194,7 @@ For each candidate PR, in the order returned by
 > For multi-line selections use `start_line` +
 > `start_side='RIGHT'` + `line` (end) on the same call.
 
-1. **Erlang review** ΓÇö fetch `gh pr diff <n>` and run a strict Erlang
+1. **Erlang review** -- fetch `gh pr diff <n>` and run a strict Erlang
    review against the
    `.kilo/workflows/erlang-review` persona. Look for: bug findings,
    missing behavioral tests on new/changed non-trivial logic,
@@ -204,19 +204,19 @@ For each candidate PR, in the order returned by
    Co-Authored footer on agent commits, missing
    `operator + model` labels on the PR. Post each finding
    **inline** at the relevant file:line.
-2. **Pre-PR build evidence** ΓÇö read the PR body for standalone
+2. **Pre-PR build evidence** -- read the PR body for standalone
    module clean-install results (`cd <module>` then repo-root
    `mvnw` / `mvnw.cmd clean install`). If absent, re-run on a
    fresh worktree pointing at the PR head; if it fails, post an
    inline comment on the relevant test/build file and request
    changes. If the PR is docs-only / non-Maven, the body should
    say so explicitly.
-3. **CI checks** ΓÇö `gh pr checks <n>` ΓÇö confirm required checks
+3. **CI checks** -- `gh pr checks <n>` -- confirm required checks
    pass or are explicitly skipped. Failures block the merge.
-4. **Review-thread state** ΓÇö `gh api graphql ... reviewThreads` ΓÇö
+4. **Review-thread state** -- `gh api graphql ... reviewThreads` --
    confirm every prior review comment has an inline reply AND a
    `resolveReviewThread` mutation. Unresolved threads block the
-   merge per root `AGENTS.md` ΓåÆ **PR Review Comment Resolution**.
+   merge per root `AGENTS.md` -> **PR Review Comment Resolution**.
 
 ### Squash-merge decision
 
@@ -233,13 +233,13 @@ The PR is **squash-merged** if **all** of the following hold:
 - PR carries `operator + model` labels per
   `.kilo/rules/operator-pr-labels.md`.
 - `mergeable == MERGEABLE`. If `mergeable == CONFLICTING`, see
-  **Conflict resolution** below ΓÇö the reviewer attempts to clear
+  **Conflict resolution** below -- the reviewer attempts to clear
   the conflict before posting a rebase request.
 
 If **any** condition fails, post the substantive finding as an
 **inline** review comment at the relevant file:line, then post a
 short top-level **summary** verdict with the right `gh pr review`
-flag (do **not** always use `--comment` — that submits a neutral
+flag (do **not** always use `--comment` -- that submits a neutral
 review, not a blocking one):
 
 | Verdict | Command |
@@ -257,16 +257,16 @@ When a candidate PR reports `CONFLICTING`, attempt to resolve the
 conflict locally before blocking on the author. The attempt
 covers three cases and is ordered least-invasive first:
 
-1. **Trivial rebase** ΓÇö fetch the PR head, attempt `git rebase
+1. **Trivial rebase** -- fetch the PR head, attempt `git rebase
    origin/main` in a disposable worktree. If the rebase applies
    cleanly (no text conflicts), run the module's pre-PR build
    (see portable `mvnw` snippet below), push the result with
    `--force-with-lease`, and proceed to the squash-merge step.
    This unblocks PRs that just need a refresh against current
    `main`.
-2. **Duplicate of an open Kilo PR** ΓÇö if the rebase fails and the
+2. **Duplicate of an open Kilo PR** -- if the rebase fails and the
    conflicting hunks overlap with an open Kilo PR on the same
-   files (see `.kilo/rules/no-force-push-development.md` ΓåÆ
+   files (see `.kilo/rules/no-force-push-development.md` ->
    exception for review-driven rebases), post a comment recommending
    closure as duplicate of the Kilo PR and skip. Do **not** attempt
    a force-push resolution that would clobber the Kilo PR. The
@@ -296,25 +296,25 @@ covers three cases and is ordered least-invasive first:
 
    If a candidate surfaces with high file-overlap (>= 50% of the
    target's touched files), post the close-as-duplicate comment.
-   Do **not** use jq `inside()` for this check ΓÇö `inside()` is a
+   Do **not** use jq `inside()` for this check -- `inside()` is a
    contiguous subarray match and would flag any single shared file.
-3. **Non-trivial conflict** ΓÇö if the rebase fails with text conflicts
+3. **Non-trivial conflict** -- if the rebase fails with text conflicts
    that are **not** a duplicate signal, post a structured review
    comment with the conflict markers (`<<<<<<<` / `=======` /
    `>>>>>>>`) excerpted from `git diff` and request a rebase from
    the author. Do **not** push a partial resolution. Do **not**
-   leave the worktree in a half-rebased state ΓÇö `git rebase --abort`
+   leave the worktree in a half-rebased state -- `git rebase --abort`
    and remove the worktree (portable path below) before moving on.
 
 #### Trivial rebase command (portable worktree + mvnw)
 
 Use a **repo-local** worktree under `.kilo/worktrees/` (gitignored)
 rather than OS-specific temp roots such as `/tmp` or `%TEMP%`. This
-matches root `AGENTS.md` ΓåÆ **Cross-Platform File I/O & Paths** and
+matches root `AGENTS.md` -> **Cross-Platform File I/O & Paths** and
 **Git worktree hygiene**.
 
 ```bash
-# Portable: repo-local disposable worktree (Windows + Unix) ΓÇö never /tmp or %TEMP%
+# Portable: repo-local disposable worktree (Windows + Unix) -- never /tmp or %TEMP%
 PR_BRANCH="<pr-branch>"            # e.g. feat/foo
 PR_NUMBER=<n>                      # PR number (int)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -361,7 +361,7 @@ branch tip moved. **Never** force-push to `main`.
 
 ```bash
 gh pr merge <n> --squash --delete-branch \
-  --subject "<concise commit subject ΓÇö match the PR title or scope>" \
+  --subject "<concise commit subject -- match the PR title or scope>" \
   --body "<PR summary; preserve original PR body unless empty>"
 ```
 
@@ -376,17 +376,17 @@ After the review pass, emit the summary block and **stop** before
 running the triage pass:
 
 ```
-PR REVIEW ΓÇö Kilo (model: $KILO_MODEL)
+PR REVIEW -- Kilo (model: $KILO_MODEL)
 
-1.  #<n>  <title>  ΓåÆ  SQUASH-MERGED | REQUESTED CHANGES | SKIPPED
-2.  #<n>  <title>  ΓåÆ  ΓÇª
+1.  #<n>  <title>  ->  SQUASH-MERGED | REQUESTED CHANGES | SKIPPED
+2.  #<n>  <title>  ->  ...
 
 (<x> reviewed, <y> merged, <z> needs changes, <w> skipped)
 ```
 
 If the summary is empty (no candidates), report
 `No open PRs from other models need a code review.` and **stop**.
-The triage pass runs in a subsequent invocation ΓÇö do not chain
+The triage pass runs in a subsequent invocation -- do not chain
 PR review and issue triage in the same run.
 
 ---
@@ -422,15 +422,15 @@ the next oldest survivor at the same priority. This contract is
 agent on one side never starts parallel work the other side has
 already claimed.
 
-1. **Label check.** Issue carries `in progress` label ΓåÆ skip. Both
+1. **Label check.** Issue carries `in progress` label -> skip. Both
    the Kilo pickup workflow and the grok nightly-PR workflow apply
    this label when they start work and remove it when a PR is opened
    so an issue is available for handoff only when no PR is in flight.
 2. **PR-reference check.** Any PR whose body references the issue
    number (via `#<n>` / "closes #N" / "fixes #N") or whose
    `closingIssuesReferences` includes the issue, in state `OPEN`
-   or `MERGED` ΓåÆ skip. (`CLOSED` without merge is **not** a
-   pickup signal ΓÇö the work was abandoned; defer to check 3.)
+   or `MERGED` -> skip. (`CLOSED` without merge is **not** a
+   pickup signal -- the work was abandoned; defer to check 3.)
 
    ```bash
    gh pr list --state all --json number,state,body,closingIssuesReferences \
@@ -442,11 +442,11 @@ already claimed.
        ) | {number, state}]'
    ```
    Note: jq `test` is POSIX ERE (no `\b`), so the regex anchors with
-   explicit non-digit boundaries to avoid `#1` matching `#10`, `#11`, ….
-   `closingIssuesReferences` is an array of `{number, …}` objects, so
+   explicit non-digit boundaries to avoid `#1` matching `#10`, `#11`, ....
+   `closingIssuesReferences` is an array of `{number, ...}` objects, so
    we map to `.number` before the integer comparison.
 3. **Comment-based claim check.** The latest 5 comments include an
-   agent-attributed pickup signal ΓÇö any of: `picking this up`,
+   agent-attributed pickup signal -- any of: `picking this up`,
    `starting work`, `picked up`, `agent progress`, `pr_opened`,
    `pr opened`, `in flight`, or a status table entry with value
    `in_progress` / `pr_opened` / `done` / `merged`. Authored by
@@ -464,18 +464,18 @@ already claimed.
 When a candidate is skipped on any of the three checks, log:
 
 ```
-SKIP #<n>: <which-check> triggered ΓÇö <one-line evidence>
+SKIP #<n>: <which-check> triggered -- <one-line evidence>
 ```
 
-ΓÇªand resume Discovery with the next oldest survivor at the same
+...and resume Discovery with the next oldest survivor at the same
 priority. If every candidate at every priority skips, report
-`No open p1..p8 issue is available to pick up.` and **stop** ΓÇö do
+`No open p1..p8 issue is available to pick up.` and **stop** -- do
 not invent work.
 
 If every `p1..p8` query returns an empty filtered list, report
-`No open p1..p8 issue is available.` and **stop** ΓÇö do not invent work.
+`No open p1..p8 issue is available.` and **stop** -- do not invent work.
 
-## Scope check ΓÇö there must be engineering to do
+## Scope check -- there must be engineering to do
 
 After the candidate row is chosen, read the issue body and recent
 comments to confirm there is real engineering work a Kilo worktree
@@ -487,14 +487,14 @@ Discovery with the next oldest survivor at the same priority) if
    implement the acceptance criteria and every one of those PRs is
    `MERGED` (or the linked child issues are closed with no open
    residual).
-2. The comments contain a tracker directive ΓÇö any of:
+2. The comments contain a tracker directive -- any of:
    `leave open as tracker`, `parent stays open until residual`,
    `close gate: #<n>`, `no further engineering slices scheduled`,
    `all AC met`. The directive must be from the issue's own audit
    comment, not a one-off remark.
 3. The remaining open child issues (if any) are documented as
    blocked on customer data (`requires customer env`, `verify ops
-   path`, etc.) ΓÇö i.e. nothing in this issue is actionable from a
+   path`, etc.) -- i.e. nothing in this issue is actionable from a
    Kilo worktree.
 
 If the candidate is a **research / spec parent** (e.g. #2400), the
@@ -507,12 +507,12 @@ skipped.
 Use this query to fetch the audit comment and the open children:
 
 ```bash
-# Latest 5 comments ΓÇö to find the tracker directive
+# Latest 5 comments -- to find the tracker directive
 gh issue view "$ISSUE" --comments --json comments --jq '.comments
   | sort_by(.createdAt) | reverse | .[0:5]
   | map({author: .author.login, body: .body[0:200]})'
 
-# Open children ΓÇö to see if any are engineering slices
+# Open children -- to see if any are engineering slices
 gh issue list --state open --json number,title --limit 200 \
   | jq --arg issue "$ISSUE" '[.[]
       | select(.title | test("issue " + $issue + "( |$)", "i"))
@@ -526,7 +526,7 @@ actionable** in one or two sentences for the triage dataset:
   #2435/#2436; #2435 needs `@Lazy` ctor-param fix").
 - For research parents, the concrete artifact to ship (e.g.
   "spec/plan file under `specs/2400-dce-explorer-parity.md`").
-- For unknown / under-specified bodies, "needs scoping" ΓÇö the
+- For unknown / under-specified bodies, "needs scoping" -- the
   next session must read the issue body and decide.
 
 ## Accumulate, then stop
@@ -540,7 +540,7 @@ MAX_PRIORITY="${MAX_PRIORITY:-p1}"
 ```
 
 If the priority walk reaches `p8` with fewer than `MAX_TASKS`
-candidates, the workflow still stops ΓÇö a short dataset is more
+candidates, the workflow still stops -- a short dataset is more
 useful than padding it with low-priority work.
 
 ## Triage dataset output
@@ -551,7 +551,7 @@ so downstream tooling can parse it:
 ### Human-readable
 
 ```
-TRIAGE ΓÇö Kilo pickup (model: $KILO_MODEL, max: $MAX_TASKS)
+TRIAGE -- Kilo pickup (model: $KILO_MODEL, max: $MAX_TASKS)
 
 1.  #1234  p1  <title>
         scope: <one-line summary>
@@ -564,8 +564,8 @@ TRIAGE ΓÇö Kilo pickup (model: $KILO_MODEL, max: $MAX_TASKS)
 (2 candidates, 3 priorities scanned)
 
 Skipped during this run:
-  - #804  tracker-only ΓÇö all engineering merged, audit says leave open
-  - #934  tracker-only ΓÇö gap-matrix says AC1/2/3/4/5/6 met
+  - #804  tracker-only -- all engineering merged, audit says leave open
+  - #934  tracker-only -- gap-matrix says AC1/2/3/4/5/6 met
 ```
 
 ### JSON
@@ -589,8 +589,8 @@ Skipped during this run:
     }
   ],
   "skipped": [
-    { "number": 804, "reason": "tracker-only ΓÇö all engineering merged, audit says leave open" },
-    { "number": 934, "reason": "tracker-only ΓÇö gap-matrix says AC1/2/3/4/5/6 met" }
+    { "number": 804, "reason": "tracker-only -- all engineering merged, audit says leave open" },
+    { "number": 934, "reason": "tracker-only -- gap-matrix says AC1/2/3/4/5/6 met" }
   ]
 }
 ```
@@ -614,7 +614,7 @@ agent to drive that one issue to a PR.
 
 ## Do **not** do
 
-- Do **not** filter on `operator:*` labels ΓÇö they are workflow
+- Do **not** filter on `operator:*` labels -- they are workflow
   attribution, not assignment, and must not disqualify a candidate.
 - Do **not** pick, branch, commit, push, or open a PR during the
   triage path. This workflow's triage phase is triage-only.
@@ -632,7 +632,7 @@ agent to drive that one issue to a PR.
 - Do **not** invent a `daily-status` label or any new label outside
   this workflow's allowlist.
 - Do **not** hardcode OS-specific temp paths (`/tmp`, `%TEMP%`) for
-  review worktrees ΓÇö use `.kilo/worktrees/review-<n>` under the
+  review worktrees -- use `.kilo/worktrees/review-<n>` under the
   repo root.
-- Do **not** use a literal path `mvnw[.cmd]` in shell examples ΓÇö
+- Do **not** use a literal path `mvnw[.cmd]` in shell examples --
   always branch on `mvnw.cmd` vs `mvnw`.

--- a/.kilo/workflows/pickup-issue.md
+++ b/.kilo/workflows/pickup-issue.md
@@ -135,7 +135,7 @@ gh pr list --state open \
     | select(
         ((.labels | map(.name) | any(. == "operator:kilo")) | not)
         and (
-          (.labels | map(.name) | any(startswith("operator:grok") or startswith("operator:night-issue-prs") or startswith("operator:minimax")))
+          (.labels | map(.name) | any(startswith("model:")))
           or ((.labels | map(.name) | any(startswith("model:"))) | not)
         )
       )
@@ -147,13 +147,20 @@ gh pr list --state open \
 oldest-first (matches the Review instructions below). Without it,
 GitHub's default sort does not guarantee age order.
 
-The filter (per the user's direction):
+The filter (per the user's direction) is **model-based**, not
+operator-based:
 
 | Condition | Meaning |
 |-----------|---------|
 | Not `operator:kilo` | Kilo has not claimed it; an independent review is owed. |
-| Has `operator:grok` / `operator:night-issue-prs` / `operator:minimax` | Other-agent work ΓÇö Kilo reviews it. |
+| Has **any** `model:*` label | Another model wrote it ΓÇö Kilo reviews it. |
 | Has **no** `model:*` label | Per the user's rule: "if no model is listed then you should select it for review." |
+
+Note: `operator:*` is workflow attribution (which agent produced the
+work), not assignment (who should review it). Per
+`.kilo/rules/operator-pr-labels.md`, it does **not** gate Kilo's
+review pick ΓÇö only the `model:*` label determines whether Kilo
+takes the PR.
 
 PRs authored by the human owner (`natechadwick-intsof`) without an
 agent attribution fall into the "no model listed" branch and are
@@ -168,21 +175,23 @@ For each candidate PR, in the order returned by
 > (2026-08-08). Use `gh api -X POST .../pulls/<n>/comments` with
 > `path` + `line` + `commit_id` to attach the comment to the
 > specific file:line in the diff. Top-level PR comments via
-> `gh pr review --comment` are reserved for summary verdicts
-> (APPROVE / REQUEST CHANGES / DUPLICATE / NEEDS REBASE) only;
-> substantive findings always go inline. The inline-comment helper:
+> `gh pr review` are reserved for summary verdicts only (see the
+> flag table below); substantive findings always go inline. The
+> inline-comment helper:
 >
 > ```bash
+> # Replace <owner>/<repo> with the actual values, <n> = PR number,
+> # <file> = repo-relative path, <line> = line in the diff,
+> # <head-sha> = SHA from `gh pr view <n> --json headRefOid --jq .headRefOid`.
 > gh api -X POST repos/<owner>/<repo>/pulls/<n>/comments \
 >   -f body='<finding>' \
 >   -f path='<file>' \
->   -F line=<n> \
+>   -F line=<line> \
 >   -F side='RIGHT' \
 >   -F commit_id='<head-sha>'
 > ```
 >
-> Use `gh pr view <n> --json headRefOid --jq .headRefOid` for the
-> commit SHA. For multi-line selections use `start_line` +
+> For multi-line selections use `start_line` +
 > `start_side='RIGHT'` + `line` (end) on the same call.
 
 1. **Erlang review** ΓÇö fetch `gh pr diff <n>` and run a strict Erlang
@@ -228,10 +237,19 @@ The PR is **squash-merged** if **all** of the following hold:
   the conflict before posting a rebase request.
 
 If **any** condition fails, post the substantive finding as an
-**inline** review comment at the relevant file:line, post a short
-top-level **summary** verdict (REQUEST CHANGES / DUPLICATE /
-NEEDS REBASE) via `gh pr review --comment`, do **not** merge, and
-move to the next candidate.
+**inline** review comment at the relevant file:line, then post a
+short top-level **summary** verdict with the right `gh pr review`
+flag (do **not** always use `--comment` — that submits a neutral
+review, not a blocking one):
+
+| Verdict | Command |
+|---------|---------|
+| APPROVE (clean) | `gh pr review <n> --approve -b "<one-line summary>"` |
+| REQUEST CHANGES (blocker) | `gh pr review <n> --request-changes -b "<inline-finding pointers + one-line summary>"` |
+| DUPLICATE | `gh pr review <n> --comment -b "DUPLICATE of #<other>: <reason>"` |
+| NEEDS REBASE | `gh pr review <n> --comment -b "NEEDS REBASE: <conflict-summary>"` |
+
+Do **not** merge and move to the next candidate.
 
 ### Conflict resolution (when `mergeable == CONFLICTING`)
 
@@ -257,8 +275,9 @@ covers three cases and is ordered least-invasive first:
 
    ```bash
    # High file-overlap = |intersection| / |target files| >= 0.5
+   TARGET=$(gh pr view <n> --json number --jq .number)
    gh pr list --state open --json number,title,files --limit 200 \
-     | jq --argjson target <pr-number> '
+     | jq --argjson target "$TARGET" '
        (map(select(.number == $target) | .files[].path) | unique) as $tf
        | .[]
        | select(.number != $target)
@@ -272,6 +291,8 @@ covers three cases and is ordered least-invasive first:
            overlap_pct: (($inter / ($tf | length)) * 100 | floor)
          }'
    ```
+   `<n>` is the PR being reviewed; `TARGET` resolves it to the
+   authoritative `number` from the GitHub API.
 
    If a candidate surfaces with high file-overlap (>= 50% of the
    target's touched files), post the close-as-duplicate comment.
@@ -294,27 +315,32 @@ matches root `AGENTS.md` ΓåÆ **Cross-Platform File I/O & Paths** and
 
 ```bash
 # Portable: repo-local disposable worktree (Windows + Unix) ΓÇö never /tmp or %TEMP%
-WORKTREE_DIR=".kilo/worktrees/review-<n>"
+PR_BRANCH="<pr-branch>"            # e.g. feat/foo
+PR_NUMBER=<n>                      # PR number (int)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKTREE_DIR="${REPO_ROOT}/.kilo/worktrees/review-${PR_NUMBER}"
+git worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true   # idempotent
 git fetch origin main
-git fetch origin "<pr-branch>"
-git worktree add "$WORKTREE_DIR" "origin/<pr-branch>"
+git fetch origin "$PR_BRANCH"
+git worktree add "$WORKTREE_DIR" "origin/$PR_BRANCH"
 cd "$WORKTREE_DIR"
 if git rebase origin/main; then
-  # From each changed module: resolve the repo-root Maven wrapper portably
-  # (adjust ../ depth so the path points at the monorepo root wrapper).
-  cd <module>
-  if [ -f ../../mvnw.cmd ]; then
-    ../../mvnw.cmd clean install
-  elif [ -f ../../mvnw ]; then
-    ../../mvnw clean install
-  elif [ -f ../mvnw.cmd ]; then
-    ../mvnw.cmd clean install
-  else
-    ../mvnw clean install
+  # Resolve the monorepo-root Maven wrapper once (works for any module depth).
+  if   [ -f "$REPO_ROOT/mvnw.cmd" ]; then WRAPPER="$REPO_ROOT/mvnw.cmd"
+  elif [ -f "$REPO_ROOT/mvnw" ];     then WRAPPER="$REPO_ROOT/mvnw"
+  else echo "FATAL: no mvnw / mvnw.cmd at $REPO_ROOT" >&2; exit 1
   fi
-  cd "$WORKTREE_DIR"
-  git push --force-with-lease origin "HEAD:<pr-branch>"
-  cd - && git worktree remove --force "$WORKTREE_DIR"
+  # Run pre-PR build per changed module. Discover modules from the diff
+  # vs origin/main (post-rebase) so we cover every module the PR touched.
+  mapfile -t MODULES < <(git diff --name-only origin/main..HEAD \
+    | xargs -I{} dirname {} | sort -u \
+    | awk -F/ 'NF==1{print "."} NF>1{print $1}' | sort -u)
+  for m in "${MODULES[@]}"; do
+    [ -f "$m/pom.xml" ] || continue
+    ( cd "$WORKTREE_DIR/$m" && "$WRAPPER" clean install )
+  done
+  git push --force-with-lease origin "HEAD:$PR_BRANCH"
+  git worktree remove --force "$WORKTREE_DIR"
   # proceed to squash-merge
 else
   git rebase --abort
@@ -323,12 +349,13 @@ else
 fi
 ```
 
-`--force-with-lease` is permitted here per the user's explicit
-instruction for review-driven rebases of third-party PRs.
-**Never force-push to `main`** ΓÇö only to the PR's own branch.
-Feature-branch rewriting still disturbs any reviewers who have based
-work on the branch, so log the rebase in the review comment so the
-author knows their branch tip moved.
+`--force-with-lease` is permitted here only because the rebase is
+against `origin/main` (not `main`) and the push target is the PR's
+own branch (never `main`). Per `.kilo/rules/no-force-push-development.md`
+this is the explicitly documented exception for **review-driven
+rebases of third-party PRs**; the comment "log the rebase in the
+review comment" is mandatory so the original author knows their
+branch tip moved. **Never** force-push to `main`.
 
 ### Squash-merge command
 
@@ -410,10 +437,14 @@ already claimed.
      --limit 500 \
      | jq --arg issue "$ISSUE" '
        [.[] | select(
-         (.body | test("#" + $issue + "\\b"))
-         or ((.closingIssuesReferences // []) | index(($issue | tonumber)) != null)
+         (.body // "" | test("(^|[^0-9])#" + $issue + "($|[^0-9])"))
+         or (((.closingIssuesReferences // []) | map(.number // empty)) | any(. == ($issue | tonumber)))
        ) | {number, state}]'
    ```
+   Note: jq `test` is POSIX ERE (no `\b`), so the regex anchors with
+   explicit non-digit boundaries to avoid `#1` matching `#10`, `#11`, ….
+   `closingIssuesReferences` is an array of `{number, …}` objects, so
+   we map to `.number` before the integer comparison.
 3. **Comment-based claim check.** The latest 5 comments include an
    agent-attributed pickup signal ΓÇö any of: `picking this up`,
    `starting work`, `picked up`, `agent progress`, `pr_opened`,

--- a/.kilo/workflows/pickup-issue.md
+++ b/.kilo/workflows/pickup-issue.md
@@ -1,10 +1,10 @@
 ---
-description: Triage the open GitHub issue backlog and select up to N (default 5) high-priority candidates that have actionable engineering work for a Kilo session. Outputs a triage dataset and stops; does not pick, branch, or commit on its own.
+description: Triage the open GitHub issue backlog and select up to N (default 5) high-priority candidates that have actionable engineering work for a Kilo session. Also runs a PR review-and-merge pass (own-thread clear + other-agent reviews) before triage. Outputs a triage dataset and stops; does not pick, branch, or commit on its own during triage.
 ---
 
 ## Goal
 
-Produce a **triage dataset** — a ranked list of the first `MAX_TASKS`
+Produce a **triage dataset** ΓÇö a ranked list of the first `MAX_TASKS`
 (default `5`) open p1..p8 issues that have actionable engineering
 work for a Kilo session. The output is a list, not a single pick,
 so the human (or a follow-up session) can decide which candidate to
@@ -13,16 +13,358 @@ actually drive to a PR.
 - **`MAX_TASKS`** (default `5`): cap on candidates returned per
   workflow run. Workflow stops once the cap is reached.
 - **`MAX_PRIORITY`** (default `p1`): highest priority bucket the
-  walk starts from. Discovery walks `p1` → `p2` → … and stops once
+  walk starts from. Discovery walks `p1` ΓåÆ `p2` ΓåÆ ΓÇª and stops once
   `MAX_TASKS` survivors are accumulated **or** every priority is
   exhausted, whichever comes first.
 
-The workflow **reads only**. It does **not** apply `in progress`
+The **triage** path **reads only**. It does **not** apply `in progress`
 labels, does **not** open branches, and does **not** commit or push.
 A separate `pick-and-work` invocation (or the human) picks one row
 from the dataset and drives it to a PR.
 
-## Discovery
+**Run order for a full session:** (1) Kilo own-PR comment resolution,
+(2) PR review pass for other agents / unlabeled PRs, (3) issue triage.
+Do **not** chain PR review and issue triage in the same run ΓÇö after
+the review pass emits its summary, **stop**; triage runs in a
+subsequent invocation.
+
+## Kilo PR comment resolution ΓÇö clear threads on YOUR OWN open PRs (run BEFORE the PR review pass)
+
+Before reviewing other agents' PRs, scan **your own** open PRs
+(any PR carrying the `operator:kilo` label) for unresolved review
+threads and resolve them per root `AGENTS.md` ΓåÆ **PR Review
+Comment Resolution**. The PR review pass downstream assumes Kilo's
+own backlog is already clean.
+
+### Discover (own PRs)
+
+```bash
+gh pr list --state open --json number,title,labels --limit 200 \
+  | jq -r '.[]
+      | select((.labels | map(.name) | any(. == "operator:kilo")))
+      | .number'
+```
+
+### Per PR ΓÇö resolve every unresolved thread
+
+For each open PR with `operator:kilo`:
+
+1. **Fetch the review threads** (GraphQL ΓÇö the REST comments API
+   does not expose thread-level resolution state):
+
+   ```bash
+   gh api graphql -H "X-GitHub-Api-Version: 2022-11-28" \
+     -f query='query($owner: String!, $repo: String!, $n: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $n) {
+           reviewThreads(first: 50) {
+             nodes {
+               id isResolved isOutdated
+               comments(first: 1) {
+                 nodes { databaseId path line body }
+               }
+             }
+           }
+         }
+       }
+     }' \
+     -f owner=<owner> -f repo=<repo> -F n=<n>
+   ```
+2. For **each unresolved** thread (regardless of who authored the
+   first comment ΓÇö your own, another agent, a human, or the
+   kilo-code-bot):
+   - Read the finding body and the file:line context.
+   - Decide the mitigation: code fix in a follow-up commit on the
+     PR's branch, doc fix, or a documented "noted ΓÇö won't fix
+     because X".
+   - **Reply inline** with the mitigation, citing the commit hash
+     (e.g. `f1908b961e`):
+
+     ```bash
+     gh api -X POST repos/<owner>/<repo>/pulls/<n>/comments/<databaseId>/replies \
+       -f body='**Mitigation (commit <hash>):** <one-paragraph fix description + test/script/doc pointer>'
+     ```
+   - **Resolve the thread** via GraphQL `resolveReviewThread`:
+
+     ```bash
+     gh api graphql -H "X-GitHub-Api-Version: 2022-11-28" \
+       -f query='mutation($threadId: ID!) {
+         resolveReviewThread(input: { threadId: $threadId }) {
+           thread { id isResolved }
+         }
+       }' -f threadId="<thread-id-PRRT_ΓÇª>"
+     ```
+3. **Outdated threads** (where the diff no longer contains the
+   offending line ΓÇö `isOutdated: true`) still need an inline
+   reply explaining the mitigation AND a `resolveReviewThread` call.
+   `isOutdated: true` is informational; it does **not** auto-resolve.
+4. **Do not** mark a thread as resolved without first replying
+   inline with a mitigation statement. A bare `resolveReviewThread`
+   call is not a substitute for a documented fix.
+
+### Sequence
+
+Run **before** the PR review pass ΓÇö clear Kilo's own backlog first,
+then review others. This ensures the PR review pass sees a clean
+review-thread state on Kilo's PRs before applying the same gate to
+incoming reviews.
+
+### Stop condition
+
+When **every** `operator:kilo` open PR has zero unresolved review
+threads, proceed to the PR review pass. Otherwise emit a one-line
+per-PR summary showing remaining unresolved count and continue
+working through the list ΓÇö never skip a thread.
+
+## PR review pass ΓÇö review-and-merge queue (run BEFORE triage)
+
+Before any new triage picks up engineering work, scan the open PR list
+for PRs authored by **another model** (or by **no model** at all) that
+need a code review from Kilo and are candidates for squash-merge on
+a clean review. The pass clears the review queue so new engineering
+starts on a clean tree.
+
+### Discover (other-agent / unlabeled PRs)
+
+```bash
+gh pr list --state open \
+  --sort created --direction asc \
+  --json number,title,author,labels,headRefName,baseRefName \
+  --limit 200 | jq -r '
+    .[]
+    | select(
+        ((.labels | map(.name) | any(. == "operator:kilo")) | not)
+        and (
+          (.labels | map(.name) | any(startswith("operator:grok") or startswith("operator:night-issue-prs") or startswith("operator:minimax")))
+          or ((.labels | map(.name) | any(startswith("model:"))) | not)
+        )
+      )
+    | "\(.number)|\(.author.login)|\(.title)"
+  '
+```
+
+`--sort created --direction asc` is required so processing order is
+oldest-first (matches the Review instructions below). Without it,
+GitHub's default sort does not guarantee age order.
+
+The filter (per the user's direction):
+
+| Condition | Meaning |
+|-----------|---------|
+| Not `operator:kilo` | Kilo has not claimed it; an independent review is owed. |
+| Has `operator:grok` / `operator:night-issue-prs` / `operator:minimax` | Other-agent work ΓÇö Kilo reviews it. |
+| Has **no** `model:*` label | Per the user's rule: "if no model is listed then you should select it for review." |
+
+PRs authored by the human owner (`natechadwick-intsof`) without an
+agent attribution fall into the "no model listed" branch and are
+selected for review unless the human has explicitly delegated them.
+
+### Review
+
+For each candidate PR, in the order returned by
+`gh pr list --sort created --direction asc` (oldest first):
+
+> **All review comments must be inline** ΓÇö per the user's rule
+> (2026-08-08). Use `gh api -X POST .../pulls/<n>/comments` with
+> `path` + `line` + `commit_id` to attach the comment to the
+> specific file:line in the diff. Top-level PR comments via
+> `gh pr review --comment` are reserved for summary verdicts
+> (APPROVE / REQUEST CHANGES / DUPLICATE / NEEDS REBASE) only;
+> substantive findings always go inline. The inline-comment helper:
+>
+> ```bash
+> gh api -X POST repos/<owner>/<repo>/pulls/<n>/comments \
+>   -f body='<finding>' \
+>   -f path='<file>' \
+>   -F line=<n> \
+>   -F side='RIGHT' \
+>   -F commit_id='<head-sha>'
+> ```
+>
+> Use `gh pr view <n> --json headRefOid --jq .headRefOid` for the
+> commit SHA. For multi-line selections use `start_line` +
+> `start_side='RIGHT'` + `line` (end) on the same call.
+
+1. **Erlang review** ΓÇö fetch `gh pr diff <n>` and run a strict Erlang
+   review against the
+   `.kilo/workflows/erlang-review` persona. Look for: bug findings,
+   missing behavioral tests on new/changed non-trivial logic,
+   non-portable path / file I/O (Windows/Unix), security issues
+   (CodeQL-style), missing or wrong copyright headers on **new**
+   files (>= 2023 must use `Intersoft Data Labs`), missing
+   Co-Authored footer on agent commits, missing
+   `operator + model` labels on the PR. Post each finding
+   **inline** at the relevant file:line.
+2. **Pre-PR build evidence** ΓÇö read the PR body for standalone
+   module clean-install results (`cd <module>` then repo-root
+   `mvnw` / `mvnw.cmd clean install`). If absent, re-run on a
+   fresh worktree pointing at the PR head; if it fails, post an
+   inline comment on the relevant test/build file and request
+   changes. If the PR is docs-only / non-Maven, the body should
+   say so explicitly.
+3. **CI checks** ΓÇö `gh pr checks <n>` ΓÇö confirm required checks
+   pass or are explicitly skipped. Failures block the merge.
+4. **Review-thread state** ΓÇö `gh api graphql ... reviewThreads` ΓÇö
+   confirm every prior review comment has an inline reply AND a
+   `resolveReviewThread` mutation. Unresolved threads block the
+   merge per root `AGENTS.md` ΓåÆ **PR Review Comment Resolution**.
+
+### Squash-merge decision
+
+The PR is **squash-merged** if **all** of the following hold:
+
+- Erlang review verdict: APPROVE (no bug findings; non-portable path
+  / file I/O absent or already justified; behavioral tests present
+  for new/changed non-trivial logic).
+- Pre-PR build evidence: present (or skipped with a documented
+  reason in the PR body).
+- CI: every required check passes or is explicitly skipped.
+- Review threads: zero unresolved threads (each prior finding has an
+  inline reply + `resolveReviewThread` call).
+- PR carries `operator + model` labels per
+  `.kilo/rules/operator-pr-labels.md`.
+- `mergeable == MERGEABLE`. If `mergeable == CONFLICTING`, see
+  **Conflict resolution** below ΓÇö the reviewer attempts to clear
+  the conflict before posting a rebase request.
+
+If **any** condition fails, post the substantive finding as an
+**inline** review comment at the relevant file:line, post a short
+top-level **summary** verdict (REQUEST CHANGES / DUPLICATE /
+NEEDS REBASE) via `gh pr review --comment`, do **not** merge, and
+move to the next candidate.
+
+### Conflict resolution (when `mergeable == CONFLICTING`)
+
+When a candidate PR reports `CONFLICTING`, attempt to resolve the
+conflict locally before blocking on the author. The attempt
+covers three cases and is ordered least-invasive first:
+
+1. **Trivial rebase** ΓÇö fetch the PR head, attempt `git rebase
+   origin/main` in a disposable worktree. If the rebase applies
+   cleanly (no text conflicts), run the module's pre-PR build
+   (see portable `mvnw` snippet below), push the result with
+   `--force-with-lease`, and proceed to the squash-merge step.
+   This unblocks PRs that just need a refresh against current
+   `main`.
+2. **Duplicate of an open Kilo PR** ΓÇö if the rebase fails and the
+   conflicting hunks overlap with an open Kilo PR on the same
+   files (see `.kilo/rules/no-force-push-development.md` ΓåÆ
+   exception for review-driven rebases), post a comment recommending
+   closure as duplicate of the Kilo PR and skip. Do **not** attempt
+   a force-push resolution that would clobber the Kilo PR. The
+   duplicate-detection heuristic computes **set overlap percentage**
+   (not a contiguous-subarray match):
+
+   ```bash
+   # High file-overlap = |intersection| / |target files| >= 0.5
+   gh pr list --state open --json number,title,files --limit 200 \
+     | jq --argjson target <pr-number> '
+       (map(select(.number == $target) | .files[].path) | unique) as $tf
+       | .[]
+       | select(.number != $target)
+       | (.files | map(.path) | unique) as $cf
+       | ($tf | map(select(. as $p | $cf | index($p) != null)) | length) as $inter
+       | select(($tf | length) > 0 and ($inter / ($tf | length)) >= 0.5)
+       | {
+           number, title,
+           overlap_count: $inter,
+           target_count: ($tf | length),
+           overlap_pct: (($inter / ($tf | length)) * 100 | floor)
+         }'
+   ```
+
+   If a candidate surfaces with high file-overlap (>= 50% of the
+   target's touched files), post the close-as-duplicate comment.
+   Do **not** use jq `inside()` for this check ΓÇö `inside()` is a
+   contiguous subarray match and would flag any single shared file.
+3. **Non-trivial conflict** ΓÇö if the rebase fails with text conflicts
+   that are **not** a duplicate signal, post a structured review
+   comment with the conflict markers (`<<<<<<<` / `=======` /
+   `>>>>>>>`) excerpted from `git diff` and request a rebase from
+   the author. Do **not** push a partial resolution. Do **not**
+   leave the worktree in a half-rebased state ΓÇö `git rebase --abort`
+   and remove the worktree (portable path below) before moving on.
+
+#### Trivial rebase command (portable worktree + mvnw)
+
+Use a **repo-local** worktree under `.kilo/worktrees/` (gitignored)
+rather than OS-specific temp roots such as `/tmp` or `%TEMP%`. This
+matches root `AGENTS.md` ΓåÆ **Cross-Platform File I/O & Paths** and
+**Git worktree hygiene**.
+
+```bash
+# Portable: repo-local disposable worktree (Windows + Unix) ΓÇö never /tmp or %TEMP%
+WORKTREE_DIR=".kilo/worktrees/review-<n>"
+git fetch origin main
+git fetch origin "<pr-branch>"
+git worktree add "$WORKTREE_DIR" "origin/<pr-branch>"
+cd "$WORKTREE_DIR"
+if git rebase origin/main; then
+  # From each changed module: resolve the repo-root Maven wrapper portably
+  # (adjust ../ depth so the path points at the monorepo root wrapper).
+  cd <module>
+  if [ -f ../../mvnw.cmd ]; then
+    ../../mvnw.cmd clean install
+  elif [ -f ../../mvnw ]; then
+    ../../mvnw clean install
+  elif [ -f ../mvnw.cmd ]; then
+    ../mvnw.cmd clean install
+  else
+    ../mvnw clean install
+  fi
+  cd "$WORKTREE_DIR"
+  git push --force-with-lease origin "HEAD:<pr-branch>"
+  cd - && git worktree remove --force "$WORKTREE_DIR"
+  # proceed to squash-merge
+else
+  git rebase --abort
+  git worktree remove --force "$WORKTREE_DIR"
+  # post duplicate-or-conflict comment; skip
+fi
+```
+
+`--force-with-lease` is permitted here per the user's explicit
+instruction for review-driven rebases of third-party PRs.
+**Never force-push to `main`** ΓÇö only to the PR's own branch.
+Feature-branch rewriting still disturbs any reviewers who have based
+work on the branch, so log the rebase in the review comment so the
+author knows their branch tip moved.
+
+### Squash-merge command
+
+```bash
+gh pr merge <n> --squash --delete-branch \
+  --subject "<concise commit subject ΓÇö match the PR title or scope>" \
+  --body "<PR summary; preserve original PR body unless empty>"
+```
+
+After merge, post a brief confirmation comment on the issue the PR
+closes (if the PR body references one). Apply `Reviewed-by: Kilo`
+trailer to the merge commit via `--body` if the GitHub UI does not
+auto-fill it.
+
+### Stop (after review pass)
+
+After the review pass, emit the summary block and **stop** before
+running the triage pass:
+
+```
+PR REVIEW ΓÇö Kilo (model: $KILO_MODEL)
+
+1.  #<n>  <title>  ΓåÆ  SQUASH-MERGED | REQUESTED CHANGES | SKIPPED
+2.  #<n>  <title>  ΓåÆ  ΓÇª
+
+(<x> reviewed, <y> merged, <z> needs changes, <w> skipped)
+```
+
+If the summary is empty (no candidates), report
+`No open PRs from other models need a code review.` and **stop**.
+The triage pass runs in a subsequent invocation ΓÇö do not chain
+PR review and issue triage in the same run.
+
+---
+
+## Discovery (issue triage)
 
 For each priority `p<N>` in `p1`..`p8`, query with explicit
 ascending-`createdAt` order so "first row" = "oldest":
@@ -42,7 +384,67 @@ For each candidate, filter out any issue whose `labels[].name` equals
 becomes the next candidate to scope-check. Capture `ISSUE=<number>`
 and `TITLE=<title>` for the steps below.
 
-## Scope check — there must be engineering to do
+### Already-picked-up check (per candidate)
+
+Before the candidate becomes the chosen issue, run **three** pickup
+checks. Any one of them signals "someone is already on it" and the
+candidate is dropped from the candidate set; Discovery resumes with
+the next oldest survivor at the same priority. This contract is
+**shared with the grok nightly-PR workflow** (host-local
+`.grok/workflows/`): both sides honor the same three checks so an
+agent on one side never starts parallel work the other side has
+already claimed.
+
+1. **Label check.** Issue carries `in progress` label ΓåÆ skip. Both
+   the Kilo pickup workflow and the grok nightly-PR workflow apply
+   this label when they start work and remove it when a PR is opened
+   so an issue is available for handoff only when no PR is in flight.
+2. **PR-reference check.** Any PR whose body references the issue
+   number (via `#<n>` / "closes #N" / "fixes #N") or whose
+   `closingIssuesReferences` includes the issue, in state `OPEN`
+   or `MERGED` ΓåÆ skip. (`CLOSED` without merge is **not** a
+   pickup signal ΓÇö the work was abandoned; defer to check 3.)
+
+   ```bash
+   gh pr list --state all --json number,state,body,closingIssuesReferences \
+     --limit 500 \
+     | jq --arg issue "$ISSUE" '
+       [.[] | select(
+         (.body | test("#" + $issue + "\\b"))
+         or ((.closingIssuesReferences // []) | index(($issue | tonumber)) != null)
+       ) | {number, state}]'
+   ```
+3. **Comment-based claim check.** The latest 5 comments include an
+   agent-attributed pickup signal ΓÇö any of: `picking this up`,
+   `starting work`, `picked up`, `agent progress`, `pr_opened`,
+   `pr opened`, `in flight`, or a status table entry with value
+   `in_progress` / `pr_opened` / `done` / `merged`. Authored by
+   a known agent handle (`grok`, `minimax`, `kilo`, or any
+   `operator:*`-attributed handle).
+
+   ```bash
+   gh issue view "$ISSUE" --comments --json comments --jq '
+     .comments | sort_by(.createdAt) | reverse | .[0:5]
+     | map({author: .author.login, body: .body})'
+   ```
+   The full comment body is preserved (no truncation) so tracker
+   directives at any character offset are still visible.
+
+When a candidate is skipped on any of the three checks, log:
+
+```
+SKIP #<n>: <which-check> triggered ΓÇö <one-line evidence>
+```
+
+ΓÇªand resume Discovery with the next oldest survivor at the same
+priority. If every candidate at every priority skips, report
+`No open p1..p8 issue is available to pick up.` and **stop** ΓÇö do
+not invent work.
+
+If every `p1..p8` query returns an empty filtered list, report
+`No open p1..p8 issue is available.` and **stop** ΓÇö do not invent work.
+
+## Scope check ΓÇö there must be engineering to do
 
 After the candidate row is chosen, read the issue body and recent
 comments to confirm there is real engineering work a Kilo worktree
@@ -54,14 +456,14 @@ Discovery with the next oldest survivor at the same priority) if
    implement the acceptance criteria and every one of those PRs is
    `MERGED` (or the linked child issues are closed with no open
    residual).
-2. The comments contain a tracker directive — any of:
+2. The comments contain a tracker directive ΓÇö any of:
    `leave open as tracker`, `parent stays open until residual`,
    `close gate: #<n>`, `no further engineering slices scheduled`,
    `all AC met`. The directive must be from the issue's own audit
    comment, not a one-off remark.
 3. The remaining open child issues (if any) are documented as
    blocked on customer data (`requires customer env`, `verify ops
-   path`, etc.) — i.e. nothing in this issue is actionable from a
+   path`, etc.) ΓÇö i.e. nothing in this issue is actionable from a
    Kilo worktree.
 
 If the candidate is a **research / spec parent** (e.g. #2400), the
@@ -74,12 +476,12 @@ skipped.
 Use this query to fetch the audit comment and the open children:
 
 ```bash
-# Latest 5 comments — to find the tracker directive
+# Latest 5 comments ΓÇö to find the tracker directive
 gh issue view "$ISSUE" --comments --json comments --jq '.comments
   | sort_by(.createdAt) | reverse | .[0:5]
   | map({author: .author.login, body: .body[0:200]})'
 
-# Open children — to see if any are engineering slices
+# Open children ΓÇö to see if any are engineering slices
 gh issue list --state open --json number,title --limit 200 \
   | jq --arg issue "$ISSUE" '[.[]
       | select(.title | test("issue " + $issue + "( |$)", "i"))
@@ -93,7 +495,7 @@ actionable** in one or two sentences for the triage dataset:
   #2435/#2436; #2435 needs `@Lazy` ctor-param fix").
 - For research parents, the concrete artifact to ship (e.g.
   "spec/plan file under `specs/2400-dce-explorer-parity.md`").
-- For unknown / under-specified bodies, "needs scoping" — the
+- For unknown / under-specified bodies, "needs scoping" ΓÇö the
   next session must read the issue body and decide.
 
 ## Accumulate, then stop
@@ -107,7 +509,7 @@ MAX_PRIORITY="${MAX_PRIORITY:-p1}"
 ```
 
 If the priority walk reaches `p8` with fewer than `MAX_TASKS`
-candidates, the workflow still stops — a short dataset is more
+candidates, the workflow still stops ΓÇö a short dataset is more
 useful than padding it with low-priority work.
 
 ## Triage dataset output
@@ -118,7 +520,7 @@ so downstream tooling can parse it:
 ### Human-readable
 
 ```
-TRIAGE — Kilo pickup (model: $KILO_MODEL, max: $MAX_TASKS)
+TRIAGE ΓÇö Kilo pickup (model: $KILO_MODEL, max: $MAX_TASKS)
 
 1.  #1234  p1  <title>
         scope: <one-line summary>
@@ -131,8 +533,8 @@ TRIAGE — Kilo pickup (model: $KILO_MODEL, max: $MAX_TASKS)
 (2 candidates, 3 priorities scanned)
 
 Skipped during this run:
-  - #804  tracker-only — all engineering merged, audit says leave open
-  - #934  tracker-only — gap-matrix says AC1/2/3/4/5/6 met
+  - #804  tracker-only ΓÇö all engineering merged, audit says leave open
+  - #934  tracker-only ΓÇö gap-matrix says AC1/2/3/4/5/6 met
 ```
 
 ### JSON
@@ -156,8 +558,8 @@ Skipped during this run:
     }
   ],
   "skipped": [
-    { "number": 804, "reason": "tracker-only — all engineering merged, audit says leave open" },
-    { "number": 934, "reason": "tracker-only — gap-matrix says AC1/2/3/4/5/6 met" }
+    { "number": 804, "reason": "tracker-only ΓÇö all engineering merged, audit says leave open" },
+    { "number": 934, "reason": "tracker-only ΓÇö gap-matrix says AC1/2/3/4/5/6 met" }
   ]
 }
 ```
@@ -167,7 +569,7 @@ readable block (so it is visible in the chat) and offer the JSON
 on request. Do **not** auto-write the dataset to disk unless the
 human asks; keep the chat output as the source of truth.
 
-## Stop
+## Stop (after triage)
 
 After emitting the dataset, the workflow is done. Do **not**:
 
@@ -181,10 +583,10 @@ agent to drive that one issue to a PR.
 
 ## Do **not** do
 
-- Do **not** filter on `operator:*` labels — they are workflow
+- Do **not** filter on `operator:*` labels ΓÇö they are workflow
   attribution, not assignment, and must not disqualify a candidate.
-- Do **not** pick, branch, commit, push, or open a PR. This
-  workflow is triage-only.
+- Do **not** pick, branch, commit, push, or open a PR during the
+  triage path. This workflow's triage phase is triage-only.
 - Do **not** pad the dataset to `MAX_TASKS` if the priority walk
   ran out earlier. Short dataset beats low-priority padding.
 - Do **not** write the dataset to disk unless the human asks. The
@@ -198,3 +600,8 @@ agent to drive that one issue to a PR.
   is unset, stop.
 - Do **not** invent a `daily-status` label or any new label outside
   this workflow's allowlist.
+- Do **not** hardcode OS-specific temp paths (`/tmp`, `%TEMP%`) for
+  review worktrees ΓÇö use `.kilo/worktrees/review-<n>` under the
+  repo root.
+- Do **not** use a literal path `mvnw[.cmd]` in shell examples ΓÇö
+  always branch on `mvnw.cmd` vs `mvnw`.


### PR DESCRIPTION
## chore(kilo): pickup-issue workflow — PR review pass + already-picked-up check

Adds two workflow steps to `.kilo/workflows/pickup-issue.md`:

### 1. Already-picked-up check (Discovery-time per-candidate filter)

Skip a candidate if any of three signals is present:

- `in progress` label
- Open/merged PR whose body or `closingIssuesReferences` references the issue number (`CLOSED` without merge does **not** count — work was abandoned)
- Latest 5 comments include an agent pickup claim (`grok` / `minimax` / `kilo` or `operator:*`-attributed handle) with status language (`pr_opened` / `done` / `merged` / `picking this up`)

**Cross-workflow contract**: the same three checks apply to the grok nightly-PR workflow (host-local `.grok/workflows/`) so neither side starts parallel work the other has claimed.

### 2. PR review pass (runs before triage)

Scan the open PR list for PRs from other models (`operator:grok`, `operator:night-issue-prs`, `operator:minimax`) **or** with no `model:*` label. For each candidate:

1. Erlang review — bug findings, missing behavioral tests, non-portable path / file I/O
2. Pre-PR build evidence — `cd <module> && …/mvnw[.cmd] clean install` in PR body, or documented skip
3. CI checks — required checks pass or explicitly skipped
4. Review-thread state — every prior comment has an inline reply + `resolveReviewThread` call

**Squash-merge only when all four pass**; otherwise post a review comment and skip. Stops with a summary block; does not chain PR review + issue triage in the same run.

### Change-class scope

Workflow rule only — no code or test changes.

### Human review (HARD GATE)

Drafted per AGENTS.md **Human review of agent rules**; approved before commit.

> Co-Authored by Kilo Code 0.16.3 using minimax-coding-plan/MiniMax-M3 with agent main.
