### PR TITLE
test(sitemanage): siteDataService hub reverse-edge freeze (#2516)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -57,8 +57,6 @@ Class-level `@Lazy` is present on `folderHelper` and `recycleService` but is **n
 
 **#2485 result:** no additional live reverse ctor edges into `folderHelper` were found. No further production `@Lazy` changes required on this slice.
 
-<<<<<<< HEAD
-=======
 ## folderHelper field / setter injection inventory (#2525)
 
 **Definition — field/setter edge:** a `@Autowired` / `@Resource` / `@Inject` annotation on a **field** declaration, or on a `setXxx` setter method, where the injected type is one of the cycle interfaces. Field/setter injection bypasses constructor `@Lazy` breaks because Spring resolves the dependency after construction has started — the field-injected dependency must already exist (or a proxy) when the bean is being instantiated.
@@ -137,7 +135,6 @@ These classes have field `@Autowired` of a target interface but are **downstream
 
 **Conclusion:** Every observed field-injected target type lives on a downstream consumer bean. None of the seven cycle-subgraph beans (`PSFolderHelper`, `PSRecycleService`, `PSWidgetAssetRelationshipService`, `PSAssetDao`, `PSContentItemDao`, `PSPageIndexService`, `PSPageDaoHelper`) carry any `@Autowired` / `@Resource` / `@Inject` field annotation on the target interfaces, nor any public setter that takes a target interface. The cycle subgraph is fully converted to constructor injection, so the existing `@Lazy` parameter breaks remain the only required protection.
 
->>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 ### Cycle-subgraph intermediates that must NOT construct-require `folderHelper`
 
 These sit on path A/B. Adding a ctor edge to `IPSFolderHelper` would short-circuit the known breaks:
@@ -392,13 +389,8 @@ listed in the original inventory and is out of scope for #2526.
 7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-<<<<<<< HEAD
-10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
-11. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
-=======
 10. ~~Optional next hubs: siteData reverse-edge freeze.~~ **Done (#2516)** — `PSSiteDataServiceHubReverseEdgeWiringTest`. Optional remaining: widgetAsset class `@Lazy` (#2519).
 11. ~~Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).~~ **Done (#2525)** — `PSFolderHelperFieldInjectionInventoryWiringTest`; cycle subgraph is fully ctor-injected, no live reverse field edges.
->>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
@@ -415,11 +407,8 @@ listed in the original inventory and is out of scope for #2526.
 - #2514 ΓÇö pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
 - #2515 ΓÇö itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
-<<<<<<< HEAD
 - #2526 — emptyRecycle / pathService near-cycle belt-and-braces (`PSEmptyRecycleServiceCycleLazyWiringTest`)
-=======
 - #2525 — folderHelper field / setter injection inventory (`PSFolderHelperFieldInjectionInventoryWiringTest`)  
 - #2516 — siteDataService hub reverse-edge freeze (`PSSiteDataServiceHubReverseEdgeWiringTest`)  
->>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 
 - #2457 / PR #2469 ΓÇö JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -57,6 +57,87 @@ Class-level `@Lazy` is present on `folderHelper` and `recycleService` but is **n
 
 **#2485 result:** no additional live reverse ctor edges into `folderHelper` were found. No further production `@Lazy` changes required on this slice.
 
+<<<<<<< HEAD
+=======
+## folderHelper field / setter injection inventory (#2525)
+
+**Definition — field/setter edge:** a `@Autowired` / `@Resource` / `@Inject` annotation on a **field** declaration, or on a `setXxx` setter method, where the injected type is one of the cycle interfaces. Field/setter injection bypasses constructor `@Lazy` breaks because Spring resolves the dependency after construction has started — the field-injected dependency must already exist (or a proxy) when the bean is being instantiated.
+
+### Cycle-subgraph classes (force-creatable while `folderHelper` is constructing)
+
+These seven classes sit on the recycle subgraph and can be forced to construct while `folderHelper` is still being created (paths A/B above). Any field/setter inject of a target interface on these classes would be a **live reverse field edge**.
+
+| Class | Injection mechanism for target interface | Disposition |
+|-------|-------------------------------------------|-------------|
+| `PSFolderHelper` → `IPSRecycleService` | ctor only (field `recycleService` is plain; only assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSRecycleService` → `IPSWidgetAssetRelationshipService` | ctor only (field `widgetAssetRelationshipService` is plain; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSWidgetAssetRelationshipService` → `IPSAssetDao`, `IPSPageIndexService` | ctor only (fields `assetDao`, `pageIndexService` are plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSAssetDao` → `IPSContentItemDao` | ctor only (field `contentItemDao` is `final`, assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSContentItemDao` → `IPSFolderHelper` | ctor only (`@Lazy`; field `folderHelper` is plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSPageIndexService` → `IPSPageDaoHelper` | ctor only (field `pageDaoHelper` is `final`, assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSPageDaoHelper` → `IPSFolderHelper` | ctor only (`@Lazy`; field `folderHelper` is plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+
+**Result:** **No live reverse field/setter edges** were found in the cycle subgraph. The #2485 ctor work fully converted the recycle subgraph to pure constructor injection (no surviving setter or field `@Autowired` for any of the target interfaces), so the `@Lazy` parameter breaks remain the only protection needed.
+
+**No production code change is required for #2525.** The peer reflection test `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525) freezes this state by asserting that none of the target fields on the cycle subgraph carry a `@Autowired` annotation (Spring would otherwise be free to re-introduce field injection).
+
+### Downstream consumer field injectors (informational, NOT reverse edges)
+
+These classes have field `@Autowired` of a target interface but are **downstream consumers** of `folderHelper` (not on its construction subgraph), so forcing their construction does **not** force `folderHelper` creation. They are listed here to document the full scan and to clarify why no `@Lazy` is required on their fields.
+
+| Class | Field-injected target type | Disposition |
+|-------|----------------------------|-------------|
+| `FolderAdaptor` (REST adaptor) | `IPSFolderHelper`, `IPSPageDaoHelper`, `IPSPageDao` | downstream consumer (also ctor-injected; field annotations are redundant with ctor). Class `@Lazy`. Not on folderHelper ctor path. |
+| `AssetAdaptor` (REST adaptor) | `IPSAssetDao` (final field) | downstream consumer (also ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PageAdaptor` (REST adaptor) | `IPSFolderHelper`, `IPSContentItemDao`, `IPSWidgetAssetRelationshipService`, `IPSAssetService` | downstream consumer (ctor-injected `final` fields; field `@Autowired` annotations redundant with ctor). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSAssetRestService` | `IPSAssetService`, `IPSWidgetAssetRelationshipService`, `IPSRecycleService`, `IPSFolderHelper` | downstream REST facade (ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageRestService` | `IPSRecycleService`, `IPSFolderHelper` | downstream REST facade (ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageService` | `IPSPageDaoHelper`, `IPSFolderHelper`, `IPSWidgetAssetRelationshipService`, `IPSContentItemDao`, `IPSRecycleService` | downstream consumer hub (#2514 freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSItemService` | `IPSRecycleService` (field `@Autowired`) | downstream consumer. Not on folderHelper ctor path. |
+| `PSAbstractWorkflowExtension` | `IPSWidgetAssetRelationshipService`, `IPSFolderHelper` | downstream extension. Not on folderHelper ctor path. |
+| `PSLivePublishChangeHandler` | `IPSFolderHelper`, `IPSWidgetAssetRelationshipService` | downstream handler. Not on folderHelper ctor path. |
+| `PSBulkApprovalJob` | `IPSFolderHelper` | downstream async job. Not on folderHelper ctor path. |
+| `PSFolderService` | `IPSFolderHelper` | downstream REST facade. Not on folderHelper ctor path. |
+| `PSTemplateService` | `IPSWidgetAssetRelationshipService`, `IPSPageDaoHelper` | downstream hub (#2477 freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageListViewProcessor` | `IPSPageDaoHelper` | downstream extension. Not on folderHelper ctor path. |
+| `PSSiteTemplateService` | `IPSFolderHelper`, `IPSAssetService`, `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteSectionService` | `IPSPageDaoHelper`, `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteSectionMetaDataService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSPageChangeHandler` | `IPSContentItemDao` | downstream handler. Not on folderHelper ctor path. |
+| `PSSitePublishServiceWebAdapter` | `IPSFolderHelper` | downstream adapter. Not on folderHelper ctor path. |
+| `PSPageCatalogService` | `IPSFolderHelper`, `IPSPageDaoHelper` | downstream REST facade. Not on folderHelper ctor path. |
+| `PSSitePublishServiceHelper` | `IPSAssetService` | downstream helper. Not on folderHelper ctor path. |
+| `PSSitePublishService` | `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteDataService` | `IPSWidgetAssetRelationshipService`, `IPSAssetDao`, `IPSFolderHelper`, `IPSItemWorkflowService` (+ field page/path) | downstream hub (#2516 reverse freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSAssetUploadFolderPathMap` | `IPSFolderHelper` | downstream helper. Not on folderHelper ctor path. |
+| `PSAssemblyItemBridge` | `IPSFolderHelper`, `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSResourceAssemblyLocation` | `IPSFolderHelper`, `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSResourceInstanceHelper` | `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSRecyclePathItemService` | `IPSRecycleService` | downstream path item service. Not on folderHelper ctor path. |
+| `PSDesignPathItemService` | `IPSFolderHelper` | downstream path item service. Not on folderHelper ctor path. |
+| `PSPageUtils` | `IPSRecycleService`, `IPSContentItemDao` | downstream utility (static `@Autowired` fields). Not on folderHelper ctor path. |
+| `PSPathService` | `IPSFolderHelper`, `IPSRecycleService` | downstream service. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSDispatchingPathService` | `IPSRecycleService`, `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSRedirectService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSTemplateDao` | `IPSContentItemDao`, `IPSFolderHelper` | downstream DAO. Not on folderHelper ctor path. |
+| `PSEmptyRecycleService` | `IPSFolderHelper` | downstream empty-recycle service. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSSharedRelationshipDeleteListener` | `IPSPageIndexService` | downstream listener. Not on folderHelper ctor path. |
+| `PSSearchService` | `IPSFolderHelper`, `IPSRecycleService` | downstream search service. Not on folderHelper ctor path. |
+| `PSSearchIndexFieldValueModifier` | `IPSFolderHelper` | downstream modifier. Not on folderHelper ctor path. |
+| `PSAssetChangeListener` | `IPSWidgetAssetRelationshipService`, `IPSPageIndexService` | downstream listener. Not on folderHelper ctor path. |
+| `PSSiteContentDao` | `IPSFolderHelper`, `IPSContentItemDao`, `IPSPageDaoHelper`, `IPSRecycleService` | downstream DAO. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSRelationshipSummaryService` | `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSLinkExtractionHelper` | `IPSFolderHelper` | downstream importer helper. Not on folderHelper ctor path. |
+| `PSPageExtractorHelper` | `IPSAssetService` | downstream importer helper. Not on folderHelper ctor path. |
+| `PSCommentsService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSIntegrityCheckerService` | `IPSAssetService` | downstream service. Not on folderHelper ctor path. |
+| `PSRecentService` | `IPSAssetService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteImportLogViewer` | `IPSFolderHelper` (static field) | downstream importer. Not on folderHelper ctor path. |
+| `PSTrafficService` | `IPSFolderHelper` (`final`) | downstream service (ctor-injected). Not on folderHelper ctor path. |
+
+**Conclusion:** Every observed field-injected target type lives on a downstream consumer bean. None of the seven cycle-subgraph beans (`PSFolderHelper`, `PSRecycleService`, `PSWidgetAssetRelationshipService`, `PSAssetDao`, `PSContentItemDao`, `PSPageIndexService`, `PSPageDaoHelper`) carry any `@Autowired` / `@Resource` / `@Inject` field annotation on the target interfaces, nor any public setter that takes a target interface. The cycle subgraph is fully converted to constructor injection, so the existing `@Lazy` parameter breaks remain the only required protection.
+
+>>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 ### Cycle-subgraph intermediates that must NOT construct-require `folderHelper`
 
 These sit on path A/B. Adding a ctor edge to `IPSFolderHelper` would short-circuit the known breaks:
@@ -79,7 +160,7 @@ Class-level `@Lazy` on these beans is **lazy init only** ΓÇö it is **false sa
 |-------|----------------|-------------|
 | `PSPageService` | yes | consumer / hub ΓÇö reverse-edge freeze done (#2514 / `PSPageServiceCycleWiringTest`) |
 | `PSItemWorkflowService` | yes | consumer / hub ΓÇö reverse freeze #2478; cycle-peer **param `@Lazy`** #2515 |
-| `PSSiteDataService` | yes | consumer / hub ΓÇö #2516 |
+| `PSSiteDataService` | yes | consumer / hub — reverse freeze #2516 / `PSSiteDataServiceHubReverseEdgeWiringTest` |
 | `PSAssetService` | yes | consumer; folderHelper param **not** `@Lazy` (pageService param **is** `@Lazy` #2476) |
 | `PSItemService` | no | consumer |
 | `PSSiteContentDao` | yes | consumer (also takes pageDaoHelper ΓÇö not a reverse edge into folderHelper creation) |
@@ -111,7 +192,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
-| 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
+| 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. Reverse-edge freeze: `PSSiteDataServiceHubReverseEdgeWiringTest` (#2516). |
 
 ### Next hottest near-cycle edge (protected ΓÇö #2476)
 
@@ -147,6 +228,29 @@ Behavior review of call sites (safe for lazy proxy):
 | Why apply now | Residual after #2478 reverse-edge freezes: belt-and-braces peer of #2476 so multi-hop eager paths through cycle peers cannot form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
 
 Protection test: `PSItemWorkflowServiceCycleLazyWiringTest` (asserts construct-require + param `@Lazy` on each chosen peer).
+
+### siteDataService hub reverse-edge freeze (protected — #2516)
+
+**`PSSiteDataService` → cycle peers / page-item hubs (constructor + page/path field inject, one-way)** with **no reverse** peer → `IPSSiteDataService` without param/field `@Lazy`.
+
+Forward edges frozen by the UnitTest:
+
+| Direction | Edge | Notes |
+|-----------|------|-------|
+| Ctor forward | siteData → `IPSFolderHelper`, `IPSWidgetAssetRelationshipService`, `IPSAssetDao`, `IPSItemWorkflowService` | Hub model (#2463 rank 6) |
+| Field forward | siteData → `PSPageService` / `PSPathService` (`@Autowired` fields) | Documented; not reverse-cycle fuel |
+| Reverse ban (ctor + non-`@Lazy` field) | cycle peers + page/item hubs must not inject `IPSSiteDataService` | Peers: folderHelper, contentItemDao, widgetAsset, recycle, assetDao, pageDaoHelper, pageService, itemWorkflow, assetService, templateService |
+
+**Scan snapshot (#2516):** none of the reverse-ban peers currently inject `IPSSiteDataService` (ctor or field). **Intentional reverse `@Lazy` exceptions:** none. Downstream consumers (path item services, REST adaptors, publish handlers, traffic/category services) remain allowed — they are not cycle fuel.
+
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on hub | Present but **not** a cycle breaker when an eager consumer forces construction |
+| Param `@Lazy` on reverse edges | **Not needed today** — no live reverse edges; freeze forbids adding them without `@Lazy` |
+| Reverse edge ban | **Hard** — #2516 / `PSSiteDataServiceHubReverseEdgeWiringTest` |
+| Why apply now | Residual after #2463 rank-6 inventory + #2478 pattern: freeze so multi-hop eager paths through cycle peers cannot form a second `BeanCurrentlyInCreationException` via siteData |
+
+Protection test: `PSSiteDataServiceHubReverseEdgeWiringTest` (forward freeze + reverse ctor/field ban; intentional exceptions documented above).
 
 ### assetServiceΓåötemplateService near-cycle (protected ΓÇö #2521)
 
@@ -288,8 +392,13 @@ listed in the original inventory and is out of scope for #2526.
 7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+<<<<<<< HEAD
 10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
 11. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
+=======
+10. ~~Optional next hubs: siteData reverse-edge freeze.~~ **Done (#2516)** — `PSSiteDataServiceHubReverseEdgeWiringTest`. Optional remaining: widgetAsset class `@Lazy` (#2519).
+11. ~~Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).~~ **Done (#2525)** — `PSFolderHelperFieldInjectionInventoryWiringTest`; cycle subgraph is fully ctor-injected, no live reverse field edges.
+>>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
@@ -306,6 +415,11 @@ listed in the original inventory and is out of scope for #2526.
 - #2514 ΓÇö pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
 - #2515 ΓÇö itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
+<<<<<<< HEAD
 - #2526 — emptyRecycle / pathService near-cycle belt-and-braces (`PSEmptyRecycleServiceCycleLazyWiringTest`)
+=======
+- #2525 — folderHelper field / setter injection inventory (`PSFolderHelperFieldInjectionInventoryWiringTest`)  
+- #2516 — siteDataService hub reverse-edge freeze (`PSSiteDataServiceHubReverseEdgeWiringTest`)  
+>>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 
 - #2457 / PR #2469 ΓÇö JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
@@ -154,22 +154,23 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
   }
 
   @Test
-  public void cyclePeersAndPageItemHubsMustNotConstructRequireSiteDataService()
-      throws NoSuchMethodException {
+  public void cyclePeersAndPageItemHubsMustNotConstructRequireSiteDataService() {
     for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
-      Constructor<?> ctor = singlePublicConstructor(peer);
-      Parameter siteData = findParamOfType(ctor, IPSSiteDataService.class);
-      if (siteData == null) {
-        continue; // desired: no reverse ctor edge
+      // Scan all declared constructors so a non-public @Autowired wiring ctor is not missed.
+      for (Constructor<?> ctor : peer.getDeclaredConstructors()) {
+        Parameter siteData = findParamOfType(ctor, IPSSiteDataService.class);
+        if (siteData == null) {
+          continue; // desired: no reverse ctor edge on this ctor
+        }
+        // Intentional exception path: only allowed with parameter @Lazy
+        assertTrue(
+            siteData.isAnnotationPresent(Lazy.class),
+            peer.getSimpleName()
+                + " construct-requires IPSSiteDataService without @Lazy — that closes a reverse"
+                + " cycle with the siteDataService hub (see #2516). Prefer method-level lookup,"
+                + " setter injection, or @Lazy on the injection point; document intentional @Lazy"
+                + " reverse edges in sitemanage-injection-cycle-inventory.md.");
       }
-      // Intentional exception path: only allowed with parameter @Lazy
-      assertTrue(
-          siteData.isAnnotationPresent(Lazy.class),
-          peer.getSimpleName()
-              + " construct-requires IPSSiteDataService without @Lazy — that closes a reverse"
-              + " cycle with the siteDataService hub (see #2516). Prefer method-level lookup,"
-              + " setter injection, or @Lazy on the injection point; document intentional @Lazy"
-              + " reverse edges in sitemanage-injection-cycle-inventory.md.");
     }
   }
 
@@ -189,7 +190,8 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
   public void cyclePeersAndPageItemHubsMustNotEagerFieldInjectSiteDataService() {
     List<String> violations = new ArrayList<>();
     for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
-      for (Field field : peer.getDeclaredFields()) {
+      // Walk hierarchy so inherited reverse edges are not silently skipped (#2516 review).
+      for (Field field : declaredFieldsIncludingInherited(peer)) {
         if (!IPSSiteDataService.class.isAssignableFrom(field.getType())
             && !PSSiteDataService.class.isAssignableFrom(field.getType())) {
           continue;
@@ -239,16 +241,44 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
         "itemWorkflow → siteDataService would reverse siteData→itemWorkflow forward edge");
   }
 
+  /**
+   * Prefer a single {@code @Autowired} declared constructor (Spring wiring ctor), then fall back
+   * to the single public constructor. Avoids missing a non-public wiring ctor when a public
+   * no-arg also exists (#2516 review).
+   */
   private static Constructor<?> singlePublicConstructor(Class<?> type)
       throws NoSuchMethodException {
-    Constructor<?>[] ctors = type.getConstructors();
-    if (ctors.length != 1) {
+    List<Constructor<?>> autowired = new ArrayList<>();
+    for (Constructor<?> ctor : type.getDeclaredConstructors()) {
+      if (ctor.isAnnotationPresent(Autowired.class)) {
+        autowired.add(ctor);
+      }
+    }
+    if (autowired.size() == 1) {
+      return autowired.get(0);
+    }
+    if (autowired.size() > 1) {
       fail(
           type.getSimpleName()
-              + " expected exactly one public constructor for wiring inspection, found "
-              + ctors.length);
+              + " expected at most one @Autowired constructor for wiring inspection, found "
+              + autowired.size());
     }
-    return ctors[0];
+    Constructor<?>[] publicCtors = type.getConstructors();
+    if (publicCtors.length == 1) {
+      return publicCtors[0];
+    }
+    Constructor<?>[] declared = type.getDeclaredConstructors();
+    if (declared.length == 1) {
+      return declared[0];
+    }
+    fail(
+        type.getSimpleName()
+            + " expected exactly one public (or single declared / @Autowired) constructor for"
+            + " wiring inspection, found public="
+            + publicCtors.length
+            + " declared="
+            + declared.length);
+    return null; // unreachable
   }
 
   private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
@@ -260,8 +290,21 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
     return null;
   }
 
+  /** Declared fields on {@code bean} and all superclasses (stops at {@link Object}). */
+  private static List<Field> declaredFieldsIncludingInherited(Class<?> bean) {
+    List<Field> fields = new ArrayList<>();
+    Class<?> current = bean;
+    while (current != null && current != Object.class) {
+      for (Field field : current.getDeclaredFields()) {
+        fields.add(field);
+      }
+      current = current.getSuperclass();
+    }
+    return fields;
+  }
+
   private static boolean hasFieldOfType(Class<?> bean, Class<?> fieldType) {
-    for (Field field : bean.getDeclaredFields()) {
+    for (Field field : declaredFieldsIncludingInherited(bean)) {
       if (fieldType.isAssignableFrom(field.getType())) {
         return true;
       }
@@ -269,19 +312,19 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
     return false;
   }
 
-  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
-      throws NoSuchMethodException {
-    Constructor<?> ctor = singlePublicConstructor(bean);
-    Parameter p = findParamOfType(ctor, forbidden);
-    if (p == null) {
-      return;
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why) {
+    for (Constructor<?> ctor : bean.getDeclaredConstructors()) {
+      Parameter p = findParamOfType(ctor, forbidden);
+      if (p == null) {
+        continue;
+      }
+      assertTrue(
+          p.isAnnotationPresent(Lazy.class),
+          bean.getSimpleName()
+              + " must not construct-require "
+              + forbidden.getSimpleName()
+              + " without @Lazy: "
+              + why);
     }
-    assertTrue(
-        p.isAnnotationPresent(Lazy.class),
-        bean.getSimpleName()
-            + " must not construct-require "
-            + forbidden.getSimpleName()
-            + " without @Lazy: "
-            + why);
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.dao.impl.PSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSAssetService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.impl.PSItemWorkflowService;
+import com.percussion.pagemanagement.dao.impl.PSPageDaoHelper;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pagemanagement.service.impl.PSPageService;
+import com.percussion.pagemanagement.service.impl.PSTemplateService;
+import com.percussion.pathmanagement.service.impl.PSPathService;
+import com.percussion.recycle.service.impl.PSRecycleService;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.dao.impl.PSContentItemDao;
+import com.percussion.share.dao.impl.PSFolderHelper;
+import com.percussion.sitemanage.service.IPSSiteDataService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Protection for the {@link PSSiteDataService} wide sitemanage hub (#2423 residual #2516).
+ *
+ * <p>Static inventory (#2463) ranked {@code PSSiteDataService} as the sixth-hottest sitemanage hub
+ * (ctor out ~15 / in ~12). It is class-{@code @Lazy} and construct-requires known-cycle peers /
+ * page-item hubs:
+ *
+ * <pre>
+ * siteDataService
+ *   → folderHelper
+ *   → widgetAssetRelationshipService
+ *   → assetDao
+ *   → itemWorkflowService
+ *   (+ field: pageService, pathService)
+ * </pre>
+ *
+ * <p>Those peers sit on or next to the known {@code folderHelper → … → contentItemDao →
+ * folderHelper} chain (broken by {@code @Lazy} on {@link PSContentItemDao}). A reverse constructor
+ * (or eager field) edge from any of those peers / page-item hubs back to {@link
+ * IPSSiteDataService} would form a new creation cycle independent of the contentItemDao {@code
+ * @Lazy} break:
+ *
+ * <pre>
+ * folderHelper → recycle → widgetAsset → assetDao → contentItemDao → folderHelper
+ *       ↑______________________ siteDataService _______________________________/
+ * </pre>
+ *
+ * <p>This test freezes the one-way hub edges and forbids reverse ctor / non-{@code @Lazy} field
+ * inject of {@code IPSSiteDataService} on the cycle peers and rank-1/2 page/item hubs. Intentional
+ * reverse edges must use parameter/field {@link Lazy @Lazy} and be documented in the inventory
+ * note.
+ *
+ * <p>Scan snapshot (2026-08-08 / #2516): none of the listed peers currently inject {@code
+ * IPSSiteDataService} (ctor or field). Downstream consumers (path items, REST adaptors, publish
+ * handlers) remain allowed — they are not cycle fuel.
+ *
+ * <p>Peers: {@link
+ * com.percussion.share.dao.impl.PSItemWorkflowServiceHubReverseEdgeWiringTest}, {@code
+ * PSPageServiceCycleWiringTest}, {@code PSContentItemDaoCycleLazyWiringTest}. Inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSSiteDataServiceHubReverseEdgeWiringTest {
+
+  /**
+   * Cycle peers that siteData construct-requires (or that sit on the folderHelper creation path)
+   * plus rank-1/2 page/item hubs that must not reverse-require siteData without {@code @Lazy}.
+   */
+  private static final Class<?>[] CYCLE_PEERS_AND_PAGE_ITEM_HUBS = {
+    PSFolderHelper.class,
+    PSContentItemDao.class,
+    PSWidgetAssetRelationshipService.class,
+    PSRecycleService.class,
+    PSAssetDao.class,
+    PSPageDaoHelper.class,
+    PSPageService.class,
+    PSItemWorkflowService.class,
+    PSAssetService.class,
+    PSTemplateService.class
+  };
+
+  @Test
+  public void siteDataServiceIsClassLevelLazy() {
+    assertTrue(
+        PSSiteDataService.class.isAnnotationPresent(Lazy.class),
+        "PSSiteDataService must carry class-level @Lazy to harden against cycle formation"
+            + " (#2423 residual #2516 / #2463 inventory). Class @Lazy defers the bean until first"
+            + " use; it is not a constructor-cycle breaker once creation starts.");
+  }
+
+  @Test
+  public void siteDataServiceConstructRequiresCyclePeers() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSSiteDataService.class);
+
+    assertNotNull(
+        findParamOfType(ctor, IPSFolderHelper.class),
+        "PSSiteDataService must still construct-require IPSFolderHelper — inventory #2463 / #2516"
+            + " hub model; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSSiteDataService must still construct-require IPSWidgetAssetRelationshipService");
+    assertNotNull(
+        findParamOfType(ctor, IPSAssetDao.class),
+        "PSSiteDataService must still construct-require IPSAssetDao");
+    assertNotNull(
+        findParamOfType(ctor, IPSItemWorkflowService.class),
+        "PSSiteDataService must still construct-require IPSItemWorkflowService");
+  }
+
+  /**
+   * Documented forward field edges (not reverse-cycle fuel): siteData → pageService / pathService.
+   * These are intentional consumer edges from the hub; the reverse (page/path → siteData) is banned
+   * via the peer scan for {@link PSPageService} (path service is not a cycle peer).
+   */
+  @Test
+  public void siteDataServiceFieldInjectsPageAndPathServices() {
+    assertTrue(
+        hasFieldOfType(PSSiteDataService.class, IPSPageService.class)
+            || hasFieldOfType(PSSiteDataService.class, PSPageService.class),
+        "PSSiteDataService should still field-inject pageService (inventory #2463 / #2516); if"
+            + " moved to ctor without @Lazy on a reverse partner, re-scan");
+    assertTrue(
+        hasFieldOfType(PSSiteDataService.class, PSPathService.class),
+        "PSSiteDataService should still field-inject pathService (inventory #2463 / #2516)");
+  }
+
+  @Test
+  public void cyclePeersAndPageItemHubsMustNotConstructRequireSiteDataService()
+      throws NoSuchMethodException {
+    for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
+      Constructor<?> ctor = singlePublicConstructor(peer);
+      Parameter siteData = findParamOfType(ctor, IPSSiteDataService.class);
+      if (siteData == null) {
+        continue; // desired: no reverse ctor edge
+      }
+      // Intentional exception path: only allowed with parameter @Lazy
+      assertTrue(
+          siteData.isAnnotationPresent(Lazy.class),
+          peer.getSimpleName()
+              + " construct-requires IPSSiteDataService without @Lazy — that closes a reverse"
+              + " cycle with the siteDataService hub (see #2516). Prefer method-level lookup,"
+              + " setter injection, or @Lazy on the injection point; document intentional @Lazy"
+              + " reverse edges in sitemanage-injection-cycle-inventory.md.");
+    }
+  }
+
+  /**
+   * Eager {@code @Autowired} field inject of {@link IPSSiteDataService} on a cycle peer / page-item
+   * hub is the same class of reverse edge as a constructor param (class-level {@code @Lazy} on the
+   * peer does not break an eager field edge from a bean already under construction).
+   *
+   * <p>Also flags unannotated fields of that type (legacy XML/setter surfaces) unless marked {@code
+   * @Lazy}.
+   *
+   * <p><strong>Intentional exceptions:</strong> none among {@link #CYCLE_PEERS_AND_PAGE_ITEM_HUBS}
+   * as of #2516. If a peer later needs a reverse edge, add field/param {@code @Lazy} and document
+   * it in the inventory (same pattern as {@code PSAssetService → IPSPageService} for #2476).
+   */
+  @Test
+  public void cyclePeersAndPageItemHubsMustNotEagerFieldInjectSiteDataService() {
+    List<String> violations = new ArrayList<>();
+    for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
+      for (Field field : peer.getDeclaredFields()) {
+        if (!IPSSiteDataService.class.isAssignableFrom(field.getType())
+            && !PSSiteDataService.class.isAssignableFrom(field.getType())) {
+          continue;
+        }
+        if (field.isAnnotationPresent(Lazy.class)) {
+          continue; // documented intentional reverse edge
+        }
+        boolean autowired = field.isAnnotationPresent(Autowired.class);
+        violations.add(
+            peer.getSimpleName()
+                + "."
+                + field.getName()
+                + (autowired ? " (@Autowired)" : " (field type)")
+                + " — reverse field edge without @Lazy");
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Cycle peers / page-item hubs must not eagerly field-inject IPSSiteDataService (use @Lazy"
+            + " or remove the edge). Violations: "
+            + String.join("; ", violations));
+  }
+
+  @Test
+  public void contentItemDaoStillHasNoSiteDataConstructorEdge() throws NoSuchMethodException {
+    // Explicit named assertion for the known-cycle break peer (contentItemDao is the @Lazy site)
+    assertNoEagerCtorParam(
+        PSContentItemDao.class,
+        IPSSiteDataService.class,
+        "contentItemDao → siteDataService would couple the cycle-break peer to the hub");
+  }
+
+  @Test
+  public void pageServiceStillHasNoSiteDataConstructorEdge() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSPageService.class,
+        IPSSiteDataService.class,
+        "pageService → siteDataService would reverse siteData→page field edge and form a hub↔hub"
+            + " cycle");
+  }
+
+  @Test
+  public void itemWorkflowStillHasNoSiteDataConstructorEdge() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSItemWorkflowService.class,
+        IPSSiteDataService.class,
+        "itemWorkflow → siteDataService would reverse siteData→itemWorkflow forward edge");
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  private static boolean hasFieldOfType(Class<?> bean, Class<?> fieldType) {
+    for (Field field : bean.getDeclaredFields()) {
+      if (fieldType.isAssignableFrom(field.getType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    if (p == null) {
+      return;
+    }
+    assertTrue(
+        p.isAnnotationPresent(Lazy.class),
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + " without @Lazy: "
+            + why);
+  }
+}


### PR DESCRIPTION
## Summary

Completes **#2516** (parent epic **#2423** residual) for the rank-6 sitemanage hub `PSSiteDataService`.

Same PR-sized freeze pattern as #2478 / #2514:

- **Ctor reverse ban** on cycle peers / page-item hubs (`PSFolderHelper`, `PSContentItemDao`, `PSWidgetAssetRelationshipService`, `PSRecycleService`, `PSAssetDao`, `PSPageDaoHelper`, `PSPageService`, `PSItemWorkflowService`, `PSAssetService`, `PSTemplateService`) unless param `@Lazy`
- **Field reverse ban** (non-`@Lazy` field inject of `IPSSiteDataService` / `PSSiteDataService` on those peers)
- **Forward-edge positive assertions**: siteData still construct-requires folderHelper, widgetAsset, assetDao, itemWorkflow; class `@Lazy`; field injects page/path
- **Intentional `@Lazy` reverse exceptions**: none (scan found no live reverse edges among peers)
- Inventory note (#2463) updated with siteData reverse-edge disposition table; residual item 10 marked done

## Parent tracker

- Parent: #2423
- Fixes #2516

## Test plan / gates

- [x] `cd projects/sitemanage && ../../mvnw.cmd test -Dtest=PSSiteDataServiceHubReverseEdgeWiringTest` — **Tests run: 8, Failures: 0**
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS** — Tests run: **778**, Failures: **0**, Errors: **0**, Skipped: 128
- [x] No new warnings attributable to this change (baseline dependency/javadoc warnings only)
- [x] Erlang-style self-review: pure freeze + inventory; portable paths N/A; companions: inventory + UnitTest peer of #2478; Intersoft 2026 copyright on new test

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
