### PR TITLE
feat(docker): perc-devctl qa-rebuild-chain driver (#2533)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -55,6 +55,7 @@ perc-devctl.py show-generated-passwords
 # QA mode — H2-in-Docker CMS for Playwright (no host install) — #1827 / #1927
 perc-devctl.py qa-up [--timeout-seconds N] [--skip-image-build]
 perc-devctl.py qa-preflight [--strict] [--no-content-hash]
+perc-devctl.py qa-rebuild-chain [--skip-tests] [--dist-only] [--then-qa-up] [--dry-run]
 perc-devctl.py qa-health [--timeout-seconds N] [--interval-seconds N] [--url URL]
 perc-devctl.py qa-down [--container NAME]
 ```
@@ -87,10 +88,38 @@ Use `--no-content-hash` for mtime-only comparison. With `--strict`, STALE return
 
 Matrix CMS cells always use the **strict** policy unless --skip-preflight is set.
 
+#### Rebuild-chain driver (#2533)
+
+When preflight reports `STALE:` (or after any sitemanage / WebUI SNAPSHOT change that must land in the installer jar), run the portable driver instead of hand-typed `cd` + `mvnw` sequences:
+
+```bash
+# Plan only (prints PLANNED STEP:… ARGV:… and RESULT:OK; no Maven)
+python3 docker/scripts/perc-devctl.py qa-rebuild-chain --dry-run
+
+# Full chain: sitemanage clean install → WebUI package -DskipTests →
+# modules/perc-distribution-tree clean package -DskipTests
+python3 docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests
+
+# Same via the standalone module (identical argv contract)
+python3 docker/scripts/qa_rebuild_chain.py --skip-tests
+
+# Installer packaging only (WAR inputs already fresh)
+python3 docker/scripts/perc-devctl.py qa-rebuild-chain --dist-only
+
+# Optional: rebuild then qa-up in one invocation
+python3 docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests --then-qa-up
+```
+
+Cross-platform notes: each step `cwd`s into the module directory and invokes the **repo-root** `mvnw` / `mvnw.cmd` with `subprocess.run([...], shell=False)` (no shell quoting). Per-step and overall `RESULT:OK` / `RESULT:FAIL` lines are agent-parseable; Maven stdout/stderr goes under `docker/logs/`.
 
 Run order recommended for agents and CI:
 
 ```bash
+# 1) Detect stale WAR vs m2 sitemanage
+python3 docker/scripts/perc-devctl.py qa-preflight --strict
+# 2) If STALE / FAIL — drive the full Maven order (do not skip WebUI)
+python3 docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests
+# 3) Confirm fresh, then bring up QA H2 cell
 python3 docker/scripts/perc-devctl.py qa-preflight --strict \
   && python3 docker/scripts/perc-devctl.py qa-up
 # or matrix directly (preflight is built-in for --product cms):

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -26,6 +26,10 @@ QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
   (#2481); the precheck runs ``docker inspect`` and prints a clear
   rebuild hint instead of waiting the full ``--probe-timeout`` for
   ``docker_health_timeout health=none`` (#2484)
+* ``qa-rebuild-chain`` — drive the documented Maven order
+  (sitemanage install → WebUI package → perc-distribution-tree package)
+  via repo-root ``mvnw``/``mvnw.cmd``, portable paths, ``shell=False``
+  (#2533 residual of #2423 / #2486)
 
 Compose ``verify`` / ``verify-fix`` / ``deploy-jar --verify`` apply the same
 Rhythmyx context log scan against the cms-dts container (#2480 companion to
@@ -442,6 +446,47 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Mtime-only comparison (disable default SHA-256 content hash).",
     )
     pqp.add_argument("--dry-run", action="store_true")
+
+    # --- Rebuild-chain driver — #2533 ---
+    pqrc = sub.add_parser(
+        "qa-rebuild-chain",
+        help=(
+            "Run sitemanage install → WebUI package → "
+            "perc-distribution-tree package via repo-root mvnw "
+            "(#2533). Use after STALE preflight or SNAPSHOT changes."
+        ),
+    )
+    pqrc.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help="Pass -DskipTests on the sitemanage step (WebUI/dist always skip).",
+    )
+    pqrc.add_argument(
+        "--dist-only",
+        action="store_true",
+        help="Only package perc-distribution-tree (WAR inputs already fresh).",
+    )
+    pqrc.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Optional wall-clock timeout per Maven step.",
+    )
+    pqrc.add_argument(
+        "--then-qa-up",
+        action="store_true",
+        help=(
+            "After a successful rebuild chain, run qa-up "
+            "(narrow optional handoff; fails if chain fails)."
+        ),
+    )
+    pqrc.add_argument(
+        "--skip-image-build",
+        action="store_true",
+        help="With --then-qa-up: pass --skip-image-build to qa-up.",
+    )
+    pqrc.add_argument("--dry-run", action="store_true")
 
     pqh = sub.add_parser(
         "qa-health",
@@ -1774,6 +1819,47 @@ def cmd_qa_preflight(
     return rc
 
 
+def cmd_qa_rebuild_chain(
+    args: argparse.Namespace, paths: tuple[Path, Path, Path]
+) -> int:
+    """Drive the documented Maven rebuild chain (#2533).
+
+    Delegates to ``docker/scripts/qa_rebuild_chain.py`` (portable
+    ``mvnw``/``mvnw.cmd``, ``shell=False``, RESULT lines). Optional
+    ``--then-qa-up`` runs ``cmd_qa_up`` after a successful chain only.
+    """
+    import qa_rebuild_chain
+
+    repo_root, _env_file, _compose_file = paths
+    log_dir = _log_dir(repo_root)
+    rc = qa_rebuild_chain.run_chain(
+        repo_root,
+        dry_run=args.dry_run,
+        skip_tests=args.skip_tests,
+        dist_only=args.dist_only,
+        log_dir=log_dir,
+        timeout_seconds=args.timeout_seconds,
+    )
+    if rc != EXIT_OK:
+        return rc
+    if not args.then_qa_up:
+        return rc
+    # Narrow handoff: reuse qa-up after a green rebuild chain.
+    # Rebuild-chain ``--timeout-seconds`` is optional (None = no Maven
+    # cap); qa-up requires a concrete probe timeout — fall back to the
+    # standard QA default when the operator did not pass one.
+    qa_up_args = argparse.Namespace(
+        dry_run=bool(args.dry_run),
+        timeout_seconds=(
+            args.timeout_seconds
+            if args.timeout_seconds is not None
+            else QA_PROBE_TIMEOUT_SECONDS_DEFAULT
+        ),
+        skip_image_build=bool(getattr(args, "skip_image_build", False)),
+    )
+    return cmd_qa_up(qa_up_args, paths)
+
+
 # ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
@@ -1795,6 +1881,7 @@ _DISPATCH = {
     "qa-health": cmd_qa_health,
     "qa-down": cmd_qa_down,
     "qa-preflight": cmd_qa_preflight,
+    "qa-rebuild-chain": cmd_qa_rebuild_chain,
 }
 
 

--- a/docker/scripts/qa_rebuild_chain.py
+++ b/docker/scripts/qa_rebuild_chain.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""QA rebuild chain driver: sitemanage → WebUI → perc-distribution-tree (#2533).
+
+Preflight (``qa_preflight.py`` / ``perc-devctl qa-preflight``) only **detects**
+a stale WebUI WAR vs a freshly installed sitemanage SNAPSHOT. Operators and
+agents still had to re-type the Maven order by hand — often wrong order,
+skipping WebUI, or packaging only ``perc-distribution-tree``.
+
+This module runs the documented portable order via the **repo-root** Maven
+wrapper (``mvnw`` / ``mvnw.cmd``), ``pathlib.Path``, and
+``subprocess.run([...], shell=False)``:
+
+1. ``projects/sitemanage`` — ``clean install`` (optional ``-DskipTests``)
+2. ``WebUI`` — ``package -DskipTests``
+3. ``modules/perc-distribution-tree`` — ``clean package -DskipTests``
+
+Each step emits a parseable ``RESULT:OK`` / ``RESULT:FAIL`` line. ``--dry-run``
+prints the planned argv + cwd for every step and never invokes Maven.
+
+Standalone::
+
+    python3 docker/scripts/qa_rebuild_chain.py [--dry-run] [--skip-tests]
+    python3 docker/scripts/qa_rebuild_chain.py --dist-only
+
+Via perc-devctl::
+
+    python3 docker/scripts/perc-devctl.py qa-rebuild-chain [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional, Sequence
+
+LOG = logging.getLogger("qa_rebuild_chain")
+
+EXIT_OK = 0
+EXIT_INVOCATION = 1
+EXIT_SUBPROCESS_FAILED = 2
+
+# Callable matching subprocess.run for tests to inject stubs.
+RunFn = Callable[..., subprocess.CompletedProcess]
+
+
+@dataclass(frozen=True)
+class ChainStep:
+    """One Maven invocation in the rebuild chain."""
+
+    label: str
+    module_rel: Path  # relative to repo root; cwd for the step
+    goals: tuple[str, ...]  # e.g. ("clean", "install") or ("package",)
+    extra_args: tuple[str, ...] = ()
+
+    def cwd(self, repo_root: Path) -> Path:
+        return (repo_root / self.module_rel).resolve()
+
+    def argv(self, mvnw: Path) -> List[str]:
+        return [str(mvnw), *self.goals, *self.extra_args]
+
+
+def resolve_mvnw(repo_root: Path) -> Path:
+    """Return the repo-root Maven wrapper path for this OS.
+
+    Windows uses ``mvnw.cmd``; Unix uses the ``mvnw`` shell script.
+    Does not require the file to exist (callers may dry-run against a
+    synthetic tree); existence is checked before a real run.
+    """
+    name = "mvnw.cmd" if sys.platform.startswith("win") else "mvnw"
+    return (repo_root / name).resolve()
+
+
+def plan_chain(
+    *,
+    skip_tests: bool = False,
+    dist_only: bool = False,
+) -> List[ChainStep]:
+    """Return the ordered list of Maven steps for the QA rebuild chain.
+
+    Parameters
+    ----------
+    skip_tests:
+        When True, pass ``-DskipTests`` on the sitemanage step as well.
+        WebUI and perc-distribution-tree always skip tests (matches the
+        documented operator commands in workbench-rest-and-qa-modes.md).
+    dist_only:
+        When True, only package ``perc-distribution-tree`` (no clean on
+        sitemanage/WebUI). Use when only installer packaging resources
+        changed and SNAPSHOT artifacts under the WAR are already fresh.
+    """
+    skip = ("-DskipTests",)
+    if dist_only:
+        return [
+            ChainStep(
+                label="qa-rebuild-dist",
+                module_rel=Path("modules") / "perc-distribution-tree",
+                goals=("package",),
+                extra_args=skip,
+            ),
+        ]
+
+    sitemanage_extra = skip if skip_tests else ()
+    return [
+        ChainStep(
+            label="qa-rebuild-sitemanage",
+            module_rel=Path("projects") / "sitemanage",
+            goals=("clean", "install"),
+            extra_args=sitemanage_extra,
+        ),
+        ChainStep(
+            label="qa-rebuild-webui",
+            module_rel=Path("WebUI"),
+            goals=("package",),
+            extra_args=skip,
+        ),
+        ChainStep(
+            label="qa-rebuild-dist",
+            module_rel=Path("modules") / "perc-distribution-tree",
+            goals=("clean", "package"),
+            extra_args=skip,
+        ),
+    ]
+
+
+def _format_planned(step: ChainStep, repo_root: Path, mvnw: Path) -> str:
+    argv = step.argv(mvnw)
+    cwd = step.cwd(repo_root)
+    # Use Path.as_posix() only for display of relative module; argv paths
+    # remain OS-native strings for subprocess.
+    return (
+        f"PLANNED STEP:{step.label} "
+        f"CWD:{cwd} "
+        f"ARGV:{subprocess.list2cmdline(argv) if sys.platform.startswith('win') else ' '.join(argv)}"
+    )
+
+
+def _print_result(ok: bool, label: str, log_path: Optional[Path] = None) -> None:
+    status = "OK" if ok else "FAIL"
+    log_part = f" LOG:{log_path}" if log_path is not None else " LOG:"
+    print(f"RESULT:{status} STEP:{label}{log_part}")
+
+
+def run_chain(
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+    skip_tests: bool = False,
+    dist_only: bool = False,
+    log_dir: Optional[Path] = None,
+    run_fn: Optional[RunFn] = None,
+    timeout_seconds: Optional[int] = None,
+) -> int:
+    """Execute (or dry-run) the rebuild chain. Returns EXIT_*.
+
+    ``run_fn`` defaults to ``subprocess.run``; unit tests inject a stub
+    that records argv/cwd and returns ``CompletedProcess``.
+
+    When ``log_dir`` is set, each real step writes stdout+stderr to
+    ``<log_dir>/<label>-<n>.log``. Dry-run still emits RESULT lines
+    without creating logs unless ``log_dir`` is provided (then a short
+    planned-argv log is written).
+    """
+    repo_root = repo_root.resolve()
+    mvnw = resolve_mvnw(repo_root)
+    steps = plan_chain(skip_tests=skip_tests, dist_only=dist_only)
+    runner = run_fn or subprocess.run
+
+    if not dry_run and not mvnw.is_file():
+        print(
+            f"ERROR: Maven wrapper not found at {mvnw} "
+            f"(expected mvnw / mvnw.cmd at repo root)",
+            file=sys.stderr,
+        )
+        _print_result(False, "qa-rebuild-chain")
+        return EXIT_INVOCATION
+
+    overall_ok = True
+    for index, step in enumerate(steps):
+        planned = _format_planned(step, repo_root, mvnw)
+        print(planned)
+        LOG.info(planned)
+
+        cwd = step.cwd(repo_root)
+        argv = step.argv(mvnw)
+        log_path: Optional[Path] = None
+        if log_dir is not None:
+            log_dir.mkdir(parents=True, exist_ok=True)
+            log_path = log_dir / f"{step.label}-{index}.log"
+
+        if dry_run:
+            if log_path is not None:
+                with log_path.open("w", encoding="utf-8") as fh:
+                    fh.write(planned + "\n")
+            _print_result(True, step.label, log_path)
+            continue
+
+        if not cwd.is_dir():
+            print(
+                f"ERROR: module directory missing for {step.label}: {cwd}",
+                file=sys.stderr,
+            )
+            _print_result(False, step.label, log_path)
+            overall_ok = False
+            break
+
+        LOG.info("Running: %s (cwd=%s)", " ".join(argv), cwd)
+        try:
+            if log_path is not None:
+                with log_path.open("w", encoding="utf-8") as fh:
+                    completed = runner(
+                        list(argv),
+                        cwd=str(cwd),
+                        shell=False,
+                        check=False,
+                        stdout=fh,
+                        stderr=subprocess.STDOUT,
+                        timeout=timeout_seconds,
+                    )
+            else:
+                completed = runner(
+                    list(argv),
+                    cwd=str(cwd),
+                    shell=False,
+                    check=False,
+                    timeout=timeout_seconds,
+                )
+        except subprocess.TimeoutExpired:
+            print(
+                f"ERROR: step {step.label} timed out after {timeout_seconds}s",
+                file=sys.stderr,
+            )
+            _print_result(False, step.label, log_path)
+            overall_ok = False
+            break
+        except OSError as exc:
+            print(f"ERROR: failed to start Maven for {step.label}: {exc}", file=sys.stderr)
+            _print_result(False, step.label, log_path)
+            overall_ok = False
+            break
+
+        if completed.returncode != 0:
+            print(
+                f"ERROR: step {step.label} exited {completed.returncode}",
+                file=sys.stderr,
+            )
+            _print_result(False, step.label, log_path)
+            overall_ok = False
+            break
+
+        _print_result(True, step.label, log_path)
+
+    chain_label = "qa-rebuild-chain"
+    if overall_ok:
+        _print_result(True, chain_label)
+        return EXIT_OK
+    _print_result(False, chain_label)
+    return EXIT_SUBPROCESS_FAILED
+
+
+def _default_repo_root() -> Path:
+    """Repo root when invoked as docker/scripts/qa_rebuild_chain.py."""
+    return Path(__file__).resolve().parents[2]
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="qa_rebuild_chain.py",
+        description=(
+            "Run the QA Maven rebuild chain: sitemanage install → "
+            "WebUI package → perc-distribution-tree package (#2533). "
+            "Uses repo-root mvnw/mvnw.cmd with shell=False."
+        ),
+    )
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Percussion CMS checkout root (default: grandparent of this script).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned argv/cwd for each step; do not invoke Maven.",
+    )
+    p.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help=(
+            "Pass -DskipTests on the sitemanage step "
+            "(WebUI and dist already skip tests)."
+        ),
+    )
+    p.add_argument(
+        "--dist-only",
+        action="store_true",
+        help=(
+            "Only run modules/perc-distribution-tree package -DskipTests "
+            "(when SNAPSHOT WAR inputs are already fresh)."
+        ),
+    )
+    p.add_argument(
+        "--log-dir",
+        type=Path,
+        default=None,
+        help="Directory for per-step logs (default: docker/logs under repo root).",
+    )
+    p.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Optional wall-clock timeout per Maven step (default: no limit).",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Verbose logging on stderr.",
+    )
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    repo_root = (
+        args.repo_root.resolve()
+        if args.repo_root is not None
+        else _default_repo_root()
+    )
+    log_dir = args.log_dir
+    if log_dir is None and not args.dry_run:
+        log_dir = repo_root / "docker" / "logs"
+    elif log_dir is None and args.dry_run:
+        # Dry-run still can write short planned logs when default log dir
+        # is useful for agent workflows; keep None to avoid mkdir noise
+        # unless operator passed --log-dir.
+        log_dir = None
+
+    return run_chain(
+        repo_root,
+        dry_run=args.dry_run,
+        skip_tests=args.skip_tests,
+        dist_only=args.dist_only,
+        log_dir=log_dir,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -176,6 +176,38 @@ class TestQaPreflight(unittest.TestCase):
         self.assertIn("dry-run", out.lower())
 
 
+class TestQaRebuildChain(unittest.TestCase):
+    """#2533: perc-devctl qa-rebuild-chain dry-run + dispatch."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.repo_root = _stub_repo_root(Path(self.td.name))
+        # Module dirs required only for real runs; dry-run still plans them.
+        (self.repo_root / "projects" / "sitemanage").mkdir(parents=True)
+        (self.repo_root / "WebUI").mkdir(parents=True)
+        (self.repo_root / "modules" / "perc-distribution-tree").mkdir(parents=True)
+        (self.repo_root / "mvnw.cmd").write_text("@echo stub\r\n", encoding="utf-8")
+        self.runner = _CliRunner(self.repo_root)
+
+    def test_qa_rebuild_chain_dry_run(self):
+        rc, out = self.runner.run(["qa-rebuild-chain", "--skip-tests"])
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("PLANNED STEP:qa-rebuild-sitemanage", out)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
+
+    def test_qa_rebuild_chain_then_qa_up_dry_run(self):
+        _clear_port_env()
+        self.addCleanup(_clear_port_env)
+        rc, out = self.runner.run(
+            ["qa-rebuild-chain", "--skip-tests", "--then-qa-up"]
+        )
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
+        self.assertIn("RESULT:OK STEP:qa-up", out)
+        self.assertIn("TEST_CMS_URL=", out)
+
+
 class TestDockerHealth(unittest.TestCase):
     """#2537 / #2481: ``_docker_health`` maps inspect output to RESULT HEALTH: values."""
 
@@ -286,6 +318,17 @@ class TestSubcommandDryRun(unittest.TestCase):
         self.assertEqual(rc, pdc.EXIT_OK)
         self.assertIn("RESULT:OK STEP:qa-down", out)
         self.assertIn(f"QA_CONTAINER:{pdc.QA_CMS_CONTAINER}", out)
+
+    def test_qa_rebuild_chain_dry_run(self):
+        (self.repo_root / "projects" / "sitemanage").mkdir(parents=True, exist_ok=True)
+        (self.repo_root / "WebUI").mkdir(parents=True, exist_ok=True)
+        (self.repo_root / "modules" / "perc-distribution-tree").mkdir(
+            parents=True, exist_ok=True
+        )
+        (self.repo_root / "mvnw.cmd").write_text("@echo stub\r\n", encoding="utf-8")
+        rc, out = self.runner.run(["qa-rebuild-chain", "--dist-only"])
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
 
     def test_it_verify_dry_run(self):
         rc, out = self.runner.run(["it-verify"])

--- a/docker/scripts/test_qa_rebuild_chain.py
+++ b/docker/scripts/test_qa_rebuild_chain.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for docker/scripts/qa_rebuild_chain.py (#2533).
+
+No real Maven: dry-run exercises planning; real-mode uses a stubbed
+``subprocess.run`` that records argv/cwd and returns CompletedProcess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any, List, Optional
+
+SCRIPTS = Path(__file__).resolve().parent
+
+_spec = importlib.util.spec_from_file_location(
+    "qa_rebuild_chain", SCRIPTS / "qa_rebuild_chain.py"
+)
+qa_rebuild_chain = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["qa_rebuild_chain"] = qa_rebuild_chain
+_spec.loader.exec_module(qa_rebuild_chain)
+
+
+class _FakeRun:
+    """Stub subprocess.run: record calls, return configurable codes."""
+
+    def __init__(self, returncodes: Optional[List[int]] = None) -> None:
+        self.calls: List[dict[str, Any]] = []
+        self.returncodes = list(returncodes) if returncodes is not None else []
+        self._i = 0
+
+    def __call__(self, argv, **kwargs):  # noqa: ANN001
+        self.calls.append({"argv": list(argv), **kwargs})
+        code = 0
+        if self._i < len(self.returncodes):
+            code = self.returncodes[self._i]
+        self._i += 1
+        return subprocess.CompletedProcess(argv, code)
+
+
+class _RepoLayout:
+    def __init__(self) -> None:
+        self.td = tempfile.TemporaryDirectory()
+        self.root = Path(self.td.name) / "repo"
+        self.root.mkdir()
+        # Module dirs the chain requires
+        (self.root / "projects" / "sitemanage").mkdir(parents=True)
+        (self.root / "WebUI").mkdir(parents=True)
+        (self.root / "modules" / "perc-distribution-tree").mkdir(parents=True)
+        (self.root / "docker" / "logs").mkdir(parents=True)
+        # Wrappers — both names so tests pass on any OS without depending
+        # on sys.platform for file presence.
+        (self.root / "mvnw").write_text("#!/bin/sh\necho stub\n", encoding="utf-8")
+        (self.root / "mvnw.cmd").write_text("@echo stub\r\n", encoding="utf-8")
+
+    def cleanup(self) -> None:
+        self.td.cleanup()
+
+
+class TestPlanChain(unittest.TestCase):
+    def test_full_chain_order_and_goals(self):
+        steps = qa_rebuild_chain.plan_chain()
+        self.assertEqual(len(steps), 3)
+        self.assertEqual(steps[0].label, "qa-rebuild-sitemanage")
+        self.assertEqual(steps[0].goals, ("clean", "install"))
+        self.assertEqual(steps[0].extra_args, ())
+        self.assertEqual(steps[1].label, "qa-rebuild-webui")
+        self.assertEqual(steps[1].goals, ("package",))
+        self.assertIn("-DskipTests", steps[1].extra_args)
+        self.assertEqual(steps[2].label, "qa-rebuild-dist")
+        self.assertEqual(steps[2].goals, ("clean", "package"))
+        self.assertIn("-DskipTests", steps[2].extra_args)
+
+    def test_skip_tests_adds_flag_to_sitemanage(self):
+        steps = qa_rebuild_chain.plan_chain(skip_tests=True)
+        self.assertIn("-DskipTests", steps[0].extra_args)
+
+    def test_dist_only_single_step(self):
+        steps = qa_rebuild_chain.plan_chain(dist_only=True)
+        self.assertEqual(len(steps), 1)
+        self.assertEqual(steps[0].label, "qa-rebuild-dist")
+        self.assertEqual(steps[0].goals, ("package",))
+
+
+class TestResolveMvnw(unittest.TestCase):
+    def test_resolve_picks_platform_wrapper_name(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            mvnw = qa_rebuild_chain.resolve_mvnw(root)
+            if sys.platform.startswith("win"):
+                self.assertTrue(str(mvnw).endswith("mvnw.cmd"))
+            else:
+                self.assertTrue(mvnw.name == "mvnw")
+
+
+class TestDryRun(unittest.TestCase):
+    def setUp(self):
+        self.layout = _RepoLayout()
+        self.addCleanup(self.layout.cleanup)
+
+    def test_dry_run_prints_planned_and_result_ok_no_subprocess(self):
+        fake = _FakeRun()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_rebuild_chain.run_chain(
+                self.layout.root,
+                dry_run=True,
+                run_fn=fake,
+            )
+        out = buf.getvalue()
+        self.assertEqual(rc, qa_rebuild_chain.EXIT_OK)
+        self.assertEqual(fake.calls, [])
+        self.assertIn("PLANNED STEP:qa-rebuild-sitemanage", out)
+        self.assertIn("PLANNED STEP:qa-rebuild-webui", out)
+        self.assertIn("PLANNED STEP:qa-rebuild-dist", out)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-sitemanage", out)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-webui", out)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-dist", out)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
+        # Planned argv must include wrapper + goals
+        self.assertIn("clean", out)
+        self.assertIn("install", out)
+        self.assertIn("package", out)
+
+    def test_dry_run_dist_only(self):
+        fake = _FakeRun()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_rebuild_chain.run_chain(
+                self.layout.root,
+                dry_run=True,
+                dist_only=True,
+                run_fn=fake,
+            )
+        out = buf.getvalue()
+        self.assertEqual(rc, qa_rebuild_chain.EXIT_OK)
+        self.assertNotIn("qa-rebuild-sitemanage", out)
+        self.assertIn("PLANNED STEP:qa-rebuild-dist", out)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
+
+
+class TestRealModeStubbed(unittest.TestCase):
+    def setUp(self):
+        self.layout = _RepoLayout()
+        self.addCleanup(self.layout.cleanup)
+
+    def test_success_runs_three_steps_shell_false(self):
+        fake = _FakeRun(returncodes=[0, 0, 0])
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_rebuild_chain.run_chain(
+                self.layout.root,
+                dry_run=False,
+                skip_tests=True,
+                log_dir=self.layout.root / "docker" / "logs",
+                run_fn=fake,
+            )
+        out = buf.getvalue()
+        self.assertEqual(rc, qa_rebuild_chain.EXIT_OK)
+        self.assertEqual(len(fake.calls), 3)
+        for call in fake.calls:
+            self.assertIs(call.get("shell"), False)
+            self.assertIn("cwd", call)
+            argv = call["argv"]
+            self.assertTrue(
+                argv[0].endswith("mvnw") or argv[0].endswith("mvnw.cmd"),
+                msg=f"argv0 should be mvnw wrapper, got {argv[0]!r}",
+            )
+
+        # Order: sitemanage → WebUI → dist
+        cwd0 = Path(fake.calls[0]["cwd"])
+        cwd1 = Path(fake.calls[1]["cwd"])
+        cwd2 = Path(fake.calls[2]["cwd"])
+        self.assertEqual(cwd0.name, "sitemanage")
+        self.assertEqual(cwd1.name, "WebUI")
+        self.assertEqual(cwd2.name, "perc-distribution-tree")
+
+        # sitemanage with skip_tests
+        self.assertIn("-DskipTests", fake.calls[0]["argv"])
+        self.assertIn("install", fake.calls[0]["argv"])
+        self.assertIn("package", fake.calls[1]["argv"])
+        self.assertIn("package", fake.calls[2]["argv"])
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
+
+    def test_failure_stops_chain(self):
+        fake = _FakeRun(returncodes=[0, 1, 0])
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_rebuild_chain.run_chain(
+                self.layout.root,
+                dry_run=False,
+                log_dir=self.layout.root / "docker" / "logs",
+                run_fn=fake,
+            )
+        out = buf.getvalue()
+        self.assertEqual(rc, qa_rebuild_chain.EXIT_SUBPROCESS_FAILED)
+        # Second step fails; third must not run
+        self.assertEqual(len(fake.calls), 2)
+        self.assertIn("RESULT:FAIL STEP:qa-rebuild-webui", out)
+        self.assertIn("RESULT:FAIL STEP:qa-rebuild-chain", out)
+        self.assertNotIn("RESULT:OK STEP:qa-rebuild-dist", out)
+
+    def test_missing_wrapper_is_invocation_error(self):
+        # Remove both wrappers
+        for name in ("mvnw", "mvnw.cmd"):
+            p = self.layout.root / name
+            if p.exists():
+                p.unlink()
+        fake = _FakeRun()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_rebuild_chain.run_chain(
+                self.layout.root,
+                dry_run=False,
+                run_fn=fake,
+            )
+        self.assertEqual(rc, qa_rebuild_chain.EXIT_INVOCATION)
+        self.assertEqual(fake.calls, [])
+        self.assertIn("RESULT:FAIL STEP:qa-rebuild-chain", buf.getvalue())
+
+
+class TestMainCli(unittest.TestCase):
+    def setUp(self):
+        self.layout = _RepoLayout()
+        self.addCleanup(self.layout.cleanup)
+
+    def test_main_dry_run_exit_zero(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = qa_rebuild_chain.main(
+                [
+                    "--repo-root",
+                    str(self.layout.root),
+                    "--dry-run",
+                    "--skip-tests",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -108,8 +108,19 @@ Productized entrypoint on `docker/scripts/perc-devctl.py` (cross-platform Python
 
 **Prereq (once per machine / after installer or sitemanage/WebUI SNAPSHOT changes):** rebuild the chain that feeds the installer. The matrix cell **bind-mounts** `modules/perc-distribution-tree/target/perc-distribution-tree.jar`; that jar unpacks **`WebUI/target/perc-web-ui-*.war`** into `Rhythmyx/WEB-INF/lib` (including `sitemanage-*.jar`). Packaging only `perc-distribution-tree` after a sitemanage-only install **does not** pick up a new sitemanage if the WebUI WAR is stale.
 
+**Preferred driver (#2533):** use the portable `perc-devctl` / `qa_rebuild_chain.py` entry point instead of hand-typed `cd` + `mvnw` (wrong order and skipped WebUI were common agent failures). It runs repo-root `mvnw`/`mvnw.cmd` with `shell=False`, prints `PLANNED STEP:` / `RESULT:OK|FAIL` lines, and supports `--dry-run`.
+
 ```bash
 # After sitemanage (or other Rhythmyx WEB-INF/lib) changes — full QA rebuild chain:
+python docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests
+# equivalent standalone:
+# python docker/scripts/qa_rebuild_chain.py --skip-tests
+# plan only: add --dry-run
+```
+
+Manual equivalent (same order the driver executes):
+
+```bash
 cd projects/sitemanage && ../../mvnw clean install   # or package if tests already green
 cd ../../WebUI && ../mvnw package -DskipTests
 cd ../modules/perc-distribution-tree && ../../mvnw clean package -DskipTests
@@ -119,9 +130,12 @@ cd ../modules/perc-distribution-tree && ../../mvnw clean package -DskipTests
 If only installer packaging scripts/resources changed (no Java SNAPSHOT under the WAR):
 
 ```bash
-cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
+python docker/scripts/perc-devctl.py qa-rebuild-chain --dist-only
+# manual: cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
 # Windows: cd modules\perc-distribution-tree && ..\..\mvnw.cmd package -DskipTests
 ```
+
+When `qa-preflight --strict` reports `STALE:`, run `qa-rebuild-chain` (not dist-only) then re-check preflight before `qa-up`. Optional one-shot: `qa-rebuild-chain --skip-tests --then-qa-up`.
 
 **Post-cycle-fix smoke (#2423 / #2437):** after the rebuild chain, `qa-up` logs must show `ServletContextHandler] Started` for ROOT/Rhythmyx and **must not** contain `BeanCurrentlyInCreationException` / `Failed startup of context`. `qa-health` → `HTTP 200/302/401/403` on the **probe URL** is the operator gate before Playwright. The default probe URL is the matrix-recommended primary `/Rhythmyx/rest/mimetypes` (#2482; Spring-managed `MimeTypeResource.ping()` — returns 404 instead of 200 when the Rhythmyx Spring `ApplicationContext` is dead). Legacy `/Rhythmyx/login` is still accepted as a fallback but only proves Jetty is up, not Spring. Override with env `RHYTHMYX_HEALTH_PATH=…` (honored by `perc-devctl.py qa-health`, in-image `rhythmyx_healthcheck.py`, and any external orchestrator). Full matrix + capability analysis: [`../ai-generated/tasks/2482-readiness-signal/rhythmyx-readiness-probe-matrix.md`](../ai-generated/tasks/2482-readiness-signal/rhythmyx-readiness-probe-matrix.md).
 


### PR DESCRIPTION
## Summary

Implements **#2533** (residual of parent **#2423** / preflight **#2486**): a portable operator driver for the documented QA Maven rebuild order so agents stop hand-typing wrong/partial chains after STALE.

- New `docker/scripts/qa_rebuild_chain.py`: sitemanage `clean install` → WebUI `package -DskipTests` → perc-distribution-tree `clean package -DskipTests`
- Repo-root `mvnw` / `mvnw.cmd`, `pathlib.Path`, `subprocess.run(..., shell=False)`
- `--dry-run` prints `PLANNED STEP:… ARGV:…`; per-step + overall `RESULT:OK|FAIL`
- Flags: `--skip-tests`, `--dist-only`, optional timeout
- `perc-devctl.py qa-rebuild-chain` (+ optional `--then-qa-up`)
- Unit tests with stubbed subprocess (`test_qa_rebuild_chain.py` + perc-devctl dry-run coverage)
- Docs: `docker/README.md`, `docs/developer-module/workbench-rest-and-qa-modes.md`

Parent tracker: #2423

## Test plan

1. `python -m pytest docker/scripts/test_qa_rebuild_chain.py docker/scripts/test_perc_devctl.py -v` → 71 passed
2. `python docker/scripts/qa_rebuild_chain.py --dry-run --skip-tests` → three PLANNED steps + RESULT:OK
3. `python docker/scripts/perc-devctl.py qa-rebuild-chain --dry-run --dist-only` → dist-only plan
4. (Manual / optional live) `qa-rebuild-chain --skip-tests` after STALE preflight, then `qa-preflight --strict` + `qa-up`

## Gates evidence

- **Erlang-style self-review:** portable Path/cwd, no shell=True, failure stops chain, tests stub subprocess, no secrets, no non-portable separators
- **Maven:** no Java modules changed — clean install N/A (Python + docs only)
- **Tests:** 71 passed (10 new rebuild-chain + perc-devctl suite)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2533

> Co-Authored by Grok Build using grok-4.5 with agent main.
