### PR TITLE
feat(perc-doctor,docker): check-logs + multi-path CMS log ERROR gate (#2556)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -275,6 +275,7 @@ Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `
 | `RESULT:OK STEP:verify CMS_HTTP:… DTS_HTTP:… HEALTH:healthy` | `perc-devctl.py verify` (and `verify-fix` / `deploy-jar --verify`) | CMS+DTS HTTP ready, docker health healthy, **and** cms-dts logs have **no** Rhythmyx context-failure markers; `VERIFY_CMS_PATH` is the matrix-recommended secondary (`/Rhythmyx/rest/folders/by-path/Assets`) (#2482) |
 | `RESULT:… HEALTH:healthy\|unhealthy\|starting\|none` | `qa-health` (matrix cell) and `verify` / `_verify_inline` (cms-dts) | Inspect status from `_docker_health` on every RESULT (OK and FAIL); `none` = container has no Health block; `unknown` = docker/container missing |
 | `RESULT:FAIL … DETAIL:rhythmyx_context_failed MATCH:…` | `qa-health`, compose `verify` / `_verify_inline`, or matrix cell `detail` | **Fail-fast**: Spring/Jetty context death detected in logs; treat stack as unusable even if HTTP / docker health answered green |
+| `RESULT:FAIL … DETAIL:server_log_errors MATCH:…` | same | **Fail-fast**: ERROR/FATAL/SEVERE in product/install logs (`server.log`, InstallPackages, install, tablefactory — same set as `perc-doctor check-logs` / #2556) |
 | `RESULT:FAIL … DETAIL:timeout after Ns (last_http=… health=…)` | `qa-health` | Probe never became ready (HTTP and/or Health not green); if logs later show context fail, re-run `qa-health` or `docker logs perc-matrix-cms-h2` |
 | `RESULT:FAIL … DETAIL:timeout after Ns (cms_http=… dts_http=… health=…)` | `verify` | Stack never became ready; scan `docker logs percussion-cms-dts` for context markers |
 | Matrix `status=fail` + `detail` containing `rhythmyx_context_failed` | `matrix-install-smoke.py` CMS cells | Same fail-fast during cell HTTP wait (container log scan) |
@@ -305,6 +306,8 @@ docker inspect -f "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end
 ```
 
 Markers (shared helper `docker/scripts/rhythmyx_ready.py`): `Failed startup of context`, `BeanCurrentlyInCreationException`, `Requested bean is currently in creation`, `Is there an unresolvable circular reference`.
+
+**CMS product/install log gate (#2556):** host probes also `docker exec` tail `jetty/base/logs/server.log`, `rxconfig/Installer/InstallPackages.log` (or `logs/…`), `install.log`, and `tablefactory.log`. Operator CLI: `perc-doctor check-logs` on an install root.
 
 ##### Docker `Health.Status` (in-image HEALTHCHECK, #2481)
 

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -89,8 +89,9 @@ if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 from perc_host_ports import find_free_port, is_port_free, resolve_host_port  # noqa: E402
 from rhythmyx_ready import (  # noqa: E402
-    DETAIL_CONTEXT_FAILED,
-    find_rhythmyx_context_failure,
+    DETAIL_CONTEXT_FAILED,  # used in DETAIL strings via assess_rhythmyx_ready
+    DETAIL_SERVER_LOG_ERRORS,  # noqa: F401 — stable DETAIL token for agents
+    assess_rhythmyx_ready,
     is_http_ready_code,
 )
 
@@ -1030,6 +1031,66 @@ def _docker_logs_tail(
     return out or err
 
 
+def _docker_read_server_log(
+    container_name: str,
+    *,
+    install_root: str = "/opt/Percussion",
+    tail_lines: int = 4000,
+    timeout: float = 30.0,
+) -> str:
+    """Tail CMS startup + install logs inside the cell (perc-doctor #2556 set)."""
+    if not container_name:
+        return ""
+    from rhythmyx_ready import container_cms_log_paths
+
+    root = install_root.rstrip("/")
+    paths = container_cms_log_paths(root)
+    logs_dir = f"{root}/jetty/base/logs"
+    n = max(1, int(tail_lines))
+    parts: list[str] = []
+    for p in paths:
+        parts.append(
+            f'if [ -f "{p}" ]; then echo "--- {p} ---"; '
+            f'tail -n {n} "{p}" 2>/dev/null || true; fi'
+        )
+    parts.append(
+        f'for f in "{logs_dir}"/*jetty*.log; do '
+        f'[ -f "$f" ] && echo "--- $f ---" && tail -n 500 "$f" 2>/dev/null || true; '
+        f"done"
+    )
+    script = "; ".join(parts)
+    try:
+        completed = subprocess.run(
+            ["docker", "exec", container_name, "sh", "-c", script],
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return (completed.stdout or "") + (completed.stderr or "")
+
+
+def _startup_log_fail_detail(
+    docker_logs: str,
+    server_logs: str,
+    *,
+    http_code: int = 0,
+) -> Optional[str]:
+    """Return DETAIL when docker logs / product logs show startup fail."""
+    _, detail = assess_rhythmyx_ready(
+        http_code if http_code else 200,
+        docker_logs,
+        server_log_text=server_logs,
+        require_http=False,
+    )
+    if DETAIL_CONTEXT_FAILED in detail or DETAIL_SERVER_LOG_ERRORS in detail:
+        return detail
+    return None
+
+
 def wait_for_http(
     url: str,
     *,
@@ -1065,19 +1126,19 @@ def wait_for_http(
     last = ""
     last_health = "unknown"
     while time.time() < deadline:
-        # Fail-fast: Jetty up + Spring context dead must not wait full timeout.
+        # Fail-fast: Jetty up + dirty Spring / product logs must not wait full timeout.
         if container_name:
             logs = _docker_logs_tail(container_name)
-            match = find_rhythmyx_context_failure(logs)
-            if match is not None:
+            server_logs = _docker_read_server_log(container_name)
+            fail_detail = _startup_log_fail_detail(logs, server_logs)
+            if fail_detail is not None:
                 health_suffix = ""
                 if require_docker_health:
                     last_health, _st = inspect_container_health(container_name)
                     health_suffix = f" health={last_health}"
                 return (
                     False,
-                    f"{DETAIL_CONTEXT_FAILED} match={match!r} "
-                    f"last={last or 'n/a'}{health_suffix}",
+                    f"{fail_detail} last={last or 'n/a'}{health_suffix}",
                 )
             if require_docker_health:
                 last_health, status = inspect_container_health(container_name)
@@ -1101,13 +1162,12 @@ def wait_for_http(
                     # Re-check logs after a "ready" HTTP so false positives fail.
                     if container_name:
                         logs = _docker_logs_tail(container_name)
-                        match = find_rhythmyx_context_failure(logs)
-                        if match is not None:
-                            return (
-                                False,
-                                f"{DETAIL_CONTEXT_FAILED} match={match!r} "
-                                f"http={code}",
-                            )
+                        server_logs = _docker_read_server_log(container_name)
+                        fail_detail = _startup_log_fail_detail(
+                            logs, server_logs, http_code=code,
+                        )
+                        if fail_detail is not None:
+                            return False, fail_detail
                     if require_docker_health:
                         # Host HTTP ready is not enough — need inspect healthy.
                         if last_health != "healthy":
@@ -1122,13 +1182,12 @@ def wait_for_http(
             if is_http_ready_code(exc.code):
                 if container_name:
                     logs = _docker_logs_tail(container_name)
-                    match = find_rhythmyx_context_failure(logs)
-                    if match is not None:
-                        return (
-                            False,
-                            f"{DETAIL_CONTEXT_FAILED} match={match!r} "
-                            f"http={exc.code}",
-                        )
+                    server_logs = _docker_read_server_log(container_name)
+                    fail_detail = _startup_log_fail_detail(
+                        logs, server_logs, http_code=exc.code,
+                    )
+                    if fail_detail is not None:
+                        return False, fail_detail
                 if require_docker_health:
                     if last_health != "healthy":
                         last = f"HTTP {exc.code} health={last_health}"
@@ -1140,16 +1199,16 @@ def wait_for_http(
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
             last = str(exc)
         time.sleep(interval_seconds)
-    # Final log scan so timeout DETAIL prefers context failure when present.
+    # Final log scan so timeout DETAIL prefers startup failure when present.
     if container_name:
         logs = _docker_logs_tail(container_name)
-        match = find_rhythmyx_context_failure(logs)
-        if match is not None:
+        server_logs = _docker_read_server_log(container_name)
+        fail_detail = _startup_log_fail_detail(logs, server_logs)
+        if fail_detail is not None:
             health_suffix = f" health={last_health}" if require_docker_health else ""
             return (
                 False,
-                f"{DETAIL_CONTEXT_FAILED} match={match!r} "
-                f"last={last or 'timeout'}{health_suffix}",
+                f"{fail_detail} last={last or 'timeout'}{health_suffix}",
             )
         if require_docker_health:
             last_health, status = inspect_container_health(container_name)

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -93,8 +93,12 @@ if str(_SCRIPTS_DIR) not in sys.path:
 from perc_host_ports import find_free_port, is_port_free, resolve_host_port  # noqa: E402
 from rhythmyx_ready import (  # noqa: E402
     DETAIL_CONTEXT_FAILED,
+    DETAIL_SERVER_LOG_ERRORS,
     assess_rhythmyx_ready,
+    container_cms_log_paths,
+    container_server_log_path,
     find_rhythmyx_context_failure,
+    find_server_log_startup_error,
 )
 
 LOG = logging.getLogger("perc-devctl")
@@ -162,6 +166,9 @@ QA_MATRIX_IMAGE_TAG = "percussion-matrix-cell:local"
 QA_IMAGE_HEALTHCHECK_OK = "ok"
 QA_IMAGE_HEALTHCHECK_MISSING = "missing"
 QA_IMAGE_HEALTHCHECK_ABSENT = "absent"
+
+# Tail size when reading jetty/base/logs + install logs inside the container (#2556).
+QA_SERVER_LOG_TAIL_LINES = 4000
 
 
 # Freeport primitives live in perc_host_ports.py (shared with matrix) — #2001/#2005.
@@ -750,6 +757,74 @@ def _docker_logs_tail(
     return out or err
 
 
+def _docker_read_server_log(
+    container_name: str,
+    *,
+    install_root: str = QA_INSTALL_ROOT,
+    tail_lines: int = QA_SERVER_LOG_TAIL_LINES,
+    timeout: float = 30.0,
+) -> str:
+    """Tail CMS startup + install logs inside the container (perc-doctor #2556 set).
+
+    Paths always use POSIX ``/``. Missing files are skipped.
+    """
+    if not container_name:
+        return ""
+    paths = container_cms_log_paths(install_root)
+    server_log = container_server_log_path(install_root)
+    logs_dir = server_log.rsplit("/", 1)[0]
+    n = max(1, int(tail_lines))
+    parts: list[str] = []
+    for p in paths:
+        parts.append(
+            f'if [ -f "{p}" ]; then echo "--- {p} ---"; '
+            f'tail -n {n} "{p}" 2>/dev/null || true; fi'
+        )
+    parts.append(
+        f'for f in "{logs_dir}"/*jetty*.log; do '
+        f'[ -f "$f" ] && echo "--- $f ---" && tail -n 500 "$f" 2>/dev/null || true; '
+        f"done"
+    )
+    script = "; ".join(parts)
+    try:
+        completed = subprocess.run(
+            ["docker", "exec", container_name, "sh", "-c", script],
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return (completed.stdout or "") + (completed.stderr or "")
+
+
+def _log_scan_fail_detail(docker_logs: str, server_logs: str) -> Optional[str]:
+    """Return assessor detail when docker logs or product logs show startup fail."""
+    _, detail = assess_rhythmyx_ready(
+        200,
+        docker_logs,
+        server_log_text=server_logs,
+        require_http=False,
+    )
+    if DETAIL_CONTEXT_FAILED in detail or DETAIL_SERVER_LOG_ERRORS in detail:
+        return detail
+    return None
+
+
+def _match_from_logs(docker_logs: str, server_logs: str, detail: str) -> str:
+    """Pick a human MATCH string from the failing log scan."""
+    if DETAIL_SERVER_LOG_ERRORS in detail:
+        return (
+            find_server_log_startup_error(server_logs, also_context_markers=False)
+            or find_server_log_startup_error(server_logs)
+            or "unknown"
+        )
+    combined = (docker_logs or "") + "\n" + (server_logs or "")
+    return find_rhythmyx_context_failure(combined) or "unknown"
+
+
 def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     """Poll CMS/DTS HTTP + docker health until ready or timeout / context fail.
 
@@ -774,7 +849,7 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     if args.dry_run:
         LOG.info(
             "DRY-RUN: verify plan: %d checks x %ds interval against %s + %s "
-            "(+ Rhythmyx context log scan on %s)",
+            "(+ Rhythmyx context + CMS product log scan on %s)",
             max_checks, interval, cms_url, dts_url, container,
         )
         with log_file.open("w", encoding="utf-8") as f:
@@ -782,7 +857,7 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
                 f"DRY-RUN: verify max_checks={max_checks} interval={interval}\n"
                 f"endpoints={cms_url} {dts_url}\n"
                 f"container={container}\n"
-                f"log_scan=rhythmyx_context_fail_markers\n"
+                f"log_scan=rhythmyx_context_fail_markers+server_log_errors\n"
             )
         print(f"RESULT:OK STEP:verify CMS_HTTP:200 DTS_HTTP:200 HEALTH:healthy LOG:{log_file}")
         return EXIT_OK
@@ -796,15 +871,21 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
         last_dts = _curl_status(dts_url, timeout=5.0)
         last_health = _docker_health(container)
         logs = _docker_logs_tail(container)
+        server_logs = _docker_read_server_log(container)
         # require_http=False: HTTP readiness is still gated by the verify
-        # code set below; this assessor is for context-fail markers only.
+        # code set below; this assessor is for log fail markers only.
         _ready_ctx, last_detail = assess_rhythmyx_ready(
-            last_cms, logs, require_http=False,
+            last_cms, logs, server_log_text=server_logs, require_http=False,
         )
 
-        # Fail-fast when Spring/Jetty already reported a dead Rhythmyx context.
-        if DETAIL_CONTEXT_FAILED in last_detail:
-            match = find_rhythmyx_context_failure(logs) or "unknown"
+        # Fail-fast: dead Spring context or ERROR/FATAL in product/install logs.
+        if DETAIL_CONTEXT_FAILED in last_detail or DETAIL_SERVER_LOG_ERRORS in last_detail:
+            match = _match_from_logs(logs, server_logs, last_detail)
+            detail_token = (
+                DETAIL_SERVER_LOG_ERRORS
+                if DETAIL_SERVER_LOG_ERRORS in last_detail
+                else DETAIL_CONTEXT_FAILED
+            )
             with log_file.open("w", encoding="utf-8") as f:
                 f.write("verify failed\n")
                 f.write(f"cms_http={last_cms}\n")
@@ -817,13 +898,13 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
                 f.write(f"cms_url={cms_url}\n")
                 f.write(f"dts_url={dts_url}\n")
                 f.write(
-                    "hint: Rhythmyx ApplicationContext failed; Jetty HTTP / "
+                    "hint: Rhythmyx startup not clean; Jetty HTTP / "
                     "docker health may still look green. Inspect docker logs "
-                    "for Spring cycle / bean errors (parent #2423 / #2480). "
-                    "Do not treat port-up as ready.\n"
+                    "and jetty/base/logs/server.log + Installer logs "
+                    "(parent #2423 / #2480 / #2556). Do not treat port-up as ready.\n"
                 )
             print(
-                f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
+                f"RESULT:FAIL STEP:verify DETAIL:{detail_token} "
                 f"MATCH:{match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
                 f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
             )
@@ -842,6 +923,7 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
                 f.write(f"cms_url={cms_url}\n")
                 f.write(f"dts_url={dts_url}\n")
                 f.write("rhythmyx_context=ok\n")
+                f.write("server_log=ok\n")
             print(
                 f"RESULT:OK STEP:verify CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
                 f"HEALTH:{last_health} LOG:{log_file}"
@@ -849,9 +931,15 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
             return EXIT_OK
         time.sleep(interval)
 
-    # Timeout path: re-scan logs once more so DETAIL prefers context failure.
+    # Timeout path: re-scan logs once more so DETAIL prefers startup failure.
     final_logs = _docker_logs_tail(container)
-    final_match = find_rhythmyx_context_failure(final_logs)
+    final_server = _docker_read_server_log(container)
+    final_detail = _log_scan_fail_detail(final_logs, final_server)
+    final_match = (
+        _match_from_logs(final_logs, final_server, final_detail)
+        if final_detail
+        else None
+    )
     with log_file.open("w", encoding="utf-8") as f:
         f.write("verify failed\n")
         f.write(f"timeout_seconds={timeout}\n")
@@ -864,8 +952,8 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
         if final_match:
             f.write(f"match={final_match}\n")
             f.write(
-                "hint: Rhythmyx context failure markers found in docker logs; "
-                "see parent #2423 / #2480. HTTP-only / health-only ready is "
+                "hint: startup failure markers found in docker logs / product logs; "
+                "see parent #2423 / #2480 / #2556. HTTP-only / health-only ready is "
                 "insufficient.\n"
             )
         f.write("--- compose ps\n")
@@ -880,7 +968,13 @@ def cmd_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
                 stderr=subprocess.STDOUT,
             )
         f.write(f"see {compose_ps_log}\n")
-    if final_match:
+    if final_detail and DETAIL_SERVER_LOG_ERRORS in final_detail:
+        print(
+            f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_SERVER_LOG_ERRORS} "
+            f"MATCH:{final_match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+            f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
+        )
+    elif final_match:
         print(
             f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
             f"MATCH:{final_match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
@@ -1017,7 +1111,7 @@ def _verify_inline(
                 f"DRY-RUN: verify-inline max_checks={max_checks} interval={interval_seconds}\n"
                 f"endpoints={cms_url} {dts_url}\n"
                 f"container={container}\n"
-                f"log_scan=rhythmyx_context_fail_markers\n"
+                f"log_scan=rhythmyx_context_fail_markers+server_log_errors\n"
             )
         return EXIT_OK, log_file
 
@@ -1029,11 +1123,17 @@ def _verify_inline(
         last_dts = _curl_status(dts_url, timeout=5.0)
         last_health = _docker_health(container)
         logs = _docker_logs_tail(container)
+        server_logs = _docker_read_server_log(container)
         _ready_ctx, detail = assess_rhythmyx_ready(
-            last_cms, logs, require_http=False,
+            last_cms, logs, server_log_text=server_logs, require_http=False,
         )
-        if DETAIL_CONTEXT_FAILED in detail:
-            match = find_rhythmyx_context_failure(logs) or "unknown"
+        if DETAIL_CONTEXT_FAILED in detail or DETAIL_SERVER_LOG_ERRORS in detail:
+            match = _match_from_logs(logs, server_logs, detail)
+            detail_token = (
+                DETAIL_SERVER_LOG_ERRORS
+                if DETAIL_SERVER_LOG_ERRORS in detail
+                else DETAIL_CONTEXT_FAILED
+            )
             with log_file.open("w", encoding="utf-8") as f:
                 f.write("verify failed\n")
                 f.write(f"cms_http={last_cms}\n")
@@ -1043,11 +1143,11 @@ def _verify_inline(
                 f.write(f"detail={detail}\n")
                 f.write(f"match={match}\n")
                 f.write(
-                    "hint: Rhythmyx ApplicationContext failed during "
-                    "verify-inline (#2480 / #2423).\n"
+                    "hint: Rhythmyx startup not clean during "
+                    "verify-inline (#2480 / #2423 / #2556).\n"
                 )
             print(
-                f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
+                f"RESULT:FAIL STEP:verify DETAIL:{detail_token} "
                 f"MATCH:{match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
                 f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
             )
@@ -1063,6 +1163,7 @@ def _verify_inline(
                 f.write(f"dts_http={last_dts}\n")
                 f.write(f"container_health={last_health}\n")
                 f.write("rhythmyx_context=ok\n")
+                f.write("server_log=ok\n")
             print(
                 f"RESULT:OK STEP:verify CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
                 f"HEALTH:{last_health} LOG:{log_file}"
@@ -1071,7 +1172,13 @@ def _verify_inline(
         time.sleep(interval_seconds)
 
     final_logs = _docker_logs_tail(container)
-    final_match = find_rhythmyx_context_failure(final_logs)
+    final_server = _docker_read_server_log(container)
+    final_detail = _log_scan_fail_detail(final_logs, final_server)
+    final_match = (
+        _match_from_logs(final_logs, final_server, final_detail)
+        if final_detail
+        else None
+    )
     with log_file.open("w", encoding="utf-8") as f:
         f.write("verify failed\n")
         f.write(f"cms_http={last_cms}\n")
@@ -1079,7 +1186,13 @@ def _verify_inline(
         f.write(f"container_health={last_health}\n")
         if final_match:
             f.write(f"match={final_match}\n")
-    if final_match:
+    if final_detail and DETAIL_SERVER_LOG_ERRORS in final_detail:
+        print(
+            f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_SERVER_LOG_ERRORS} "
+            f"MATCH:{final_match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
+            f"HEALTH:{last_health} CONTAINER:{container} LOG:{log_file}"
+        )
+    elif final_match:
         print(
             f"RESULT:FAIL STEP:verify DETAIL:{DETAIL_CONTEXT_FAILED} "
             f"MATCH:{final_match} CMS_HTTP:{last_cms} DTS_HTTP:{last_dts} "
@@ -1443,14 +1556,16 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
     * HTTP status on the probe URL is in the ready set (200/302/401/403), **and**
     * Recent ``docker logs`` for the QA cell do **not** contain Rhythmyx
       ApplicationContext failure markers (see :mod:`rhythmyx_ready`), **and**
+    * Product/install logs (``server.log``, InstallPackages, install,
+      tablefactory — #2556 / perc-doctor check-logs) have no ERROR/FATAL/SEVERE, **and**
     * Docker ``Health.Status`` for the QA cell is ``healthy`` (matrix HEALTHCHECK
       after #2481 — same gate as compose ``verify`` for cms-dts).
 
     RESULT lines always include ``HEALTH:<status>`` so operators see host
     log-scan **and** inspect health in one line (#2537 residual of #2481).
 
-    Context-failure markers cause **immediate** FAIL even when HTTP answers
-    (Jetty up, Spring webapp dead — #2462 residual of #2423).
+    Context-failure markers or product-log ERRORs cause **immediate** FAIL even
+    when HTTP answers (Jetty up, dirty startup — #2462 / #2556).
     """
     repo_root, _env_file, _compose_file = paths
     log_dir = _log_dir(repo_root)
@@ -1465,7 +1580,7 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
     if args.dry_run:
         LOG.info(
             "DRY-RUN: qa-health plan: %d checks x %ds interval against %s "
-            "(+ Rhythmyx context log scan + docker Health.Status on %s)",
+            "(+ Rhythmyx context + product log scan + docker Health.Status on %s)",
             max_checks,
             interval,
             url,
@@ -1476,7 +1591,7 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
                 f"DRY-RUN: qa-health max_checks={max_checks} interval={interval}\n"
                 f"url={url}\n"
                 f"container={container}\n"
-                f"log_scan=rhythmyx_context_fail_markers\n"
+                f"log_scan=rhythmyx_context_fail_markers+server_log_errors\n"
                 f"docker_health=inspect Health.Status\n"
             )
         print(
@@ -1492,11 +1607,19 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
         last_code = _curl_status(url, timeout=5.0)
         last_health = _docker_health(container)
         logs = _docker_logs_tail(container)
-        ready, last_detail = assess_rhythmyx_ready(last_code, logs)
+        server_logs = _docker_read_server_log(container)
+        ready, last_detail = assess_rhythmyx_ready(
+            last_code, logs, server_log_text=server_logs,
+        )
 
-        # Fail-fast when Spring/Jetty already reported a dead Rhythmyx context.
-        if DETAIL_CONTEXT_FAILED in last_detail:
-            match = find_rhythmyx_context_failure(logs) or "unknown"
+        # Fail-fast: dead Spring context or ERROR/FATAL in product/install logs.
+        if DETAIL_CONTEXT_FAILED in last_detail or DETAIL_SERVER_LOG_ERRORS in last_detail:
+            match = _match_from_logs(logs, server_logs, last_detail)
+            detail_token = (
+                DETAIL_SERVER_LOG_ERRORS
+                if DETAIL_SERVER_LOG_ERRORS in last_detail
+                else DETAIL_CONTEXT_FAILED
+            )
             with log_file.open("w", encoding="utf-8") as f:
                 f.write("qa-health failed\n")
                 f.write(f"url={url}\n")
@@ -1507,12 +1630,12 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
                 f.write(f"detail={last_detail}\n")
                 f.write(f"match={match}\n")
                 f.write(
-                    "hint: Rhythmyx ApplicationContext failed; Jetty HTTP may "
-                    "still bind. Inspect docker logs for Spring cycle / bean "
-                    "errors (parent #2423). Do not treat port-up as ready.\n"
+                    "hint: Rhythmyx startup not clean; Jetty HTTP may "
+                    "still bind. Inspect docker logs and jetty/base/logs/server.log "
+                    "+ Installer logs (parent #2423 / #2556). Do not treat port-up as ready.\n"
                 )
             print(
-                f"RESULT:FAIL STEP:qa-health DETAIL:{DETAIL_CONTEXT_FAILED} "
+                f"RESULT:FAIL STEP:qa-health DETAIL:{detail_token} "
                 f"MATCH:{match} HTTP:{last_code} HEALTH:{last_health} "
                 f"URL:{url} CONTAINER:{container} LOG:{log_file}"
             )
@@ -1528,6 +1651,7 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
                 f.write(f"check={check}\n")
                 f.write(f"container={container}\n")
                 f.write("rhythmyx_context=ok\n")
+                f.write("server_log=ok\n")
             print(
                 f"RESULT:OK STEP:qa-health HTTP:{last_code} HEALTH:{last_health} "
                 f"URL:{url} CONTAINER:{container} LOG:{log_file}"
@@ -1536,9 +1660,15 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
 
         time.sleep(interval)
 
-    # Timeout path: re-scan logs once more so DETAIL prefers context failure.
+    # Timeout path: re-scan logs once more so DETAIL prefers startup failure.
     final_logs = _docker_logs_tail(container)
-    final_match = find_rhythmyx_context_failure(final_logs)
+    final_server = _docker_read_server_log(container)
+    final_detail = _log_scan_fail_detail(final_logs, final_server)
+    final_match = (
+        _match_from_logs(final_logs, final_server, final_detail)
+        if final_detail
+        else None
+    )
     with log_file.open("w", encoding="utf-8") as f:
         f.write("qa-health failed\n")
         f.write(f"url={url}\n")
@@ -1551,17 +1681,23 @@ def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
         if final_match:
             f.write(f"match={final_match}\n")
             f.write(
-                "hint: Rhythmyx context failure markers found in docker logs; "
-                "see parent #2423. HTTP-only ready is insufficient.\n"
+                "hint: startup failure markers found in docker logs / product logs; "
+                "see parent #2423 / #2556. HTTP-only ready is insufficient.\n"
             )
         else:
             f.write(
                 "hint: run qa-up first; ensure installer jar is built "
                 "(modules/perc-distribution-tree package); if Jetty is up but "
-                "login fails, scan docker logs for Failed startup of context; "
+                "login fails, scan docker logs and jetty/base/logs/server.log; "
                 "also check docker inspect Health.Status on the QA cell\n"
             )
-    if final_match:
+    if final_detail and DETAIL_SERVER_LOG_ERRORS in final_detail:
+        print(
+            f"RESULT:FAIL STEP:qa-health DETAIL:{DETAIL_SERVER_LOG_ERRORS} "
+            f"MATCH:{final_match} HTTP:{last_code} HEALTH:{last_health} "
+            f"URL:{url} CONTAINER:{container} LOG:{log_file}"
+        )
+    elif final_match:
         print(
             f"RESULT:FAIL STEP:qa-health DETAIL:{DETAIL_CONTEXT_FAILED} "
             f"MATCH:{final_match} HTTP:{last_code} HEALTH:{last_health} "

--- a/docker/scripts/rhythmyx_ready.py
+++ b/docker/scripts/rhythmyx_ready.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Rhythmyx / CMS readiness helpers for docker health probes (#2462 / #2423).
+"""Rhythmyx / CMS readiness helpers for docker health probes (#2462 / #2423 / #2556).
 
 Jetty can bind its HTTP connector while the ROOT/Rhythmyx webapp Spring
 ``ApplicationContext`` failed to start (circular beans, missing deps, etc.).
 HTTP-only probes then look green (or hang until timeout) while login/REST
-are dead.
+are dead. Product logs under ``jetty/base/logs/server.log`` and install logs
+under ``rxconfig/Installer/`` may also show ERROR/FATAL while HTTP answers.
 
 This module provides pure, stdlib-only helpers:
 
 * HTTP status codes that count as "something answered" for login/REST
 * Log-text markers that mean the Rhythmyx webapp context failed
-* A small assessor that combines HTTP + log scan for fail-fast
+* `server.log` / install-log ERROR/FATAL/SEVERE scanners (#2556)
+* A small assessor that combines HTTP + log scans for fail-fast
 * A documented **probe URL matrix** (#2482) so operators pick an HTTP
   endpoint that *actually implies* the Rhythmyx Spring context is up,
-  rather than just proving Jetty answered (the legacy ``/Rhythmyx/login``
+  rather than just proving Jetty answered (the legacy `/Rhythmyx/login`
   probe is weak because the login JSP renders even with a dead Spring
   context — only the form POST fails).
 
@@ -22,10 +24,13 @@ Callers: ``perc-devctl.py`` (``qa-health``, compose ``verify`` /
 ``_verify_inline``), ``matrix-install-smoke.py`` (``wait_for_http``),
 and in-image ``rhythmyx_healthcheck.py`` (Docker HEALTHCHECK / #2481).
 No secrets; no network I/O here.
+
+Rules align with ``perc-doctor check-logs`` (#2556).
 """
 
 from __future__ import annotations
 
+import re
 from typing import Dict, FrozenSet, Optional, Sequence, Tuple
 
 # Login / REST probes treat these as "endpoint is up" (auth may still apply).
@@ -40,8 +45,52 @@ RHYTHMYX_CONTEXT_FAIL_MARKERS: Tuple[str, ...] = (
     "Is there an unresolvable circular reference",
 )
 
-# RESULT / DETAIL token for agent parsers (stable contract).
+# RESULT / DETAIL tokens for agent parsers (stable contract).
 DETAIL_CONTEXT_FAILED = "rhythmyx_context_failed"
+DETAIL_SERVER_LOG_ERRORS = "server_log_errors"
+
+# Container-side install root default (Linux matrix / QA cells).
+DEFAULT_INSTALL_ROOT = "/opt/Percussion"
+# Primary product log (Log4j RollingFile under jetty base).
+DEFAULT_SERVER_LOG_REL = "jetty/base/logs/server.log"
+# Full CMS install/startup log set (perc-doctor check-logs / #2556). Paths use /.
+CMS_STARTUP_INSTALL_LOG_RELS: Tuple[str, ...] = (
+    "jetty/base/logs/server.log",
+    "rxconfig/Installer/InstallPackages.log",
+    "logs/InstallPackages.log",
+    "rxconfig/Installer/install.log",
+    "rxconfig/Installer/tablefactory.log",
+    "tablefactory.log",
+)
+
+# Log4j2 / JUL-style severity tokens on a line (case-sensitive levels so
+# prose like "error manager" does not false-positive).
+# Matches: " ERROR ", "[ERROR]", "ERROR:", leading "ERROR " / "FATAL " / "SEVERE ".
+_SERVER_LOG_SEVERITY_RE = re.compile(
+    r"(?:^|[\s\[])(?:ERROR|FATAL|SEVERE)(?:[\s\]:]|$)"
+)
+
+# Known non-fatal noise (prefer empty — keep startup clean).
+SERVER_LOG_ERROR_ALLOWLIST: Tuple[str, ...] = ()
+
+# Max characters of the matched line returned in DETAIL/MATCH.
+_MATCH_LINE_MAX = 240
+
+
+def container_server_log_path(install_root: str = DEFAULT_INSTALL_ROOT) -> str:
+    """POSIX path to ``server.log`` inside a CMS container (always ``/``)."""
+    root = (install_root or DEFAULT_INSTALL_ROOT).rstrip("/")
+    if not root:
+        root = DEFAULT_INSTALL_ROOT
+    return root + "/" + DEFAULT_SERVER_LOG_REL
+
+
+def container_cms_log_paths(install_root: str = DEFAULT_INSTALL_ROOT) -> Tuple[str, ...]:
+    """POSIX paths for CMS startup + install logs inside a container."""
+    root = (install_root or DEFAULT_INSTALL_ROOT).rstrip("/")
+    if not root:
+        root = DEFAULT_INSTALL_ROOT
+    return tuple(root + "/" + rel for rel in CMS_STARTUP_INSTALL_LOG_RELS)
 
 # ---------------------------------------------------------------------------
 # Probe URL matrix (#2482). Pure data; no network I/O.
@@ -215,6 +264,55 @@ def find_rhythmyx_context_failure(
     return None
 
 
+def _normalize_log_lines(log_text: str) -> Sequence[str]:
+    if not log_text:
+        return ()
+    return [
+        ln.strip("\r")
+        for ln in log_text.replace("\r\n", "\n").split("\n")
+        if ln.strip()
+    ]
+
+
+def _is_allowlisted_error_line(line: str) -> bool:
+    for needle in SERVER_LOG_ERROR_ALLOWLIST:
+        if needle and needle in line:
+            return True
+    return False
+
+
+def find_server_log_startup_error(
+    log_text: str,
+    *,
+    also_context_markers: bool = True,
+) -> Optional[str]:
+    """Return a short description of the first startup error in log text.
+
+    Scans for:
+
+    1. Rhythmyx context-failure markers (optional)
+    2. Lines with ERROR / FATAL / SEVERE severity (Log4j / JUL style)
+
+    Empty input is treated as "no evidence of failure yet".
+    """
+    if not log_text:
+        return None
+
+    if also_context_markers:
+        ctx = find_rhythmyx_context_failure(log_text)
+        if ctx is not None:
+            return ctx
+
+    for line in _normalize_log_lines(log_text):
+        if _is_allowlisted_error_line(line):
+            continue
+        if _SERVER_LOG_SEVERITY_RE.search(line):
+            if len(line) <= _MATCH_LINE_MAX:
+                return line
+            return line[: _MATCH_LINE_MAX - 3] + "..."
+    return None
+
+
 def is_http_ready_code(code: int) -> bool:
     """True when ``code`` is an accepted login/REST probe response."""
     return int(code) in HTTP_READY_CODES
@@ -224,23 +322,48 @@ def assess_rhythmyx_ready(
     http_code: int,
     log_text: str = "",
     *,
+    server_log_text: str = "",
     require_http: bool = True,
 ) -> Tuple[bool, str]:
-    """Combine HTTP probe + log scan into a ready / not-ready verdict.
+    """Combine HTTP probe + log scans into a ready / not-ready verdict.
 
     Returns ``(ready, detail)`` where ``detail`` is a short machine-friendly
     reason when not ready, or ``ok`` when ready.
 
-    Rules (issue #2462):
+    Rules (#2462 / #2556):
 
-    1. Any context-failure marker in logs → **not ready** (fail-fast), even
-       if HTTP returned a ready code (dead Spring webapp behind Jetty).
-    2. If ``require_http`` and HTTP is not a ready code → not ready.
-    3. Else ready.
+    1. Any context-failure marker in ``log_text`` **or** ``server_log_text``
+       → **not ready** (fail-fast), even if HTTP returned a ready code.
+    2. Any ERROR/FATAL/SEVERE line in ``server_log_text`` → **not ready**
+       (``DETAIL_SERVER_LOG_ERRORS``).
+    3. If ``require_http`` and HTTP is not a ready code → not ready.
+    4. Else ready.
+
+    ``log_text`` is typically recent ``docker logs``. ``server_log_text`` is
+    product/install log files from the container (``check-logs`` path set).
+    Empty ``server_log_text`` skips the file ERROR gate (files not written yet).
     """
-    match = find_rhythmyx_context_failure(log_text)
+    combined = log_text or ""
+    if server_log_text:
+        if combined:
+            combined = combined + "\n" + server_log_text
+        else:
+            combined = server_log_text
+
+    match = find_rhythmyx_context_failure(combined)
     if match is not None:
         return False, f"{DETAIL_CONTEXT_FAILED} match={match!r} http={http_code}"
+
+    file_err = find_server_log_startup_error(
+        server_log_text or "",
+        also_context_markers=False,
+    )
+    if file_err is not None:
+        return (
+            False,
+            f"{DETAIL_SERVER_LOG_ERRORS} match={file_err!r} http={http_code}",
+        )
+
     if require_http and not is_http_ready_code(http_code):
         return False, f"http_not_ready http={http_code}"
     return True, "ok"

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -404,6 +404,13 @@ class WaitForContainerHealthyPolicyTests(unittest.TestCase):
 class WaitForHttpContextFailTests(unittest.TestCase):
     """#2462: matrix probe must fail-fast on Rhythmyx context death."""
 
+    def setUp(self):
+        self._slog = unittest.mock.patch.object(
+            smoke, "_docker_read_server_log", return_value=""
+        )
+        self._slog.start()
+        self.addCleanup(self._slog.stop)
+
     def test_wait_for_http_dry_run(self):
         ok, detail = smoke.wait_for_http(
             "http://127.0.0.1:9993/Rhythmyx/login",
@@ -499,6 +506,14 @@ class WaitForHttpContextFailTests(unittest.TestCase):
 
 class WaitForHttpDockerHealthTests(unittest.TestCase):
     """#2535: CMS wait requires Health.Status=healthy + host belt-and-braces."""
+
+    def setUp(self):
+        # Isolate from live docker exec of product logs (#2556).
+        self._slog = unittest.mock.patch.object(
+            smoke, "_docker_read_server_log", return_value=""
+        )
+        self._slog.start()
+        self.addCleanup(self._slog.stop)
 
     def test_require_health_fail_fast_unhealthy(self):
         """Unhealthy inspect must not wait the full probe timeout."""

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -340,6 +340,11 @@ class TestVerifyRealMode(unittest.TestCase):
         self.addCleanup(self.td.cleanup)
         self.repo_root = _stub_repo_root(Path(self.td.name))
         self.runner = _CliRunner(self.repo_root)
+        self._slog = unittest.mock.patch.object(
+            pdc, "_docker_read_server_log", return_value=""
+        )
+        self._slog.start()
+        self.addCleanup(self._slog.stop)
 
     def test_verify_first_check_succeeds(self):
         """When curl + docker inspect + clean logs all return success values,
@@ -713,6 +718,12 @@ class TestQaHealthRealMode(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         self.addCleanup(self.td.cleanup)
         self.repo_root = _stub_repo_root(Path(self.td.name))
+        # Do not docker-exec a live CMS from unit tests (#2556 product log scan).
+        self._slog = unittest.mock.patch.object(
+            pdc, "_docker_read_server_log", return_value=""
+        )
+        self._slog.start()
+        self.addCleanup(self._slog.stop)
 
     def test_qa_health_success_on_first_check(self):
         with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \

--- a/docker/scripts/test_rhythmyx_ready.py
+++ b/docker/scripts/test_rhythmyx_ready.py
@@ -77,6 +77,23 @@ class FindContextFailureTests(unittest.TestCase):
         self.assertIsNone(rr.find_rhythmyx_context_failure(text))
 
 
+class ServerLogErrorTests(unittest.TestCase):
+    def test_error_line(self):
+        text = "INFO boot\nERROR [PSX] boom failed\n"
+        match = rr.find_server_log_startup_error(text)
+        self.assertIsNotNone(match)
+        self.assertIn("ERROR", match)
+
+    def test_empty_clean(self):
+        self.assertIsNone(rr.find_server_log_startup_error(""))
+
+    def test_container_cms_log_paths(self):
+        paths = rr.container_cms_log_paths("/opt/Percussion")
+        self.assertIn("/opt/Percussion/jetty/base/logs/server.log", paths)
+        self.assertIn("/opt/Percussion/rxconfig/Installer/install.log", paths)
+        self.assertIn("/opt/Percussion/rxconfig/Installer/tablefactory.log", paths)
+
+
 class AssessReadyTests(unittest.TestCase):
     def test_http_ready_clean_logs(self):
         ok, detail = rr.assess_rhythmyx_ready(200, "Server Started")
@@ -91,6 +108,15 @@ class AssessReadyTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn(rr.DETAIL_CONTEXT_FAILED, detail)
         self.assertIn("Failed startup of context", detail)
+
+    def test_http_ready_but_server_log_error(self):
+        ok, detail = rr.assess_rhythmyx_ready(
+            200,
+            "INFO docker clean",
+            server_log_text="INFO ok\nERROR [PSX] residual\n",
+        )
+        self.assertFalse(ok)
+        self.assertIn(rr.DETAIL_SERVER_LOG_ERRORS, detail)
 
     def test_http_not_ready_clean_logs(self):
         ok, detail = rr.assess_rhythmyx_ready(0, "")

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,10 +2,10 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232) (`clean-temp`), [#2233](https://github.com/intersoftdatalabs-in/percussioncms/issues/2233) (`check-config` / `fix-permissions`), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2556](https://github.com/intersoftdatalabs-in/percussioncms/issues/2556) (`check-logs`), [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232) (`clean-temp`), [#2233](https://github.com/intersoftdatalabs-in/percussioncms/issues/2233) (`check-config` / `fix-permissions`), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
 **Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
-**Shipped commands:** `diagnose`/`health` (read-only), `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `clean-temp`, `check-config`, `fix-permissions` with global `--dry-run` / `--install-root` / `-v`  
-**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` for clean-* commands (wired in sitemanage); diagnose / `check-config` / `fix-permissions` are CLI-first
+**Shipped commands:** `diagnose`/`health` (read-only), `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `clean-temp`, `check-config`, `check-logs`, `fix-permissions` with global `--dry-run` / `--install-root` / `-v`  
+**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` for clean-* commands (wired in sitemanage); diagnose / `check-config` / `check-logs` / `fix-permissions` are CLI-first
 
 **Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
 
@@ -244,6 +244,30 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
 # Apply (Windows example)
 java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
   --install-root C:\Percussion -v clean-temp
+```
+
+#### `check-logs` / `check-startup-logs`
+
+Read-only scan of known CMS **install and startup logs** for ERROR / FATAL / SEVERE and Rhythmyx context-death markers. **Never deletes or writes.** Alias: `check-startup-logs`.
+
+| Phase | Paths (relative to `--install-root`; first existing alternate wins) |
+|-------|---------------------------------------------------------------------|
+| **startup** | `jetty/base/logs/server.log` |
+| **install** | `rxconfig/Installer/InstallPackages.log` or `logs/InstallPackages.log`; `rxconfig/Installer/install.log`; `rxconfig/Installer/tablefactory.log` or `tablefactory.log` |
+| **all** (default) | startup + install |
+
+| Option | Meaning |
+|--------|---------|
+| `--phase all\|startup\|install` | Which groups to scan (default `all`) |
+| `--tail-lines N` | Max lines from the end of each log (default 4000) |
+| `--require-startup` | FAIL if `server.log` is missing |
+| `--require-install` | FAIL if no install-phase logs are present |
+
+Missing optional files are **SKIP** (not FAIL) unless require flags are set. Exit non-zero when any FAIL. Emits `RESULT:OK|FAIL STEP:check-logs` for agents. Rules align with Docker `qa-health` (`docker/scripts/rhythmyx_ready.py`).
+
+```bash
+perc-doctor --install-root /opt/Percussion -v check-logs --require-startup
+perc-doctor --install-root C:\Percussion -v check-logs --phase install
 ```
 
 #### `check-config`

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -88,6 +88,25 @@ bin\perc-doctor.bat -v diagnose
 
 Exit code is non-zero when any check is `FAIL` (e.g. missing `jetty/base` or `rxconfig`). WARN-only outcomes still exit 0.
 
+### `check-logs` / `check-startup-logs` (read-only)
+
+Scan CMS install/startup log **content** for ERROR/FATAL/SEVERE and Spring/Jetty context-death markers. Does not delete logs. Prefer after install and after first CMS start.
+
+| Phase | Logs |
+|-------|------|
+| startup | `jetty/base/logs/server.log` |
+| install | `InstallPackages.log`, `install.log`, `tablefactory.log` (under `rxconfig/Installer` or known alternates) |
+
+```bash
+# Linux / macOS — require a clean server.log after startup
+./bin/perc-doctor -v check-logs --require-startup
+
+# Windows — install-phase logs only
+bin\perc-doctor.bat -v check-logs --phase install
+```
+
+Exit non-zero when any scanned log has ERROR/FATAL/SEVERE. Missing optional files are skipped unless `--require-startup` / `--require-install`.
+
 ### `clean-heap-dumps`
 
 Removes recursive `*.hprof` under the install root (case-insensitive). Scope is hard-limited to `--install-root`.

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckLogsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckLogsCommand.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Read-only scan of known CMS install/startup logs for ERROR/FATAL/SEVERE and Rhythmyx context
+ * death markers ({@code check-logs}).
+ *
+ * <p>Never deletes or writes. Paths stay under the install root via {@link InstallRootGuard}.
+ *
+ * <p>Global {@code --dry-run} is accepted for CLI parity and echoed on the report; it has no effect
+ * because this command is always non-mutating.
+ *
+ * <p>Issue: #2556
+ */
+public final class CheckLogsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "check-logs";
+
+  /** Alias. */
+  public static final String COMMAND_ALIAS = "check-startup-logs";
+
+  public static final String PHASE_ALL = "all";
+  public static final String PHASE_STARTUP = "startup";
+  public static final String PHASE_INSTALL = "install";
+
+  /** Default tail size when reading large log files. */
+  public static final int DEFAULT_TAIL_LINES = 4000;
+
+  /** Max absolute bytes to pull when tailing (safety cap). */
+  static final long MAX_TAIL_BYTES = 8L * 1024 * 1024;
+
+  /**
+   * Startup phase log relative paths (forward-slash segments). First existing path wins per row
+   * group when multiple alternates are listed in one {@link LogTarget}.
+   */
+  static final LogTarget[] STARTUP_LOGS = {
+    new LogTarget(
+        "log.server",
+        "CMS server.log (Jetty Log4j2)",
+        true,
+        new String[] {"jetty/base/logs/server.log"}),
+  };
+
+  /** Install / package / schema logs. */
+  static final LogTarget[] INSTALL_LOGS = {
+    new LogTarget(
+        "log.install-packages",
+        "Package install log",
+        false,
+        new String[] {
+          "rxconfig/Installer/InstallPackages.log", "logs/InstallPackages.log"
+        }),
+    new LogTarget(
+        "log.install",
+        "Installer session log",
+        false,
+        new String[] {"rxconfig/Installer/install.log"}),
+    new LogTarget(
+        "log.tablefactory",
+        "TableFactory schema/data log",
+        false,
+        new String[] {
+          "rxconfig/Installer/tablefactory.log", "tablefactory.log"
+        }),
+  };
+
+  /** One logical log with alternate relative paths (first existing is scanned). */
+  static final class LogTarget {
+    final String id;
+    final String description;
+    /** When phase requires this target and file is missing → FAIL if required flag set. */
+    final boolean startupRole;
+
+    final String[] relativePaths;
+
+    LogTarget(String id, String description, boolean startupRole, String[] relativePaths) {
+      this.id = id;
+      this.description = description;
+      this.startupRole = startupRole;
+      this.relativePaths = relativePaths;
+    }
+  }
+
+  /** Command options. */
+  public static final class Options {
+    private final String phase;
+    private final int tailLines;
+    private final boolean requireStartup;
+    private final boolean requireInstall;
+
+    /**
+     * @param phase {@link #PHASE_ALL}, {@link #PHASE_STARTUP}, or {@link #PHASE_INSTALL}
+     * @param tailLines max lines to read from the end of each log (minimum 1)
+     * @param requireStartup FAIL when no startup server.log present
+     * @param requireInstall FAIL when no install-phase log files present
+     */
+    public Options(String phase, int tailLines, boolean requireStartup, boolean requireInstall) {
+      this.phase = phase == null || phase.isEmpty() ? PHASE_ALL : phase.toLowerCase(Locale.ROOT);
+      this.tailLines = Math.max(1, tailLines);
+      this.requireStartup = requireStartup;
+      this.requireInstall = requireInstall;
+    }
+
+    public static Options defaults() {
+      return new Options(PHASE_ALL, DEFAULT_TAIL_LINES, false, false);
+    }
+
+    public String getPhase() {
+      return phase;
+    }
+
+    public int getTailLines() {
+      return tailLines;
+    }
+
+    public boolean isRequireStartup() {
+      return requireStartup;
+    }
+
+    public boolean isRequireInstall() {
+      return requireInstall;
+    }
+  }
+
+  private CheckLogsCommand() {}
+
+  public static boolean isCheckLogsCommand(String command) {
+    return COMMAND_NAME.equals(command) || COMMAND_ALIAS.equals(command);
+  }
+
+  /**
+   * Parse phase token; throws {@link IllegalArgumentException} when unknown.
+   *
+   * @param raw phase string
+   * @return normalized phase
+   */
+  public static String parsePhase(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return PHASE_ALL;
+    }
+    String p = raw.trim().toLowerCase(Locale.ROOT);
+    if (PHASE_ALL.equals(p) || PHASE_STARTUP.equals(p) || PHASE_INSTALL.equals(p)) {
+      return p;
+    }
+    throw new IllegalArgumentException(
+        "--phase must be all, startup, or install (got: " + raw + ")");
+  }
+
+  /**
+   * Run log content checks under {@code installRoot}.
+   *
+   * @param installRoot CMS install root
+   * @param dryRun echoed global flag only
+   * @param options phase / tail / require flags
+   * @return report
+   * @throws IllegalArgumentException if install root invalid
+   * @throws IOException on unrecoverable I/O (individual files prefer FAIL/SKIP rows)
+   */
+  public static CheckLogsReport execute(Path installRoot, boolean dryRun, Options options)
+      throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    Options opts = options != null ? options : Options.defaults();
+    CheckLogsReport report =
+        new CheckLogsReport(COMMAND_NAME, root, dryRun, opts.getPhase());
+
+    report.add(
+        new CheckLogsReport.Check(
+            "install-root",
+            CheckLogsReport.CheckStatus.PASS,
+            "Install root exists and is a directory",
+            root,
+            null));
+    report.add(
+        new CheckLogsReport.Check(
+            "phase",
+            CheckLogsReport.CheckStatus.INFO,
+            "Scanning phase="
+                + opts.getPhase()
+                + " tailLines="
+                + opts.getTailLines()
+                + " requireStartup="
+                + opts.isRequireStartup()
+                + " requireInstall="
+                + opts.isRequireInstall(),
+            null,
+            null));
+
+    List<LogTarget> targets = selectTargets(opts.getPhase());
+    int startupSeen = 0;
+    int installSeen = 0;
+
+    for (LogTarget target : targets) {
+      ScanOutcome outcome = scanTarget(root, target, opts.getTailLines());
+      report.add(outcome.check);
+      if (outcome.filePresent) {
+        if (target.startupRole) {
+          startupSeen++;
+        } else {
+          installSeen++;
+        }
+      }
+    }
+
+    if (opts.isRequireStartup()
+        && (PHASE_ALL.equals(opts.getPhase()) || PHASE_STARTUP.equals(opts.getPhase()))
+        && startupSeen == 0) {
+      report.add(
+          new CheckLogsReport.Check(
+              "require.startup",
+              CheckLogsReport.CheckStatus.FAIL,
+              "require-startup: no jetty/base/logs/server.log found under install root",
+              null,
+              "missing_server_log"));
+    }
+    if (opts.isRequireInstall()
+        && (PHASE_ALL.equals(opts.getPhase()) || PHASE_INSTALL.equals(opts.getPhase()))
+        && installSeen == 0) {
+      report.add(
+          new CheckLogsReport.Check(
+              "require.install",
+              CheckLogsReport.CheckStatus.FAIL,
+              "require-install: no install/package/tablefactory logs found under install root",
+              null,
+              "missing_install_logs"));
+    }
+
+    return report;
+  }
+
+  public static CheckLogsReport execute(Path installRoot, boolean dryRun) throws IOException {
+    return execute(installRoot, dryRun, Options.defaults());
+  }
+
+  static List<LogTarget> selectTargets(String phase) {
+    List<LogTarget> list = new ArrayList<>();
+    if (PHASE_ALL.equals(phase) || PHASE_STARTUP.equals(phase)) {
+      for (LogTarget t : STARTUP_LOGS) {
+        list.add(t);
+      }
+    }
+    if (PHASE_ALL.equals(phase) || PHASE_INSTALL.equals(phase)) {
+      for (LogTarget t : INSTALL_LOGS) {
+        list.add(t);
+      }
+    }
+    return list;
+  }
+
+  private static final class ScanOutcome {
+    final CheckLogsReport.Check check;
+    final boolean filePresent;
+
+    ScanOutcome(CheckLogsReport.Check check, boolean filePresent) {
+      this.check = check;
+      this.filePresent = filePresent;
+    }
+  }
+
+  static ScanOutcome scanTarget(Path root, LogTarget target, int tailLines) {
+    Path found = null;
+    for (String rel : target.relativePaths) {
+      Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, rel);
+      if (resolved != null && Files.isRegularFile(resolved)) {
+        found = resolved;
+        break;
+      }
+    }
+    if (found == null) {
+      String tried = String.join(", ", target.relativePaths);
+      return new ScanOutcome(
+          new CheckLogsReport.Check(
+              target.id + ".present",
+              CheckLogsReport.CheckStatus.SKIP,
+              target.description + " not present (tried: " + tried + ")",
+              null,
+              null),
+          false);
+    }
+
+    try {
+      String text = readTail(found, tailLines);
+      String match = LogScanRules.findStartupError(text);
+      if (match != null) {
+        return new ScanOutcome(
+            new CheckLogsReport.Check(
+                target.id + ".content",
+                CheckLogsReport.CheckStatus.FAIL,
+                target.description + " contains ERROR/FATAL/SEVERE or context-failure marker",
+                found,
+                match),
+            true);
+      }
+      return new ScanOutcome(
+          new CheckLogsReport.Check(
+              target.id + ".content",
+              CheckLogsReport.CheckStatus.PASS,
+              target.description + " clean (no ERROR/FATAL/SEVERE or context markers in tail)",
+              found,
+              null),
+          true);
+    } catch (IOException e) {
+      return new ScanOutcome(
+          new CheckLogsReport.Check(
+              target.id + ".content",
+              CheckLogsReport.CheckStatus.FAIL,
+              target.description + " unreadable: " + e.getMessage(),
+              found,
+              "unreadable"),
+          true);
+    }
+  }
+
+  /**
+   * Read the last {@code tailLines} lines of {@code file} (UTF-8, falls back to platform default on
+   * decode issues by reading bytes as ISO-8859-1).
+   */
+  static String readTail(Path file, int tailLines) throws IOException {
+    Objects.requireNonNull(file, "file");
+    long size = Files.size(file);
+    if (size == 0) {
+      return "";
+    }
+    if (size <= MAX_TAIL_BYTES && size <= 512 * 1024) {
+      // Small files: read whole content.
+      return Files.readString(file, StandardCharsets.UTF_8);
+    }
+    // Tail from the end using RandomAccessFile (cross-platform).
+    int linesWanted = Math.max(1, tailLines);
+    long maxBytes = Math.min(size, MAX_TAIL_BYTES);
+    try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "r")) {
+      long start = Math.max(0, size - maxBytes);
+      raf.seek(start);
+      long toRead = size - start;
+      if (toRead > Integer.MAX_VALUE) {
+        toRead = Integer.MAX_VALUE;
+      }
+      byte[] buf = new byte[(int) toRead];
+      int read = raf.read(buf);
+      if (read <= 0) {
+        return "";
+      }
+      String chunk = decodeLenient(buf, read);
+      if (start > 0) {
+        // Drop partial first line when we mid-file seeked.
+        int nl = chunk.indexOf('\n');
+        if (nl >= 0 && nl + 1 < chunk.length()) {
+          chunk = chunk.substring(nl + 1);
+        }
+      }
+      return lastNLines(chunk, linesWanted);
+    }
+  }
+
+  static String decodeLenient(byte[] buf, int len) {
+    String utf8 = new String(buf, 0, len, StandardCharsets.UTF_8);
+    // If the file is pure ASCII/UTF-8 this is fine; for legacy encodings operators still get
+    // searchable ERROR tokens.
+    if (utf8.indexOf('\uFFFD') < 0) {
+      return utf8;
+    }
+    return new String(buf, 0, len, Charset.forName("ISO-8859-1"));
+  }
+
+  static String lastNLines(String text, int n) {
+    if (text == null || text.isEmpty() || n <= 0) {
+      return text == null ? "" : text;
+    }
+    String normalized = text.replace("\r\n", "\n").replace('\r', '\n');
+    String[] lines = normalized.split("\n", -1);
+    if (lines.length <= n) {
+      return normalized;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (int i = lines.length - n; i < lines.length; i++) {
+      if (sb.length() > 0) {
+        sb.append('\n');
+      }
+      sb.append(lines[i]);
+    }
+    return sb.toString();
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckLogsReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckLogsReport.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Read-only log content scan report for {@code check-logs}. Never implies filesystem mutations.
+ */
+public final class CheckLogsReport {
+
+  /** Outcome severity for a single log file scan. */
+  public enum CheckStatus {
+    /** File present and free of ERROR/FATAL/SEVERE / context markers. */
+    PASS,
+    /** File missing and not required for the selected phase. */
+    SKIP,
+    /** Non-fatal concern (e.g. unreadable with soft policy — reserved). */
+    WARN,
+    /** Errors found, required file missing, or unreadable when required. */
+    FAIL,
+    /** Pure information. */
+    INFO
+  }
+
+  /** One log-file scan row. */
+  public static final class Check {
+    private final String id;
+    private final CheckStatus status;
+    private final String message;
+    private final Path path;
+    private final String match;
+
+    /**
+     * @param id stable id (e.g. {@code log.server})
+     * @param status outcome
+     * @param message human-readable detail
+     * @param path optional path under install root
+     * @param match optional first error line / marker (may be null)
+     */
+    public Check(String id, CheckStatus status, String message, Path path, String match) {
+      this.id = Objects.requireNonNull(id, "id");
+      this.status = Objects.requireNonNull(status, "status");
+      this.message = Objects.requireNonNull(message, "message");
+      this.path = path;
+      this.match = match;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public CheckStatus getStatus() {
+      return status;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public Path getPath() {
+      return path;
+    }
+
+    public String getMatch() {
+      return match;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final String phase;
+  private final List<Check> checks = new ArrayList<>();
+
+  /**
+   * @param command command token
+   * @param installRoot resolved install root
+   * @param dryRun echoed global flag
+   * @param phase scan phase ({@code all}, {@code startup}, {@code install})
+   */
+  public CheckLogsReport(String command, Path installRoot, boolean dryRun, String phase) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+    this.phase = Objects.requireNonNull(phase, "phase");
+  }
+
+  public void add(Check check) {
+    checks.add(Objects.requireNonNull(check, "check"));
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  public String getPhase() {
+    return phase;
+  }
+
+  public List<Check> getChecks() {
+    return Collections.unmodifiableList(checks);
+  }
+
+  public int getCheckCount() {
+    return checks.size();
+  }
+
+  public int getPassCount() {
+    return count(CheckStatus.PASS);
+  }
+
+  public int getSkipCount() {
+    return count(CheckStatus.SKIP);
+  }
+
+  public int getWarnCount() {
+    return count(CheckStatus.WARN);
+  }
+
+  public int getFailCount() {
+    return count(CheckStatus.FAIL);
+  }
+
+  public int getInfoCount() {
+    return count(CheckStatus.INFO);
+  }
+
+  /** @return true when no FAIL entries */
+  public boolean isHealthy() {
+    return getFailCount() == 0;
+  }
+
+  /** First FAIL match string, if any (for RESULT MATCH). */
+  public String firstFailMatch() {
+    for (Check c : checks) {
+      if (c.getStatus() == CheckStatus.FAIL && c.getMatch() != null && !c.getMatch().isEmpty()) {
+        return c.getMatch();
+      }
+    }
+    for (Check c : checks) {
+      if (c.getStatus() == CheckStatus.FAIL) {
+        return c.getMessage();
+      }
+    }
+    return null;
+  }
+
+  private int count(CheckStatus status) {
+    int n = 0;
+    for (Check c : checks) {
+      if (c.getStatus() == status) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -31,7 +31,7 @@ import java.time.Duration;
  *
  * <p>Commands: {@code diagnose}/{@code health}, {@code clean-heap-dumps}, {@code
  * clean-install-backups}, {@code clean-logs}, {@code clean-temp}, {@code check-config}, {@code
- * fix-permissions}.
+ * check-logs}, {@code fix-permissions}.
  */
 public final class DoctorCli {
 
@@ -91,6 +91,8 @@ public final class DoctorCli {
               + CleanTempCommand.COMMAND_NAME
               + ", "
               + CheckConfigCommand.COMMAND_NAME
+              + ", "
+              + CheckLogsCommand.COMMAND_NAME
               + ", or "
               + FixPermissionsCommand.COMMAND_NAME);
       printHelp(err);
@@ -154,6 +156,18 @@ public final class DoctorCli {
         printCheckConfigReport(report, parsed.verbose, out);
         return report.isHealthy() ? EXIT_OK : EXIT_ERROR;
       }
+      if (CheckLogsCommand.isCheckLogsCommand(parsed.command)) {
+        CheckLogsCommand.Options logOpts =
+            new CheckLogsCommand.Options(
+                parsed.logPhase,
+                parsed.logTailLines,
+                parsed.requireStartupLogs,
+                parsed.requireInstallLogs);
+        CheckLogsReport report =
+            CheckLogsCommand.execute(installRoot, parsed.dryRun, logOpts);
+        printCheckLogsReport(report, parsed.verbose, out);
+        return report.isHealthy() ? EXIT_OK : EXIT_ERROR;
+      }
       if (FixPermissionsCommand.COMMAND_NAME.equals(parsed.command)) {
         FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, parsed.dryRun);
         printFixPermissionsReport(report, parsed.verbose, out);
@@ -175,6 +189,10 @@ public final class DoctorCli {
               + CleanTempCommand.COMMAND_NAME
               + ", "
               + CheckConfigCommand.COMMAND_NAME
+              + ", "
+              + CheckLogsCommand.COMMAND_NAME
+              + "/"
+              + CheckLogsCommand.COMMAND_ALIAS
               + ", "
               + FixPermissionsCommand.COMMAND_NAME);
       printHelp(err);
@@ -200,6 +218,14 @@ public final class DoctorCli {
     boolean keepCurrent = true;
     /** True when the user passed {@code --keep-current} or {@code --no-keep-current}. */
     boolean keepCurrentExplicit;
+    /** {@code check-logs} phase: all | startup | install. */
+    String logPhase = CheckLogsCommand.PHASE_ALL;
+    /** {@code check-logs} tail line count. */
+    int logTailLines = CheckLogsCommand.DEFAULT_TAIL_LINES;
+    /** {@code check-logs}: FAIL when startup server.log missing. */
+    boolean requireStartupLogs;
+    /** {@code check-logs}: FAIL when no install-phase logs present. */
+    boolean requireInstallLogs;
   }
 
   /**
@@ -236,6 +262,28 @@ public final class DoctorCli {
       } else if ("--no-keep-current".equals(a)) {
         parsed.keepCurrent = false;
         parsed.keepCurrentExplicit = true;
+      } else if ("--phase".equals(a)) {
+        if (i + 1 >= args.length) {
+          throw new IllegalArgumentException(
+              "--phase requires all|startup|install");
+        }
+        parsed.logPhase = CheckLogsCommand.parsePhase(args[++i]);
+      } else if ("--tail-lines".equals(a)) {
+        if (i + 1 >= args.length) {
+          throw new IllegalArgumentException("--tail-lines requires a positive integer");
+        }
+        try {
+          parsed.logTailLines = Integer.parseInt(args[++i]);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException("--tail-lines must be an integer");
+        }
+        if (parsed.logTailLines < 1) {
+          throw new IllegalArgumentException("--tail-lines must be >= 1");
+        }
+      } else if ("--require-startup".equals(a)) {
+        parsed.requireStartupLogs = true;
+      } else if ("--require-install".equals(a)) {
+        parsed.requireInstallLogs = true;
       } else if (a.startsWith("-")) {
         throw new IllegalArgumentException("unknown option: " + a);
       } else if (parsed.command == null) {
@@ -253,7 +301,7 @@ public final class DoctorCli {
     stream.println(
         "CMS Doctor — install diagnose + safe install-tree maintenance"
             + " (diagnose/health, clean-heap-dumps, clean-install-backups, clean-logs,"
-            + " clean-temp, check-config, fix-permissions).");
+            + " clean-temp, check-config, check-logs, fix-permissions).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -276,6 +324,11 @@ public final class DoctorCli {
     stream.println(
         "  check-config           Read-only value/misconfig checks (server + repository props)");
     stream.println(
+        "  check-logs             Read-only ERROR/FATAL scan of CMS install/startup logs"
+            + " (server.log, InstallPackages, install, tablefactory)");
+    stream.println(
+        "  check-startup-logs     Alias for check-logs");
+    stream.println(
         "  fix-permissions        Report/fix allowlisted launcher + log-dir modes (POSIX)");
     stream.println();
     stream.println("clean-logs options:");
@@ -285,6 +338,16 @@ public final class DoctorCli {
         "  --keep-current         Never delete active current *.log/*.out (default)");
     stream.println(
         "  --no-keep-current      Allow deleting active current log basenames");
+    stream.println();
+    stream.println("check-logs options:");
+    stream.println(
+        "  --phase all|startup|install   Which log groups to scan (default: all)");
+    stream.println(
+        "  --tail-lines N                Max lines from end of each log (default: 4000)");
+    stream.println(
+        "  --require-startup             FAIL if jetty/base/logs/server.log is missing");
+    stream.println(
+        "  --require-install             FAIL if no install-phase logs are present");
     stream.println();
     stream.println("Examples:");
     stream.println("  perc-doctor --install-root /opt/Percussion -v diagnose");
@@ -304,6 +367,10 @@ public final class DoctorCli {
     stream.println(
         "  perc-doctor --install-root /opt/Percussion --dry-run -v check-config");
     stream.println("  perc-doctor --install-root C:\\Percussion -v check-config");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion -v check-logs --require-startup");
+    stream.println(
+        "  perc-doctor --install-root C:\\Percussion -v check-logs --phase install");
     stream.println(
         "  perc-doctor --install-root /opt/Percussion --dry-run -v fix-permissions");
     stream.println("  perc-doctor --install-root C:\\Percussion -v fix-permissions");
@@ -365,6 +432,41 @@ public final class DoctorCli {
       for (CheckConfigReport.Check c : report.getChecks()) {
         String pathPart = c.getPath() == null ? "" : " path=" + c.getPath();
         out.println("  " + c.getStatus() + " " + c.getId() + " " + c.getMessage() + pathPart);
+      }
+    } else if (report.getCheckCount() > 0) {
+      out.println("(use -v/--verbose for check list)");
+    }
+  }
+
+  static void printCheckLogsReport(CheckLogsReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("phase=" + report.getPhase());
+    out.println("read-only=true");
+    out.println("checks=" + report.getCheckCount());
+    out.println("pass=" + report.getPassCount());
+    out.println("skip=" + report.getSkipCount());
+    out.println("warn=" + report.getWarnCount());
+    out.println("fail=" + report.getFailCount());
+    out.println("info=" + report.getInfoCount());
+    out.println("healthy=" + report.isHealthy());
+    if (!report.isHealthy()) {
+      String match = report.firstFailMatch();
+      if (match != null) {
+        out.println("RESULT:FAIL STEP:check-logs DETAIL:server_log_errors MATCH:" + match);
+      } else {
+        out.println("RESULT:FAIL STEP:check-logs DETAIL:server_log_errors");
+      }
+    } else {
+      out.println("RESULT:OK STEP:check-logs");
+    }
+    if (verbose) {
+      for (CheckLogsReport.Check c : report.getChecks()) {
+        String pathPart = c.getPath() == null ? "" : " path=" + c.getPath();
+        String matchPart = c.getMatch() == null ? "" : " match=" + c.getMatch();
+        out.println(
+            "  " + c.getStatus() + " " + c.getId() + " " + c.getMessage() + pathPart + matchPart);
       }
     } else if (report.getCheckCount() > 0) {
       out.println("(use -v/--verbose for check list)");

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/LogScanRules.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/LogScanRules.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Shared pure rules for CMS install/startup log content scans ({@code check-logs}).
+ *
+ * <p>Aligned with {@code docker/scripts/rhythmyx_ready.py}: Rhythmyx context-death markers and
+ * Log4j/JUL-style ERROR / FATAL / SEVERE lines. Keep allowlists empty by default so startup stays
+ * clean.
+ */
+public final class LogScanRules {
+
+  /** Max characters of a matched line returned to operators / RESULT MATCH. */
+  public static final int MATCH_LINE_MAX = 240;
+
+  /**
+   * Substrings from Jetty / Spring logs when ROOT/Rhythmyx context fails (same set as docker
+   * readiness probes).
+   */
+  public static final String[] RHYTHMYX_CONTEXT_FAIL_MARKERS = {
+    "Failed startup of context",
+    "BeanCurrentlyInCreationException",
+    "Requested bean is currently in creation",
+    "Is there an unresolvable circular reference"
+  };
+
+  /**
+   * Log4j2 / JUL-style severity tokens on a line. Matches {@code ERROR}, {@code FATAL}, {@code
+   * SEVERE} as whole tokens (case-sensitive log levels so prose like "error manager" does not
+   * match). Not inside identifiers like {@code ERROR_CODE}.
+   */
+  private static final Pattern SEVERITY_RE =
+      Pattern.compile("(?:^|[\\s\\[])(?:ERROR|FATAL|SEVERE)(?:[\\s\\]:]|$)");
+
+  private LogScanRules() {}
+
+  /**
+   * Return the first Rhythmyx context-failure marker found in {@code logText}, or null.
+   *
+   * @param logText log content (may be null/empty)
+   * @return first matching marker, or null
+   */
+  public static String findContextFailureMarker(String logText) {
+    if (logText == null || logText.isEmpty()) {
+      return null;
+    }
+    for (String marker : RHYTHMYX_CONTEXT_FAIL_MARKERS) {
+      if (marker != null && !marker.isEmpty() && logText.contains(marker)) {
+        return marker;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Return a short description of the first startup / install error in {@code logText}.
+   *
+   * <p>Order: context markers first, then the first ERROR/FATAL/SEVERE line (truncated).
+   *
+   * @param logText log content (may be null/empty — treated as clean / no evidence yet)
+   * @return match description, or null when clean
+   */
+  public static String findStartupError(String logText) {
+    return findStartupError(logText, true);
+  }
+
+  /**
+   * @param logText log content
+   * @param alsoContextMarkers when true, also scan for Rhythmyx context markers
+   * @return match description, or null when clean
+   */
+  public static String findStartupError(String logText, boolean alsoContextMarkers) {
+    if (logText == null || logText.isEmpty()) {
+      return null;
+    }
+    if (alsoContextMarkers) {
+      String ctx = findContextFailureMarker(logText);
+      if (ctx != null) {
+        return ctx;
+      }
+    }
+    String[] lines = logText.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1);
+    for (String raw : lines) {
+      if (raw == null) {
+        continue;
+      }
+      String line = raw.strip();
+      if (line.isEmpty()) {
+        continue;
+      }
+      if (SEVERITY_RE.matcher(line).find()) {
+        return clip(line);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Whether {@code logText} is free of context markers and ERROR/FATAL/SEVERE lines.
+   *
+   * @param logText log content
+   * @return true when no error evidence
+   */
+  public static boolean isClean(String logText) {
+    return findStartupError(logText) == null;
+  }
+
+  static String clip(String line) {
+    Objects.requireNonNull(line, "line");
+    if (line.length() <= MATCH_LINE_MAX) {
+      return line;
+    }
+    return line.substring(0, MATCH_LINE_MAX - 3) + "...";
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CheckLogsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CheckLogsCommandTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CheckLogsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+  }
+
+  @Test
+  void missingLogsSkipAndStayHealthyWithoutRequireFlags() throws Exception {
+    CheckLogsReport report = CheckLogsCommand.execute(installRoot, true);
+    assertEquals(CheckLogsCommand.COMMAND_NAME, report.getCommand());
+    assertTrue(report.isDryRun());
+    assertTrue(report.isHealthy());
+    assertTrue(report.getSkipCount() >= 1);
+  }
+
+  @Test
+  void cleanServerLogPasses() throws Exception {
+    Path log =
+        Files.createDirectories(installRoot.resolve("jetty").resolve("base").resolve("logs"))
+            .resolve("server.log");
+    Files.writeString(
+        log,
+        "2026-08-09 INFO [Server] Started\nINFO [PSServer] ready\n",
+        StandardCharsets.UTF_8);
+
+    CheckLogsReport report =
+        CheckLogsCommand.execute(
+            installRoot,
+            false,
+            new CheckLogsCommand.Options(CheckLogsCommand.PHASE_STARTUP, 1000, true, false));
+    assertTrue(report.isHealthy());
+    assertTrue(report.getPassCount() >= 1);
+    assertTrue(hasStatus(report, CheckLogsReport.CheckStatus.PASS, "log.server.content"));
+  }
+
+  @Test
+  void errorInServerLogFails() throws Exception {
+    Path log =
+        Files.createDirectories(installRoot.resolve("jetty").resolve("base").resolve("logs"))
+            .resolve("server.log");
+    Files.writeString(
+        log,
+        "INFO start\nERROR [PSX] bean wiring failed\n",
+        StandardCharsets.UTF_8);
+
+    CheckLogsReport report =
+        CheckLogsCommand.execute(
+            installRoot,
+            false,
+            new CheckLogsCommand.Options(CheckLogsCommand.PHASE_STARTUP, 1000, false, false));
+    assertFalse(report.isHealthy());
+    assertEquals(1, report.getFailCount());
+    assertTrue(report.firstFailMatch().contains("ERROR"));
+  }
+
+  @Test
+  void installPhaseScansInstallPackagesAndTableFactory() throws Exception {
+    Path installer = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(
+        installer.resolve("InstallPackages.log"),
+        "INFO package ok\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        installer.resolve("install.log"), "INFO install complete\n", StandardCharsets.UTF_8);
+    Files.writeString(
+        installer.resolve("tablefactory.log"),
+        "ERROR tablefactory failed\n",
+        StandardCharsets.UTF_8);
+
+    CheckLogsReport report =
+        CheckLogsCommand.execute(
+            installRoot,
+            false,
+            new CheckLogsCommand.Options(CheckLogsCommand.PHASE_INSTALL, 500, false, true));
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatus(report, CheckLogsReport.CheckStatus.FAIL, "log.tablefactory.content"));
+  }
+
+  @Test
+  void requireStartupFailsWhenServerLogMissing() throws Exception {
+    CheckLogsReport report =
+        CheckLogsCommand.execute(
+            installRoot,
+            false,
+            new CheckLogsCommand.Options(CheckLogsCommand.PHASE_STARTUP, 100, true, false));
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatus(report, CheckLogsReport.CheckStatus.FAIL, "require.startup"));
+  }
+
+  @Test
+  void parsePhaseRejectsUnknown() {
+    assertThrows(IllegalArgumentException.class, () -> CheckLogsCommand.parsePhase("nope"));
+    assertEquals(CheckLogsCommand.PHASE_ALL, CheckLogsCommand.parsePhase("ALL"));
+  }
+
+  @Test
+  void lastNLinesHelper() {
+    // split("\n", -1) keeps a trailing empty segment after a final newline
+    assertEquals("c\nd", CheckLogsCommand.lastNLines("a\nb\nc\nd", 2));
+    assertEquals("d\n", CheckLogsCommand.lastNLines("a\nb\nc\nd\n", 2));
+  }
+
+  private static boolean hasStatus(
+      CheckLogsReport report, CheckLogsReport.CheckStatus status, String id) {
+    return report.getChecks().stream()
+        .anyMatch(c -> c.getStatus() == status && id.equals(c.getId()));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -89,6 +89,59 @@ class DoctorCliTest {
   }
 
   @Test
+  void checkLogsViaCliFailsOnServerError() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-check-logs"));
+    Path log =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"))
+            .resolve("server.log");
+    Files.writeString(log, "INFO ok\nERROR [x] bad\n", StandardCharsets.UTF_8);
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root",
+              root.toString(),
+              "-v",
+              "check-logs",
+              "--phase",
+              "startup",
+              "--require-startup"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_ERROR, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("healthy=false"));
+    assertTrue(out.contains("RESULT:FAIL STEP:check-logs"));
+    assertTrue(out.contains("ERROR"));
+  }
+
+  @Test
+  void checkLogsViaCliCleanExitOk() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-check-logs-ok"));
+    Path log =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"))
+            .resolve("server.log");
+    Files.writeString(log, "INFO [Server] Started\n", StandardCharsets.UTF_8);
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "check-logs", "--phase", "startup"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(outBuf.toString(StandardCharsets.UTF_8).contains("RESULT:OK STEP:check-logs"));
+  }
+
+  @Test
   void unknownOptionIsUsageError() {
     ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
     ByteArrayOutputStream errBuf = new ByteArrayOutputStream();

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/LogScanRulesTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/LogScanRulesTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LogScanRulesTest {
+
+  @Test
+  void cleanInfoOnly() {
+    String text =
+        "2026-08-09 01:00:00,001 INFO  [Server] Started @7879ms\n"
+            + "2026-08-09 01:00:01,000 INFO  [PSServer] Server is ready\n";
+    assertNull(LogScanRules.findStartupError(text));
+    assertTrue(LogScanRules.isClean(text));
+  }
+
+  @Test
+  void errorLineDetected() {
+    String text =
+        "INFO boot\n" + "2026-08-09 01:00:01,000 ERROR [PSSomething] boom failed\n";
+    String match = LogScanRules.findStartupError(text);
+    assertNotNull(match);
+    assertTrue(match.contains("ERROR"));
+    assertTrue(match.contains("boom failed"));
+    assertFalse(LogScanRules.isClean(text));
+  }
+
+  @Test
+  void fatalAndSevere() {
+    assertNotNull(LogScanRules.findStartupError("FATAL [Init] cannot continue\n"));
+    assertNotNull(LogScanRules.findStartupError("SEVERE: something broke\n"));
+  }
+
+  @Test
+  void contextMarkers() {
+    assertTrue(
+        LogScanRules.findStartupError("WARN Failed startup of context Rhythmyx\n")
+            .contains("Failed startup of context"));
+    assertNotNull(
+        LogScanRules.findStartupError(
+            "BeanCurrentlyInCreationException: folderHelper\n"));
+  }
+
+  @Test
+  void emptyIsClean() {
+    assertNull(LogScanRules.findStartupError(""));
+    assertNull(LogScanRules.findStartupError(null));
+    assertTrue(LogScanRules.isClean(null));
+  }
+
+  @Test
+  void crlfNormalized() {
+    String match = LogScanRules.findStartupError("INFO ok\r\nERROR [x] bad\r\n");
+    assertNotNull(match);
+    assertTrue(match.contains("ERROR"));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -147,6 +147,7 @@ class PercDoctorPackagingTest {
             && (guideText.contains("diagnose") || guideText.contains("health"))
             && guideText.contains("clean-temp")
             && guideText.contains("check-config")
+            && guideText.contains("check-logs")
             && guideText.contains("fix-permissions"),
         "install guide must cover all shipped commands including diagnose/health");
     assertTrue(


### PR DESCRIPTION
## Summary

Implements [#2556](https://github.com/intersoftdatalabs-in/percussioncms/issues/2556): require clean CMS install/startup logs for operator doctor and Docker QA readiness.

### `perc-doctor check-logs` (alias `check-startup-logs`)
- Read-only scan of known logs under `--install-root`
- **startup:** `jetty/base/logs/server.log`
- **install:** `InstallPackages.log`, `install.log`, `tablefactory.log` (Installer or known alternates)
- Options: `--phase all|startup|install`, `--tail-lines N`, `--require-startup`, `--require-install`
- Emits `RESULT:OK|FAIL STEP:check-logs` for agents
- Case-sensitive ERROR/FATAL/SEVERE (avoids “error manager” false positives) + Rhythmyx context markers

### Docker readiness (optional residual of #2556)
- `qa-health`, compose `verify` / `_verify_inline`, matrix `wait_for_http` now `docker exec` tail the **same path set**
- Fail-fast DETAIL: `server_log_errors` (in addition to existing `rhythmyx_context_failed` + Health.Status gates)

## Test plan
- [x] `cd modules/perc-doctor && ../../mvnw clean test` (green locally)
- [x] `python -m pytest docker/scripts/test_rhythmyx_ready.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q` (147 passed)
- [ ] Optional live: `perc-doctor -v check-logs --require-startup` on an install
- [ ] Optional live: `perc-devctl qa-health` against a cell with dirty `server.log` → `DETAIL:server_log_errors`

## Notes
- Compose image HEALTHCHECK remains HTTP + in-container context markers; full multi-file gate is host `qa-health` / `verify` / doctor.
- Night workflow script changes are **not** in this PR.

> Co-Authored by Grok Build using grok-4.5 with agent main.