### PR TITLE
fix(perc-content-explorer): type PSWizardDialog maps + pure helpers (#2546)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2546-pswizarddialog-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2546-pswizarddialog-rawtypes-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue #2546 PSWizardDialog rawtypes
+
+**Date:** 2026-08-08  
+**Module:** `modules/DesktopContentExplorer` (`perc-content-explorer`)  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Scope
+
+Clear `-Xlint:rawtypes` / unchecked on `PSWizardDialog` (wizard + CX copies) and tightly coupled `PSWizardCommandPanel`. Pure helpers + unit tests. No cataloger this-escape (#2547).
+
+## Findings
+
+| Severity | Finding | Disposition |
+|----------|---------|-------------|
+| none | Raw `Map` / `Iterator` / `Class` / `Constructor` on both dialog copies | Fixed: `Map<Integer, IPSWizardPanel>`, typed reflection |
+| none | Summary append semantics | Preserved via pure `collectSummaryBody` matching historical `Iterator.hasNext()` rule |
+| note | Residual non-rawtypes warnings on dialogs (`serialVersionUID`, non-transient fields, this-escape) | Out of scope for this residual; not introduced by typing |
+| note | Duplicate `PSWizardDialog` in `cx` and `wizard` packages | CX delegates pure helpers to wizard package; full consolidation out of scope |
+
+## Tests
+
+- `PSWizardDialogTest` (9): resolvePageType, isValidPageType, summary body rules, prepend instruction, ordered summaries, collectPageData
+- `PSWizardCommandPanelTest` (1): null dialog constructor
+
+## Build
+
+```text
+cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install
+BUILD SUCCESS
+Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
+```
+
+## Gate
+
+**PASS** — no bugs, portable (no path I/O), companions present (pure helpers + tests), module clean install green.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSWizardDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSWizardDialog.java
@@ -29,13 +29,16 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.lang.reflect.Constructor;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.swing.JPanel;
 
 /**
  * A standard wizard dialog using the card layout for easy 'next' and 'back' wizard functonality.
+ *
+ * <p>Pure typing helpers live on {@link com.percussion.wizard.PSWizardDialog} so both CX and
+ * wizard-package dialogs share one tested implementation.
  */
 public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   /**
@@ -75,7 +78,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   public void onNext() {
     try {
       Integer key = Integer.valueOf(m_pageIndex);
-      IPSWizardPanel panel = (IPSWizardPanel) m_pages.get(key);
+      IPSWizardPanel panel = m_pages.get(key);
       panel.validatePanel();
 
       while (panel.skipNext()) {
@@ -84,7 +87,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
 
         key = Integer.valueOf(m_pageIndex);
         m_skippedPages.put(key, m_pages.get(key));
-        panel = (IPSWizardPanel) m_pages.get(key);
+        panel = m_pages.get(key);
       }
 
       m_cards.next(m_mainPanel);
@@ -105,7 +108,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
     --m_pageIndex;
 
     Integer key = Integer.valueOf(m_pageIndex);
-    IPSWizardPanel panel = (IPSWizardPanel) m_skippedPages.get(key);
+    IPSWizardPanel panel = m_skippedPages.get(key);
     while (panel != null) {
       m_skippedPages.remove(key);
 
@@ -113,7 +116,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
       --m_pageIndex;
 
       key = Integer.valueOf(m_pageIndex);
-      panel = (IPSWizardPanel) m_skippedPages.get(key);
+      panel = m_skippedPages.get(key);
     }
 
     updateControls();
@@ -137,11 +140,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * @see Object[] IPSWizardDialog#getData()
    */
   public Object[] getData() {
-    Object[] data = new Object[m_pages.size()];
-    for (int i = 0; i < m_pages.size(); i++)
-      data[i] = ((IPSWizardPanel) m_pages.get(Integer.valueOf(i))).getData();
-
-    return data;
+    return com.percussion.wizard.PSWizardDialog.collectPageData(m_pages);
   }
 
   /**
@@ -182,7 +181,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
     panel.setPreferredSize(new Dimension(600, 300));
     System.out.println("Number of pages =" + pages.length);
     for (int i = 0; i < pages.length; i++) {
-      Object[] page = (Object[]) pages[i];
+      Object[] page = pages[i];
       System.out.println("create page " + (String) page[PAGE_PANEL]);
 
       Integer key = Integer.valueOf(i);
@@ -202,15 +201,6 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   }
 
   /**
-   * Are we on the first wizard page?
-   *
-   * @return <code>true</code> if we are, <code>false</code> otherwise.
-   */
-  private boolean isFirst() {
-    return m_pageIndex == 0;
-  }
-
-  /**
    * Are we on the last wizard page?
    *
    * @return <code>true</code> if we are, <code>false</code> otherwise.
@@ -225,10 +215,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * @return the type of the currently active page, one of the <code>TYPE_XXX</code> values.
    */
   private int getPageType() {
-    if (isFirst()) return TYPE_FIRST;
-    else if (isLast()) return TYPE_LAST;
-
-    return TYPE_MID;
+    return com.percussion.wizard.PSWizardDialog.resolvePageType(m_pageIndex, m_pages.size());
   }
 
   /**
@@ -244,29 +231,17 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
        * Collect the summaries from all pages to build the instruction
        * set on the last wizard page.
        */
-      StringBuffer summary = new StringBuffer();
+      List<String> summaries =
+          com.percussion.wizard.PSWizardDialog.collectOrderedSummaries(m_pages, m_skippedPages);
+      String body = com.percussion.wizard.PSWizardDialog.collectSummaryBody(summaries);
 
-      IPSWizardPanel page = null;
-      Iterator keys = m_pages.keySet().iterator();
-      while (keys.hasNext()) {
-        Integer key = (Integer) keys.next();
-        page = (IPSWizardPanel) m_pages.get(key);
-        if (m_skippedPages.get(key) != null) continue;
-
-        String sum = page.getSummary();
-        if (sum.trim().length() == 0) continue;
-
-        if (keys.hasNext()) summary.append(sum + "\n");
+      IPSWizardPanel page = m_pages.get(Integer.valueOf(m_pages.size() - 1));
+      if (m_lastPageInstruction == null) {
+        m_lastPageInstruction = page.getInstruction();
       }
-
-      /*
-       * Pre-pend the last page instruction to the summaries collected
-       * from all pages and set the new instruction for the last wizard
-       * page.
-       */
-      if (m_lastPageInstruction == null) m_lastPageInstruction = page.getInstruction();
-      summary.insert(0, m_lastPageInstruction + "\n\n");
-      page.setInstruction(summary.toString());
+      page.setInstruction(
+          com.percussion.wizard.PSWizardDialog.prependLastPageInstruction(
+              m_lastPageInstruction, body));
     }
   }
 
@@ -281,10 +256,10 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
     System.out.println("Instantiate PSWizardPanel");
     PSWizardPanel page = null;
     try {
-      Class c = Class.forName(className);
-      Constructor ctor = c.getConstructor(new Class[] {PSContentExplorerApplet.class});
+      Class<?> c = Class.forName(className);
+      Constructor<?> ctor = c.getConstructor(PSContentExplorerApplet.class);
 
-      page = (PSWizardPanel) ctor.newInstance(new Object[] {m_applet});
+      page = (PSWizardPanel) ctor.newInstance(m_applet);
     } catch (Exception e) {
       System.out.println("Error finding class " + className);
       e.printStackTrace();
@@ -307,17 +282,17 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * 0) while the map value is the page as <code>IPSWizardPanel</code>. Initialized in {@link
    * #createMainPanel(Object[][])}, never changed after that.
    */
-  private Map m_pages = new TreeMap();
+  private final Map<Integer, IPSWizardPanel> m_pages = new TreeMap<>();
 
   /**
    * The map used to keep track of skipped wizard pages. The map key is an <code>Integer</code> with
    * the page index (starting at 0) while the map value is the page as <code>IPSWizardPanel</code>.
    * Initialized to an empty map, updated on calls to {@link #onNext()} or {@link #onBack()}.
    */
-  private Map m_skippedPages = new TreeMap();
+  private final Map<Integer, IPSWizardPanel> m_skippedPages = new TreeMap<>();
 
   /** The card layout used for the wizards main panel. */
-  private CardLayout m_cards = new CardLayout();
+  private final CardLayout m_cards = new CardLayout();
 
   /**
    * The main wizard panel, initialized during construction, never <code>null</code> or changed

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardCommandPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardCommandPanel.java
@@ -47,12 +47,12 @@ public class PSWizardCommandPanel extends JPanel implements ActionListener {
    * Constructs a new wizard panel.
    *
    * @param dialog the wizard dialog instance for which to create the command panel, not <code>null
-   *     </code>, must be an instance of <code>IPSWizardDialog</code>.
+   *     </code>.
    */
   public PSWizardCommandPanel(IPSWizardDialog dialog) {
-    if (!(dialog instanceof IPSWizardDialog))
-      throw new IllegalArgumentException(
-          "dialog cannot be null and must be an instanceof IPSWizardDialog");
+    if (dialog == null) {
+      throw new IllegalArgumentException("dialog cannot be null");
+    }
 
     m_dialog = dialog;
     initPanel();
@@ -110,11 +110,9 @@ public class PSWizardCommandPanel extends JPanel implements ActionListener {
    * @param type the panel type to be validated.
    */
   private void validateType(int type) {
-    for (int i = 0; i < IPSWizardDialog.TYPES.length; i++) {
-      if (IPSWizardDialog.TYPES[i] == type) return;
+    if (!PSWizardDialog.isValidPageType(type)) {
+      throw new IllegalArgumentException("type must be one of the IPSWizardDialog.TYPE_XXX values");
     }
-
-    throw new IllegalArgumentException("type must be one of the IPSWizardDialog.TYPE_XXX values");
   }
 
   /** Initializes the panel UI. */

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/wizard/PSWizardDialog.java
@@ -25,7 +25,8 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.lang.reflect.Constructor;
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.swing.JPanel;
@@ -65,13 +66,142 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
     initDialog(pages);
   }
 
+  /**
+   * Resolves the wizard page type for a zero-based page index. Pure helper for unit tests.
+   *
+   * @param pageIndex zero-based index of the active page
+   * @param pageCount total number of pages, must be &gt; 0
+   * @return one of {@link IPSWizardDialog#TYPE_FIRST}, {@link IPSWizardDialog#TYPE_MID}, {@link
+   *     IPSWizardDialog#TYPE_LAST}
+   * @throws IllegalArgumentException if pageCount or pageIndex is invalid
+   */
+  public static int resolvePageType(int pageIndex, int pageCount) {
+    if (pageCount <= 0) {
+      throw new IllegalArgumentException("pageCount must be > 0");
+    }
+    if (pageIndex < 0 || pageIndex >= pageCount) {
+      throw new IllegalArgumentException("pageIndex out of range");
+    }
+    if (pageIndex == 0) {
+      return TYPE_FIRST;
+    }
+    if (pageIndex >= pageCount - 1) {
+      return TYPE_LAST;
+    }
+    return TYPE_MID;
+  }
+
+  /**
+   * Returns whether {@code type} is one of {@link IPSWizardDialog#TYPES}. Pure helper for unit
+   * tests.
+   *
+   * @param type candidate page type
+   * @return <code>true</code> when type is valid
+   */
+  public static boolean isValidPageType(int type) {
+    for (int t : TYPES) {
+      if (t == type) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Builds the last-page summary body from ordered page summaries, preserving historical append
+   * rules: a non-empty summary is appended with a trailing newline only when it is not the last
+   * page index in the wizard (skipped pages are {@code null} entries; empty summaries are
+   * omitted). Pure helper for unit tests.
+   *
+   * @param summaries ordered by page index; {@code null} entry means the page was skipped
+   * @return summary body without the original instruction prefix, never <code>null</code>
+   */
+  public static String collectSummaryBody(List<String> summaries) {
+    if (summaries == null || summaries.isEmpty()) {
+      return "";
+    }
+    StringBuilder summary = new StringBuilder();
+    int n = summaries.size();
+    for (int i = 0; i < n; i++) {
+      String sum = summaries.get(i);
+      if (sum == null) {
+        continue;
+      }
+      if (sum.trim().isEmpty()) {
+        continue;
+      }
+      // Matches Iterator.hasNext() after next(): only non-final map keys append.
+      if (i < n - 1) {
+        summary.append(sum).append('\n');
+      }
+    }
+    return summary.toString();
+  }
+
+  /**
+   * Collects non-skipped page summaries in page-index order for {@link #collectSummaryBody(List)}.
+   * Pure helper for unit tests.
+   *
+   * @param pages wizard pages keyed by page index, may not be <code>null</code>
+   * @param skippedPages skipped pages keyed by page index, may be <code>null</code>
+   * @return ordered list with {@code null} for skipped pages, never <code>null</code>
+   */
+  public static List<String> collectOrderedSummaries(
+      Map<Integer, IPSWizardPanel> pages, Map<Integer, IPSWizardPanel> skippedPages) {
+    if (pages == null) {
+      throw new IllegalArgumentException("pages cannot be null");
+    }
+    List<String> summaries = new ArrayList<>(pages.size());
+    for (Map.Entry<Integer, IPSWizardPanel> e : pages.entrySet()) {
+      if (skippedPages != null && skippedPages.get(e.getKey()) != null) {
+        summaries.add(null);
+        continue;
+      }
+      IPSWizardPanel panel = e.getValue();
+      summaries.add(panel == null ? "" : panel.getSummary());
+    }
+    return summaries;
+  }
+
+  /**
+   * Prepends the original last-page instruction to a collected summary body. Pure helper for unit
+   * tests.
+   *
+   * @param originalInstruction instruction saved from the last page, may be <code>null</code>
+   * @param summaryBody body from {@link #collectSummaryBody(List)}, may be <code>null</code>
+   * @return combined last-page instruction text, never <code>null</code>
+   */
+  public static String prependLastPageInstruction(String originalInstruction, String summaryBody) {
+    String orig = originalInstruction == null ? "" : originalInstruction;
+    String body = summaryBody == null ? "" : summaryBody;
+    return orig + "\n\n" + body;
+  }
+
+  /**
+   * Collects panel data in page-index order. Pure helper for unit tests.
+   *
+   * @param pages wizard pages keyed by page index, may not be <code>null</code>
+   * @return array of page data (each element may be <code>null</code>), never <code>null</code>
+   */
+  public static Object[] collectPageData(Map<Integer, IPSWizardPanel> pages) {
+    if (pages == null) {
+      throw new IllegalArgumentException("pages cannot be null");
+    }
+    Object[] data = new Object[pages.size()];
+    for (int i = 0; i < pages.size(); i++) {
+      IPSWizardPanel panel = pages.get(Integer.valueOf(i));
+      data[i] = panel == null ? null : panel.getData();
+    }
+    return data;
+  }
+
   /* (non-Javadoc)
    * @see IPSWizardDialog#onNext()
    */
   public void onNext() {
     try {
       Integer key = Integer.valueOf(m_pageIndex);
-      IPSWizardPanel panel = (IPSWizardPanel) m_pages.get(key);
+      IPSWizardPanel panel = m_pages.get(key);
       panel.validatePanel();
 
       while (panel.skipNext()) {
@@ -80,7 +210,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
 
         key = Integer.valueOf(m_pageIndex);
         m_skippedPages.put(key, m_pages.get(key));
-        panel = (IPSWizardPanel) m_pages.get(key);
+        panel = m_pages.get(key);
       }
 
       m_cards.next(m_mainPanel);
@@ -101,7 +231,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
     --m_pageIndex;
 
     Integer key = Integer.valueOf(m_pageIndex);
-    IPSWizardPanel panel = (IPSWizardPanel) m_skippedPages.get(key);
+    IPSWizardPanel panel = m_skippedPages.get(key);
     while (panel != null) {
       m_skippedPages.remove(key);
 
@@ -109,7 +239,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
       --m_pageIndex;
 
       key = Integer.valueOf(m_pageIndex);
-      panel = (IPSWizardPanel) m_skippedPages.get(key);
+      panel = m_skippedPages.get(key);
     }
 
     updateControls();
@@ -133,11 +263,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * @see Object[] IPSWizardDialog#getData()
    */
   public Object[] getData() {
-    Object[] data = new Object[m_pages.size()];
-    for (int i = 0; i < m_pages.size(); i++)
-      data[i] = ((IPSWizardPanel) m_pages.get(Integer.valueOf(i))).getData();
-
-    return data;
+    return collectPageData(m_pages);
   }
 
   /**
@@ -178,7 +304,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
     panel.setPreferredSize(new Dimension(600, 300));
     System.out.println("Number of pages =" + pages.length);
     for (int i = 0; i < pages.length; i++) {
-      Object[] page = (Object[]) pages[i];
+      Object[] page = pages[i];
       System.out.println("create page " + (String) page[PAGE_PANEL]);
 
       Integer key = Integer.valueOf(i);
@@ -198,15 +324,6 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
   }
 
   /**
-   * Are we on the first wizard page?
-   *
-   * @return <code>true</code> if we are, <code>false</code> otherwise.
-   */
-  private boolean isFirst() {
-    return m_pageIndex == 0;
-  }
-
-  /**
    * Are we on the last wizard page?
    *
    * @return <code>true</code> if we are, <code>false</code> otherwise.
@@ -221,10 +338,7 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * @return the type of the currently active page, one of the <code>TYPE_XXX</code> values.
    */
   private int getPageType() {
-    if (isFirst()) return TYPE_FIRST;
-    else if (isLast()) return TYPE_LAST;
-
-    return TYPE_MID;
+    return resolvePageType(m_pageIndex, m_pages.size());
   }
 
   /**
@@ -240,29 +354,14 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
        * Collect the summaries from all pages to build the instruction
        * set on the last wizard page.
        */
-      StringBuffer summary = new StringBuffer();
+      List<String> summaries = collectOrderedSummaries(m_pages, m_skippedPages);
+      String body = collectSummaryBody(summaries);
 
-      IPSWizardPanel page = null;
-      Iterator keys = m_pages.keySet().iterator();
-      while (keys.hasNext()) {
-        Integer key = (Integer) keys.next();
-        page = (IPSWizardPanel) m_pages.get(key);
-        if (m_skippedPages.get(key) != null) continue;
-
-        String sum = page.getSummary();
-        if (sum.trim().length() == 0) continue;
-
-        if (keys.hasNext()) summary.append(sum + "\n");
+      IPSWizardPanel page = m_pages.get(Integer.valueOf(m_pages.size() - 1));
+      if (m_lastPageInstruction == null) {
+        m_lastPageInstruction = page.getInstruction();
       }
-
-      /*
-       * Pre-pend the last page instruction to the summaries collected
-       * from all pages and set the new instruction for the last wizard
-       * page.
-       */
-      if (m_lastPageInstruction == null) m_lastPageInstruction = page.getInstruction();
-      summary.insert(0, m_lastPageInstruction + "\n\n");
-      page.setInstruction(summary.toString());
+      page.setInstruction(prependLastPageInstruction(m_lastPageInstruction, body));
     }
   }
 
@@ -277,10 +376,10 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
     System.out.println("Instantiate PSWizardPanel");
     PSWizardPanel page = null;
     try {
-      Class c = Class.forName(className);
-      Constructor ctor = c.getConstructor(new Class[] {PSContentExplorerApplet.class});
+      Class<?> c = Class.forName(className);
+      Constructor<?> ctor = c.getConstructor(PSContentExplorerApplet.class);
 
-      page = (PSWizardPanel) ctor.newInstance(new Object[] {m_applet});
+      page = (PSWizardPanel) ctor.newInstance(m_applet);
     } catch (Exception e) {
       System.out.println("Error finding class " + className);
       e.printStackTrace();
@@ -303,17 +402,17 @@ public class PSWizardDialog extends PSDialog implements IPSWizardDialog {
    * 0) while the map value is the page as <code>IPSWizardPanel</code>. Initialized in {@link
    * #createMainPanel(Object[][])}, never changed after that.
    */
-  private Map m_pages = new TreeMap();
+  private final Map<Integer, IPSWizardPanel> m_pages = new TreeMap<>();
 
   /**
    * The map used to keep track of skipped wizard pages. The map key is an <code>Integer</code> with
    * the page index (starting at 0) while the map value is the page as <code>IPSWizardPanel</code>.
    * Initialized to an empty map, updated on calls to {@link #onNext()} or {@link #onBack()}.
    */
-  private Map m_skippedPages = new TreeMap();
+  private final Map<Integer, IPSWizardPanel> m_skippedPages = new TreeMap<>();
 
   /** The card layout used for the wizards main panel. */
-  private CardLayout m_cards = new CardLayout();
+  private final CardLayout m_cards = new CardLayout();
 
   /**
    * The main wizard panel, initialized during construction, never <code>null</code> or changed

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardCommandPanelTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardCommandPanelTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.wizard;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/** Construction / type validation coverage for {@link PSWizardCommandPanel}. */
+public class PSWizardCommandPanelTest {
+
+  @Test
+  public void constructorRejectsNullDialog() {
+    assertThrows(IllegalArgumentException.class, () -> new PSWizardCommandPanel(null));
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardDialogTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/wizard/PSWizardDialogTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.wizard;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for pure helpers on {@link PSWizardDialog}. */
+public class PSWizardDialogTest {
+
+  @Test
+  public void resolvePageTypeFirstMidLast() {
+    assertEquals(IPSWizardDialog.TYPE_FIRST, PSWizardDialog.resolvePageType(0, 3));
+    assertEquals(IPSWizardDialog.TYPE_MID, PSWizardDialog.resolvePageType(1, 3));
+    assertEquals(IPSWizardDialog.TYPE_LAST, PSWizardDialog.resolvePageType(2, 3));
+  }
+
+  @Test
+  public void resolvePageTypeSinglePageIsFirstAndLast() {
+    // Single page is both first and last; historical isFirst check wins → TYPE_FIRST.
+    assertEquals(IPSWizardDialog.TYPE_FIRST, PSWizardDialog.resolvePageType(0, 1));
+  }
+
+  @Test
+  public void resolvePageTypeRejectsInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> PSWizardDialog.resolvePageType(0, 0));
+    assertThrows(IllegalArgumentException.class, () -> PSWizardDialog.resolvePageType(-1, 2));
+    assertThrows(IllegalArgumentException.class, () -> PSWizardDialog.resolvePageType(2, 2));
+  }
+
+  @Test
+  public void isValidPageTypeAcceptsTypeConstantsOnly() {
+    assertTrue(PSWizardDialog.isValidPageType(IPSWizardDialog.TYPE_FIRST));
+    assertTrue(PSWizardDialog.isValidPageType(IPSWizardDialog.TYPE_MID));
+    assertTrue(PSWizardDialog.isValidPageType(IPSWizardDialog.TYPE_LAST));
+    assertFalse(PSWizardDialog.isValidPageType(-1));
+    assertFalse(PSWizardDialog.isValidPageType(99));
+  }
+
+  @Test
+  public void collectSummaryBodyPreservesHistoricalAppendRules() {
+    // Non-final keys with content append with newline; final key never appends.
+    List<String> four = Arrays.asList("A", "B", "", "C");
+    assertEquals("A\nB\n", PSWizardDialog.collectSummaryBody(four));
+
+    // Skipped (null) middle page does not break has-more-keys rule for earlier page.
+    List<String> withSkip = Arrays.asList("A", null, "B", "C");
+    assertEquals("A\nB\n", PSWizardDialog.collectSummaryBody(withSkip));
+
+    // Only final page has content → empty body (historical).
+    assertEquals("", PSWizardDialog.collectSummaryBody(Arrays.asList("", "", "OnlyLast")));
+  }
+
+  @Test
+  public void collectSummaryBodyEmptyAndNullSafe() {
+    assertEquals("", PSWizardDialog.collectSummaryBody(null));
+    assertEquals("", PSWizardDialog.collectSummaryBody(Collections.emptyList()));
+  }
+
+  @Test
+  public void prependLastPageInstructionJoinsWithBlankLine() {
+    assertEquals("Intro\n\nA\n", PSWizardDialog.prependLastPageInstruction("Intro", "A\n"));
+    assertEquals("\n\n", PSWizardDialog.prependLastPageInstruction(null, null));
+  }
+
+  @Test
+  public void collectOrderedSummariesMarksSkippedAsNull() {
+    Map<Integer, IPSWizardPanel> pages = new TreeMap<>();
+    pages.put(0, stubPanel("s0", "d0"));
+    pages.put(1, stubPanel("s1", "d1"));
+    pages.put(2, stubPanel("s2", "d2"));
+
+    Map<Integer, IPSWizardPanel> skipped = new TreeMap<>();
+    skipped.put(1, pages.get(1));
+
+    List<String> ordered = PSWizardDialog.collectOrderedSummaries(pages, skipped);
+    assertEquals(Arrays.asList("s0", null, "s2"), ordered);
+  }
+
+  @Test
+  public void collectPageDataInIndexOrder() {
+    Map<Integer, IPSWizardPanel> pages = new TreeMap<>();
+    pages.put(0, stubPanel("a", "d0"));
+    pages.put(1, stubPanel("b", "d1"));
+
+    assertArrayEquals(new Object[] {"d0", "d1"}, PSWizardDialog.collectPageData(pages));
+    assertThrows(IllegalArgumentException.class, () -> PSWizardDialog.collectPageData(null));
+  }
+
+  private static IPSWizardPanel stubPanel(String summary, Object data) {
+    return new IPSWizardPanel() {
+      @Override
+      public void validatePanel() {
+        // no-op
+      }
+
+      @Override
+      public boolean skipNext() {
+        return false;
+      }
+
+      @Override
+      public String getSummary() {
+        return summary;
+      }
+
+      @Override
+      public Object getData() {
+        return data;
+      }
+
+      @Override
+      public void setData(Object d) {
+        // no-op
+      }
+
+      @Override
+      public String getInstruction() {
+        return "";
+      }
+
+      @Override
+      public void setInstruction(String instruction) {
+        // no-op
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Residual `-Xlint:rawtypes` / unchecked cleanup under parent **#2045** / monorepo **#2200** (issue **#2546**): type maps and reflection on `PSWizardDialog` (wizard package + CX copy) and tighten `PSWizardCommandPanel`.

- `Map<Integer, IPSWizardPanel>` for pages / skipped pages (both dialog copies)
- Typed `Class<?>` / `Constructor<?>` in panel instantiation
- Pure helpers on `com.percussion.wizard.PSWizardDialog`: `resolvePageType`, `isValidPageType`, `collectSummaryBody`, `collectOrderedSummaries`, `prependLastPageInstruction`, `collectPageData`
- CX dialog delegates pure helpers to wizard package (no behavior fork)
- `PSWizardCommandPanel`: null-safe ctor; type validation via `isValidPageType`
- Tests: `PSWizardDialogTest` (9), `PSWizardCommandPanelTest` (1)
- Erlang: `docs/ai-generated/code-reviews/issue-2546-pswizarddialog-rawtypes-erlang.md`

**Fixes #2546.** Parent tracker: #2045.

Out of scope (pre-existing / separate residuals): serialVersionUID / this-escape on dialogs; cataloger this-escape (#2547); PSActionManager cloning-options unchecked from community mappings.

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Tests run: **74**, Failures: 0 (includes 10 new wizard pure-helper tests)
- [x] No rawtypes/unchecked warnings remain on named `PSWizardDialog` / `PSWizardCommandPanel` sources

## Gates
- Erlang self-review: pass
- Per-module clean install: perc-content-explorer standalone
- No product behavior change intended (summary append rules preserved)

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2546

> Co-Authored by Grok Build using grok-4.5 with agent main.