### PR TITLE
feat(docker): #2536 HEALTHCHECK unhealthy inject proof

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -302,7 +302,36 @@ docker inspect -f "{{.State.Health.Status}}" percussion-cms-dts
 
 **Rebuild note:** matrix image build context is `docker/` (not `docker/matrix/` alone) so HEALTHCHECK scripts are copied in. After pulling this change, rebuild with `matrix-install-smoke.py` (default) or `docker build -t percussion-matrix-cell:local -f docker/matrix/Dockerfile docker/`. Compose cms-dts: `docker compose build cms-dts`.
 
-Unit tests: `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_rhythmyx_healthcheck.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q`.
+Unit tests: `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_rhythmyx_healthcheck.py docker/scripts/test_healthcheck_unhealthy_inject_proof.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q`.
+
+##### HEALTHCHECK unhealthy inject proof (#2536 residual of #2481)
+
+Agent-safe harness that proves the assessor (and optionally a keep cell) reports **unhealthy** when a known Rhythmyx context-failure marker is present in the Jetty log path the in-image HEALTHCHECK tails.
+
+| Mode | Needs Docker / full install? | What it proves |
+|------|------------------------------|----------------|
+| **mock** (default) | No — temp fixture tree + HTTP override | Healthy path (clean logs + HTTP 200) → exit 0; inject `Failed startup of context` into `jetty/base/logs/jetty.log` → exit 1 + `rhythmyx_context_failed`; recovery after clean rewrite → exit 0 |
+| **live** | Yes — running keep cell (`perc-matrix-cms-h2` or `--container`) | `docker exec` appends marker into container Jetty log; re-runs baked `rhythmyx_healthcheck.py`; optional `--require-inspect-unhealthy` for `docker inspect` Health.Status |
+
+```bash
+# CI / overnight (no Docker, no CMS install):
+python docker/scripts/healthcheck_unhealthy_inject_proof.py
+# RESULT:OK STEP:healthcheck-unhealthy-inject-proof MODE:mock DETAIL:healthy+inject_unhealthy_ok
+
+# Quiet (RESULT line only):
+python docker/scripts/healthcheck_unhealthy_inject_proof.py --quiet
+
+# After qa-up / matrix --keep (optional live inject):
+python docker/scripts/perc-devctl.py qa-up
+python docker/scripts/healthcheck_unhealthy_inject_proof.py --mode live
+# RESULT:OK STEP:healthcheck-unhealthy-inject-proof MODE:live …
+# Optional: also wait for Docker HEALTHCHECK interval to flip inspect:
+python docker/scripts/healthcheck_unhealthy_inject_proof.py --mode live --require-inspect-unhealthy
+docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2
+# unhealthy
+```
+
+Cross-platform: host paths use `pathlib.Path` (Windows/macOS/Linux); container paths always use `/`. Unit tests: `docker/scripts/test_healthcheck_unhealthy_inject_proof.py`.
 
 ### `docker/scripts/freeport-concurrent-smoke.py`
 

--- a/docker/scripts/healthcheck_unhealthy_inject_proof.py
+++ b/docker/scripts/healthcheck_unhealthy_inject_proof.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Live/scripted proof that Docker HEALTHCHECK reports unhealthy (#2536 / #2481).
+
+Parent epic #2423 residual of #2481. Unit tests already cover
+``rhythmyx_healthcheck`` assessor logic; this harness proves the **end-to-end
+contract operators care about**:
+
+1. **Healthy path** — HTTP ready codes + clean Jetty logs → assessor exit 0
+   (maps to Docker ``Health.Status=healthy`` once the in-image HEALTHCHECK runs).
+2. **Unhealthy inject path** — same HTTP ready, but a known Rhythmyx
+   context-failure marker is present under the Jetty log path the HEALTHCHECK
+   tails → assessor exit 1 + ``rhythmyx_context_failed`` detail.
+
+Modes
+-----
+* **mock** (default, agent-safe / CI) — builds a temporary install-root fixture
+  under the OS temp dir (or ``--fixture-root``), writes Jetty logs with Path
+  joins (Windows host + Linux container portable), and runs
+  :func:`rhythmyx_healthcheck.run_healthcheck` with HTTP overrides (no Docker,
+  no full CMS install).
+* **live** — against a keep cell (``perc-matrix-cms-h2``) or named container:
+  append the marker into the container Jetty log via ``docker exec``, then
+  re-run the in-container healthcheck and/or ``docker inspect`` Health.Status.
+  Requires Docker + a running cell; skip for overnight CI unless the stack is up.
+
+Agent-parseable stdout ends with::
+
+    RESULT:OK STEP:healthcheck-unhealthy-inject-proof MODE:mock
+    RESULT:FAIL STEP:healthcheck-unhealthy-inject-proof MODE:mock REASON:...
+
+Exit codes: 0 success, 1 failure / invocation error.
+
+No secrets. Stdlib + sibling ``rhythmyx_healthcheck`` / ``rhythmyx_ready``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence, Tuple
+
+# Sibling helpers (stdlib only). Same import pattern as freeport / matrix.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from rhythmyx_healthcheck import (  # noqa: E402
+    EXIT_HEALTHY,
+    EXIT_UNHEALTHY,
+    collect_log_text,
+    discover_jetty_log_paths,
+    run_healthcheck,
+)
+from rhythmyx_ready import (  # noqa: E402
+    DETAIL_CONTEXT_FAILED,
+    RHYTHMYX_CONTEXT_FAIL_MARKERS,
+)
+
+EXIT_OK = 0
+EXIT_FAIL = 1
+
+STEP = "healthcheck-unhealthy-inject-proof"
+
+# Marker injected into Jetty logs (must match rhythmyx_ready markers).
+DEFAULT_INJECT_MARKER = "Failed startup of context"
+assert DEFAULT_INJECT_MARKER in RHYTHMYX_CONTEXT_FAIL_MARKERS
+
+# Relative Jetty log path under install root (POSIX segments via Path — portable).
+JETTY_LOG_REL = ("jetty", "base", "logs", "jetty.log")
+
+# Default live container names (qa-up / matrix --keep).
+DEFAULT_LIVE_CONTAINERS = (
+    "perc-matrix-cms-h2",
+    "percussion-cms-dts",
+)
+
+DEFAULT_CONTAINER_INSTALL_ROOT = "/opt/Percussion"
+
+
+def format_result_line(
+    ok: bool,
+    *,
+    mode: str,
+    reason: str = "",
+    detail: str = "",
+) -> str:
+    """Build a single RESULT:OK|FAIL line (pure; unit-tested)."""
+    status = "OK" if ok else "FAIL"
+    parts = [f"RESULT:{status}", f"STEP:{STEP}", f"MODE:{mode}"]
+    if detail:
+        parts.append(f"DETAIL:{detail}")
+    if reason and not ok:
+        # Keep REASON free of spaces that break shell scrapers when possible.
+        safe = reason.replace("\n", " ").strip()
+        parts.append(f"REASON:{safe}")
+    return " ".join(parts)
+
+
+def jetty_log_path(install_root: Path) -> Path:
+    """Return portable Path to the default Jetty log under ``install_root``."""
+    path = Path(install_root)
+    for part in JETTY_LOG_REL:
+        path = path / part
+    return path
+
+
+def write_jetty_log(
+    install_root: Path,
+    body: str,
+    *,
+    encoding: str = "utf-8",
+) -> Path:
+    """Create Jetty log directory tree and write ``body``. Returns log path."""
+    log_path = jetty_log_path(install_root)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(body, encoding=encoding)
+    return log_path
+
+
+def append_jetty_log(install_root: Path, line: str) -> Path:
+    """Append a line to the Jetty log (creates file if missing)."""
+    log_path = jetty_log_path(install_root)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8", newline="\n") as fh:
+        if not line.endswith("\n"):
+            line = line + "\n"
+        fh.write(line)
+    return log_path
+
+
+def clean_log_body() -> str:
+    """Minimal clean Jetty log body (no context-failure markers)."""
+    return (
+        "INFO [Server] Started @1234ms\n"
+        "INFO [WebAppContext] Started o.e.j.w.WebAppContext@abc{/Rhythmyx}\n"
+    )
+
+
+def inject_log_body(marker: str = DEFAULT_INJECT_MARKER) -> str:
+    """Jetty log body that includes a known context-failure marker."""
+    return (
+        clean_log_body()
+        + f"WARN [WebAppContext] {marker} oeje11w.WebAppContext@deadbeef"
+        + "{/Rhythmyx,file:///opt/Percussion/jetty/base/webapps/Rhythmyx/}\n"
+        + "Caused by: org.springframework.beans.factory."
+        "BeanCurrentlyInCreationException: folderHelper\n"
+    )
+
+
+def assess_fixture(
+    install_root: Path,
+    *,
+    http_code: int = 200,
+    product: str = "cms",
+) -> Tuple[int, str]:
+    """Run healthcheck against a local fixture tree (HTTP overridden)."""
+    return run_healthcheck(
+        product=product,
+        install_root=Path(install_root),
+        http_code_override=int(http_code),
+    )
+
+
+def parse_health_status(raw: str) -> str:
+    """Normalize ``docker inspect`` Health.Status text (pure).
+
+    Accepts plain status (``healthy``), JSON health object, or full inspect
+    blob. Empty / unknown → ``unknown``.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return "unknown"
+    # Plain single-token status from -f "{{.State.Health.Status}}"
+    lower = text.lower()
+    if lower in ("healthy", "unhealthy", "starting", "none", "unknown"):
+        return lower
+    # JSON object or array from docker inspect
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        # Last line may be the status if mixed noise
+        last = text.splitlines()[-1].strip().lower()
+        if last in ("healthy", "unhealthy", "starting", "none"):
+            return last
+        return "unknown"
+    if isinstance(data, list) and data:
+        data = data[0]
+    if not isinstance(data, dict):
+        return "unknown"
+    # Full container inspect: State.Health.Status
+    state = data.get("State")
+    if isinstance(state, dict):
+        health = state.get("Health")
+        if isinstance(health, dict):
+            status = str(health.get("Status") or "").strip().lower()
+            return status or "none"
+        return "none"
+    # Health object alone
+    status = str(data.get("Status") or "").strip().lower()
+    return status or "unknown"
+
+
+def expected_healthy(http_code: int, log_text: str) -> bool:
+    """True when mock proof should expect EXIT_HEALTHY (pure)."""
+    code, _detail = run_healthcheck(
+        product="cms",
+        http_code_override=int(http_code),
+        log_text_override=log_text,
+    )
+    return code == EXIT_HEALTHY
+
+
+def run_mock_proof(
+    *,
+    fixture_root: Optional[Path] = None,
+    marker: str = DEFAULT_INJECT_MARKER,
+    http_code: int = 200,
+) -> Tuple[bool, List[str]]:
+    """Execute healthy + unhealthy-inject fixture proof. No Docker.
+
+    Returns ``(ok, log_lines)``.
+    """
+    lines: List[str] = []
+    own_temp: Optional[Path] = None
+
+    def log(msg: str) -> None:
+        lines.append(msg)
+
+    try:
+        if fixture_root is None:
+            own_temp = Path(tempfile.mkdtemp(prefix="perc-hc-inject-"))
+            root = own_temp
+        else:
+            root = Path(fixture_root)
+            root.mkdir(parents=True, exist_ok=True)
+
+        log(f"MODE mock fixture_root={root}")
+
+        # --- 1) Healthy path: clean logs + HTTP ready ---
+        clean_path = write_jetty_log(root, clean_log_body())
+        discovered = discover_jetty_log_paths(root)
+        if clean_path not in discovered:
+            return False, lines + [
+                f"FAIL discover: expected {clean_path} in {discovered}"
+            ]
+        log(f"OK wrote clean jetty log path={clean_path}")
+
+        code_ok, detail_ok = assess_fixture(root, http_code=http_code)
+        if code_ok != EXIT_HEALTHY:
+            return False, lines + [
+                f"FAIL healthy path: exit={code_ok} detail={detail_ok!r}"
+            ]
+        if DETAIL_CONTEXT_FAILED in detail_ok:
+            return False, lines + [
+                f"FAIL healthy path: unexpected context fail detail={detail_ok!r}"
+            ]
+        log(f"OK healthy path exit={code_ok} detail={detail_ok}")
+
+        # --- 2) Unhealthy inject: same HTTP ready, marker in Jetty log ---
+        inject_path = write_jetty_log(root, inject_log_body(marker))
+        log_text = collect_log_text(root)
+        if marker not in log_text:
+            return False, lines + [
+                f"FAIL inject: marker {marker!r} not found in collected log text"
+            ]
+        log(f"OK injected marker={marker!r} into {inject_path}")
+
+        code_bad, detail_bad = assess_fixture(root, http_code=http_code)
+        if code_bad != EXIT_UNHEALTHY:
+            return False, lines + [
+                f"FAIL unhealthy inject: exit={code_bad} detail={detail_bad!r}"
+            ]
+        if DETAIL_CONTEXT_FAILED not in detail_bad:
+            return False, lines + [
+                f"FAIL unhealthy inject: missing {DETAIL_CONTEXT_FAILED} "
+                f"in detail={detail_bad!r}"
+            ]
+        log(
+            f"OK unhealthy inject exit={code_bad} detail={detail_bad} "
+            f"(maps to Docker Health.Status=unhealthy)"
+        )
+
+        # --- 3) Document healthy recovery after marker removal ---
+        write_jetty_log(root, clean_log_body())
+        code_rec, detail_rec = assess_fixture(root, http_code=http_code)
+        if code_rec != EXIT_HEALTHY:
+            return False, lines + [
+                f"FAIL recovery healthy: exit={code_rec} detail={detail_rec!r}"
+            ]
+        log(f"OK recovery healthy path exit={code_rec} detail={detail_rec}")
+
+        log("OK healthcheck unhealthy inject proof complete (mock)")
+        return True, lines
+    finally:
+        if own_temp is not None:
+            shutil.rmtree(own_temp, ignore_errors=True)
+
+
+def _docker_run(
+    argv: Sequence[str],
+    *,
+    timeout: float = 60.0,
+    run: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> subprocess.CompletedProcess:
+    """Run a docker argv list (shell=False). Inject ``run`` for tests."""
+    runner = run or subprocess.run
+    return runner(
+        list(argv),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        shell=False,
+    )
+
+
+def docker_health_status(
+    container: str,
+    *,
+    run: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> str:
+    """Return normalized Health.Status for ``container`` via docker inspect."""
+    cp = _docker_run(
+        [
+            "docker",
+            "inspect",
+            "-f",
+            "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+            container,
+        ],
+        run=run,
+    )
+    if cp.returncode != 0:
+        err = (cp.stderr or cp.stdout or "").strip()
+        return f"error:{err}" if err else "error"
+    return parse_health_status(cp.stdout or "")
+
+
+def docker_container_running(
+    container: str,
+    *,
+    run: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> bool:
+    """True when ``docker inspect`` reports running=true."""
+    cp = _docker_run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", container],
+        run=run,
+    )
+    if cp.returncode != 0:
+        return False
+    return (cp.stdout or "").strip().lower() in ("true", "1")
+
+
+def docker_inject_marker(
+    container: str,
+    *,
+    install_root: str = DEFAULT_CONTAINER_INSTALL_ROOT,
+    marker: str = DEFAULT_INJECT_MARKER,
+    run: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> Tuple[bool, str]:
+    """Append context-failure marker to Jetty log inside the container.
+
+    Uses ``docker exec`` + ``sh -c`` with a single printf line (no host
+    path separators hardcoded for the container FS — container is Linux).
+    """
+    # Container paths always use '/'; build with posix-style join for the remote.
+    remote_log = "/".join(
+        [install_root.rstrip("/")] + list(JETTY_LOG_REL)
+    )
+    remote_dir = remote_log.rsplit("/", 1)[0]
+    # Inject a single-line WARN with the marker (shell-safe: no quotes in marker).
+    inject_line = f"WARN [WebAppContext] {marker} inject-proof"
+    # Use mkdir + printf via sh -c; escape carefully.
+    script = (
+        f'mkdir -p "{remote_dir}" && '
+        f'printf "%s\\n" "{inject_line}" >> "{remote_log}"'
+    )
+    cp = _docker_run(
+        ["docker", "exec", container, "sh", "-c", script],
+        run=run,
+    )
+    if cp.returncode != 0:
+        err = (cp.stderr or cp.stdout or "docker exec failed").strip()
+        return False, err
+    return True, remote_log
+
+
+def docker_run_incontainer_healthcheck(
+    container: str,
+    *,
+    install_root: str = DEFAULT_CONTAINER_INSTALL_ROOT,
+    run: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> Tuple[int, str]:
+    """Execute the in-image healthcheck CLI inside ``container``.
+
+    Prefers ``/usr/local/lib/perc/rhythmyx_healthcheck.py`` (matrix image bake
+    path from #2481). Falls back to ``python3 -c`` assessor only when missing.
+    """
+    script_candidates = (
+        "/usr/local/lib/perc/rhythmyx_healthcheck.py",
+        "/usr/local/lib/rhythmyx_healthcheck.py",
+    )
+    for remote in script_candidates:
+        cp = _docker_run(
+            [
+                "docker",
+                "exec",
+                "-e",
+                f"INSTALL_ROOT={install_root}",
+                container,
+                "python3",
+                remote,
+                "--install-root",
+                install_root,
+            ],
+            timeout=120.0,
+            run=run,
+        )
+        # 127 / not found → try next; other codes are health results.
+        out = (cp.stdout or "").strip()
+        err = (cp.stderr or "").strip()
+        detail = out or err or f"exit={cp.returncode}"
+        if cp.returncode in (0, 1):
+            return int(cp.returncode), detail
+        if "No such file" in err or "can't open file" in err.lower():
+            continue
+        # Usage / other — still return
+        return int(cp.returncode), detail
+    return EXIT_FAIL, "rhythmyx_healthcheck.py not found in container"
+
+
+def run_live_proof(
+    *,
+    container: str,
+    install_root: str = DEFAULT_CONTAINER_INSTALL_ROOT,
+    marker: str = DEFAULT_INJECT_MARKER,
+    require_inspect_unhealthy: bool = False,
+    run: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> Tuple[bool, List[str]]:
+    """Inject marker into a running cell and assert in-container healthcheck fails.
+
+    When ``require_inspect_unhealthy`` is True, also wait/assert Docker
+    ``Health.Status=unhealthy`` (may need HEALTHCHECK interval time; default
+    off so a single exec of the healthcheck CLI is enough proof).
+    """
+    lines: List[str] = []
+
+    def log(msg: str) -> None:
+        lines.append(msg)
+
+    log(f"MODE live container={container} install_root={install_root}")
+
+    if not docker_container_running(container, run=run):
+        return False, lines + [
+            f"FAIL container not running: {container} "
+            f"(start with perc-devctl qa-up or matrix --keep)"
+        ]
+    log(f"OK container running={container}")
+
+    status_before = docker_health_status(container, run=run)
+    log(f"NOTE Health.Status before inject={status_before}")
+
+    ok_inj, inj_detail = docker_inject_marker(
+        container,
+        install_root=install_root,
+        marker=marker,
+        run=run,
+    )
+    if not ok_inj:
+        return False, lines + [f"FAIL docker inject: {inj_detail}"]
+    log(f"OK injected marker into container log path={inj_detail}")
+
+    hc_code, hc_detail = docker_run_incontainer_healthcheck(
+        container,
+        install_root=install_root,
+        run=run,
+    )
+    if hc_code != EXIT_UNHEALTHY:
+        return False, lines + [
+            f"FAIL live healthcheck: expected exit={EXIT_UNHEALTHY} "
+            f"got exit={hc_code} detail={hc_detail!r}"
+        ]
+    if DETAIL_CONTEXT_FAILED not in hc_detail:
+        # Some older images may only print short detail; still require unhealthy exit.
+        log(
+            f"NOTE live healthcheck unhealthy but detail missing "
+            f"{DETAIL_CONTEXT_FAILED}: {hc_detail!r}"
+        )
+    else:
+        log(f"OK live healthcheck exit={hc_code} detail={hc_detail}")
+
+    if require_inspect_unhealthy:
+        status_after = docker_health_status(container, run=run)
+        log(f"NOTE Health.Status after inject={status_after}")
+        if status_after != "unhealthy":
+            return False, lines + [
+                f"FAIL inspect: expected unhealthy got {status_after!r} "
+                f"(HEALTHCHECK interval may not have re-run yet; "
+                f"re-run docker inspect later or use in-container CLI proof)"
+            ]
+        log("OK docker inspect Health.Status=unhealthy")
+
+    log("OK healthcheck unhealthy inject proof complete (live)")
+    return True, lines
+
+
+def resolve_live_container(
+    preferred: str = "",
+    *,
+    candidates: Sequence[str] = DEFAULT_LIVE_CONTAINERS,
+    run: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> Optional[str]:
+    """Pick first running container from preferred + candidates."""
+    order: List[str] = []
+    if preferred and preferred.strip():
+        order.append(preferred.strip())
+    for name in candidates:
+        if name not in order:
+            order.append(name)
+    for name in order:
+        if docker_container_running(name, run=run):
+            return name
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Prove HEALTHCHECK unhealthy on context-failure inject "
+            "(#2536 residual of #2481). Default mock mode needs no Docker."
+        )
+    )
+    p.add_argument(
+        "--mode",
+        choices=("mock", "live"),
+        default=os.environ.get("HC_INJECT_PROOF_MODE", "mock"),
+        help="mock=fixture+assessor (default); live=docker inject into keep cell",
+    )
+    p.add_argument(
+        "--fixture-root",
+        default="",
+        help="Optional install-root directory for mock mode (default: temp dir)",
+    )
+    p.add_argument(
+        "--marker",
+        default=DEFAULT_INJECT_MARKER,
+        help="Context-failure marker to inject (must be in rhythmyx_ready list)",
+    )
+    p.add_argument(
+        "--http-code",
+        type=int,
+        default=200,
+        help="HTTP override for mock mode (default 200 ready)",
+    )
+    p.add_argument(
+        "--container",
+        default=os.environ.get("HC_INJECT_PROOF_CONTAINER", ""),
+        help="Live mode container name (default: first running keep cell)",
+    )
+    p.add_argument(
+        "--install-root",
+        default=os.environ.get(
+            "INSTALL_ROOT",
+            os.environ.get("PERC_INSTALL_ROOT", DEFAULT_CONTAINER_INSTALL_ROOT),
+        ),
+        help="Container install root for live mode",
+    )
+    p.add_argument(
+        "--require-inspect-unhealthy",
+        action="store_true",
+        help=(
+            "Live mode: also require docker inspect Health.Status=unhealthy "
+            "(needs HEALTHCHECK re-interval)"
+        ),
+    )
+    p.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only print the RESULT line",
+    )
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    mode = (args.mode or "mock").strip().lower()
+    marker = (args.marker or DEFAULT_INJECT_MARKER).strip()
+
+    if marker not in RHYTHMYX_CONTEXT_FAIL_MARKERS:
+        print(
+            format_result_line(
+                False,
+                mode=mode,
+                reason=f"marker not in RHYTHMYX_CONTEXT_FAIL_MARKERS: {marker!r}",
+            ),
+            flush=True,
+        )
+        return EXIT_FAIL
+
+    if mode == "mock":
+        fixture = Path(args.fixture_root) if args.fixture_root else None
+        ok, lines = run_mock_proof(
+            fixture_root=fixture,
+            marker=marker,
+            http_code=int(args.http_code),
+        )
+    elif mode == "live":
+        run = subprocess.run  # real docker
+        container = (args.container or "").strip()
+        if not container:
+            resolved = resolve_live_container(run=run)
+            if not resolved:
+                msg = (
+                    "no running keep cell "
+                    f"(tried {', '.join(DEFAULT_LIVE_CONTAINERS)}); "
+                    "start with perc-devctl qa-up or pass --container"
+                )
+                if not args.quiet:
+                    print(msg, flush=True)
+                print(
+                    format_result_line(False, mode=mode, reason=msg),
+                    flush=True,
+                )
+                return EXIT_FAIL
+            container = resolved
+        ok, lines = run_live_proof(
+            container=container,
+            install_root=str(args.install_root),
+            marker=marker,
+            require_inspect_unhealthy=bool(args.require_inspect_unhealthy),
+            run=run,
+        )
+    else:
+        print(
+            format_result_line(False, mode=mode, reason=f"unknown mode {mode}"),
+            flush=True,
+        )
+        return EXIT_FAIL
+
+    if not args.quiet:
+        for line in lines:
+            print(line, flush=True)
+
+    detail = ""
+    if ok:
+        detail = "healthy+inject_unhealthy_ok"
+    else:
+        # Surface last FAIL line in DETAIL when present
+        for line in reversed(lines):
+            if line.startswith("FAIL"):
+                detail = line
+                break
+    reason = ""
+    if not ok and detail:
+        reason = detail
+    print(format_result_line(ok, mode=mode, reason=reason, detail=detail if ok else ""), flush=True)
+    return EXIT_OK if ok else EXIT_FAIL
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/scripts/test_healthcheck_unhealthy_inject_proof.py
+++ b/docker/scripts/test_healthcheck_unhealthy_inject_proof.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for healthcheck_unhealthy_inject_proof.py (#2536)."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import List, Optional
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def _load(path: Path, name: str):
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+proof = _load(
+    SCRIPTS / "healthcheck_unhealthy_inject_proof.py",
+    "healthcheck_unhealthy_inject_proof",
+)
+
+
+def _cp(
+    code: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=code,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class FormatResultLineTests(unittest.TestCase):
+    def test_ok_mock(self):
+        line = proof.format_result_line(True, mode="mock", detail="healthy+inject_unhealthy_ok")
+        self.assertTrue(line.startswith("RESULT:OK"))
+        self.assertIn(f"STEP:{proof.STEP}", line)
+        self.assertIn("MODE:mock", line)
+        self.assertIn("DETAIL:healthy+inject_unhealthy_ok", line)
+
+    def test_fail_includes_reason(self):
+        line = proof.format_result_line(
+            False,
+            mode="live",
+            reason="container not running",
+        )
+        self.assertTrue(line.startswith("RESULT:FAIL"))
+        self.assertIn("MODE:live", line)
+        self.assertIn("REASON:container not running", line)
+
+
+class JettyLogPathTests(unittest.TestCase):
+    def test_portable_join(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            path = proof.jetty_log_path(root)
+            # Must use Path segments (jetty/base/logs/jetty.log), not hardcoded OS sep
+            self.assertEqual(path.name, "jetty.log")
+            self.assertEqual(path.parent.name, "logs")
+            self.assertTrue(str(path).endswith(str(Path("jetty") / "base" / "logs" / "jetty.log")))
+
+    def test_write_and_append(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            p1 = proof.write_jetty_log(root, proof.clean_log_body())
+            self.assertTrue(p1.is_file())
+            self.assertIn("Server] Started", p1.read_text(encoding="utf-8"))
+            p2 = proof.append_jetty_log(root, "EXTRA LINE")
+            self.assertEqual(p1, p2)
+            self.assertIn("EXTRA LINE", p2.read_text(encoding="utf-8"))
+
+
+class ParseHealthStatusTests(unittest.TestCase):
+    def test_plain_tokens(self):
+        self.assertEqual(proof.parse_health_status("healthy"), "healthy")
+        self.assertEqual(proof.parse_health_status("UNHEALTHY\n"), "unhealthy")
+        self.assertEqual(proof.parse_health_status("starting"), "starting")
+        self.assertEqual(proof.parse_health_status(""), "unknown")
+
+    def test_full_inspect_json(self):
+        blob = json.dumps(
+            {
+                "State": {
+                    "Running": True,
+                    "Health": {"Status": "unhealthy", "FailingStreak": 2},
+                }
+            }
+        )
+        self.assertEqual(proof.parse_health_status(blob), "unhealthy")
+
+    def test_health_object_json(self):
+        blob = json.dumps({"Status": "healthy", "Log": []})
+        self.assertEqual(proof.parse_health_status(blob), "healthy")
+
+    def test_list_inspect(self):
+        blob = json.dumps([{"State": {"Health": {"Status": "starting"}}}])
+        self.assertEqual(proof.parse_health_status(blob), "starting")
+
+    def test_none_when_no_health(self):
+        blob = json.dumps({"State": {"Running": True}})
+        self.assertEqual(proof.parse_health_status(blob), "none")
+
+
+class MockProofTests(unittest.TestCase):
+    def test_run_mock_proof_ok(self):
+        ok, lines = proof.run_mock_proof()
+        self.assertTrue(ok, msg="\n".join(lines))
+        joined = "\n".join(lines)
+        self.assertIn("OK healthy path", joined)
+        self.assertIn("OK unhealthy inject", joined)
+        self.assertIn("OK recovery healthy", joined)
+        self.assertIn(proof.DEFAULT_INJECT_MARKER, joined)
+
+    def test_run_mock_proof_with_fixture_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "install"
+            ok, lines = proof.run_mock_proof(fixture_root=root)
+            self.assertTrue(ok, msg="\n".join(lines))
+            # Fixture root should retain last written clean log after recovery
+            log_path = proof.jetty_log_path(root)
+            self.assertTrue(log_path.is_file())
+            body = log_path.read_text(encoding="utf-8")
+            self.assertNotIn(proof.DEFAULT_INJECT_MARKER, body)
+
+    def test_inject_body_contains_marker(self):
+        body = proof.inject_log_body()
+        self.assertIn(proof.DEFAULT_INJECT_MARKER, body)
+        self.assertIn("BeanCurrentlyInCreationException", body)
+
+    def test_assess_fixture_unhealthy_after_inject(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            proof.write_jetty_log(root, proof.inject_log_body())
+            code, detail = proof.assess_fixture(root, http_code=302)
+            self.assertEqual(code, 1)
+            self.assertIn("rhythmyx_context_failed", detail)
+
+    def test_expected_healthy_helper(self):
+        self.assertTrue(proof.expected_healthy(200, proof.clean_log_body()))
+        self.assertFalse(proof.expected_healthy(200, proof.inject_log_body()))
+        self.assertFalse(proof.expected_healthy(0, proof.clean_log_body()))
+
+
+class LiveProofPureLogicTests(unittest.TestCase):
+    """Live mode with injected subprocess.run — no real Docker."""
+
+    def test_docker_container_running_true(self):
+        def fake_run(argv, **_kwargs):
+            self.assertEqual(argv[0], "docker")
+            return _cp(0, stdout="true\n")
+
+        self.assertTrue(
+            proof.docker_container_running("perc-matrix-cms-h2", run=fake_run)
+        )
+
+    def test_docker_container_running_false(self):
+        def fake_run(argv, **_kwargs):
+            return _cp(1, stderr="Error: No such object")
+
+        self.assertFalse(proof.docker_container_running("missing", run=fake_run))
+
+    def test_docker_health_status(self):
+        def fake_run(argv, **_kwargs):
+            return _cp(0, stdout="unhealthy\n")
+
+        self.assertEqual(
+            proof.docker_health_status("c1", run=fake_run),
+            "unhealthy",
+        )
+
+    def test_docker_inject_marker_ok(self):
+        calls: List[List[str]] = []
+
+        def fake_run(argv, **_kwargs):
+            calls.append(list(argv))
+            return _cp(0, stdout="")
+
+        ok, path = proof.docker_inject_marker(
+            "perc-matrix-cms-h2",
+            install_root="/opt/Percussion",
+            run=fake_run,
+        )
+        self.assertTrue(ok)
+        self.assertIn("jetty.log", path)
+        self.assertTrue(path.startswith("/opt/Percussion/"))
+        # Container path uses '/' (Linux container), not Windows sep
+        self.assertNotIn("\\", path)
+        self.assertEqual(calls[0][0:3], ["docker", "exec", "perc-matrix-cms-h2"])
+
+    def test_docker_run_incontainer_healthcheck_unhealthy(self):
+        def fake_run(argv, **_kwargs):
+            # Simulate healthcheck CLI exit 1 with context fail detail
+            if argv[-1].endswith("rhythmyx_healthcheck.py") or (
+                len(argv) > 4 and "rhythmyx_healthcheck.py" in argv[4]
+            ):
+                return _cp(
+                    1,
+                    stdout=(
+                        "rhythmyx_context_failed match='Failed startup of context' "
+                        "http=200\n"
+                    ),
+                )
+            # Also match when script is argv element
+            for a in argv:
+                if "rhythmyx_healthcheck.py" in a:
+                    return _cp(
+                        1,
+                        stdout="rhythmyx_context_failed match='Failed startup of context' http=200\n",
+                    )
+            return _cp(1, stderr="unexpected")
+
+        code, detail = proof.docker_run_incontainer_healthcheck(
+            "perc-matrix-cms-h2",
+            run=fake_run,
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("rhythmyx_context_failed", detail)
+
+    def test_run_live_proof_ok_with_stubs(self):
+        state = {"running": True, "status": "healthy", "injected": False}
+
+        def fake_run(argv, **_kwargs):
+            cmd = " ".join(argv)
+            if "inspect" in argv and "Running" in cmd:
+                return _cp(0, stdout="true\n" if state["running"] else "false\n")
+            if "inspect" in argv and "Health" in cmd:
+                return _cp(0, stdout=state["status"] + "\n")
+            if "exec" in argv and "printf" in cmd:
+                state["injected"] = True
+                state["status"] = "unhealthy"
+                return _cp(0)
+            if "exec" in argv and "rhythmyx_healthcheck.py" in cmd:
+                if state["injected"]:
+                    return _cp(
+                        1,
+                        stdout=(
+                            "rhythmyx_context_failed "
+                            "match='Failed startup of context' http=200\n"
+                        ),
+                    )
+                return _cp(0, stdout="ok\n")
+            return _cp(1, stderr=f"unexpected argv={argv}")
+
+        ok, lines = proof.run_live_proof(
+            container="perc-matrix-cms-h2",
+            run=fake_run,
+        )
+        self.assertTrue(ok, msg="\n".join(lines))
+        self.assertTrue(state["injected"])
+        joined = "\n".join(lines)
+        self.assertIn("OK live healthcheck", joined)
+
+    def test_run_live_proof_fails_when_not_running(self):
+        def fake_run(argv, **_kwargs):
+            return _cp(1, stderr="No such object")
+
+        ok, lines = proof.run_live_proof(container="gone", run=fake_run)
+        self.assertFalse(ok)
+        self.assertTrue(any("not running" in ln for ln in lines))
+
+    def test_resolve_live_container(self):
+        def fake_run(argv, **_kwargs):
+            name = argv[-1]
+            if name == "perc-matrix-cms-h2":
+                return _cp(0, stdout="true\n")
+            return _cp(1)
+
+        name = proof.resolve_live_container(run=fake_run)
+        self.assertEqual(name, "perc-matrix-cms-h2")
+
+
+class MainCliTests(unittest.TestCase):
+    def test_main_mock_quiet_ok(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = proof.main(["--mode", "mock", "--quiet"])
+        self.assertEqual(rc, proof.EXIT_OK)
+        out = buf.getvalue()
+        self.assertIn(f"RESULT:OK STEP:{proof.STEP} MODE:mock", out)
+
+    def test_main_mock_verbose(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = proof.main(["--mode", "mock"])
+        self.assertEqual(rc, proof.EXIT_OK)
+        out = buf.getvalue()
+        self.assertIn("OK healthy path", out)
+        self.assertIn("RESULT:OK", out)
+
+    def test_main_bad_marker(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = proof.main(["--mode", "mock", "--marker", "not-a-real-marker"])
+        self.assertEqual(rc, proof.EXIT_FAIL)
+        self.assertIn("RESULT:FAIL", buf.getvalue())
+
+    def test_main_live_no_container(self):
+        def fake_run(argv, **_kwargs):
+            return _cp(1, stderr="No such object")
+
+        buf = io.StringIO()
+        with mock.patch.object(proof.subprocess, "run", side_effect=fake_run):
+            with redirect_stdout(buf):
+                rc = proof.main(["--mode", "live", "--quiet"])
+        self.assertEqual(rc, proof.EXIT_FAIL)
+        self.assertIn("RESULT:FAIL", buf.getvalue())
+        self.assertIn("MODE:live", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Completes **#2481 residual #2536**: agent-safe live/scripted proof that Docker HEALTHCHECK / `rhythmyx_healthcheck` reports **unhealthy** when a known Jetty Rhythmyx context-failure marker is present (inject/fixture), and **healthy** on clean logs + HTTP ready.

- **Parent epic:** #2423
- **Related:** #2481 / PR #2534
- **Operator:** Grok: night-issue-prs (model grok-4.5)

### What shipped

| Artifact | Role |
|----------|------|
| `docker/scripts/healthcheck_unhealthy_inject_proof.py` | Mock fixture proof (default, no Docker) + optional `--mode live` inject into keep cell |
| `docker/scripts/test_healthcheck_unhealthy_inject_proof.py` | Pure assessor/fixture/inspect parsing + stubbed live docker tests |
| `docker/README.md` | Operator docs, RESULT line, mock vs live table |

### Modes

- **mock** (CI / overnight): temp install-root fixture under OS temp; Path-portable Jetty log write; HTTP override; asserts exit 0 → inject marker → exit 1 + `rhythmyx_context_failed` → recovery exit 0
- **live** (optional keep cell): `docker exec` append marker; re-run in-image healthcheck; optional `--require-inspect-unhealthy`

### RESULT contract

`
RESULT:OK STEP:healthcheck-unhealthy-inject-proof MODE:mock DETAIL:healthy+inject_unhealthy_ok
RESULT:FAIL STEP:healthcheck-unhealthy-inject-proof MODE:… REASON:…
`

## Test plan

- [x] `python -m pytest docker/scripts/test_healthcheck_unhealthy_inject_proof.py docker/scripts/test_rhythmyx_healthcheck.py -q` → 45 passed
- [x] `python docker/scripts/healthcheck_unhealthy_inject_proof.py` → RESULT:OK MODE:mock
- [x] `python docker/scripts/healthcheck_unhealthy_inject_proof.py --quiet` → RESULT:OK
- [x] bad marker → RESULT:FAIL exit 1
- [ ] Optional operator: `qa-up` then `--mode live` against `perc-matrix-cms-h2`

## Gates evidence

- **Erlang self-review:** pure Path joins for host fixture; container paths use `/`; no secrets; no non-portable path asserts; behavioral unit tests for pure logic + stubbed live path
- **Maven:** N/A (`docker/scripts` + README only; no Java module changed)
- **Cross-platform:** Windows host verified (temp fixture + pytest green)

Fixes #2536

> Co-Authored by Grok Build using grok-4.5 with agent main.