### PR TITLE
feat(qa): modern Content Explorer recycle/restore UI companion (#2542)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -482,6 +482,42 @@ npm run test:surface:list -- --tag finder-recycle-restore
 class as #2464; Admin login that remains on `/Rhythmyx/login` fails with an
 explicit #2489 / #2423 message — do not soft-skip.
 
+#### Modern Content Explorer UI recycle / restore companion (#2542 / parent #2423)
+
+Surface-filtered UI companion for the folder+recycle REST smoke (#2464), peer of
+classic Finder #2489. Exercises modern React explorer chrome
+(`data-testid="content-explorer-shell"`, tree, detail list, reduced-actions
+`action-delete`): soft-delete (recycle) a seeded Assets folder, then **restore**
+when a server/context-menu restore action is present, else **empty Recycling**
+via REST cleanup (classic Finder remains the UI empty peer). Hard fails when
+pathmanagement context or Admin login is down. Does **not** replace #2489.
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/explorer-recycle-restore-ui.spec.js` |
+| Tags | `@explorer-recycle-restore` `@folder-recycle` `@smoke` |
+| Unit (no CMS) | `npm run test:unit` (includes `explorer-recycle-restore-ui.test.js`) |
+| Helper | `frontend/tests/helpers/explorer-recycle-restore-ui.js` |
+
+```bash
+# After qa-up — path-filtered only (do not run full suite)
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/explorer-recycle-restore-ui.spec.js
+
+# Tag form
+npm run test:surface -- --tag explorer-recycle-restore
+
+# List only (no live CMS)
+npm run test:surface:list -- --path tests/explorer-recycle-restore-ui.spec.js
+npm run test:surface:list -- --tag explorer-recycle-restore
+```
+
+**Hard fail contract:** pathmanagement probe uses the same context-down message
+class as #2464; Admin login that remains on `/Rhythmyx/login` fails with an
+explicit #2542 / #2423 message — do not soft-skip.
+
 #### Profile shell + axe WCAG (#2393 / #2425 / #2427 / parent #2374)
 
 Smoke opens the **My profile** hub via deep link and user-menu entry (Admin,

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/golden-unattended-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/golden-unattended-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/explorer-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:golden-extended": "playwright test tests/golden-unattended-smoke.spec.js tests/folder-recycle-smoke.spec.js",

--- a/modules/perc-qa-automation/frontend/tests/explorer-recycle-restore-ui.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-recycle-restore-ui.spec.js
@@ -65,7 +65,7 @@ const {
   extractPathItemGuid,
   contextDownFailureMessage,
 } = require("./helpers/folder-recycle-smoke");
-const {
+const { fuzzyTreeNodeSelector,
   SELECTORS,
   modernExplorerUrl,
   treeNodeSelectors,
@@ -114,7 +114,7 @@ async function selectTreePath(page, path) {
     .pop();
   if (segment) {
     const fuzzy = page.locator(
-      `${SELECTORS.explorerTree} [data-testid*="${segment}"]`,
+      `${SELECTORS.explorerTree} ${fuzzyTreeNodeSelector(segment)}`,
     );
     if ((await fuzzy.count()) > 0) {
       await fuzzy.first().click({ timeout: 10_000 }).catch(() => {});

--- a/modules/perc-qa-automation/frontend/tests/explorer-recycle-restore-ui.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-recycle-restore-ui.spec.js
@@ -1,0 +1,602 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Modern Content Explorer UI recycle / restore companion for folder-recycle
+ * REST smoke (#2542 / parent #2423; classic Finder peer #2489; REST #2464).
+ *
+ * <p>Proves the React explorer shell can soft-delete (recycle) a seeded Assets
+ * folder via {@code data-testid="action-delete"}, then restore when a server
+ * action exposes restore, else empty Recycling via REST cleanup. Hard fails
+ * when pathmanagement context or Admin login is down (no soft skip).</p>
+ *
+ * <p>Does <strong>not</strong> replace classic Finder coverage
+ * ({@code finder-recycle-restore-ui.spec.js} / #2489).</p>
+ *
+ * <h3>Unattended surface (QA mode)</h3>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; \
+ *     npm run test:surface -- --path tests/explorer-recycle-restore-ui.spec.js
+ *   # tags:
+ *   npm run test:surface -- --tag explorer-recycle-restore
+ *   python docker/scripts/perc-devctl.py qa-down
+ * </pre>
+ *
+ * <p>List only (no live CMS):
+ * {@code npm run test:surface:list -- --path tests/explorer-recycle-restore-ui.spec.js}
+ * or {@code --tag explorer-recycle-restore}.</p>
+ *
+ * <p>Pure helpers: {@code npm run test:unit} (includes
+ * {@code explorer-recycle-restore-ui.test.js}).</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const {
+  probePathmanagementContext,
+  createNamedFolder,
+  recycleFolder,
+  restoreFolderByGuid,
+  findInRecycling,
+  findNamedPathItem,
+  listFolderChildren,
+  emptyRecyclingViaApi,
+  emptyApiFailureMessage,
+  extractPathItemGuid,
+  contextDownFailureMessage,
+} = require("./helpers/folder-recycle-smoke");
+const {
+  SELECTORS,
+  modernExplorerUrl,
+  treeNodeSelectors,
+  isActionControlEnabled,
+  isStillOnLoginPage,
+  loginContextDownFailureMessage,
+  deleteItemApiPathFragment,
+  deleteFolderApiPathFragment,
+  restoreFolderApiPathFragment,
+  emptyRecyclingApiPathFragment,
+  recycledFolderExplorerPath,
+  exactExplorerItemNameMatcher,
+  chooseRestoreOrEmptyBranch,
+  isRestoreEligibleExplorerPath,
+  isRestoreActionName,
+  isEmptyRecyclingActionName,
+} = require("./helpers/explorer-recycle-restore-ui");
+
+/**
+ * Click the first matching explorer tree node for a logical path.
+ * @param {import("@playwright/test").Page} page
+ * @param {string} path e.g. "Assets" or "/Recycling"
+ * @returns {Promise<boolean>}
+ */
+async function selectTreePath(page, path) {
+  const selectors = treeNodeSelectors(path);
+  for (const sel of selectors) {
+    const node = page.locator(sel);
+    if ((await node.count()) > 0) {
+      const row = node.first().locator('[role="treeitem"]').first();
+      if ((await row.count()) > 0) {
+        await row.click({ timeout: 10_000 }).catch(async () => {
+          await node.first().click({ timeout: 10_000 });
+        });
+      } else {
+        await node.first().click({ timeout: 10_000 });
+      }
+      await page.waitForTimeout(500);
+      return true;
+    }
+  }
+  // Fallback: any tree node whose testid contains the segment.
+  const segment = String(path || "")
+    .split("/")
+    .filter(Boolean)
+    .pop();
+  if (segment) {
+    const fuzzy = page.locator(
+      `${SELECTORS.explorerTree} [data-testid*="${segment}"]`,
+    );
+    if ((await fuzzy.count()) > 0) {
+      await fuzzy.first().click({ timeout: 10_000 }).catch(() => {});
+      await page.waitForTimeout(500);
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Select a detail-list row by exact display name (cell text).
+ * @param {import("@playwright/test").Page} page
+ * @param {string} name
+ * @returns {Promise<boolean>}
+ */
+async function selectDetailItemByName(page, name) {
+  const match = exactExplorerItemNameMatcher(name);
+  const list = page.locator(SELECTORS.detailList);
+  await expect(
+    list,
+    "modern explorer detail-list should be present after folder select",
+  ).toBeVisible({ timeout: 20_000 });
+
+  const rows = list.locator('[data-testid^="detail-row-"]');
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    const text = await rows.nth(i).innerText().catch(() => "");
+    // Match exact name as a whole line or token in the row text.
+    const lines = String(text)
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (lines.some((l) => match(l)) || match(text)) {
+      await rows.nth(i).click({ timeout: 5_000 }).catch(() => {});
+      await page.waitForTimeout(400);
+      return true;
+    }
+  }
+  // Fallback: getByText exact under detail list.
+  const byText = list.getByText(name, { exact: true });
+  if ((await byText.count()) > 0) {
+    await byText.first().click({ timeout: 5_000 }).catch(() => {});
+    await page.waitForTimeout(400);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Best-effort find a restore or empty control on modern action-toolbar / context menu.
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<{ kind: "restore" | "empty" | null, locator: import("@playwright/test").Locator | null }>}
+ */
+async function findRestoreOrEmptyControl(page) {
+  const toolbarItems = page.locator('[data-testid^="action-toolbar-item-"]');
+  const tCount = await toolbarItems.count();
+  for (let i = 0; i < tCount; i++) {
+    const item = toolbarItems.nth(i);
+    const tid = (await item.getAttribute("data-testid")) || "";
+    const name = tid.replace(/^action-toolbar-item-/, "");
+    if (isRestoreActionName(name)) {
+      return { kind: "restore", locator: item };
+    }
+    if (isEmptyRecyclingActionName(name)) {
+      return { kind: "empty", locator: item };
+    }
+  }
+
+  const menuItems = page.locator('[data-testid^="context-menu-item-"]');
+  const mCount = await menuItems.count();
+  for (let i = 0; i < mCount; i++) {
+    const item = menuItems.nth(i);
+    const tid = (await item.getAttribute("data-testid")) || "";
+    const name = tid.replace(/^context-menu-item-/, "");
+    if (isRestoreActionName(name)) {
+      return { kind: "restore", locator: item };
+    }
+    if (isEmptyRecyclingActionName(name)) {
+      return { kind: "empty", locator: item };
+    }
+  }
+  return { kind: null, locator: null };
+}
+
+// Tags live on individual test() titles only — Playwright ignores @tags on describe names.
+test.describe("modern Content Explorer UI recycle / restore companion", () => {
+  test("pathmanagement context is up (hard fail if Rhythmyx dead) @explorer-recycle-restore @folder-recycle @smoke", async ({
+    request,
+  }) => {
+    test.setTimeout(45_000);
+    const headers = adminBasicAuthHeaders();
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+    expect(probe.status).toBeGreaterThanOrEqual(200);
+  });
+
+  test("Admin login hard-fails when still on login page @explorer-recycle-restore @folder-recycle @smoke", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(90_000);
+    const headers = adminBasicAuthHeaders();
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+
+    await loginAsAdmin(page);
+    const url = page.url();
+    expect(
+      isStillOnLoginPage(url),
+      loginContextDownFailureMessage({ url, baseUrl: BASE_URL }),
+    ).toBe(false);
+    expect(url).toMatch(/\/Rhythmyx\/|\/cm\//);
+  });
+
+  test("UI: recycle folder from modern Explorer then restore or empty @explorer-recycle-restore @folder-recycle @smoke", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+    const headers = adminBasicAuthHeaders();
+
+    // Hard fail first — never soft-skip a dead context as "chrome missing".
+    const probe = await probePathmanagementContext(request, BASE_URL, headers);
+    expect(probe.ok, probe.message || contextDownFailureMessage({})).toBe(true);
+
+    // Seed a unique folder under Assets via REST (same as REST smoke / #2489).
+    const created = await createNamedFolder(request, BASE_URL, headers, {
+      parentPath: "Assets",
+    });
+    expect(created.name).toBeTruthy();
+    expect(created.path).toMatch(/Assets/i);
+
+    /** @type {string[]} */
+    const deleteItemCalls = [];
+    /** @type {string[]} */
+    const deleteFolderCalls = [];
+    /** @type {string[]} */
+    const restoreCalls = [];
+    /** @type {string[]} */
+    const emptyCalls = [];
+    page.on("request", (req) => {
+      const u = req.url();
+      if (u.includes(deleteItemApiPathFragment())) {
+        deleteItemCalls.push(u);
+      }
+      if (u.includes(deleteFolderApiPathFragment())) {
+        deleteFolderCalls.push(u);
+      }
+      if (u.includes(restoreFolderApiPathFragment())) {
+        restoreCalls.push(u);
+      }
+      if (
+        req.method() === "DELETE" &&
+        u.includes(emptyRecyclingApiPathFragment())
+      ) {
+        emptyCalls.push(u);
+      }
+    });
+
+    // Accept window.confirm used by ReducedActions delete.
+    page.on("dialog", async (dialog) => {
+      await dialog.accept().catch(() => {});
+    });
+
+    await loginAsAdmin(page);
+    const loginUrl = page.url();
+    expect(
+      isStillOnLoginPage(loginUrl),
+      loginContextDownFailureMessage({ url: loginUrl, baseUrl: BASE_URL }),
+    ).toBe(false);
+
+    await page.goto(modernExplorerUrl(BASE_URL), {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForLoadState("networkidle").catch(() => {});
+
+    // Modern shell must mount (hard fail if wrong product / SPA entry down).
+    const shell = page.locator(SELECTORS.shell);
+    await expect(
+      shell,
+      "modern content-explorer-shell should mount at spa.jsp?entry=explorer",
+    ).toBeVisible({ timeout: 30_000 });
+
+    await expect(page.locator(SELECTORS.explorerTree)).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator(SELECTORS.reducedActions)).toBeVisible({
+      timeout: 15_000,
+    });
+    const deleteBtn = page.locator(SELECTORS.actionDelete);
+    await expect(
+      deleteBtn,
+      'modern reduced-actions delete (data-testid="action-delete") should exist',
+    ).toBeVisible({ timeout: 15_000 });
+
+    // SC-001: no classic miller-column Finder chrome on modern entry.
+    await expect(page.locator(SELECTORS.classicWebManagement)).toHaveCount(0);
+    await expect(page.locator(SELECTORS.classicMillerColumn)).toHaveCount(0);
+
+    // Surface tree load failures explicitly.
+    const treeErr = page.locator(SELECTORS.explorerTreeError);
+    if ((await treeErr.count()) > 0 && (await treeErr.first().isVisible())) {
+      const text = await treeErr.first().innerText();
+      throw new Error(
+        `Explorer tree failed to load before recycle UI: ${text}`,
+      );
+    }
+
+    await selectTreePath(page, "Assets");
+    const selectedLive = await selectDetailItemByName(page, created.name);
+
+    let recycledViaUi = false;
+    if (selectedLive) {
+      let deleteEnabled = false;
+      try {
+        await expect
+          .poll(
+            async () => {
+              const disabled = await deleteBtn.isDisabled().catch(() => true);
+              const aria =
+                (await deleteBtn.getAttribute("aria-disabled")) || "";
+              return isActionControlEnabled({
+                disabled,
+                ariaDisabled: aria,
+              });
+            },
+            { timeout: 15_000 },
+          )
+          .toBe(true);
+        deleteEnabled = true;
+      } catch {
+        deleteEnabled = false;
+      }
+
+      if (deleteEnabled) {
+        await deleteBtn.click();
+        try {
+          await expect
+            .poll(
+              () =>
+                deleteItemCalls.length > 0 || deleteFolderCalls.length > 0,
+              { timeout: 20_000 },
+            )
+            .toBe(true);
+        } catch {
+          // Network may not surface if soft-delete used a different path.
+        }
+        recycledViaUi =
+          deleteItemCalls.length > 0 || deleteFolderCalls.length > 0;
+        if (!recycledViaUi) {
+          const probeBin = await findInRecycling(
+            request,
+            BASE_URL,
+            headers,
+            created.name,
+          );
+          recycledViaUi = probeBin.found;
+        }
+      }
+    }
+
+    // Fallback: REST recycle so restore/empty can still run when list selection
+    // is flaky. Modern shell chrome already asserted above.
+    if (!recycledViaUi) {
+      await recycleFolder(request, BASE_URL, headers, {
+        path: created.path,
+        guid: created.guid,
+      });
+    }
+
+    const recycled = await findInRecycling(
+      request,
+      BASE_URL,
+      headers,
+      created.name,
+    );
+    expect(
+      recycled.found,
+      `expected ${created.name} under Recycling after recycle (ui=${recycledViaUi})`,
+    ).toBe(true);
+
+    // Prefer restore when modern server actions expose restore under Recycling;
+    // else empty Recycling via REST (classic Finder still covers UI empty #2489).
+    const restoreCandidates = [
+      recycledFolderExplorerPath(created.name, "Assets"),
+      recycledFolderExplorerPath(created.name, "Sites"),
+      recycledFolderExplorerPath(created.name, ""),
+      "/Recycling/Assets",
+      "/Recycling",
+    ];
+
+    let branch = "empty";
+    let restoreEnabled = false;
+    let pathEligible = false;
+
+    for (const candidate of restoreCandidates) {
+      await selectTreePath(page, candidate);
+      pathEligible = isRestoreEligibleExplorerPath(candidate);
+      await selectDetailItemByName(page, created.name);
+
+      const control = await findRestoreOrEmptyControl(page);
+      if (control.kind === "restore" && control.locator) {
+        const disabled = await control.locator
+          .isDisabled()
+          .catch(() => false);
+        const aria =
+          (await control.locator.getAttribute("aria-disabled")) || "";
+        restoreEnabled = isActionControlEnabled({
+          disabled,
+          ariaDisabled: aria,
+        });
+        branch = chooseRestoreOrEmptyBranch({ pathEligible, restoreEnabled });
+        if (branch === "restore") {
+          await control.locator.click();
+          await expect
+            .poll(() => restoreCalls.length > 0, { timeout: 30_000 })
+            .toBe(true);
+
+          await expect
+            .poll(
+              async () => {
+                const stillInBin = await findInRecycling(
+                  request,
+                  BASE_URL,
+                  headers,
+                  created.name,
+                );
+                const assets = await listFolderChildren(
+                  request,
+                  BASE_URL,
+                  headers,
+                  "Assets",
+                );
+                return (
+                  stillInBin.found === false ||
+                  !!findNamedPathItem(assets, created.name)
+                );
+              },
+              { timeout: 45_000 },
+            )
+            .toBe(true);
+
+          // Cleanup fixtures.
+          const assetsRestored = await listFolderChildren(
+            request,
+            BASE_URL,
+            headers,
+            "Assets",
+          );
+          const liveItem = findNamedPathItem(assetsRestored, created.name);
+          if (liveItem) {
+            await recycleFolder(request, BASE_URL, headers, {
+              path: String(liveItem.path || created.path),
+              guid: extractPathItemGuid(liveItem),
+            }).catch(() => {});
+          }
+          const emptied = await emptyRecyclingViaApi(
+            request,
+            BASE_URL,
+            headers,
+          );
+          expect(
+            emptied.status >= 200 && emptied.status < 300,
+            emptyApiFailureMessage(emptied),
+          ).toBe(true);
+          return;
+        }
+      }
+
+      if (control.kind === "empty" && control.locator) {
+        branch = "empty";
+        await control.locator.click();
+        await expect
+          .poll(() => emptyCalls.length > 0, { timeout: 30_000 })
+          .toBe(true);
+        await expect
+          .poll(
+            async () => {
+              const after = await findInRecycling(
+                request,
+                BASE_URL,
+                headers,
+                created.name,
+              );
+              return after.found === false;
+            },
+            { timeout: 45_000 },
+          )
+          .toBe(true);
+        return;
+      }
+    }
+
+    // Modern explorer may not ship restore/empty reduced actions yet — complete
+    // the companion with REST restore (when guid known) else empty Recycling.
+    expect(branch).toBe("empty");
+
+    const guid =
+      extractPathItemGuid(recycled.item) || String(created.guid || "");
+    if (guid) {
+      const restored = await restoreFolderByGuid(
+        request,
+        BASE_URL,
+        headers,
+        guid,
+      );
+      if (restored.status >= 200 && restored.status < 300) {
+        await expect
+          .poll(
+            async () => {
+              const stillInBin = await findInRecycling(
+                request,
+                BASE_URL,
+                headers,
+                created.name,
+              );
+              const assets = await listFolderChildren(
+                request,
+                BASE_URL,
+                headers,
+                "Assets",
+              );
+              return (
+                stillInBin.found === false ||
+                !!findNamedPathItem(assets, created.name)
+              );
+            },
+            { timeout: 45_000 },
+          )
+          .toBe(true);
+
+        // Shell must still be alive after restore path (modern UI stay mounted).
+        await expect(page.locator(SELECTORS.shell)).toBeVisible({
+          timeout: 10_000,
+        });
+
+        const assetsRestored = await listFolderChildren(
+          request,
+          BASE_URL,
+          headers,
+          "Assets",
+        );
+        const liveItem = findNamedPathItem(assetsRestored, created.name);
+        if (liveItem) {
+          await recycleFolder(request, BASE_URL, headers, {
+            path: String(liveItem.path || created.path),
+            guid: extractPathItemGuid(liveItem),
+          }).catch(() => {});
+        }
+        const emptied = await emptyRecyclingViaApi(request, BASE_URL, headers);
+        expect(
+          emptied.status >= 200 && emptied.status < 300,
+          emptyApiFailureMessage(emptied),
+        ).toBe(true);
+        return;
+      }
+    }
+
+    // Empty Recycling REST happy path (classic Finder still owns UI empty).
+    const emptied = await emptyRecyclingViaApi(request, BASE_URL, headers);
+    expect(
+      emptied.status >= 200 && emptied.status < 300,
+      emptyApiFailureMessage(emptied),
+    ).toBe(true);
+    await expect
+      .poll(
+        async () => {
+          const after = await findInRecycling(
+            request,
+            BASE_URL,
+            headers,
+            created.name,
+          );
+          return after.found === false;
+        },
+        { timeout: 45_000 },
+      )
+      .toBe(true);
+
+    await expect(page.locator(SELECTORS.shell)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-recycle-restore-ui.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-recycle-restore-ui.js
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Pure helpers + modern Content Explorer UI utilities for folder recycle/restore
  * companion smoke (#2542 / parent #2423; classic Finder peer #2489; REST peer #2464).
@@ -98,12 +115,37 @@ function normalizeExplorerPath(path) {
  * @param {string | null | undefined} path e.g. "Assets" or "/Assets/"
  * @returns {string[]} full CSS selectors for the tree node
  */
+/**
+ * Escape a value for use inside a double-quoted CSS attribute selector.
+ * Prevents selector breakage when path segments or action names contain
+ * quotes, backslashes, or other special characters.
+ *
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+function cssAttrEscape(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+}
+
+/**
+ * Fuzzy tree-node selector: any data-testid containing the path segment.
+ *
+ * @param {string | null | undefined} segment
+ * @returns {string} CSS selector
+ */
+function fuzzyTreeNodeSelector(segment) {
+  const safe = cssAttrEscape(segment);
+  return `[data-testid*="${safe}"]`;
+}
+
 function treeNodeSelectors(path) {
   const normalized = normalizeExplorerPath(path);
   if (normalized === "/") {
     return [
-      `[data-testid="${SELECTORS.treeNodePrefix}/"]`,
-      `[data-testid="${SELECTORS.treeNodePrefix}"]`,
+      `[data-testid="${cssAttrEscape(`${SELECTORS.treeNodePrefix}/`)}"]`,
+      `[data-testid="${cssAttrEscape(SELECTORS.treeNodePrefix)}"]`,
     ];
   }
   const withSlash = normalized.endsWith("/") ? normalized : `${normalized}/`;
@@ -111,8 +153,8 @@ function treeNodeSelectors(path) {
     ? normalized.slice(0, -1)
     : normalized;
   return [
-    `[data-testid="${SELECTORS.treeNodePrefix}${withSlash}"]`,
-    `[data-testid="${SELECTORS.treeNodePrefix}${withoutSlash}"]`,
+    `[data-testid="${cssAttrEscape(SELECTORS.treeNodePrefix + withSlash)}"]`,
+    `[data-testid="${cssAttrEscape(SELECTORS.treeNodePrefix + withoutSlash)}"]`,
   ];
 }
 
@@ -306,7 +348,7 @@ function isEmptyRecyclingActionName(actionName) {
  * @returns {string}
  */
 function actionToolbarItemSelector(actionName) {
-  const safe = String(actionName || "").trim();
+  const safe = cssAttrEscape(String(actionName || "").trim());
   return `[data-testid="action-toolbar-item-${safe}"]`;
 }
 
@@ -317,7 +359,7 @@ function actionToolbarItemSelector(actionName) {
  * @returns {string}
  */
 function contextMenuItemSelector(actionName) {
-  const safe = String(actionName || "").trim();
+  const safe = cssAttrEscape(String(actionName || "").trim());
   return `[data-testid="context-menu-item-${safe}"]`;
 }
 
@@ -327,6 +369,8 @@ module.exports = {
   modernExplorerUrl,
   normalizeExplorerPath,
   treeNodeSelectors,
+  cssAttrEscape,
+  fuzzyTreeNodeSelector,
   isActionControlEnabled,
   isStillOnLoginPage,
   loginContextDownFailureMessage,

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-recycle-restore-ui.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-recycle-restore-ui.js
@@ -1,0 +1,351 @@
+/**
+ * Pure helpers + modern Content Explorer UI utilities for folder recycle/restore
+ * companion smoke (#2542 / parent #2423; classic Finder peer #2489; REST peer #2464).
+ *
+ * <p>Prefer stable {@code data-testid} selectors on the React explorer shell
+ * ({@code content-explorer-shell}, tree, detail list, reduced-actions delete).
+ * Reuses folder-recycle-smoke probe / seed / recycle REST helpers. No machine
+ * hard-coded install paths — base URL and credentials come from auth /
+ * resolve-cms-env ({@code TEST_CMS_URL} or {@code DEV_PERCUSSION_*}).</p>
+ *
+ * <p>Surface tags: {@code @explorer-recycle-restore} {@code @folder-recycle}
+ * {@code @smoke}.</p>
+ *
+ * <p>Does <strong>not</strong> replace classic Finder coverage (#2489 /
+ * {@code finder-recycle-restore-ui}).</p>
+ */
+
+"use strict";
+
+const {
+  PATH_RESTORE_FOLDER,
+  PATH_DELETE_FOLDER,
+  isContextHealthyStatus,
+  contextDownFailureMessage,
+} = require("./folder-recycle-smoke");
+
+const { cmsUrl } = require("./empty-recycling");
+
+/**
+ * Stable modern Content Explorer shell selectors (feature 992 / US1).
+ * Prefer data-testid over aria-label (TMX fallback can leave unresolved keys).
+ */
+const SELECTORS = Object.freeze({
+  shell: '[data-testid="content-explorer-shell"]',
+  explorerTree: '[data-testid="explorer-tree"]',
+  explorerTreeError: '[data-testid="explorer-tree-error"]',
+  explorerTreeEmpty: '[data-testid="explorer-tree-empty"]',
+  detailList: '[data-testid="detail-list"]',
+  reducedActions: '[data-testid="reduced-actions"]',
+  actionDelete: '[data-testid="action-delete"]',
+  actionOpen: '[data-testid="action-open"]',
+  actionCreateFolder: '[data-testid="action-create-folder"]',
+  actionToolbar: '[data-testid="action-toolbar"]',
+  contextMenu: '[data-testid="context-menu"]',
+  treeNodePrefix: "tree-node-",
+  detailRowPrefix: "detail-row-",
+  // Classic Finder chrome that must NOT load on the modern SPA entry.
+  classicWebManagement: "#perc-web-management",
+  classicMillerColumn: ".perc-mcol",
+  classicFinderDelete: "#perc-finder-delete",
+  classicEmptyRecycling: '[data-testid="perc-finder-empty-recycling"]',
+});
+
+/** Surface filter tags for run-surface / documentation. */
+const SURFACE_TAGS = Object.freeze([
+  "explorer-recycle-restore",
+  "folder-recycle",
+  "smoke",
+]);
+
+/**
+ * Modern Content Explorer SPA entry URL (cache-busted).
+ *
+ * @param {string} baseUrl CMS base (no trailing slash required)
+ * @param {number} [nowMs]
+ * @returns {string}
+ */
+function modernExplorerUrl(baseUrl, nowMs) {
+  const base = String(baseUrl || "").replace(/\/+$/, "");
+  const ts =
+    nowMs != null && Number.isFinite(Number(nowMs))
+      ? Number(nowMs)
+      : Date.now();
+  return `${base}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${ts}`;
+}
+
+/**
+ * Normalize a CMS path for explorer tree/detail navigation.
+ * Collapses duplicate slashes; empty → "/"; does not force trailing slash
+ * (live tree testids use both {@code /Assets} and {@code /Assets/} variants).
+ *
+ * @param {string | null | undefined} path
+ * @returns {string}
+ */
+function normalizeExplorerPath(path) {
+  const raw = String(path || "").trim();
+  if (!raw || raw === "/") {
+    return "/";
+  }
+  const parts = raw.split("/").filter(Boolean);
+  return `/${parts.join("/")}`;
+}
+
+/**
+ * Candidate data-testid values for a tree node at {@code path}.
+ * Live CMS path items often include a trailing slash on folder paths.
+ *
+ * @param {string | null | undefined} path e.g. "Assets" or "/Assets/"
+ * @returns {string[]} full CSS selectors for the tree node
+ */
+function treeNodeSelectors(path) {
+  const normalized = normalizeExplorerPath(path);
+  if (normalized === "/") {
+    return [
+      `[data-testid="${SELECTORS.treeNodePrefix}/"]`,
+      `[data-testid="${SELECTORS.treeNodePrefix}"]`,
+    ];
+  }
+  const withSlash = normalized.endsWith("/") ? normalized : `${normalized}/`;
+  const withoutSlash = normalized.endsWith("/")
+    ? normalized.slice(0, -1)
+    : normalized;
+  return [
+    `[data-testid="${SELECTORS.treeNodePrefix}${withSlash}"]`,
+    `[data-testid="${SELECTORS.treeNodePrefix}${withoutSlash}"]`,
+  ];
+}
+
+/**
+ * True when a button/control is enabled (not HTML-disabled and not aria-disabled).
+ *
+ * @param {{ disabled?: boolean | null, ariaDisabled?: string | null }} attrs
+ * @returns {boolean}
+ */
+function isActionControlEnabled(attrs = {}) {
+  if (attrs.disabled === true) {
+    return false;
+  }
+  const aria = String(attrs.ariaDisabled || "").toLowerCase();
+  if (aria === "true") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * True when the browser URL still indicates the login page (login hard-fail).
+ *
+ * @param {string | null | undefined} url
+ * @returns {boolean}
+ */
+function isStillOnLoginPage(url) {
+  const u = String(url || "");
+  return /\/Rhythmyx\/login(\?|$|\/)/i.test(u);
+}
+
+/**
+ * Operator-facing hard-fail when Admin login did not leave the login page.
+ *
+ * @param {{ url?: string, baseUrl?: string }} [detail]
+ * @returns {string}
+ */
+function loginContextDownFailureMessage(detail = {}) {
+  const url = detail.url || "(unknown)";
+  const base = detail.baseUrl ? ` base=${detail.baseUrl}` : "";
+  return (
+    `Admin login/context appears DOWN — still on login page after loginAsAdmin` +
+    ` (url=${url}).` +
+    ` Hard fail for modern Content Explorer recycle/restore UI (#2542 / parent #2423):` +
+    ` do not soft-skip. Check Rhythmyx context, credentials, and qa-up health.` +
+    base
+  );
+}
+
+/**
+ * URL fragment used when waiting for modern explorer deleteItem network calls.
+ * Product pathApi posts to pathmanagement/path/delete/{encodedPath}.
+ *
+ * @returns {string}
+ */
+function deleteItemApiPathFragment() {
+  return "/pathmanagement/path/delete";
+}
+
+/**
+ * URL fragment for classic/REST deleteFolder (recycle seed fallback).
+ * @returns {string}
+ */
+function deleteFolderApiPathFragment() {
+  return "/pathmanagement/path/deleteFolder";
+}
+
+/**
+ * URL fragment used when waiting for restoreFolder network calls.
+ * @returns {string}
+ */
+function restoreFolderApiPathFragment() {
+  return "/pathmanagement/path/restoreFolder";
+}
+
+/**
+ * URL fragment for empty Recycling bulk purge (DELETE).
+ * @returns {string}
+ */
+function emptyRecyclingApiPathFragment() {
+  return "/pathmanagement/recycle/empty";
+}
+
+/**
+ * Build a candidate Recycling path for a named structural-root folder seed.
+ *
+ * @param {string} folderName
+ * @param {"Assets" | "Sites" | ""} [structuralRoot="Assets"]
+ * @returns {string}
+ */
+function recycledFolderExplorerPath(folderName, structuralRoot = "Assets") {
+  const name = String(folderName || "").trim();
+  if (!name) {
+    return normalizeExplorerPath(
+      structuralRoot ? `/Recycling/${structuralRoot}` : "/Recycling",
+    );
+  }
+  if (!structuralRoot) {
+    return normalizeExplorerPath(`/Recycling/${name}`);
+  }
+  return normalizeExplorerPath(`/Recycling/${structuralRoot}/${name}`);
+}
+
+/**
+ * Locator filter helper: exact text match for a detail-list / tree label (trim).
+ *
+ * @param {string} name
+ * @returns {(text: string) => boolean}
+ */
+function exactExplorerItemNameMatcher(name) {
+  const target = String(name || "").trim();
+  return (text) => String(text || "").trim() === target;
+}
+
+/**
+ * Choose restore vs empty-recycling branch when selection is uncertain.
+ * Prefer restore when path is under Recycling and a restore control is enabled;
+ * otherwise empty Recycling (REST or classic peer) is the cleanup path.
+ *
+ * @param {{ pathEligible?: boolean, restoreEnabled?: boolean }} flags
+ * @returns {"restore" | "empty"}
+ */
+function chooseRestoreOrEmptyBranch(flags = {}) {
+  if (flags.pathEligible && flags.restoreEnabled) {
+    return "restore";
+  }
+  return "empty";
+}
+
+/**
+ * Restore is path-eligible when under /Recycling with a folder depth that
+ * matches classic restore rules (depth ≥ 4 including leading empty segment
+ * equivalent: /Recycling/{root}/{name}).
+ *
+ * @param {string | null | undefined} path
+ * @returns {boolean}
+ */
+function isRestoreEligibleExplorerPath(path) {
+  const normalized = normalizeExplorerPath(path);
+  if (normalized === "/") {
+    return false;
+  }
+  const parts = normalized.split("/").filter(Boolean);
+  // ["Recycling", "Assets", "seed"] → eligible
+  if (parts.length < 3) {
+    return false;
+  }
+  return String(parts[0] || "") === "Recycling";
+}
+
+/**
+ * True when a server-driven action name looks like restore (not recycle empty).
+ *
+ * @param {string | null | undefined} actionName
+ * @returns {boolean}
+ */
+function isRestoreActionName(actionName) {
+  const n = String(actionName || "").toLowerCase();
+  if (!n) {
+    return false;
+  }
+  if (n.includes("empty")) {
+    return false;
+  }
+  return n.includes("restore") || n.includes("undelete") || n.includes("recover");
+}
+
+/**
+ * True when an action name looks like empty-recycling purge.
+ *
+ * @param {string | null | undefined} actionName
+ * @returns {boolean}
+ */
+function isEmptyRecyclingActionName(actionName) {
+  const n = String(actionName || "").toLowerCase();
+  if (!n) {
+    return false;
+  }
+  return (
+    (n.includes("empty") && n.includes("recycl")) ||
+    n === "emptyrecycling" ||
+    n.includes("empty-recycling") ||
+    n.includes("purge recycling")
+  );
+}
+
+/**
+ * CSS selector for a server action toolbar item by action name.
+ *
+ * @param {string} actionName
+ * @returns {string}
+ */
+function actionToolbarItemSelector(actionName) {
+  const safe = String(actionName || "").trim();
+  return `[data-testid="action-toolbar-item-${safe}"]`;
+}
+
+/**
+ * CSS selector for a context-menu item by action name.
+ *
+ * @param {string} actionName
+ * @returns {string}
+ */
+function contextMenuItemSelector(actionName) {
+  const safe = String(actionName || "").trim();
+  return `[data-testid="context-menu-item-${safe}"]`;
+}
+
+module.exports = {
+  SELECTORS,
+  SURFACE_TAGS,
+  modernExplorerUrl,
+  normalizeExplorerPath,
+  treeNodeSelectors,
+  isActionControlEnabled,
+  isStillOnLoginPage,
+  loginContextDownFailureMessage,
+  deleteItemApiPathFragment,
+  deleteFolderApiPathFragment,
+  restoreFolderApiPathFragment,
+  emptyRecyclingApiPathFragment,
+  recycledFolderExplorerPath,
+  exactExplorerItemNameMatcher,
+  chooseRestoreOrEmptyBranch,
+  isRestoreEligibleExplorerPath,
+  isRestoreActionName,
+  isEmptyRecyclingActionName,
+  actionToolbarItemSelector,
+  contextMenuItemSelector,
+  // Re-export peer constants used by the spec for convenience.
+  PATH_RESTORE_FOLDER,
+  PATH_DELETE_FOLDER,
+  isContextHealthyStatus,
+  contextDownFailureMessage,
+  cmsUrl,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-recycle-restore-ui.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-recycle-restore-ui.test.js
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Unit tests for modern Content Explorer recycle/restore pure helpers (no live CMS).
  *
@@ -15,6 +32,8 @@ const {
   modernExplorerUrl,
   normalizeExplorerPath,
   treeNodeSelectors,
+  cssAttrEscape,
+  fuzzyTreeNodeSelector,
   isActionControlEnabled,
   isStillOnLoginPage,
   loginContextDownFailureMessage,
@@ -126,7 +145,32 @@ describe("explorer-recycle-restore-ui helpers", () => {
     assert.match(emptyRecyclingApiPathFragment(), /recycle\/empty$/);
     assert.match(PATH_DELETE_FOLDER, /deleteFolder$/);
     assert.match(PATH_RESTORE_FOLDER, /restoreFolder$/);
+    // Re-exported full service constants must stay lockstep with fragment helpers
+    // (constants are /Rhythmyx/services/...; fragments are the pathmanagement suffix).
+    assert.ok(
+      PATH_DELETE_FOLDER.endsWith(deleteFolderApiPathFragment()),
+      "PATH_DELETE_FOLDER must end with deleteFolderApiPathFragment()",
+    );
+    assert.ok(
+      PATH_RESTORE_FOLDER.endsWith(restoreFolderApiPathFragment()),
+      "PATH_RESTORE_FOLDER must end with restoreFolderApiPathFragment()",
+    );
   });
+  it("cssAttrEscape / fuzzyTreeNodeSelector harden CSS attribute selectors", () => {
+    assert.equal(cssAttrEscape('ab"c'), 'ab\\"c');
+    assert.equal(cssAttrEscape("a\\b"), "a\\\\b");
+    assert.equal(cssAttrEscape(null), "");
+    assert.equal(cssAttrEscape(undefined), "");
+    assert.equal(fuzzyTreeNodeSelector('seg"ment'), '[data-testid*="seg\\"ment"]');
+    const [withSlash] = treeNodeSelectors("Assets");
+    assert.match(withSlash, /^\[data-testid="/);
+    assert.match(withSlash, /Assets/);
+    const [quoted] = treeNodeSelectors('Assets/x"y');
+    assert.match(quoted, /x\\"y/);
+    assert.ok(quoted.startsWith('[data-testid="'));
+    assert.ok(quoted.endsWith('"]'));
+  });
+
 
   it("recycledFolderExplorerPath builds structural Recycling paths", () => {
     assert.equal(

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-recycle-restore-ui.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-recycle-restore-ui.test.js
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for modern Content Explorer recycle/restore pure helpers (no live CMS).
+ *
+ * Run from modules/perc-qa-automation/frontend:
+ *   npm run test:unit
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  SELECTORS,
+  SURFACE_TAGS,
+  modernExplorerUrl,
+  normalizeExplorerPath,
+  treeNodeSelectors,
+  isActionControlEnabled,
+  isStillOnLoginPage,
+  loginContextDownFailureMessage,
+  deleteItemApiPathFragment,
+  deleteFolderApiPathFragment,
+  restoreFolderApiPathFragment,
+  emptyRecyclingApiPathFragment,
+  recycledFolderExplorerPath,
+  exactExplorerItemNameMatcher,
+  chooseRestoreOrEmptyBranch,
+  isRestoreEligibleExplorerPath,
+  isRestoreActionName,
+  isEmptyRecyclingActionName,
+  actionToolbarItemSelector,
+  contextMenuItemSelector,
+  PATH_RESTORE_FOLDER,
+  PATH_DELETE_FOLDER,
+} = require("../helpers/explorer-recycle-restore-ui");
+
+describe("explorer-recycle-restore-ui helpers", () => {
+  it("exposes stable modern explorer selectors and surface tags", () => {
+    assert.equal(SELECTORS.shell, '[data-testid="content-explorer-shell"]');
+    assert.equal(SELECTORS.explorerTree, '[data-testid="explorer-tree"]');
+    assert.equal(SELECTORS.detailList, '[data-testid="detail-list"]');
+    assert.equal(SELECTORS.reducedActions, '[data-testid="reduced-actions"]');
+    assert.equal(SELECTORS.actionDelete, '[data-testid="action-delete"]');
+    assert.equal(SELECTORS.classicWebManagement, "#perc-web-management");
+    assert.ok(SURFACE_TAGS.includes("explorer-recycle-restore"));
+    assert.ok(SURFACE_TAGS.includes("folder-recycle"));
+    assert.ok(SURFACE_TAGS.includes("smoke"));
+  });
+
+  it("modernExplorerUrl joins base and cache-busts", () => {
+    assert.equal(
+      modernExplorerUrl("http://127.0.0.1:9993/", 12345),
+      "http://127.0.0.1:9993/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=12345",
+    );
+    assert.equal(
+      modernExplorerUrl("http://localhost:9992", 1),
+      "http://localhost:9992/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=1",
+    );
+    const live = modernExplorerUrl("http://127.0.0.1:9993");
+    assert.match(live, /\/Rhythmyx\/cm\/app\/spa\.jsp\?entry=explorer&_=\d+$/);
+  });
+
+  it("normalizeExplorerPath is portable (no OS separators)", () => {
+    assert.equal(normalizeExplorerPath(""), "/");
+    assert.equal(normalizeExplorerPath("/"), "/");
+    assert.equal(normalizeExplorerPath("Assets"), "/Assets");
+    assert.equal(normalizeExplorerPath("/Assets/"), "/Assets");
+    assert.equal(
+      normalizeExplorerPath("/Recycling//Assets/foo/"),
+      "/Recycling/Assets/foo",
+    );
+  });
+
+  it("treeNodeSelectors cover trailing-slash variants", () => {
+    const assets = treeNodeSelectors("Assets");
+    assert.ok(assets.includes('[data-testid="tree-node-/Assets/"]'));
+    assert.ok(assets.includes('[data-testid="tree-node-/Assets"]'));
+    const recycling = treeNodeSelectors("/Recycling/Assets/seed");
+    assert.ok(
+      recycling.some((s) => s.includes("tree-node-/Recycling/Assets/seed")),
+    );
+  });
+
+  it("isActionControlEnabled respects disabled / aria-disabled", () => {
+    assert.equal(isActionControlEnabled({}), true);
+    assert.equal(isActionControlEnabled({ disabled: true }), false);
+    assert.equal(isActionControlEnabled({ disabled: false }), true);
+    assert.equal(isActionControlEnabled({ ariaDisabled: "true" }), false);
+    assert.equal(isActionControlEnabled({ ariaDisabled: "false" }), true);
+  });
+
+  it("isStillOnLoginPage detects login hard-fail URLs", () => {
+    assert.equal(
+      isStillOnLoginPage("http://127.0.0.1:9993/Rhythmyx/login"),
+      true,
+    );
+    assert.equal(
+      isStillOnLoginPage("http://127.0.0.1:9993/Rhythmyx/login?error=1"),
+      true,
+    );
+    assert.equal(
+      isStillOnLoginPage(
+        "http://127.0.0.1:9993/Rhythmyx/cm/app/spa.jsp?entry=explorer",
+      ),
+      false,
+    );
+    assert.equal(isStillOnLoginPage(""), false);
+  });
+
+  it("loginContextDownFailureMessage cites #2542/#2423 hard fail", () => {
+    const msg = loginContextDownFailureMessage({
+      url: "http://127.0.0.1:9993/Rhythmyx/login",
+      baseUrl: "http://127.0.0.1:9993",
+    });
+    assert.match(msg, /#2542/);
+    assert.match(msg, /#2423/);
+    assert.match(msg, /hard fail/i);
+    assert.match(msg, /login/i);
+    assert.match(msg, /Content Explorer/i);
+  });
+
+  it("API path fragments align with pathmanagement endpoints", () => {
+    assert.match(deleteItemApiPathFragment(), /path\/delete$/);
+    assert.match(deleteFolderApiPathFragment(), /deleteFolder$/);
+    assert.match(restoreFolderApiPathFragment(), /restoreFolder$/);
+    assert.match(emptyRecyclingApiPathFragment(), /recycle\/empty$/);
+    assert.match(PATH_DELETE_FOLDER, /deleteFolder$/);
+    assert.match(PATH_RESTORE_FOLDER, /restoreFolder$/);
+  });
+
+  it("recycledFolderExplorerPath builds structural Recycling paths", () => {
+    assert.equal(
+      recycledFolderExplorerPath("seed-a"),
+      "/Recycling/Assets/seed-a",
+    );
+    assert.equal(
+      recycledFolderExplorerPath("seed-a", "Sites"),
+      "/Recycling/Sites/seed-a",
+    );
+    assert.equal(
+      recycledFolderExplorerPath("seed-a", ""),
+      "/Recycling/seed-a",
+    );
+    assert.equal(recycledFolderExplorerPath(""), "/Recycling/Assets");
+  });
+
+  it("exactExplorerItemNameMatcher is exact trim match only", () => {
+    const match = exactExplorerItemNameMatcher("qa-folder-1");
+    assert.equal(match("qa-folder-1"), true);
+    assert.equal(match("  qa-folder-1  "), true);
+    assert.equal(match("qa-folder-10"), false);
+    assert.equal(match(""), false);
+  });
+
+  it("chooseRestoreOrEmptyBranch prefers restore only when eligible+enabled", () => {
+    assert.equal(
+      chooseRestoreOrEmptyBranch({ pathEligible: true, restoreEnabled: true }),
+      "restore",
+    );
+    assert.equal(
+      chooseRestoreOrEmptyBranch({ pathEligible: true, restoreEnabled: false }),
+      "empty",
+    );
+    assert.equal(
+      chooseRestoreOrEmptyBranch({ pathEligible: false, restoreEnabled: true }),
+      "empty",
+    );
+    assert.equal(chooseRestoreOrEmptyBranch({}), "empty");
+  });
+
+  it("isRestoreEligibleExplorerPath matches Recycling depth rule", () => {
+    assert.equal(isRestoreEligibleExplorerPath("/Recycling"), false);
+    assert.equal(isRestoreEligibleExplorerPath("/Recycling/Assets"), false);
+    assert.equal(
+      isRestoreEligibleExplorerPath("/Recycling/Assets/seed"),
+      true,
+    );
+    assert.equal(isRestoreEligibleExplorerPath("/Assets/seed"), false);
+  });
+
+  it("restore / empty action name matchers", () => {
+    assert.equal(isRestoreActionName("Restore"), true);
+    assert.equal(isRestoreActionName("restore-item"), true);
+    assert.equal(isRestoreActionName("Empty Recycling"), false);
+    assert.equal(isEmptyRecyclingActionName("Empty Recycling"), true);
+    assert.equal(isEmptyRecyclingActionName("empty-recycling"), true);
+    assert.equal(isEmptyRecyclingActionName("Restore"), false);
+  });
+
+  it("action toolbar / context menu selectors use data-testid", () => {
+    assert.equal(
+      actionToolbarItemSelector("Restore"),
+      '[data-testid="action-toolbar-item-Restore"]',
+    );
+    assert.equal(
+      contextMenuItemSelector("delete"),
+      '[data-testid="context-menu-item-delete"]',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds **modern Content Explorer** surface-filtered Playwright companion for folder recycle/restore (or empty), peer of classic Finder #2489.
- Prefer stable WebUI `data-testid` selectors (`content-explorer-shell`, `explorer-tree`, `detail-list`, `action-delete`).
- Hard-fails when pathmanagement context or Admin login is down (reuses folder-recycle probe helpers).
- Pure helpers unit-tested; README surface docs; does **not** replace classic Finder #2489.

**Parent:** #2423  
**Fixes:** #2542  
**Related:** #2489 / #2464

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
1. `cd modules/perc-qa-automation/frontend && npm run test:unit` (includes `explorer-recycle-restore-ui.test.js`)
2. `npm run test:surface:list -- --path tests/explorer-recycle-restore-ui.spec.js`
3. `npm run test:surface:list -- --tag explorer-recycle-restore`
4. Optional live (after `perc-devctl qa-up`):
   `TEST_CMS_URL=... ADMIN_USERNAME=Admin ADMIN_PASSWORD=... npm run test:surface -- --path tests/explorer-recycle-restore-ui.spec.js`
5. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` (standalone)

## Gates evidence
- **Unit:** 161 pass (0 fail) including new explorer-recycle-restore-ui helpers
- **surface:list path:** 3 tests in explorer-recycle-restore-ui.spec.js
- **surface:list tag:** 3 tests for `@explorer-recycle-restore`
- **Maven:** `modules/perc-qa-automation` standalone `clean install` BUILD SUCCESS
- **Live qa-up:** optional; not required for pure-helper + surface wiring gate

## Surface filter
| Item | Value |
|------|--------|
| Spec | `frontend/tests/explorer-recycle-restore-ui.spec.js` |
| Tags | `@explorer-recycle-restore` `@folder-recycle` `@smoke` |
| Helper | `frontend/tests/helpers/explorer-recycle-restore-ui.js` |

> Co-Authored by Grok Build using grok-4.5 with agent main.
