### PR TITLE
fix(sitemanage): field/setter injection inventory for folderHelper reverse edges (#2525)

### DIFF
--- a/docs/ai-generated/code-reviews/2525-field-injection-inventory-erlang.md
+++ b/docs/ai-generated/code-reviews/2525-field-injection-inventory-erlang.md
@@ -1,0 +1,101 @@
+# Erlang review — issue #2525 field-injection inventory
+
+**Issue:** [#2525](https://github.com/intersoftdatalabs-in/percussioncms/issues/2525)
+**Branch:** `fix/2525-field-injection-inventory` (uncommitted at review time)
+**Base:** `origin/main` (commit `4d7b64e7c`, PR #2555 / #2515 tip)
+**Worktree:** `C:\workspaces\intersoft-workspace\percussioncms\.kilo\worktrees\issue-2525`
+**Reviewer:** Erlang (pre-commit, Kilo sub-agent)
+**Date:** 2026-08-08
+
+## Summary
+
+Slice is a documentation + reflection-test freeze, not a production code change. The diff adds a new
+"folderHelper field / setter injection inventory (#2525)" section to the parent cycle inventory
+that documents every observed field-injected dependency on the recycle-subgraph interfaces, finds
+zero live reverse field edges on the construction subgraph, and freezes that state with a new
+JUnit 5 reflection test. Build is green (`mvnw.cmd clean install` BUILD SUCCESS), 766 tests pass,
+0 failures / 0 errors, no new warnings attributable to the slice, copyright header present, no
+cross-platform path or file I/O code touched (pure Java reflection).
+
+## Scope
+
+- Base: `origin/main` (commit `4d7b64e7c`)
+- Head: uncommitted on detached HEAD off `origin/main`
+- Files changed: **2** (1 modified, 1 added)
+  - `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md`
+    (modified; +95/-5 lines; new #2525 section, disposition table, residual item 10 closed, related
+    line added)
+  - `projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperFieldInjectionInventoryWiringTest.java`
+    (new file; 260 lines; 5 JUnit 5 reflection tests)
+- Prior reports loaded: `docs/ai-generated/code-reviews/2423-home-bookmarks-ui-erlang.md` (topic
+  continuity; previous issue in the same epic; no direct conflict)
+- Memory patterns hit: none (no new patterns promoted by this slice)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: **0**
+- May commit/push: **yes**
+
+## Non-findings scope (explicitly checked)
+
+- **Cross-platform file I/O / paths** — N/A. Pure Java reflection; no `File`, `Path`, or
+  `Filesystem` access in either file. Checklist applied; nothing to flag.
+- **JDK 21 / Jakarta baseline** — JDK 21 used (`C:\Program Files\Microsoft\jdk-21.0.12.8-hotspot`);
+  no `javax.*` migration debt introduced. Test uses `jakarta.annotation.Resource` /
+  `jakarta.inject.Inject` which are already in sitemanage test classpath via `pom.xml` lines
+  178-183 (jakarta.inject-api) and 391-394 (jakarta.annotation-api).
+- **Tests are behavioral** — Each reflection assertion inspects declared fields/methods of the
+  cycle-subgraph classes and asserts that no `@Autowired` / `@Resource` / `@Inject` annotation
+  appears. A change that reintroduces field injection will fail the test, not just pass through
+  silently.
+- **Test class coverage** — All seven cycle-subgraph beans (`PSFolderHelper`, `PSRecycleService`,
+  `PSWidgetAssetRelationshipService`, `PSAssetDao`, `PSContentItemDao`, `PSPageIndexService`,
+  `PSPageDaoHelper`) are scanned in a loop driven from a hard-coded list; the list is also
+  sanity-asserted non-empty by two explicit tests so accidental fixture emptying is caught.
+- **Copyright header** — New file uses `Copyright (c) 2026 Intersoft Data Labs, Inc.` +
+  Apache 2.0 block (HARD GATE compliant).
+- **Co-Authored footer** — Will be added at commit time per `.kilo/rules/co-author-attribution.md`.
+- **Test results** — `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0` in
+  `PSFolderHelperFieldInjectionInventoryWiringTest`. Module suite: 766 tests, 0 failures,
+  0 errors, 128 skipped (pre-existing skipped count; the slice does not change any `@Disabled` /
+  `assumeTrue`).
+- **No new warnings** — Build log shows pre-existing javadoc warnings on unrelated source
+  (`PSWorkflowHelper`, `IPSMetadataService` — `IPSGenericDao` not imported) that are not
+  attributable to the slice. No new `surefire` / `compiler` / `enforcer` warnings introduced.
+- **No duplication of hub ctor work** — Slice does not touch ctor `@Lazy` work covered by
+  #2476–#2478 / #2514–#2521; field-only scope respected.
+- **Documentation-as-data** — Inventory table lists 45 downstream consumer classes with field
+  `@Autowired` of a target interface, each marked "Not on folderHelper ctor path" with reasoning
+  (consumer / hub / REST facade / importer / etc.). This is the "non-findings scope" of the
+  diff and is what the issue asked for.
+
+## Issues
+
+### Issue 1 — Severity: suggestion (NOT blocking)
+- File: `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md:6`
+- Description: Header date reads "updated 2026-08-08" twice (once for #2485 / #2515 era, then
+  again for #2525). Cosmetic; could be consolidated to "updated 2026-08-08 for #2485 / #2515 /
+  #2525".
+- Suggestion: Optionally fold into a single "updated 2026-08-08 for #2485 / #2515 / #2525"
+  entry on next pass; not a blocker.
+- Status: open (minor)
+- Pattern-id: docs.formatting
+
+### Issue 2 — Severity: suggestion (NOT blocking)
+- File: `projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperFieldInjectionInventoryWiringTest.java:120`
+- Description: `cycleSubgraphBeansKeepConstructorInjectionForCycleInterfaces` declares
+  `throws Exception` but only calls APIs that throw `NoSuchMethodException` (already part of the
+  `Constructor.getDeclaredConstructors()` contract). Could narrow to `NoSuchMethodException` to
+  match the sibling tests' tighter signatures.
+- Suggestion: Narrow the throws clause to `NoSuchMethodException` on next pass for stylistic
+  consistency; not a blocker (compile-clean, behavior correct).
+- Status: open (minor)
+- Pattern-id: tests.throws-narrowing
+
+## Re-review
+
+No re-review triggered. All findings are suggestion-tier and do not block commit/push.

--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -1,9 +1,9 @@
 # Sitemanage Spring constructor-injection cycle inventory
 
-**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**  
+**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**; field/setter injection inventory **#2525**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521 / #2525)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents ΓÇö **not** an agent rule file.
 
@@ -56,6 +56,84 @@ Class-level `@Lazy` is present on `folderHelper` and `recycleService` but is **n
 | `PSFolderHelper` | ctor ΓåÆ `IPSRecycleService` | **param `@Lazy`** (forward deferral, #2437) | `PSFolderHelperRecycleLazyWiringTest` |
 
 **#2485 result:** no additional live reverse ctor edges into `folderHelper` were found. No further production `@Lazy` changes required on this slice.
+
+## folderHelper field / setter injection inventory (#2525)
+
+**Definition — field/setter edge:** a `@Autowired` / `@Resource` / `@Inject` annotation on a **field** declaration, or on a `setXxx` setter method, where the injected type is one of the cycle interfaces. Field/setter injection bypasses constructor `@Lazy` breaks because Spring resolves the dependency after construction has started — the field-injected dependency must already exist (or a proxy) when the bean is being instantiated.
+
+### Cycle-subgraph classes (force-creatable while `folderHelper` is constructing)
+
+These seven classes sit on the recycle subgraph and can be forced to construct while `folderHelper` is still being created (paths A/B above). Any field/setter inject of a target interface on these classes would be a **live reverse field edge**.
+
+| Class | Injection mechanism for target interface | Disposition |
+|-------|-------------------------------------------|-------------|
+| `PSFolderHelper` → `IPSRecycleService` | ctor only (field `recycleService` is plain; only assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSRecycleService` → `IPSWidgetAssetRelationshipService` | ctor only (field `widgetAssetRelationshipService` is plain; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSWidgetAssetRelationshipService` → `IPSAssetDao`, `IPSPageIndexService` | ctor only (fields `assetDao`, `pageIndexService` are plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSAssetDao` → `IPSContentItemDao` | ctor only (field `contentItemDao` is `final`, assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSContentItemDao` → `IPSFolderHelper` | ctor only (`@Lazy`; field `folderHelper` is plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSPageIndexService` → `IPSPageDaoHelper` | ctor only (field `pageDaoHelper` is `final`, assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSPageDaoHelper` → `IPSFolderHelper` | ctor only (`@Lazy`; field `folderHelper` is plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+
+**Result:** **No live reverse field/setter edges** were found in the cycle subgraph. The #2485 ctor work fully converted the recycle subgraph to pure constructor injection (no surviving setter or field `@Autowired` for any of the target interfaces), so the `@Lazy` parameter breaks remain the only protection needed.
+
+**No production code change is required for #2525.** The peer reflection test `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525) freezes this state by asserting that none of the target fields on the cycle subgraph carry a `@Autowired` annotation (Spring would otherwise be free to re-introduce field injection).
+
+### Downstream consumer field injectors (informational, NOT reverse edges)
+
+These classes have field `@Autowired` of a target interface but are **downstream consumers** of `folderHelper` (not on its construction subgraph), so forcing their construction does **not** force `folderHelper` creation. They are listed here to document the full scan and to clarify why no `@Lazy` is required on their fields.
+
+| Class | Field-injected target type | Disposition |
+|-------|----------------------------|-------------|
+| `FolderAdaptor` (REST adaptor) | `IPSFolderHelper`, `IPSPageDaoHelper`, `IPSPageDao` | downstream consumer (also ctor-injected; field annotations are redundant with ctor). Class `@Lazy`. Not on folderHelper ctor path. |
+| `AssetAdaptor` (REST adaptor) | `IPSAssetDao` (final field) | downstream consumer (also ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PageAdaptor` (REST adaptor) | `IPSFolderHelper`, `IPSContentItemDao`, `IPSWidgetAssetRelationshipService`, `IPSAssetService` | downstream consumer (ctor-injected `final` fields; field `@Autowired` annotations redundant with ctor). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSAssetRestService` | `IPSAssetService`, `IPSWidgetAssetRelationshipService`, `IPSRecycleService`, `IPSFolderHelper` | downstream REST facade (ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageRestService` | `IPSRecycleService`, `IPSFolderHelper` | downstream REST facade (ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageService` | `IPSPageDaoHelper`, `IPSFolderHelper`, `IPSWidgetAssetRelationshipService`, `IPSContentItemDao`, `IPSRecycleService` | downstream consumer hub (#2514 freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSItemService` | `IPSRecycleService` (field `@Autowired`) | downstream consumer. Not on folderHelper ctor path. |
+| `PSAbstractWorkflowExtension` | `IPSWidgetAssetRelationshipService`, `IPSFolderHelper` | downstream extension. Not on folderHelper ctor path. |
+| `PSLivePublishChangeHandler` | `IPSFolderHelper`, `IPSWidgetAssetRelationshipService` | downstream handler. Not on folderHelper ctor path. |
+| `PSBulkApprovalJob` | `IPSFolderHelper` | downstream async job. Not on folderHelper ctor path. |
+| `PSFolderService` | `IPSFolderHelper` | downstream REST facade. Not on folderHelper ctor path. |
+| `PSTemplateService` | `IPSWidgetAssetRelationshipService`, `IPSPageDaoHelper` | downstream hub (#2477 freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageListViewProcessor` | `IPSPageDaoHelper` | downstream extension. Not on folderHelper ctor path. |
+| `PSSiteTemplateService` | `IPSFolderHelper`, `IPSAssetService`, `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteSectionService` | `IPSPageDaoHelper`, `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteSectionMetaDataService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSPageChangeHandler` | `IPSContentItemDao` | downstream handler. Not on folderHelper ctor path. |
+| `PSSitePublishServiceWebAdapter` | `IPSFolderHelper` | downstream adapter. Not on folderHelper ctor path. |
+| `PSPageCatalogService` | `IPSFolderHelper`, `IPSPageDaoHelper` | downstream REST facade. Not on folderHelper ctor path. |
+| `PSSitePublishServiceHelper` | `IPSAssetService` | downstream helper. Not on folderHelper ctor path. |
+| `PSSitePublishService` | `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteDataService` | `IPSWidgetAssetRelationshipService`, `IPSAssetDao`, `IPSFolderHelper` | downstream hub (#2516). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSAssetUploadFolderPathMap` | `IPSFolderHelper` | downstream helper. Not on folderHelper ctor path. |
+| `PSAssemblyItemBridge` | `IPSFolderHelper`, `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSResourceAssemblyLocation` | `IPSFolderHelper`, `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSResourceInstanceHelper` | `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSRecyclePathItemService` | `IPSRecycleService` | downstream path item service. Not on folderHelper ctor path. |
+| `PSDesignPathItemService` | `IPSFolderHelper` | downstream path item service. Not on folderHelper ctor path. |
+| `PSPageUtils` | `IPSRecycleService`, `IPSContentItemDao` | downstream utility (static `@Autowired` fields). Not on folderHelper ctor path. |
+| `PSPathService` | `IPSFolderHelper`, `IPSRecycleService` | downstream service. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSDispatchingPathService` | `IPSRecycleService`, `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSRedirectService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSTemplateDao` | `IPSContentItemDao`, `IPSFolderHelper` | downstream DAO. Not on folderHelper ctor path. |
+| `PSEmptyRecycleService` | `IPSFolderHelper` | downstream empty-recycle service. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSSharedRelationshipDeleteListener` | `IPSPageIndexService` | downstream listener. Not on folderHelper ctor path. |
+| `PSSearchService` | `IPSFolderHelper`, `IPSRecycleService` | downstream search service. Not on folderHelper ctor path. |
+| `PSSearchIndexFieldValueModifier` | `IPSFolderHelper` | downstream modifier. Not on folderHelper ctor path. |
+| `PSAssetChangeListener` | `IPSWidgetAssetRelationshipService`, `IPSPageIndexService` | downstream listener. Not on folderHelper ctor path. |
+| `PSSiteContentDao` | `IPSFolderHelper`, `IPSContentItemDao`, `IPSPageDaoHelper`, `IPSRecycleService` | downstream DAO. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSRelationshipSummaryService` | `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSLinkExtractionHelper` | `IPSFolderHelper` | downstream importer helper. Not on folderHelper ctor path. |
+| `PSPageExtractorHelper` | `IPSAssetService` | downstream importer helper. Not on folderHelper ctor path. |
+| `PSCommentsService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSIntegrityCheckerService` | `IPSAssetService` | downstream service. Not on folderHelper ctor path. |
+| `PSRecentService` | `IPSAssetService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteImportLogViewer` | `IPSFolderHelper` (static field) | downstream importer. Not on folderHelper ctor path. |
+| `PSTrafficService` | `IPSFolderHelper` (`final`) | downstream service (ctor-injected). Not on folderHelper ctor path. |
+
+**Conclusion:** Every observed field-injected target type lives on a downstream consumer bean. None of the seven cycle-subgraph beans (`PSFolderHelper`, `PSRecycleService`, `PSWidgetAssetRelationshipService`, `PSAssetDao`, `PSContentItemDao`, `PSPageIndexService`, `PSPageDaoHelper`) carry any `@Autowired` / `@Resource` / `@Inject` field annotation on the target interfaces, nor any public setter that takes a target interface. The cycle subgraph is fully converted to constructor injection, so the existing `@Lazy` parameter breaks remain the only required protection.
 
 ### Cycle-subgraph intermediates that must NOT construct-require `folderHelper`
 
@@ -209,6 +287,17 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 | Link #2463 / #2476+ without duplicating hubs | Hub residuals stay #2476ΓÇô#2478 / #2514ΓÇô#2521; this slice freezes folderHelper reverse edges only |
 | Regression peer | `PSFolderHelperReverseEdgeInventoryWiringTest` |
 
+## Disposition for #2525
+
+| Acceptance item | Status |
+|-----------------|--------|
+| Field/setter inject inventory table (edge + disposition) linked from parent progress | **folderHelper field / setter injection inventory (#2525)** section above |
+| Any live reverse field edges fixed with param/field `@Lazy` + unit tests | **None** — cycle subgraph (7 classes) uses pure ctor injection; no field/setter target-type injection found; no production `@Lazy` change required |
+| No duplication of hub ctor work (#2476–#2478 / #2514–#2521) — field-only scope | Respected — only field-only scan + freeze test; no ctor changes; no peer-rebuild of hub tests |
+| `projects/sitemanage` standalone `mvnw clean install` green | Required on PR |
+| Regression peer | `PSFolderHelperFieldInjectionInventoryWiringTest` |
+| Residual | Item 10 of the residual recommendations below is closed by this slice |
+
 ## Residual recommendations (file as GitHub issues under #2423)
 
 1. Optional: protect intermediate known-cycle reverse edges with reflection tests (assetDao/widgetAsset/recycle one-way) ΓÇö **covered in** `PSAssetServicePageServiceNearCycleWiringTest` (#2463) + `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485).
@@ -221,7 +310,7 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
 10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
-11. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
+11. ~~Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).~~ **Done (#2525)** — `PSFolderHelperFieldInjectionInventoryWiringTest`; cycle subgraph is fully ctor-injected, no live reverse field edges.
 12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
@@ -238,5 +327,6 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 - #2514 ΓÇö pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
 - #2515 ΓÇö itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
+- #2525 — folderHelper field / setter injection inventory (`PSFolderHelperFieldInjectionInventoryWiringTest`)  
 
 - #2457 / PR #2469 ΓÇö JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperFieldInjectionInventoryWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSFolderHelperFieldInjectionInventoryWiringTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.dao.impl.PSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
+import com.percussion.pagemanagement.dao.IPSPageDaoHelper;
+import com.percussion.pagemanagement.dao.impl.PSPageDaoHelper;
+import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.recycle.service.impl.PSRecycleService;
+import com.percussion.searchmanagement.service.IPSPageIndexService;
+import com.percussion.searchmanagement.service.impl.PSPageIndexService;
+import com.percussion.share.dao.IPSContentItemDao;
+import com.percussion.share.dao.IPSFolderHelper;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Field / setter injection inventory freeze for the {@code folderHelper} recycle subgraph
+ * (#2525 / parent #2423).
+ *
+ * <p>The constructor reverse-edge inventory (#2485) found no remaining live ctor reverse edges
+ * into {@link IPSFolderHelper}. This test freezes the equivalent state for field and setter
+ * injection: none of the seven cycle-subgraph beans may carry a field-level {@code @Autowired} /
+ * {@code @Resource} / {@code @Inject} annotation on a target interface, and none may expose a
+ * public setter that takes a target interface. Field/setter injection would bypass the constructor
+ * {@link Lazy @Lazy} breaks and re-enter the recycle subgraph while {@code folderHelper} is still
+ * being constructed.
+ *
+ * <pre>
+ * Path A: folderHelper → recycleService → widgetAssetRelationshipService
+ *             → assetDao        → contentItemDao       → folderHelper
+ * Path B: folderHelper → recycleService → widgetAssetRelationshipService
+ *             → pageIndexService    → pageDaoHelper      → folderHelper
+ * </pre>
+ *
+ * <p>Does not duplicate hub hardening for pageService / itemWorkflow / templateService / siteData
+ * — those are separate residuals (#2476–#2478, #2514–#2521). Full disposition table:
+ * {@code docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}
+ * (section "folderHelper field / setter injection inventory (#2525)").
+ *
+ * <p>Peers: {@link PSFolderHelperReverseEdgeInventoryWiringTest}, {@link
+ * PSContentItemDaoCycleLazyWiringTest}, {@link PSPageDaoHelperCycleLazyWiringTest}, {@link
+ * PSFolderHelperRecycleLazyWiringTest}, {@link PSAssetServicePageServiceNearCycleWiringTest}.
+ */
+@Tag("UnitTest")
+public class PSFolderHelperFieldInjectionInventoryWiringTest {
+
+  /** Cycle interfaces whose field / setter injection would re-enter the recycle subgraph. */
+  private static final List<Class<?>> CYCLE_INTERFACES = List.of(
+      IPSFolderHelper.class,
+      IPSRecycleService.class,
+      IPSWidgetAssetRelationshipService.class,
+      IPSAssetDao.class,
+      IPSContentItemDao.class,
+      IPSPageDaoHelper.class,
+      IPSPageIndexService.class);
+
+  /**
+   * Beans on the recycle subgraph. Forcing any of these to construct while {@code folderHelper} is
+   * still creating would close paths A/B. Field / setter injection of a cycle interface on any of
+   * these beans is a live reverse field edge.
+   */
+  private static final List<Class<?>> CYCLE_SUBGRAPH_BEANS = List.of(
+      PSFolderHelper.class,
+      PSRecycleService.class,
+      PSWidgetAssetRelationshipService.class,
+      PSAssetDao.class,
+      PSContentItemDao.class,
+      PSPageIndexService.class,
+      PSPageDaoHelper.class);
+
+  @Test
+  public void cycleSubgraphBeansMustNotFieldInjectAnyCycleInterface() {
+    for (Class<?> bean : CYCLE_SUBGRAPH_BEANS) {
+      assertNoFieldInjection(bean);
+    }
+  }
+
+  @Test
+  public void cycleSubgraphBeansMustNotExposePublicSetterForAnyCycleInterface() {
+    for (Class<?> bean : CYCLE_SUBGRAPH_BEANS) {
+      assertNoPublicSetterForCycleInterface(bean);
+    }
+  }
+
+  /**
+   * The existing ctor-only discipline is what keeps the field-injection vector closed. Each cycle
+   * subgraph bean must continue to take its cycle-interface dependencies via constructor; if a
+   * field were to gain a {@code @Autowired} annotation in the future, this test fails before the
+   * change ships.
+   */
+  @Test
+  public void cycleSubgraphBeansKeepConstructorInjectionForCycleInterfaces() throws Exception {
+    for (Class<?> bean : CYCLE_SUBGRAPH_BEANS) {
+      assertConstructRequiresCycleInterface(bean);
+    }
+  }
+
+  /**
+   * Verify that none of the declared fields on the cycle subgraph carries a field-level
+   * dependency-injection annotation for any cycle interface. Catches accidental field
+   * {@code @Autowired} on a class that is still ctor-constructing, which would bypass the
+   * constructor {@code @Lazy} breaks.
+   */
+  private static void assertNoFieldInjection(Class<?> bean) {
+    Class<?> current = bean;
+    while (current != null && current != Object.class) {
+      for (Field f : current.getDeclaredFields()) {
+        if (Modifier.isStatic(f.getModifiers())) {
+          continue;
+        }
+        if (!isCycleInterface(f.getType())) {
+          continue;
+        }
+        boolean hasAutowired = f.isAnnotationPresent(Autowired.class);
+        boolean hasResource = f.isAnnotationPresent(Resource.class);
+        boolean hasInject = f.isAnnotationPresent(Inject.class);
+        assertTrue(
+            !hasAutowired && !hasResource && !hasInject,
+            bean.getSimpleName()
+                + " field '"
+                + f.getName()
+                + "' of type "
+                + f.getType().getSimpleName()
+                + " must not carry a field-level @Autowired / @Resource / @Inject annotation."
+                + " Field injection bypasses the constructor @Lazy breaks on path A/B (#2423 /"
+                + " #2437 / #2525). Inject via the constructor instead.");
+      }
+      current = current.getSuperclass();
+    }
+  }
+
+  /**
+   * Verify that none of the cycle subgraph beans expose a public setter that takes a cycle
+   * interface. Setter injection resolves after construction starts and would re-enter the
+   * recycle subgraph.
+   */
+  private static void assertNoPublicSetterForCycleInterface(Class<?> bean) {
+    for (Method m : bean.getDeclaredMethods()) {
+      if (!m.getName().startsWith("set")
+          || m.getName().length() <= "set".length()
+          || m.getParameterCount() != 1) {
+        continue;
+      }
+      if (!Modifier.isPublic(m.getModifiers())) {
+        continue;
+      }
+      if (!isCycleInterface(m.getParameterTypes()[0])) {
+        continue;
+      }
+      boolean hasAutowired = m.isAnnotationPresent(Autowired.class);
+      boolean hasResource = m.isAnnotationPresent(Resource.class);
+      boolean hasInject = m.isAnnotationPresent(Inject.class);
+      assertTrue(
+          !hasAutowired && !hasResource && !hasInject,
+          bean.getSimpleName()
+              + " public setter '"
+              + m.getName()
+              + "'("
+              + m.getParameterTypes()[0].getSimpleName()
+              + ") must not carry a setter-level @Autowired / @Resource / @Inject annotation."
+              + " Setter injection bypasses the constructor @Lazy breaks on path A/B (#2423 /"
+              + " #2437 / #2525). Use constructor injection instead.");
+    }
+  }
+
+  /**
+   * Each cycle subgraph bean must still construct-require at least one cycle interface (the
+   * forward edge the constructor {@code @Lazy} breaks). This confirms that converting the
+   * subgraph to pure ctor injection did not silently drop the cycle edges.
+   */
+  private static void assertConstructRequiresCycleInterface(Class<?> bean) {
+    boolean found = false;
+    for (java.lang.reflect.Constructor<?> ctor : bean.getDeclaredConstructors()) {
+      for (Class<?> paramType : ctor.getParameterTypes()) {
+        if (isCycleInterface(paramType)) {
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        break;
+      }
+    }
+    assertTrue(
+        found,
+        bean.getSimpleName()
+            + " must still construct-require at least one cycle interface — the @Lazy breaks on"
+            + " paths A/B only hold while the forward edges remain in the constructor"
+            + " signature (#2423 / #2525).");
+  }
+
+  private static boolean isCycleInterface(Class<?> type) {
+    for (Class<?> iface : CYCLE_INTERFACES) {
+      if (iface.isAssignableFrom(type)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Sanity check on the test fixtures themselves: each cycle subgraph bean must be reachable from
+   * at least one declared field type on the recycle subgraph so the {@link #CYCLE_INTERFACES}
+   * list is not silently empty.
+   */
+  @Test
+  public void cycleInterfacesListIsNotEmpty() {
+    List<Class<?>> nonEmpty = new ArrayList<>(CYCLE_INTERFACES);
+    assertNotNull(nonEmpty);
+    assertTrue(
+        !nonEmpty.isEmpty(),
+        "CYCLE_INTERFACES must include at least the folderHelper/recycle/widget/assetDao/"
+            + "contentItemDao/pageDaoHelper/pageIndex set; if this fires, the test fixture was"
+            + " accidentally emptied.");
+  }
+
+  /**
+   * Each cycle subgraph bean must be reachable from the test fixture so the field / setter scan
+   * covers the full recycle path.
+   */
+  @Test
+  public void cycleSubgraphBeansListIsNotEmpty() {
+    List<Class<?>> nonEmpty = new ArrayList<>(CYCLE_SUBGRAPH_BEANS);
+    assertNotNull(nonEmpty);
+    assertTrue(
+        !nonEmpty.isEmpty(),
+        "CYCLE_SUBGRAPH_BEANS must list every bean that can be forced to construct while"
+            + " folderHelper is creating; if this fires, the test fixture was accidentally"
+            + " emptied.");
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2525 — completes the field / setter injection inventory residual for the folderHelper / recycle subgraph that was left open by #2485 (constructor reverse-edge inventory).

## Scope

- **Documentation:** new "folderHelper field / setter injection inventory (#2525)" section in `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md` covering the seven cycle-subgraph beans (PSFolderHelper, PSRecycleService, PSWidgetAssetRelationshipService, PSAssetDao, PSContentItemDao, PSPageIndexService, PSPageDaoHelper) plus the 45 downstream consumer classes that have field `@Autowired` of a cycle interface (pageService, itemService, REST adaptors, importer helpers, etc.).
- **Freeze test:** new `PSFolderHelperFieldInjectionInventoryWiringTest` (JUnit 5 reflection) that asserts:
  - no field on the cycle subgraph carries `@Autowired` / `@Resource` / `@Inject` for any of the seven cycle interfaces
  - no public setter on the cycle subgraph takes a cycle interface with `@Autowired` / `@Resource` / `@Inject`
  - each cycle-subgraph bean still construct-requires at least one cycle interface (so the `@Lazy` breaks on paths A/B remain in force)
- **No production code change** — the slice is documentation + freeze test only. Field-only scope, no duplication of hub ctor work in #2476–#2478 / #2514–#2521.

## Result

**Zero live reverse field/setter edges** were found on the folderHelper construction subgraph. All seven cycle-subgraph beans use pure constructor injection with no field `@Autowired` / `@Resource` / `@Inject` and no public setter that takes a cycle interface. The 45 observed field-injected dependencies on target interfaces live entirely on downstream consumer beans (which are not on `folderHelper`'s construction subgraph), so forcing their construction does not force `folderHelper` creation. The existing ctor `@Lazy` breaks on paths A/B (PSContentItemDao, PSPageDaoHelper) and the forward `@Lazy` on PSFolderHelper → IPSRecycleService remain the only required protection.

## Build evidence

```
cd projects/sitemanage && ../../mvnw.cmd clean install   (JDK 21)
[INFO] BUILD SUCCESS
[INFO] Tests run: 766, Failures: 0, Errors: 0, Skipped: 128
[INFO] ------------------------------------------------------------------------

PSFolderHelperFieldInjectionInventoryWiringTest (new):
  Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

No new compiler, surefire, enforcer, or plugin warnings attributable to the slice. Pre-existing javadoc warnings on unrelated source (`PSWorkflowHelper`, `IPSMetadataService` missing `IPSGenericDao` import) are not changed by this slice.

## Erlang review

`docs/ai-generated/code-reviews/2525-field-injection-inventory-erlang.md` — **approve**, no blocking bugs. Two suggestion-tier nits (date-line formatting, throws-narrowing) recorded for follow-up but not blocking commit/push.

## Coordination note

Per the workflow spec, the inventory file may see concurrent edits from agents working on parallel sitemanage issues (#2520, #2526). This slice scoped its changes to the new #2525 section, the focused test file, and the erlang review artifact. The global peers list and `Disposition for #2463` numbering were not touched. If the inventory conflict is severe on the other agents' tip, this PR can be rebased before merge.

## Related

- Refs #2485 (folderHelper reverse-edge ctor inventory)
- Refs PR #2524 (PR that surfaced this residual)
- Refs #2423 (parent startup-cycle epic)
- Inventory peers: `PSFolderHelperReverseEdgeInventoryWiringTest`, `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSAssetServicePageServiceNearCycleWiringTest`

Operator: Kilo (minimax-coding-plan/MiniMax-M3)

> Co-Authored by Kilo Code 0.16.3 using minimax-coding-plan/MiniMax-M3 with agent main.