### PR TITLE
fix(perc-content-explorer): type relationships manager + process monitor (#2446)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2446-dce-relationships-process-monitor-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2446-dce-relationships-process-monitor-erlang.md
@@ -1,0 +1,23 @@
+# Erlang self-review — issue #2446 PSItemRelationshipsManager + PSProcessMonitor
+
+## Scope
+- Type collections/iterators on `PSItemRelationshipsManager` and pure helpers on `PSProcessMonitor`
+- Call site: `PSActionManager` DT dependency load uses typed `Iterator<PSNode>`
+- Unit tests for pure helpers
+- Module: `modules/DesktopContentExplorer` (`perc-content-explorer`)
+
+## Findings
+- **None (bugs):** Typed iterators match `PSComponentSummaries.iterator()` / `getSummaries()` contracts (`Iterator<PSComponentSummary>`). Label formatting behavior preserved (LinkedHashMap order in tests).
+- **None (paths):** No filesystem I/O changes.
+- **None (tests):** 10 new pure-helper tests; full module suite 64 / 0 failures.
+
+## Residual (module still hot under #2045)
+Compile still reports pre-existing Xlint outside named files, e.g.:
+- `PSContentExplorerStatusDialog` (#2445)
+- `PSDesktopExplorerWindow` (#2444)
+- `PSActionManager` cloning / `PSCommunityMappingsPage.OutputData` unchecked Map
+- `PSWizardDialog` raw Map
+- Cataloger `this-escape` after prior typing batches
+
+## Verdict
+**Approve** for PR under #2446. Named residual classes clean of raw Iterator/cast paths addressed here; module clean install green.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSActionManager.java
@@ -1814,7 +1814,7 @@ public class PSActionManager implements IPSConstants, IPSSelectionListener {
       // Load children using Item Relationship Manager for dependency tree
       // mode
       if (m_applet.getView().equals(PSUiMode.TYPE_VIEW_DT)) {
-        children = asNodes(m_irsManager.loadDependencies(node));
+        children = m_irsManager.loadDependencies(node);
       } else {
         /**
          * If the node type is "Folder" or "SystemFolder" or "SystemSite" load the children using

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSItemRelationshipsManager.java
@@ -39,6 +39,7 @@ import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -51,16 +52,6 @@ import org.w3c.dom.NodeList;
 
 /** The manager class to use to get ancestors or descendants of an item for a relationship. */
 public class PSItemRelationshipsManager {
-  /**
-   * Constructs the manager with supplied parameters.
-   *
-   * @param proxy the remote proxy to use to execute a relationship request to the server, may not
-   *     be <code>null</code>.
-   * @param folderMgr Never <code>null</code>.
-   * @param remCataloger the remote cataloger to use to get list of available relationships, may not
-   *     be <code>null</code>
-   * @param docBase applet base Url to make any server requests, may not be <code>null</code>
-   */
   /**
    * Constructs the manager with supplied parameters.
    *
@@ -124,7 +115,7 @@ public class PSItemRelationshipsManager {
    * @throws PSCmsException if an error happens loading dependencies
    * @throws PSContentExplorerException if an error happens loading details of dependencies
    */
-  public Iterator loadDependencies(PSNode parentNode)
+  public Iterator<PSNode> loadDependencies(PSNode parentNode)
       throws PSCmsException, PSContentExplorerException {
     if (parentNode == null) throw new IllegalArgumentException("parentNode may not be null.");
 
@@ -169,9 +160,9 @@ public class PSItemRelationshipsManager {
 
         // filter dependents for current revision
         summaries = new PSComponentSummaries();
-        Iterator walker = testSummaries.iterator();
+        Iterator<PSComponentSummary> walker = testSummaries.iterator();
         while (walker.hasNext()) {
-          PSComponentSummary summary = (PSComponentSummary) walker.next();
+          PSComponentSummary summary = walker.next();
           filter.setOwner(summary.getCurrentLocator());
           if (!m_proxy.getSummaries(filter, true).isEmpty()) summaries.add(summary);
         }
@@ -189,9 +180,9 @@ public class PSItemRelationshipsManager {
     List<Integer> idList = new ArrayList<>();
     // Set the 'relationship', 'rs_type' and the locator as properties of each
     // node
-    Iterator it = summaries.iterator();
+    Iterator<PSComponentSummary> it = summaries.iterator();
     while (it.hasNext()) {
-      PSComponentSummary dependent = (PSComponentSummary) it.next();
+      PSComponentSummary dependent = it.next();
 
       PSLocator locator = dependent.getCurrentLocator();
       int id = locator.getId();
@@ -238,26 +229,84 @@ public class PSItemRelationshipsManager {
         node.setProperty(IPSConstants.PROPERTY_RELATIONSHIP, relationship);
 
         node.setProperty(PROP_RS_LOOKUP_TYPE, rsType);
-        String label = node.getLabel();
-        Map<String, Object> rowData = node.getRowData();
-        if (rowData != null) {
-          Iterator<Object> values = rowData.values().iterator();
-          int ii = 0;
-          while (values.hasNext()) {
-            if (ii == 0) label += " (";
-            else if (ii > 0) label += " - ";
-            label += values.next().toString();
-            ii++;
-          }
-          if (ii > 0) label += ")";
-          node.setLabel(label);
-        }
+        node.setLabel(formatDependencyLabel(node.getLabel(), node.getRowData()));
       }
       resList.addAll(list);
     }
 
     parentNode.setChildren(resList.iterator());
     return resList.iterator();
+  }
+
+  /**
+   * Appends display-format row values to a dependency node label. Pure helper for unit tests.
+   *
+   * @param baseLabel the node label before row data, may be <code>null</code>
+   * @param rowData display-format column values, may be <code>null</code> or empty
+   * @return the formatted label, never <code>null</code>
+   */
+  public static String formatDependencyLabel(String baseLabel, Map<String, ?> rowData) {
+    String label = baseLabel == null ? "" : baseLabel;
+    if (rowData == null || rowData.isEmpty()) {
+      return label;
+    }
+    StringBuilder result = new StringBuilder(label);
+    int ii = 0;
+    for (Object value : rowData.values()) {
+      if (ii == 0) {
+        result.append(" (");
+      } else {
+        result.append(" - ");
+      }
+      result.append(value == null ? "null" : value.toString());
+      ii++;
+    }
+    if (ii > 0) {
+      result.append(')');
+    }
+    return result.toString();
+  }
+
+  /**
+   * Returns whether a relationship slot is still allowed (registered template slot or inline).
+   * Pure helper for unit tests.
+   *
+   * @param slotId the relationship <code>sys_slotid</code>, may be <code>null</code>
+   * @param registeredSlots slots registered to the owner content type templates, may be <code>null
+   *     </code>
+   * @param inlineSlots known inline slot ids, may be <code>null</code>
+   * @return <code>true</code> when the slot is registered or inline
+   */
+  public static boolean isAllowedRelationshipSlot(
+      String slotId, Collection<String> registeredSlots, Collection<String> inlineSlots) {
+    if (slotId == null) {
+      return false;
+    }
+    return (registeredSlots != null && registeredSlots.contains(slotId))
+        || (inlineSlots != null && inlineSlots.contains(slotId));
+  }
+
+  /**
+   * Filters component summaries to those whose content id is in the allowed set. Pure helper for
+   * unit tests.
+   *
+   * @param summaries summaries to filter, may be <code>null</code>
+   * @param allowedContentIds content ids as strings, may be <code>null</code>
+   * @return matching summaries in encounter order, never <code>null</code>
+   */
+  public static List<PSComponentSummary> filterSummariesByContentIds(
+      Iterator<PSComponentSummary> summaries, Collection<String> allowedContentIds) {
+    List<PSComponentSummary> result = new ArrayList<>();
+    if (summaries == null || allowedContentIds == null || allowedContentIds.isEmpty()) {
+      return result;
+    }
+    while (summaries.hasNext()) {
+      PSComponentSummary sum = summaries.next();
+      if (sum != null && allowedContentIds.contains(String.valueOf(sum.getContentId()))) {
+        result.add(sum);
+      }
+    }
+    return result;
   }
 
   /**
@@ -309,20 +358,13 @@ public class PSItemRelationshipsManager {
         Object[] args = new Object[] {e.getLocalizedMessage()};
         throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, args);
       }
-      if (slotId != null && cid != null) {
-        if (regSlots.contains(slotId) || inlineSlots.contains(slotId)) {
-          contentIds.add(cid);
-        }
+      if (cid != null && isAllowedRelationshipSlot(slotId, regSlots, inlineSlots)) {
+        contentIds.add(cid);
       }
     }
     PSComponentSummaries allsummaries = m_proxy.getSummaries(filter, false);
-    Iterator siter = allsummaries.getSummaries();
-    while (siter.hasNext()) {
-      PSComponentSummary sum = (PSComponentSummary) siter.next();
-      String cid = "" + sum.getContentId();
-      if (contentIds.contains(cid)) {
-        summaries.add(sum);
-      }
+    for (PSComponentSummary sum : filterSummariesByContentIds(allsummaries.getSummaries(), contentIds)) {
+      summaries.add(sum);
     }
     return summaries;
   }

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSProcessMonitor.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSProcessMonitor.java
@@ -30,22 +30,54 @@ public class PSProcessMonitor {
    * Constructs this object to monitor the processing of supplied number of nodes.
    *
    * @param total the total number of nodes to process, may not be &lt;= 0.
-   * @throws IllegalArgumentException if total is invalid.
-   */
-  /**
-   * Constructs this object to monitor the processing of supplied number of nodes.
-   *
-   * @param total the total number of nodes to process, may not be &lt;= 0.
    * @param applet the content explorer applet, may not be <code>null</code>.
-   * @throws IllegalArgumentException if total is invalid.
+   * @throws IllegalArgumentException if total is invalid or applet is <code>null</code>.
    */
   public PSProcessMonitor(int total, PSContentExplorerApplet applet) {
-    if (total <= 0) throw new IllegalArgumentException("total may not be <= 0");
+    if (!isValidTotal(total)) throw new IllegalArgumentException("total may not be <= 0");
 
     if (applet == null) throw new IllegalArgumentException("applet must not be null");
     m_applet = applet;
 
     m_total = total;
+  }
+
+  /**
+   * Returns whether a total node count is valid for construction. Pure helper for unit tests.
+   *
+   * @param total candidate total
+   * @return <code>true</code> when total is positive
+   */
+  public static boolean isValidTotal(int total) {
+    return total > 0;
+  }
+
+  /**
+   * Returns whether a status constant is one of {@code STATUS_xxx}. Pure helper for unit tests.
+   *
+   * @param status candidate status value
+   * @return <code>true</code> when status is in range
+   */
+  public static boolean isValidStatus(int status) {
+    return status >= STATUS_INIT && status <= STATUS_COMPLETE;
+  }
+
+  /**
+   * Computes dialog percent-complete for the current node index. Pure helper for unit tests.
+   *
+   * @param current 1-based index of the node being processed
+   * @param total total nodes being processed, must be &gt; 0
+   * @return percent in range 0..100
+   * @throws IllegalArgumentException if current/total are invalid
+   */
+  public static int computePercentDone(int current, int total) {
+    if (!isValidTotal(total)) {
+      throw new IllegalArgumentException("total may not be <= 0");
+    }
+    if (current <= 0 || current > total) {
+      throw new IllegalArgumentException("current may not be <= 0 or > actual total");
+    }
+    return (current - 1) * 100 / total;
   }
 
   /**
@@ -69,8 +101,8 @@ public class PSProcessMonitor {
    * @throws IllegalArgumentException if any parameter is invalid
    */
   public void updateStatus(int current, PSNode processingNode) {
-    if (current > m_total || current <= 0)
-      throw new IllegalArgumentException("current may not be <= 0 or > actual total");
+    // validate range via pure helper (throws on invalid)
+    int percentDone = computePercentDone(current, m_total);
 
     if (processingNode == null)
       throw new IllegalArgumentException("processingNode may not be null.");
@@ -82,9 +114,9 @@ public class PSProcessMonitor {
       String msg =
           MessageFormat.format(
               m_applet.getResourceString(getClass(), "Processing the {0} <{1}>"),
-              new String[] {m_curProcessNode.getType(), m_curProcessNode.getLabel()});
+              m_curProcessNode.getType(),
+              m_curProcessNode.getLabel());
 
-      int percentDone = (m_current - 1) * 100 / m_total;
       m_dlg.updateStatus(msg, percentDone);
     }
   }
@@ -109,8 +141,7 @@ public class PSProcessMonitor {
    * @throws IllegalArgumentException if any currentStatus is invalid
    */
   public synchronized void setStatus(int currentStatus) {
-    if (currentStatus < STATUS_INIT || currentStatus > STATUS_COMPLETE)
-      throw new IllegalArgumentException("invalid status");
+    if (!isValidStatus(currentStatus)) throw new IllegalArgumentException("invalid status");
 
     synchronized (m_syncObject) {
       m_status = currentStatus;

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSItemRelationshipsManagerTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSItemRelationshipsManagerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.PSComponentSummary;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for pure helpers on {@link PSItemRelationshipsManager}. */
+public class PSItemRelationshipsManagerTest {
+
+  @Test
+  public void formatDependencyLabelNullAndEmptyRowData() {
+    assertEquals("", PSItemRelationshipsManager.formatDependencyLabel(null, null));
+    assertEquals("Base", PSItemRelationshipsManager.formatDependencyLabel("Base", null));
+    assertEquals(
+        "Base",
+        PSItemRelationshipsManager.formatDependencyLabel("Base", Collections.emptyMap()));
+  }
+
+  @Test
+  public void formatDependencyLabelAppendsRowValuesInOrder() {
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("sys_title", "Hello");
+    row.put("sys_contentid", "42");
+
+    assertEquals(
+        "Item (Hello - 42)",
+        PSItemRelationshipsManager.formatDependencyLabel("Item", row));
+  }
+
+  @Test
+  public void formatDependencyLabelHandlesNullValue() {
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("col", null);
+    assertEquals("L (null)", PSItemRelationshipsManager.formatDependencyLabel("L", row));
+  }
+
+  @Test
+  public void isAllowedRelationshipSlotRegisteredOrInline() {
+    List<String> reg = Arrays.asList("10", "20");
+    List<String> inline = Arrays.asList("99");
+
+    assertTrue(PSItemRelationshipsManager.isAllowedRelationshipSlot("10", reg, inline));
+    assertTrue(PSItemRelationshipsManager.isAllowedRelationshipSlot("99", reg, inline));
+    assertFalse(PSItemRelationshipsManager.isAllowedRelationshipSlot("55", reg, inline));
+    assertFalse(PSItemRelationshipsManager.isAllowedRelationshipSlot(null, reg, inline));
+    assertFalse(PSItemRelationshipsManager.isAllowedRelationshipSlot("10", null, null));
+  }
+
+  @Test
+  public void filterSummariesByContentIdsKeepsMatchesInOrder() {
+    PSComponentSummary a = summary(101, "a");
+    PSComponentSummary b = summary(202, "b");
+    PSComponentSummary c = summary(303, "c");
+    Iterator<PSComponentSummary> all = Arrays.asList(a, b, c).iterator();
+
+    List<PSComponentSummary> filtered =
+        PSItemRelationshipsManager.filterSummariesByContentIds(
+            all, Arrays.asList("303", "101"));
+
+    assertEquals(2, filtered.size());
+    assertEquals(101, filtered.get(0).getContentId());
+    assertEquals(303, filtered.get(1).getContentId());
+  }
+
+  @Test
+  public void filterSummariesByContentIdsNullSafe() {
+    assertTrue(
+        PSItemRelationshipsManager.filterSummariesByContentIds(null, Arrays.asList("1"))
+            .isEmpty());
+    assertTrue(
+        PSItemRelationshipsManager.filterSummariesByContentIds(
+                Collections.emptyIterator(), null)
+            .isEmpty());
+    assertTrue(
+        PSItemRelationshipsManager.filterSummariesByContentIds(
+                Collections.emptyIterator(), Collections.emptyList())
+            .isEmpty());
+  }
+
+  private static PSComponentSummary summary(int contentId, String name) {
+    return new PSComponentSummary(
+        contentId,
+        1,
+        1,
+        -1,
+        PSComponentSummary.TYPE_ITEM,
+        name,
+        1L,
+        0);
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSProcessMonitorTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSProcessMonitorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for pure helpers on {@link PSProcessMonitor}. */
+public class PSProcessMonitorTest {
+
+  @Test
+  public void isValidTotalRequiresPositive() {
+    assertFalse(PSProcessMonitor.isValidTotal(0));
+    assertFalse(PSProcessMonitor.isValidTotal(-1));
+    assertTrue(PSProcessMonitor.isValidTotal(1));
+  }
+
+  @Test
+  public void isValidStatusAcceptsStatusConstantsOnly() {
+    assertTrue(PSProcessMonitor.isValidStatus(PSProcessMonitor.STATUS_INIT));
+    assertTrue(PSProcessMonitor.isValidStatus(PSProcessMonitor.STATUS_RUN));
+    assertTrue(PSProcessMonitor.isValidStatus(PSProcessMonitor.STATUS_PAUSE));
+    assertTrue(PSProcessMonitor.isValidStatus(PSProcessMonitor.STATUS_STOP));
+    assertTrue(PSProcessMonitor.isValidStatus(PSProcessMonitor.STATUS_COMPLETE));
+    assertFalse(PSProcessMonitor.isValidStatus(0));
+    assertFalse(PSProcessMonitor.isValidStatus(PSProcessMonitor.STATUS_COMPLETE + 1));
+  }
+
+  @Test
+  public void computePercentDoneBoundaries() {
+    assertEquals(0, PSProcessMonitor.computePercentDone(1, 4));
+    assertEquals(25, PSProcessMonitor.computePercentDone(2, 4));
+    assertEquals(50, PSProcessMonitor.computePercentDone(3, 4));
+    assertEquals(75, PSProcessMonitor.computePercentDone(4, 4));
+    assertEquals(0, PSProcessMonitor.computePercentDone(1, 1));
+  }
+
+  @Test
+  public void computePercentDoneRejectsInvalid() {
+    assertThrows(
+        IllegalArgumentException.class, () -> PSProcessMonitor.computePercentDone(0, 4));
+    assertThrows(
+        IllegalArgumentException.class, () -> PSProcessMonitor.computePercentDone(5, 4));
+    assertThrows(
+        IllegalArgumentException.class, () -> PSProcessMonitor.computePercentDone(1, 0));
+  }
+}


### PR DESCRIPTION
## Summary
Residual `-Xlint` batch under parent **#2045** / monorepo **#2200** (residual of **#2384**, issue **#2446**): type collections/iterators on `PSItemRelationshipsManager` and pure helpers on `PSProcessMonitor`.

- `PSItemRelationshipsManager.loadDependencies` returns `Iterator<PSNode>`
- Typed `Iterator<PSComponentSummary>` over summaries (no raw casts)
- Pure helpers: `formatDependencyLabel`, `isAllowedRelationshipSlot`, `filterSummariesByContentIds`
- `PSProcessMonitor`: `isValidTotal` / `isValidStatus` / `computePercentDone` pure helpers
- `PSActionManager` DT view: drop `asNodes` cast bridge at `loadDependencies` call site
- Tests: `PSItemRelationshipsManagerTest` (6), `PSProcessMonitorTest` (4)
- Erlang: `docs/ai-generated/code-reviews/issue-2446-dce-relationships-process-monitor-erlang.md`

**Fixes #2446.** Parent tracker: #2045.

Module remains hot (pre-existing residuals #2444, #2445, #2439 + further ActionManager/Wizard/cataloger this-escape).

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Tests run: **64**, Failures: 0 (includes 10 new pure-helper tests)
- [x] No new warnings on named files `PSItemRelationshipsManager` / `PSProcessMonitor`

## Gates
- Erlang self-review: pass
- Per-module clean install: perc-content-explorer standalone
- No product behavior change intended

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2446

> Co-Authored by Grok Build using grok-4.5 with agent main.