### PR TITLE
fix(system): parameterize residual PSDbComponentSet subclasses (#2454)

### DIFF
--- a/system/services/src/com/percussion/services/assembly/impl/nav/PSNavConfig.java
+++ b/system/services/src/com/percussion/services/assembly/impl/nav/PSNavConfig.java
@@ -194,11 +194,11 @@ public class PSNavConfig
       {
          throw new PSNavException(this.getClass().getName(), e);
       }
-      Iterator variants = m_allVariants.iterator();
+      Iterator<PSContentTypeTemplate> variants = m_allVariants.iterator();
       log.debug("scanning all variants");
       while (variants.hasNext())
       {
-         PSContentTypeTemplate current = (PSContentTypeTemplate) variants.next();
+         PSContentTypeTemplate current = variants.next();
          log.debug("variant {}" , current.getName());
          for(IPSGuid g : m_navonTypes) {
             if (current.supportsContentType(g.getUUID())) {

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentDefProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentDefProcessorProxy.java
@@ -76,11 +76,11 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
 
         Element[] elems = proxy.load("PSContentTypeVariantSet", keys);
 
-        PSDbComponentSet<?> vs = new PSContentTypeVariantSet(elems);
+        PSContentTypeVariantSet vs = new PSContentTypeVariantSet(elems);
 
-        Iterator<?> it = vs.iterator();
+        Iterator<PSContentTypeTemplate> it = vs.iterator();
         while (it.hasNext()) {
-          PSContentTypeTemplate v = (PSContentTypeTemplate) it.next();
+          PSContentTypeTemplate v = it.next();
 
           checkContentVariant(v);
         }
@@ -95,11 +95,11 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
 
         Element[] elems = proxy.load("PSSlotTypeSet", keys);
 
-        PSDbComponentSet<?> slots = new PSSlotTypeSet(elems);
+        PSSlotTypeSet slots = new PSSlotTypeSet(elems);
 
-        Iterator<?> it = slots.iterator();
+        Iterator<PSSlotType> it = slots.iterator();
         while (it.hasNext()) {
-          PSSlotType s = (PSSlotType) it.next();
+          PSSlotType s = it.next();
 
           checkSlotType(s);
         }
@@ -113,11 +113,11 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
         PSKey[] keys = PSContentType.createKeys(ctIds);
         Element[] elems = proxy.load("PSContentTypeSet", keys);
 
-        PSDbComponentSet<?> cts = new PSContentTypeSet(elems);
+        PSContentTypeSet cts = new PSContentTypeSet(elems);
 
-        Iterator<?> it = cts.iterator();
+        Iterator<PSContentType> it = cts.iterator();
         while (it.hasNext()) {
-          PSContentType ct = (PSContentType) it.next();
+          PSContentType ct = it.next();
         }
       }
     } catch (Throwable ex) {
@@ -127,16 +127,16 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
   }
 
   private static void checkContentVariant(PSContentTypeTemplate v) {
-    PSDbComponentSet<?> slots = v.getVariantSlots();
+    PSVariantSlotTypeSet slots = v.getVariantSlots();
 
     if (slots == null) {
       System.out.println("No slots for the variant");
     }
 
-    Iterator<?> it1 = slots.iterator();
+    Iterator<PSVariantSlotType> it1 = slots.iterator();
 
     while (it1.hasNext()) {
-      PSVariantSlotType slot = (PSVariantSlotType) it1.next();
+      PSVariantSlotType slot = it1.next();
       int slotid = slot.getSlotId();
       int vid1 = slot.getVariantId();
       int bp = 0;
@@ -150,12 +150,12 @@ public class PSComponentDefProcessorProxy extends PSProcessorProxy {
     int systemSlot = s.getSystemSlot();
     int slotType = s.getSlotType();
 
-    PSDbComponentSet<?> slotV = s.getSlotVariants();
+    PSSlotTypeContentTypeVariantSet slotV = s.getSlotVariants();
 
-    Iterator<?> it1 = slotV.iterator();
+    Iterator<PSSlotTypeContentTypeVariant> it1 = slotV.iterator();
 
     while (it1.hasNext()) {
-      PSSlotTypeContentTypeVariant vslot = (PSSlotTypeContentTypeVariant) it1.next();
+      PSSlotTypeContentTypeVariant vslot = it1.next();
       int slotid = vslot.getSlotId();
       long ctypeid = vslot.getContentTypeId();
       int vid = vslot.getVariantId();

--- a/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeSet.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Element;
  * This class is a thin wrapper of the PSDbComponentSet that represents a set of PSContentType
  * objects.
  */
-public class PSContentTypeSet extends PSDbComponentSet {
+public class PSContentTypeSet extends PSDbComponentSet<PSContentType> {
   /** Default constructor. See {@link PSDbComponentSet#PSDbComponentSet(Class)} for more details. */
   @SuppressWarnings("unused")
   public PSContentTypeSet() throws PSCmsException {
@@ -56,9 +56,9 @@ public class PSContentTypeSet extends PSDbComponentSet {
     if (name == null || name.length() < 1)
       throw new IllegalArgumentException("name must not be null");
 
-    Iterator iter = iterator();
+    Iterator<PSContentType> iter = iterator();
     while (iter.hasNext()) {
-      PSContentType element = (PSContentType) iter.next();
+      PSContentType element = iter.next();
       if (element.getName().equalsIgnoreCase(name)) return element;
     }
     return null;
@@ -74,9 +74,9 @@ public class PSContentTypeSet extends PSDbComponentSet {
     if (contentTypeId < 0)
       throw new IllegalArgumentException("contentTypeId must be greater than 0");
 
-    Iterator iter = iterator();
+    Iterator<PSContentType> iter = iterator();
     while (iter.hasNext()) {
-      PSContentType element = (PSContentType) iter.next();
+      PSContentType element = iter.next();
       if (element.getTypeId() == contentTypeId) return element;
     }
     return null;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeVariantSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeVariantSet.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Element;
  * @deprecated Use the assembly service to load and manipulate variant information
  */
 @Deprecated
-public class PSContentTypeVariantSet extends PSDbComponentSet {
+public class PSContentTypeVariantSet extends PSDbComponentSet<PSContentTypeTemplate> {
   /** Default constructor. See {@link PSDbComponentSet#PSDbComponentSet(Class)} for more details. */
   @SuppressWarnings("unused")
   public PSContentTypeVariantSet() throws PSCmsException {
@@ -85,9 +85,9 @@ public class PSContentTypeVariantSet extends PSDbComponentSet {
     if (variantName == null || variantName.length() < 1)
       throw new IllegalArgumentException("variantName must not be null");
 
-    Iterator iter = iterator();
+    Iterator<PSContentTypeTemplate> iter = iterator();
     while (iter.hasNext()) {
-      PSContentTypeTemplate element = (PSContentTypeTemplate) iter.next();
+      PSContentTypeTemplate element = iter.next();
       if (element.getName().equalsIgnoreCase(variantName)) return element;
     }
     return null;
@@ -102,9 +102,9 @@ public class PSContentTypeVariantSet extends PSDbComponentSet {
   public PSContentTypeTemplate getContentVariantById(int variantId) {
     if (variantId < 0) throw new IllegalArgumentException("variantId must be greater than 0");
 
-    Iterator iter = iterator();
+    Iterator<PSContentTypeTemplate> iter = iterator();
     while (iter.hasNext()) {
-      PSContentTypeTemplate element = (PSContentTypeTemplate) iter.next();
+      PSContentTypeTemplate element = iter.next();
       if (element.getVariantId() == variantId) return element;
     }
     return null;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSlotTypeContentTypeVariantSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSlotTypeContentTypeVariantSet.java
@@ -25,7 +25,8 @@ import org.w3c.dom.Element;
  * This wrapps up a relationship between the parent CONTENTVARIANTS and the child RXSLOTCONTENT
  * tables.
  */
-public class PSSlotTypeContentTypeVariantSet extends PSDbComponentSet {
+public class PSSlotTypeContentTypeVariantSet
+    extends PSDbComponentSet<PSSlotTypeContentTypeVariant> {
   /** Default constructor. See {@link PSDbComponentSet#PSDbComponentSet(Class)} for more details. */
   public PSSlotTypeContentTypeVariantSet() {
     super(PSSlotTypeContentTypeVariant.class);
@@ -74,9 +75,9 @@ public class PSSlotTypeContentTypeVariantSet extends PSDbComponentSet {
    *     otherwise.
    */
   public boolean isVariantAllowed(int variantid) {
-    Iterator iter = iterator();
+    Iterator<PSSlotTypeContentTypeVariant> iter = iterator();
     while (iter.hasNext()) {
-      PSSlotTypeContentTypeVariant element = (PSSlotTypeContentTypeVariant) iter.next();
+      PSSlotTypeContentTypeVariant element = iter.next();
       if (element.getVariantId() == variantid) return true;
     }
     return false;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSlotTypeSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSlotTypeSet.java
@@ -24,7 +24,7 @@ import org.w3c.dom.Element;
 /**
  * This class is a thin wrapper of the PSDbComponentSet that represents a set of PSSlotType objects.
  */
-public class PSSlotTypeSet extends PSDbComponentSet {
+public class PSSlotTypeSet extends PSDbComponentSet<PSSlotType> {
   /** Default constructor. See {@link PSDbComponentSet#PSDbComponentSet(Class)} for more details. */
   public PSSlotTypeSet() throws PSCmsException {
     super(PSSlotType.class);
@@ -58,9 +58,9 @@ public class PSSlotTypeSet extends PSDbComponentSet {
     if (slotName == null || slotName.length() < 1)
       throw new IllegalArgumentException("slotName must not be null");
 
-    Iterator iter = iterator();
+    Iterator<PSSlotType> iter = iterator();
     while (iter.hasNext()) {
-      PSSlotType element = (PSSlotType) iter.next();
+      PSSlotType element = iter.next();
       if (element.getSlotName().equalsIgnoreCase(slotName)) return element;
     }
     return null;
@@ -75,9 +75,9 @@ public class PSSlotTypeSet extends PSDbComponentSet {
   public PSSlotType getSlotTypeById(int slotId) {
     if (slotId < 0) throw new IllegalArgumentException("slotId must be greater than 0");
 
-    Iterator iter = iterator();
+    Iterator<PSSlotType> iter = iterator();
     while (iter.hasNext()) {
-      PSSlotType element = (PSSlotType) iter.next();
+      PSSlotType element = iter.next();
       if (element.getSlotId() == slotId) return element;
     }
     return null;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSVariantSlotTypeSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSVariantSlotTypeSet.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Element;
  *
  * @deprecated use the assembly service instead
  */
-public class PSVariantSlotTypeSet extends PSDbComponentSet {
+public class PSVariantSlotTypeSet extends PSDbComponentSet<PSVariantSlotType> {
   /** Default constructor. See {@link PSDbComponentList#PSDbComponentList()} for more details. */
   public PSVariantSlotTypeSet() {
     super(PSVariantSlotType.class);

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSNavFolderUtils.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSNavFolderUtils.java
@@ -845,10 +845,10 @@ public class PSNavFolderUtils {
 
     int variantId = -1;
     PSSlotTypeContentTypeVariantSet cvs = ourSlot.getSlotVariants();
-    Iterator it = cvs.iterator();
+    Iterator<PSSlotTypeContentTypeVariant> it = cvs.iterator();
 
     while (it.hasNext()) {
-      PSSlotTypeContentTypeVariant xtv = (PSSlotTypeContentTypeVariant) it.next();
+      PSSlotTypeContentTypeVariant xtv = it.next();
       if (config.getNavonTypeIds().contains(xtv.getContentTypeId())) {
         variantId = xtv.getVariantId();
         break;

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSNavSlot.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSNavSlot.java
@@ -58,9 +58,9 @@ public class PSNavSlot {
       log.debug("no child variants");
       return;
     }
-    Iterator children = childVars.iterator();
+    Iterator<PSSlotTypeContentTypeVariant> children = childVars.iterator();
     while (children.hasNext()) { // loop through all allowed variants in this slot
-      PSSlotTypeContentTypeVariant childVar = (PSSlotTypeContentTypeVariant) children.next();
+      PSSlotTypeContentTypeVariant childVar = children.next();
       PSContentTypeTemplate navonVar = navonVariants.getContentVariantById(childVar.getVariantId());
       if (navonVar != null
           && config

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSNavUtil.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSNavUtil.java
@@ -254,9 +254,9 @@ public class PSNavUtil {
     }
     PSContentTypeVariantSet variants = loadVariantSet(req);
 
-    Iterator iter = variants.iterator();
+    Iterator<PSContentTypeTemplate> iter = variants.iterator();
     while (iter.hasNext()) {
-      PSContentTypeTemplate current = (PSContentTypeTemplate) iter.next();
+      PSContentTypeTemplate current = iter.next();
       if (current.supportsContentType((int) contentTypeId)
           && current.getName().equals(variantName)) {
         return current;
@@ -286,9 +286,9 @@ public class PSNavUtil {
     PSNavConfig config = PSNavConfig.getInstance(req);
     PSContentTypeVariantSet variants = config.getAllVariants();
 
-    Iterator iter = variants.iterator();
+    Iterator<PSContentTypeTemplate> iter = variants.iterator();
     while (iter.hasNext()) {
-      PSContentTypeTemplate current = (PSContentTypeTemplate) iter.next();
+      PSContentTypeTemplate current = iter.next();
       if ((contentTypeId == -1 || current.supportsContentType((int) contentTypeId))
           && current.getVariantId() == variantId) {
         return current;

--- a/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentSetSubclassesTypedTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentSetSubclassesTypedTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for residual {@link PSDbComponentSet} subclass type parameters (#2454 / epic
+ * #2022). Verifies typed iterators and typed lookup helpers without casts.
+ */
+public class PSDbComponentSetSubclassesTypedTest {
+
+  @Test
+  public void contentTypeSetLookupByNameAndIdIsTyped() throws Exception {
+    PSContentTypeSet set = new PSContentTypeSet();
+    PSContentType page =
+        new PSContentType(10, "percPage", "Page", "desc", "../rx_cePage/page.html", false, 1);
+    PSContentType folder =
+        new PSContentType(20, "percFolder", "Folder", "", "../rx_ceFolder/folder.html", true, 2);
+    set.add(page);
+    set.add(folder);
+
+    assertEquals(2, set.size());
+    assertSame(page, set.getContentTypeByName("PERCPAGE"));
+    assertSame(folder, set.getContentTypeById(20));
+    assertNull(set.getContentTypeByName("missing"));
+    assertNull(set.getContentTypeById(99));
+
+    Iterator<PSContentType> it = set.iterator();
+    assertTrue(it.hasNext());
+    PSContentType first = it.next();
+    assertNotNull(first.getName());
+
+    assertThrows(IllegalArgumentException.class, () -> set.getContentTypeByName(null));
+    assertThrows(IllegalArgumentException.class, () -> set.getContentTypeByName(""));
+    assertThrows(IllegalArgumentException.class, () -> set.getContentTypeById(-1));
+  }
+
+  @Test
+  public void slotTypeSetLookupByNameAndIdIsTyped() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element a = sampleSlotTypeElement(doc, 2, "sys_content");
+    Element b = sampleSlotTypeElement(doc, 4, "rffList");
+
+    PSSlotTypeSet set = new PSSlotTypeSet(new Element[] {a, b});
+    assertEquals(2, set.size());
+    assertEquals("sys_content", set.getSlotTypeByName("SYS_CONTENT").getSlotName());
+    assertEquals(4, set.getSlotTypeById(4).getSlotId());
+    assertNull(set.getSlotTypeByName("nope"));
+    assertNull(set.getSlotTypeById(99));
+
+    Iterator<PSSlotType> it = set.iterator();
+    PSSlotType first = it.next();
+    assertTrue(first.getSlotId() > 0);
+
+    assertThrows(IllegalArgumentException.class, () -> set.getSlotTypeByName(null));
+    assertThrows(IllegalArgumentException.class, () -> set.getSlotTypeById(-1));
+  }
+
+  @Test
+  public void contentTypeVariantSetLookupByNameAndIdIsTyped() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element a = sampleTemplateElement(doc, 11, "Page");
+    Element b = sampleTemplateElement(doc, 25, "Snippet");
+
+    PSContentTypeVariantSet set = new PSContentTypeVariantSet(new Element[] {a, b});
+    assertEquals(2, set.size());
+    assertEquals("Page", set.getContentVariantByName("page").getName());
+    assertEquals(25, set.getContentVariantById(25).getVariantId());
+    assertNull(set.getContentVariantByName("missing"));
+    assertNull(set.getContentVariantById(99));
+
+    Iterator<PSContentTypeTemplate> it = set.iterator();
+    PSContentTypeTemplate first = it.next();
+    assertNotNull(first.getName());
+
+    assertThrows(IllegalArgumentException.class, () -> set.getContentVariantByName(""));
+    assertThrows(IllegalArgumentException.class, () -> set.getContentVariantById(-1));
+  }
+
+  @Test
+  public void variantSlotTypeSetTypedIteratorAndSize() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSVariantSlotTypeSet set = new PSVariantSlotTypeSet();
+    set.add(new PSVariantSlotType(sampleVariantSlotTypeElement(doc, 42, 7)));
+    set.add(new PSVariantSlotType(sampleVariantSlotTypeElement(doc, 42, 8)));
+    assertEquals(2, set.size());
+
+    int count = 0;
+    Iterator<PSVariantSlotType> it = set.iterator();
+    while (it.hasNext()) {
+      PSVariantSlotType entry = it.next();
+      assertEquals(42, entry.getVariantId());
+      assertTrue(entry.getSlotId() == 7 || entry.getSlotId() == 8);
+      count++;
+    }
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void slotTypeContentTypeVariantSetIsVariantAllowedTyped() {
+    PSSlotTypeContentTypeVariantSet set = new PSSlotTypeContentTypeVariantSet();
+    set.add(PSSlotTypeContentTypeVariant.create(1, 301, 11));
+    set.add(PSSlotTypeContentTypeVariant.create(1, 302, 25));
+
+    assertTrue(set.isVariantAllowed(11));
+    assertTrue(set.isVariantAllowed(25));
+    assertFalse(set.isVariantAllowed(99));
+    assertThrows(IllegalArgumentException.class, () -> set.isVariantAllowed((PSContentTypeTemplate) null));
+
+    Iterator<PSSlotTypeContentTypeVariant> it = set.iterator();
+    PSSlotTypeContentTypeVariant first = it.next();
+    assertEquals(1, first.getSlotId());
+    assertTrue(first.getVariantId() == 11 || first.getVariantId() == 25);
+  }
+
+  private static Element sampleSlotTypeElement(Document doc, int slotId, String name) {
+    PSKey key = new PSKey(new String[] {"SLOTID"}, new String[] {String.valueOf(slotId)}, true);
+    Element root = doc.createElement("PSXSlotType");
+    root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    root.setAttribute("systemSlot", "0");
+    root.setAttribute("slotType", "0");
+    root.setAttribute("allowedRelationshipName", "ActiveAssembly");
+    root.appendChild(key.toXml(doc));
+    Element slotName = doc.createElement("SlotName");
+    slotName.appendChild(doc.createTextNode(name));
+    root.appendChild(slotName);
+    Element slotDesc = doc.createElement("SlotDesc");
+    slotDesc.appendChild(doc.createTextNode("desc-" + name));
+    root.appendChild(slotDesc);
+    return root;
+  }
+
+  private static Element sampleTemplateElement(Document doc, int variantId, String name) {
+    PSKey key =
+        new PSKey(new String[] {"TEMPLATE_ID"}, new String[] {String.valueOf(variantId)}, true);
+    Element root = doc.createElement("PSXContentTypeTemplate");
+    root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    root.setAttribute("outputFormat", "1");
+    root.setAttribute("aaType", "0");
+    root.appendChild(key.toXml(doc));
+    Element desc = doc.createElement("VariantDescription");
+    desc.appendChild(doc.createTextNode(name));
+    root.appendChild(desc);
+    Element url = doc.createElement("AssemblyUrl");
+    url.appendChild(doc.createTextNode("../assembly/render"));
+    root.appendChild(url);
+    return root;
+  }
+
+  private static Element sampleVariantSlotTypeElement(Document doc, int variantId, int slotId) {
+    PSKey key =
+        new PSKey(
+            new String[] {"VARIANTID", "SLOTID"},
+            new String[] {String.valueOf(variantId), String.valueOf(slotId)},
+            true);
+    Element root = doc.createElement("PSXVariantSlotType");
+    root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    root.appendChild(key.toXml(doc));
+    return root;
+  }
+}

--- a/system/src/test/java/com/percussion/testing/PSContentHelper.java
+++ b/system/src/test/java/com/percussion/testing/PSContentHelper.java
@@ -489,9 +489,9 @@ public class PSContentHelper implements IPSResultDocumentProcessor {
           config.getAllSlots().getSlotTypeByName(config.getNavLandingPageSlotNames().get(0));
       PSSlotTypeContentTypeVariantSet cvs = landingSlot.getSlotVariants();
       int variantId = -1;
-      Iterator it = cvs.iterator();
+      Iterator<PSSlotTypeContentTypeVariant> it = cvs.iterator();
       while (it.hasNext()) {
-        PSSlotTypeContentTypeVariant xtv = (PSSlotTypeContentTypeVariant) it.next();
+        PSSlotTypeContentTypeVariant xtv = it.next();
         if (xtv.getContentTypeId() == itemDef.getTypeId()) {
           variantId = xtv.getVariantId();
           break;


### PR DESCRIPTION
## Summary
Parameterizes residual raw `PSDbComponentSet` subclasses in `com.percussion.cms.objectstore` (slice 2g of epic #2022 / grandparent #2200), following the peer pattern from #2401 (`PSObjectAcl extends PSDbComponentSet<PSObjectAclEntry>`) and `PSComponentSummaries`.

### Typed subclasses
| Class | Type parameter |
|-------|----------------|
| `PSContentTypeVariantSet` | `PSContentTypeTemplate` |
| `PSSlotTypeSet` | `PSSlotType` |
| `PSContentTypeSet` | `PSContentType` |
| `PSVariantSlotTypeSet` | `PSVariantSlotType` |
| `PSSlotTypeContentTypeVariantSet` | `PSSlotTypeContentTypeVariant` |

### Call-site cleanup
Dropped unnecessary casts when iterating these sets in:
- `PSNavUtil`, `PSNavSlot`, `PSNavFolderUtils`
- `PSNavConfig`
- `PSComponentDefProcessorProxy`
- `PSContentHelper` (test helper)

### Out of scope
- `design.objectstore` `IPSComponent` interface redesign (#2455)
- `PSDbComponentList` hierarchy mega-refactor

**Fixes #2454**  
**Parent:** #2022

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] New unit tests: `PSDbComponentSetSubclassesTypedTest` (5 tests — typed lookups, iterators, `isVariantAllowed`)
- [x] `cd system && ../mvnw clean install` → **BUILD SUCCESS**
- [x] Tests run: **1326**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] No new warnings attributable to this change (baseline warnings only)

## Gates evidence
- Erlang-style self-review: type-only API tightening; no path/file I/O; companions = peer pattern + tests + call-site cast removal
- Module: `system` only
- No UI / installer impact → no human QA issue

> Co-Authored by Grok Build using grok-4.5 with agent main.