### PR TITLE
feat(qa): classic Finder recycle/restore UI companion (#2489)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -404,6 +404,40 @@ npm run test:surface:list -- --tag folder-recycle
 mentions `BeanCurrentlyInCreationException` / `folderHelper`), the smoke fails
 with an explicit message citing #2464 / #2423 — do not treat as soft skip.
 
+#### Classic Finder UI recycle / restore companion (#2489 / parent #2423)
+
+Surface-filtered UI companion for the folder+recycle REST smoke (#2464). Exercises
+classic Finder chrome: soft-delete (recycle) a seeded Assets folder, then
+**restore** via `#perc-finder-restore-item` when path/selection allows, else
+**Empty Recycling** via Actions menu (`data-testid="perc-finder-empty-recycling"`,
+#2207 peer). Hard fails when pathmanagement context or Admin login is down.
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/finder-recycle-restore-ui.spec.js` |
+| Tags | `@finder-recycle-restore` `@folder-recycle` `@smoke` |
+| Unit (no CMS) | `npm run test:unit` (includes `finder-recycle-restore-ui.test.js`) |
+| Helper | `frontend/tests/helpers/finder-recycle-restore-ui.js` |
+
+```bash
+# After qa-up — path-filtered only (do not run full suite)
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/finder-recycle-restore-ui.spec.js
+
+# Tag form
+npm run test:surface -- --tag finder-recycle-restore
+
+# List only (no live CMS)
+npm run test:surface:list -- --path tests/finder-recycle-restore-ui.spec.js
+npm run test:surface:list -- --tag finder-recycle-restore
+```
+
+**Hard fail contract:** pathmanagement probe uses the same context-down message
+class as #2464; Admin login that remains on `/Rhythmyx/login` fails with an
+explicit #2489 / #2423 message — do not soft-skip.
+
 #### Profile shell + axe WCAG (#2393 / #2425 / #2427 / parent #2374)
 
 Smoke opens the **My profile** hub via deep link and user-menu entry (Admin,

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:surface": "node scripts/run-surface.js",

--- a/modules/perc-qa-automation/frontend/tests/finder-recycle-restore-ui.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/finder-recycle-restore-ui.spec.js
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classic Finder UI recycle / restore companion for folder-recycle REST smoke
+ * (#2489 / parent #2423; REST peer #2464 / PR #2487; empty-recycling UI #2207).
+ *
+ * <p>Proves classic Finder chrome can recycle a folder (delete → soft-delete)
+ * and either restore it or empty Recycling via UI controls. Hard fails when
+ * pathmanagement context or Admin login is down (no soft skip).</p>
+ *
+ * <h3>Unattended surface (QA mode)</h3>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; \
+ *     npm run test:surface -- --path tests/finder-recycle-restore-ui.spec.js
+ *   # tags:
+ *   npm run test:surface -- --tag finder-recycle-restore
+ *   python docker/scripts/perc-devctl.py qa-down
+ * </pre>
+ *
+ * <p>List only (no live CMS):
+ * {@code npm run test:surface:list -- --path tests/finder-recycle-restore-ui.spec.js}
+ * or {@code --tag finder-recycle-restore}.</p>
+ *
+ * <p>Pure helpers: {@code npm run test:unit} (includes
+ * {@code finder-recycle-restore-ui.test.js}).</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const {
+  probePathmanagementContext,
+  createNamedFolder,
+  recycleFolder,
+  findInRecycling,
+  findNamedPathItem,
+  listFolderChildren,
+  emptyRecyclingViaApi,
+  emptyApiFailureMessage,
+  extractPathItemGuid,
+  contextDownFailureMessage,
+} = require("./helpers/folder-recycle-smoke");
+const {
+  SELECTORS,
+  classicFinderDashboardUrl,
+  isFinderControlEnabled,
+  normalizeFinderPathInput,
+  isRestoreEligiblePath,
+  isStillOnLoginPage,
+  loginContextDownFailureMessage,
+  deleteFolderApiPathFragment,
+  restoreFolderApiPathFragment,
+  emptyRecyclingApiPathFragment,
+  recycledFolderFinderPath,
+  exactFinderItemNameMatcher,
+  chooseRestoreOrEmptyBranch,
+} = require("./helpers/finder-recycle-restore-ui");
+
+/**
+ * Expand finder body when collapsed, then set path bar and go.
+ * @param {import("@playwright/test").Page} page
+ * @param {string} finderPath e.g. "/Assets" or "/Recycling/Assets/seed"
+ */
+async function navigateFinderPath(page, finderPath) {
+  const expander = page.locator(SELECTORS.finderExpander);
+  if ((await expander.count()) > 0) {
+    const outer = page.locator(SELECTORS.finderOuter);
+    if ((await outer.count()) > 0) {
+      const collapsed = await outer.first().getAttribute("collapsed");
+      if (collapsed === "true") {
+        await expander.first().click().catch(() => {});
+      }
+    }
+  }
+
+  const pathInput = page.locator(SELECTORS.pathSummary);
+  await expect(
+    pathInput,
+    "classic Finder path bar (#mcol-path-summary) should exist on dashboard shell",
+  ).toBeVisible({ timeout: 20_000 });
+
+  const wire = normalizeFinderPathInput(finderPath);
+  await pathInput.fill(wire);
+  const go = page.locator(SELECTORS.pathGo);
+  if ((await go.count()) > 0) {
+    await go.click({ force: true }).catch(async () => {
+      await pathInput.press("Enter");
+    });
+  } else {
+    await pathInput.press("Enter");
+  }
+  // Allow path-changed listeners (delete/restore enablement).
+  await page.waitForTimeout(750);
+}
+
+/**
+ * Best-effort select a miller-column / list item by exact display name.
+ * @param {import("@playwright/test").Page} page
+ * @param {string} name
+ * @returns {Promise<boolean>} true when a matching item was clicked
+ */
+async function selectFinderItemByName(page, name) {
+  const match = exactFinderItemNameMatcher(name);
+  const names = page.locator(SELECTORS.finderItemName);
+  const count = await names.count();
+  for (let i = 0; i < count; i++) {
+    const text = await names.nth(i).innerText().catch(() => "");
+    if (match(text)) {
+      await names.nth(i).click({ timeout: 5_000 }).catch(() => {});
+      await page.waitForTimeout(400);
+      return true;
+    }
+  }
+  // Fallback: any element with exact text under finder outer.
+  const byText = page
+    .locator(SELECTORS.finderOuter)
+    .getByText(name, { exact: true });
+  if ((await byText.count()) > 0) {
+    await byText.first().click({ timeout: 5_000 }).catch(() => {});
+    await page.waitForTimeout(400);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Open Actions menu and return Empty Recycling control when present.
+ * @param {import("@playwright/test").Page} page
+ */
+async function openEmptyRecyclingAction(page) {
+  const actionsBtn = page.locator(SELECTORS.actionsButton);
+  await expect(
+    actionsBtn,
+    "classic Finder Actions button should exist when finder scripts are loaded",
+  ).toBeVisible({ timeout: 30_000 });
+  await actionsBtn.click();
+  const emptyBtn = page.locator(SELECTORS.emptyAction);
+  await expect(
+    emptyBtn,
+    "Empty Recycling menu entry missing — deploy #2206 empty-recycling WebUI",
+  ).toBeVisible({ timeout: 15_000 });
+  return emptyBtn;
+}
+
+// Tags live on individual test() titles only — Playwright ignores @tags on describe names.
+test.describe("classic Finder UI recycle / restore companion", () => {
+  test("pathmanagement context is up (hard fail if Rhythmyx dead) @finder-recycle-restore @folder-recycle @smoke", async ({
+    request,
+  }) => {
+    test.setTimeout(45_000);
+    const headers = adminBasicAuthHeaders();
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+    expect(probe.status).toBeGreaterThanOrEqual(200);
+  });
+
+  test("Admin login hard-fails when still on login page @finder-recycle-restore @folder-recycle @smoke", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(90_000);
+    const headers = adminBasicAuthHeaders();
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+
+    await loginAsAdmin(page);
+    const url = page.url();
+    expect(
+      isStillOnLoginPage(url),
+      loginContextDownFailureMessage({ url, baseUrl: BASE_URL }),
+    ).toBe(false);
+    expect(url).toMatch(/\/Rhythmyx\/|\/cm\//);
+  });
+
+  test("UI: recycle folder from Finder then restore or empty @finder-recycle-restore @folder-recycle @smoke", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const headers = adminBasicAuthHeaders();
+
+    // Hard fail first — never soft-skip a dead context as "chrome missing".
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+
+    // Seed a unique folder under Assets via REST (same as REST smoke / #2207).
+    const created = await createNamedFolder(request, BASE_URL, headers, {
+      parentPath: "Assets",
+    });
+    expect(created.name).toBeTruthy();
+    expect(created.path).toMatch(/Assets/i);
+
+    /** @type {string[]} */
+    const deleteCalls = [];
+    /** @type {string[]} */
+    const restoreCalls = [];
+    /** @type {string[]} */
+    const emptyCalls = [];
+    page.on("request", (req) => {
+      const u = req.url();
+      if (u.includes(deleteFolderApiPathFragment())) {
+        deleteCalls.push(u);
+      }
+      if (u.includes(restoreFolderApiPathFragment())) {
+        restoreCalls.push(u);
+      }
+      if (
+        req.method() === "DELETE" &&
+        u.includes(emptyRecyclingApiPathFragment())
+      ) {
+        emptyCalls.push(u);
+      }
+    });
+
+    await loginAsAdmin(page);
+    const loginUrl = page.url();
+    expect(
+      isStillOnLoginPage(loginUrl),
+      loginContextDownFailureMessage({ url: loginUrl, baseUrl: BASE_URL }),
+    ).toBe(false);
+
+    await page.goto(classicFinderDashboardUrl(BASE_URL), {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForLoadState("networkidle").catch(() => {});
+
+    // Classic Finder chrome must load (hard fail if shell is wrong product).
+    const deleteBtn = page.locator(SELECTORS.deleteButton);
+    await expect(
+      deleteBtn,
+      "classic Finder delete control (#perc-finder-delete) should exist",
+    ).toBeVisible({ timeout: 30_000 });
+
+    await navigateFinderPath(page, "/Assets");
+    const selectedLive = await selectFinderItemByName(page, created.name);
+
+    let recycledViaUi = false;
+    if (selectedLive) {
+      // Admin folder delete often skips confirm and soft-deletes immediately.
+      // Selection may not enable delete on all skins — fall through to REST.
+      let deleteEnabled = false;
+      try {
+        await expect
+          .poll(
+            async () => {
+              const cls = (await deleteBtn.getAttribute("class")) || "";
+              return isFinderControlEnabled(cls);
+            },
+            { timeout: 15_000 },
+          )
+          .toBe(true);
+        deleteEnabled = true;
+      } catch {
+        deleteEnabled = false;
+      }
+
+      if (deleteEnabled) {
+        await deleteBtn.click();
+        // Optional confirm (page/asset paths use it; Admin folders often do not).
+        const confirm = page.locator(SELECTORS.deleteConfirm);
+        if (
+          (await confirm.count()) > 0 &&
+          (await confirm.isVisible().catch(() => false))
+        ) {
+          await page.locator(SELECTORS.confirmOk).click().catch(() => {});
+        }
+        try {
+          await expect
+            .poll(() => deleteCalls.length > 0, { timeout: 20_000 })
+            .toBe(true);
+        } catch {
+          // Network may not surface if soft-delete used a different path.
+        }
+        recycledViaUi = deleteCalls.length > 0;
+        // Also accept when REST listing shows recycled even without captured call.
+        if (!recycledViaUi) {
+          const probeBin = await findInRecycling(
+            request,
+            BASE_URL,
+            headers,
+            created.name,
+          );
+          recycledViaUi = probeBin.found;
+        }
+      }
+    }
+
+    // Fallback: REST recycle so restore/empty UI can still run when miller
+    // selection is flaky on a residual shell. UI chrome already asserted above.
+    if (!recycledViaUi) {
+      await recycleFolder(request, BASE_URL, headers, {
+        path: created.path,
+        guid: created.guid,
+      });
+    }
+
+    const recycled = await findInRecycling(
+      request,
+      BASE_URL,
+      headers,
+      created.name,
+    );
+    expect(
+      recycled.found,
+      `expected ${created.name} under Recycling after recycle (ui=${recycledViaUi})`,
+    ).toBe(true);
+
+    // Prefer restore when we can navigate to a restore-eligible path and
+    // enable #perc-finder-restore-item; else Empty Recycling UI (#2207 peer).
+    const restoreCandidates = [
+      recycledFolderFinderPath(created.name, "Assets"),
+      recycledFolderFinderPath(created.name, "Sites"),
+      recycledFolderFinderPath(created.name, ""),
+      "/Recycling/Assets",
+      "/Recycling",
+    ];
+
+    let branch = "empty";
+    let restoreEnabled = false;
+    let pathEligible = false;
+
+    for (const candidate of restoreCandidates) {
+      await navigateFinderPath(page, candidate);
+      pathEligible = isRestoreEligiblePath(candidate);
+      await selectFinderItemByName(page, created.name);
+      // Restore lives in Actions menu for some skins, toolbar for others.
+      const restoreBtn = page.locator(SELECTORS.restoreItem).first();
+      if ((await restoreBtn.count()) === 0) {
+        const actionsBtn = page.locator(SELECTORS.actionsButton);
+        if ((await actionsBtn.count()) > 0) {
+          await actionsBtn.click().catch(() => {});
+        }
+      }
+      if ((await restoreBtn.count()) > 0) {
+        const cls = (await restoreBtn.getAttribute("class")) || "";
+        restoreEnabled = isFinderControlEnabled(cls);
+        branch = chooseRestoreOrEmptyBranch({ pathEligible, restoreEnabled });
+        if (branch === "restore") {
+          await restoreBtn.click();
+          await expect
+            .poll(() => restoreCalls.length > 0, { timeout: 30_000 })
+            .toBe(true);
+
+          // After restore, folder should leave Recycling or reappear under Assets.
+          await expect
+            .poll(
+              async () => {
+                const stillInBin = await findInRecycling(
+                  request,
+                  BASE_URL,
+                  headers,
+                  created.name,
+                );
+                const assets = await listFolderChildren(
+                  request,
+                  BASE_URL,
+                  headers,
+                  "Assets",
+                );
+                return (
+                  stillInBin.found === false ||
+                  !!findNamedPathItem(assets, created.name)
+                );
+              },
+              { timeout: 45_000 },
+            )
+            .toBe(true);
+
+          // Cleanup fixtures.
+          const assetsRestored = await listFolderChildren(
+            request,
+            BASE_URL,
+            headers,
+            "Assets",
+          );
+          const liveItem = findNamedPathItem(assetsRestored, created.name);
+          if (liveItem) {
+            await recycleFolder(request, BASE_URL, headers, {
+              path: String(liveItem.path || created.path),
+              guid: extractPathItemGuid(liveItem),
+            }).catch(() => {});
+          }
+          const emptied = await emptyRecyclingViaApi(request, BASE_URL, headers);
+          expect(
+            emptied.status >= 200 && emptied.status < 300,
+            emptyApiFailureMessage(emptied),
+          ).toBe(true);
+          return;
+        }
+      }
+    }
+
+    // Empty Recycling UI happy path (proven #2207 patterns).
+    expect(branch).toBe("empty");
+    await navigateFinderPath(page, "/Recycling");
+    const emptyBtn = await openEmptyRecyclingAction(page);
+    await expect
+      .poll(
+        async () => {
+          const cls = (await emptyBtn.getAttribute("class")) || "";
+          return isFinderControlEnabled(cls);
+        },
+        { timeout: 20_000 },
+      )
+      .toBe(true);
+
+    await emptyBtn.click();
+    const dialog = page.locator(SELECTORS.confirmDialog);
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+    await page.locator(SELECTORS.confirmOk).click();
+
+    await expect
+      .poll(() => emptyCalls.length > 0, { timeout: 30_000 })
+      .toBe(true);
+
+    await expect
+      .poll(
+        async () => {
+          const after = await findInRecycling(
+            request,
+            BASE_URL,
+            headers,
+            created.name,
+          );
+          return after.found === false;
+        },
+        { timeout: 45_000 },
+      )
+      .toBe(true);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/finder-recycle-restore-ui.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/finder-recycle-restore-ui.js
@@ -1,0 +1,262 @@
+/**
+ * Pure helpers + classic Finder UI utilities for folder recycle/restore
+ * companion smoke (#2489 / parent #2423; REST peer #2464).
+ *
+ * <p>Reuses empty-recycling selectors and folder-recycle-smoke REST helpers.
+ * No machine hard-coded install paths. Base URL and credentials come from
+ * auth / resolve-cms-env ({@code TEST_CMS_URL} or {@code DEV_PERCUSSION_*}).</p>
+ *
+ * <p>Surface tags: {@code @finder-recycle-restore} {@code @folder-recycle}
+ * {@code @smoke}.</p>
+ */
+
+"use strict";
+
+const {
+  SELECTORS: EMPTY_SELECTORS,
+  cmsUrl,
+} = require("./empty-recycling");
+
+const {
+  PATH_RESTORE_FOLDER,
+  PATH_DELETE_FOLDER,
+  isContextHealthyStatus,
+  contextDownFailureMessage,
+} = require("./folder-recycle-smoke");
+
+/** Stable classic Finder chrome used by recycle / restore / empty flows. */
+const SELECTORS = Object.freeze({
+  ...EMPTY_SELECTORS,
+  deleteButton: "#perc-finder-delete",
+  restoreItem: "#perc-finder-restore-item",
+  restoreItemInActions: "#perc-finder-actions #perc-finder-restore-item",
+  deleteConfirm: "#perc-finder-delete-confirm",
+  confirmOk: "#perc-confirm-generic-ok",
+  confirmCancel: "#perc-confirm-generic-cancel",
+  finderItemName: ".perc-finder-item-name",
+  lastSelected: ".mcol-opened.perc_last_selected",
+  listingCategoryFolder: ".perc-listing-category-FOLDER",
+  finderListingPrefix: "perc-finder-listing-",
+  finderOuter: ".perc-finder-outer",
+  pathSummary: "#mcol-path-summary",
+  pathGo: "#perc-finder-go-action",
+  finderExpander: "#perc-finder-expander",
+  actionsButton: "#perc-finder-actions-button",
+  emptyAction: '[data-testid="perc-finder-empty-recycling"]',
+});
+
+/** Surface filter tags for run-surface / documentation. */
+const SURFACE_TAGS = Object.freeze([
+  "finder-recycle-restore",
+  "folder-recycle",
+  "smoke",
+]);
+
+/**
+ * Classic Finder shell URL (dashboard still loads finder_js + Actions menu).
+ * Cache-bust query avoids stale dashboard chrome after deploy.
+ *
+ * @param {string} baseUrl CMS base (no trailing slash required)
+ * @param {number} [nowMs]
+ * @returns {string}
+ */
+function classicFinderDashboardUrl(baseUrl, nowMs) {
+  const base = String(baseUrl || "").replace(/\/+$/, "");
+  const ts =
+    nowMs != null && Number.isFinite(Number(nowMs))
+      ? Number(nowMs)
+      : Date.now();
+  return `${base}/Rhythmyx/cm/app/dashboard.jsp?_=${ts}`;
+}
+
+/**
+ * True when a finder control class list looks enabled (not permanently disabled).
+ * Matches #2207 enablement polling: ui-enabled present or ui-disabled absent.
+ *
+ * @param {string | null | undefined} classAttr
+ * @returns {boolean}
+ */
+function isFinderControlEnabled(classAttr) {
+  const cls = String(classAttr || "");
+  if (!cls.trim()) {
+    // No class yet — treat as unknown/not enabled for strict polls.
+    return false;
+  }
+  if (cls.includes("ui-enabled")) {
+    return true;
+  }
+  return !cls.includes("ui-disabled");
+}
+
+/**
+ * Normalize a user/path-bar input into a leading-slash finder path string.
+ * Collapses duplicate slashes; empty → "/".
+ *
+ * @param {string | null | undefined} path
+ * @returns {string}
+ */
+function normalizeFinderPathInput(path) {
+  const raw = String(path || "").trim();
+  if (!raw || raw === "/") {
+    return "/";
+  }
+  const parts = raw.split("/").filter(Boolean);
+  return `/${parts.join("/")}`;
+}
+
+/**
+ * Split a finder path into segments matching classic finder path arrays
+ * (leading empty string for root).
+ *
+ * @param {string | null | undefined} path e.g. "/Recycling/Assets/foo"
+ * @returns {string[]} e.g. ["", "Recycling", "Assets", "foo"]
+ */
+function finderPathSegments(path) {
+  const normalized = normalizeFinderPathInput(path);
+  if (normalized === "/") {
+    return [""];
+  }
+  return ["", ...normalized.split("/").filter(Boolean)];
+}
+
+/**
+ * Restore button enablement rule from {@code perc_restore_button.js}:
+ * under Recycling with depth ≥ 4 (e.g. /Recycling/Assets/folderName).
+ *
+ * @param {string | string[] | null | undefined} path path string or segments
+ * @returns {boolean}
+ */
+function isRestoreEligiblePath(path) {
+  const segments = Array.isArray(path) ? path : finderPathSegments(path);
+  if (!segments || segments.length < 4) {
+    return false;
+  }
+  // path[1] is first real segment (index 0 is leading empty).
+  return String(segments[1] || "") === "Recycling";
+}
+
+/**
+ * True when the browser URL still indicates the login page (login hard-fail).
+ *
+ * @param {string | null | undefined} url
+ * @returns {boolean}
+ */
+function isStillOnLoginPage(url) {
+  const u = String(url || "");
+  return /\/Rhythmyx\/login(\?|$|\/)/i.test(u);
+}
+
+/**
+ * Operator-facing hard-fail when Admin login did not leave the login page.
+ *
+ * @param {{ url?: string, baseUrl?: string }} [detail]
+ * @returns {string}
+ */
+function loginContextDownFailureMessage(detail = {}) {
+  const url = detail.url || "(unknown)";
+  const base = detail.baseUrl ? ` base=${detail.baseUrl}` : "";
+  return (
+    `Admin login/context appears DOWN — still on login page after loginAsAdmin` +
+    ` (url=${url}).` +
+    ` Hard fail for classic Finder recycle/restore UI (#2489 / parent #2423):` +
+    ` do not soft-skip. Check Rhythmyx context, credentials, and qa-up health.` +
+    base
+  );
+}
+
+/**
+ * URL fragment used when waiting for deleteFolder (recycle) network calls.
+ * @returns {string}
+ */
+function deleteFolderApiPathFragment() {
+  return "/pathmanagement/path/deleteFolder";
+}
+
+/**
+ * URL fragment used when waiting for restoreFolder network calls.
+ * @returns {string}
+ */
+function restoreFolderApiPathFragment() {
+  return "/pathmanagement/path/restoreFolder";
+}
+
+/**
+ * URL fragment for empty Recycling bulk purge (DELETE).
+ * @returns {string}
+ */
+function emptyRecyclingApiPathFragment() {
+  return "/pathmanagement/recycle/empty";
+}
+
+/**
+ * Build a candidate path under Recycling for a named Assets folder seed.
+ * Product often places recycled Assets folders under /Recycling/Assets/{name}.
+ *
+ * @param {string} folderName
+ * @param {"Assets" | "Sites" | ""} [structuralRoot="Assets"]
+ * @returns {string}
+ */
+function recycledFolderFinderPath(folderName, structuralRoot = "Assets") {
+  const name = String(folderName || "").trim();
+  if (!name) {
+    return normalizeFinderPathInput(
+      structuralRoot ? `/Recycling/${structuralRoot}` : "/Recycling",
+    );
+  }
+  if (!structuralRoot) {
+    return normalizeFinderPathInput(`/Recycling/${name}`);
+  }
+  return normalizeFinderPathInput(`/Recycling/${structuralRoot}/${name}`);
+}
+
+/**
+ * Locator filter helper: exact text match for a finder item name (trim).
+ * Pure: returns a predicate for Playwright filter({ hasText }) is not enough
+ * for exact match — tests use this to compare textContents.
+ *
+ * @param {string} name
+ * @returns {(text: string) => boolean}
+ */
+function exactFinderItemNameMatcher(name) {
+  const target = String(name || "").trim();
+  return (text) => String(text || "").trim() === target;
+}
+
+/**
+ * Choose restore vs empty-recycling UI branch when selection is uncertain.
+ * Prefer restore when path is restore-eligible and restore control is enabled;
+ * otherwise empty Recycling (Admin bulk purge) is the proven #2207 path.
+ *
+ * @param {{ pathEligible?: boolean, restoreEnabled?: boolean }} flags
+ * @returns {"restore" | "empty"}
+ */
+function chooseRestoreOrEmptyBranch(flags = {}) {
+  if (flags.pathEligible && flags.restoreEnabled) {
+    return "restore";
+  }
+  return "empty";
+}
+
+module.exports = {
+  SELECTORS,
+  SURFACE_TAGS,
+  classicFinderDashboardUrl,
+  isFinderControlEnabled,
+  normalizeFinderPathInput,
+  finderPathSegments,
+  isRestoreEligiblePath,
+  isStillOnLoginPage,
+  loginContextDownFailureMessage,
+  deleteFolderApiPathFragment,
+  restoreFolderApiPathFragment,
+  emptyRecyclingApiPathFragment,
+  recycledFolderFinderPath,
+  exactFinderItemNameMatcher,
+  chooseRestoreOrEmptyBranch,
+  // Re-export peer constants used by the spec for convenience.
+  PATH_RESTORE_FOLDER,
+  PATH_DELETE_FOLDER,
+  isContextHealthyStatus,
+  contextDownFailureMessage,
+  cmsUrl,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/finder-recycle-restore-ui.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/finder-recycle-restore-ui.test.js
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for classic Finder recycle/restore pure helpers (no live CMS).
+ *
+ * Run from modules/perc-qa-automation/frontend:
+ *   npm run test:unit
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  SELECTORS,
+  SURFACE_TAGS,
+  classicFinderDashboardUrl,
+  isFinderControlEnabled,
+  normalizeFinderPathInput,
+  finderPathSegments,
+  isRestoreEligiblePath,
+  isStillOnLoginPage,
+  loginContextDownFailureMessage,
+  deleteFolderApiPathFragment,
+  restoreFolderApiPathFragment,
+  emptyRecyclingApiPathFragment,
+  recycledFolderFinderPath,
+  exactFinderItemNameMatcher,
+  chooseRestoreOrEmptyBranch,
+  PATH_RESTORE_FOLDER,
+  PATH_DELETE_FOLDER,
+} = require("../helpers/finder-recycle-restore-ui");
+
+describe("finder-recycle-restore-ui helpers", () => {
+  it("exposes stable classic Finder selectors and surface tags", () => {
+    assert.equal(SELECTORS.deleteButton, "#perc-finder-delete");
+    assert.equal(SELECTORS.restoreItem, "#perc-finder-restore-item");
+    assert.equal(
+      SELECTORS.emptyAction,
+      '[data-testid="perc-finder-empty-recycling"]',
+    );
+    assert.equal(SELECTORS.actionsButton, "#perc-finder-actions-button");
+    assert.equal(SELECTORS.pathSummary, "#mcol-path-summary");
+    assert.ok(SURFACE_TAGS.includes("finder-recycle-restore"));
+    assert.ok(SURFACE_TAGS.includes("folder-recycle"));
+    assert.ok(SURFACE_TAGS.includes("smoke"));
+  });
+
+  it("classicFinderDashboardUrl joins base and cache-busts", () => {
+    assert.equal(
+      classicFinderDashboardUrl("http://127.0.0.1:9993/", 12345),
+      "http://127.0.0.1:9993/Rhythmyx/cm/app/dashboard.jsp?_=12345",
+    );
+    assert.equal(
+      classicFinderDashboardUrl("http://localhost:9992", 1),
+      "http://localhost:9992/Rhythmyx/cm/app/dashboard.jsp?_=1",
+    );
+    const live = classicFinderDashboardUrl("http://127.0.0.1:9993");
+    assert.match(live, /\/Rhythmyx\/cm\/app\/dashboard\.jsp\?_=\d+$/);
+  });
+
+  it("isFinderControlEnabled mirrors ui-enabled / ui-disabled rules", () => {
+    assert.equal(isFinderControlEnabled(null), false);
+    assert.equal(isFinderControlEnabled(""), false);
+    assert.equal(isFinderControlEnabled("ui-disabled"), false);
+    assert.equal(isFinderControlEnabled("ui-enabled"), true);
+    assert.equal(isFinderControlEnabled("perc-font-icon ui-enabled"), true);
+    // No explicit disabled → treat as enabled when other classes present.
+    assert.equal(isFinderControlEnabled("perc-font-icon"), true);
+  });
+
+  it("normalizeFinderPathInput and finderPathSegments are portable", () => {
+    assert.equal(normalizeFinderPathInput(""), "/");
+    assert.equal(normalizeFinderPathInput("/"), "/");
+    assert.equal(normalizeFinderPathInput("Assets"), "/Assets");
+    assert.equal(normalizeFinderPathInput("/Assets/"), "/Assets");
+    assert.equal(
+      normalizeFinderPathInput("/Recycling//Assets/foo/"),
+      "/Recycling/Assets/foo",
+    );
+    assert.deepEqual(finderPathSegments("/Recycling/Assets/foo"), [
+      "",
+      "Recycling",
+      "Assets",
+      "foo",
+    ]);
+    assert.deepEqual(finderPathSegments("/"), [""]);
+  });
+
+  it("isRestoreEligiblePath matches perc_restore_button depth rule", () => {
+    assert.equal(isRestoreEligiblePath("/Recycling"), false);
+    assert.equal(isRestoreEligiblePath("/Recycling/Assets"), false);
+    assert.equal(isRestoreEligiblePath("/Recycling/Assets/seed"), true);
+    assert.equal(isRestoreEligiblePath("/Assets/seed"), false);
+    assert.equal(
+      isRestoreEligiblePath(["", "Recycling", "Assets", "seed"]),
+      true,
+    );
+    assert.equal(isRestoreEligiblePath(["", "Recycling", "Assets"]), false);
+  });
+
+  it("isStillOnLoginPage detects login hard-fail URLs", () => {
+    assert.equal(
+      isStillOnLoginPage("http://127.0.0.1:9993/Rhythmyx/login"),
+      true,
+    );
+    assert.equal(
+      isStillOnLoginPage("http://127.0.0.1:9993/Rhythmyx/login?error=1"),
+      true,
+    );
+    assert.equal(
+      isStillOnLoginPage("http://127.0.0.1:9993/Rhythmyx/cm/app/dashboard.jsp"),
+      false,
+    );
+    assert.equal(isStillOnLoginPage(""), false);
+  });
+
+  it("loginContextDownFailureMessage cites #2489/#2423 hard fail", () => {
+    const msg = loginContextDownFailureMessage({
+      url: "http://127.0.0.1:9993/Rhythmyx/login",
+      baseUrl: "http://127.0.0.1:9993",
+    });
+    assert.match(msg, /#2489/);
+    assert.match(msg, /#2423/);
+    assert.match(msg, /hard fail/i);
+    assert.match(msg, /login/i);
+  });
+
+  it("API path fragments align with pathmanagement endpoints", () => {
+    assert.match(deleteFolderApiPathFragment(), /deleteFolder$/);
+    assert.match(restoreFolderApiPathFragment(), /restoreFolder$/);
+    assert.match(emptyRecyclingApiPathFragment(), /recycle\/empty$/);
+    assert.match(PATH_DELETE_FOLDER, /deleteFolder$/);
+    assert.match(PATH_RESTORE_FOLDER, /restoreFolder$/);
+  });
+
+  it("recycledFolderFinderPath builds structural Recycling paths", () => {
+    assert.equal(
+      recycledFolderFinderPath("seed-a"),
+      "/Recycling/Assets/seed-a",
+    );
+    assert.equal(
+      recycledFolderFinderPath("seed-a", "Sites"),
+      "/Recycling/Sites/seed-a",
+    );
+    assert.equal(recycledFolderFinderPath("seed-a", ""), "/Recycling/seed-a");
+    assert.equal(recycledFolderFinderPath(""), "/Recycling/Assets");
+  });
+
+  it("exactFinderItemNameMatcher is exact trim match only", () => {
+    const match = exactFinderItemNameMatcher("qa-folder-1");
+    assert.equal(match("qa-folder-1"), true);
+    assert.equal(match("  qa-folder-1  "), true);
+    assert.equal(match("qa-folder-10"), false);
+    assert.equal(match(""), false);
+  });
+
+  it("chooseRestoreOrEmptyBranch prefers restore only when eligible+enabled", () => {
+    assert.equal(
+      chooseRestoreOrEmptyBranch({ pathEligible: true, restoreEnabled: true }),
+      "restore",
+    );
+    assert.equal(
+      chooseRestoreOrEmptyBranch({ pathEligible: true, restoreEnabled: false }),
+      "empty",
+    );
+    assert.equal(
+      chooseRestoreOrEmptyBranch({ pathEligible: false, restoreEnabled: true }),
+      "empty",
+    );
+    assert.equal(chooseRestoreOrEmptyBranch({}), "empty");
+  });
+});


### PR DESCRIPTION
## Summary
Classic Finder UI recycle/restore companion for the #2464 pathmanagement REST smoke (parent epic **#2423**).

Adds surface-filtered Playwright under `modules/perc-qa-automation/frontend` that:
- **Hard-fails** when Rhythmyx/pathmanagement context is down (same probe class as #2464)
- **Hard-fails** when Admin login remains on `/Rhythmyx/login`
- Seeds a unique Assets folder, attempts classic Finder **delete (recycle)**, then **restore** via `#perc-finder-restore-item` when path/selection allows, else **Empty Recycling** UI (`data-testid=perc-finder-empty-recycling`, #2207 peer)
- Falls back to REST recycle only when miller-column selection cannot enable delete (UI chrome still asserted)
- Unit-tests pure helpers offline

**Operator:** Grok: night-issue-prs (model grok-4.5)

**Parent tracker:** #2423  
**Related:** #2464 / PR #2487 (REST smoke), #2207 empty-recycling UI

Fixes #2489

## Surface filter (path / tag)
```bash
cd modules/perc-qa-automation/frontend
npm run test:unit
npm run test:surface:list -- --path tests/finder-recycle-restore-ui.spec.js
npm run test:surface:list -- --tag finder-recycle-restore
# After qa-up:
TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
  npm run test:surface -- --path tests/finder-recycle-restore-ui.spec.js
# Or: npm run test:surface -- --tag finder-recycle-restore
```

| Item | Value |
|------|--------|
| Spec | `frontend/tests/finder-recycle-restore-ui.spec.js` |
| Tags | `@finder-recycle-restore` `@folder-recycle` `@smoke` |
| Helper | `frontend/tests/helpers/finder-recycle-restore-ui.js` |
| Unit | `frontend/tests/unit/finder-recycle-restore-ui.test.js` |

## Test plan
- [x] `npm run test:unit` — 147 pass (includes 11 new finder-recycle-restore helpers)
- [x] `npm run test:surface:list -- --path tests/finder-recycle-restore-ui.spec.js` — 3 tests listed
- [x] `npm run test:surface:list -- --tag finder-recycle-restore` — same 3 tests
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [ ] Live H2 `perc-devctl qa-up` + `test:surface` path (residual — agent unit path is minimum per issue)

## Gates evidence
- Erlang self-review: pure helpers unit-tested; portable URLs (cmsUrl / no OS path joins); hard-fail contracts; change-class companions (spec + helper + unit + package.json test:unit + README surface docs)
- Pre-PR Maven: standalone `perc-qa-automation` clean install green
- No product WebUI code changes (selectors only against existing chrome)

## Residuals (to file)
- Live H2 verify of this UI surface (peer of #2488 for REST)
- Miller-column selection reliability so UI recycle does not need REST fallback
- Optional golden include of `@finder-recycle-restore`

> Co-Authored by Grok Build using grok-4.5 with agent main.