### PR TITLE
fix(qa): harden Finder miller selection for UI recycle (#2541)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -474,13 +474,26 @@ npm run test:surface:list -- --tag folder-recycle
 mentions `BeanCurrentlyInCreationException` / `folderHelper`), the smoke fails
 with an explicit message citing #2464 / #2423 — do not treat as soft skip.
 
-#### Classic Finder UI recycle / restore companion (#2489 / parent #2423)
+#### Classic Finder UI recycle / restore companion (#2489 / residual #2541 / parent #2423)
 
 Surface-filtered UI companion for the folder+recycle REST smoke (#2464). Exercises
 classic Finder chrome: soft-delete (recycle) a seeded Assets folder, then
 **restore** via `#perc-finder-restore-item` when path/selection allows, else
 **Empty Recycling** via Actions menu (`data-testid="perc-finder-empty-recycling"`,
 #2207 peer). Hard fails when pathmanagement context or Admin login is down.
+
+**#2541 selection reliability:** happy-path recycle uses ordered strategies so
+`#perc-finder-delete` enables without REST soft-delete fallback:
+
+1. Path-bar navigate to `/Assets/{name}` (fires path_changed depth &gt; 2)
+2. Click `#perc-finder-listing-{guid}` when seed guid is known
+3. Miller column: `.mcol-listing[title=…]` / `.perc-finder-item-name` parent
+4. List view: `.perc-datatable-row` exact name
+
+REST `deleteFolder` remains only as last-resort residual-shell recovery (annotated
+warning). Residual product chrome gaps: no `data-testid` on miller listings or
+list rows; delete/restore enablement is class-based (`ui-enabled` /
+`ui-disabled`) only — Empty Recycling is the main `data-testid` control.
 
 | Item | Value |
 |------|--------|

--- a/modules/perc-qa-automation/frontend/tests/finder-recycle-restore-ui.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/finder-recycle-restore-ui.spec.js
@@ -16,11 +16,17 @@
 
 /**
  * Classic Finder UI recycle / restore companion for folder-recycle REST smoke
- * (#2489 / parent #2423; REST peer #2464 / PR #2487; empty-recycling UI #2207).
+ * (#2489 residual #2541 / parent #2423; REST peer #2464 / PR #2487;
+ * empty-recycling UI #2207).
  *
  * <p>Proves classic Finder chrome can recycle a folder (delete → soft-delete)
  * and either restore it or empty Recycling via UI controls. Hard fails when
  * pathmanagement context or Admin login is down (no soft skip).</p>
+ *
+ * <p>#2541 hardens miller-column / list selection so happy-path recycle uses
+ * {@code #perc-finder-delete} without REST soft-delete fallback. Strategies:
+ * path-bar to /Assets/{name}, listing-id, miller title/name, list-row. REST
+ * recycle remains only as last-resort residual-shell recovery (logged).</p>
  *
  * <h3>Unattended surface (QA mode)</h3>
  * <pre>
@@ -73,6 +79,11 @@ const {
   emptyRecyclingApiPathFragment,
   recycledFolderFinderPath,
   exactFinderItemNameMatcher,
+  finderRecycleSelectStrategies,
+  isDeleteEligiblePath,
+  pathBarReflectsFolderName,
+  shouldUseRestRecycleFallback,
+  millerSelectionFailureMessage,
   chooseRestoreOrEmptyBranch,
 } = require("./helpers/finder-recycle-restore-ui");
 
@@ -109,38 +120,206 @@ async function navigateFinderPath(page, finderPath) {
   } else {
     await pathInput.press("Enter");
   }
-  // Allow path-changed listeners (delete/restore enablement).
-  await page.waitForTimeout(750);
+  // Allow path-changed listeners (delete/restore enablement) + column load.
+  await page.waitForTimeout(900);
 }
 
 /**
- * Best-effort select a miller-column / list item by exact display name.
+ * Prefer miller column view when the chooser is present (list-view variance).
+ * @param {import("@playwright/test").Page} page
+ */
+async function preferColumnView(page) {
+  const col = page.locator(SELECTORS.chooseColumnView);
+  if ((await col.count()) === 0) {
+    return;
+  }
+  const disabled = await col.first().getAttribute("class").catch(() => "");
+  if (String(disabled || "").includes("ui-state-disabled")) {
+    return;
+  }
+  await col.first().click({ timeout: 3_000 }).catch(() => {});
+  await page.waitForTimeout(400);
+}
+
+/**
+ * Click a miller listing / list row by exact display name (column + list).
+ * Prefers clicking the listing parent (.mcol-listing) so path_changed fires.
  * @param {import("@playwright/test").Page} page
  * @param {string} name
  * @returns {Promise<boolean>} true when a matching item was clicked
  */
 async function selectFinderItemByName(page, name) {
   const match = exactFinderItemNameMatcher(name);
+
+  // 1) Miller listing by title attribute (product sets title = displayLabel).
+  const byTitle = page.locator(
+    `${SELECTORS.millerListing}[title="${String(name).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`,
+  );
+  if ((await byTitle.count()) > 0) {
+    await byTitle.first().click({ timeout: 5_000 }).catch(() => {});
+    await page.waitForTimeout(500);
+    return true;
+  }
+
+  // 2) Miller item-name text → click parent listing.
   const names = page.locator(SELECTORS.finderItemName);
   const count = await names.count();
   for (let i = 0; i < count; i++) {
     const text = await names.nth(i).innerText().catch(() => "");
     if (match(text)) {
-      await names.nth(i).click({ timeout: 5_000 }).catch(() => {});
-      await page.waitForTimeout(400);
+      const listing = names.nth(i).locator("xpath=ancestor-or-self::*[contains(@class,'mcol-listing')][1]");
+      if ((await listing.count()) > 0) {
+        await listing.first().click({ timeout: 5_000 }).catch(() => {});
+      } else {
+        await names.nth(i).click({ timeout: 5_000 }).catch(() => {});
+      }
+      await page.waitForTimeout(500);
       return true;
     }
   }
-  // Fallback: any element with exact text under finder outer.
+
+  // 3) List view rows (PercFinderListView).
+  const rows = page.locator(SELECTORS.listViewRow);
+  const rowCount = await rows.count();
+  for (let i = 0; i < rowCount; i++) {
+    const text = await rows.nth(i).innerText().catch(() => "");
+    const lines = String(text || "")
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (lines.some((line) => match(line)) || match(text)) {
+      await rows.nth(i).click({ timeout: 5_000 }).catch(() => {});
+      await page.waitForTimeout(500);
+      return true;
+    }
+  }
+
+  // 4) Any exact text under finder outer.
   const byText = page
     .locator(SELECTORS.finderOuter)
     .getByText(name, { exact: true });
   if ((await byText.count()) > 0) {
     await byText.first().click({ timeout: 5_000 }).catch(() => {});
-    await page.waitForTimeout(400);
+    await page.waitForTimeout(500);
     return true;
   }
   return false;
+}
+
+/**
+ * Poll until #perc-finder-delete looks enabled (ui-enabled / not ui-disabled).
+ * @param {import("@playwright/test").Locator} deleteBtn
+ * @param {number} [timeoutMs=15_000]
+ * @returns {Promise<boolean>}
+ */
+async function waitForDeleteEnabled(deleteBtn, timeoutMs = 15_000) {
+  try {
+    await expect
+      .poll(
+        async () => {
+          const cls = (await deleteBtn.getAttribute("class")) || "";
+          return isFinderControlEnabled(cls);
+        },
+        { timeout: timeoutMs },
+      )
+      .toBe(true);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Apply ordered #2541 strategies so selection enables UI recycle.
+ * @param {import("@playwright/test").Page} page
+ * @param {import("@playwright/test").Locator} deleteBtn
+ * @param {{ name: string, parentPath?: string, guid?: string }} target
+ * @returns {Promise<{ selected: boolean, deleteEnabled: boolean, strategiesTried: string[], pathBar: string }>}
+ */
+async function selectForUiRecycle(page, deleteBtn, target) {
+  const strategies = finderRecycleSelectStrategies(target);
+  /** @type {string[]} */
+  const strategiesTried = [];
+  let selected = false;
+  let deleteEnabled = false;
+
+  await preferColumnView(page);
+
+  for (const strategy of strategies) {
+    strategiesTried.push(strategy.kind);
+
+    if (strategy.kind === "path-bar" && strategy.path) {
+      await navigateFinderPath(page, strategy.path);
+      const barAfter = await page
+        .locator(SELECTORS.pathSummary)
+        .inputValue()
+        .catch(() => "");
+      selected =
+        pathBarReflectsFolderName(barAfter, target.name) ||
+        isDeleteEligiblePath(barAfter);
+    } else if (strategy.kind === "listing-id" && strategy.selector) {
+      // Ensure parent column is open first so listing exists.
+      await navigateFinderPath(page, normalizeFinderPathInput(target.parentPath || "Assets"));
+      const listing = page.locator(strategy.selector);
+      if ((await listing.count()) > 0) {
+        await listing.first().click({ timeout: 5_000 }).catch(() => {});
+        await page.waitForTimeout(500);
+        selected = true;
+      }
+    } else if (
+      strategy.kind === "miller-title" ||
+      strategy.kind === "miller-name" ||
+      strategy.kind === "list-row"
+    ) {
+      await navigateFinderPath(page, normalizeFinderPathInput(target.parentPath || "Assets"));
+      // Wait briefly for seeded folder to appear in column/list.
+      try {
+        await expect
+          .poll(
+            async () => {
+              const names = page.locator(SELECTORS.finderItemName);
+              const n = await names.count();
+              for (let i = 0; i < n; i++) {
+                const t = await names.nth(i).innerText().catch(() => "");
+                if (exactFinderItemNameMatcher(target.name)(t)) {
+                  return true;
+                }
+              }
+              const rows = page.locator(SELECTORS.listViewRow);
+              const rc = await rows.count();
+              for (let i = 0; i < rc; i++) {
+                const t = await rows.nth(i).innerText().catch(() => "");
+                if (String(t || "").includes(target.name)) {
+                  return true;
+                }
+              }
+              return false;
+            },
+            { timeout: 12_000 },
+          )
+          .toBe(true);
+      } catch {
+        // Item not visible yet — still try click strategies below.
+      }
+      selected = (await selectFinderItemByName(page, target.name)) || selected;
+    }
+
+    deleteEnabled = await waitForDeleteEnabled(deleteBtn, 12_000);
+    if (selected && deleteEnabled) {
+      break;
+    }
+    // If path-bar made delete eligible path but control still disabled, keep trying.
+    if (deleteEnabled) {
+      selected = true;
+      break;
+    }
+  }
+
+  const pathBar = await page
+    .locator(SELECTORS.pathSummary)
+    .inputValue()
+    .catch(() => "");
+  return { selected, deleteEnabled, strategiesTried, pathBar };
 }
 
 /**
@@ -251,63 +430,68 @@ test.describe("classic Finder UI recycle / restore companion", () => {
       "classic Finder delete control (#perc-finder-delete) should exist",
     ).toBeVisible({ timeout: 30_000 });
 
-    await navigateFinderPath(page, "/Assets");
-    const selectedLive = await selectFinderItemByName(page, created.name);
+    // #2541: ordered strategies (path-bar / listing-id / miller / list) so
+    // #perc-finder-delete enables without relying on REST soft-delete first.
+    const selection = await selectForUiRecycle(page, deleteBtn, {
+      name: created.name,
+      parentPath: "Assets",
+      guid: created.guid,
+    });
 
     let recycledViaUi = false;
-    if (selectedLive) {
-      // Admin folder delete often skips confirm and soft-deletes immediately.
-      // Selection may not enable delete on all skins — fall through to REST.
-      let deleteEnabled = false;
+    if (selection.selected && selection.deleteEnabled) {
+      await deleteBtn.click();
+      // Optional confirm (page/asset paths use it; Admin folders often do not).
+      const confirm = page.locator(SELECTORS.deleteConfirm);
+      if (
+        (await confirm.count()) > 0 &&
+        (await confirm.isVisible().catch(() => false))
+      ) {
+        await page.locator(SELECTORS.confirmOk).click().catch(() => {});
+      }
       try {
         await expect
-          .poll(
-            async () => {
-              const cls = (await deleteBtn.getAttribute("class")) || "";
-              return isFinderControlEnabled(cls);
-            },
-            { timeout: 15_000 },
-          )
+          .poll(() => deleteCalls.length > 0, { timeout: 20_000 })
           .toBe(true);
-        deleteEnabled = true;
       } catch {
-        deleteEnabled = false;
+        // Network may not surface if soft-delete used a different path.
       }
-
-      if (deleteEnabled) {
-        await deleteBtn.click();
-        // Optional confirm (page/asset paths use it; Admin folders often do not).
-        const confirm = page.locator(SELECTORS.deleteConfirm);
-        if (
-          (await confirm.count()) > 0 &&
-          (await confirm.isVisible().catch(() => false))
-        ) {
-          await page.locator(SELECTORS.confirmOk).click().catch(() => {});
-        }
-        try {
-          await expect
-            .poll(() => deleteCalls.length > 0, { timeout: 20_000 })
-            .toBe(true);
-        } catch {
-          // Network may not surface if soft-delete used a different path.
-        }
-        recycledViaUi = deleteCalls.length > 0;
-        // Also accept when REST listing shows recycled even without captured call.
-        if (!recycledViaUi) {
-          const probeBin = await findInRecycling(
-            request,
-            BASE_URL,
-            headers,
-            created.name,
-          );
-          recycledViaUi = probeBin.found;
-        }
+      recycledViaUi = deleteCalls.length > 0;
+      // Also accept when REST listing shows recycled even without captured call.
+      if (!recycledViaUi) {
+        const probeBin = await findInRecycling(
+          request,
+          BASE_URL,
+          headers,
+          created.name,
+        );
+        recycledViaUi = probeBin.found;
       }
     }
 
-    // Fallback: REST recycle so restore/empty UI can still run when miller
-    // selection is flaky on a residual shell. UI chrome already asserted above.
-    if (!recycledViaUi) {
+    // Last-resort REST only when UI selection/enablement failed (residual shell).
+    // Happy path must not need this (#2541).
+    if (
+      shouldUseRestRecycleFallback({
+        selected: selection.selected,
+        deleteEnabled: selection.deleteEnabled,
+        recycledViaUi,
+      })
+    ) {
+      test.info().annotations.push({
+        type: "warning",
+        description: millerSelectionFailureMessage({
+          name: created.name,
+          strategiesTried: selection.strategiesTried,
+          pathBar: selection.pathBar,
+        }),
+      });
+      await recycleFolder(request, BASE_URL, headers, {
+        path: created.path,
+        guid: created.guid,
+      });
+    } else if (!recycledViaUi) {
+      // Selected + enabled but click did not recycle — still try REST recover.
       await recycleFolder(request, BASE_URL, headers, {
         path: created.path,
         guid: created.guid,

--- a/modules/perc-qa-automation/frontend/tests/helpers/finder-recycle-restore-ui.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/finder-recycle-restore-ui.js
@@ -1,6 +1,6 @@
 /**
  * Pure helpers + classic Finder UI utilities for folder recycle/restore
- * companion smoke (#2489 / parent #2423; REST peer #2464).
+ * companion smoke (#2489 residual #2541 / parent #2423; REST peer #2464).
  *
  * <p>Reuses empty-recycling selectors and folder-recycle-smoke REST helpers.
  * No machine hard-coded install paths. Base URL and credentials come from
@@ -8,6 +8,25 @@
  *
  * <p>Surface tags: {@code @finder-recycle-restore} {@code @folder-recycle}
  * {@code @smoke}.</p>
+ *
+ * <h3>Selection reliability (#2541)</h3>
+ * <p>Classic Finder delete (#perc-finder-delete) enables only after path_changed
+ * with depth &gt; 2 (see perc_delete_page_button.js). Happy path must select or
+ * path-navigate to the seeded Assets folder so UI recycle works without REST
+ * soft-delete fallback. Strategies cover miller column + list view skins.</p>
+ *
+ * <h3>Residual product chrome / testid gaps</h3>
+ * <ul>
+ *   <li>Miller listings use id {@code perc-finder-listing-{id}} and class
+ *       {@code mcol-listing} / {@code perc-finder-item-name} — no stable
+ *       {@code data-testid} on individual folder rows.</li>
+ *   <li>List view rows use {@code perc-datatable-row} with jQuery row data —
+ *       no {@code data-testid} per path item.</li>
+ *   <li>Delete/restore enablement is class-based ({@code ui-enabled} /
+ *       {@code ui-disabled}), not aria-disabled / HTML disabled.</li>
+ *   <li>Only Empty Recycling has {@code data-testid="perc-finder-empty-recycling"}
+ *       (#2206); recycle/restore still rely on id selectors.</li>
+ * </ul>
  */
 
 "use strict";
@@ -35,8 +54,13 @@ const SELECTORS = Object.freeze({
   confirmCancel: "#perc-confirm-generic-cancel",
   finderItemName: ".perc-finder-item-name",
   lastSelected: ".mcol-opened.perc_last_selected",
+  millerListing: ".mcol-listing",
   listingCategoryFolder: ".perc-listing-category-FOLDER",
   finderListingPrefix: "perc-finder-listing-",
+  listViewRow: ".perc-datatable-row",
+  listViewRowHighlighted: ".perc-datatable-row-highlighted",
+  chooseColumnView: "#perc-finder-choose-columnview",
+  chooseListView: "#perc-finder-choose-listview",
   finderOuter: ".perc-finder-outer",
   pathSummary: "#mcol-path-summary",
   pathGo: "#perc-finder-go-action",
@@ -223,6 +247,194 @@ function exactFinderItemNameMatcher(name) {
 }
 
 /**
+ * Escape a value for use inside a double-quoted CSS attribute selector.
+ * Prevents selector breakage when folder names contain quotes or backslashes.
+ *
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+function cssAttrEscape(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+}
+
+/**
+ * CSS id selector for a miller listing built from product idFromItem:
+ * {@code #perc-finder-listing-{id}}.
+ *
+ * @param {string | null | undefined} itemId content id / guid postfix
+ * @returns {string} empty when id missing
+ */
+function finderListingIdSelector(itemId) {
+  const raw = String(itemId || "").trim();
+  if (!raw) {
+    return "";
+  }
+  // Product: id = "perc-finder-listing-" + item.id (ids often start with digits).
+  // Full id always starts with a letter (prefix), so #id is valid when raw is
+  // word/colon/hyphen characters; otherwise fall back to attribute selector.
+  const fullId = `${SELECTORS.finderListingPrefix}${raw}`;
+  if (/^[\w:-]+$/.test(raw)) {
+    return `#${fullId}`;
+  }
+  return `[id="${cssAttrEscape(fullId)}"]`;
+}
+
+/**
+ * Full finder path to a named folder under a structural parent (default Assets).
+ *
+ * @param {string} folderName
+ * @param {string} [parentPath="Assets"]
+ * @returns {string} e.g. "/Assets/qa-folder-1"
+ */
+function folderFinderPath(folderName, parentPath = "Assets") {
+  const name = String(folderName || "").trim();
+  const parent = normalizeFinderPathInput(parentPath);
+  if (!name) {
+    return parent;
+  }
+  if (parent === "/") {
+    return normalizeFinderPathInput(`/${name}`);
+  }
+  return normalizeFinderPathInput(`${parent}/${name}`);
+}
+
+/**
+ * True when path-bar / path_changed depth is deep enough for delete enablement.
+ * Product rule: mcol_path.length &gt; 2 (e.g. ["", "Assets", "seed"]).
+ *
+ * @param {string | string[] | null | undefined} path
+ * @returns {boolean}
+ */
+function isDeleteEligiblePath(path) {
+  const segments = Array.isArray(path) ? path : finderPathSegments(path);
+  return Array.isArray(segments) && segments.length > 2;
+}
+
+/**
+ * True when the path bar value indicates the named item is the current path leaf.
+ *
+ * @param {string | null | undefined} pathBarValue
+ * @param {string | null | undefined} folderName
+ * @returns {boolean}
+ */
+function pathBarReflectsFolderName(pathBarValue, folderName) {
+  const name = String(folderName || "").trim();
+  if (!name) {
+    return false;
+  }
+  const segments = finderPathSegments(pathBarValue);
+  if (segments.length < 2) {
+    return false;
+  }
+  return String(segments[segments.length - 1] || "").trim() === name;
+}
+
+/**
+ * Ordered pure strategies to put a named Assets (or parent) folder in selection
+ * so #perc-finder-delete can enable. Spec applies these against live DOM.
+ *
+ * <ol>
+ *   <li>{@code path-bar} — navigate path bar to /Parent/Name (most reliable;
+ *       fires path_changed with depth &gt; 2 without miller click races)</li>
+ *   <li>{@code listing-id} — click #perc-finder-listing-{guid} when known</li>
+ *   <li>{@code miller-title} — click .mcol-listing[title=name]</li>
+ *   <li>{@code miller-name} — click parent listing of matching item-name text</li>
+ *   <li>{@code list-row} — click .perc-datatable-row containing exact name</li>
+ * </ol>
+ *
+ * @param {{ name: string, parentPath?: string, guid?: string }} opts
+ * @returns {Array<{
+ *   kind: "path-bar" | "listing-id" | "miller-title" | "miller-name" | "list-row",
+ *   path?: string,
+ *   selector?: string,
+ *   name?: string
+ * }>}
+ */
+function finderRecycleSelectStrategies(opts = {}) {
+  const name = String(opts.name || "").trim();
+  const parentPath = opts.parentPath != null ? opts.parentPath : "Assets";
+  const guid = String(opts.guid || "").trim();
+  /** @type {Array<{ kind: string, path?: string, selector?: string, name?: string }>} */
+  const strategies = [];
+
+  if (name) {
+    strategies.push({
+      kind: "path-bar",
+      path: folderFinderPath(name, parentPath),
+    });
+  }
+
+  if (guid) {
+    const sel = finderListingIdSelector(guid);
+    if (sel) {
+      strategies.push({ kind: "listing-id", selector: sel, name });
+    }
+  }
+
+  if (name) {
+    const safe = cssAttrEscape(name);
+    strategies.push({
+      kind: "miller-title",
+      selector: `${SELECTORS.millerListing}[title="${safe}"]`,
+      name,
+    });
+    strategies.push({
+      kind: "miller-name",
+      selector: SELECTORS.finderItemName,
+      name,
+    });
+    strategies.push({
+      kind: "list-row",
+      selector: SELECTORS.listViewRow,
+      name,
+    });
+  }
+
+  return strategies;
+}
+
+/**
+ * Whether REST soft-delete fallback is still needed after UI selection attempts.
+ * Happy path (#2541): selected + delete enabled ⇒ no REST.
+ *
+ * @param {{ selected?: boolean, deleteEnabled?: boolean, recycledViaUi?: boolean }} flags
+ * @returns {boolean}
+ */
+function shouldUseRestRecycleFallback(flags = {}) {
+  if (flags.recycledViaUi) {
+    return false;
+  }
+  if (flags.selected && flags.deleteEnabled) {
+    // Selection + enablement succeeded; caller should click delete — not REST yet.
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Operator message when UI selection never enabled delete (residual chrome gap).
+ *
+ * @param {{ name?: string, strategiesTried?: string[], pathBar?: string }} detail
+ * @returns {string}
+ */
+function millerSelectionFailureMessage(detail = {}) {
+  const name = detail.name || "(unknown)";
+  const tried = Array.isArray(detail.strategiesTried)
+    ? detail.strategiesTried.join(", ")
+    : "(n/a)";
+  const pathBar = detail.pathBar ? ` pathBar=${detail.pathBar}` : "";
+  return (
+    `Classic Finder miller/list selection did not enable #perc-finder-delete` +
+    ` for folder "${name}" (strategies tried: ${tried}).` +
+    ` Residual chrome gaps: no data-testid on miller listings / list rows;` +
+    ` delete uses ui-enabled/ui-disabled classes only (#2541).` +
+    pathBar
+  );
+}
+
+/**
  * Choose restore vs empty-recycling UI branch when selection is uncertain.
  * Prefer restore when path is restore-eligible and restore control is enabled;
  * otherwise empty Recycling (Admin bulk purge) is the proven #2207 path.
@@ -252,6 +464,14 @@ module.exports = {
   emptyRecyclingApiPathFragment,
   recycledFolderFinderPath,
   exactFinderItemNameMatcher,
+  cssAttrEscape,
+  finderListingIdSelector,
+  folderFinderPath,
+  isDeleteEligiblePath,
+  pathBarReflectsFolderName,
+  finderRecycleSelectStrategies,
+  shouldUseRestRecycleFallback,
+  millerSelectionFailureMessage,
   chooseRestoreOrEmptyBranch,
   // Re-export peer constants used by the spec for convenience.
   PATH_RESTORE_FOLDER,

--- a/modules/perc-qa-automation/frontend/tests/unit/finder-recycle-restore-ui.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/finder-recycle-restore-ui.test.js
@@ -24,6 +24,14 @@ const {
   emptyRecyclingApiPathFragment,
   recycledFolderFinderPath,
   exactFinderItemNameMatcher,
+  cssAttrEscape,
+  finderListingIdSelector,
+  folderFinderPath,
+  isDeleteEligiblePath,
+  pathBarReflectsFolderName,
+  finderRecycleSelectStrategies,
+  shouldUseRestRecycleFallback,
+  millerSelectionFailureMessage,
   chooseRestoreOrEmptyBranch,
   PATH_RESTORE_FOLDER,
   PATH_DELETE_FOLDER,
@@ -39,6 +47,9 @@ describe("finder-recycle-restore-ui helpers", () => {
     );
     assert.equal(SELECTORS.actionsButton, "#perc-finder-actions-button");
     assert.equal(SELECTORS.pathSummary, "#mcol-path-summary");
+    assert.equal(SELECTORS.millerListing, ".mcol-listing");
+    assert.equal(SELECTORS.listViewRow, ".perc-datatable-row");
+    assert.equal(SELECTORS.chooseColumnView, "#perc-finder-choose-columnview");
     assert.ok(SURFACE_TAGS.includes("finder-recycle-restore"));
     assert.ok(SURFACE_TAGS.includes("folder-recycle"));
     assert.ok(SURFACE_TAGS.includes("smoke"));
@@ -167,5 +178,103 @@ describe("finder-recycle-restore-ui helpers", () => {
       "empty",
     );
     assert.equal(chooseRestoreOrEmptyBranch({}), "empty");
+  });
+
+  it("cssAttrEscape and finderListingIdSelector are safe", () => {
+    assert.equal(cssAttrEscape('a"b'), 'a\\"b');
+    assert.equal(cssAttrEscape("a\\b"), "a\\\\b");
+    assert.equal(finderListingIdSelector(""), "");
+    assert.equal(
+      finderListingIdSelector("0-101-456"),
+      "#perc-finder-listing-0-101-456",
+    );
+    assert.equal(
+      finderListingIdSelector('x"y'),
+      '[id="perc-finder-listing-x\\"y"]',
+    );
+  });
+
+  it("folderFinderPath and isDeleteEligiblePath match product depth rule", () => {
+    assert.equal(folderFinderPath("seed-a"), "/Assets/seed-a");
+    assert.equal(folderFinderPath("seed-a", "Sites"), "/Sites/seed-a");
+    assert.equal(folderFinderPath("", "Assets"), "/Assets");
+    assert.equal(isDeleteEligiblePath("/Assets"), false);
+    assert.equal(isDeleteEligiblePath("/Assets/seed-a"), true);
+    assert.equal(isDeleteEligiblePath(["", "Assets", "seed-a"]), true);
+    assert.equal(isDeleteEligiblePath("/"), false);
+  });
+
+  it("pathBarReflectsFolderName matches path leaf only", () => {
+    assert.equal(pathBarReflectsFolderName("/Assets/seed-a", "seed-a"), true);
+    assert.equal(pathBarReflectsFolderName("/Assets/seed-a/", "seed-a"), true);
+    assert.equal(pathBarReflectsFolderName("/Assets", "seed-a"), false);
+    assert.equal(pathBarReflectsFolderName("/Assets/seed-ab", "seed-a"), false);
+    assert.equal(pathBarReflectsFolderName("", "seed-a"), false);
+  });
+
+  it("finderRecycleSelectStrategies orders path-bar then miller then list", () => {
+    const withGuid = finderRecycleSelectStrategies({
+      name: "qa-folder-1",
+      parentPath: "Assets",
+      guid: "0-101-99",
+    });
+    assert.equal(withGuid[0].kind, "path-bar");
+    assert.equal(withGuid[0].path, "/Assets/qa-folder-1");
+    assert.equal(withGuid[1].kind, "listing-id");
+    assert.equal(withGuid[1].selector, "#perc-finder-listing-0-101-99");
+    assert.equal(withGuid[2].kind, "miller-title");
+    assert.match(withGuid[2].selector, /mcol-listing\[title=/);
+    assert.equal(withGuid[3].kind, "miller-name");
+    assert.equal(withGuid[4].kind, "list-row");
+
+    const noGuid = finderRecycleSelectStrategies({ name: "only-name" });
+    assert.equal(noGuid[0].kind, "path-bar");
+    assert.ok(!noGuid.some((s) => s.kind === "listing-id"));
+    assert.equal(finderRecycleSelectStrategies({}).length, 0);
+  });
+
+  it("shouldUseRestRecycleFallback is false on UI happy path", () => {
+    assert.equal(
+      shouldUseRestRecycleFallback({
+        selected: true,
+        deleteEnabled: true,
+        recycledViaUi: true,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldUseRestRecycleFallback({
+        selected: true,
+        deleteEnabled: true,
+        recycledViaUi: false,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldUseRestRecycleFallback({
+        selected: false,
+        deleteEnabled: false,
+      }),
+      true,
+    );
+    assert.equal(
+      shouldUseRestRecycleFallback({
+        selected: true,
+        deleteEnabled: false,
+      }),
+      true,
+    );
+  });
+
+  it("millerSelectionFailureMessage cites #2541 and residual chrome gaps", () => {
+    const msg = millerSelectionFailureMessage({
+      name: "seed",
+      strategiesTried: ["path-bar", "miller-title"],
+      pathBar: "/Assets",
+    });
+    assert.match(msg, /#2541/);
+    assert.match(msg, /data-testid/i);
+    assert.match(msg, /seed/);
+    assert.match(msg, /path-bar/);
   });
 });


### PR DESCRIPTION
## Summary

Hardens classic Finder miller-column / list selection for the #2489 Finder recycle/restore surface so **happy-path UI recycle uses `#perc-finder-delete` without REST soft-delete fallback**.

- Parent epic: #2423
- Implements: #2541 (residual of #2489 / PR #2539)
- Module: `modules/perc-qa-automation` only (no product WebUI change)

### Changes
- Pure helpers: ordered select strategies (path-bar → listing-id → miller title/name → list-row), delete-eligible path depth, path-bar leaf match, REST-fallback decision, residual chrome gap messaging
- Spec: `selectForUiRecycle` prefers column view, waits for delete enablement, clicks recycle; REST only as last-resort residual-shell recovery (annotated)
- Unit tests for new pure helpers
- README documents #2541 strategies + residual testid gaps

### Residual product chrome gaps (documented, not fixed in product)
- No `data-testid` on miller listings / list rows
- Delete/restore enablement is class-based (`ui-enabled` / `ui-disabled`) only
- Empty Recycling remains the main `data-testid` control

## Test plan
- [x] `cd modules/perc-qa-automation/frontend && npm run test:unit` — 177 pass (includes expanded `finder-recycle-restore-ui.test.js`)
- [x] `npm run test:surface:list -- --path tests/finder-recycle-restore-ui.spec.js` — 3 tests listed
- [x] `npm run test:surface:list -- --tag finder-recycle-restore` — 3 tests listed
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [ ] Optional live: `perc-devctl qa-up` + `TEST_CMS_URL=… npm run test:surface -- --path tests/finder-recycle-restore-ui.spec.js`

## Gates evidence
- Pre-PR Maven: standalone clean install of `perc-qa-automation` — SUCCESS
- Erlang-style self-review: pure helpers + behavioral unit tests; portable paths (no OS separators); change-class companions (helper + unit + spec + README) complete
- No product WebUI/source change — Playwright companion hardening only

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2541

> Co-Authored by Grok Build using grok-4.5 with agent main.
