### PR TITLE
fix(system,sitemanage): parentFolders Set + empty-folder recycle (#2488)

### DIFF
--- a/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
@@ -231,8 +231,15 @@ async function createNamedFolder(request, baseUrl, headers, opts = {}) {
   }
   if (!addRes.ok()) {
     const text = await addRes.text().catch(() => "");
+    // Product 404 JSON (Path not found / Errors) means pathmanagement is live —
+    // do not mis-label as the pre-#2423 "context dead" class of bug (#2488).
+    const productPathError =
+      (addRes.status() === 404 || addRes.status() === 500) &&
+      /"Errors"|Path not found|Transaction silently rolled back|parentFolders|PropertyAccessException/i.test(
+        text,
+      );
     // Surface context-down class failures with the hard-fail message.
-    if (!isContextHealthyStatus(addRes.status())) {
+    if (!isContextHealthyStatus(addRes.status()) && !productPathError) {
       throw new Error(
         contextDownFailureMessage({
           status: addRes.status(),

--- a/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/folder-recycle-smoke.js
@@ -214,6 +214,38 @@ async function probePathmanagementContext(request, baseUrl, headers) {
  * @param {{ parentPath?: string, name?: string }} [opts]
  * @returns {Promise<{ name: string, path: string, guid: string, raw: object }>}
  */
+
+/**
+ * True when an addNewFolder/pathmanagement failure body is a *product* path error
+ * (context is live) rather than the pre-#2423 "context dead" class of bug.
+ *
+ * <p>Stable product markers: Jackson {@code "Errors"}, "Path not found", and Spring
+ * {@code Transaction silently rolled back}. The #2488 Hibernate 6 regression is
+ * matched only when {@code parentFolders} co-occurs with PersistentSet /
+ * PropertyAccessException stack markers — those substrings alone can appear in
+ * docs or other payloads, so they are never used as lone matchers.</p>
+ *
+ * @param {number} status HTTP status
+ * @param {string | null | undefined} body response text
+ * @returns {boolean}
+ */
+function isProductPathErrorBody(status, body) {
+  if (status !== 404 && status !== 500) {
+    return false;
+  }
+  const text = String(body || "");
+  if (/"Errors"|Path not found|Transaction silently rolled back/i.test(text)) {
+    return true;
+  }
+  // #2488: HashSet parentFolders + Hibernate PersistentSet injection failure.
+  return (
+    /parentFolders/i.test(text) &&
+    /PropertyAccessException|PersistentSet|Could not set value of type/i.test(
+      text,
+    )
+  );
+}
+
 async function createNamedFolder(request, baseUrl, headers, opts = {}) {
   const parent = String(opts.parentPath || "Assets").replace(/^\/+|\/+$/g, "");
   const name = opts.name || uniqueSeedFolderName("qa-folder-recycle");
@@ -233,11 +265,7 @@ async function createNamedFolder(request, baseUrl, headers, opts = {}) {
     const text = await addRes.text().catch(() => "");
     // Product 404 JSON (Path not found / Errors) means pathmanagement is live —
     // do not mis-label as the pre-#2423 "context dead" class of bug (#2488).
-    const productPathError =
-      (addRes.status() === 404 || addRes.status() === 500) &&
-      /"Errors"|Path not found|Transaction silently rolled back|parentFolders|PropertyAccessException/i.test(
-        text,
-      );
+    const productPathError = isProductPathErrorBody(addRes.status(), text);
     // Surface context-down class failures with the hard-fail message.
     if (!isContextHealthyStatus(addRes.status()) && !productPathError) {
       throw new Error(
@@ -417,6 +445,7 @@ module.exports = {
   PATH_DELETE_FOLDER,
   RECYCLE_EMPTY_PATH,
   isContextHealthyStatus,
+  isProductPathErrorBody,
   contextDownFailureMessage,
   extractPathItem,
   extractPathItemGuid,

--- a/modules/perc-qa-automation/frontend/tests/unit/folder-recycle-smoke.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/folder-recycle-smoke.test.js
@@ -11,6 +11,7 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const {
   isContextHealthyStatus,
+  isProductPathErrorBody,
   contextDownFailureMessage,
   extractPathItem,
   extractPathItemGuid,
@@ -33,6 +34,26 @@ describe("folder-recycle-smoke helpers", () => {
     assert.equal(isContextHealthyStatus(0), false);
     assert.equal(isContextHealthyStatus(null), false);
     assert.equal(isContextHealthyStatus(undefined), false);
+  });
+
+
+  it("isProductPathErrorBody classifies product vs context-down bodies (#2488)", () => {
+    assert.equal(isProductPathErrorBody(404, '{"Errors":{"global":["Path not found"]}}'), true);
+    assert.equal(isProductPathErrorBody(404, "Path not found for Assets"), true);
+    assert.equal(isProductPathErrorBody(500, "Transaction silently rolled back"), true);
+    // Lone parentFolders / PropertyAccessException must not match (docs/noise).
+    assert.equal(isProductPathErrorBody(500, "docs mention parentFolders field"), false);
+    assert.equal(isProductPathErrorBody(500, "PropertyAccessException alone"), false);
+    // #2488 Hibernate stack: both markers required.
+    assert.equal(
+      isProductPathErrorBody(
+        500,
+        "PropertyAccessException: Could not set value of type [PersistentSet] on parentFolders",
+      ),
+      true,
+    );
+    assert.equal(isProductPathErrorBody(503, "Path not found"), false);
+    assert.equal(isProductPathErrorBody(200, "Path not found"), false);
   });
 
   it("contextDownFailureMessage cites #2464/#2423 and folderHelper cycle", () => {

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
@@ -376,9 +376,16 @@ public class PSRecycleService implements IPSRecycleService {
         // created one first when deleting a child item.
 
         renameIfRequired(guid, FOLDER_TYPE, true);
-        // We need to delete this relationship, not just update config id
-        // as we already created a new realtionship for recycle folder
-        systemWs.deleteRelationships(Collections.singletonList(rel.getGuid()));
+        // Convert the folder relationship to recycled type (parity with
+        // {@link #recycleItem}). Deleting the FOLDER relationship alone
+        // orphaned empty folders: they left Assets/Sites but never appeared
+        // under Recycling, so folder-recycle smoke failed after create
+        // (#2488 residual of #2423 / #2464). createRootSiteDeleteRelationship
+        // above prepares structural recycle path; this converts the leaf.
+        updateRelationshipConfigId(RECYCLED_TYPE, rel);
+        if (cache != null) {
+          updateParentFolders(guid, FOLDER_TYPE, RECYCLED_TYPE);
+        }
       }
     } catch (PSErrorsException
         | PSErrorException

--- a/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleServiceEmptyFolderRecycleTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleServiceEmptyFolderRecycleTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.service.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.cms.handlers.PSRelationshipCommandHandler;
+import com.percussion.cms.objectstore.server.PSRelationshipProcessor;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.design.objectstore.PSRelationship;
+import com.percussion.design.objectstore.PSRelationshipConfig;
+import com.percussion.fastforward.managednav.IPSManagedNavService;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.server.cache.PSFolderRelationshipCache;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.share.data.PSDataItemSummary;
+import com.percussion.share.service.IPSDataItemSummaryService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.system.IPSSystemWs;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Empty-folder recycle must convert the FOLDER relationship to RECYCLED (not delete it), or folders
+ * leave Assets/Sites without appearing under Recycling (#2488 residual of #2423 / #2464).
+ */
+@ExtendWith(MockitoExtension.class)
+class PSRecycleServiceEmptyFolderRecycleTest {
+
+  // UUID < 300 so updateParentFolders short-circuits (system-folder guard).
+  private static final int FOLDER_CONTENT_ID = 250;
+  private static final String FOLDER_PATH = "//Folders/$System$/Assets/qa-empty-folder";
+
+  @Mock private IPSSystemWs systemWs;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSDataItemSummaryService itemSummaryService;
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSManagedNavService navService;
+  @Mock private IPSWidgetAssetRelationshipService widgetAssetRelationshipService;
+
+  private PSRecycleService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSRecycleService(
+            systemWs,
+            idMapper,
+            itemSummaryService,
+            contentWs,
+            workflowHelper,
+            navService,
+            widgetAssetRelationshipService);
+  }
+
+  @Test
+  void recycleFolder_emptyFolder_convertsRelationshipAndDoesNotDelete() throws Exception {
+    IPSGuid folderGuid = new PSLegacyGuid(FOLDER_CONTENT_ID, 1);
+    PSLocator dependent = new PSLocator(FOLDER_CONTENT_ID, 1);
+    PSRelationshipConfig folderConfig = mock(PSRelationshipConfig.class);
+    when(folderConfig.getName()).thenReturn(PSRelationshipConfig.TYPE_FOLDER_CONTENT);
+
+    PSRelationship folderRel = mock(PSRelationship.class);
+    lenient().when(folderRel.getDependent()).thenReturn(dependent);
+    when(folderRel.getConfig()).thenReturn(folderConfig);
+    lenient().when(folderRel.getId()).thenReturn(7001);
+    lenient().when(folderRel.getGuid()).thenReturn(new PSLegacyGuid(7001, 1));
+
+    when(idMapper.getContentId(folderGuid)).thenReturn(FOLDER_CONTENT_ID);
+
+    PSDataItemSummary summary = new PSDataItemSummary();
+    summary.setFolderPaths(List.of(FOLDER_PATH));
+    when(itemSummaryService.find(folderGuid.toString(), PSRelationshipConfig.TYPE_FOLDER_CONTENT))
+        .thenReturn(summary);
+
+    // createRootSiteDeleteRelationship early-out when pathids too short
+    when(contentWs.findPathIds(FOLDER_PATH)).thenReturn(Collections.emptyList());
+
+    PSFolderRelationshipCache cache = mock(PSFolderRelationshipCache.class);
+    when(cache.getChildren(any(PSLocator.class), any())).thenReturn(Collections.emptyList());
+
+    when(systemWs.loadRelationships(any())).thenReturn(List.of(folderRel));
+
+    PSRelationshipConfig recycledConfig = mock(PSRelationshipConfig.class);
+    PSRelationshipProcessor processor = mock(PSRelationshipProcessor.class);
+    when(processor.checkIfRelationshipAlreadyExists(any())).thenReturn(null);
+
+    try (MockedStatic<PSFolderRelationshipCache> cacheStatic =
+            mockStatic(PSFolderRelationshipCache.class);
+        MockedStatic<PSRelationshipCommandHandler> cmdStatic =
+            mockStatic(PSRelationshipCommandHandler.class);
+        MockedStatic<PSRelationshipProcessor> procStatic =
+            mockStatic(PSRelationshipProcessor.class)) {
+      cacheStatic.when(PSFolderRelationshipCache::getInstance).thenReturn(cache);
+      cmdStatic
+          .when(
+              () ->
+                  PSRelationshipCommandHandler.getRelationshipConfig(
+                      PSRelationshipConfig.TYPE_RECYCLED_CONTENT))
+          .thenReturn(recycledConfig);
+      procStatic.when(PSRelationshipProcessor::getInstance).thenReturn(processor);
+
+      service.recycleFolder(folderGuid);
+    }
+
+    // Must convert to recycled — not delete the relationship (orphan path).
+    verify(systemWs, never()).deleteRelationships(anyList());
+    verify(folderRel).setConfig(recycledConfig);
+    verify(systemWs).saveRelationships(anyList());
+  }
+}

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
@@ -1487,8 +1487,14 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
    * A concrete {@code HashSet} field type fails with {@code PropertyAccessException: Could not set
    * value of type [PersistentSet] ... parentFolders (setter)} and breaks Assets path listing /
    * addNewFolder (folder-recycle smoke #2488 residual of #2423 / #2464).
+   *
+   * <p>{@code @SuppressWarnings("serial")}: {@link Set} is not itself {@link Serializable}, so
+   * {@code -Xlint:serial} would warn on this {@link Serializable} outer type. Runtime values are
+   * always {@link HashSet} (initializer) or Hibernate {@code PersistentSet} (both Serializable).
+   * Do <strong>not</strong> widen the field back to concrete {@code HashSet} to silence serial —
+   * that reintroduces the #2488 PersistentSet injection failure.
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "serial"})
   @OneToMany(targetEntity = PSRelationshipData.class, fetch = FetchType.LAZY)
   @JoinColumn(name = "DEPENDENT_ID")
   @Filter(

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
@@ -1481,6 +1481,12 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
    * Owning relationship information, used for folder restrictions in JCR searches. Lazy loaded to
    * avoid issues with performance and transient to avoid issues with lazy loading and any
    * serialization.
+   *
+   * <p>Field type <strong>must</strong> be the {@link Set} interface (not {@link HashSet}):
+   * Hibernate 6 injects {@code org.hibernate.collection.spi.PersistentSet} into association fields.
+   * A concrete {@code HashSet} field type fails with {@code PropertyAccessException: Could not set
+   * value of type [PersistentSet] ... parentFolders (setter)} and breaks Assets path listing /
+   * addNewFolder (folder-recycle smoke #2488 residual of #2423 / #2464).
    */
   @SuppressWarnings("unused")
   @OneToMany(targetEntity = PSRelationshipData.class, fetch = FetchType.LAZY)
@@ -1488,8 +1494,7 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
   @Filter(
       name = "relationshipConfigFilter",
       condition = "CONFIG_ID = " + PSRelationshipConfig.ID_FOLDER_CONTENT)
-  // HashSet (not Set) so the field type is Serializable under -Xlint:serial
-  private HashSet<PSRelationshipData> parentFolders = new HashSet<>();
+  private Set<PSRelationshipData> parentFolders = new HashSet<>();
 
   /**
    * Specifies the permissions set on the item encapsulated by this object for the user accessing

--- a/system/src/test/java/com/percussion/cms/objectstore/PSComponentSummaryTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSComponentSummaryTest.java
@@ -276,4 +276,31 @@ public class PSComponentSummaryTest {
 
     assertNotNull(timezone);
   }
+
+  /**
+   * Hibernate 6 injects {@code PersistentSet} into association fields. The {@code parentFolders}
+   * field must be typed as {@link java.util.Set} (interface), not {@link java.util.HashSet}, or
+   * Assets path listing / addNewFolder fails with PropertyAccessException (#2488).
+   */
+  @Test
+  public void testParentFoldersFieldAcceptsNonHashSetCollection() throws Exception {
+    var field = PSComponentSummary.class.getDeclaredField("parentFolders");
+    assertEquals(
+        java.util.Set.class,
+        field.getType(),
+        "parentFolders must be Set (not HashSet) so Hibernate can inject PersistentSet");
+
+    field.setAccessible(true);
+    // Fresh summary via valid folder ctor path used elsewhere in this class
+    var summary =
+        new PSComponentSummary(
+            300, 1, 1, 1, PSComponentSummary.TYPE_FOLDER, "folder_parent_folders", 301, 3);
+
+    // Simulate Hibernate field injection with a Set that is not HashSet (e.g. PersistentSet)
+    java.util.Set<?> injected = new java.util.LinkedHashSet<>();
+    field.set(summary, injected);
+
+    assertSame(injected, field.get(summary));
+    assertNotNull(summary.getParentFolderRelationships());
+  }
 }


### PR DESCRIPTION
## Summary
Live H2 `qa-up` surface residual for folder-recycle smoke (#2488 / parent #2423 / related #2464). The first live run exposed two product bugs that blocked green evidence; both are fixed and re-proven on freeport H2 QA.

1. **Hibernate 6 `parentFolders` field type** — `PSComponentSummary.parentFolders` was `HashSet`, so Hibernate could not inject `PersistentSet` → Assets path listing / `addNewFolder` failed with `PropertyAccessException`.
2. **Empty-folder recycle orphan** — `PSRecycleService.recycleFolder` deleted the FOLDER relationship for empty folders instead of converting to RECYCLED (unlike `recycleItem`), so folders left Assets but never appeared under Recycling.
3. **Smoke harness** — do not mislabel product JSON `404 Path not found` as pre-#2423 context-down.

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] `PSComponentSummaryTest` (5 tests) green; `PSRecycleServiceEmptyFolderRecycleTest` green
- [x] `npm run test:unit` in perc-qa-automation/frontend (147 pass)
- [x] Live: `python docker/scripts/perc-devctl.py qa-up` (freeport host) + `qa-health` → `RESULT:OK HTTP:200`
- [x] Live: `TEST_CMS_URL=… npm run test:surface -- --path tests/folder-recycle-smoke.spec.js` → **3 passed**
- [x] Agent started stack will be `qa-down` after this PR

## Gates evidence
- Modules: `system`, `sitemanage` (+ harness helper in `perc-qa-automation` — no Maven module install required for helper-only JS)
- No new warnings introduced beyond baseline dependency-analyze noise
- Live surface green after hot-deploy of fixed jars into `perc-matrix-cms-h2`

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2423  
Related: #2464 / PR #2487

Fixes #2488

> Co-Authored by Grok Build using grok-4.5 with agent main.
