### PR TITLE
test(sitemanage): complete pageService hub reverse-edge freeze (#2514)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -2,8 +2,8 @@
 
 **Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521 / #2525 / #2514 field+peer expansion)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514 — ctor + field reverse-edge freeze, mirrors #2478), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents ΓÇö **not** an agent rule file.
 
@@ -106,7 +106,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 
 | Rank | Bean | Approx. ctor out / in (interest graph) | Notes |
 |------|------|----------------------------------------|-------|
-| 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze covered by `PSPageServiceCycleWiringTest` (2026-08-08, #2514). |
+| 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze: `PSPageServiceCycleWiringTest` (#2514 — ctor + non-`@Lazy` field bans on cycle peers; intentional `@Lazy` partner: `PSAssetService` #2476). |
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset` with **param `@Lazy`** (#2515). Class `@Lazy`. Reverse-edge freeze: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478). |
 | 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
@@ -125,6 +125,37 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | Why not skip param `@Lazy` | Inventory residual after #2463: without it, a future reverse edge or multi-hop eager path would form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
 
 Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + param `@Lazy` + no reverse).
+
+### pageService hub reverse-edge freeze (#2514)
+
+**`PSPageService`** is rank-1 (ctor out ~11 / in ~28). Forward construct-requires cycle peers; reverse edges into `IPSPageService` from those peers (or eager field inject) are frozen.
+
+#### Cycle peers scanned (ctor + field)
+
+| Peer class | Ctor → `IPSPageService` | Field → `IPSPageService` | Disposition |
+|------------|-------------------------|--------------------------|-------------|
+| `PSFolderHelper` | none | none | **Ban** reverse |
+| `PSContentItemDao` | none | none | **Ban** reverse (cycle-break peer) |
+| `PSRecycleService` | none | none | **Ban** reverse |
+| `PSWidgetAssetRelationshipService` | none | none | **Ban** reverse |
+| `PSItemWorkflowService` | none | none (removed unused field 2026-08-09) | **Ban** reverse; dead `pageService` field removed |
+| `PSAssetDao` | none | none | **Ban** reverse (cycle intermediate) |
+
+#### Intentional `@Lazy` reverse partner (not banned)
+
+| From bean | Edge | Disposition | Regression test |
+|-----------|------|-------------|-----------------|
+| `PSAssetService` | ctor → `IPSPageService` **param `@Lazy`** | **Intentional** consumer edge (#2476); keep `@Lazy` | `PSPageServiceCycleWiringTest.assetServiceIntentionalPageServiceEdgeIsLazy` + `PSAssetServicePageServiceNearCycleWiringTest` |
+
+#### Freeze coverage (`PSPageServiceCycleWiringTest`)
+
+- Class `@Lazy` on `PSPageService`
+- Forward edges still present (folderHelper, contentItemDao, recycleService, widgetAsset, itemWorkflow)
+- Cycle peers: no reverse ctor without `@Lazy`; no eager field inject without `@Lazy`
+- Explicit `contentItemDao` no reverse edge
+- Documented intentional `PSAssetService` `@Lazy` partner
+
+**No additional production `@Lazy` required** for #2514 beyond the dead-field cleanup on `PSItemWorkflowService`.
 
 ### ItemWorkflow hub cycle-peer param `@Lazy` (#2515)
 
@@ -283,7 +314,7 @@ listed in the original inventory and is out of scope for #2526.
 2. ~~Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param~~ ΓÇö **done (#2476)**.
 3. ~~ItemWorkflow hub reverse-edge tests.~~ Done: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478).
 4. ~~Hub hardening: `PSTemplateService` class `@Lazy` + reverse-edge tests.~~ **Done (#2477)** ΓÇö `PSTemplateServiceCycleWiringTest`.
-5. ~~`PSPageService` reverse-edge freeze.~~ **Done (#2514)** ΓÇö `PSPageServiceCycleWiringTest`.
+5. ~~`PSPageService` reverse-edge freeze.~~ **Done (#2514)** — `PSPageServiceCycleWiringTest` (ctor + field reverse bans; intentional `PSAssetService` `@Lazy` partner; unused itemWorkflow `pageService` field removed).
 6. ~~Optional: param `@Lazy` on itemWorkflow ΓåÆ cycle peers.~~ **Done (#2515)** ΓÇö `PSItemWorkflowServiceCycleLazyWiringTest`.
 7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
@@ -131,7 +131,8 @@ public class PSItemWorkflowService implements IPSItemWorkflowService {
   IPSFolderHelper folderHelper;
   IPSWorkflowService workflowService;
   IPSiteDao siteDao;
-  IPSPageService pageService;
+  // pageService field intentionally omitted — was an unused reverse edge into the rank-1 hub
+  // (see #2514 / PSPageServiceCycleWiringTest). Use IPSPageService.PAGE_CONTENT_TYPE only.
   IPSSiteManager siteMgr;
   IPSSystemWs systemWs;
   private IPSRecycleService recycleService;

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSPageServiceCycleWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSPageServiceCycleWiringTest.java
@@ -19,38 +19,79 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.percussion.assetmanagement.dao.impl.PSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSAssetService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.impl.PSItemWorkflowService;
 import com.percussion.pagemanagement.service.IPSPageService;
 import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.recycle.service.impl.PSRecycleService;
 import com.percussion.share.dao.IPSContentItemDao;
 import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.dao.impl.PSContentItemDao;
+import com.percussion.share.dao.impl.PSFolderHelper;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
 /**
- * Reverse-edge cycle protection for {@link PSPageService} (#2423 residual #2514).
+ * Reverse-edge cycle protection for the {@link PSPageService} high fan-in hub (#2423 residual
+ * #2514).
  *
  * <p>Per the static inventory in {@code
  * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md},
  * {@code PSPageService} is the rank-1 sitemanage fan-in hub (out ~11 / in ~28) and
- * construct-requires the cycle peers {@code contentItemDao}, {@code folderHelper},
- * {@code recycleService}, {@code widgetAssetRelationshipService}, and {@code
- * itemWorkflow}. The forward edges are intentional and broken on the {@code contentItemDao}
- * side via class {@code @Lazy} there. This test forbids the reverse edges: cycle peers and
- * other high-risk partners must not construct-require {@link IPSPageService}, since adding
- * such a reverse edge would close a new cycle path even with class {@code @Lazy} on
- * {@code PSPageService} (peer-cycle reasoning — see {@code
- * PSAssetServicePageServiceNearCycleWiringTest}).</p>
+ * construct-requires the cycle peers:
  *
- * <p>Peers: {@code PSAssetServicePageServiceNearCycleWiringTest} ({@code PSAssetService}
- * ↔ {@code PSPageService}), {@code PSContentItemDaoCycleLazyWiringTest} (folderHelper cycle
- * break), {@code PSTemplateServiceCycleWiringTest} (#2477).</p>
+ * <pre>
+ * pageService
+ *   → contentItemDao
+ *   → folderHelper
+ *   → recycleService
+ *   → widgetAssetRelationshipService
+ *   → itemWorkflow
+ * </pre>
+ *
+ * <p>The forward edges are intentional and broken on the {@code contentItemDao} side via param
+ * {@code @Lazy} there (path A). This test freezes the reverse direction: cycle peers and related
+ * high-risk hubs must not construct-require or eagerly field-inject {@link IPSPageService} without
+ * parameter/field {@link Lazy @Lazy}, since adding such a reverse edge would close a new cycle path
+ * independent of the contentItemDao break.
+ *
+ * <p><strong>Intentional {@code @Lazy} exception (documented, not banned):</strong> {@link
+ * PSAssetService} construct-requires {@code IPSPageService} with param {@code @Lazy} (#2476). That
+ * is a product consumer edge, not a cycle-peer reverse. It is asserted as present + {@code @Lazy}
+ * below; the companion reverse ban ({@code PSPageService ↛ IPSAssetService}) lives in {@code
+ * PSAssetServicePageServiceNearCycleWiringTest}.
+ *
+ * <p>Peers: {@code PSItemWorkflowServiceHubReverseEdgeWiringTest} (#2478 pattern this class
+ * mirrors), {@code PSAssetServicePageServiceNearCycleWiringTest}, {@code
+ * PSContentItemDaoCycleLazyWiringTest}, {@code PSTemplateServiceCycleWiringTest} (#2477).
  */
 @Tag("UnitTest")
 public class PSPageServiceCycleWiringTest {
+
+  /**
+   * Cycle peers and high-risk intermediates that pageService construct-requires (or that sit on
+   * the known folderHelper→…→contentItemDao chain). None of these may reverse-require {@link
+   * IPSPageService} without {@code @Lazy}.
+   */
+  private static final Class<?>[] CYCLE_PEERS = {
+    PSFolderHelper.class,
+    PSContentItemDao.class,
+    PSRecycleService.class,
+    PSWidgetAssetRelationshipService.class,
+    PSItemWorkflowService.class,
+    PSAssetDao.class
+  };
 
   @Test
   public void pageServiceIsClassLevelLazy() {
@@ -59,63 +100,124 @@ public class PSPageServiceCycleWiringTest {
         "PSPageService must carry class-level @Lazy to harden against cycle formation"
             + " (#2423 residual #2514 / #2463 inventory). Class @Lazy defers the bean until"
             + " first use, breaking any eager consumer path that could close a cycle through"
-            + " pageService.");
+            + " pageService. Class @Lazy is lazy-init only — not a substitute for reverse-edge"
+            + " bans or param @Lazy on reverse partners.");
+  }
+
+  @Test
+  public void pageServiceConstructRequiresCyclePeers() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSPageService.class);
+
+    assertNotNull(
+        findParamOfType(ctor, IPSFolderHelper.class),
+        "PSPageService must still construct-require IPSFolderHelper — inventory #2463 / #2514 hub"
+            + " model; the cycle is broken on contentItemDao, not by removing this forward edge");
+    assertNotNull(
+        findParamOfType(ctor, IPSContentItemDao.class),
+        "PSPageService must still construct-require IPSContentItemDao; removing the edge would"
+            + " invalidate the contentItemDao @Lazy break relative to this hub");
+    assertNotNull(
+        findParamOfType(ctor, IPSRecycleService.class),
+        "PSPageService must still construct-require IPSRecycleService; reverse-edge into recycle is"
+            + " forbidden below");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSPageService must still construct-require IPSWidgetAssetRelationshipService (inventory"
+            + " #2463 cycle peer)");
+    assertNotNull(
+        findParamOfType(ctor, IPSItemWorkflowService.class),
+        "PSPageService must still construct-require IPSItemWorkflowService (inventory #2463 cycle"
+            + " peer); reverse itemWorkflow→pageService is banned below");
   }
 
   /**
-   * The reverse edges are the dangerous ones: cycle peers must not construct-require
-   * IPSPageService. This locks down the four cycle peers the #2463 inventory named.
-   *
-   * <p>Note: {@code PSAssetService} already takes {@link IPSPageService} as a forward
-   * ctor edge (param {@code @Lazy}, peer #2476 / #2463). That edge is intentional and
-   * mitigated by the param-level {@code @Lazy} on {@code PSAssetService}, so it is
-   * <em>not</em> banned here. The companion reverse-edge check lives in
-   * {@code PSAssetServicePageServiceNearCycleWiringTest}: that test forbids
-   * {@code PSPageService → IPSAssetService} (the other direction of the near-cycle).</p>
+   * Reverse edges are the dangerous ones: cycle peers must not construct-require {@link
+   * IPSPageService} without param {@code @Lazy}. Intentional reverse edges (none among cycle peers
+   * today) must use parameter {@code @Lazy} and be documented in the inventory note.
    */
   @Test
   public void cyclePeersMustNotConstructRequirePageService() throws NoSuchMethodException {
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.share.dao.impl.PSFolderHelper.class),
-        IPSPageService.class,
-        "folderHelper → pageService would close a folderHelper↔pageService cycle");
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.share.dao.impl.PSContentItemDao.class),
-        IPSPageService.class,
-        "contentItemDao → pageService would reverse the existing pageService→contentItemDao"
-            + " forward edge and form a new cycle path");
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.recycle.service.impl.PSRecycleService.class),
-        IPSPageService.class,
-        "recycleService → pageService would close a pageService↔recycleService cycle branch");
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.itemmanagement.service.impl.PSItemWorkflowService.class),
-        IPSPageService.class,
-        "itemWorkflow → pageService would close a pageService↔itemWorkflow cycle branch");
+    for (Class<?> peer : CYCLE_PEERS) {
+      Constructor<?> ctor = singlePublicConstructor(peer);
+      Parameter page = findParamOfType(ctor, IPSPageService.class);
+      if (page == null) {
+        continue; // desired: no reverse ctor edge
+      }
+      // Intentional exception path: only allowed with parameter @Lazy
+      assertTrue(
+          page.isAnnotationPresent(Lazy.class),
+          peer.getSimpleName()
+              + " construct-requires IPSPageService without @Lazy — that closes a reverse cycle"
+              + " with the pageService hub (see #2514). Prefer method-level lookup, setter"
+              + " injection, or @Lazy on the injection point; document intentional @Lazy reverse"
+              + " edges in sitemanage-injection-cycle-inventory.md.");
+    }
   }
 
   /**
-   * Belt-and-braces: PSPageService must keep construct-requiring its cycle peers (forward
-   * edges). The cycle is broken by contentItemDao's class @Lazy, not by removing the
-   * forward edges. If anyone removes a forward edge they should also remove the
-   * corresponding reverse-edge ban here AND update the inventory.
+   * Eager {@code @Autowired} field inject of {@link IPSPageService} on a cycle peer is the same
+   * class of reverse edge as a constructor param (class-level {@code @Lazy} on the peer does not
+   * break an eager field edge from a bean already under construction).
+   *
+   * <p>Also flags unannotated fields of that type (legacy XML/setter surfaces) unless marked {@code
+   * @Lazy}.
    */
   @Test
-  public void pageServiceConstructorKeepsCyclePeerForwardEdges() throws NoSuchMethodException {
-    Constructor<?> ctor = singlePublicConstructor(PSPageService.class);
-    assertHasCtorParam(ctor, IPSFolderHelper.class, "PSPageService must still construct-require"
-        + " folderHelper (cycle inventory #2463); the cycle is broken on contentItemDao, not"
-        + " here");
-    assertHasCtorParam(ctor, IPSContentItemDao.class, "PSPageService must still construct-require"
-        + " contentItemDao (cycle inventory #2463); removing the edge would invalidate the"
-        + " contentItemDao @Lazy break");
-    assertHasCtorParam(ctor, IPSRecycleService.class, "PSPageService must still construct-require"
-        + " recycleService (cycle inventory #2463); reverse-edge into recycle is forbidden"
-        + " above");
+  public void cyclePeersMustNotEagerFieldInjectPageService() {
+    List<String> violations = new ArrayList<>();
+    for (Class<?> peer : CYCLE_PEERS) {
+      for (Field field : peer.getDeclaredFields()) {
+        if (!IPSPageService.class.isAssignableFrom(field.getType())) {
+          continue;
+        }
+        if (field.isAnnotationPresent(Lazy.class)) {
+          continue; // documented intentional reverse edge
+        }
+        boolean autowired = field.isAnnotationPresent(Autowired.class);
+        violations.add(
+            peer.getSimpleName()
+                + "."
+                + field.getName()
+                + (autowired ? " (@Autowired)" : " (field type)")
+                + " — reverse field edge without @Lazy");
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Cycle peers must not eagerly field-inject IPSPageService (use @Lazy or remove the edge)."
+            + " Violations: "
+            + String.join("; ", violations));
+  }
+
+  /**
+   * Documented intentional reverse partner: {@link PSAssetService} → {@link IPSPageService} with
+   * param {@code @Lazy} (#2476). Not a cycle peer of the folderHelper chain, but the next-hottest
+   * near-cycle consumer of pageService. Must remain {@code @Lazy}; bare reverse would re-open
+   * assetService↔pageService risk independent of folderHelper.
+   */
+  @Test
+  public void assetServiceIntentionalPageServiceEdgeIsLazy() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSAssetService.class);
+    Parameter pageParam = findParamOfType(ctor, IPSPageService.class);
+    assertNotNull(
+        pageParam,
+        "PSAssetService must still construct-require IPSPageService — inventory #2463 / #2476"
+            + " intentional reverse partner of the pageService hub; if removed, update inventory"
+            + " and PSAssetServicePageServiceNearCycleWiringTest");
+    assertTrue(
+        pageParam.isAnnotationPresent(Lazy.class),
+        "IPSPageService constructor parameter on PSAssetService must remain @Lazy (intentional"
+            + " reverse partner of the pageService hub; see #2476 / #2514). Do not drop @Lazy"
+            + " without a new cycle break documented in the inventory.");
+  }
+
+  @Test
+  public void contentItemDaoStillHasNoPageServiceConstructorEdge() throws NoSuchMethodException {
+    // Explicit named assertion for the known-cycle break peer (contentItemDao is the @Lazy site)
+    assertNoEagerCtorParam(
+        PSContentItemDao.class,
+        IPSPageService.class,
+        "contentItemDao → pageService would couple the cycle-break peer to the rank-1 hub");
   }
 
   @Test
@@ -123,8 +225,10 @@ public class PSPageServiceCycleWiringTest {
     // Sanity guard: PSPageService must declare exactly one public constructor for Spring
     // wiring inspection; this test enforces the assumption shared by all assertions above.
     Constructor<?> ctor = singlePublicConstructor(PSPageService.class);
-    assertNotNull(ctor, "PSPageService must declare exactly one public constructor for Spring"
-        + " wiring inspection; this test enforces the assumption");
+    assertNotNull(
+        ctor,
+        "PSPageService must declare exactly one public constructor for Spring wiring inspection;"
+            + " this test enforces the assumption");
   }
 
   private static Constructor<?> singlePublicConstructor(Class<?> type)
@@ -139,32 +243,28 @@ public class PSPageServiceCycleWiringTest {
     return ctors[0];
   }
 
-  private static void assertNoCtorParam(
-      Constructor<?> ctor, Class<?> forbidden, String why) {
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
     for (Parameter p : ctor.getParameters()) {
-      if (forbidden.isAssignableFrom(p.getType())) {
-        fail(
-            ctor.getDeclaringClass().getSimpleName()
-                + " must not construct-require "
-                + forbidden.getSimpleName()
-                + ": "
-                + why);
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
       }
     }
+    return null;
   }
 
-  private static void assertHasCtorParam(
-      Constructor<?> ctor, Class<?> expected, String why) {
-    for (Parameter p : ctor.getParameters()) {
-      if (expected.isAssignableFrom(p.getType())) {
-        return;
-      }
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    if (p == null) {
+      return;
     }
-    fail(
-        ctor.getDeclaringClass().getSimpleName()
-            + " must still construct-require "
-            + expected.getSimpleName()
-            + ": "
+    assertTrue(
+        p.isAnnotationPresent(Lazy.class),
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + " without @Lazy: "
             + why);
   }
 }


### PR DESCRIPTION
## Summary

Completes **#2514** (parent epic **#2423** residual) for the rank-1 sitemanage hub `PSPageService`.

Earlier cluster PR #2548 absorbed an initial ctor-only reverse-edge freeze. This PR brings the freeze up to the **#2478** `PSItemWorkflowServiceHubReverseEdgeWiringTest` pattern:

- **Ctor reverse ban** on cycle peers / high-risk intermediates (`PSFolderHelper`, `PSContentItemDao`, `PSRecycleService`, `PSWidgetAssetRelationshipService`, `PSItemWorkflowService`, `PSAssetDao`) unless param `@Lazy`
- **Field reverse ban** (non-`@Lazy` field inject of `IPSPageService` on those peers)
- **Forward-edge positive assertions** kept (folderHelper, contentItemDao, recycleService, widgetAsset, itemWorkflow)
- **Intentional `@Lazy` exception documented**: `PSAssetService → IPSPageService` param `@Lazy` (#2476)
- **Production cleanup**: remove unused `IPSPageService pageService` field on `PSItemWorkflowService` (dead reverse field edge)
- Inventory note expanded with pageService reverse-edge scan table

## Parent tracker

- Parent: #2423
- Fixes #2514

## Test plan / gates

- [x] `cd projects/sitemanage && ../../mvnw.cmd test -Dtest=PSPageServiceCycleWiringTest` — **Tests run: 7, Failures: 0**
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS** — Tests run: **834**, Failures: **0**, Errors: **0**, Skipped: 128
- [x] No new warnings attributable to this change
- [x] Erlang-style self-review: pure freeze + dead-field removal; portable paths N/A; companions: inventory + UnitTest peer of #2478

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
