### PR TITLE
fix(docker): surface Health.Status on qa-health RESULT lines (#2537)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -256,10 +256,11 @@ Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `
 
 | Signal | Where | Operator meaning |
 |--------|--------|------------------|
-| `RESULT:OK STEP:qa-health HTTP:…` | `perc-devctl.py qa-health` | Probe URL ready **and** recent `docker logs` have **no** Rhythmyx context-failure markers |
+| `RESULT:OK STEP:qa-health HTTP:… HEALTH:healthy …` | `perc-devctl.py qa-health` | Probe URL ready, docker `Health.Status=healthy` for the QA cell, **and** recent `docker logs` have **no** Rhythmyx context-failure markers (#2537 / #2481) |
 | `RESULT:OK STEP:verify CMS_HTTP:… DTS_HTTP:… HEALTH:healthy` | `perc-devctl.py verify` (and `verify-fix` / `deploy-jar --verify`) | CMS+DTS HTTP ready, docker health healthy, **and** cms-dts logs have **no** Rhythmyx context-failure markers |
+| `RESULT:… HEALTH:healthy\|unhealthy\|starting\|none` | `qa-health` (matrix cell) and `verify` / `_verify_inline` (cms-dts) | Inspect status from `_docker_health` on every RESULT (OK and FAIL); `none` = container has no Health block; `unknown` = docker/container missing |
 | `RESULT:FAIL … DETAIL:rhythmyx_context_failed MATCH:…` | `qa-health`, compose `verify` / `_verify_inline`, or matrix cell `detail` | **Fail-fast**: Spring/Jetty context death detected in logs; treat stack as unusable even if HTTP / docker health answered green |
-| `RESULT:FAIL … DETAIL:timeout after Ns (last_http=…)` | `qa-health` | Probe never became ready; if logs later show context fail, re-run `qa-health` or `docker logs perc-matrix-cms-h2` |
+| `RESULT:FAIL … DETAIL:timeout after Ns (last_http=… health=…)` | `qa-health` | Probe never became ready (HTTP and/or Health not green); if logs later show context fail, re-run `qa-health` or `docker logs perc-matrix-cms-h2` |
 | `RESULT:FAIL … DETAIL:timeout after Ns (cms_http=… dts_http=… health=…)` | `verify` | Stack never became ready; scan `docker logs percussion-cms-dts` for context markers |
 | Matrix `status=fail` + `detail` containing `rhythmyx_context_failed` | `matrix-install-smoke.py` CMS cells | Same fail-fast during cell HTTP wait (container log scan) |
 | Matrix `status=fail` + `detail` containing `docker_health_unhealthy` | `matrix-install-smoke.py` CMS cells / `qa-up` | **Fail-fast** when `docker inspect` already reports `Health.Status=unhealthy` — does **not** burn full `--probe-timeout` (#2535 / #2481) |
@@ -267,6 +268,7 @@ Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `
 | Docker `Health.Status=healthy` | matrix cell / cms-dts image HEALTHCHECK (#2481) | In-container login probe ready **and** local Jetty logs have **no** context-failure markers |
 | Docker `Health.Status=unhealthy` | same | Context failed and/or login not ready — **do not** attach Playwright; inspect health log + `docker logs` |
 | Docker `Health.Status=starting` | same | Still inside HEALTHCHECK `start_period` (matrix cells: long install window) |
+| Docker `Health.Status=none` | container without HEALTHCHECK | Inspect has no `.State.Health` block (`_docker_health` → `none`) |
 
 ##### Matrix / qa-up wait policy (CMS cells, #2535)
 
@@ -298,26 +300,30 @@ Matrix cells (`percussion-matrix-cell:local`) and the cms-dts image bake `docker
 | `percussion-cms-dts` (compose) | `docker inspect -f "{{.State.Health.Status}}" percussion-cms-dts` | Same for bind-mounted host install |
 
 ```bash
-# After qa-up (or matrix --keep), re-check readiness with log scan:
+# After qa-up (or matrix --keep), re-check readiness with log scan + Health.Status (#2537):
 python docker/scripts/perc-devctl.py qa-health
+# OK example:
+# RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy URL:… CONTAINER:perc-matrix-cms-h2 LOG:…
 # FAIL example (do not attach Playwright):
-# RESULT:FAIL STEP:qa-health DETAIL:rhythmyx_context_failed MATCH:Failed startup of context …
+# RESULT:FAIL STEP:qa-health DETAIL:rhythmyx_context_failed MATCH:Failed startup of context … HEALTH:unhealthy …
 docker logs perc-matrix-cms-h2 2>&1 | findstr /i "Failed startup BeanCurrently circular folderHelper"
 # Unix: docker logs perc-matrix-cms-h2 2>&1 | grep -E 'Failed startup|BeanCurrently|circular'
 
 # Docker HEALTHCHECK (orchestrators / docker ps HEALTH column) — #2481:
-docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2
-# healthy | unhealthy | starting
+docker inspect -f "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}" perc-matrix-cms-h2
+# healthy | unhealthy | starting | none
 docker inspect -f "{{json .State.Health}}" perc-matrix-cms-h2
 # Last health log lines include assessor detail (e.g. rhythmyx_context_failed …)
 
-# After compose up, verify also scans cms-dts logs (#2480):
+# After compose up, verify also scans cms-dts logs (#2480) and prints HEALTH: (#2537):
 python docker/scripts/perc-devctl.py verify
+# OK example:
+# RESULT:OK STEP:verify CMS_HTTP:200 DTS_HTTP:200 HEALTH:healthy LOG:…
 # FAIL example:
-# RESULT:FAIL STEP:verify DETAIL:rhythmyx_context_failed MATCH:Failed startup of context …
+# RESULT:FAIL STEP:verify DETAIL:rhythmyx_context_failed MATCH:Failed startup of context … HEALTH:… …
 docker logs percussion-cms-dts 2>&1 | findstr /i "Failed startup BeanCurrently circular folderHelper"
 # Unix: docker logs percussion-cms-dts 2>&1 | grep -E 'Failed startup|BeanCurrently|circular'
-docker inspect -f "{{.State.Health.Status}}" percussion-cms-dts
+docker inspect -f "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}" percussion-cms-dts
 ```
 
 **Rebuild note:** matrix image build context is `docker/` (not `docker/matrix/` alone) so HEALTHCHECK scripts are copied in. After pulling this change, rebuild with `matrix-install-smoke.py` (default) or `docker build -t percussion-matrix-cell:local -f docker/matrix/Dockerfile docker/`. Compose cms-dts: `docker compose build cms-dts`.

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -15,7 +15,9 @@ QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
 * ``qa-health`` — poll published CMS URL until ready (clear timeout);
   fail-fast when Jetty logs show Rhythmyx ApplicationContext failure
   (``Failed startup of context`` / ``BeanCurrentlyInCreationException``)
-  even if HTTP still answers (#2462 / #2423)
+  even if HTTP still answers (#2462 / #2423). RESULT lines include
+  ``HEALTH:healthy|unhealthy|starting|none`` from ``docker inspect``
+  (matrix cell HEALTHCHECK — #2481 residual #2537)
 * ``qa-down`` — destroy the QA cell (frees ports; no multi-GB orphans)
 * ``qa-preflight`` — rebuild-chain preflight; detect a stale WebUI WAR vs
   a freshly built sitemanage SNAPSHOT (#2486)
@@ -23,6 +25,8 @@ QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
 Compose ``verify`` / ``verify-fix`` / ``deploy-jar --verify`` apply the same
 Rhythmyx context log scan against the cms-dts container (#2480 companion to
 #2462): HTTP + docker health alone is not enough when Spring context is dead.
+Both ``qa-health`` (matrix cell) and ``verify`` (cms-dts) print ``HEALTH:``
+from ``_docker_health`` so host log-scan and inspect status share one RESULT.
 
 Each subcommand logs its full output to a timestamped file under
 ``docker/logs/`` and emits a single ``RESULT:OK STEP:<step> LOG:<path>``
@@ -638,11 +642,26 @@ def _curl_status(url: str, *, timeout: float) -> int:
 
 
 def _docker_health(container_name: str) -> str:
-    """Return the docker health status string for ``container_name``,
-    or 'unknown' if docker is missing / container absent.
+    """Return docker ``Health.Status`` for ``container_name``.
+
+    Values typically seen by operators / RESULT lines (#2481 / #2537):
+
+    * ``healthy`` / ``unhealthy`` / ``starting`` — when the image has a HEALTHCHECK
+    * ``none`` — container exists but has no ``.State.Health`` block
+    * ``unknown`` — docker missing, inspect failed, or empty output
     """
+    if not container_name:
+        return "unknown"
     completed = subprocess.run(
-        ["docker", "inspect", "-f", "{{.State.Health.Status}}", container_name],
+        [
+            "docker",
+            "inspect",
+            "-f",
+            # Prefer explicit none over docker template error when Health is absent
+            # (same pattern as matrix-install-smoke wait-for-health).
+            "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+            container_name,
+        ],
         shell=False,
         check=False,
         capture_output=True,
@@ -1272,7 +1291,12 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
 
     * HTTP status on the probe URL is in the ready set (200/302/401/403), **and**
     * Recent ``docker logs`` for the QA cell do **not** contain Rhythmyx
-      ApplicationContext failure markers (see :mod:`rhythmyx_ready`).
+      ApplicationContext failure markers (see :mod:`rhythmyx_ready`), **and**
+    * Docker ``Health.Status`` for the QA cell is ``healthy`` (matrix HEALTHCHECK
+      after #2481 — same gate as compose ``verify`` for cms-dts).
+
+    RESULT lines always include ``HEALTH:<status>`` so operators see host
+    log-scan **and** inspect health in one line (#2537 residual of #2481).
 
     Context-failure markers cause **immediate** FAIL even when HTTP answers
     (Jetty up, Spring webapp dead — #2462 residual of #2423).
@@ -1290,7 +1314,7 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
     if args.dry_run:
         LOG.info(
             "DRY-RUN: qa-health plan: %d checks x %ds interval against %s "
-            "(+ Rhythmyx context log scan on %s)",
+            "(+ Rhythmyx context log scan + docker Health.Status on %s)",
             max_checks,
             interval,
             url,
@@ -1302,32 +1326,22 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
                 f"url={url}\n"
                 f"container={container}\n"
                 f"log_scan=rhythmyx_context_fail_markers\n"
+                f"docker_health=inspect Health.Status\n"
             )
         print(
             f"RESULT:OK STEP:qa-health HTTP:200 URL:{url} "
-            f"CONTAINER:{container} LOG:{log_file}"
+            f"HEALTH:healthy CONTAINER:{container} LOG:{log_file}"
         )
         return EXIT_OK
 
     last_code = 0
+    last_health = "unknown"
     last_detail = "not_checked"
     for check in range(1, max_checks + 1):
         last_code = _curl_status(url, timeout=5.0)
+        last_health = _docker_health(container)
         logs = _docker_logs_tail(container)
         ready, last_detail = assess_rhythmyx_ready(last_code, logs)
-        if ready:
-            with log_file.open("w", encoding="utf-8") as f:
-                f.write("qa-health success\n")
-                f.write(f"url={url}\n")
-                f.write(f"http={last_code}\n")
-                f.write(f"check={check}\n")
-                f.write(f"container={container}\n")
-                f.write("rhythmyx_context=ok\n")
-            print(
-                f"RESULT:OK STEP:qa-health HTTP:{last_code} URL:{url} "
-                f"CONTAINER:{container} LOG:{log_file}"
-            )
-            return EXIT_OK
 
         # Fail-fast when Spring/Jetty already reported a dead Rhythmyx context.
         if DETAIL_CONTEXT_FAILED in last_detail:
@@ -1336,6 +1350,7 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
                 f.write("qa-health failed\n")
                 f.write(f"url={url}\n")
                 f.write(f"last_http={last_code}\n")
+                f.write(f"container_health={last_health}\n")
                 f.write(f"check={check}\n")
                 f.write(f"container={container}\n")
                 f.write(f"detail={last_detail}\n")
@@ -1347,10 +1362,26 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
                 )
             print(
                 f"RESULT:FAIL STEP:qa-health DETAIL:{DETAIL_CONTEXT_FAILED} "
-                f"MATCH:{match} HTTP:{last_code} URL:{url} "
-                f"CONTAINER:{container} LOG:{log_file}"
+                f"MATCH:{match} HTTP:{last_code} HEALTH:{last_health} "
+                f"URL:{url} CONTAINER:{container} LOG:{log_file}"
             )
             return EXIT_SUBPROCESS_FAILED
+
+        # HTTP + clean logs + docker healthy (parity with compose verify).
+        if ready and last_health == "healthy":
+            with log_file.open("w", encoding="utf-8") as f:
+                f.write("qa-health success\n")
+                f.write(f"url={url}\n")
+                f.write(f"http={last_code}\n")
+                f.write(f"container_health={last_health}\n")
+                f.write(f"check={check}\n")
+                f.write(f"container={container}\n")
+                f.write("rhythmyx_context=ok\n")
+            print(
+                f"RESULT:OK STEP:qa-health HTTP:{last_code} HEALTH:{last_health} "
+                f"URL:{url} CONTAINER:{container} LOG:{log_file}"
+            )
+            return EXIT_OK
 
         time.sleep(interval)
 
@@ -1361,6 +1392,7 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
         f.write("qa-health failed\n")
         f.write(f"url={url}\n")
         f.write(f"last_http={last_code}\n")
+        f.write(f"container_health={last_health}\n")
         f.write(f"timeout_seconds={timeout}\n")
         f.write(f"interval_seconds={interval}\n")
         f.write(f"container={container}\n")
@@ -1375,19 +1407,20 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
             f.write(
                 "hint: run qa-up first; ensure installer jar is built "
                 "(modules/perc-distribution-tree package); if Jetty is up but "
-                "login fails, scan docker logs for Failed startup of context\n"
+                "login fails, scan docker logs for Failed startup of context; "
+                "also check docker inspect Health.Status on the QA cell\n"
             )
     if final_match:
         print(
             f"RESULT:FAIL STEP:qa-health DETAIL:{DETAIL_CONTEXT_FAILED} "
-            f"MATCH:{final_match} HTTP:{last_code} URL:{url} "
-            f"CONTAINER:{container} LOG:{log_file}"
+            f"MATCH:{final_match} HTTP:{last_code} HEALTH:{last_health} "
+            f"URL:{url} CONTAINER:{container} LOG:{log_file}"
         )
     else:
         print(
             f"RESULT:FAIL STEP:qa-health DETAIL:timeout after {timeout}s "
-            f"(last_http={last_code}) URL:{url} CONTAINER:{container} "
-            f"LOG:{log_file}"
+            f"(last_http={last_code} health={last_health}) URL:{url} "
+            f"CONTAINER:{container} LOG:{log_file}"
         )
     return EXIT_SUBPROCESS_FAILED
 

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -173,6 +173,40 @@ class TestQaPreflight(unittest.TestCase):
         self.assertIn("dry-run", out.lower())
 
 
+class TestDockerHealth(unittest.TestCase):
+    """#2537 / #2481: ``_docker_health`` maps inspect output to RESULT HEALTH: values."""
+
+    def test_empty_container_name_is_unknown(self):
+        self.assertEqual(pdc._docker_health(""), "unknown")
+
+    def test_inspect_failure_is_unknown(self):
+        with unittest.mock.patch.object(pdc.subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Error: No such object"
+            )
+            self.assertEqual(pdc._docker_health("missing"), "unknown")
+            argv = mock_run.call_args[0][0]
+            self.assertEqual(argv[0:3], ["docker", "inspect", "-f"])
+            self.assertIn("{{if .State.Health}}", argv[3])
+            self.assertEqual(argv[4], "missing")
+
+    def test_health_status_passed_through(self):
+        for status in ("healthy", "unhealthy", "starting", "none"):
+            with self.subTest(status=status):
+                with unittest.mock.patch.object(pdc.subprocess, "run") as mock_run:
+                    mock_run.return_value = subprocess.CompletedProcess(
+                        args=[], returncode=0, stdout=status + "\n", stderr=""
+                    )
+                    self.assertEqual(pdc._docker_health("perc-matrix-cms-h2"), status)
+
+    def test_blank_stdout_is_unknown(self):
+        with unittest.mock.patch.object(pdc.subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="  \n", stderr=""
+            )
+            self.assertEqual(pdc._docker_health("c"), "unknown")
+
+
 class TestSubcommandDryRun(unittest.TestCase):
     """Every subcommand that supports ``--dry-run`` returns EXIT_OK and
     emits RESULT:OK without invoking docker / curl / mvn.
@@ -241,6 +275,7 @@ class TestSubcommandDryRun(unittest.TestCase):
         self.assertEqual(rc, pdc.EXIT_OK)
         self.assertIn("RESULT:OK STEP:qa-health", out)
         self.assertIn("HTTP:200", out)
+        self.assertIn("HEALTH:healthy", out)
         self.assertIn(pdc.QA_CMS_CONTAINER, out)
 
     def test_qa_down_dry_run(self):
@@ -598,9 +633,11 @@ class TestQaHealthRealMode(unittest.TestCase):
 
     def test_qa_health_success_on_first_check(self):
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
              unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
              unittest.mock.patch.object(pdc.time, "sleep"):
             mock_curl.return_value = 200
+            mock_health.return_value = "healthy"
             mock_logs.return_value = "INFO [Server] Started @7879ms\n"
             import io
             from contextlib import redirect_stdout
@@ -614,13 +651,17 @@ class TestQaHealthRealMode(unittest.TestCase):
         self.assertEqual(rc, pdc.EXIT_OK)
         self.assertIn("RESULT:OK STEP:qa-health", out)
         self.assertIn("HTTP:200", out)
+        self.assertIn("HEALTH:healthy", out)
         mock_logs.assert_called()
+        mock_health.assert_called_with(pdc.QA_CMS_CONTAINER)
 
     def test_qa_health_timeout_emits_clear_error(self):
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
              unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
              unittest.mock.patch.object(pdc.time, "sleep"):
             mock_curl.return_value = 0
+            mock_health.return_value = "starting"
             mock_logs.return_value = ""
             import io
             from contextlib import redirect_stdout
@@ -636,6 +677,7 @@ class TestQaHealthRealMode(unittest.TestCase):
         self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
         self.assertIn("RESULT:FAIL STEP:qa-health", out)
         self.assertIn("timeout", out)
+        self.assertIn("health=starting", out)
         self.assertIn("LOG:", out)
         self.assertNotIn("LOG:\n", out)
 
@@ -648,9 +690,11 @@ class TestQaHealthRealMode(unittest.TestCase):
             "INFO  [AbstractConnector] Started {HTTP/1.1}{0.0.0.0:9992}\n"
         )
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
              unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
              unittest.mock.patch.object(pdc.time, "sleep") as mock_sleep:
             mock_curl.return_value = 200
+            mock_health.return_value = "unhealthy"
             mock_logs.return_value = dead_ctx
             import io
             from contextlib import redirect_stdout
@@ -667,6 +711,7 @@ class TestQaHealthRealMode(unittest.TestCase):
         self.assertIn("RESULT:FAIL STEP:qa-health", out)
         self.assertIn("rhythmyx_context_failed", out)
         self.assertIn("Failed startup of context", out)
+        self.assertIn("HEALTH:unhealthy", out)
         # Fail-fast: must not burn the full poll budget.
         mock_sleep.assert_not_called()
 
@@ -674,9 +719,11 @@ class TestQaHealthRealMode(unittest.TestCase):
         """When HTTP never ready but logs show context fail, DETAIL uses that."""
         dead_ctx = "Failed startup of context Rhythmyx\n"
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
              unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
              unittest.mock.patch.object(pdc.time, "sleep"):
             mock_curl.return_value = 0
+            mock_health.return_value = "unhealthy"
             # max_checks=1 (5//5): one in-loop scan (empty) + one final scan (fail).
             mock_logs.side_effect = ["", dead_ctx]
             import io
@@ -693,6 +740,56 @@ class TestQaHealthRealMode(unittest.TestCase):
         self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
         self.assertIn("rhythmyx_context_failed", out)
         self.assertIn("Failed startup of context", out)
+        self.assertIn("HEALTH:unhealthy", out)
+
+    def test_qa_health_http_ok_but_health_starting_not_ready(self):
+        """#2537: HTTP ready alone is insufficient until Health.Status=healthy."""
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
+             unittest.mock.patch.object(pdc.time, "sleep"):
+            mock_curl.return_value = 200
+            mock_health.return_value = "starting"
+            mock_logs.return_value = "INFO [Server] Started @7879ms\n"
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "qa-health",
+                    "--timeout-seconds", "5",
+                    "--interval-seconds", "5",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
+        self.assertIn("RESULT:FAIL STEP:qa-health", out)
+        self.assertIn("timeout", out)
+        self.assertIn("health=starting", out)
+        mock_health.assert_called_with(pdc.QA_CMS_CONTAINER)
+
+    def test_qa_health_surfaces_health_none(self):
+        """#2537: HEALTH:none when container has no Health block."""
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc, "_docker_health") as mock_health, \
+             unittest.mock.patch.object(pdc, "_docker_logs_tail") as mock_logs, \
+             unittest.mock.patch.object(pdc.time, "sleep"):
+            mock_curl.return_value = 200
+            mock_health.return_value = "none"
+            mock_logs.return_value = "INFO [Server] Started\n"
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "qa-health",
+                    "--timeout-seconds", "5",
+                    "--interval-seconds", "5",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
+        self.assertIn("health=none", out)
 
 
 class TestQaDownRealMode(unittest.TestCase):


### PR DESCRIPTION
## Summary
Surfaces Docker `Health.Status` on `perc-devctl` `qa-health` RESULT lines for matrix QA cells, consistently with compose `verify` / cms-dts after #2481 HEALTHCHECK.

**Parent:** #2423  
**Related:** #2481 / PR #2534  
**Fixes:** #2537

### Changes
- `qa-health` RESULT always includes `HEALTH:healthy|unhealthy|starting|none` (or `unknown` if inspect fails)
- OK path requires HTTP ready + clean Rhythmyx context logs **and** `Health.Status=healthy` (parity with `verify`)
- `_docker_health` uses `{{if .State.Health}}…{{else}}none{{end}}` template (same idea as matrix-install-smoke)
- `docker/README.md` signal table + examples document matrix and cms-dts HEALTH columns
- Unit tests mock `_docker_health` for success, starting, none, unhealthy, and inspect failure

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
1. `cd docker/scripts && python -m unittest test_perc_devctl.py -v` → **55 tests OK**
2. (Optional live) After `qa-up`, run `qa-health` and confirm RESULT contains `HEALTH:healthy` or fails with `HEALTH:…` when not ready
3. Compose `verify` still prints `HEALTH:healthy` and fails context-failed with HEALTH present

## Gates evidence
- **Maven clean install:** N/A — no Maven modules changed (Python docker scripts + README only)
- **Unit tests:** `python -m unittest test_perc_devctl.py` → Ran 55, Failures: 0
- **Erlang-style self-review:** no new bugs; portable paths (`pathlib`/existing helpers only); no non-portable path construction; companions = tests + README table row
- **Human QA:** not required (agent-safe script RESULT contract; no product UI/install)

> Co-Authored by Grok Build using grok-4.5 with agent main.