### PR TITLE
fix(sitemanage): param @Lazy on templateService forward ctor edges (#2520)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -1,9 +1,9 @@
 # Sitemanage Spring constructor-injection cycle inventory
 
-**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**  
+**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**; templateService param `@Lazy` **#2520**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2520 / #2521)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSTemplateServiceParamLazyWiringTest` (#2520), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents ΓÇö **not** an agent rule file.
 
@@ -108,7 +108,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 |------|------|----------------------------------------|-------|
 | 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze covered by `PSPageServiceCycleWiringTest` (2026-08-08, #2514). |
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset` with **param `@Lazy`** (#2515). Class `@Lazy`. Reverse-edge freeze: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478). |
-| 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
+| 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Forward ctor edges to `widgetAsset` / `pageDao` / `pageDaoHelper` / `templateDao` carry **param `@Lazy`** (2026-08-08, #2520). Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
 | 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
@@ -148,6 +148,29 @@ Behavior review of call sites (safe for lazy proxy):
 
 Protection test: `PSItemWorkflowServiceCycleLazyWiringTest` (asserts construct-require + param `@Lazy` on each chosen peer).
 
+### TemplateService hub forward-edge param `@Lazy` (#2520)
+
+**`PSTemplateService` → forward ctor edges to known-cycle peers (constructor, param `@Lazy` as of #2520)** with **no reverse** peer → `IPSTemplateService` (frozen by #2477 / `PSTemplateServiceCycleWiringTest`).
+
+Behavior review of call sites (safe for lazy proxy):
+
+| Peer param | Ctor body | Post-construction use | Param `@Lazy`? |
+|------------|-----------|----------------------|----------------|
+| `IPSTemplateDao` | field assign only | save / load / find / generateTemplate | **yes** |
+| `IPSWidgetAssetRelationshipService` | field assign only | shared/linked/local asset relations on save / import / create | **yes** |
+| `IPSPageDao` | field assign only | `isValidPageId` on save | **yes** |
+| `IPSPageDaoHelper` | field assign only | `findPageIdsByTemplateInRecentRevision` / `replaceTemplateForPageInOlderRevisions` on delete | **yes** |
+| `IPSWidgetService` | **used in ctor** (`new RegionWidgetValidator(widgetService)`) | n/a | **no** — lazy proxy not safe here |
+
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on hub | Present (#2477) but **not** a cycle breaker when an eager consumer forces construction |
+| Param `@Lazy` on four forward edges | **Added (#2520)** — Spring injects proxies; safe because ctor never method-calls those peers (widgetService is intentionally excluded — it is consumed in the ctor body) |
+| Reverse edge ban | Kept — #2477 / `PSTemplateServiceCycleWiringTest` |
+| Why apply now | Residual after #2477 class-level + reverse-edge freeze: belt-and-braces peer of #2476 / #2515 so multi-hop eager paths through cycle peers cannot form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
+
+Protection test: `PSTemplateServiceParamLazyWiringTest` (asserts construct-require + param `@Lazy` on each chosen peer; widgetService intentionally excluded).
+
 ### assetServiceΓåötemplateService near-cycle (protected ΓÇö #2521)
 
 **`PSAssetService` ΓåÆ `IPSTemplateService` (constructor, one-way)** with **no reverse** `PSTemplateService` ΓåÆ `IPSAssetService` (ctor or non-`@Lazy` field).
@@ -178,12 +201,13 @@ These must not gain reverse constructor dependencies:
 
 Constructor-parameter `@Lazy` remains rare in this module. Scan snapshot (after #2485):
 
-- `PSContentItemDao` ΓåÆ `IPSFolderHelper` (`@Lazy`) ΓÇö known reverse edge path A (#2435)
-- `PSPageDaoHelper` ΓåÆ `IPSFolderHelper` (`@Lazy`) ΓÇö known reverse edge path B (#2437)
-- `PSFolderHelper` ΓåÆ `IPSRecycleService` (`@Lazy`) ΓÇö forward deferral of recycle subgraph (#2437)
-- `PSAssetService` ΓåÆ `IPSPageService` (`@Lazy`) ΓÇö near-cycle belt-and-braces (#2476)
-- `PSItemWorkflowService` ΓåÆ `IPSAssetDao` / `IPSFolderHelper` / `IPSRecycleService` / `IPSWidgetAssetRelationshipService` (`@Lazy`) ΓÇö hub cycle-peer belt-and-braces (#2515)
-- `PSRecentRestService` ΓåÆ `IPSRecentService` (`@Lazy`) ΓÇö rest convenience, not cycle-related
+- `PSContentItemDao` → `IPSFolderHelper` (`@Lazy`) — known reverse edge path A (#2435)
+- `PSPageDaoHelper` → `IPSFolderHelper` (`@Lazy`) — known reverse edge path B (#2437)
+- `PSFolderHelper` → `IPSRecycleService` (`@Lazy`) — forward deferral of recycle subgraph (#2437)
+- `PSAssetService` → `IPSPageService` (`@Lazy`) — near-cycle belt-and-braces (#2476)
+- `PSItemWorkflowService` → `IPSAssetDao` / `IPSFolderHelper` / `IPSRecycleService` / `IPSWidgetAssetRelationshipService` (`@Lazy`) — hub cycle-peer belt-and-braces (#2515)
+- `PSTemplateService` → `IPSTemplateDao` / `IPSWidgetAssetRelationshipService` / `IPSPageDao` / `IPSPageDaoHelper` (`@Lazy`) — hub forward-edge belt-and-braces (#2520)
+- `PSRecentRestService` → `IPSRecentService` (`@Lazy`) — rest convenience, not cycle-related
 
 Class-level `@Lazy` is common on REST facades and many services; treat it as lazy *init*, not a cycle breaker.
 
@@ -285,12 +309,13 @@ listed in the original inventory and is out of scope for #2526.
 4. ~~Hub hardening: `PSTemplateService` class `@Lazy` + reverse-edge tests.~~ **Done (#2477)** ΓÇö `PSTemplateServiceCycleWiringTest`.
 5. ~~`PSPageService` reverse-edge freeze.~~ **Done (#2514)** ΓÇö `PSPageServiceCycleWiringTest`.
 6. ~~Optional: param `@Lazy` on itemWorkflow ΓåÆ cycle peers.~~ **Done (#2515)** ΓÇö `PSItemWorkflowServiceCycleLazyWiringTest`.
-7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
-8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
-9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
-11. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
-12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
+7. ~~Optional: param `@Lazy` on templateService → forward-cycle peers.~~ **Done (#2520)** — `PSTemplateServiceParamLazyWiringTest`. widgetService intentionally excluded (consumed in ctor body).
+8. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
+9. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
+10. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+11. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
+12. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
+13. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
 
@@ -305,6 +330,7 @@ listed in the original inventory and is out of scope for #2526.
 - #2485 ΓÇö folderHelper reverse-edge inventory  
 - #2514 ΓÇö pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
 - #2515 ΓÇö itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
+- #2520 — templateService forward-edge param `@Lazy` (`PSTemplateServiceParamLazyWiringTest`)
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
 - #2526 — emptyRecycle / pathService near-cycle belt-and-braces (`PSEmptyRecycleServiceCycleLazyWiringTest`)
 

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
@@ -131,10 +131,10 @@ public class PSTemplateService implements IPSTemplateService {
 
   @Autowired
   public PSTemplateService(
-      IPSTemplateDao templateDao,
-      IPSWidgetAssetRelationshipService widgetAssetRelationshipService,
-      IPSPageDao pageDao,
-      IPSPageDaoHelper pageDaoHelper,
+      @Lazy IPSTemplateDao templateDao,
+      @Lazy IPSWidgetAssetRelationshipService widgetAssetRelationshipService,
+      @Lazy IPSPageDao pageDao,
+      @Lazy IPSPageDaoHelper pageDaoHelper,
       IPSWidgetService widgetService,
       IPSWorkflowHelper workflowHelper,
       IPSWidgetDao widgetDao,

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSTemplateServiceParamLazyWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSTemplateServiceParamLazyWiringTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.pagemanagement.dao.IPSPageDao;
+import com.percussion.pagemanagement.dao.IPSPageDaoHelper;
+import com.percussion.pagemanagement.dao.IPSTemplateDao;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Belt-and-braces param {@code @Lazy} on {@link PSTemplateService} → forward ctor edges to
+ * known-cycle peers (#2423 residual #2520, peer of #2515 itemWorkflow + #2476 assetService→page).
+ *
+ * <p>Static inventory (#2463 / #2485) ranks {@code PSTemplateService} as a top-3 sitemanage hub.
+ * It construct-requires peers on or next to the known cycle subgraph:
+ *
+ * <pre>
+ * templateService
+ *   → templateDao                       (@Lazy param — #2520)
+ *   → widgetAssetRelationshipService    (@Lazy param — #2520)
+ *   → pageDao                           (@Lazy param — #2520)
+ *   → pageDaoHelper                     (@Lazy param — #2520)
+ * </pre>
+ *
+ * <p>Class-level {@code @Lazy} on the hub (#2477) does <em>not</em> break constructor dependency
+ * edges when an eager consumer forces creation. Parameter {@code @Lazy} injects proxies (peer of
+ * {@link PSItemWorkflowServiceCycleLazyWiringTest} / {@link
+ * PSAssetServicePageServiceNearCycleWiringTest}). Reverse edges from these peers back to {@code
+ * IPSTemplateService} remain banned by {@link PSTemplateServiceCycleWiringTest} (#2477).
+ *
+ * <p>Behavior review (#2520): ctor body only field-assigns the four peers listed above; method
+ * calls happen only on save / load / template workflow paths post-construction. Lazy proxies are
+ * therefore safe for the chosen edges. {@code IPSWidgetService} is intentionally NOT annotated
+ * here — the ctor body uses it to construct {@code RegionWidgetValidator}.
+ *
+ * <p>Inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSTemplateServiceParamLazyWiringTest {
+
+  @Test
+  public void templateServiceConstructRequiresForwardEdges() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSTemplateService.class);
+    assertNotNull(
+        findParamOfType(ctor, IPSTemplateDao.class),
+        "PSTemplateService must still construct-require IPSTemplateDao — inventory #2463 / #2520"
+            + " hub model; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSTemplateService must still construct-require IPSWidgetAssetRelationshipService");
+    assertNotNull(
+        findParamOfType(ctor, IPSPageDao.class),
+        "PSTemplateService must still construct-require IPSPageDao");
+    assertNotNull(
+        findParamOfType(ctor, IPSPageDaoHelper.class),
+        "PSTemplateService must still construct-require IPSPageDaoHelper");
+  }
+
+  @Test
+  public void templateDaoConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSTemplateDao.class,
+        "IPSTemplateDao constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " templateDao is only field-assigned in the ctor (used on save / load / find paths).");
+  }
+
+  @Test
+  public void widgetAssetRelationshipServiceConstructorParameterIsLazy()
+      throws NoSuchMethodException {
+    assertParamLazy(
+        IPSWidgetAssetRelationshipService.class,
+        "IPSWidgetAssetRelationshipService constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " widgetAsset is only used post-construction (shared/linked/local asset relations on"
+            + " save / import / create).");
+  }
+
+  @Test
+  public void pageDaoConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSPageDao.class,
+        "IPSPageDao constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " pageDao is only used post-construction (isValidPageId on save).");
+  }
+
+  @Test
+  public void pageDaoHelperConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSPageDaoHelper.class,
+        "IPSPageDaoHelper constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " pageDaoHelper is only used post-construction (pageIdsByTemplate / replaceTemplate"
+            + " on delete).");
+  }
+
+  private static void assertParamLazy(Class<?> paramType, String message)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSTemplateService.class);
+    Parameter param = findParamOfType(ctor, paramType);
+    assertNotNull(
+        param,
+        "Expected a " + paramType.getSimpleName() + " constructor parameter on PSTemplateService");
+    assertTrue(param.isAnnotationPresent(Lazy.class), message);
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #2423 residual **#2520** — belt-and-braces param `@Lazy` on `PSTemplateService` forward ctor edges to known-cycle peers (templateDao / widgetAsset / pageDao / pageDaoHelper), peer of #2515 itemWorkflow + #2476 assetService.

**Disposition:** param `@Lazy` on four forward edges (matches the issue boundary: widgetAsset + pageDao at minimum). widgetService is intentionally excluded — the ctor body uses it to construct `new RegionWidgetValidator(widgetService)`.

### Behavior review (safe for lazy proxy)

| Peer param | Ctor body | Post-construction use | Param `@Lazy`? |
|------------|-----------|----------------------|----------------|
| `IPSTemplateDao` | field assign only | save / load / find / generateTemplate | **yes** |
| `IPSWidgetAssetRelationshipService` | field assign only | shared/linked/local asset relations on save / import / create | **yes** |
| `IPSPageDao` | field assign only | `isValidPageId` on save | **yes** |
| `IPSPageDaoHelper` | field assign only | `findPageIdsByTemplateInRecentRevision` / `replaceTemplateForPageInOlderRevisions` on delete | **yes** |
| `IPSWidgetService` | **used in ctor** (`new RegionWidgetValidator(widgetService)`) | n/a | **no** — lazy proxy not safe here |

### Changes

- `PSTemplateService` — `@Lazy` on `templateDao` / `widgetAssetRelationshipService` / `pageDao` / `pageDaoHelper` ctor params
- New: `PSTemplateServiceParamLazyWiringTest` (`@Tag("UnitTest")`, peer of `PSItemWorkflowServiceCycleLazyWiringTest`)
  - Asserts construct-require on each chosen edge
  - Asserts `param.isAnnotationPresent(Lazy.class)` on each chosen edge
  - Single-public-ctor sanity guard
- Inventory: `sitemanage-injection-cycle-inventory.md` — new section for #2520 with behavior review table; header line, rank-3 hub row, constructor-`@Lazy` parameter edges list, residual #12, and Related entry updated.

### Related

- Fixes #2520
- Parent #2423
- Peers: #2477 / PR #2518 (templateService class `@Lazy`), #2515 / PR #2555 (itemWorkflow param `@Lazy`), #2476 (assetService→pageService param `@Lazy`)

Operator: Kilo (minimax-coding-plan/MiniMax-M3)

## Test plan

- [x] `cd projects/sitemanage && ../../mvnw.cmd test -Dtest=PSTemplateServiceParamLazyWiringTest`
  - Tests run: 5, Failures: 0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install`
  - **BUILD SUCCESS**
  - Tests run: 827, Failures: 0, Errors: 0, Skipped: 128
  - No new warnings attributable to this change (annotation + reflection UnitTest + inventory doc only; baseline javadoc/dependency-analyze warnings unchanged)

## Gates

| Gate | Result |
|------|--------|
| Erlang-style self-review | Pass — no bugs; portable (annotation + reflection); companions (production + new test + inventory update) complete |
| Standalone module clean install | `cd projects/sitemanage; ../../mvnw.cmd clean install` BUILD SUCCESS |
| New test green | 5/5 |
| Module suite green | 827/827 (Skipped 128 — pre-existing) |
| Product UI / installer | N/A — pure Spring wiring hardening / unit reflection |
| Human QA | Not required (no UI/install behavior) |

> Co-Authored by Kilo Code 0.16.3 using minimax-coding-plan/MiniMax-M3 with agent main.
