### PR TITLE
fix(sitemanage): param @Lazy on itemWorkflow cycle-peer ctor edges (#2515)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -1,9 +1,9 @@
 # Sitemanage Spring constructor-injection cycle inventory
 
-**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**  
+**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents — **not** an agent rule file.
 
@@ -78,7 +78,7 @@ Class-level `@Lazy` on these beans is **lazy init only** — it is **false safet
 | Class | Class `@Lazy`? | Disposition |
 |-------|----------------|-------------|
 | `PSPageService` | yes | consumer / hub — reverse-edge freeze done (#2514 / `PSPageServiceCycleWiringTest`) |
-| `PSItemWorkflowService` | yes | consumer / hub — #2478 / #2515 |
+| `PSItemWorkflowService` | yes | consumer / hub — reverse freeze #2478; cycle-peer **param `@Lazy`** #2515 |
 | `PSSiteDataService` | yes | consumer / hub — #2516 |
 | `PSAssetService` | yes | consumer; folderHelper param **not** `@Lazy` (pageService param **is** `@Lazy` #2476) |
 | `PSItemService` | no | consumer |
@@ -107,7 +107,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | Rank | Bean | Approx. ctor out / in (interest graph) | Notes |
 |------|------|----------------------------------------|-------|
 | 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze covered by `PSPageServiceCycleWiringTest` (2026-08-08, #2514). |
-| 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset`. Class `@Lazy`. |
+| 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset` with **param `@Lazy`** (#2515). Class `@Lazy`. Reverse-edge freeze: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478). |
 | 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
@@ -125,6 +125,28 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | Why not skip param `@Lazy` | Inventory residual after #2463: without it, a future reverse edge or multi-hop eager path would form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
 
 Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + param `@Lazy` + no reverse).
+
+### ItemWorkflow hub cycle-peer param `@Lazy` (#2515)
+
+**`PSItemWorkflowService` → known-cycle peers (constructor, param `@Lazy` as of #2515)** with **no reverse** peer → `IPSItemWorkflowService` (frozen by #2478).
+
+Behavior review of call sites (safe for lazy proxy):
+
+| Peer param | Ctor body | Post-construction use | Param `@Lazy`? |
+|------------|-----------|----------------------|----------------|
+| `IPSAssetDao` | field assign only | **unused** in production methods today | **yes** |
+| `IPSFolderHelper` | field assign only | folder path / access / workflow id on transition paths | **yes** |
+| `IPSRecycleService` | field assign only | `isInRecycler` checks | **yes** |
+| `IPSWidgetAssetRelationshipService` | field assign only | shared/linked/local asset relations on checkout/transition | **yes** |
+
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on hub | Present but **not** a cycle breaker when an eager consumer forces construction |
+| Param `@Lazy` on four forward edges | **Added (#2515)** — Spring injects proxies; safe because ctor never method-calls peers |
+| Reverse edge ban | Kept — #2478 / `PSItemWorkflowServiceHubReverseEdgeWiringTest` |
+| Why apply now | Residual after #2478 reverse-edge freezes: belt-and-braces peer of #2476 so multi-hop eager paths through cycle peers cannot form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
+
+Protection test: `PSItemWorkflowServiceCycleLazyWiringTest` (asserts construct-require + param `@Lazy` on each chosen peer).
 
 ### Other one-way edges to keep one-way (known cycle intermediate)
 
@@ -147,13 +169,14 @@ Constructor-parameter `@Lazy` remains rare in this module. Scan snapshot (after 
 - `PSPageDaoHelper` → `IPSFolderHelper` (`@Lazy`) — known reverse edge path B (#2437)
 - `PSFolderHelper` → `IPSRecycleService` (`@Lazy`) — forward deferral of recycle subgraph (#2437)
 - `PSAssetService` → `IPSPageService` (`@Lazy`) — near-cycle belt-and-braces (#2476)
+- `PSItemWorkflowService` → `IPSAssetDao` / `IPSFolderHelper` / `IPSRecycleService` / `IPSWidgetAssetRelationshipService` (`@Lazy`) — hub cycle-peer belt-and-braces (#2515)
 - `PSRecentRestService` → `IPSRecentService` (`@Lazy`) — rest convenience, not cycle-related
 
 Class-level `@Lazy` is common on REST facades and many services; treat it as lazy *init*, not a cycle breaker.
 
 ## Who constructs `IPSFolderHelper` (no param `@Lazy`)
 
-Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g. `PSPageService`, `PSItemService`, `PSItemWorkflowService`, `PSSiteDataService`, path item services). That is OK **only while** the live reverse edges above keep param `@Lazy` (or another edge on the same cycle is broken). Full table: **folderHelper reverse-edge inventory (#2485)** above.
+Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g. `PSPageService`, `PSItemService`, `PSSiteDataService`, path item services). `PSItemWorkflowService` now **does** use param `@Lazy` on `folderHelper` and other cycle peers (#2515). Remaining consumer-only injectors are OK **only while** the live reverse edges above keep param `@Lazy` (or another edge on the same cycle is broken). Full table: **folderHelper reverse-edge inventory (#2485)** above.
 
 ## Disposition for #2463
 
@@ -180,11 +203,12 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 3. ~~ItemWorkflow hub reverse-edge tests.~~ Done: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478).
 4. ~~Hub hardening: `PSTemplateService` class `@Lazy` + reverse-edge tests.~~ **Done (#2477)** — `PSTemplateServiceCycleWiringTest`.
 5. ~~`PSPageService` reverse-edge freeze.~~ **Done (#2514)** — `PSPageServiceCycleWiringTest`.
-6. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
-7. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-8. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
-9. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
-10. Optional residual: belt-and-braces param `@Lazy` on high-fan-in consumer hubs that inject both `folderHelper` and recycle peers — only if product risk warrants; do not treat class `@Lazy` as the fix.
+6. ~~Optional: param `@Lazy` on itemWorkflow → cycle peers.~~ **Done (#2515)** — `PSItemWorkflowServiceCycleLazyWiringTest`.
+7. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
+8. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+9. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
+10. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
+11. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers — only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
 
@@ -198,4 +222,6 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 - #2478 — itemWorkflow hub reverse-edge protection (`PSItemWorkflowServiceHubReverseEdgeWiringTest`)  
 - #2485 — folderHelper reverse-edge inventory  
 - #2514 — pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
+- #2515 — itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
+
 - #2457 / PR #2469 — JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
@@ -143,19 +143,25 @@ public class PSItemWorkflowService implements IPSItemWorkflowService {
       IPSContentWs contentWs,
       IPSIdMapper idMapper,
       IPSSecurityWs securityWs,
-      IPSWidgetAssetRelationshipService widgetAssetRelationshipService,
+      // Belt-and-braces (#2515 / #2463): class-level @Lazy does not break constructor edges when an
+      // eager consumer forces creation. Param @Lazy injects cycle-peer proxies so a future reverse
+      // edge (or multi-hop eager path through the folderHelper→…→contentItemDao chain) cannot form
+      // BeanCurrentlyInCreationException independent of the contentItemDao @Lazy break (#2478 hub).
+      // All four peers are used only post-construction (field assign in ctor; never method-called
+      // during construction). See PSItemWorkflowServiceCycleLazyWiringTest.
+      @Lazy IPSWidgetAssetRelationshipService widgetAssetRelationshipService,
       IPSPageDao pageDao,
       IPSSystemService systemService,
       IPSWorkflowHelper workflowHelper,
-      IPSAssetDao assetDao,
+      @Lazy IPSAssetDao assetDao,
       IPSDataItemSummaryService dataItemSummaryService,
-      IPSFolderHelper folderHelper,
+      @Lazy IPSFolderHelper folderHelper,
       IPSWorkflowService workflowService,
       IPSiteDao siteDao,
       IPSSiteManager siteMgr,
       IPSSystemWs systemWs,
       IPSAsyncJobService asyncJobService,
-      IPSRecycleService recycleService) {
+      @Lazy IPSRecycleService recycleService) {
     super();
     this.contentWs = contentWs;
     this.idMapper = idMapper;

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemWorkflowServiceCycleLazyWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSItemWorkflowServiceCycleLazyWiringTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.service.impl.PSItemWorkflowService;
+import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.share.dao.IPSFolderHelper;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Belt-and-braces param {@code @Lazy} on {@link PSItemWorkflowService} → known-cycle peer edges
+ * (#2423 residual #2515, peer of #2476 assetService→pageService).
+ *
+ * <p>Static inventory (#2463) ranks {@code PSItemWorkflowService} as the second-hottest sitemanage
+ * hub. It construct-requires peers on the known {@code folderHelper → … → contentItemDao →
+ * folderHelper} chain:
+ *
+ * <pre>
+ * itemWorkflowService
+ *   → assetDao                         (@Lazy param — #2515)
+ *   → folderHelper                     (@Lazy param — #2515)
+ *   → recycleService                   (@Lazy param — #2515)
+ *   → widgetAssetRelationshipService   (@Lazy param — #2515)
+ * </pre>
+ *
+ * <p>Class-level {@code @Lazy} on the hub does <em>not</em> break constructor dependency edges when
+ * an eager consumer forces creation. Parameter {@code @Lazy} injects proxies (peer of {@link
+ * PSContentItemDaoCycleLazyWiringTest}). Reverse edges from these peers back to {@code
+ * IPSItemWorkflowService} remain banned by {@link PSItemWorkflowServiceHubReverseEdgeWiringTest}
+ * (#2478).
+ *
+ * <p>Behavior review (#2515): ctor body only field-assigns the four peers; method calls happen only
+ * on checkout/transition/shared-asset paths post-construction ({@code assetDao} is assigned but
+ * unused in production methods today). Lazy proxies are therefore safe for the chosen edges.
+ *
+ * <p>Inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSItemWorkflowServiceCycleLazyWiringTest {
+
+  @Test
+  public void itemWorkflowConstructRequiresCyclePeers() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSItemWorkflowService.class);
+    assertNotNull(
+        findParamOfType(ctor, IPSAssetDao.class),
+        "PSItemWorkflowService must still construct-require IPSAssetDao — inventory #2463 / #2515"
+            + " hub model; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSFolderHelper.class),
+        "PSItemWorkflowService must still construct-require IPSFolderHelper");
+    assertNotNull(
+        findParamOfType(ctor, IPSRecycleService.class),
+        "PSItemWorkflowService must still construct-require IPSRecycleService");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSItemWorkflowService must still construct-require IPSWidgetAssetRelationshipService");
+  }
+
+  @Test
+  public void assetDaoConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSAssetDao.class,
+        "IPSAssetDao constructor parameter on PSItemWorkflowService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2515 / #2463)."
+            + " assetDao is only field-assigned in the ctor (unused post-construction today).");
+  }
+
+  @Test
+  public void folderHelperConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSFolderHelper.class,
+        "IPSFolderHelper constructor parameter on PSItemWorkflowService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2515 / #2463)."
+            + " folderHelper is only used post-construction (folder path / access / workflow id).");
+  }
+
+  @Test
+  public void recycleServiceConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSRecycleService.class,
+        "IPSRecycleService constructor parameter on PSItemWorkflowService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2515 / #2463)."
+            + " recycleService is only used post-construction (isInRecycler checks).");
+  }
+
+  @Test
+  public void widgetAssetRelationshipServiceConstructorParameterIsLazy()
+      throws NoSuchMethodException {
+    assertParamLazy(
+        IPSWidgetAssetRelationshipService.class,
+        "IPSWidgetAssetRelationshipService constructor parameter on PSItemWorkflowService must be"
+            + " @Lazy (belt-and-braces cycle-peer protection; see #2515 / #2463)."
+            + " widgetAsset is only used post-construction (shared/linked/local asset relations).");
+  }
+
+  private static void assertParamLazy(Class<?> paramType, String message)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSItemWorkflowService.class);
+    Parameter param = findParamOfType(ctor, paramType);
+    assertNotNull(
+        param,
+        "Expected a " + paramType.getSimpleName() + " constructor parameter on PSItemWorkflowService");
+    assertTrue(param.isAnnotationPresent(Lazy.class), message);
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Belt-and-braces residual of parent **#2423** / reverse-edge freeze **#2478**: mark `PSItemWorkflowService` constructor parameters that point at known-cycle peers with parameter-level `@Lazy` (same pattern as **#2476** assetService→pageService).

**Chosen edges (all safe — post-construction only):**

| Param | Call-site review | `@Lazy` |
|-------|------------------|---------|
| `IPSAssetDao` | field-assign only; unused in methods today | yes |
| `IPSFolderHelper` | folder path / access / workflow id on transition paths | yes |
| `IPSRecycleService` | `isInRecycler` checks | yes |
| `IPSWidgetAssetRelationshipService` | shared/linked/local asset relations on checkout/transition | yes |

Ctor body never method-calls these peers (only assigns fields), so lazy proxies are safe.

**Also:**
- New `PSItemWorkflowServiceCycleLazyWiringTest` freezes construct-require + `@Lazy` on each chosen param (peer of `PSContentItemDaoCycleLazyWiringTest`)
- Inventory updated: `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md` (#2548 cluster already merged; this rebased on current main)

**Parent:** #2423  
**Fixes:** #2515

## Test plan

- [x] `cd projects/sitemanage && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] `Tests run: 822, Failures: 0, Errors: 0, Skipped: 128`
- [x] Focused: `PSItemWorkflowServiceCycleLazyWiringTest` (5) + `PSItemWorkflowServiceHubReverseEdgeWiringTest` (4) green
- [x] No product regression on workflow unit surfaces (module suite green)
- [x] Erlang-style self-review: annotation freeze tests, portable paths N/A, companions (inventory + tests) complete

## Gates evidence

```
cd projects/sitemanage
../../mvnw clean install
# BUILD SUCCESS
# Tests run: 822, Failures: 0, Errors: 0, Skipped: 128
```

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.