### PR TITLE
fix(docker): SHA-256 sitemanage content compare in qa-preflight (#2532)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -54,12 +54,12 @@ perc-devctl.py inspect-install
 perc-devctl.py show-generated-passwords
 # QA mode — H2-in-Docker CMS for Playwright (no host install) — #1827 / #1927
 perc-devctl.py qa-up [--timeout-seconds N] [--skip-image-build]
-perc-devctl.py qa-preflight [--strict]
+perc-devctl.py qa-preflight [--strict] [--no-content-hash]
 perc-devctl.py qa-health [--timeout-seconds N] [--interval-seconds N] [--url URL]
 perc-devctl.py qa-down [--container NAME]
 ```
 
-#### Rebuild-chain preflight (#2486)
+#### Rebuild-chain preflight (#2486 / #2532)
 
 `perc-devctl.py qa-preflight [--strict]` (or the standalone `python3 docker/scripts/qa_preflight.py`) detects a **stale WebUI WAR** vs a freshly built sitemanage SNAPSHOT **before** `qa-up`. Without this gate, re-running only `sitemanage → install` and then `qa-up` leaves the old `sitemanage-*.jar` bundled inside the `perc-web-ui-*.war` (which `perc-distribution-tree` unpacks into `Rhythmyx/WEB-INF/lib`). The container then loads the stale classpath and the cycle / DI fix appears to regress even though the m2 snapshot is correct.
 
@@ -67,14 +67,29 @@ The preflight compares:
 
 - `~/.m2/repository/com/percussion/sitemanage/sitemanage-*.jar` — the freshly installed snapshot, and
 - `WebUI/target/perc-web-ui-*.war` — the WAR whose `WEB-INF/lib/sitemanage-*.jar` the dist tree will unpack.
+- Optionally a loose `sitemanage-*.jar` under `modules/perc-distribution-tree/target` when present.
 
-If the WAR was built **before** the m2 jar was last installed (or the WAR / WAR-side jar is missing), it prints `STALE:` plus the file paths and mtimes and (with `--strict`) returns exit code `2`. Without `--strict` it prints the same line and returns `0` so callers can log without blocking.
+**Content-hash mode (default, #2532):** SHA-256 of the m2 jar bytes is compared to the `WEB-INF/lib/sitemanage-*.jar` zip entry inside the WAR (streamed; no full WAR extract). When both hashes are available they are the **primary** signal:
+
+- Hashes differ → `STALE: sitemanage content hash mismatch (m2 vs war)` even if mtimes look fresh (clock skew, cache restore, `touch`-only rebuilds).
+- Hashes match → `FRESH` even if WAR mtime is older than m2 (mtime false positive).
+- Hashes unavailable → fall back to WAR mtime vs m2 mtime (legacy #2486 behaviour).
+
+Use `--no-content-hash` for mtime-only comparison. With `--strict`, STALE returns exit code `2`; without `--strict` it prints the same line and returns `0` so callers can log without blocking.
 
 Run order recommended for agents and CI:
 
 ```bash
 python3 docker/scripts/perc-devctl.py qa-preflight --strict \
   && python3 docker/scripts/perc-devctl.py qa-up
+```
+
+Standalone (same flags):
+
+```bash
+python3 docker/scripts/qa_preflight.py --strict --repo-root .
+# mtime-only fallback:
+python3 docker/scripts/qa_preflight.py --strict --no-content-hash
 ```
 
 Each subcommand writes full output to a timestamped file under `docker/logs/<label>-<ts>.log` and emits a single `RESULT:OK STEP:<label> LOG:<path>` (or `RESULT:FAIL`) line on stdout so agent workflows can parse the result without parsing free-form output.

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -403,17 +403,22 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     pqu.add_argument("--dry-run", action="store_true")
 
-    # --- Rebuild-chain preflight — #2486 ---
+    # --- Rebuild-chain preflight — #2486 / #2532 ---
     pqp = sub.add_parser(
         "qa-preflight",
         help=(
             "Detect a stale WebUI WAR vs a freshly built sitemanage "
-            "SNAPSHOT before qa-up (#2486). Exits non-zero in --strict "
-            "mode when stale; otherwise prints the STALE: line and "
-            "returns OK."
+            "SNAPSHOT before qa-up (#2486 / #2532). Default content-hash "
+            "(SHA-256 m2 jar vs WAR zip entry); --no-content-hash for "
+            "mtime-only. Exits non-zero in --strict mode when stale."
         ),
     )
     pqp.add_argument("--strict", action="store_true")
+    pqp.add_argument(
+        "--no-content-hash",
+        action="store_true",
+        help="Mtime-only comparison (disable default SHA-256 content hash).",
+    )
     pqp.add_argument("--dry-run", action="store_true")
 
     pqh = sub.add_parser(
@@ -1470,12 +1475,14 @@ def cmd_qa_down(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int
 def cmd_qa_preflight(
     args: argparse.Namespace, paths: tuple[Path, Path, Path]
 ) -> int:
-    """Run the rebuild-chain preflight (#2486).
+    """Run the rebuild-chain preflight (#2486 / #2532).
 
     Detects a stale WebUI WAR vs a freshly built sitemanage SNAPSHOT
     so the operator / agent does not launch a container that
     silently ships an outdated ``sitemanage-*.jar`` inside the WAR.
-    Delegates to ``docker/scripts/qa_preflight.py``.
+    Default uses SHA-256 content hash (mtime-resistant); pass
+    ``--no-content-hash`` for legacy mtime-only. Delegates to
+    ``docker/scripts/qa_preflight.py``.
     """
     import qa_preflight
 
@@ -1486,13 +1493,14 @@ def cmd_qa_preflight(
         print("RESULT:OK STEP:qa-preflight LOG:")
         print("PREFLIGHT: dry-run — skipping filesystem checks")
         return EXIT_OK
-    rc = qa_preflight.main(
-        [
-            "--repo-root", str(repo_root),
-            "--log-file", str(log_file),
-            "--strict" if args.strict else "--no-strict",
-        ]
-    )
+    argv = [
+        "--repo-root", str(repo_root),
+        "--log-file", str(log_file),
+        "--strict" if args.strict else "--no-strict",
+    ]
+    if getattr(args, "no_content_hash", False):
+        argv.append("--no-content-hash")
+    rc = qa_preflight.main(argv)
     # Mirror the rest of perc-devctl: emit a single RESULT line for agents.
     if rc == 0:
         print(f"RESULT:OK STEP:qa-preflight LOG:{log_file}")

--- a/docker/scripts/qa_preflight.py
+++ b/docker/scripts/qa_preflight.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """QA preflight: detect a stale WebUI WAR in the dist tree vs the freshly
-built sitemanage SNAPSHOT (#2486).
+built sitemanage SNAPSHOT (#2486 / #2532).
 
 When a developer / CI pipeline rebuilds sitemanage without re-packaging
 perc-distribution-tree, the unpack step copies a **stale**
@@ -19,9 +19,17 @@ The preflight compares:
 * the ``sitemanage-*.jar`` inside the **WebUI WAR** that the dist
   tree will unpack into the container.
 
-If the WAR-side jar is older than (or missing) the m2-side jar, the
-preflight prints a clear, single-line ``STALE:`` summary so the agent
-or human running ``perc-devctl qa-up`` can fix the chain before the
+**Content-hash mode (default, #2532):** SHA-256 of the m2 jar bytes vs
+the ``WEB-INF/lib/sitemanage-*.jar`` zip entry inside the WAR. This is
+mtime-resistant: clock skew, restore-from-cache, and ``touch``-only
+rebuilds no longer produce false FRESH / false STALE. When both hashes
+are available they are the primary signal; mtime is the fallback when
+hashing is unavailable. Optional dist-tree jar is compared the same way
+when present.
+
+If the WAR-side jar content differs from (or is missing vs) the m2-side
+jar, the preflight prints a clear, single-line ``STALE:`` summary so the
+agent or human running ``perc-devctl qa-up`` can fix the chain before the
 container starts. Exit code is ``0`` when fresh, ``2`` when stale
 (strict). A non-strict mode (``--no-strict``) only prints the
 ``STALE:`` line and returns ``0`` so callers can log without blocking.
@@ -34,10 +42,12 @@ run ``python3 docker/scripts/qa_preflight.py`` (or
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
 import os
 import re
 import sys
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
@@ -54,6 +64,8 @@ _SITEMANAGE_JAR_PATTERN = re.compile(
 _WEBUI_WAR_PATTERN = re.compile(
     r"^perc-web-ui-.*\.war$"
 )
+# Chunk size for streaming SHA-256 over jar / zip entry bytes.
+_HASH_CHUNK = 1024 * 1024
 
 LOG = logging.getLogger("qa_preflight")
 
@@ -62,9 +74,10 @@ LOG = logging.getLogger("qa_preflight")
 class PreflightResult:
     """One row in the preflight report."""
 
-    label: str  # "m2:sitemanage" / "war:sitemanage" / "war:webui"
+    label: str  # "m2:sitemanage" / "war:sitemanage" / "war:webui" / "dist:sitemanage"
     path: Optional[Path]
     mtime: Optional[float]  # seconds since epoch; None when missing
+    sha256: Optional[str] = None  # hex digest; None when missing or not computed
 
     def is_present(self) -> bool:
         return self.path is not None and self.mtime is not None
@@ -99,6 +112,31 @@ def find_webui_war(repo_root: Path) -> Optional[Path]:
     return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
+def find_sitemanage_in_dist(repo_root: Path) -> Optional[Path]:
+    """Locate an optional loose ``sitemanage-*.jar`` under the dist tree.
+
+    Looks under ``modules/perc-distribution-tree/target`` for a jar whose
+    name matches ``sitemanage-*.jar`` (depth-limited walk). Missing dist
+    layout is normal for many developer trees — return ``None`` and skip
+    the optional dist row.
+    """
+    target = repo_root / "modules" / "perc-distribution-tree" / "target"
+    if not target.is_dir():
+        return None
+    candidates: list[Path] = []
+    # Depth-limited walk via Path.rglob is fine for target trees; filter
+    # by name pattern only (portable Path, no hardcoded separators).
+    try:
+        for p in target.rglob("sitemanage-*.jar"):
+            if p.is_file() and _SITEMANAGE_JAR_PATTERN.match(p.name):
+                candidates.append(p)
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
 def war_bundles_sitemanage(war_path: Path) -> bool:
     """Return ``True`` when the WAR contains a ``sitemanage-*.jar`` entry.
 
@@ -106,21 +144,83 @@ def war_bundles_sitemanage(war_path: Path) -> bool:
     preflight stays filesystem-only and never touches a multi-GB
     extract cache. A bundled ``sitemanage-*.jar`` is the explicit
     signal that the dist tree will unpack a stale sitemanage into the
-    Rhythmyx webapp; the freshness comparison then keys off the WAR
-    file mtime (when the WAR was built) vs the m2 jar mtime (when
-    sitemanage was last installed). If the m2 jar was updated after the
-    WAR was built, the WAR's bundled copy is by definition stale.
+    Rhythmyx webapp.
     """
-    if war_path is None or not war_path.is_file():
-        return False
-    import zipfile
+    return find_sitemanage_zip_entry(war_path) is not None
 
-    with zipfile.ZipFile(war_path, "r") as zf:
-        for name in zf.namelist():
-            base = name.rsplit("/", 1)[-1]
-            if base.startswith(_M2_ARTIFACT + "-") and base.endswith(".jar"):
-                return True
-    return False
+
+def find_sitemanage_zip_entry(archive_path: Optional[Path]) -> Optional[str]:
+    """Return the zip entry name of ``sitemanage-*.jar`` inside a WAR/zip.
+
+    Prefers ``WEB-INF/lib/sitemanage-*.jar`` when present; otherwise the
+    first matching ``sitemanage-*.jar`` basenamed entry. Zip entry paths
+    always use ``/`` (ZIP format), independent of OS separators.
+    """
+    if archive_path is None or not archive_path.is_file():
+        return None
+    try:
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            lib_hits: list[str] = []
+            other_hits: list[str] = []
+            for name in zf.namelist():
+                base = name.rsplit("/", 1)[-1]
+                if not (base.startswith(_M2_ARTIFACT + "-") and base.endswith(".jar")):
+                    continue
+                # Prefer WEB-INF/lib/… (product layout)
+                if "/WEB-INF/lib/" in ("/" + name.replace("\\", "/")) or name.startswith(
+                    "WEB-INF/lib/"
+                ):
+                    lib_hits.append(name)
+                else:
+                    other_hits.append(name)
+            if lib_hits:
+                return sorted(lib_hits)[0]
+            if other_hits:
+                return sorted(other_hits)[0]
+    except (OSError, zipfile.BadZipFile):
+        return None
+    return None
+
+
+def sha256_file(path: Optional[Path]) -> Optional[str]:
+    """Stream SHA-256 hex digest of a file; ``None`` when missing/unreadable."""
+    if path is None or not path.is_file():
+        return None
+    try:
+        h = hashlib.sha256()
+        with path.open("rb") as fh:
+            while True:
+                chunk = fh.read(_HASH_CHUNK)
+                if not chunk:
+                    break
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def sha256_zip_entry(archive_path: Optional[Path], entry_name: Optional[str]) -> Optional[str]:
+    """Stream SHA-256 of one zip entry without extracting to disk."""
+    if archive_path is None or entry_name is None or not archive_path.is_file():
+        return None
+    try:
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            h = hashlib.sha256()
+            with zf.open(entry_name, "r") as entry:
+                while True:
+                    chunk = entry.read(_HASH_CHUNK)
+                    if not chunk:
+                        break
+                    h.update(chunk)
+            return h.hexdigest()
+    except (OSError, KeyError, zipfile.BadZipFile):
+        return None
+
+
+def sha256_sitemanage_in_war(war_path: Optional[Path]) -> Optional[str]:
+    """SHA-256 of the bundled ``sitemanage-*.jar`` entry inside a WAR."""
+    entry = find_sitemanage_zip_entry(war_path)
+    return sha256_zip_entry(war_path, entry)
 
 
 def _mtime(path: Optional[Path]) -> Optional[float]:
@@ -129,45 +229,114 @@ def _mtime(path: Optional[Path]) -> Optional[float]:
     return path.stat().st_mtime
 
 
-def run_preflight(repo_root: Path, m2_root: Path) -> list[PreflightResult]:
+def run_preflight(
+    repo_root: Path,
+    m2_root: Path,
+    *,
+    content_hash: bool = True,
+) -> list[PreflightResult]:
     """Compute the preflight rows; never raises.
 
     Missing artifacts are reported as ``is_present() == False`` rather
     than as exceptions so the caller can render a single summary line
     and decide on exit code based on the strict / non-strict policy.
 
-    The "war:sitemanage" row reports the WAR file mtime, not an
-    extracted jar mtime. The preflight keys off the WAR's build time
-    vs the m2 jar's install time — see {@link is_stale} for the
-    rationale.
+    When ``content_hash`` is True (default), each present jar/war-entry
+    row carries a ``sha256`` hex digest for content comparison.
     """
     m2_jar = find_sitemanage_in_m2(m2_root)
     webui_war = find_webui_war(repo_root)
-    war_bundles = war_bundles_sitemanage(webui_war) if webui_war else False
+    war_entry = find_sitemanage_zip_entry(webui_war) if webui_war else None
+    war_bundles = war_entry is not None
+    dist_jar = find_sitemanage_in_dist(repo_root)
 
-    return [
-        PreflightResult("m2:sitemanage", m2_jar, _mtime(m2_jar)),
-        PreflightResult("war:webui", webui_war, _mtime(webui_war)),
+    m2_sha = sha256_file(m2_jar) if content_hash else None
+    war_sha = (
+        sha256_zip_entry(webui_war, war_entry)
+        if content_hash and war_bundles
+        else None
+    )
+    dist_sha = sha256_file(dist_jar) if content_hash else None
+
+    rows = [
+        PreflightResult("m2:sitemanage", m2_jar, _mtime(m2_jar), m2_sha),
+        PreflightResult("war:webui", webui_war, _mtime(webui_war), None),
         # ``war:sitemanage`` is a derived row: present iff the WAR
         # bundles a sitemanage jar; its mtime mirrors the WAR file so
-        # the comparison below is "WAR built before m2 was updated".
+        # the mtime fallback is "WAR built before m2 was updated".
         PreflightResult(
             "war:sitemanage",
             webui_war if war_bundles else None,
             _mtime(webui_war) if war_bundles else None,
+            war_sha,
         ),
     ]
+    # Optional dist row — only include when a loose dist jar exists so
+    # reports stay short for the common "no dist target" case.
+    if dist_jar is not None:
+        rows.append(
+            PreflightResult(
+                "dist:sitemanage",
+                dist_jar,
+                _mtime(dist_jar),
+                dist_sha,
+            )
+        )
+    return rows
 
 
-def is_stale(rows: Iterable[PreflightResult]) -> bool:
-    """Return ``True`` when the WAR was built before the m2 sitemanage jar
-    was last installed, or when the WAR / m2 jar is missing entirely.
+def _hash_pair(
+    rows: Iterable[PreflightResult], left: str, right: str
+) -> tuple[Optional[str], Optional[str]]:
+    by_label = {r.label: r for r in rows}
+    a = by_label.get(left)
+    b = by_label.get(right)
+    return (
+        a.sha256 if a is not None else None,
+        b.sha256 if b is not None else None,
+    )
+
+
+def content_hash_mismatch(rows: Iterable[PreflightResult]) -> Optional[str]:
+    """Return a short mismatch label when content hashes disagree.
+
+    Checks m2 vs WAR first (primary acceptance for #2532), then m2 vs
+    optional dist. Returns ``None`` when hashes match or are unavailable.
+    """
+    row_list = list(rows)
+    m2_h, war_h = _hash_pair(row_list, "m2:sitemanage", "war:sitemanage")
+    if m2_h is not None and war_h is not None and m2_h != war_h:
+        return "m2-vs-war"
+    m2_h, dist_h = _hash_pair(row_list, "m2:sitemanage", "dist:sitemanage")
+    if m2_h is not None and dist_h is not None and m2_h != dist_h:
+        return "m2-vs-dist"
+    return None
+
+
+def content_hashes_agree(rows: Iterable[PreflightResult]) -> bool:
+    """True when m2 and war hashes are both present and equal."""
+    m2_h, war_h = _hash_pair(list(rows), "m2:sitemanage", "war:sitemanage")
+    return m2_h is not None and war_h is not None and m2_h == war_h
+
+
+def is_stale(rows: Iterable[PreflightResult], *, content_hash: bool = True) -> bool:
+    """Return ``True`` when the WAR-side sitemanage is stale vs m2.
 
     Missing m2-side jar is **not** considered stale (the developer may
     not have built sitemanage yet); the preflight prints a ``NOTE:``
     line so the operator knows the check was a no-op.
+
+    When ``content_hash`` is True and both m2 + war hashes are available
+    they are the **primary** signal (mtime-resistant, #2532):
+
+    * hashes differ → STALE
+    * hashes match → FRESH (even if mtimes look inverted)
+
+    When hashes are unavailable, fall back to WAR mtime vs m2 mtime.
+    Missing WAR / missing bundled sitemanage still counts as STALE.
     """
-    by_label = {r.label: r for r in rows}
+    row_list = list(rows)
+    by_label = {r.label: r for r in row_list}
     m2 = by_label.get("m2:sitemanage")
     war = by_label.get("war:sitemanage")
     war_war = by_label.get("war:webui")
@@ -177,26 +346,57 @@ def is_stale(rows: Iterable[PreflightResult]) -> bool:
         return True  # no WAR at all → qa-up will fail anyway
     if war is None or not war.is_present():
         return True  # WAR present but does not bundle sitemanage → cannot preflight
+
+    if content_hash:
+        mismatch = content_hash_mismatch(row_list)
+        if mismatch is not None:
+            return True
+        if content_hashes_agree(row_list):
+            # Content matches — also require optional dist match if present
+            # (content_hash_mismatch already caught dist mismatch above).
+            return False
+        # Hashes unavailable on one side — fall through to mtime.
+
     return war.mtime < m2.mtime  # type: ignore[operator]
 
 
-def format_report(rows: Iterable[PreflightResult], strict: bool) -> str:
+def format_report(
+    rows: Iterable[PreflightResult],
+    strict: bool,
+    *,
+    content_hash: bool = True,
+) -> str:
     """Render the preflight rows as a single-line summary plus detail."""
-    by_label = {r.label: r for r in rows}
-    stale = is_stale(rows)
+    row_list = list(rows)
+    by_label = {r.label: r for r in row_list}
+    stale = is_stale(row_list, content_hash=content_hash)
     m2 = by_label.get("m2:sitemanage")
-    war = by_label.get("war:sitemanage")
-    war_war = by_label.get("war:webui")
 
     if m2 is None or not m2.is_present():
         note = "NOTE: no sitemanage jar in m2 — build sitemanage first; check skipped"
     elif stale:
-        note = (
-            "STALE: war:sitemanage is older than m2:sitemanage — "
-            "repackage perc-distribution-tree (or run mvn install on the WebUI module)"
-        )
+        mismatch = content_hash_mismatch(row_list) if content_hash else None
+        if mismatch == "m2-vs-war":
+            note = (
+                "STALE: sitemanage content hash mismatch (m2 vs war) — "
+                "repackage WebUI / perc-distribution-tree "
+                "(hashes differ even if mtimes look fresh)"
+            )
+        elif mismatch == "m2-vs-dist":
+            note = (
+                "STALE: sitemanage content hash mismatch (m2 vs dist) — "
+                "repackage perc-distribution-tree"
+            )
+        else:
+            note = (
+                "STALE: war:sitemanage is older than m2:sitemanage — "
+                "repackage perc-distribution-tree (or run mvn install on the WebUI module)"
+            )
     else:
-        note = "FRESH: war:sitemanage >= m2:sitemanage"
+        if content_hash and content_hashes_agree(row_list):
+            note = "FRESH: m2 and war sitemanage content hashes match"
+        else:
+            note = "FRESH: war:sitemanage >= m2:sitemanage"
 
     parts = [
         f"PREFLIGHT: {note}",
@@ -204,6 +404,9 @@ def format_report(rows: Iterable[PreflightResult], strict: bool) -> str:
         f"  war:webui       = {_render(by_label.get('war:webui'))}",
         f"  war:sitemanage  = {_render(by_label.get('war:sitemanage'))}",
     ]
+    dist = by_label.get("dist:sitemanage")
+    if dist is not None:
+        parts.append(f"  dist:sitemanage = {_render(dist)}")
     if not strict and stale:
         parts.append("  (non-strict mode: returning OK; qa-up will likely use a stale jar)")
     return "\n".join(parts)
@@ -212,7 +415,8 @@ def format_report(rows: Iterable[PreflightResult], strict: bool) -> str:
 def _render(row: Optional[PreflightResult]) -> str:
     if row is None or not row.is_present():
         return "<missing>"
-    return f"{row.path}  mtime={row.mtime:.0f}"
+    sha = f"  sha256={row.sha256[:12]}…" if row.sha256 else ""
+    return f"{row.path}  mtime={row.mtime:.0f}{sha}"
 
 
 def _default_m2_root() -> Path:
@@ -228,7 +432,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         prog="qa-preflight",
         description=(
             "Detect a stale WebUI WAR vs a freshly built sitemanage "
-            "SNAPSHOT before running perc-devctl qa-up (#2486)."
+            "SNAPSHOT before running perc-devctl qa-up (#2486 / #2532)."
         ),
     )
     parser.add_argument(
@@ -243,11 +447,37 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=_default_m2_root(),
         help="Maven local repository root (default: ~/.m2/repository).",
     )
-    parser.add_argument(
+    strict_group = parser.add_mutually_exclusive_group()
+    strict_group.add_argument(
         "--strict",
+        dest="strict",
         action="store_true",
-        help="Exit non-zero when stale (default: exit 0, print STALE: line).",
+        help="Exit non-zero when stale.",
     )
+    strict_group.add_argument(
+        "--no-strict",
+        dest="strict",
+        action="store_false",
+        help="Print STALE: but exit 0 (default).",
+    )
+    parser.set_defaults(strict=False)
+    hash_group = parser.add_mutually_exclusive_group()
+    hash_group.add_argument(
+        "--content-hash",
+        dest="content_hash",
+        action="store_true",
+        help=(
+            "Compare SHA-256 of m2 sitemanage jar vs WAR zip entry "
+            "(default; mtime-resistant, #2532)."
+        ),
+    )
+    hash_group.add_argument(
+        "--no-content-hash",
+        dest="content_hash",
+        action="store_false",
+        help="Mtime-only comparison (legacy #2486 behaviour).",
+    )
+    parser.set_defaults(content_hash=True)
     parser.add_argument(
         "--log-file",
         type=Path,
@@ -266,9 +496,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
 
-    rows = run_preflight(args.repo_root, args.m2_root)
-    stale = is_stale(rows)
-    report = format_report(rows, strict=args.strict)
+    rows = run_preflight(
+        args.repo_root, args.m2_root, content_hash=args.content_hash
+    )
+    stale = is_stale(rows, content_hash=args.content_hash)
+    report = format_report(rows, strict=args.strict, content_hash=args.content_hash)
     print(report)
     if args.log_file is not None:
         args.log_file.parent.mkdir(parents=True, exist_ok=True)

--- a/docker/scripts/test_qa_preflight.py
+++ b/docker/scripts/test_qa_preflight.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Unit tests for docker/scripts/qa_preflight.py (#2486).
+"""Unit tests for docker/scripts/qa_preflight.py (#2486 / #2532).
 
 Filesystem-only: builds a synthetic repo + m2 layout in a tempdir and
-exercises the preflight without docker, maven, or curl.
+exercises the preflight without docker, maven, or curl. Includes
+SHA-256 content-hash cases with synthetic WAR/m2 bytes (#2532).
 """
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import io
 import os
@@ -28,17 +30,39 @@ assert _spec.loader is not None
 sys.modules["qa_preflight"] = qa_preflight
 _spec.loader.exec_module(qa_preflight)
 
+# Shared synthetic jar payloads for content-hash tests.
+_BYTES_A = b"sitemanage-jar-payload-A-v1"
+_BYTES_B = b"sitemanage-jar-payload-B-v2-different"
 
-def _touch(path: Path, mtime: float) -> None:
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_jar(path: Path, data: bytes, mtime: float) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(b"")
+    path.write_bytes(data)
     os.utime(path, (mtime, mtime))
 
 
-def _make_war(war_path: Path, *, sitemanage_jar_name: str = "sitemanage-1.0.0.jar") -> None:
+def _touch(path: Path, mtime: float) -> None:
+    """Legacy empty-file helper used by mtime-only tests."""
+    _write_jar(path, b"", mtime)
+
+
+def _make_war(
+    war_path: Path,
+    *,
+    sitemanage_jar_name: str = "sitemanage-1.0.0.jar",
+    sitemanage_bytes: bytes = b"PK fake",
+    mtime: float | None = None,
+) -> None:
     war_path.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(war_path, "w") as zf:
-        zf.writestr("WEB-INF/lib/" + sitemanage_jar_name, b"PK fake")
+        # ZIP entry paths always use '/' regardless of OS.
+        zf.writestr("WEB-INF/lib/" + sitemanage_jar_name, sitemanage_bytes)
+    if mtime is not None:
+        os.utime(war_path, (mtime, mtime))
 
 
 class _Repo:
@@ -66,27 +90,51 @@ class TestPreflightFresh(unittest.TestCase):
         self.repo = self.repo_helper.layout_repo()
         self.m2 = self.repo_helper.layout_m2()
 
-    def test_fresh_when_war_at_or_after_m2(self):
-        # m2 jar older than WAR's mtime → FRESH (WAR was built after m2 install)
+    def test_fresh_when_war_at_or_after_m2_mtime_only(self):
+        # m2 jar older than WAR's mtime → FRESH under mtime-only mode
         _touch(self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar", 200)
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar")
-        os.utime(war_path, (300, 300))
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=300)
 
-        rows = qa_preflight.run_preflight(self.repo, self.m2)
-        self.assertFalse(qa_preflight.is_stale(rows))
-        report = qa_preflight.format_report(rows, strict=True)
+        rows = qa_preflight.run_preflight(
+            self.repo, self.m2, content_hash=False
+        )
+        self.assertFalse(qa_preflight.is_stale(rows, content_hash=False))
+        report = qa_preflight.format_report(rows, strict=True, content_hash=False)
         self.assertIn("FRESH", report)
 
-    def test_fresh_when_war_exactly_at_m2(self):
+    def test_fresh_when_war_exactly_at_m2_mtime_only(self):
         same = 200
         _touch(self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar", same)
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar")
-        os.utime(war_path, (same, same))
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=same)
 
-        rows = qa_preflight.run_preflight(self.repo, self.m2)
-        self.assertFalse(qa_preflight.is_stale(rows))
+        rows = qa_preflight.run_preflight(
+            self.repo, self.m2, content_hash=False
+        )
+        self.assertFalse(qa_preflight.is_stale(rows, content_hash=False))
+
+    def test_fresh_when_content_hashes_match_despite_mtime_skew(self):
+        # WAR mtime older than m2 → would be mtime-STALE, but identical
+        # bytes → content-hash FRESH (#2532 mtime-resistant).
+        _write_jar(
+            self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar",
+            _BYTES_A,
+            500,
+        )
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(
+            war_path,
+            sitemanage_jar_name="sitemanage-8.2.0-SNAPSHOT.jar",
+            sitemanage_bytes=_BYTES_A,
+            mtime=100,
+        )
+
+        rows = qa_preflight.run_preflight(self.repo, self.m2, content_hash=True)
+        self.assertFalse(qa_preflight.is_stale(rows, content_hash=True))
+        report = qa_preflight.format_report(rows, strict=True, content_hash=True)
+        self.assertIn("FRESH", report)
+        self.assertIn("content hashes match", report)
 
 
 class TestPreflightStale(unittest.TestCase):
@@ -96,22 +144,22 @@ class TestPreflightStale(unittest.TestCase):
         self.repo = self.repo_helper.layout_repo()
         self.m2 = self.repo_helper.layout_m2()
 
-    def test_stale_when_war_built_before_m2_update(self):
+    def test_stale_when_war_built_before_m2_update_mtime_only(self):
         _touch(self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar", 300)
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar")
-        os.utime(war_path, (250, 250))
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=250)
 
-        rows = qa_preflight.run_preflight(self.repo, self.m2)
-        self.assertTrue(qa_preflight.is_stale(rows))
-        report = qa_preflight.format_report(rows, strict=True)
+        rows = qa_preflight.run_preflight(
+            self.repo, self.m2, content_hash=False
+        )
+        self.assertTrue(qa_preflight.is_stale(rows, content_hash=False))
+        report = qa_preflight.format_report(rows, strict=True, content_hash=False)
         self.assertIn("STALE", report)
 
     def test_strict_returns_nonzero_when_stale(self):
         _touch(self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar", 300)
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar")
-        os.utime(war_path, (250, 250))
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=250)
 
         buf = io.StringIO()
         with redirect_stdout(buf):
@@ -119,6 +167,7 @@ class TestPreflightStale(unittest.TestCase):
                 "--repo-root", str(self.repo),
                 "--m2-root", str(self.m2),
                 "--strict",
+                "--no-content-hash",
             ])
         self.assertEqual(rc, 2)
         self.assertIn("STALE", buf.getvalue())
@@ -126,14 +175,31 @@ class TestPreflightStale(unittest.TestCase):
     def test_non_strict_returns_zero_when_stale(self):
         _touch(self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar", 300)
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar")
-        os.utime(war_path, (250, 250))
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=250)
 
         buf = io.StringIO()
         with redirect_stdout(buf):
             rc = qa_preflight.main([
                 "--repo-root", str(self.repo),
                 "--m2-root", str(self.m2),
+                "--no-content-hash",
+            ])
+        self.assertEqual(rc, 0)
+        self.assertIn("STALE", buf.getvalue())
+
+    def test_no_strict_flag_accepted(self):
+        """perc-devctl passes --no-strict; argparse must accept it."""
+        _touch(self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar", 300)
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=250)
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_preflight.main([
+                "--repo-root", str(self.repo),
+                "--m2-root", str(self.m2),
+                "--no-strict",
+                "--no-content-hash",
             ])
         self.assertEqual(rc, 0)
         self.assertIn("STALE", buf.getvalue())
@@ -148,14 +214,181 @@ class TestPreflightStale(unittest.TestCase):
     def test_stale_when_war_does_not_bundle_sitemanage(self):
         _touch(self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar", 300)
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        # WAR without sitemanage jar inside
         with zipfile.ZipFile(war_path, "w") as zf:
             zf.writestr("WEB-INF/lib/some-other.jar", b"PK fake")
         os.utime(war_path, (250, 250))
 
         rows = qa_preflight.run_preflight(self.repo, self.m2)
-        # War present but doesn't bundle sitemanage → cannot preflight → stale (incomplete dist)
+        # War present but doesn't bundle sitemanage → cannot preflight → stale
         self.assertTrue(qa_preflight.is_stale(rows))
+
+
+class TestContentHash(unittest.TestCase):
+    """#2532: SHA-256 m2 jar vs WAR zip entry (mtime-resistant)."""
+
+    def setUp(self):
+        self.repo_helper = _Repo()
+        self.addCleanup(self.repo_helper.cleanup)
+        self.repo = self.repo_helper.layout_repo()
+        self.m2 = self.repo_helper.layout_m2()
+
+    def test_stale_when_hashes_differ_even_if_mtimes_look_fresh(self):
+        # WAR mtime newer than m2 → mtime would say FRESH, but different
+        # payload → content-hash STALE.
+        _write_jar(
+            self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar",
+            _BYTES_A,
+            100,
+        )
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(
+            war_path,
+            sitemanage_jar_name="sitemanage-8.2.0-SNAPSHOT.jar",
+            sitemanage_bytes=_BYTES_B,
+            mtime=900,
+        )
+
+        rows = qa_preflight.run_preflight(self.repo, self.m2, content_hash=True)
+        self.assertTrue(qa_preflight.is_stale(rows, content_hash=True))
+        self.assertEqual(qa_preflight.content_hash_mismatch(rows), "m2-vs-war")
+        report = qa_preflight.format_report(rows, strict=True, content_hash=True)
+        self.assertIn("STALE", report)
+        self.assertIn("content hash mismatch", report)
+        self.assertIn("m2 vs war", report)
+        # Mtime-only would incorrectly call this fresh:
+        self.assertFalse(qa_preflight.is_stale(rows, content_hash=False))
+
+    def test_hashes_equal_for_matching_synthetic_bytes(self):
+        _write_jar(
+            self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar",
+            _BYTES_A,
+            100,
+        )
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(
+            war_path,
+            sitemanage_jar_name="sitemanage-8.2.0-SNAPSHOT.jar",
+            sitemanage_bytes=_BYTES_A,
+            mtime=100,
+        )
+
+        rows = qa_preflight.run_preflight(self.repo, self.m2, content_hash=True)
+        by = {r.label: r for r in rows}
+        expected = _sha(_BYTES_A)
+        self.assertEqual(by["m2:sitemanage"].sha256, expected)
+        self.assertEqual(by["war:sitemanage"].sha256, expected)
+        self.assertTrue(qa_preflight.content_hashes_agree(rows))
+        self.assertIsNone(qa_preflight.content_hash_mismatch(rows))
+
+    def test_sha256_zip_entry_streams_entry_bytes(self):
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(
+            war_path,
+            sitemanage_jar_name="sitemanage-x.jar",
+            sitemanage_bytes=_BYTES_B,
+        )
+        entry = qa_preflight.find_sitemanage_zip_entry(war_path)
+        self.assertIsNotNone(entry)
+        self.assertEqual(
+            qa_preflight.sha256_zip_entry(war_path, entry),
+            _sha(_BYTES_B),
+        )
+        self.assertEqual(
+            qa_preflight.sha256_sitemanage_in_war(war_path),
+            _sha(_BYTES_B),
+        )
+
+    def test_sha256_file_matches_hashlib(self):
+        jar = self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar"
+        _write_jar(jar, _BYTES_A, 50)
+        self.assertEqual(qa_preflight.sha256_file(jar), _sha(_BYTES_A))
+        self.assertIsNone(qa_preflight.sha256_file(None))
+        self.assertIsNone(qa_preflight.sha256_file(self.m2 / "missing.jar"))
+
+    def test_strict_content_hash_mismatch_exit_2(self):
+        _write_jar(
+            self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar",
+            _BYTES_A,
+            100,
+        )
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(
+            war_path,
+            sitemanage_jar_name="sitemanage-8.2.0-SNAPSHOT.jar",
+            sitemanage_bytes=_BYTES_B,
+            mtime=900,
+        )
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_preflight.main([
+                "--repo-root", str(self.repo),
+                "--m2-root", str(self.m2),
+                "--strict",
+                "--content-hash",
+            ])
+        self.assertEqual(rc, 2)
+        out = buf.getvalue()
+        self.assertIn("STALE", out)
+        self.assertIn("content hash mismatch", out)
+
+    def test_optional_dist_hash_mismatch(self):
+        _write_jar(
+            self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar",
+            _BYTES_A,
+            100,
+        )
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(
+            war_path,
+            sitemanage_jar_name="sitemanage-8.2.0-SNAPSHOT.jar",
+            sitemanage_bytes=_BYTES_A,
+            mtime=100,
+        )
+        # Loose dist jar with different content under perc-distribution-tree.
+        dist_jar = (
+            self.repo
+            / "modules"
+            / "perc-distribution-tree"
+            / "target"
+            / "Rhythmyx"
+            / "WEB-INF"
+            / "lib"
+            / "sitemanage-8.2.0-SNAPSHOT.jar"
+        )
+        _write_jar(dist_jar, _BYTES_B, 100)
+
+        rows = qa_preflight.run_preflight(self.repo, self.m2, content_hash=True)
+        labels = {r.label for r in rows}
+        self.assertIn("dist:sitemanage", labels)
+        self.assertEqual(qa_preflight.content_hash_mismatch(rows), "m2-vs-dist")
+        self.assertTrue(qa_preflight.is_stale(rows, content_hash=True))
+        report = qa_preflight.format_report(rows, strict=True, content_hash=True)
+        self.assertIn("m2 vs dist", report)
+
+    def test_content_hash_default_on(self):
+        _write_jar(
+            self.m2 / qa_preflight._M2_DIR / "sitemanage-8.2.0-SNAPSHOT.jar",
+            _BYTES_A,
+            100,
+        )
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        _make_war(
+            war_path,
+            sitemanage_jar_name="sitemanage-8.2.0-SNAPSHOT.jar",
+            sitemanage_bytes=_BYTES_B,
+            mtime=900,
+        )
+        # Default (no flags) uses content-hash.
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_preflight.main([
+                "--repo-root", str(self.repo),
+                "--m2-root", str(self.m2),
+                "--strict",
+            ])
+        self.assertEqual(rc, 2)
+        self.assertIn("content hash mismatch", buf.getvalue())
 
 
 class TestPreflightNoOp(unittest.TestCase):
@@ -167,8 +400,7 @@ class TestPreflightNoOp(unittest.TestCase):
 
     def test_no_m2_jar_means_noop(self):
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar")
-        os.utime(war_path, (250, 250))
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=250)
 
         rows = qa_preflight.run_preflight(self.repo, self.m2)
         # Not stale: the developer hasn't built sitemanage yet, so the check is a no-op.
@@ -198,8 +430,7 @@ class TestPreflightNoArtifacts(unittest.TestCase):
 
     def test_handles_missing_m2_root(self):
         war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar")
-        os.utime(war_path, (250, 250))
+        _make_war(war_path, sitemanage_jar_name="sitemanage-1.0.0.jar", mtime=250)
         rows = qa_preflight.run_preflight(self.repo, self.repo_helper.root / "no-m2")
         # m2 missing entirely → no-op
         self.assertFalse(qa_preflight.is_stale(rows))
@@ -224,8 +455,18 @@ class TestWarBundlesSitemanage(unittest.TestCase):
 
     def test_war_bundles_sitemanage_false_for_missing_war(self):
         self.assertFalse(
-            qa_preflight.war_bundles_sitemanage(self.repo / "WebUI" / "target" / "missing.war")
+            qa_preflight.war_bundles_sitemanage(
+                self.repo / "WebUI" / "target" / "missing.war"
+            )
         )
+
+    def test_find_sitemanage_zip_entry_prefers_web_inf_lib(self):
+        war_path = self.repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+        with zipfile.ZipFile(war_path, "w") as zf:
+            zf.writestr("other/sitemanage-old.jar", b"old")
+            zf.writestr("WEB-INF/lib/sitemanage-new.jar", b"new")
+        entry = qa_preflight.find_sitemanage_zip_entry(war_path)
+        self.assertEqual(entry, "WEB-INF/lib/sitemanage-new.jar")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements **#2532** (parent **#2423**, residual of **#2486** / PR #2529): default **SHA-256 content-hash** mode in `docker/scripts/qa_preflight.py` so sitemanage freshness is mtime-resistant.

- Stream SHA-256 of m2 `sitemanage-*.jar` vs `WEB-INF/lib/sitemanage-*.jar` zip entry inside `WebUI/target/perc-web-ui-*.war` (no full WAR extract)
- **STALE** with clear reason when hashes differ even if mtimes look fresh
- **FRESH** when hashes match despite mtime skew
- Optional loose dist jar under `modules/perc-distribution-tree/target` when present
- `--no-content-hash` for legacy mtime-only; accept `--no-strict` for perc-devctl
- `perc-devctl qa-preflight --no-content-hash` wired through
- Docs in `docker/README.md` rebuild-preflight section

**Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #2532  
Parent tracker: #2423

## Test plan

1. `python docker/scripts/test_qa_preflight.py -v` — **24 tests, OK** (synthetic WAR/m2 bytes, hash mismatch with fresh mtimes, hash match with skew, optional dist, CLI flags)
2. `python docker/scripts/test_perc_devctl.py -v` — **58 tests, OK** (includes `qa-preflight` dry-run)
3. `python docker/scripts/perc-devctl.py qa-preflight --dry-run` — RESULT:OK

## Gates evidence

- **Change class:** docker script / preflight tooling (no Maven module sources changed)
- **Maven clean install:** N/A (Python scripts + README only under `docker/`)
- **Erlang-style self-review:** portable `Path` / zip entry `/`; no hardcoded FS separators; behavioral unit tests for hash + mtime paths; no secrets
- **No human QA needed:** pure agent-safe filesystem preflight; no UI/install/runtime product change

## Residual

None for this slice. Sibling residuals remain open as filed earlier: #2531 (matrix wire), and any other #2423 slices.

> Co-Authored by Grok Build using grok-4.5 with agent main.