### PR TITLE
fix(perc-qa-automation): include @folder-recycle in extended golden smoke (#2490)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -74,6 +74,10 @@ npm run test:golden
 # npm run test:surface -- --path tests/golden-unattended-smoke.spec.js
 # npx playwright test tests/golden-unattended-smoke.spec.js --grep @golden
 
+# Optional extended set (#2490): golden + @folder-recycle multi-path (not full suite)
+# npm run test:golden-extended
+# npm run test:golden-extended:list   # no live CMS
+
 cd ../../..
 python docker/scripts/perc-devctl.py qa-down
 ```
@@ -95,6 +99,7 @@ set TEST_DB_TYPE=h2
 set TEST_PRODUCT=cms
 
 call npm run test:golden
+REM Optional extended: call npm run test:golden-extended
 
 cd ..\..\..
 python docker\scripts\perc-devctl.py qa-down
@@ -102,16 +107,46 @@ python docker\scripts\perc-devctl.py qa-down
 
 | Item | Value |
 |------|--------|
-| Spec | `frontend/tests/golden-unattended-smoke.spec.js` |
-| npm | `npm run test:golden` |
-| Tags | `@smoke` / `@golden` (also via `npm run test:surface -- --tag golden`) |
+| Spec (baseline) | `frontend/tests/golden-unattended-smoke.spec.js` |
+| npm (baseline) | `npm run test:golden` |
+| Tags (baseline) | `@smoke` / `@golden` (also via `npm run test:surface -- --tag golden`) |
+| Specs (extended) | baseline + `frontend/tests/folder-recycle-smoke.spec.js` (`@folder-recycle`) |
+| npm (extended) | `npm run test:golden-extended` / `npm run test:golden-extended:list` |
+| Inventory helper | `frontend/tests/helpers/golden-unattended-smoke-set.js` (#2490) |
 | Failure artifacts | `modules/perc-qa-automation/frontend/test-results/` |
 | HTML report | `modules/perc-qa-automation/frontend/playwright-report/` |
 | Attach runbook | [playwright-failure-artifacts.md](../../docs/developer-module/playwright-failure-artifacts.md) |
 | Stack lifecycle | [workbench-rest-and-qa-modes.md](../../docs/developer-module/workbench-rest-and-qa-modes.md) §2 |
 
+#### Extended golden + `@folder-recycle` (#2490 / parent #2423)
+
+**Decision: include** `@folder-recycle` in the **optional extended** golden/unattended
+multi-path set — not in the minimal default and **not** the full Playwright suite.
+
+| Tier | npm | Specs | When to use |
+|------|-----|-------|-------------|
+| **Baseline** (default) | `npm run test:golden` | `golden-unattended-smoke.spec.js` only | Fastest unattended login + Explorer gate |
+| **Extended** | `npm run test:golden-extended` | baseline + `folder-recycle-smoke.spec.js` | Overnight / post-#2423 recycle REST smoke without full suite |
+
+```bash
+# List only (no live CMS) — proves surface wiring
+cd modules/perc-qa-automation/frontend
+npm run test:golden-extended:list
+# or surface-filter form:
+npm run test:surface:list -- --path tests/folder-recycle-smoke.spec.js
+npm run test:surface:list -- --tag folder-recycle
+
+# Live after qa-up
+TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… npm run test:golden-extended
+```
+
+Canonical inventory (unit-tested lockstep with package.json):
+`frontend/tests/helpers/golden-unattended-smoke-set.js`. Live H2 proof residual:
+#2488. Finder UI companion is separate (#2489 / `@finder-recycle-restore`).
+
 **Hard bans:** do not commit passwords; do not hardcode host port `:9993` as the only URL
-(use freeport `TEST_CMS_URL` from `qa-up`).
+(use freeport `TEST_CMS_URL` from `qa-up`). Do **not** replace `test:golden` with the
+full suite; use path/tag/`test:golden-extended` only.
 
 ### Demo-sites Sample Site residual (#1750 / #2194)
 
@@ -370,7 +405,7 @@ npm run test:surface:list -- --tag locale
 
 Does **not** expand Spanish/#961 residual matrix scope (tracked separately).
 
-#### Folder + recycle REST smoke (#2464 / parent #2423)
+#### Folder + recycle REST smoke (#2464 / parent #2423 / #2490)
 
 Surface-filtered regression after the `folderHelper` → `recycleService` Spring
 cycle break. Proves pathmanagement is up (hard fail if Rhythmyx context is dead),
@@ -378,12 +413,17 @@ then create folder under Assets → soft-delete (recycle) → restore by guid wh
 available, else purge via empty Recycling. Optional Admin login check when
 context is healthy.
 
+**Golden/unattended placement (#2490):** included in **`npm run test:golden-extended`**
+(multi-path with baseline golden). **Not** in default `npm run test:golden`.
+Still available as a standalone surface path/tag below.
+
 | Item | Value |
 |------|--------|
 | Spec | `frontend/tests/folder-recycle-smoke.spec.js` |
 | Tags | `@folder-recycle` `@smoke` |
-| Unit (no CMS) | `npm run test:unit` (includes `folder-recycle-smoke.test.js`) |
+| Unit (no CMS) | `npm run test:unit` (includes `folder-recycle-smoke.test.js`, `golden-unattended-smoke-set.test.js`) |
 | Helper | `frontend/tests/helpers/folder-recycle-smoke.js` |
+| Extended golden | `npm run test:golden-extended` / `test:golden-extended:list` |
 
 ```bash
 # After qa-up — path-filtered only (do not run full suite)
@@ -394,6 +434,10 @@ TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
 
 # Tag form
 npm run test:surface -- --tag folder-recycle
+
+# Extended golden multi-path (baseline + this surface) — #2490
+npm run test:golden-extended
+npm run test:golden-extended:list
 
 # List only (no live CMS)
 npm run test:surface:list -- --path tests/folder-recycle-smoke.spec.js

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,9 +7,11 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/golden-unattended-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
+    "test:golden-extended": "playwright test tests/golden-unattended-smoke.spec.js tests/folder-recycle-smoke.spec.js",
+    "test:golden-extended:list": "playwright test --list tests/golden-unattended-smoke.spec.js tests/folder-recycle-smoke.spec.js",
     "test:surface": "node scripts/run-surface.js",
     "test:surface:print": "node scripts/run-surface.js --print-only",
     "test:surface:list": "node scripts/run-surface.js --list",

--- a/modules/perc-qa-automation/frontend/tests/folder-recycle-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/folder-recycle-smoke.spec.js
@@ -35,12 +35,16 @@
  *     npm run test:surface -- --path tests/folder-recycle-smoke.spec.js
  *   # tags:
  *   npm run test:surface -- --tag folder-recycle
+ *   # extended golden multi-path (baseline + this surface) — #2490:
+ *   npm run test:golden-extended
+ *   npm run test:golden-extended:list
  *   python docker/scripts/perc-devctl.py qa-down
  * </pre>
  *
  * <p>List only (no live CMS):
  * {@code npm run test:surface:list -- --path tests/folder-recycle-smoke.spec.js}
- * or {@code --tag folder-recycle}.</p>
+ * or {@code --tag folder-recycle}. Inventory:
+ * {@code helpers/golden-unattended-smoke-set.js}.</p>
  */
 
 const { test, expect } = require("@playwright/test");

--- a/modules/perc-qa-automation/frontend/tests/golden-unattended-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/golden-unattended-smoke.spec.js
@@ -30,10 +30,13 @@
  *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
  *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; TEST_DB_TYPE=h2 \
  *     npm run test:golden
+ *   # optional extended (#2490): golden + @folder-recycle multi-path
+ *   # npm run test:golden-extended
  *   python docker/scripts/perc-devctl.py qa-down
  * </pre>
  *
- * <p>Windows (cmd) one-shot: see module README → Golden unattended smoke.</p>
+ * <p>Windows (cmd) one-shot: see module README → Golden unattended smoke.
+ * Extended set inventory: {@code helpers/golden-unattended-smoke-set.js}.</p>
  *
  * <p>Failure artifacts: {@code test-results/}, {@code playwright-report/}
  * under this frontend directory. Attach runbook:

--- a/modules/perc-qa-automation/frontend/tests/helpers/golden-unattended-smoke-set.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/golden-unattended-smoke-set.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Golden / unattended Playwright smoke surface inventory (#2490 / parent #2423).
+ *
+ * <p><strong>Decision:</strong> include {@code @folder-recycle} in the
+ * <em>extended</em> golden unattended multi-path set. The minimal default
+ * ({@code npm run test:golden}) remains login + Content Explorer only so agents
+ * never default to the full suite.</p>
+ *
+ * <p>Used by unit tests and docs; keep in lockstep with package.json scripts
+ * {@code test:golden} and {@code test:golden-extended}.</p>
+ *
+ * @module helpers/golden-unattended-smoke-set
+ */
+
+"use strict";
+
+/**
+ * @typedef {"baseline" | "extended"} GoldenTier
+ */
+
+/**
+ * @typedef {object} GoldenSmokeEntry
+ * @property {string} id stable inventory id
+ * @property {string} file Playwright spec under tests/
+ * @property {string} path path relative to frontend/ for surface / playwright CLI
+ * @property {string} tag primary Playwright title tag (without @)
+ * @property {GoldenTier} tier baseline = test:golden; extended also in golden-extended
+ * @property {string} [notes] short operator note
+ */
+
+/**
+ * Spec path prefix used by npm scripts and surface filter (under frontend/).
+ * @type {string}
+ */
+const TESTS_PREFIX = "tests/";
+
+/**
+ * Canonical golden unattended surface inventory.
+ *
+ * @type {GoldenSmokeEntry[]}
+ */
+const GOLDEN_UNATTENDED_SMOKE_SET = [
+  {
+    id: "golden-login-explorer",
+    file: "golden-unattended-smoke.spec.js",
+    path: `${TESTS_PREFIX}golden-unattended-smoke.spec.js`,
+    tag: "golden",
+    tier: "baseline",
+    notes:
+      "Minimal unattended reference: Admin login + Content Explorer (#2065 / #1928)",
+  },
+  {
+    id: "folder-recycle",
+    file: "folder-recycle-smoke.spec.js",
+    path: `${TESTS_PREFIX}folder-recycle-smoke.spec.js`,
+    tag: "folder-recycle",
+    tier: "extended",
+    notes:
+      "Post-#2423 pathmanagement + recycle REST smoke; optional overnight extended set (#2490)",
+  },
+];
+
+/**
+ * Entries in the minimal golden set ({@code npm run test:golden}).
+ *
+ * @returns {GoldenSmokeEntry[]}
+ */
+function listBaselineEntries() {
+  return GOLDEN_UNATTENDED_SMOKE_SET.filter((e) => e.tier === "baseline");
+}
+
+/**
+ * Entries in the extended golden set ({@code npm run test:golden-extended}):
+ * baseline plus optional surfaces such as folder-recycle.
+ *
+ * @returns {GoldenSmokeEntry[]}
+ */
+function listExtendedEntries() {
+  return GOLDEN_UNATTENDED_SMOKE_SET.slice();
+}
+
+/**
+ * Playwright CLI path args for a tier (relative to frontend/).
+ *
+ * @param {GoldenTier} tier
+ * @returns {string[]}
+ */
+function pathsForTier(tier) {
+  if (tier === "baseline") {
+    return listBaselineEntries().map((e) => e.path);
+  }
+  if (tier === "extended") {
+    return listExtendedEntries().map((e) => e.path);
+  }
+  throw new TypeError(`Unknown golden tier: ${tier}`);
+}
+
+/**
+ * @param {string} id inventory id
+ * @returns {GoldenSmokeEntry}
+ */
+function getGoldenEntry(id) {
+  const found = GOLDEN_UNATTENDED_SMOKE_SET.find((e) => e.id === id);
+  if (!found) {
+    throw new Error(`Unknown golden unattended smoke entry id: ${id}`);
+  }
+  return found;
+}
+
+module.exports = {
+  GOLDEN_UNATTENDED_SMOKE_SET,
+  TESTS_PREFIX,
+  listBaselineEntries,
+  listExtendedEntries,
+  pathsForTier,
+  getGoldenEntry,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/golden-unattended-smoke-set.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/golden-unattended-smoke-set.test.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for golden unattended smoke inventory (#2490).
+ * Ensures @folder-recycle is wired into the extended set only, and package.json
+ * scripts stay in lockstep with the inventory paths.
+ *
+ * Run: npm run test:unit  (from frontend/)
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  GOLDEN_UNATTENDED_SMOKE_SET,
+  listBaselineEntries,
+  listExtendedEntries,
+  pathsForTier,
+  getGoldenEntry,
+} = require("../helpers/golden-unattended-smoke-set");
+
+const PACKAGE_JSON = path.join(__dirname, "..", "..", "package.json");
+
+/**
+ * @param {string} scriptBody
+ * @param {string} relPath
+ * @returns {boolean}
+ */
+function scriptMentionsPath(scriptBody, relPath) {
+  // package.json uses forward-slash paths (Playwright CLI) on all platforms
+  return String(scriptBody).includes(relPath.replace(/\\/g, "/"));
+}
+
+describe("GOLDEN_UNATTENDED_SMOKE_SET", () => {
+  it("includes baseline golden and extended folder-recycle (#2490)", () => {
+    const ids = new Set(GOLDEN_UNATTENDED_SMOKE_SET.map((e) => e.id));
+    assert.ok(ids.has("golden-login-explorer"));
+    assert.ok(ids.has("folder-recycle"));
+  });
+
+  it("requires unique ids", () => {
+    const ids = GOLDEN_UNATTENDED_SMOKE_SET.map((e) => e.id);
+    assert.equal(ids.length, new Set(ids).size);
+  });
+
+  it("baseline is golden only (minimal unattended default)", () => {
+    const baseline = listBaselineEntries();
+    assert.equal(baseline.length, 1);
+    assert.equal(baseline[0].id, "golden-login-explorer");
+    assert.deepEqual(pathsForTier("baseline"), [
+      "tests/golden-unattended-smoke.spec.js",
+    ]);
+  });
+
+  it("extended includes folder-recycle without becoming full suite", () => {
+    const extended = listExtendedEntries();
+    assert.ok(extended.length >= 2);
+    assert.ok(extended.some((e) => e.id === "folder-recycle"));
+    const paths = pathsForTier("extended");
+    assert.ok(paths.includes("tests/golden-unattended-smoke.spec.js"));
+    assert.ok(paths.includes("tests/folder-recycle-smoke.spec.js"));
+    // Guard: do not silently grow into a full-suite default
+    assert.ok(
+      paths.length <= 8,
+      `extended set too large (${paths.length}); keep multi-path smoke small`,
+    );
+  });
+
+  it("folder-recycle entry uses surface tag and path peers", () => {
+    const entry = getGoldenEntry("folder-recycle");
+    assert.equal(entry.tier, "extended");
+    assert.equal(entry.tag, "folder-recycle");
+    assert.equal(entry.path, "tests/folder-recycle-smoke.spec.js");
+    assert.equal(entry.file, "folder-recycle-smoke.spec.js");
+  });
+
+  it("pathsForTier rejects unknown tier", () => {
+    assert.throws(() => pathsForTier("full-suite"), /Unknown golden tier/);
+  });
+
+  it("getGoldenEntry rejects unknown id", () => {
+    assert.throws(() => getGoldenEntry("not-a-real-id"), /Unknown golden/);
+  });
+});
+
+describe("package.json golden scripts lockstep (#2490)", () => {
+  it("test:golden stays baseline-only; test:golden-extended wires folder-recycle", () => {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf8"));
+    const scripts = pkg.scripts || {};
+
+    assert.ok(scripts["test:golden"], "test:golden required");
+    assert.ok(
+      scripts["test:golden-extended"],
+      "test:golden-extended required for optional @folder-recycle overnight set",
+    );
+    assert.ok(
+      scripts["test:golden-extended:list"],
+      "test:golden-extended:list required (no live CMS)",
+    );
+
+    const baselinePaths = pathsForTier("baseline");
+    const extendedPaths = pathsForTier("extended");
+
+    for (const p of baselinePaths) {
+      assert.ok(
+        scriptMentionsPath(scripts["test:golden"], p),
+        `test:golden must include ${p}`,
+      );
+    }
+    // Minimal golden must NOT pull folder-recycle by default
+    assert.ok(
+      !scriptMentionsPath(scripts["test:golden"], "folder-recycle-smoke.spec.js"),
+      "test:golden must remain minimal (no folder-recycle path)",
+    );
+
+    for (const p of extendedPaths) {
+      assert.ok(
+        scriptMentionsPath(scripts["test:golden-extended"], p),
+        `test:golden-extended must include ${p}`,
+      );
+      assert.ok(
+        scriptMentionsPath(scripts["test:golden-extended:list"], p),
+        `test:golden-extended:list must include ${p}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
**Decision (issue #2490 / parent #2423):** **include** `@folder-recycle` in the **optional extended** golden/unattended multi-path smoke set — **not** in default `npm run test:golden`, and **not** the full Playwright suite.

- `npm run test:golden` — baseline only (`golden-unattended-smoke.spec.js`)
- `npm run test:golden-extended` / `test:golden-extended:list` — baseline + `folder-recycle-smoke.spec.js`
- Inventory: `frontend/tests/helpers/golden-unattended-smoke-set.js` (unit-tested lockstep with `package.json`)
- Module README documents baseline vs extended tiers and hard bans

**Parent tracker:** #2423  
**Fixes:** #2490

## Test plan
1. `cd modules/perc-qa-automation/frontend && npm run test:unit` → **144 pass / 0 fail**
2. `npm run test:golden-extended:list` → **5 tests in 2 files** (golden + folder-recycle)
3. `npm run test:surface:list -- --path tests/folder-recycle-smoke.spec.js` → **3 tests in 1 file**
4. `cd modules/perc-qa-automation && ../../mvnw clean install` → **BUILD SUCCESS**

## Gates evidence
- Erlang-style self-review: docs/wiring only; portable path strings in package scripts use forward slashes (Playwright CLI); no full-suite default; no live CMS required for acceptance
- Pre-PR Maven: standalone `perc-qa-automation` clean install green
- No human QA: pure automation surface wiring / docs (no product UI / installer change)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
