### PR TITLE
fix(docker): CMS matrix/qa-up wait requires Health.Status=healthy (#2535)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -248,7 +248,7 @@ python docker/scripts/perc-devctl.py down
 
 #### QA mode (`qa-up` / `qa-health` / `qa-down`)
 
-Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for the resolved probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`), prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section. Concurrent freeport checklist: **Two-worktree concurrent freeport smoke** above.
+Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for docker `Health.Status=healthy` **and** the resolved host probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`) with host log scan, prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section. Concurrent freeport checklist: **Two-worktree concurrent freeport smoke** above.
 
 ##### Rhythmyx ApplicationContext fail-fast (#2462 / #2480 / #2423)
 
@@ -262,9 +262,29 @@ Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `
 | `RESULT:FAIL … DETAIL:timeout after Ns (last_http=…)` | `qa-health` | Probe never became ready; if logs later show context fail, re-run `qa-health` or `docker logs perc-matrix-cms-h2` |
 | `RESULT:FAIL … DETAIL:timeout after Ns (cms_http=… dts_http=… health=…)` | `verify` | Stack never became ready; scan `docker logs percussion-cms-dts` for context markers |
 | Matrix `status=fail` + `detail` containing `rhythmyx_context_failed` | `matrix-install-smoke.py` CMS cells | Same fail-fast during cell HTTP wait (container log scan) |
+| Matrix `status=fail` + `detail` containing `docker_health_unhealthy` | `matrix-install-smoke.py` CMS cells / `qa-up` | **Fail-fast** when `docker inspect` already reports `Health.Status=unhealthy` — does **not** burn full `--probe-timeout` (#2535 / #2481) |
+| Matrix `status=fail` + `detail` containing `docker_health_timeout` | same | Probe timed out while health was still `starting` / not `healthy` |
 | Docker `Health.Status=healthy` | matrix cell / cms-dts image HEALTHCHECK (#2481) | In-container login probe ready **and** local Jetty logs have **no** context-failure markers |
 | Docker `Health.Status=unhealthy` | same | Context failed and/or login not ready — **do not** attach Playwright; inspect health log + `docker logs` |
 | Docker `Health.Status=starting` | same | Still inside HEALTHCHECK `start_period` (matrix cells: long install window) |
+
+##### Matrix / qa-up wait policy (CMS cells, #2535)
+
+After the in-image HEALTHCHECK lands (#2481), **CMS** matrix cells (and therefore `perc-devctl qa-up`, which delegates to `matrix-install-smoke.py --product cms --db h2 --keep`) wait with this combined policy:
+
+1. **Host log scan** (`rhythmyx_ready` markers) — fail-fast on context death (unchanged belt-and-braces from #2462).
+2. **Docker `Health.Status`** — require `healthy`; **fail-fast** when inspect already reports `unhealthy` (do not wait full `--probe-timeout`).
+3. **Host HTTP probe** — `/Rhythmyx/login` ready codes (200/302/401/403).
+
+HTTP alone during HEALTHCHECK `start_period` (status still `starting`) is **not** enough. Rebuild the matrix image after pulling HEALTHCHECK changes so the cell has a real health block.
+
+```bash
+# CMS cell / qa-up wait DETAIL tokens (matrix JSON detail / probe failed: …):
+#   docker_health_unhealthy health=unhealthy status=running …
+#   docker_health_timeout health=starting status=running last=HTTP 200 …
+#   rhythmyx_context_failed match='Failed startup of context' …
+docker inspect -f "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}" perc-matrix-cms-h2
+```
 
 Markers (shared helper `docker/scripts/rhythmyx_ready.py`): `Failed startup of context`, `BeanCurrentlyInCreationException`, `Requested bean is currently in creation`, `Is there an unresolvable circular reference`.
 

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -10,7 +10,10 @@ Layer 1 harness:
        - copies/mounts the installer jar
        - silent + no-tty install with ``--db.*``
        - starts Jetty (CMS) or Tomcat (DTS)
-  4. Probe login / health URL from the host
+  4. Probe login / health URL from the host; CMS cells also require
+     docker ``Health.Status=healthy`` (fail-fast when already unhealthy —
+     #2535 residual of #2481 HEALTHCHECK) while keeping host
+     ``rhythmyx_ready`` log scan as belt-and-braces
   5. Record JSON + RESULT line under ``docker/logs/``
   6. Destroy the cell unless ``--keep``
   7. Stop external DBs this process started (unless ``--keep`` / ``--keep-db``)
@@ -96,6 +99,18 @@ LOG = logging.getLogger("matrix-install-smoke")
 EXIT_OK = 0
 EXIT_INVOCATION = 1
 EXIT_CELL_FAILED = 2
+
+# DETAIL tokens for docker Health.Status wait policy (#2535 residual of #2481).
+# Coordinate RESULT shape with perc-devctl HEALTH: column (#2537): same tokens.
+DETAIL_DOCKER_UNHEALTHY = "docker_health_unhealthy"
+DETAIL_DOCKER_HEALTH_TIMEOUT = "docker_health_timeout"
+DETAIL_CONTAINER_NOT_RUNNING = "container_not_running"
+
+# docker inspect format shared by DB + CMS health waits (#2481 / #2535).
+_DOCKER_HEALTH_INSPECT_FMT = (
+    "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}"
+    "|{{.State.Status}}"
+)
 
 DEFAULT_COMPOSE_FILE = "docker-compose.yml"
 DEFAULT_ENV_FILE = ".env.compose"
@@ -771,14 +786,58 @@ def start_db(
         except ValueError:
             healthy_timeout = 0
         if healthy_timeout > 0:
-            if not wait_for_container_healthy(
+            ok, detail = wait_for_container_healthy(
                 container, healthy_timeout, dry_run=dry_run
-            ):
+            )
+            if not ok:
                 raise RuntimeError(
-                    f"Timed out waiting for healthy status on {container} "
-                    f"after {healthy_timeout}s (db_type={db_type})"
+                    f"Waiting for healthy status on {container} failed after "
+                    f"{healthy_timeout}s (db_type={db_type}): {detail}"
                 )
     return started_by_matrix
+
+
+def inspect_container_health(
+    container: str,
+    *,
+    timeout: float = 30.0,
+) -> Tuple[str, str]:
+    """Return ``(health_status, container_status)`` from ``docker inspect``.
+
+    * ``health_status`` — ``healthy`` / ``unhealthy`` / ``starting`` / ``none``
+      when inspect succeeds; ``unknown`` when docker is missing or inspect fails.
+    * ``container_status`` — e.g. ``running`` / ``exited`` / empty / ``unknown``.
+
+    Pure side-effect: one ``docker inspect`` call. Unit-testable via
+    ``subprocess.run`` mock (#2535).
+    """
+    if not container:
+        return "unknown", "unknown"
+    try:
+        proc = subprocess.run(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                _DOCKER_HEALTH_INSPECT_FMT,
+                container,
+            ],
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        LOG.debug("inspect_container_health %s: %s", container, exc)
+        return "unknown", "unknown"
+    if proc.returncode != 0:
+        return "unknown", "unknown"
+    raw = (proc.stdout or "").strip()
+    health, _, status = raw.partition("|")
+    health = health.strip().lower() or "unknown"
+    status = status.strip().lower() or "unknown"
+    return health, status
 
 
 def wait_for_container_healthy(
@@ -787,63 +846,77 @@ def wait_for_container_healthy(
     *,
     dry_run: bool,
     interval_seconds: float = 5.0,
-) -> bool:
+    allow_no_healthcheck: bool = True,
+) -> Tuple[bool, str]:
     """Wait until ``docker inspect`` reports Health.Status == healthy.
 
-    Containers without a healthcheck (Status empty / none) are treated as ready
-    once they are running, so other compose DB profiles stay non-blocking.
+    Returns ``(ok, detail)`` where ``detail`` is a short machine-friendly token
+    string for cell / RuntimeError messages (#2535).
+
+    Policy:
+
+    * ``healthy`` → success immediately.
+    * ``unhealthy`` → **fail-fast** (do not wait remaining timeout). Docker has
+      already decided the HEALTHCHECK failed (DB or CMS cell).
+    * ``exited`` / ``dead`` / ``removing`` → fail-fast.
+    * ``starting`` → keep polling until timeout.
+    * No healthcheck (``none`` / empty) + running:
+      - if ``allow_no_healthcheck`` (default, compose DB profiles without a
+        healthcheck) → treat as ready;
+      - else keep waiting / timeout (CMS cells require a real HEALTHCHECK).
+
+    Host-side log scan is **not** done here — CMS cells use
+    :func:`wait_for_http` with ``require_docker_health=True`` for the combined
+    policy (Health.Status + host HTTP + ``rhythmyx_ready`` log scan).
     """
     if dry_run:
         LOG.info("DRY-RUN: wait for healthy %s (%ss)", container, timeout_seconds)
-        return True
+        return True, "dry-run"
     deadline = time.time() + timeout_seconds
+    last_health = "unknown"
+    last_status = "unknown"
     while time.time() < deadline:
-        try:
-            proc = subprocess.run(
-                [
-                    "docker",
-                    "inspect",
-                    "--format",
-                    "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}|{{.State.Status}}",
-                    container,
-                ],
-                shell=False,
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=30,
+        health, status = inspect_container_health(container)
+        last_health, last_status = health, status
+        if health == "healthy":
+            LOG.info("Container %s is healthy", container)
+            return True, f"healthy status={status}"
+        if health == "unhealthy":
+            detail = (
+                f"{DETAIL_DOCKER_UNHEALTHY} health={health} status={status}"
             )
-            raw = (proc.stdout or "").strip()
-            health, _, status = raw.partition("|")
-            health = health.strip().lower()
-            status = status.strip().lower()
-            if health == "healthy":
-                LOG.info("Container %s is healthy", container)
-                return True
-            if health in ("", "none") and status == "running":
-                LOG.info(
-                    "Container %s is running (no healthcheck); treating as ready",
-                    container,
-                )
-                return True
-            if status in ("exited", "dead", "removing"):
-                LOG.error("Container %s is %s (health=%s)", container, status, health)
-                return False
+            LOG.error("Container %s is unhealthy — fail-fast (%s)", container, detail)
+            return False, detail
+        if status in ("exited", "dead", "removing"):
+            detail = (
+                f"{DETAIL_CONTAINER_NOT_RUNNING} status={status} health={health}"
+            )
+            LOG.error("Container %s is %s (health=%s)", container, status, health)
+            return False, detail
+        if allow_no_healthcheck and health in ("", "none") and status == "running":
             LOG.info(
-                "Waiting for %s healthy (health=%s status=%s)",
+                "Container %s is running (no healthcheck); treating as ready",
                 container,
-                health or "?",
-                status or "?",
             )
-        except (OSError, subprocess.SubprocessError) as exc:
-            LOG.debug("wait_for_container_healthy %s: %s", container, exc)
+            return True, f"no_healthcheck status={status}"
+        LOG.info(
+            "Waiting for %s healthy (health=%s status=%s)",
+            container,
+            health or "?",
+            status or "?",
+        )
         time.sleep(interval_seconds)
+    detail = (
+        f"{DETAIL_DOCKER_HEALTH_TIMEOUT} health={last_health} "
+        f"status={last_status} timeout={timeout_seconds}s"
+    )
     LOG.error(
-        "Timed out waiting for healthy status on %s after %ss",
+        "Timed out waiting for healthy status on %s after %ss (%s)",
         container,
         timeout_seconds,
+        detail,
     )
-    return False
+    return False, detail
 
 
 def stop_external_dbs(
@@ -964,6 +1037,7 @@ def wait_for_http(
     interval_seconds: float = 5.0,
     dry_run: bool,
     container_name: Optional[str] = None,
+    require_docker_health: bool = False,
 ) -> Tuple[bool, str]:
     """Poll ``url`` until HTTP ready codes, or fail-fast on Rhythmyx context death.
 
@@ -971,21 +1045,54 @@ def wait_for_http(
     ``docker logs`` for Spring/Jetty ApplicationContext failure markers.
     A dead Rhythmyx context fails the probe **immediately** even if Jetty
     still answers HTTP (#2462 residual of #2423).
+
+    When ``require_docker_health`` is True (CMS matrix cells / qa-up path after
+    #2481 — issue #2535), each poll also reads ``docker inspect`` Health.Status:
+
+    * ``unhealthy`` → fail-fast with :data:`DETAIL_DOCKER_UNHEALTHY` (do not
+      wait the full ``timeout_seconds``).
+    * Success requires Health.Status ``healthy`` **and** HTTP ready **and**
+      no context-failure markers (host log scan remains belt-and-braces).
+    * ``starting`` / ``none`` / ``unknown`` → keep polling until timeout.
+
+    DETAIL strings use stable tokens so agents / RESULT parsers can match
+    ``docker_health_unhealthy`` and ``rhythmyx_context_failed`` (coordinate
+    with perc-devctl ``HEALTH:`` column from #2537).
     """
     if dry_run:
         return True, "dry-run"
     deadline = time.time() + timeout_seconds
     last = ""
+    last_health = "unknown"
     while time.time() < deadline:
         # Fail-fast: Jetty up + Spring context dead must not wait full timeout.
         if container_name:
             logs = _docker_logs_tail(container_name)
             match = find_rhythmyx_context_failure(logs)
             if match is not None:
+                health_suffix = ""
+                if require_docker_health:
+                    last_health, _st = inspect_container_health(container_name)
+                    health_suffix = f" health={last_health}"
                 return (
                     False,
-                    f"{DETAIL_CONTEXT_FAILED} match={match!r} last={last or 'n/a'}",
+                    f"{DETAIL_CONTEXT_FAILED} match={match!r} "
+                    f"last={last or 'n/a'}{health_suffix}",
                 )
+            if require_docker_health:
+                last_health, status = inspect_container_health(container_name)
+                if last_health == "unhealthy":
+                    return (
+                        False,
+                        f"{DETAIL_DOCKER_UNHEALTHY} health={last_health} "
+                        f"status={status} last={last or 'n/a'}",
+                    )
+                if status in ("exited", "dead", "removing"):
+                    return (
+                        False,
+                        f"{DETAIL_CONTAINER_NOT_RUNNING} status={status} "
+                        f"health={last_health} last={last or 'n/a'}",
+                    )
         try:
             req = urllib.request.Request(url, method="GET")
             with urllib.request.urlopen(req, timeout=10) as resp:
@@ -1001,7 +1108,14 @@ def wait_for_http(
                                 f"{DETAIL_CONTEXT_FAILED} match={match!r} "
                                 f"http={code}",
                             )
-                    return True, f"HTTP {code}"
+                    if require_docker_health:
+                        # Host HTTP ready is not enough — need inspect healthy.
+                        if last_health != "healthy":
+                            last = f"HTTP {code} health={last_health}"
+                        else:
+                            return True, f"HTTP {code} health={last_health}"
+                    else:
+                        return True, f"HTTP {code}"
                 last = f"HTTP {code}"
         except urllib.error.HTTPError as exc:
             # Some login paths return 401/403 before auth — treat as up.
@@ -1015,7 +1129,13 @@ def wait_for_http(
                             f"{DETAIL_CONTEXT_FAILED} match={match!r} "
                             f"http={exc.code}",
                         )
-                return True, f"HTTP {exc.code}"
+                if require_docker_health:
+                    if last_health != "healthy":
+                        last = f"HTTP {exc.code} health={last_health}"
+                    else:
+                        return True, f"HTTP {exc.code} health={last_health}"
+                else:
+                    return True, f"HTTP {exc.code}"
             last = f"HTTPError {exc.code}"
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             last = str(exc)
@@ -1025,9 +1145,24 @@ def wait_for_http(
         logs = _docker_logs_tail(container_name)
         match = find_rhythmyx_context_failure(logs)
         if match is not None:
+            health_suffix = f" health={last_health}" if require_docker_health else ""
             return (
                 False,
-                f"{DETAIL_CONTEXT_FAILED} match={match!r} last={last or 'timeout'}",
+                f"{DETAIL_CONTEXT_FAILED} match={match!r} "
+                f"last={last or 'timeout'}{health_suffix}",
+            )
+        if require_docker_health:
+            last_health, status = inspect_container_health(container_name)
+            if last_health == "unhealthy":
+                return (
+                    False,
+                    f"{DETAIL_DOCKER_UNHEALTHY} health={last_health} "
+                    f"status={status} last={last or 'timeout'}",
+                )
+            return (
+                False,
+                f"{DETAIL_DOCKER_HEALTH_TIMEOUT} health={last_health} "
+                f"status={status} last={last or 'timeout'}",
             )
     return False, last or "timeout"
 
@@ -1136,12 +1271,16 @@ def run_cell(
 
     # Capture container logs while waiting. CMS cells pass container_name so
     # a dead Rhythmyx ApplicationContext fails the probe even if Jetty HTTP
-    # still answers (#2462 / #2423).
+    # still answers (#2462 / #2423). After #2481 HEALTHCHECK, CMS cells also
+    # require docker Health.Status=healthy and fail-fast when already
+    # unhealthy (#2535). Host log scan remains belt-and-braces.
+    is_cms = cell.product == "cms"
     ok, detail = wait_for_http(
         probe_url,
         timeout_seconds=probe_timeout,
         dry_run=dry_run,
-        container_name=name if cell.product == "cms" else None,
+        container_name=name if is_cms else None,
+        require_docker_health=is_cms,
     )
     if not dry_run:
         logs = _run(

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -1212,11 +1212,14 @@ def _qa_fetch_admin_password(container_name: str) -> Optional[str]:
 
 
 def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
-    """Bring up CMS on H2 in Docker and wait until the probe URL is ready.
+    """Bring up CMS on H2 in Docker and wait until the cell is ready.
 
     Delegates install/start/health-wait to ``matrix-install-smoke.py`` with
-    ``--product cms --db h2 --keep``. On success prints ``TEST_CMS_URL`` and
-    admin credential guidance for Playwright / agents.
+    ``--product cms --db h2 --keep``. CMS wait requires docker
+    ``Health.Status=healthy`` (fail-fast when already unhealthy — #2535 /
+    #2481), host HTTP probe, and host ``rhythmyx_ready`` log scan. On success
+    prints ``TEST_CMS_URL`` and admin credential guidance for Playwright /
+    agents.
 
     Host port is resolved via :func:`ensure_qa_cms_host_port` (env override
     or freeport) and exported as ``QA_CMS_HOST_PORT`` / ``CMS_HOST_PORT`` so

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -271,11 +271,11 @@ class DockerRunArgvTests(unittest.TestCase):
         self.assertIn("WAIT_DB_SECONDS=600", joined)
 
     def test_wait_for_container_healthy_dry_run(self):
-        self.assertTrue(
-            smoke.wait_for_container_healthy(
-                "percussion-oracle", 30, dry_run=True
-            )
+        ok, detail = smoke.wait_for_container_healthy(
+            "percussion-oracle", 30, dry_run=True
         )
+        self.assertTrue(ok)
+        self.assertEqual(detail, "dry-run")
 
     def test_build_matrix_image_uses_docker_dir_context(self):
         """#2481: build context is docker/ so HEALTHCHECK scripts can COPY in."""
@@ -305,6 +305,100 @@ class DockerRunArgvTests(unittest.TestCase):
         # Context path is …/docker (parent of matrix/), not …/docker/matrix alone.
         self.assertEqual(Path(argv[-1]), root / "docker")
         self.assertEqual(Path(argv[argv.index("-f") + 1]), root / "docker" / "matrix" / "Dockerfile")
+
+
+class WaitForContainerHealthyPolicyTests(unittest.TestCase):
+    """#2535: docker Health.Status wait policy (fail-fast unhealthy)."""
+
+    def test_inspect_container_health_parses_format(self):
+        import unittest.mock
+        import subprocess as sp
+
+        proc = sp.CompletedProcess(
+            args=[], returncode=0, stdout="healthy|running\n", stderr=""
+        )
+        with unittest.mock.patch.object(smoke.subprocess, "run", return_value=proc):
+            health, status = smoke.inspect_container_health("perc-matrix-cms-h2")
+        self.assertEqual(health, "healthy")
+        self.assertEqual(status, "running")
+
+    def test_inspect_container_health_none_when_no_healthblock(self):
+        import unittest.mock
+        import subprocess as sp
+
+        proc = sp.CompletedProcess(
+            args=[], returncode=0, stdout="none|running\n", stderr=""
+        )
+        with unittest.mock.patch.object(smoke.subprocess, "run", return_value=proc):
+            health, status = smoke.inspect_container_health("some-db")
+        self.assertEqual(health, "none")
+        self.assertEqual(status, "running")
+
+    def test_wait_for_container_healthy_fail_fast_unhealthy(self):
+        """Do not burn the full timeout when inspect already reports unhealthy."""
+        import unittest.mock
+
+        with unittest.mock.patch.object(
+            smoke, "inspect_container_health", return_value=("unhealthy", "running")
+        ) as mock_inspect, unittest.mock.patch.object(
+            smoke.time, "sleep"
+        ) as mock_sleep:
+            ok, detail = smoke.wait_for_container_healthy(
+                "perc-matrix-cms-h2",
+                timeout_seconds=600,
+                dry_run=False,
+                interval_seconds=5,
+            )
+        self.assertFalse(ok)
+        self.assertIn(smoke.DETAIL_DOCKER_UNHEALTHY, detail)
+        self.assertIn("health=unhealthy", detail)
+        mock_inspect.assert_called()
+        mock_sleep.assert_not_called()
+
+    def test_wait_for_container_healthy_success(self):
+        import unittest.mock
+
+        with unittest.mock.patch.object(
+            smoke, "inspect_container_health", return_value=("healthy", "running")
+        ), unittest.mock.patch.object(smoke.time, "sleep") as mock_sleep:
+            ok, detail = smoke.wait_for_container_healthy(
+                "percussion-oracle",
+                timeout_seconds=30,
+                dry_run=False,
+            )
+        self.assertTrue(ok)
+        self.assertIn("healthy", detail)
+        mock_sleep.assert_not_called()
+
+    def test_wait_for_container_healthy_no_healthcheck_allowed(self):
+        import unittest.mock
+
+        with unittest.mock.patch.object(
+            smoke, "inspect_container_health", return_value=("none", "running")
+        ):
+            ok, detail = smoke.wait_for_container_healthy(
+                "percussion-mysql",
+                timeout_seconds=30,
+                dry_run=False,
+                allow_no_healthcheck=True,
+            )
+        self.assertTrue(ok)
+        self.assertIn("no_healthcheck", detail)
+
+    def test_wait_for_container_healthy_exited_fail_fast(self):
+        import unittest.mock
+
+        with unittest.mock.patch.object(
+            smoke, "inspect_container_health", return_value=("none", "exited")
+        ), unittest.mock.patch.object(smoke.time, "sleep") as mock_sleep:
+            ok, detail = smoke.wait_for_container_healthy(
+                "dead-box",
+                timeout_seconds=100,
+                dry_run=False,
+            )
+        self.assertFalse(ok)
+        self.assertIn(smoke.DETAIL_CONTAINER_NOT_RUNNING, detail)
+        mock_sleep.assert_not_called()
 
 
 class WaitForHttpContextFailTests(unittest.TestCase):
@@ -401,6 +495,134 @@ class WaitForHttpContextFailTests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(detail, "HTTP 200")
         mock_logs.assert_not_called()
+
+
+class WaitForHttpDockerHealthTests(unittest.TestCase):
+    """#2535: CMS wait requires Health.Status=healthy + host belt-and-braces."""
+
+    def test_require_health_fail_fast_unhealthy(self):
+        """Unhealthy inspect must not wait the full probe timeout."""
+        import unittest.mock
+
+        with unittest.mock.patch.object(
+            smoke, "_docker_logs_tail", return_value="Jetty started\n"
+        ), unittest.mock.patch.object(
+            smoke, "inspect_container_health", return_value=("unhealthy", "running")
+        ), unittest.mock.patch.object(
+            smoke.time, "sleep"
+        ) as mock_sleep, unittest.mock.patch.object(
+            smoke.urllib.request, "urlopen"
+        ) as mock_http:
+            ok, detail = smoke.wait_for_http(
+                "http://127.0.0.1:9993/Rhythmyx/login",
+                timeout_seconds=600,
+                interval_seconds=5,
+                dry_run=False,
+                container_name="perc-matrix-cms-h2",
+                require_docker_health=True,
+            )
+        self.assertFalse(ok)
+        self.assertIn(smoke.DETAIL_DOCKER_UNHEALTHY, detail)
+        self.assertIn("health=unhealthy", detail)
+        mock_http.assert_not_called()
+        mock_sleep.assert_not_called()
+
+    def test_require_health_success_when_healthy_and_http_ok(self):
+        import unittest.mock
+
+        class _Resp:
+            def getcode(self):
+                return 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        with unittest.mock.patch.object(
+            smoke, "_docker_logs_tail", return_value="Server Started\n"
+        ), unittest.mock.patch.object(
+            smoke, "inspect_container_health", return_value=("healthy", "running")
+        ), unittest.mock.patch.object(
+            smoke.urllib.request, "urlopen", return_value=_Resp()
+        ), unittest.mock.patch.object(smoke.time, "sleep") as mock_sleep:
+            ok, detail = smoke.wait_for_http(
+                "http://127.0.0.1:9993/Rhythmyx/login",
+                timeout_seconds=30,
+                interval_seconds=5,
+                dry_run=False,
+                container_name="perc-matrix-cms-h2",
+                require_docker_health=True,
+            )
+        self.assertTrue(ok)
+        self.assertIn("HTTP 200", detail)
+        self.assertIn("health=healthy", detail)
+        mock_sleep.assert_not_called()
+
+    def test_require_health_waits_while_starting_even_if_http_ok(self):
+        """HTTP green during start_period is not enough — need healthy."""
+        import unittest.mock
+
+        class _Resp:
+            def getcode(self):
+                return 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        # First poll: starting; second: healthy.
+        health_seq = iter(
+            [("starting", "running"), ("healthy", "running")]
+        )
+
+        def _inspect(_name, **_kw):
+            return next(health_seq)
+
+        with unittest.mock.patch.object(
+            smoke, "_docker_logs_tail", return_value="ok\n"
+        ), unittest.mock.patch.object(
+            smoke, "inspect_container_health", side_effect=_inspect
+        ), unittest.mock.patch.object(
+            smoke.urllib.request, "urlopen", return_value=_Resp()
+        ), unittest.mock.patch.object(smoke.time, "sleep") as mock_sleep:
+            ok, detail = smoke.wait_for_http(
+                "http://127.0.0.1:9993/Rhythmyx/login",
+                timeout_seconds=30,
+                interval_seconds=0.01,
+                dry_run=False,
+                container_name="perc-matrix-cms-h2",
+                require_docker_health=True,
+            )
+        self.assertTrue(ok)
+        self.assertIn("health=healthy", detail)
+        mock_sleep.assert_called()
+
+    def test_require_health_still_fail_fast_on_context_log_markers(self):
+        """Host rhythmyx_ready log scan remains belt-and-braces (#2462)."""
+        import unittest.mock
+
+        dead = "Failed startup of context Rhythmyx\n"
+        with unittest.mock.patch.object(
+            smoke, "_docker_logs_tail", return_value=dead
+        ), unittest.mock.patch.object(
+            smoke, "inspect_container_health", return_value=("starting", "running")
+        ), unittest.mock.patch.object(smoke.time, "sleep") as mock_sleep:
+            ok, detail = smoke.wait_for_http(
+                "http://127.0.0.1:9993/Rhythmyx/login",
+                timeout_seconds=600,
+                interval_seconds=5,
+                dry_run=False,
+                container_name="perc-matrix-cms-h2",
+                require_docker_health=True,
+            )
+        self.assertFalse(ok)
+        self.assertIn(smoke.DETAIL_CONTEXT_FAILED, detail)
+        self.assertIn("health=starting", detail)
+        mock_sleep.assert_not_called()
 
 
 class InstallArgvTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

After #2481 in-image HEALTHCHECK, matrix CMS cells and `perc-devctl qa-up` (which delegates to `matrix-install-smoke.py`) now **require** `docker inspect` Health.Status=healthy, with clear DETAIL tokens and **fail-fast** when health is already unhealthy. Host `rhythmyx_ready` log scan remains belt-and-braces.

**Parent:** #2423  
**Related:** #2481 / PR #2534, #2537 / PR #2550 (RESULT HEALTH: surface — sequential peer)  
**Fixes:** #2535

### Changes

- `inspect_container_health()` — shared inspect helper (healthy|unhealthy|starting|none|unknown)
- `wait_for_container_healthy()` returns `(ok, detail)`; **fail-fast** on unhealthy / exited (DB + CMS)
- CMS cells: `wait_for_http(..., require_docker_health=True)` — success needs HTTP ready + healthy + no context-fail markers
- DETAIL tokens: `docker_health_unhealthy`, `docker_health_timeout`, `container_not_running` (coordinate with #2537 HEALTH: RESULT shape)
- Unit tests with mocked inspect (fail-fast, success, starting to healthy, log-scan belt-and-braces)
- `docker/README.md` operator table + wait-policy section
- `cmd_qa_up` docstring notes the combined wait policy

### Non-Maven

`docker/scripts` only — no Maven module clean install required.

## Test plan

- [x] `python -m pytest docker/scripts/test_matrix_install_smoke.py -q` → **77 passed**
- [ ] Optional live: rebuild matrix image, `perc-devctl qa-up`, confirm unhealthy context fails fast with `docker_health_unhealthy` / log markers

## Gates evidence

- Erlang self-review: no bugs found; portable paths (no new path I/O); pure Python unit tests with mocks
- Pre-PR Maven: N/A (docker scripts / README only)
- No residual agent work on this slice

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
