### PR TITLE
fix(dce): type PSCommunityMappingsPage.OutputData for PSCloningOptions (#2545)

### DIFF
--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCommunityMappingsPage.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/wizards/PSCommunityMappingsPage.java
@@ -27,8 +27,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EventObject;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import javax.swing.DefaultCellEditor;
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
@@ -243,29 +243,72 @@ public class PSCommunityMappingsPage extends PSWizardPanel {
     private PSCommunityContentTypeMapperCataloger m_commCtMapper;
   }
 
-  /** The data object returned by this wizard page. */
-  public class OutputData extends HashMap {
+  /**
+   * Source → target community id map produced by this wizard page. Typed for direct use as {@link
+   * Map}{@code <? extends Integer, ? extends Integer>} (e.g. {@code PSCloningOptions} constructors)
+   * without unchecked conversion. Only entries where source and target ids differ are included.
+   */
+  public static class OutputData extends HashMap<Integer, Integer> {
+    private static final long serialVersionUID = 1L;
+
     /**
      * Constructs a new source - target community id map as specified by the wizard user. The map
      * key is the source community id and the map value the target community id both as <code>
-     * Integer</code>. Only mappings where the target community id differes from the source
-     * community id are returned.
+     * Integer</code>. Only mappings where the target community id differs from the source community
+     * id are returned.
      *
      * @param model the table model from which to construct the data object, assumed not <code>null
      *     </code>.
      */
     private OutputData(TableModel model) {
+      putAll(buildMappingsFromModel(model));
+    }
+
+    /**
+     * Builds differing source→target community id mappings from a table model whose cells hold
+     * {@link PSCommunityCataloger.Community} values in the source and target columns. Scan stops at
+     * the first row with a null source or target (legacy wizard semantics).
+     *
+     * @param model table model, not <code>null</code>
+     * @return map of source id → target id for remapped communities only; never <code>null</code>,
+     *     may be empty
+     */
+    static Map<Integer, Integer> buildMappingsFromModel(TableModel model) {
+      if (model == null) throw new IllegalArgumentException("model may not be null");
+
+      Map<Integer, Integer> map = new HashMap<>();
       for (int i = 0; i < model.getRowCount(); i++) {
         PSCommunityCataloger.Community source =
             (PSCommunityCataloger.Community) model.getValueAt(i, SOURCE_COLUMN_INDEX);
         PSCommunityCataloger.Community target =
             (PSCommunityCataloger.Community) model.getValueAt(i, TARGET_COLUMN_INDEX);
 
-        if (source == null || target == null) break;
-
-        if (source.getId() != target.getId())
-          put(Integer.valueOf(source.getId()), Integer.valueOf(target.getId()));
+        if (!appendMappingIfDifferent(map, source, target)) break;
       }
+      return map;
+    }
+
+    /**
+     * Appends a community remapping when both communities are non-null and their ids differ.
+     *
+     * @param map destination map, not <code>null</code>
+     * @param source source community, may be <code>null</code>
+     * @param target target community, may be <code>null</code>
+     * @return <code>false</code> if either community is <code>null</code> (caller should stop
+     *     scanning); <code>true</code> if the row was processed (mapping added or skipped as
+     *     identity)
+     */
+    static boolean appendMappingIfDifferent(
+        Map<Integer, Integer> map,
+        PSCommunityCataloger.Community source,
+        PSCommunityCataloger.Community target) {
+      if (map == null) throw new IllegalArgumentException("map may not be null");
+      if (source == null || target == null) return false;
+
+      if (source.getId() != target.getId()) {
+        map.put(Integer.valueOf(source.getId()), Integer.valueOf(target.getId()));
+      }
+      return true;
     }
   }
 

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/wizards/PSCommunityMappingsOutputDataTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/wizards/PSCommunityMappingsOutputDataTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx.wizards;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.PSCloningOptions;
+import com.percussion.cx.catalogers.PSCommunityCataloger;
+import java.util.HashMap;
+import java.util.Map;
+import javax.swing.table.DefaultTableModel;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed community mapping helpers used by copy-site cloning options (#2545).
+ */
+public class PSCommunityMappingsOutputDataTest {
+
+  @Test
+  public void appendMappingIfDifferent_addsOnlyWhenIdsDiffer() {
+    Map<Integer, Integer> map = new HashMap<>();
+    PSCommunityCataloger.Community src = community(1001, "Default");
+    PSCommunityCataloger.Community same = community(1001, "Default");
+    PSCommunityCataloger.Community tgt = community(1002, "Editor");
+
+    assertTrue(PSCommunityMappingsPage.OutputData.appendMappingIfDifferent(map, src, same));
+    assertTrue(map.isEmpty());
+
+    assertTrue(PSCommunityMappingsPage.OutputData.appendMappingIfDifferent(map, src, tgt));
+    assertEquals(1, map.size());
+    assertEquals(Integer.valueOf(1002), map.get(1001));
+  }
+
+  @Test
+  public void appendMappingIfDifferent_nullCommunityStopsScan() {
+    Map<Integer, Integer> map = new HashMap<>();
+    PSCommunityCataloger.Community src = community(1, "A");
+
+    assertFalse(PSCommunityMappingsPage.OutputData.appendMappingIfDifferent(map, null, src));
+    assertFalse(PSCommunityMappingsPage.OutputData.appendMappingIfDifferent(map, src, null));
+    assertTrue(map.isEmpty());
+  }
+
+  @Test
+  public void appendMappingIfDifferent_rejectsNullMap() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSCommunityMappingsPage.OutputData.appendMappingIfDifferent(
+                null, community(1, "A"), community(2, "B")));
+  }
+
+  @Test
+  public void buildMappingsFromModel_skipsIdentityAndStopsAtNullRow() {
+    DefaultTableModel model =
+        new DefaultTableModel(new Object[] {"Source", "Target"}, 0);
+    model.addRow(new Object[] {community(10, "SrcA"), community(20, "TgtA")});
+    model.addRow(new Object[] {community(30, "SrcB"), community(30, "SrcB")}); // identity
+    model.addRow(new Object[] {community(40, "SrcC"), community(50, "TgtC")});
+    model.addRow(new Object[] {null, community(60, "AfterNull")});
+    model.addRow(new Object[] {community(70, "Unreached"), community(80, "Unreached")});
+
+    Map<Integer, Integer> map = PSCommunityMappingsPage.OutputData.buildMappingsFromModel(model);
+
+    assertEquals(2, map.size());
+    assertEquals(Integer.valueOf(20), map.get(10));
+    assertEquals(Integer.valueOf(50), map.get(40));
+    assertFalse(map.containsKey(30));
+    assertFalse(map.containsKey(70));
+  }
+
+  @Test
+  public void buildMappingsFromModel_rejectsNullModel() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSCommunityMappingsPage.OutputData.buildMappingsFromModel(null));
+  }
+
+  /**
+   * Verifies that a typed {@code Map<Integer, Integer>} (the OutputData shape produced by {@link
+   * PSCommunityMappingsPage.OutputData#buildMappingsFromModel}) is accepted by {@link
+   * PSCloningOptions} without an unchecked cast — same call-site shape as {@code PSActionManager}.
+   */
+  @Test
+  public void typedMap_assignableToCloningOptionsParameter() {
+    DefaultTableModel model = new DefaultTableModel(new Object[] {"Source", "Target"}, 0);
+    model.addRow(new Object[] {community(100, "From"), community(200, "To")});
+
+    Map<Integer, Integer> mappings =
+        PSCommunityMappingsPage.OutputData.buildMappingsFromModel(model);
+
+    PSCloningOptions options =
+        new PSCloningOptions(
+            PSCloningOptions.TYPE_SITE_SUBFOLDER,
+            "folder",
+            PSCloningOptions.COPY_ALL_CONTENT,
+            PSCloningOptions.COPYCONTENT_AS_NEW_COPY,
+            mappings);
+
+    Map<Integer, Integer> stored = options.getCommunityMappings();
+    assertEquals(1, stored.size());
+    assertEquals(Integer.valueOf(200), stored.get(100));
+  }
+
+  private static PSCommunityCataloger.Community community(int id, String name) {
+    return PSCommunityCataloger.createCommunity(id, name, name);
+  }
+}


### PR DESCRIPTION
## Summary
Types `PSCommunityMappingsPage.OutputData` as `HashMap<Integer, Integer>` so `PSActionManager` site / site-subfolder cloning can pass community mappings into `PSCloningOptions` (`Map<? extends Integer, ? extends Integer>`) without unchecked Map conversion.

- Make `OutputData` a **static** nested class extending `HashMap<Integer, Integer>`
- Extract pure helpers: `buildMappingsFromModel`, `appendMappingIfDifferent`
- Unit tests for identity skip, null-row stop, table model collection, and `PSCloningOptions` acceptance

**Parent:** #2045 (monorepo #2200)
**Fixes:** #2545

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw clean install` → **BUILD SUCCESS**
- [x] Tests run: **70**, Failures: **0** (includes 6 new `PSCommunityMappingsOutputDataTest`)
- [x] No new unchecked Map warnings on `PSCommunityMappingsPage` / cloning call sites in `PSActionManager`
- [x] Left other DCE residuals (#2546 / #2547 and remaining #2045 slices) alone

## Gates
| Gate | Result |
|------|--------|
| Change + unit tests | Yes |
| Erlang-style self-review | No bugs; no path I/O; portable |
| Standalone module clean install | BUILD SUCCESS |
| In-scope commit only | 2 files |
| Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |

**Operator:** Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
