### PR TITLE
fix(utils): PSConcurrentList/PSCollection Serializable for serial-field (#2450)

### DIFF
--- a/modules/utils/src/main/java/com/percussion/util/PSCollection.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSCollection.java
@@ -31,6 +31,13 @@ import java.util.Objects;
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class PSCollection extends PSConcurrentList {
+
+  /**
+   * Serialization id. Parent {@link PSConcurrentList} owns list payload serialization; this class
+   * adds {@link #m_memberClass} via default field serialization.
+   */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a collection object to store objects of the specified type.
    *

--- a/modules/utils/src/main/java/com/percussion/util/PSConcurrentList.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSConcurrentList.java
@@ -17,6 +17,10 @@
 
 package com.percussion.util;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -28,9 +32,32 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.UnaryOperator;
 
-public class PSConcurrentList<T> implements List<T> {
-  private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-  private final ReentrantLock rentrantLock = new ReentrantLock();
+/**
+ * Thread-safe {@link List} backed by an {@link ArrayList} and read/write locks.
+ *
+ * <p>Implements {@link Serializable} so product types that hold {@code PSCollection} / collection
+ * subclasses clear {@code -Xlint:serial} serial-field diagnostics. Locks are not serializable and
+ * are reinitialized on deserialization; only list contents are persisted.
+ *
+ * @param <T> element type
+ */
+public class PSConcurrentList<T> implements List<T>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Read/write lock protecting {@link #list}. Transient: recreated in {@link
+   * #readObject(ObjectInputStream)}.
+   */
+  private transient ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+
+  /**
+   * Exclusive lock used by {@link #sort(Comparator)}. Transient: recreated in {@link
+   * #readObject(ObjectInputStream)}.
+   */
+  private transient ReentrantLock rentrantLock = new ReentrantLock();
+
+  /** Backing list; transient so custom serialization owns the payload. */
   private transient volatile List<T> list;
 
   public PSConcurrentList() {
@@ -46,7 +73,51 @@ public class PSConcurrentList<T> implements List<T> {
   }
 
   public PSConcurrentList(List<T> list) {
-    this.list = list;
+    this.list = list != null ? list : new ArrayList<>();
+  }
+
+  /**
+   * Serialize list contents under a read lock. Locks themselves are not written.
+   *
+   * @param out the stream
+   * @throws IOException on write failure
+   */
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+    List<T> snapshot;
+    ReadWriteLock lock = readWriteLock;
+    if (lock == null) {
+      lock = new ReentrantReadWriteLock();
+      readWriteLock = lock;
+    }
+    lock.readLock().lock();
+    try {
+      List<T> current = list;
+      snapshot = current == null ? new ArrayList<>() : new ArrayList<>(current);
+    } finally {
+      lock.readLock().unlock();
+    }
+    out.writeObject(snapshot);
+  }
+
+  /**
+   * Restore list contents and reinitialize non-serializable locks.
+   *
+   * @param in the stream
+   * @throws IOException on read failure
+   * @throws ClassNotFoundException if an element class is missing
+   */
+  @SuppressWarnings("unchecked")
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    readWriteLock = new ReentrantReadWriteLock();
+    rentrantLock = new ReentrantLock();
+    Object raw = in.readObject();
+    if (raw == null) {
+      list = new ArrayList<>();
+    } else {
+      list = new ArrayList<>((List<T>) raw);
+    }
   }
 
   public boolean remove(Object o) {

--- a/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSConcurrentListSerializationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Java serialization checks for {@link PSConcurrentList} / {@link PSCollection} (#2450 / parent
+ * #2022 residual). Locks must reinitialize; list contents and member class must round-trip.
+ */
+public class PSConcurrentListSerializationTest {
+
+  @Test
+  public void testImplementsSerializableAndDeclaresUid() throws Exception {
+    assertTrue(Serializable.class.isAssignableFrom(PSConcurrentList.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSCollection.class));
+
+    Field listUid = PSConcurrentList.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(listUid.getModifiers()) && Modifier.isFinal(listUid.getModifiers()));
+    listUid.setAccessible(true);
+    assertEquals(1L, listUid.getLong(null));
+
+    Field collUid = PSCollection.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(collUid.getModifiers()) && Modifier.isFinal(collUid.getModifiers()));
+    collUid.setAccessible(true);
+    assertEquals(1L, collUid.getLong(null));
+  }
+
+  @Test
+  public void testConcurrentListRoundTripPreservesOrderAndContents() throws Exception {
+    PSConcurrentList<String> original = new PSConcurrentList<>();
+    original.add("alpha");
+    original.add("beta");
+    original.add("gamma");
+
+    PSConcurrentList<String> restored = roundTrip(original);
+
+    assertNotNull(restored);
+    assertEquals(3, restored.size());
+    assertEquals(Arrays.asList("alpha", "beta", "gamma"), List.copyOf(restored));
+    // Post-deser mutability / lock reinit: write path must not NPE
+    assertTrue(restored.add("delta"));
+    assertEquals(4, restored.size());
+    assertEquals("delta", restored.get(3));
+  }
+
+  @Test
+  public void testEmptyConcurrentListRoundTrip() throws Exception {
+    PSConcurrentList<Integer> original = new PSConcurrentList<>();
+    PSConcurrentList<Integer> restored = roundTrip(original);
+    assertNotNull(restored);
+    assertTrue(restored.isEmpty());
+    assertTrue(restored.add(42));
+    assertEquals(1, restored.size());
+  }
+
+  @Test
+  public void testCollectionRoundTripPreservesMemberClassAndElements() throws Exception {
+    PSCollection original = new PSCollection(String.class);
+    original.add("one");
+    original.add("two");
+
+    PSCollection restored = roundTrip(original);
+
+    assertNotNull(restored);
+    assertEquals(String.class, restored.getMemberClassType());
+    assertEquals(2, restored.size());
+    assertEquals("one", restored.get(0));
+    assertEquals("two", restored.get(1));
+    // Type guard still works after deserialization
+    restored.add("three");
+    assertEquals(3, restored.size());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(value);
+      bytes = bos.toByteArray();
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      return (T) ois.readObject();
+    }
+  }
+}

--- a/system/src/main/java/com/percussion/design/objectstore/PSCollectionComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCollectionComponent.java
@@ -33,6 +33,13 @@ import org.w3c.dom.Element;
  */
 public abstract class PSCollectionComponent extends com.percussion.util.PSCollection
     implements IPSComponent {
+
+  /**
+   * Serialization id. Inherits list + member-class serialization from {@link PSCollection}; this
+   * class adds {@link #m_id} via default field serialization.
+   */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Simplified method for converted a collection to XML.
    *

--- a/system/src/test/java/com/percussion/design/objectstore/PSCollectionComponentSerializationTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSCollectionComponentSerializationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.util.PSCollection;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Serialization surface for {@link PSCollectionComponent} after {@code PSConcurrentList} became
+ * {@link Serializable} (#2450 / parent #2022 residual). Concrete minimal subclass avoids XML/wire
+ * dependencies while exercising id + collection payload round-trip.
+ */
+public class PSCollectionComponentSerializationTest {
+
+  @Test
+  public void testCollectionComponentDeclaresUidAndIsSerializable() throws Exception {
+    assertTrue(Serializable.class.isAssignableFrom(PSCollectionComponent.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSCollection.class));
+    Field f = PSCollectionComponent.class.getDeclaredField("serialVersionUID");
+    assertTrue(Modifier.isStatic(f.getModifiers()) && Modifier.isFinal(f.getModifiers()));
+    f.setAccessible(true);
+    assertEquals(1L, f.getLong(null));
+  }
+
+  @Test
+  public void testRoundTripPreservesIdMemberClassAndElements() throws Exception {
+    TestCollectionComponent original = new TestCollectionComponent();
+    original.setId(77);
+    original.add("a");
+    original.add("b");
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(original);
+      bytes = bos.toByteArray();
+    }
+
+    TestCollectionComponent restored;
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      restored = (TestCollectionComponent) ois.readObject();
+    }
+
+    assertNotNull(restored);
+    assertEquals(77, restored.getId());
+    assertEquals(String.class, restored.getMemberClassType());
+    assertEquals(2, restored.size());
+    assertEquals("a", restored.get(0));
+    assertEquals("b", restored.get(1));
+    // Locks reinitialized: mutation must succeed
+    assertTrue(restored.add("c"));
+    assertEquals(3, restored.size());
+  }
+
+  /** Minimal concrete {@link PSCollectionComponent} for Java serialization tests only. */
+  private static final class TestCollectionComponent extends PSCollectionComponent {
+
+    private static final long serialVersionUID = 1L;
+
+    TestCollectionComponent() {
+      super(String.class);
+    }
+
+    @Override
+    public Element toXml(Document doc) {
+      throw new UnsupportedOperationException("not used in serialization test");
+    }
+
+    @Override
+    public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents) {
+      throw new UnsupportedOperationException("not used in serialization test");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Root-cause residual of parent epic **#2022** (grandparent #2200) after hottest-editor serial-field batch (#2405 / PR #2449).

`-Xlint:serial` **serial-field** diagnostics cascade from fields typed as `PSCollection` / `PSCollectionComponent` subclasses (e.g. `PSValidationRules`, `PSInputTranslations`, `PSDisplayMapper`, …) because `PSConcurrentList` was not `Serializable` (locks + transient list).

This PR makes the concurrent list hierarchy product-safe for Java serialization:
- **`PSConcurrentList`**: implements `Serializable`; locks are `transient` and reinitialized in `readObject`; `writeObject` serializes an `ArrayList` snapshot under the read lock
- **`PSCollection`** / **`PSCollectionComponent`**: `serialVersionUID = 1L` (list + member class + component id via default fields where applicable)
- Unit tests for ser/deser round-trips (list, collection, component)

**No wire/XML behavior change** — only Java serialization surface for compiler lint + future ser/deser correctness.

**Parent tracker:** #2022  
**Fixes:** #2450  
**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan
1. `cd modules/utils && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 326, Failures: 0; includes `PSConcurrentListSerializationTest` 4 tests)
2. `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 1320, Failures: 0; includes `PSCollectionComponentSerializationTest` 2 tests)
3. JDK 21 via `JAVA_HOME`
4. No new warnings attributable to this change
5. Manual QA not required (pure tech-debt / serialization surface; agent-proven)

## Gates evidence
| Gate | Result |
|------|--------|
| Behavioral unit tests | yes (utils + system) |
| Erlang-style self-review | no bugs / portable (no path I/O) / companions = ser tests |
| Standalone clean install modules/utils | BUILD SUCCESS |
| Standalone clean install system | BUILD SUCCESS |
| Human QA issue | skipped — no UI/install; fully agent-proven |

## Residual / measurement notes
Making `PSCollection` Serializable clears **serial-field** on holders of that type / subclasses. Other `-Xlint:serial` classes of warnings under #2022 (missing `serialVersionUID` on unrelated types, non-serializable field types other than collections) remain on the epic and are **out of scope** for this slice (see issue body: this-escape #2404, cms.objectstore rawtypes #2401).

No additional PR-sized residual filed under #2450 — acceptance for this slice is covered by this PR. Parent #2022 remains open for broader javac warning cleanup (p8).

> Co-Authored by Grok Build using grok-4.5 with agent main.
