### PR TITLE
fix(docker): wire qa-preflight into matrix-install-smoke (#2531)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -59,9 +59,17 @@ perc-devctl.py qa-health [--timeout-seconds N] [--interval-seconds N] [--url URL
 perc-devctl.py qa-down [--container NAME]
 ```
 
-#### Rebuild-chain preflight (#2486 / #2532)
+#### Rebuild-chain preflight (#2486 / #2532 / matrix wire-up #2531)
 
 `perc-devctl.py qa-preflight [--strict]` (or the standalone `python3 docker/scripts/qa_preflight.py`) detects a **stale WebUI WAR** vs a freshly built sitemanage SNAPSHOT **before** `qa-up`. Without this gate, re-running only `sitemanage → install` and then `qa-up` leaves the old `sitemanage-*.jar` bundled inside the `perc-web-ui-*.war` (which `perc-distribution-tree` unpacks into `Rhythmyx/WEB-INF/lib`). The container then loads the stale classpath and the cycle / DI fix appears to regress even though the m2 snapshot is correct.
+
+**Matrix CMS path (strict by default):** `matrix-install-smoke.py` runs the same preflight **before install/start** whenever `--product` includes `cms` (including GHA / operator matrix entrypoints that call the harness directly without `perc-devctl qa-up`). On `STALE` it exits with code `2` and prints `RESULT:FAIL STEP:matrix-preflight DETAIL:preflight_stale` — no cell is started. Opt out only when intentionally debugging:
+
+```bash
+python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --skip-preflight
+```
+
+DTS-only matrices (`--product dts`) skip this gate (no WebUI WAR on that path). See **Matrix install smoke** below for the full CLI matrix.
 
 The preflight compares:
 
@@ -77,11 +85,16 @@ The preflight compares:
 
 Use `--no-content-hash` for mtime-only comparison. With `--strict`, STALE returns exit code `2`; without `--strict` it prints the same line and returns `0` so callers can log without blocking.
 
+Matrix CMS cells always use the **strict** policy unless --skip-preflight is set.
+
+
 Run order recommended for agents and CI:
 
 ```bash
 python3 docker/scripts/perc-devctl.py qa-preflight --strict \
   && python3 docker/scripts/perc-devctl.py qa-up
+# or matrix directly (preflight is built-in for --product cms):
+python3 docker/scripts/matrix-install-smoke.py --product cms --db h2
 ```
 
 Standalone (same flags):
@@ -420,15 +433,17 @@ cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
 cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../../mvnw package -DskipTests
 
 # CMS + H2 (no external DB container)
+# Strict rebuild-chain preflight runs first (#2531 / #2486); STALE → exit 2
 python3 docker/scripts/matrix-install-smoke.py --product cms --db h2
 
 # CMS + PostgreSQL (starts compose profile postgres)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql
 
-# Both products × H2 and PostgreSQL
+# Both products × H2 and PostgreSQL (CMS preflight still runs once before cells)
 python3 docker/scripts/matrix-install-smoke.py --product cms,dts --db h2,postgresql
 
 # DTS only × Layer-1 DB matrix without Oracle (H2 + common external profiles)
+# DTS-only skips WebUI WAR preflight
 python3 docker/scripts/matrix-install-smoke.py --product dts --db h2,postgresql,mysql,sqlserver
 
 # CMS + Oracle XE (opt-in; heavy image — see Oracle section below)
@@ -448,10 +463,14 @@ python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --k
 # Force-stop every external DB used by this matrix (including pre-existing)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql,mysql --stop-db
 
-# Dry-run (no docker)
+# Dry-run (no docker) — preflight still runs (filesystem-only) unless skipped
 python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --dry-run --skip-image-build
 # Dry-run Oracle cell metadata (still needs passwords in env / .env.compose)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle --dry-run --skip-image-build
+
+# Opt out of strict CMS preflight only when debugging a known-stale tree
+# (not recommended for CI). See Rebuild-chain preflight above.
+python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --skip-preflight
 ```
 
 ### Oracle compose profile (#1508 / live residual #2083)

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -58,11 +58,15 @@ Usage
     # Dry-run (no docker/mvn)
     python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --dry-run
 
+    # CMS cells run rebuild-chain preflight by default (strict STALE refuse).
+    # Override only when intentionally debugging a known-stale tree:
+    python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --skip-preflight
+
 Exit codes
 ----------
 0  all selected cells passed
 1  invocation / config error
-2  one or more cells failed
+2  one or more cells failed (including CMS preflight STALE)
 """
 
 from __future__ import annotations
@@ -93,6 +97,7 @@ from rhythmyx_ready import (  # noqa: E402
     find_rhythmyx_context_failure,
     is_http_ready_code,
 )
+import qa_preflight  # noqa: E402  # rebuild-chain preflight (#2531 / #2486)
 
 LOG = logging.getLogger("matrix-install-smoke")
 
@@ -105,6 +110,8 @@ EXIT_CELL_FAILED = 2
 DETAIL_DOCKER_UNHEALTHY = "docker_health_unhealthy"
 DETAIL_DOCKER_HEALTH_TIMEOUT = "docker_health_timeout"
 DETAIL_CONTAINER_NOT_RUNNING = "container_not_running"
+# Rebuild-chain preflight refused CMS matrix cells (#2531 residual of #2486).
+DETAIL_PREFLIGHT_STALE = "preflight_stale"
 
 # docker inspect format shared by DB + CMS health waits (#2481 / #2535).
 _DOCKER_HEALTH_INSPECT_FMT = (
@@ -424,6 +431,29 @@ def parse_csv(value: str, allowed: Sequence[str], label: str) -> List[str]:
 
 def expand_matrix(products: Sequence[str], dbs: Sequence[str]) -> List[CellSpec]:
     return [CellSpec(product=p, db_type=d) for p in products for d in dbs]
+
+
+def check_cms_rebuild_preflight(
+    repo_root: Path,
+    m2_root: Optional[Path] = None,
+) -> Tuple[bool, str]:
+    """Run rebuild-chain preflight for CMS product cells (#2531 / #2486).
+
+    Compares the newest ``sitemanage-*.jar`` under the maven local repo with
+    the ``perc-web-ui-*.war`` under ``WebUI/target`` so a stale WAR cannot
+    silently ship into the matrix cell installer path.
+
+    Returns ``(ok, report)`` where ``ok`` is False when the tree is STALE
+    (strict refuse). Missing m2 sitemanage is not STALE (check is a no-op
+    NOTE); see :func:`qa_preflight.is_stale`.
+
+    Pure filesystem — no docker, curl, or maven. Safe to call from dry-run
+    and unit tests with a stub ``repo_root`` / ``m2_root``.
+    """
+    m2 = m2_root if m2_root is not None else qa_preflight._default_m2_root()
+    rows = qa_preflight.run_preflight(repo_root, m2)
+    report = qa_preflight.format_report(rows, strict=True)
+    return (not qa_preflight.is_stale(rows), report)
 
 
 # Customer-shipped installer assembly names (maven-assembly finalName, not *-SNAPSHOT.jar).
@@ -1403,6 +1433,23 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Do not docker build the matrix cell image",
     )
     p.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help=(
+            "Skip CMS rebuild-chain preflight (WebUI WAR vs m2 sitemanage). "
+            "Default is strict: refuse CMS cells when STALE (#2531 / #2486)."
+        ),
+    )
+    p.add_argument(
+        "--m2-root",
+        type=Path,
+        default=None,
+        help=(
+            "Maven local repository root for CMS preflight "
+            "(default: ~/.m2/repository). Intended for tests / CI overrides."
+        ),
+    )
+    p.add_argument(
         "--dry-run",
         action="store_true",
         help="Print planned docker/compose commands without executing",
@@ -1443,6 +1490,39 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     LOG.info("Using compose env file %s", env_file)
     cells = expand_matrix(products, dbs)
+
+    # CMS rebuild-chain preflight (#2531): refuse before install/start when the
+    # WebUI WAR is older than m2 sitemanage (or WAR missing while m2 present).
+    # DTS-only matrices skip this gate. Operators who intentionally bypass use
+    # --skip-preflight (e.g. known-stale debug; not recommended for CI).
+    if "cms" in products:
+        if args.skip_preflight:
+            LOG.warning(
+                "Skipping CMS rebuild-chain preflight (--skip-preflight); "
+                "cells may install a stale WebUI WAR"
+            )
+            print("PREFLIGHT: skipped (--skip-preflight)")
+        else:
+            m2_root = (
+                args.m2_root.resolve()
+                if args.m2_root is not None
+                else None
+            )
+            preflight_ok, preflight_report = check_cms_rebuild_preflight(
+                repo_root, m2_root
+            )
+            print(preflight_report)
+            if not preflight_ok:
+                LOG.error(
+                    "CMS rebuild-chain preflight STALE — refusing matrix "
+                    "before install/start (use --skip-preflight to override)"
+                )
+                print(
+                    f"RESULT:FAIL STEP:matrix-preflight "
+                    f"DETAIL:{DETAIL_PREFLIGHT_STALE}"
+                )
+                return EXIT_CELL_FAILED
+
     # Pin compose DB host publishes once for the whole matrix so concurrent
     # worktrees get a stable freeport set before any compose up (#2004).
     db_host_ports = ensure_compose_db_host_ports(dbs)

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -447,13 +447,47 @@ def check_cms_rebuild_preflight(
     (strict refuse). Missing m2 sitemanage is not STALE (check is a no-op
     NOTE); see :func:`qa_preflight.is_stale`.
 
+    Corrupt / truncated WARs (``zipfile.BadZipFile``) and other preflight I/O
+    errors are treated as not-ok so callers can emit ``RESULT:FAIL
+    STEP:matrix-preflight DETAIL:preflight_stale`` instead of a traceback.
+
     Pure filesystem — no docker, curl, or maven. Safe to call from dry-run
     and unit tests with a stub ``repo_root`` / ``m2_root``.
     """
+    import zipfile
+
     m2 = m2_root if m2_root is not None else qa_preflight._default_m2_root()
-    rows = qa_preflight.run_preflight(repo_root, m2)
-    report = qa_preflight.format_report(rows, strict=True)
-    return (not qa_preflight.is_stale(rows), report)
+    try:
+        rows = qa_preflight.run_preflight(repo_root, m2)
+        report = qa_preflight.format_report(rows, strict=True)
+        ok = not qa_preflight.is_stale(rows)
+        # qa_preflight already swallows BadZipFile as "war:sitemanage missing";
+        # annotate explicitly when the WAR exists but is not a valid zip so
+        # CI logs are actionable without a traceback.
+        if not ok:
+            war = qa_preflight.find_webui_war(repo_root)
+            if war is not None and war.is_file():
+                try:
+                    with zipfile.ZipFile(war, "r") as zf:
+                        zf.namelist()
+                except zipfile.BadZipFile as exc:
+                    report = (
+                        "STALE: WebUI WAR is not a valid zip "
+                        f"(corrupt or truncated): {exc}\n{report}"
+                    )
+                    LOG.error("%s", report.splitlines()[0])
+        return (ok, report)
+    except zipfile.BadZipFile as exc:
+        # Defense in depth if qa_preflight starts re-raising BadZipFile.
+        report = (
+            f"STALE: WebUI WAR is not a valid zip (corrupt or truncated): {exc}"
+        )
+        LOG.error("%s", report)
+        return (False, report)
+    except OSError as exc:
+        report = f"STALE: rebuild-chain preflight I/O error: {exc}"
+        LOG.error("%s", report)
+        return (False, report)
 
 
 # Customer-shipped installer assembly names (maven-assembly finalName, not *-SNAPSHOT.jar).

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -1204,17 +1204,26 @@ class DryRunCliTests(unittest.TestCase):
 class CmsPreflightGateTests(unittest.TestCase):
     """#2531 — matrix CMS path refuses STALE rebuild-chain (strict + skip)."""
 
+    # Shared payload so content-hash mode (#2532) treats m2 jar and WAR entry
+    # as FRESH when mtimes also allow it.
+    _SITEMANAGE_PAYLOAD = b"sitemanage-preflight-test-payload-v1"
+
     def _touch(self, path: Path, mtime: float) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"")
+        path.write_bytes(self._SITEMANAGE_PAYLOAD)
         os.utime(path, (mtime, mtime))
 
-    def _make_war(self, war_path: Path) -> None:
+    def _make_war(self, war_path: Path, mtime: float | None = None) -> None:
         import zipfile
 
         war_path.parent.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(war_path, "w") as zf:
-            zf.writestr("WEB-INF/lib/sitemanage-8.2.0-SNAPSHOT.jar", b"PK fake")
+            zf.writestr(
+                "WEB-INF/lib/sitemanage-8.2.0-SNAPSHOT.jar",
+                self._SITEMANAGE_PAYLOAD,
+            )
+        if mtime is not None:
+            os.utime(war_path, (mtime, mtime))
 
     def _layout(self, root: Path) -> tuple[Path, Path]:
         """Return (repo, m2) under root with matrix CMS jar layout."""
@@ -1242,6 +1251,8 @@ class CmsPreflightGateTests(unittest.TestCase):
         return repo, m2
 
     def test_check_cms_rebuild_preflight_stale(self):
+        import zipfile
+
         with tempfile.TemporaryDirectory() as td:
             repo, m2 = self._layout(Path(td))
             jar = (
@@ -1253,8 +1264,13 @@ class CmsPreflightGateTests(unittest.TestCase):
                 / "sitemanage-8.2.0-SNAPSHOT.jar"
             )
             war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-            self._make_war(war)
+            # Content-hash primary (#2532): different jar vs WAR-entry bytes → STALE.
             self._touch(jar, 300)
+            with zipfile.ZipFile(war, "w") as zf:
+                zf.writestr(
+                    "WEB-INF/lib/sitemanage-8.2.0-SNAPSHOT.jar",
+                    b"stale-war-entry-different-bytes",
+                )
             os.utime(war, (200, 200))
             ok, report = smoke.check_cms_rebuild_preflight(repo, m2)
             self.assertFalse(ok)
@@ -1279,7 +1295,31 @@ class CmsPreflightGateTests(unittest.TestCase):
             self.assertTrue(ok)
             self.assertIn("FRESH", report)
 
-    def test_main_refuses_stale_cms_before_cells(self):
+    def test_check_cms_rebuild_preflight_corrupt_war(self):
+        """Zero-byte / truncated WAR must not traceback; refuse as STALE (#2531)."""
+        with tempfile.TemporaryDirectory() as td:
+            repo, m2 = self._layout(Path(td))
+            jar = (
+                m2
+                / "com"
+                / "percussion"
+                / "sitemanage"
+                / "sitemanage"
+                / "sitemanage-8.2.0-SNAPSHOT.jar"
+            )
+            war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+            # Corrupt: not a zip (empty or truncated garbage). qa_preflight
+            # swallows BadZipFile and reports war:sitemanage missing → STALE;
+            # matrix wrapper also catches raised BadZipFile if that changes.
+            war.write_bytes(b"not-a-zip")
+            self._touch(jar, 300)
+            ok, report = smoke.check_cms_rebuild_preflight(repo, m2)
+            self.assertFalse(ok)
+            self.assertIn("STALE", report)
+
+
+    def test_main_refuses_corrupt_war_before_cells(self):
+        """main() must RESULT:FAIL matrix-preflight on corrupt WAR, not crash."""
         import io
         from contextlib import redirect_stdout
 
@@ -1294,8 +1334,52 @@ class CmsPreflightGateTests(unittest.TestCase):
                 / "sitemanage-8.2.0-SNAPSHOT.jar"
             )
             war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-            self._make_war(war)
+            war.write_bytes(b"")  # zero-byte WAR
             self._touch(jar, 300)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = smoke.main(
+                    [
+                        "--repo-root",
+                        str(repo),
+                        "--m2-root",
+                        str(m2),
+                        "--product",
+                        "cms",
+                        "--db",
+                        "h2",
+                        "--dry-run",
+                        "--skip-image-build",
+                    ]
+                )
+            out = buf.getvalue()
+            self.assertEqual(rc, smoke.EXIT_CELL_FAILED)
+            self.assertIn("matrix-preflight", out)
+            self.assertIn(smoke.DETAIL_PREFLIGHT_STALE, out)
+            self.assertIn("RESULT:FAIL", out)
+
+    def test_main_refuses_stale_cms_before_cells(self):
+        import io
+        import zipfile
+        from contextlib import redirect_stdout
+
+        with tempfile.TemporaryDirectory() as td:
+            repo, m2 = self._layout(Path(td))
+            jar = (
+                m2
+                / "com"
+                / "percussion"
+                / "sitemanage"
+                / "sitemanage"
+                / "sitemanage-8.2.0-SNAPSHOT.jar"
+            )
+            war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+            self._touch(jar, 300)
+            with zipfile.ZipFile(war, "w") as zf:
+                zf.writestr(
+                    "WEB-INF/lib/sitemanage-8.2.0-SNAPSHOT.jar",
+                    b"stale-war-entry-different-bytes",
+                )
             os.utime(war, (200, 200))
             buf = io.StringIO()
             with redirect_stdout(buf):
@@ -1321,6 +1405,7 @@ class CmsPreflightGateTests(unittest.TestCase):
 
     def test_main_skip_preflight_allows_stale(self):
         import io
+        import zipfile
         from contextlib import redirect_stdout
 
         with tempfile.TemporaryDirectory() as td:
@@ -1334,8 +1419,12 @@ class CmsPreflightGateTests(unittest.TestCase):
                 / "sitemanage-8.2.0-SNAPSHOT.jar"
             )
             war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
-            self._make_war(war)
             self._touch(jar, 300)
+            with zipfile.ZipFile(war, "w") as zf:
+                zf.writestr(
+                    "WEB-INF/lib/sitemanage-8.2.0-SNAPSHOT.jar",
+                    b"stale-war-entry-different-bytes",
+                )
             os.utime(war, (200, 200))
             buf = io.StringIO()
             with redirect_stdout(buf):

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -968,6 +968,7 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
                         "postgresql",
                         "--dry-run",
                         "--skip-image-build",
+                        "--skip-preflight",
                     ]
                 )
             self.assertEqual(rc, 0)
@@ -1120,6 +1121,8 @@ class DryRunCliTests(unittest.TestCase):
     def test_dry_run_exits_zero_for_h2(self):
         # dry-run still needs a jar on disk for resolve in run_cell —
         # dry-run path resolves jar before docker; create a stub tree.
+        # --skip-preflight: this case exercises cell/docker planning, not
+        # the rebuild-chain gate (see CmsPreflightGateTests).
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             self._stub_repo(root)
@@ -1133,6 +1136,7 @@ class DryRunCliTests(unittest.TestCase):
                     "h2",
                     "--dry-run",
                     "--skip-image-build",
+                    "--skip-preflight",
                 ]
             )
             self.assertEqual(rc, 0)
@@ -1152,6 +1156,7 @@ class DryRunCliTests(unittest.TestCase):
                     "postgresql",
                     "--dry-run",
                     "--skip-image-build",
+                    "--skip-preflight",
                 ]
             )
             self.assertEqual(rc, 0)
@@ -1178,6 +1183,7 @@ class DryRunCliTests(unittest.TestCase):
                         "oracle",
                         "--dry-run",
                         "--skip-image-build",
+                        "--skip-preflight",
                     ]
                 )
             self.assertEqual(rc, 0)
@@ -1193,6 +1199,261 @@ class DryRunCliTests(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             smoke._build_parser().parse_args(["--keep-db", "--stop-db"])
         self.assertNotEqual(ctx.exception.code, 0)
+
+
+class CmsPreflightGateTests(unittest.TestCase):
+    """#2531 — matrix CMS path refuses STALE rebuild-chain (strict + skip)."""
+
+    def _touch(self, path: Path, mtime: float) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"")
+        os.utime(path, (mtime, mtime))
+
+    def _make_war(self, war_path: Path) -> None:
+        import zipfile
+
+        war_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(war_path, "w") as zf:
+            zf.writestr("WEB-INF/lib/sitemanage-8.2.0-SNAPSHOT.jar", b"PK fake")
+
+    def _layout(self, root: Path) -> tuple[Path, Path]:
+        """Return (repo, m2) under root with matrix CMS jar layout."""
+        repo = root / "repo"
+        m2 = root / "m2"
+        target = repo / "modules" / "perc-distribution-tree" / "target"
+        target.mkdir(parents=True)
+        (target / "perc-distribution-tree.jar").write_bytes(b"stub-jar-content")
+        (repo / "docker" / "logs").mkdir(parents=True)
+        (repo / "docker" / "matrix").mkdir(parents=True)
+        (repo / "docker" / "matrix" / "Dockerfile").write_text(
+            "FROM scratch\n", encoding="utf-8"
+        )
+        (repo / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+        (repo / ".env.compose.example").write_text(
+            "POSTGRES_PASSWORD=test-local-only\n"
+            "MYSQL_PASSWORD=test-local-only\n"
+            "MSSQL_SA_PASSWORD=test-local-only\n"
+            "ORACLE_APP_PASSWORD=test-local-only\n"
+            "ORACLE_PASSWORD=test-local-only\n",
+            encoding="utf-8",
+        )
+        (repo / "WebUI" / "target").mkdir(parents=True)
+        (m2 / "com" / "percussion" / "sitemanage" / "sitemanage").mkdir(parents=True)
+        return repo, m2
+
+    def test_check_cms_rebuild_preflight_stale(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo, m2 = self._layout(Path(td))
+            jar = (
+                m2
+                / "com"
+                / "percussion"
+                / "sitemanage"
+                / "sitemanage"
+                / "sitemanage-8.2.0-SNAPSHOT.jar"
+            )
+            war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+            self._make_war(war)
+            self._touch(jar, 300)
+            os.utime(war, (200, 200))
+            ok, report = smoke.check_cms_rebuild_preflight(repo, m2)
+            self.assertFalse(ok)
+            self.assertIn("STALE", report)
+
+    def test_check_cms_rebuild_preflight_fresh(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo, m2 = self._layout(Path(td))
+            jar = (
+                m2
+                / "com"
+                / "percussion"
+                / "sitemanage"
+                / "sitemanage"
+                / "sitemanage-8.2.0-SNAPSHOT.jar"
+            )
+            war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+            self._make_war(war)
+            self._touch(jar, 200)
+            os.utime(war, (300, 300))
+            ok, report = smoke.check_cms_rebuild_preflight(repo, m2)
+            self.assertTrue(ok)
+            self.assertIn("FRESH", report)
+
+    def test_main_refuses_stale_cms_before_cells(self):
+        import io
+        from contextlib import redirect_stdout
+
+        with tempfile.TemporaryDirectory() as td:
+            repo, m2 = self._layout(Path(td))
+            jar = (
+                m2
+                / "com"
+                / "percussion"
+                / "sitemanage"
+                / "sitemanage"
+                / "sitemanage-8.2.0-SNAPSHOT.jar"
+            )
+            war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+            self._make_war(war)
+            self._touch(jar, 300)
+            os.utime(war, (200, 200))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = smoke.main(
+                    [
+                        "--repo-root",
+                        str(repo),
+                        "--m2-root",
+                        str(m2),
+                        "--product",
+                        "cms",
+                        "--db",
+                        "h2",
+                        "--dry-run",
+                        "--skip-image-build",
+                    ]
+                )
+            out = buf.getvalue()
+            self.assertEqual(rc, smoke.EXIT_CELL_FAILED)
+            self.assertIn("STALE", out)
+            self.assertIn("matrix-preflight", out)
+            self.assertIn(smoke.DETAIL_PREFLIGHT_STALE, out)
+
+    def test_main_skip_preflight_allows_stale(self):
+        import io
+        from contextlib import redirect_stdout
+
+        with tempfile.TemporaryDirectory() as td:
+            repo, m2 = self._layout(Path(td))
+            jar = (
+                m2
+                / "com"
+                / "percussion"
+                / "sitemanage"
+                / "sitemanage"
+                / "sitemanage-8.2.0-SNAPSHOT.jar"
+            )
+            war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+            self._make_war(war)
+            self._touch(jar, 300)
+            os.utime(war, (200, 200))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = smoke.main(
+                    [
+                        "--repo-root",
+                        str(repo),
+                        "--m2-root",
+                        str(m2),
+                        "--product",
+                        "cms",
+                        "--db",
+                        "h2",
+                        "--dry-run",
+                        "--skip-image-build",
+                        "--skip-preflight",
+                    ]
+                )
+            out = buf.getvalue()
+            self.assertEqual(rc, 0)
+            self.assertIn("skip-preflight", out)
+            self.assertNotIn("matrix-preflight", out)
+
+    def test_main_fresh_preflight_continues_dry_run(self):
+        import io
+        from contextlib import redirect_stdout
+
+        with tempfile.TemporaryDirectory() as td:
+            repo, m2 = self._layout(Path(td))
+            jar = (
+                m2
+                / "com"
+                / "percussion"
+                / "sitemanage"
+                / "sitemanage"
+                / "sitemanage-8.2.0-SNAPSHOT.jar"
+            )
+            war = repo / "WebUI" / "target" / "perc-web-ui-8.2.0-SNAPSHOT.war"
+            self._make_war(war)
+            self._touch(jar, 200)
+            os.utime(war, (300, 300))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = smoke.main(
+                    [
+                        "--repo-root",
+                        str(repo),
+                        "--m2-root",
+                        str(m2),
+                        "--product",
+                        "cms",
+                        "--db",
+                        "h2",
+                        "--dry-run",
+                        "--skip-image-build",
+                    ]
+                )
+            out = buf.getvalue()
+            self.assertEqual(rc, 0)
+            self.assertIn("FRESH", out)
+            self.assertIn("RESULT:OK STEP:matrix", out)
+
+    def test_main_dts_only_skips_preflight_gate(self):
+        """DTS product path does not require WebUI WAR preflight."""
+        import io
+        from contextlib import redirect_stdout
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            # DTS installer jar only; no WebUI / m2 — would be STALE for CMS.
+            dts_target = (
+                root
+                / "deliverytiersuite"
+                / "delivery-tier-suite"
+                / "delivery-tier-distribution"
+                / "target"
+            )
+            dts_target.mkdir(parents=True)
+            (dts_target / "delivery-tier-distribution.jar").write_bytes(b"dts-stub")
+            (root / "docker" / "logs").mkdir(parents=True)
+            (root / "docker" / "matrix").mkdir(parents=True)
+            (root / "docker" / "matrix" / "Dockerfile").write_text(
+                "FROM scratch\n", encoding="utf-8"
+            )
+            (root / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+            (root / ".env.compose.example").write_text(
+                "POSTGRES_PASSWORD=test-local-only\n",
+                encoding="utf-8",
+            )
+            empty_m2 = root / "empty-m2"
+            empty_m2.mkdir()
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = smoke.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--m2-root",
+                        str(empty_m2),
+                        "--product",
+                        "dts",
+                        "--db",
+                        "h2",
+                        "--dry-run",
+                        "--skip-image-build",
+                    ]
+                )
+            out = buf.getvalue()
+            self.assertEqual(rc, 0)
+            self.assertNotIn("matrix-preflight", out)
+            self.assertNotIn("STALE", out)
+
+    def test_parser_exposes_skip_preflight_and_m2_root(self):
+        args = smoke._build_parser().parse_args(
+            ["--skip-preflight", "--m2-root", "/tmp/fake-m2"]
+        )
+        self.assertTrue(args.skip_preflight)
+        self.assertEqual(args.m2_root, Path("/tmp/fake-m2"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Wires the rebuild-chain preflight (`qa_preflight`) into `matrix-install-smoke.py` for **CMS** product cells so GHA / operator matrix entrypoints that call the harness **without** `perc-devctl qa-up` still refuse a stale WebUI WAR before install/start.

- **Parent:** #2423
- **Fixes:** #2531
- **Operator:** Grok: night-issue-prs (model grok-4.5)

### Behavior

| Case | Result |
|------|--------|
| `--product` includes `cms`, preflight **STALE** | Exit `2`, `RESULT:FAIL STEP:matrix-preflight DETAIL:preflight_stale` — no cell started |
| `--product` includes `cms`, preflight **FRESH** / no m2 jar (NOTE skip) | Continues to image/cells |
| `--skip-preflight` | Explicit opt-out (debug only) |
| `--product dts` only | Preflight not run |

New CLI: `--skip-preflight`, `--m2-root` (tests/CI override).

### Docs

`docker/README.md` rebuild-chain section + matrix CLI examples cross-link matrix strict gate and skip flag.

## Test plan

- [x] Unit tests (dry-run / stub repo):
  - `python -m pytest docker/scripts/test_matrix_install_smoke.py docker/scripts/test_qa_preflight.py -q`
  - Result: **98 passed**
- [x] Cases: STALE refuse, FRESH continue, `--skip-preflight` allows STALE, DTS-only skips gate, parser flags
- [ ] Live multi-RDBMS matrix **not** required for this residual (agent-safe / filesystem gate only)

## Gates evidence

- **Modules:** `docker/scripts` (Python only) — no Maven module sources changed → no `mvnw clean install` required
- **Erlang-style self-review:** pure filesystem preflight; portable `Path` / `~/.m2` via `expanduser`; no new non-portable separators; DTS path unchanged; companions = unit tests + README
- **Human QA:** not required — CI/operator tooling, fully unit-tested; no product UI / installer UX change

> Co-Authored by Grok Build using grok-4.5 with agent main.
