### PR TITLE
cluster: sitemanage cycle inventory thrash (#2520/#2514/#2516/#2519)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -1,9 +1,9 @@
 # Sitemanage Spring constructor-injection cycle inventory
 
-**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**; field/setter injection inventory **#2525**  
+**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514** / **#2519**; itemWorkflow param `@Lazy` **#2515**; field/setter injection inventory **#2525**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521 / #2525)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2519 / #2521 / #2525)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` (#2519), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents ΓÇö **not** an agent rule file.
 
@@ -187,9 +187,23 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze covered by `PSPageServiceCycleWiringTest` (2026-08-08, #2514). |
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset` with **param `@Lazy`** (#2515). Class `@Lazy`. Reverse-edge freeze: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478). |
 | 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
-| 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
+| 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | Class `@Lazy` (2026-08-09, #2519). On known cycle path. Reverse-edge freeze: `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest`. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
 | 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
+
+### WidgetAsset hub class `@Lazy` + reverse-edge freezes (#2519)
+
+**`PSWidgetAssetRelationshipService`** sits **on** the known folderHelper creation path (paths A/B above) with high fan-in from recycle / page / template / itemWorkflow / assetService.
+
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on hub | **Added (#2519)** — hub alignment with page/template/itemWorkflow; defers init until first use. **Not** a constructor-edge cycle breaker when an eager consumer forces construction |
+| Forward edges kept | widgetAsset → `IPSAssetDao` / `IPSPageIndexService` (path A/B); recycle / page / template still construct-require the hub (intentional fan-in) |
+| Reverse edge ban | **Hard** — cycle-path peers (`assetDao`, `contentItemDao`, `folderHelper`, `pageIndexService`, `pageDaoHelper`) must not construct-require or eagerly field-inject `IPSWidgetAssetRelationshipService` without param/field `@Lazy`. Hub must not reverse-require `IPSRecycleService` / `IPSPageService` / `IPSTemplateService` (would reverse known fan-in / mid-chain edges) |
+| Param `@Lazy` on forward cycle edges | **Not** added here — contentItemDao / pageDaoHelper already carry the cycle breaks; optional belt-and-braces on consumers remains separate residual territory |
+| managedLink path C | **Out of scope** — remains #2527 (do not ctor-inject `IPSManagedLinkService` onto this hub) |
+
+Protection test: `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` (class `@Lazy` + forward freezes + reverse ctor/field bans + named assetDao/recycle/page/template assertions).
 
 ### Next hottest near-cycle edge (protected ΓÇö #2476)
 
@@ -309,7 +323,7 @@ Many path/item services inject `IPSFolderHelper` without parameter `@Lazy` (e.g.
 7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
+10. ~~Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).~~ **widgetAsset done (#2519)** — class `@Lazy` + `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest`. siteData remains #2516 if still open.
 11. ~~Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).~~ **Done (#2525)** — `PSFolderHelperFieldInjectionInventoryWiringTest`; cycle subgraph is fully ctor-injected, no live reverse field edges.
 12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 

--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -57,8 +57,6 @@ Class-level `@Lazy` is present on `folderHelper` and `recycleService` but is **n
 
 **#2485 result:** no additional live reverse ctor edges into `folderHelper` were found. No further production `@Lazy` changes required on this slice.
 
-<<<<<<< HEAD
-=======
 ## folderHelper field / setter injection inventory (#2525)
 
 **Definition — field/setter edge:** a `@Autowired` / `@Resource` / `@Inject` annotation on a **field** declaration, or on a `setXxx` setter method, where the injected type is one of the cycle interfaces. Field/setter injection bypasses constructor `@Lazy` breaks because Spring resolves the dependency after construction has started — the field-injected dependency must already exist (or a proxy) when the bean is being instantiated.
@@ -137,7 +135,6 @@ These classes have field `@Autowired` of a target interface but are **downstream
 
 **Conclusion:** Every observed field-injected target type lives on a downstream consumer bean. None of the seven cycle-subgraph beans (`PSFolderHelper`, `PSRecycleService`, `PSWidgetAssetRelationshipService`, `PSAssetDao`, `PSContentItemDao`, `PSPageIndexService`, `PSPageDaoHelper`) carry any `@Autowired` / `@Resource` / `@Inject` field annotation on the target interfaces, nor any public setter that takes a target interface. The cycle subgraph is fully converted to constructor injection, so the existing `@Lazy` parameter breaks remain the only required protection.
 
->>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 ### Cycle-subgraph intermediates that must NOT construct-require `folderHelper`
 
 These sit on path A/B. Adding a ctor edge to `IPSFolderHelper` would short-circuit the known breaks:
@@ -392,13 +389,8 @@ listed in the original inventory and is out of scope for #2526.
 7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-<<<<<<< HEAD
-10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
-11. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
-=======
 10. ~~Optional next hubs: siteData reverse-edge freeze.~~ **Done (#2516)** — `PSSiteDataServiceHubReverseEdgeWiringTest`. Optional remaining: widgetAsset class `@Lazy` (#2519).
 11. ~~Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).~~ **Done (#2525)** — `PSFolderHelperFieldInjectionInventoryWiringTest`; cycle subgraph is fully ctor-injected, no live reverse field edges.
->>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
@@ -415,11 +407,8 @@ listed in the original inventory and is out of scope for #2526.
 - #2514 ΓÇö pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
 - #2515 ΓÇö itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
-<<<<<<< HEAD
 - #2526 — emptyRecycle / pathService near-cycle belt-and-braces (`PSEmptyRecycleServiceCycleLazyWiringTest`)
-=======
 - #2525 — folderHelper field / setter injection inventory (`PSFolderHelperFieldInjectionInventoryWiringTest`)  
 - #2516 — siteDataService hub reverse-edge freeze (`PSSiteDataServiceHubReverseEdgeWiringTest`)  
->>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 
 - #2457 / PR #2469 ΓÇö JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -1,9 +1,9 @@
 # Sitemanage Spring constructor-injection cycle inventory
 
-**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**  
+**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**; templateService param `@Lazy` **#2520**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2520 / #2521)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSTemplateServiceParamLazyWiringTest` (#2520), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents ΓÇö **not** an agent rule file.
 
@@ -108,7 +108,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 |------|------|----------------------------------------|-------|
 | 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze covered by `PSPageServiceCycleWiringTest` (2026-08-08, #2514). |
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset` with **param `@Lazy`** (#2515). Class `@Lazy`. Reverse-edge freeze: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478). |
-| 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
+| 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Forward ctor edges to `widgetAsset` / `pageDao` / `pageDaoHelper` / `templateDao` carry **param `@Lazy`** (2026-08-08, #2520). Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
 | 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
@@ -148,6 +148,29 @@ Behavior review of call sites (safe for lazy proxy):
 
 Protection test: `PSItemWorkflowServiceCycleLazyWiringTest` (asserts construct-require + param `@Lazy` on each chosen peer).
 
+### TemplateService hub forward-edge param `@Lazy` (#2520)
+
+**`PSTemplateService` → forward ctor edges to known-cycle peers (constructor, param `@Lazy` as of #2520)** with **no reverse** peer → `IPSTemplateService` (frozen by #2477 / `PSTemplateServiceCycleWiringTest`).
+
+Behavior review of call sites (safe for lazy proxy):
+
+| Peer param | Ctor body | Post-construction use | Param `@Lazy`? |
+|------------|-----------|----------------------|----------------|
+| `IPSTemplateDao` | field assign only | save / load / find / generateTemplate | **yes** |
+| `IPSWidgetAssetRelationshipService` | field assign only | shared/linked/local asset relations on save / import / create | **yes** |
+| `IPSPageDao` | field assign only | `isValidPageId` on save | **yes** |
+| `IPSPageDaoHelper` | field assign only | `findPageIdsByTemplateInRecentRevision` / `replaceTemplateForPageInOlderRevisions` on delete | **yes** |
+| `IPSWidgetService` | **used in ctor** (`new RegionWidgetValidator(widgetService)`) | n/a | **no** — lazy proxy not safe here |
+
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on hub | Present (#2477) but **not** a cycle breaker when an eager consumer forces construction |
+| Param `@Lazy` on four forward edges | **Added (#2520)** — Spring injects proxies; safe because ctor never method-calls those peers (widgetService is intentionally excluded — it is consumed in the ctor body) |
+| Reverse edge ban | Kept — #2477 / `PSTemplateServiceCycleWiringTest` |
+| Why apply now | Residual after #2477 class-level + reverse-edge freeze: belt-and-braces peer of #2476 / #2515 so multi-hop eager paths through cycle peers cannot form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
+
+Protection test: `PSTemplateServiceParamLazyWiringTest` (asserts construct-require + param `@Lazy` on each chosen peer; widgetService intentionally excluded).
+
 ### assetServiceΓåötemplateService near-cycle (protected ΓÇö #2521)
 
 **`PSAssetService` ΓåÆ `IPSTemplateService` (constructor, one-way)** with **no reverse** `PSTemplateService` ΓåÆ `IPSAssetService` (ctor or non-`@Lazy` field).
@@ -178,12 +201,13 @@ These must not gain reverse constructor dependencies:
 
 Constructor-parameter `@Lazy` remains rare in this module. Scan snapshot (after #2485):
 
-- `PSContentItemDao` ΓåÆ `IPSFolderHelper` (`@Lazy`) ΓÇö known reverse edge path A (#2435)
-- `PSPageDaoHelper` ΓåÆ `IPSFolderHelper` (`@Lazy`) ΓÇö known reverse edge path B (#2437)
-- `PSFolderHelper` ΓåÆ `IPSRecycleService` (`@Lazy`) ΓÇö forward deferral of recycle subgraph (#2437)
-- `PSAssetService` ΓåÆ `IPSPageService` (`@Lazy`) ΓÇö near-cycle belt-and-braces (#2476)
-- `PSItemWorkflowService` ΓåÆ `IPSAssetDao` / `IPSFolderHelper` / `IPSRecycleService` / `IPSWidgetAssetRelationshipService` (`@Lazy`) ΓÇö hub cycle-peer belt-and-braces (#2515)
-- `PSRecentRestService` ΓåÆ `IPSRecentService` (`@Lazy`) ΓÇö rest convenience, not cycle-related
+- `PSContentItemDao` → `IPSFolderHelper` (`@Lazy`) — known reverse edge path A (#2435)
+- `PSPageDaoHelper` → `IPSFolderHelper` (`@Lazy`) — known reverse edge path B (#2437)
+- `PSFolderHelper` → `IPSRecycleService` (`@Lazy`) — forward deferral of recycle subgraph (#2437)
+- `PSAssetService` → `IPSPageService` (`@Lazy`) — near-cycle belt-and-braces (#2476)
+- `PSItemWorkflowService` → `IPSAssetDao` / `IPSFolderHelper` / `IPSRecycleService` / `IPSWidgetAssetRelationshipService` (`@Lazy`) — hub cycle-peer belt-and-braces (#2515)
+- `PSTemplateService` → `IPSTemplateDao` / `IPSWidgetAssetRelationshipService` / `IPSPageDao` / `IPSPageDaoHelper` (`@Lazy`) — hub forward-edge belt-and-braces (#2520)
+- `PSRecentRestService` → `IPSRecentService` (`@Lazy`) — rest convenience, not cycle-related
 
 Class-level `@Lazy` is common on REST facades and many services; treat it as lazy *init*, not a cycle breaker.
 
@@ -285,12 +309,13 @@ listed in the original inventory and is out of scope for #2526.
 4. ~~Hub hardening: `PSTemplateService` class `@Lazy` + reverse-edge tests.~~ **Done (#2477)** ΓÇö `PSTemplateServiceCycleWiringTest`.
 5. ~~`PSPageService` reverse-edge freeze.~~ **Done (#2514)** ΓÇö `PSPageServiceCycleWiringTest`.
 6. ~~Optional: param `@Lazy` on itemWorkflow ΓåÆ cycle peers.~~ **Done (#2515)** ΓÇö `PSItemWorkflowServiceCycleLazyWiringTest`.
-7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
-8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
-9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
-11. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
-12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
+7. ~~Optional: param `@Lazy` on templateService → forward-cycle peers.~~ **Done (#2520)** — `PSTemplateServiceParamLazyWiringTest`. widgetService intentionally excluded (consumed in ctor body).
+8. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
+9. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
+10. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+11. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
+12. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
+13. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
 
@@ -305,6 +330,7 @@ listed in the original inventory and is out of scope for #2526.
 - #2485 ΓÇö folderHelper reverse-edge inventory  
 - #2514 ΓÇö pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
 - #2515 ΓÇö itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
+- #2520 — templateService forward-edge param `@Lazy` (`PSTemplateServiceParamLazyWiringTest`)
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
 - #2526 — emptyRecycle / pathService near-cycle belt-and-braces (`PSEmptyRecycleServiceCycleLazyWiringTest`)
 

--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -57,6 +57,87 @@ Class-level `@Lazy` is present on `folderHelper` and `recycleService` but is **n
 
 **#2485 result:** no additional live reverse ctor edges into `folderHelper` were found. No further production `@Lazy` changes required on this slice.
 
+<<<<<<< HEAD
+=======
+## folderHelper field / setter injection inventory (#2525)
+
+**Definition — field/setter edge:** a `@Autowired` / `@Resource` / `@Inject` annotation on a **field** declaration, or on a `setXxx` setter method, where the injected type is one of the cycle interfaces. Field/setter injection bypasses constructor `@Lazy` breaks because Spring resolves the dependency after construction has started — the field-injected dependency must already exist (or a proxy) when the bean is being instantiated.
+
+### Cycle-subgraph classes (force-creatable while `folderHelper` is constructing)
+
+These seven classes sit on the recycle subgraph and can be forced to construct while `folderHelper` is still being created (paths A/B above). Any field/setter inject of a target interface on these classes would be a **live reverse field edge**.
+
+| Class | Injection mechanism for target interface | Disposition |
+|-------|-------------------------------------------|-------------|
+| `PSFolderHelper` → `IPSRecycleService` | ctor only (field `recycleService` is plain; only assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSRecycleService` → `IPSWidgetAssetRelationshipService` | ctor only (field `widgetAssetRelationshipService` is plain; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSWidgetAssetRelationshipService` → `IPSAssetDao`, `IPSPageIndexService` | ctor only (fields `assetDao`, `pageIndexService` are plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSAssetDao` → `IPSContentItemDao` | ctor only (field `contentItemDao` is `final`, assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSContentItemDao` → `IPSFolderHelper` | ctor only (`@Lazy`; field `folderHelper` is plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSPageIndexService` → `IPSPageDaoHelper` | ctor only (field `pageDaoHelper` is `final`, assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+| `PSPageDaoHelper` → `IPSFolderHelper` | ctor only (`@Lazy`; field `folderHelper` is plain; assigned in ctor; no setter; no field `@Autowired`) | OK — no field edge |
+
+**Result:** **No live reverse field/setter edges** were found in the cycle subgraph. The #2485 ctor work fully converted the recycle subgraph to pure constructor injection (no surviving setter or field `@Autowired` for any of the target interfaces), so the `@Lazy` parameter breaks remain the only protection needed.
+
+**No production code change is required for #2525.** The peer reflection test `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525) freezes this state by asserting that none of the target fields on the cycle subgraph carry a `@Autowired` annotation (Spring would otherwise be free to re-introduce field injection).
+
+### Downstream consumer field injectors (informational, NOT reverse edges)
+
+These classes have field `@Autowired` of a target interface but are **downstream consumers** of `folderHelper` (not on its construction subgraph), so forcing their construction does **not** force `folderHelper` creation. They are listed here to document the full scan and to clarify why no `@Lazy` is required on their fields.
+
+| Class | Field-injected target type | Disposition |
+|-------|----------------------------|-------------|
+| `FolderAdaptor` (REST adaptor) | `IPSFolderHelper`, `IPSPageDaoHelper`, `IPSPageDao` | downstream consumer (also ctor-injected; field annotations are redundant with ctor). Class `@Lazy`. Not on folderHelper ctor path. |
+| `AssetAdaptor` (REST adaptor) | `IPSAssetDao` (final field) | downstream consumer (also ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PageAdaptor` (REST adaptor) | `IPSFolderHelper`, `IPSContentItemDao`, `IPSWidgetAssetRelationshipService`, `IPSAssetService` | downstream consumer (ctor-injected `final` fields; field `@Autowired` annotations redundant with ctor). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSAssetRestService` | `IPSAssetService`, `IPSWidgetAssetRelationshipService`, `IPSRecycleService`, `IPSFolderHelper` | downstream REST facade (ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageRestService` | `IPSRecycleService`, `IPSFolderHelper` | downstream REST facade (ctor-injected). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageService` | `IPSPageDaoHelper`, `IPSFolderHelper`, `IPSWidgetAssetRelationshipService`, `IPSContentItemDao`, `IPSRecycleService` | downstream consumer hub (#2514 freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSItemService` | `IPSRecycleService` (field `@Autowired`) | downstream consumer. Not on folderHelper ctor path. |
+| `PSAbstractWorkflowExtension` | `IPSWidgetAssetRelationshipService`, `IPSFolderHelper` | downstream extension. Not on folderHelper ctor path. |
+| `PSLivePublishChangeHandler` | `IPSFolderHelper`, `IPSWidgetAssetRelationshipService` | downstream handler. Not on folderHelper ctor path. |
+| `PSBulkApprovalJob` | `IPSFolderHelper` | downstream async job. Not on folderHelper ctor path. |
+| `PSFolderService` | `IPSFolderHelper` | downstream REST facade. Not on folderHelper ctor path. |
+| `PSTemplateService` | `IPSWidgetAssetRelationshipService`, `IPSPageDaoHelper` | downstream hub (#2477 freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSPageListViewProcessor` | `IPSPageDaoHelper` | downstream extension. Not on folderHelper ctor path. |
+| `PSSiteTemplateService` | `IPSFolderHelper`, `IPSAssetService`, `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteSectionService` | `IPSPageDaoHelper`, `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteSectionMetaDataService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSPageChangeHandler` | `IPSContentItemDao` | downstream handler. Not on folderHelper ctor path. |
+| `PSSitePublishServiceWebAdapter` | `IPSFolderHelper` | downstream adapter. Not on folderHelper ctor path. |
+| `PSPageCatalogService` | `IPSFolderHelper`, `IPSPageDaoHelper` | downstream REST facade. Not on folderHelper ctor path. |
+| `PSSitePublishServiceHelper` | `IPSAssetService` | downstream helper. Not on folderHelper ctor path. |
+| `PSSitePublishService` | `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteDataService` | `IPSWidgetAssetRelationshipService`, `IPSAssetDao`, `IPSFolderHelper`, `IPSItemWorkflowService` (+ field page/path) | downstream hub (#2516 reverse freeze). Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSAssetUploadFolderPathMap` | `IPSFolderHelper` | downstream helper. Not on folderHelper ctor path. |
+| `PSAssemblyItemBridge` | `IPSFolderHelper`, `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSResourceAssemblyLocation` | `IPSFolderHelper`, `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSResourceInstanceHelper` | `IPSAssetService` | downstream assembler. Not on folderHelper ctor path. |
+| `PSRecyclePathItemService` | `IPSRecycleService` | downstream path item service. Not on folderHelper ctor path. |
+| `PSDesignPathItemService` | `IPSFolderHelper` | downstream path item service. Not on folderHelper ctor path. |
+| `PSPageUtils` | `IPSRecycleService`, `IPSContentItemDao` | downstream utility (static `@Autowired` fields). Not on folderHelper ctor path. |
+| `PSPathService` | `IPSFolderHelper`, `IPSRecycleService` | downstream service. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSDispatchingPathService` | `IPSRecycleService`, `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSRedirectService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSTemplateDao` | `IPSContentItemDao`, `IPSFolderHelper` | downstream DAO. Not on folderHelper ctor path. |
+| `PSEmptyRecycleService` | `IPSFolderHelper` | downstream empty-recycle service. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSSharedRelationshipDeleteListener` | `IPSPageIndexService` | downstream listener. Not on folderHelper ctor path. |
+| `PSSearchService` | `IPSFolderHelper`, `IPSRecycleService` | downstream search service. Not on folderHelper ctor path. |
+| `PSSearchIndexFieldValueModifier` | `IPSFolderHelper` | downstream modifier. Not on folderHelper ctor path. |
+| `PSAssetChangeListener` | `IPSWidgetAssetRelationshipService`, `IPSPageIndexService` | downstream listener. Not on folderHelper ctor path. |
+| `PSSiteContentDao` | `IPSFolderHelper`, `IPSContentItemDao`, `IPSPageDaoHelper`, `IPSRecycleService` | downstream DAO. Class `@Lazy`. Not on folderHelper ctor path. |
+| `PSRelationshipSummaryService` | `IPSWidgetAssetRelationshipService` | downstream service. Not on folderHelper ctor path. |
+| `PSLinkExtractionHelper` | `IPSFolderHelper` | downstream importer helper. Not on folderHelper ctor path. |
+| `PSPageExtractorHelper` | `IPSAssetService` | downstream importer helper. Not on folderHelper ctor path. |
+| `PSCommentsService` | `IPSFolderHelper` | downstream service. Not on folderHelper ctor path. |
+| `PSIntegrityCheckerService` | `IPSAssetService` | downstream service. Not on folderHelper ctor path. |
+| `PSRecentService` | `IPSAssetService` | downstream service. Not on folderHelper ctor path. |
+| `PSSiteImportLogViewer` | `IPSFolderHelper` (static field) | downstream importer. Not on folderHelper ctor path. |
+| `PSTrafficService` | `IPSFolderHelper` (`final`) | downstream service (ctor-injected). Not on folderHelper ctor path. |
+
+**Conclusion:** Every observed field-injected target type lives on a downstream consumer bean. None of the seven cycle-subgraph beans (`PSFolderHelper`, `PSRecycleService`, `PSWidgetAssetRelationshipService`, `PSAssetDao`, `PSContentItemDao`, `PSPageIndexService`, `PSPageDaoHelper`) carry any `@Autowired` / `@Resource` / `@Inject` field annotation on the target interfaces, nor any public setter that takes a target interface. The cycle subgraph is fully converted to constructor injection, so the existing `@Lazy` parameter breaks remain the only required protection.
+
+>>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 ### Cycle-subgraph intermediates that must NOT construct-require `folderHelper`
 
 These sit on path A/B. Adding a ctor edge to `IPSFolderHelper` would short-circuit the known breaks:
@@ -79,7 +160,7 @@ Class-level `@Lazy` on these beans is **lazy init only** ΓÇö it is **false sa
 |-------|----------------|-------------|
 | `PSPageService` | yes | consumer / hub ΓÇö reverse-edge freeze done (#2514 / `PSPageServiceCycleWiringTest`) |
 | `PSItemWorkflowService` | yes | consumer / hub ΓÇö reverse freeze #2478; cycle-peer **param `@Lazy`** #2515 |
-| `PSSiteDataService` | yes | consumer / hub ΓÇö #2516 |
+| `PSSiteDataService` | yes | consumer / hub — reverse freeze #2516 / `PSSiteDataServiceHubReverseEdgeWiringTest` |
 | `PSAssetService` | yes | consumer; folderHelper param **not** `@Lazy` (pageService param **is** `@Lazy` #2476) |
 | `PSItemService` | no | consumer |
 | `PSSiteContentDao` | yes | consumer (also takes pageDaoHelper ΓÇö not a reverse edge into folderHelper creation) |
@@ -111,7 +192,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
 | 5 | `PSAssetService` | out ~8 / in ~14 | Ctor takes `IPSPageService` with param `@Lazy` (#2476) (and folder/asset/widget/item). Class `@Lazy`. |
-| 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. |
+| 6 | `PSSiteDataService` | out ~15 / in ~12 | Wide hub; class `@Lazy`; field injects page/path. Reverse-edge freeze: `PSSiteDataServiceHubReverseEdgeWiringTest` (#2516). |
 
 ### Next hottest near-cycle edge (protected ΓÇö #2476)
 
@@ -147,6 +228,29 @@ Behavior review of call sites (safe for lazy proxy):
 | Why apply now | Residual after #2478 reverse-edge freezes: belt-and-braces peer of #2476 so multi-hop eager paths through cycle peers cannot form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
 
 Protection test: `PSItemWorkflowServiceCycleLazyWiringTest` (asserts construct-require + param `@Lazy` on each chosen peer).
+
+### siteDataService hub reverse-edge freeze (protected — #2516)
+
+**`PSSiteDataService` → cycle peers / page-item hubs (constructor + page/path field inject, one-way)** with **no reverse** peer → `IPSSiteDataService` without param/field `@Lazy`.
+
+Forward edges frozen by the UnitTest:
+
+| Direction | Edge | Notes |
+|-----------|------|-------|
+| Ctor forward | siteData → `IPSFolderHelper`, `IPSWidgetAssetRelationshipService`, `IPSAssetDao`, `IPSItemWorkflowService` | Hub model (#2463 rank 6) |
+| Field forward | siteData → `PSPageService` / `PSPathService` (`@Autowired` fields) | Documented; not reverse-cycle fuel |
+| Reverse ban (ctor + non-`@Lazy` field) | cycle peers + page/item hubs must not inject `IPSSiteDataService` | Peers: folderHelper, contentItemDao, widgetAsset, recycle, assetDao, pageDaoHelper, pageService, itemWorkflow, assetService, templateService |
+
+**Scan snapshot (#2516):** none of the reverse-ban peers currently inject `IPSSiteDataService` (ctor or field). **Intentional reverse `@Lazy` exceptions:** none. Downstream consumers (path item services, REST adaptors, publish handlers, traffic/category services) remain allowed — they are not cycle fuel.
+
+| Aspect | Disposition |
+|--------|-------------|
+| Class-level `@Lazy` on hub | Present but **not** a cycle breaker when an eager consumer forces construction |
+| Param `@Lazy` on reverse edges | **Not needed today** — no live reverse edges; freeze forbids adding them without `@Lazy` |
+| Reverse edge ban | **Hard** — #2516 / `PSSiteDataServiceHubReverseEdgeWiringTest` |
+| Why apply now | Residual after #2463 rank-6 inventory + #2478 pattern: freeze so multi-hop eager paths through cycle peers cannot form a second `BeanCurrentlyInCreationException` via siteData |
+
+Protection test: `PSSiteDataServiceHubReverseEdgeWiringTest` (forward freeze + reverse ctor/field ban; intentional exceptions documented above).
 
 ### assetServiceΓåötemplateService near-cycle (protected ΓÇö #2521)
 
@@ -288,8 +392,13 @@ listed in the original inventory and is out of scope for #2526.
 7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 9. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
+<<<<<<< HEAD
 10. Optional next hubs: siteData (#2516); widgetAsset class `@Lazy` (#2519).
 11. Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).
+=======
+10. ~~Optional next hubs: siteData reverse-edge freeze.~~ **Done (#2516)** — `PSSiteDataServiceHubReverseEdgeWiringTest`. Optional remaining: widgetAsset class `@Lazy` (#2519).
+11. ~~Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).~~ **Done (#2525)** — `PSFolderHelperFieldInjectionInventoryWiringTest`; cycle subgraph is fully ctor-injected, no live reverse field edges.
+>>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 12. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
 
 ## Related
@@ -306,6 +415,11 @@ listed in the original inventory and is out of scope for #2526.
 - #2514 ΓÇö pageService hub reverse-edge freeze (`PSPageServiceCycleWiringTest`)  
 - #2515 ΓÇö itemWorkflow cycle-peer param `@Lazy` (`PSItemWorkflowServiceCycleLazyWiringTest`)  
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
+<<<<<<< HEAD
 - #2526 — emptyRecycle / pathService near-cycle belt-and-braces (`PSEmptyRecycleServiceCycleLazyWiringTest`)
+=======
+- #2525 — folderHelper field / setter injection inventory (`PSFolderHelperFieldInjectionInventoryWiringTest`)  
+- #2516 — siteDataService hub reverse-edge freeze (`PSSiteDataServiceHubReverseEdgeWiringTest`)  
+>>>>>>> 6d56ede3d2 (test(sitemanage): siteDataService hub reverse-edge freeze (#2516))
 
 - #2457 / PR #2469 ΓÇö JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -2,8 +2,8 @@
 
 **Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514**; itemWorkflow param `@Lazy` **#2515**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2521 / #2525 / #2514 field+peer expansion)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525), `PSTemplateServiceCycleWiringTest` (#2477), `PSPageServiceCycleWiringTest` (#2514 — ctor + field reverse-edge freeze, mirrors #2478), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents ΓÇö **not** an agent rule file.
 
@@ -106,7 +106,7 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 
 | Rank | Bean | Approx. ctor out / in (interest graph) | Notes |
 |------|------|----------------------------------------|-------|
-| 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze covered by `PSPageServiceCycleWiringTest` (2026-08-08, #2514). |
+| 1 | `PSPageService` | out ~11 / in ~28 | Injects `contentItemDao`, `folderHelper`, `recycleService`, `widgetAsset`, `itemWorkflow`. Class `@Lazy`. Reverse-edge freeze: `PSPageServiceCycleWiringTest` (#2514 — ctor + non-`@Lazy` field bans on cycle peers; intentional `@Lazy` partner: `PSAssetService` #2476). |
 | 2 | `PSItemWorkflowService` | out ~7 / in ~23 | Injects `assetDao`, `folderHelper`, `recycleService`, `widgetAsset` with **param `@Lazy`** (#2515). Class `@Lazy`. Reverse-edge freeze: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478). |
 | 3 | `PSTemplateService` | out ~6 / in ~20 | Class `@Lazy` (2026-08-08, #2477). Injects `widgetAsset`, page/template DAOs. Belt-and-braces reverse-edge ban covered by `PSTemplateServiceCycleWiringTest`. |
 | 4 | `PSWidgetAssetRelationshipService` | out ~4 / in ~18 | **Not** class `@Lazy`. On known cycle path. |
@@ -125,6 +125,37 @@ These beans have high constructor fan-in and sit on or next to the known cycle p
 | Why not skip param `@Lazy` | Inventory residual after #2463: without it, a future reverse edge or multi-hop eager path would form a second `BeanCurrentlyInCreationException` independent of the folderHelper fix |
 
 Protection test: `PSAssetServicePageServiceNearCycleWiringTest` (asserts one-way ctor edge + param `@Lazy` + no reverse).
+
+### pageService hub reverse-edge freeze (#2514)
+
+**`PSPageService`** is rank-1 (ctor out ~11 / in ~28). Forward construct-requires cycle peers; reverse edges into `IPSPageService` from those peers (or eager field inject) are frozen.
+
+#### Cycle peers scanned (ctor + field)
+
+| Peer class | Ctor → `IPSPageService` | Field → `IPSPageService` | Disposition |
+|------------|-------------------------|--------------------------|-------------|
+| `PSFolderHelper` | none | none | **Ban** reverse |
+| `PSContentItemDao` | none | none | **Ban** reverse (cycle-break peer) |
+| `PSRecycleService` | none | none | **Ban** reverse |
+| `PSWidgetAssetRelationshipService` | none | none | **Ban** reverse |
+| `PSItemWorkflowService` | none | none (removed unused field 2026-08-09) | **Ban** reverse; dead `pageService` field removed |
+| `PSAssetDao` | none | none | **Ban** reverse (cycle intermediate) |
+
+#### Intentional `@Lazy` reverse partner (not banned)
+
+| From bean | Edge | Disposition | Regression test |
+|-----------|------|-------------|-----------------|
+| `PSAssetService` | ctor → `IPSPageService` **param `@Lazy`** | **Intentional** consumer edge (#2476); keep `@Lazy` | `PSPageServiceCycleWiringTest.assetServiceIntentionalPageServiceEdgeIsLazy` + `PSAssetServicePageServiceNearCycleWiringTest` |
+
+#### Freeze coverage (`PSPageServiceCycleWiringTest`)
+
+- Class `@Lazy` on `PSPageService`
+- Forward edges still present (folderHelper, contentItemDao, recycleService, widgetAsset, itemWorkflow)
+- Cycle peers: no reverse ctor without `@Lazy`; no eager field inject without `@Lazy`
+- Explicit `contentItemDao` no reverse edge
+- Documented intentional `PSAssetService` `@Lazy` partner
+
+**No additional production `@Lazy` required** for #2514 beyond the dead-field cleanup on `PSItemWorkflowService`.
 
 ### ItemWorkflow hub cycle-peer param `@Lazy` (#2515)
 
@@ -283,7 +314,7 @@ listed in the original inventory and is out of scope for #2526.
 2. ~~Optional: add `@Lazy` on `PSAssetService`'s `IPSPageService` ctor param~~ ΓÇö **done (#2476)**.
 3. ~~ItemWorkflow hub reverse-edge tests.~~ Done: `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478).
 4. ~~Hub hardening: `PSTemplateService` class `@Lazy` + reverse-edge tests.~~ **Done (#2477)** ΓÇö `PSTemplateServiceCycleWiringTest`.
-5. ~~`PSPageService` reverse-edge freeze.~~ **Done (#2514)** ΓÇö `PSPageServiceCycleWiringTest`.
+5. ~~`PSPageService` reverse-edge freeze.~~ **Done (#2514)** — `PSPageServiceCycleWiringTest` (ctor + field reverse bans; intentional `PSAssetService` `@Lazy` partner; unused itemWorkflow `pageService` field removed).
 6. ~~Optional: param `@Lazy` on itemWorkflow ΓåÆ cycle peers.~~ **Done (#2515)** ΓÇö `PSItemWorkflowServiceCycleLazyWiringTest`.
 7. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 8. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipService.java
@@ -90,9 +90,18 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
+/**
+ * Widget/asset relationship hub on the known {@code folderHelper} creation path (inventory #2463
+ * rank-4). Class-level {@link Lazy @Lazy} defers bean creation until first use (hub alignment with
+ * page/template/itemWorkflow; #2519). Class {@code @Lazy} is <em>not</em> a constructor-edge cycle
+ * breaker when an eager consumer forces full construction — reverse-edge freezes live in {@code
+ * PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest}.
+ */
 @Component("widgetAssetRelationshipService")
+@Lazy
 public class PSWidgetAssetRelationshipService implements IPSWidgetAssetRelationshipService {
   private IPSWidgetService widgetService;
 

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemWorkflowService.java
@@ -131,7 +131,8 @@ public class PSItemWorkflowService implements IPSItemWorkflowService {
   IPSFolderHelper folderHelper;
   IPSWorkflowService workflowService;
   IPSiteDao siteDao;
-  IPSPageService pageService;
+  // pageService field intentionally omitted — was an unused reverse edge into the rank-1 hub
+  // (see #2514 / PSPageServiceCycleWiringTest). Use IPSPageService.PAGE_CONTENT_TYPE only.
   IPSSiteManager siteMgr;
   IPSSystemWs systemWs;
   private IPSRecycleService recycleService;

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
@@ -131,10 +131,10 @@ public class PSTemplateService implements IPSTemplateService {
 
   @Autowired
   public PSTemplateService(
-      IPSTemplateDao templateDao,
-      IPSWidgetAssetRelationshipService widgetAssetRelationshipService,
-      IPSPageDao pageDao,
-      IPSPageDaoHelper pageDaoHelper,
+      @Lazy IPSTemplateDao templateDao,
+      @Lazy IPSWidgetAssetRelationshipService widgetAssetRelationshipService,
+      @Lazy IPSPageDao pageDao,
+      @Lazy IPSPageDaoHelper pageDaoHelper,
       IPSWidgetService widgetService,
       IPSWorkflowHelper workflowHelper,
       IPSWidgetDao widgetDao,

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSPageServiceCycleWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSPageServiceCycleWiringTest.java
@@ -19,38 +19,79 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.percussion.assetmanagement.dao.impl.PSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSAssetService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.impl.PSItemWorkflowService;
 import com.percussion.pagemanagement.service.IPSPageService;
 import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.recycle.service.impl.PSRecycleService;
 import com.percussion.share.dao.IPSContentItemDao;
 import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.dao.impl.PSContentItemDao;
+import com.percussion.share.dao.impl.PSFolderHelper;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
 /**
- * Reverse-edge cycle protection for {@link PSPageService} (#2423 residual #2514).
+ * Reverse-edge cycle protection for the {@link PSPageService} high fan-in hub (#2423 residual
+ * #2514).
  *
  * <p>Per the static inventory in {@code
  * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md},
  * {@code PSPageService} is the rank-1 sitemanage fan-in hub (out ~11 / in ~28) and
- * construct-requires the cycle peers {@code contentItemDao}, {@code folderHelper},
- * {@code recycleService}, {@code widgetAssetRelationshipService}, and {@code
- * itemWorkflow}. The forward edges are intentional and broken on the {@code contentItemDao}
- * side via class {@code @Lazy} there. This test forbids the reverse edges: cycle peers and
- * other high-risk partners must not construct-require {@link IPSPageService}, since adding
- * such a reverse edge would close a new cycle path even with class {@code @Lazy} on
- * {@code PSPageService} (peer-cycle reasoning — see {@code
- * PSAssetServicePageServiceNearCycleWiringTest}).</p>
+ * construct-requires the cycle peers:
  *
- * <p>Peers: {@code PSAssetServicePageServiceNearCycleWiringTest} ({@code PSAssetService}
- * ↔ {@code PSPageService}), {@code PSContentItemDaoCycleLazyWiringTest} (folderHelper cycle
- * break), {@code PSTemplateServiceCycleWiringTest} (#2477).</p>
+ * <pre>
+ * pageService
+ *   → contentItemDao
+ *   → folderHelper
+ *   → recycleService
+ *   → widgetAssetRelationshipService
+ *   → itemWorkflow
+ * </pre>
+ *
+ * <p>The forward edges are intentional and broken on the {@code contentItemDao} side via param
+ * {@code @Lazy} there (path A). This test freezes the reverse direction: cycle peers and related
+ * high-risk hubs must not construct-require or eagerly field-inject {@link IPSPageService} without
+ * parameter/field {@link Lazy @Lazy}, since adding such a reverse edge would close a new cycle path
+ * independent of the contentItemDao break.
+ *
+ * <p><strong>Intentional {@code @Lazy} exception (documented, not banned):</strong> {@link
+ * PSAssetService} construct-requires {@code IPSPageService} with param {@code @Lazy} (#2476). That
+ * is a product consumer edge, not a cycle-peer reverse. It is asserted as present + {@code @Lazy}
+ * below; the companion reverse ban ({@code PSPageService ↛ IPSAssetService}) lives in {@code
+ * PSAssetServicePageServiceNearCycleWiringTest}.
+ *
+ * <p>Peers: {@code PSItemWorkflowServiceHubReverseEdgeWiringTest} (#2478 pattern this class
+ * mirrors), {@code PSAssetServicePageServiceNearCycleWiringTest}, {@code
+ * PSContentItemDaoCycleLazyWiringTest}, {@code PSTemplateServiceCycleWiringTest} (#2477).
  */
 @Tag("UnitTest")
 public class PSPageServiceCycleWiringTest {
+
+  /**
+   * Cycle peers and high-risk intermediates that pageService construct-requires (or that sit on
+   * the known folderHelper→…→contentItemDao chain). None of these may reverse-require {@link
+   * IPSPageService} without {@code @Lazy}.
+   */
+  private static final Class<?>[] CYCLE_PEERS = {
+    PSFolderHelper.class,
+    PSContentItemDao.class,
+    PSRecycleService.class,
+    PSWidgetAssetRelationshipService.class,
+    PSItemWorkflowService.class,
+    PSAssetDao.class
+  };
 
   @Test
   public void pageServiceIsClassLevelLazy() {
@@ -59,63 +100,124 @@ public class PSPageServiceCycleWiringTest {
         "PSPageService must carry class-level @Lazy to harden against cycle formation"
             + " (#2423 residual #2514 / #2463 inventory). Class @Lazy defers the bean until"
             + " first use, breaking any eager consumer path that could close a cycle through"
-            + " pageService.");
+            + " pageService. Class @Lazy is lazy-init only — not a substitute for reverse-edge"
+            + " bans or param @Lazy on reverse partners.");
+  }
+
+  @Test
+  public void pageServiceConstructRequiresCyclePeers() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSPageService.class);
+
+    assertNotNull(
+        findParamOfType(ctor, IPSFolderHelper.class),
+        "PSPageService must still construct-require IPSFolderHelper — inventory #2463 / #2514 hub"
+            + " model; the cycle is broken on contentItemDao, not by removing this forward edge");
+    assertNotNull(
+        findParamOfType(ctor, IPSContentItemDao.class),
+        "PSPageService must still construct-require IPSContentItemDao; removing the edge would"
+            + " invalidate the contentItemDao @Lazy break relative to this hub");
+    assertNotNull(
+        findParamOfType(ctor, IPSRecycleService.class),
+        "PSPageService must still construct-require IPSRecycleService; reverse-edge into recycle is"
+            + " forbidden below");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSPageService must still construct-require IPSWidgetAssetRelationshipService (inventory"
+            + " #2463 cycle peer)");
+    assertNotNull(
+        findParamOfType(ctor, IPSItemWorkflowService.class),
+        "PSPageService must still construct-require IPSItemWorkflowService (inventory #2463 cycle"
+            + " peer); reverse itemWorkflow→pageService is banned below");
   }
 
   /**
-   * The reverse edges are the dangerous ones: cycle peers must not construct-require
-   * IPSPageService. This locks down the four cycle peers the #2463 inventory named.
-   *
-   * <p>Note: {@code PSAssetService} already takes {@link IPSPageService} as a forward
-   * ctor edge (param {@code @Lazy}, peer #2476 / #2463). That edge is intentional and
-   * mitigated by the param-level {@code @Lazy} on {@code PSAssetService}, so it is
-   * <em>not</em> banned here. The companion reverse-edge check lives in
-   * {@code PSAssetServicePageServiceNearCycleWiringTest}: that test forbids
-   * {@code PSPageService → IPSAssetService} (the other direction of the near-cycle).</p>
+   * Reverse edges are the dangerous ones: cycle peers must not construct-require {@link
+   * IPSPageService} without param {@code @Lazy}. Intentional reverse edges (none among cycle peers
+   * today) must use parameter {@code @Lazy} and be documented in the inventory note.
    */
   @Test
   public void cyclePeersMustNotConstructRequirePageService() throws NoSuchMethodException {
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.share.dao.impl.PSFolderHelper.class),
-        IPSPageService.class,
-        "folderHelper → pageService would close a folderHelper↔pageService cycle");
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.share.dao.impl.PSContentItemDao.class),
-        IPSPageService.class,
-        "contentItemDao → pageService would reverse the existing pageService→contentItemDao"
-            + " forward edge and form a new cycle path");
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.recycle.service.impl.PSRecycleService.class),
-        IPSPageService.class,
-        "recycleService → pageService would close a pageService↔recycleService cycle branch");
-    assertNoCtorParam(
-        singlePublicConstructor(
-            com.percussion.itemmanagement.service.impl.PSItemWorkflowService.class),
-        IPSPageService.class,
-        "itemWorkflow → pageService would close a pageService↔itemWorkflow cycle branch");
+    for (Class<?> peer : CYCLE_PEERS) {
+      Constructor<?> ctor = singlePublicConstructor(peer);
+      Parameter page = findParamOfType(ctor, IPSPageService.class);
+      if (page == null) {
+        continue; // desired: no reverse ctor edge
+      }
+      // Intentional exception path: only allowed with parameter @Lazy
+      assertTrue(
+          page.isAnnotationPresent(Lazy.class),
+          peer.getSimpleName()
+              + " construct-requires IPSPageService without @Lazy — that closes a reverse cycle"
+              + " with the pageService hub (see #2514). Prefer method-level lookup, setter"
+              + " injection, or @Lazy on the injection point; document intentional @Lazy reverse"
+              + " edges in sitemanage-injection-cycle-inventory.md.");
+    }
   }
 
   /**
-   * Belt-and-braces: PSPageService must keep construct-requiring its cycle peers (forward
-   * edges). The cycle is broken by contentItemDao's class @Lazy, not by removing the
-   * forward edges. If anyone removes a forward edge they should also remove the
-   * corresponding reverse-edge ban here AND update the inventory.
+   * Eager {@code @Autowired} field inject of {@link IPSPageService} on a cycle peer is the same
+   * class of reverse edge as a constructor param (class-level {@code @Lazy} on the peer does not
+   * break an eager field edge from a bean already under construction).
+   *
+   * <p>Also flags unannotated fields of that type (legacy XML/setter surfaces) unless marked {@code
+   * @Lazy}.
    */
   @Test
-  public void pageServiceConstructorKeepsCyclePeerForwardEdges() throws NoSuchMethodException {
-    Constructor<?> ctor = singlePublicConstructor(PSPageService.class);
-    assertHasCtorParam(ctor, IPSFolderHelper.class, "PSPageService must still construct-require"
-        + " folderHelper (cycle inventory #2463); the cycle is broken on contentItemDao, not"
-        + " here");
-    assertHasCtorParam(ctor, IPSContentItemDao.class, "PSPageService must still construct-require"
-        + " contentItemDao (cycle inventory #2463); removing the edge would invalidate the"
-        + " contentItemDao @Lazy break");
-    assertHasCtorParam(ctor, IPSRecycleService.class, "PSPageService must still construct-require"
-        + " recycleService (cycle inventory #2463); reverse-edge into recycle is forbidden"
-        + " above");
+  public void cyclePeersMustNotEagerFieldInjectPageService() {
+    List<String> violations = new ArrayList<>();
+    for (Class<?> peer : CYCLE_PEERS) {
+      for (Field field : peer.getDeclaredFields()) {
+        if (!IPSPageService.class.isAssignableFrom(field.getType())) {
+          continue;
+        }
+        if (field.isAnnotationPresent(Lazy.class)) {
+          continue; // documented intentional reverse edge
+        }
+        boolean autowired = field.isAnnotationPresent(Autowired.class);
+        violations.add(
+            peer.getSimpleName()
+                + "."
+                + field.getName()
+                + (autowired ? " (@Autowired)" : " (field type)")
+                + " — reverse field edge without @Lazy");
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Cycle peers must not eagerly field-inject IPSPageService (use @Lazy or remove the edge)."
+            + " Violations: "
+            + String.join("; ", violations));
+  }
+
+  /**
+   * Documented intentional reverse partner: {@link PSAssetService} → {@link IPSPageService} with
+   * param {@code @Lazy} (#2476). Not a cycle peer of the folderHelper chain, but the next-hottest
+   * near-cycle consumer of pageService. Must remain {@code @Lazy}; bare reverse would re-open
+   * assetService↔pageService risk independent of folderHelper.
+   */
+  @Test
+  public void assetServiceIntentionalPageServiceEdgeIsLazy() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSAssetService.class);
+    Parameter pageParam = findParamOfType(ctor, IPSPageService.class);
+    assertNotNull(
+        pageParam,
+        "PSAssetService must still construct-require IPSPageService — inventory #2463 / #2476"
+            + " intentional reverse partner of the pageService hub; if removed, update inventory"
+            + " and PSAssetServicePageServiceNearCycleWiringTest");
+    assertTrue(
+        pageParam.isAnnotationPresent(Lazy.class),
+        "IPSPageService constructor parameter on PSAssetService must remain @Lazy (intentional"
+            + " reverse partner of the pageService hub; see #2476 / #2514). Do not drop @Lazy"
+            + " without a new cycle break documented in the inventory.");
+  }
+
+  @Test
+  public void contentItemDaoStillHasNoPageServiceConstructorEdge() throws NoSuchMethodException {
+    // Explicit named assertion for the known-cycle break peer (contentItemDao is the @Lazy site)
+    assertNoEagerCtorParam(
+        PSContentItemDao.class,
+        IPSPageService.class,
+        "contentItemDao → pageService would couple the cycle-break peer to the rank-1 hub");
   }
 
   @Test
@@ -123,8 +225,10 @@ public class PSPageServiceCycleWiringTest {
     // Sanity guard: PSPageService must declare exactly one public constructor for Spring
     // wiring inspection; this test enforces the assumption shared by all assertions above.
     Constructor<?> ctor = singlePublicConstructor(PSPageService.class);
-    assertNotNull(ctor, "PSPageService must declare exactly one public constructor for Spring"
-        + " wiring inspection; this test enforces the assumption");
+    assertNotNull(
+        ctor,
+        "PSPageService must declare exactly one public constructor for Spring wiring inspection;"
+            + " this test enforces the assumption");
   }
 
   private static Constructor<?> singlePublicConstructor(Class<?> type)
@@ -139,32 +243,28 @@ public class PSPageServiceCycleWiringTest {
     return ctors[0];
   }
 
-  private static void assertNoCtorParam(
-      Constructor<?> ctor, Class<?> forbidden, String why) {
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
     for (Parameter p : ctor.getParameters()) {
-      if (forbidden.isAssignableFrom(p.getType())) {
-        fail(
-            ctor.getDeclaringClass().getSimpleName()
-                + " must not construct-require "
-                + forbidden.getSimpleName()
-                + ": "
-                + why);
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
       }
     }
+    return null;
   }
 
-  private static void assertHasCtorParam(
-      Constructor<?> ctor, Class<?> expected, String why) {
-    for (Parameter p : ctor.getParameters()) {
-      if (expected.isAssignableFrom(p.getType())) {
-        return;
-      }
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    if (p == null) {
+      return;
     }
-    fail(
-        ctor.getDeclaringClass().getSimpleName()
-            + " must still construct-require "
-            + expected.getSimpleName()
-            + ": "
+    assertTrue(
+        p.isAnnotationPresent(Lazy.class),
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + " without @Lazy: "
             + why);
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSTemplateServiceParamLazyWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSTemplateServiceParamLazyWiringTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.pagemanagement.dao.IPSPageDao;
+import com.percussion.pagemanagement.dao.IPSPageDaoHelper;
+import com.percussion.pagemanagement.dao.IPSTemplateDao;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Belt-and-braces param {@code @Lazy} on {@link PSTemplateService} → forward ctor edges to
+ * known-cycle peers (#2423 residual #2520, peer of #2515 itemWorkflow + #2476 assetService→page).
+ *
+ * <p>Static inventory (#2463 / #2485) ranks {@code PSTemplateService} as a top-3 sitemanage hub.
+ * It construct-requires peers on or next to the known cycle subgraph:
+ *
+ * <pre>
+ * templateService
+ *   → templateDao                       (@Lazy param — #2520)
+ *   → widgetAssetRelationshipService    (@Lazy param — #2520)
+ *   → pageDao                           (@Lazy param — #2520)
+ *   → pageDaoHelper                     (@Lazy param — #2520)
+ * </pre>
+ *
+ * <p>Class-level {@code @Lazy} on the hub (#2477) does <em>not</em> break constructor dependency
+ * edges when an eager consumer forces creation. Parameter {@code @Lazy} injects proxies (peer of
+ * {@link PSItemWorkflowServiceCycleLazyWiringTest} / {@link
+ * PSAssetServicePageServiceNearCycleWiringTest}). Reverse edges from these peers back to {@code
+ * IPSTemplateService} remain banned by {@link PSTemplateServiceCycleWiringTest} (#2477).
+ *
+ * <p>Behavior review (#2520): ctor body only field-assigns the four peers listed above; method
+ * calls happen only on save / load / template workflow paths post-construction. Lazy proxies are
+ * therefore safe for the chosen edges. {@code IPSWidgetService} is intentionally NOT annotated
+ * here — the ctor body uses it to construct {@code RegionWidgetValidator}.
+ *
+ * <p>Inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSTemplateServiceParamLazyWiringTest {
+
+  @Test
+  public void templateServiceConstructRequiresForwardEdges() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSTemplateService.class);
+    assertNotNull(
+        findParamOfType(ctor, IPSTemplateDao.class),
+        "PSTemplateService must still construct-require IPSTemplateDao — inventory #2463 / #2520"
+            + " hub model; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSTemplateService must still construct-require IPSWidgetAssetRelationshipService");
+    assertNotNull(
+        findParamOfType(ctor, IPSPageDao.class),
+        "PSTemplateService must still construct-require IPSPageDao");
+    assertNotNull(
+        findParamOfType(ctor, IPSPageDaoHelper.class),
+        "PSTemplateService must still construct-require IPSPageDaoHelper");
+  }
+
+  @Test
+  public void templateDaoConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSTemplateDao.class,
+        "IPSTemplateDao constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " templateDao is only field-assigned in the ctor (used on save / load / find paths).");
+  }
+
+  @Test
+  public void widgetAssetRelationshipServiceConstructorParameterIsLazy()
+      throws NoSuchMethodException {
+    assertParamLazy(
+        IPSWidgetAssetRelationshipService.class,
+        "IPSWidgetAssetRelationshipService constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " widgetAsset is only used post-construction (shared/linked/local asset relations on"
+            + " save / import / create).");
+  }
+
+  @Test
+  public void pageDaoConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSPageDao.class,
+        "IPSPageDao constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " pageDao is only used post-construction (isValidPageId on save).");
+  }
+
+  @Test
+  public void pageDaoHelperConstructorParameterIsLazy() throws NoSuchMethodException {
+    assertParamLazy(
+        IPSPageDaoHelper.class,
+        "IPSPageDaoHelper constructor parameter on PSTemplateService must be @Lazy"
+            + " (belt-and-braces cycle-peer protection; see #2520 / #2463)."
+            + " pageDaoHelper is only used post-construction (pageIdsByTemplate / replaceTemplate"
+            + " on delete).");
+  }
+
+  private static void assertParamLazy(Class<?> paramType, String message)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSTemplateService.class);
+    Parameter param = findParamOfType(ctor, paramType);
+    assertNotNull(
+        param,
+        "Expected a " + paramType.getSimpleName() + " constructor parameter on PSTemplateService");
+    assertTrue(param.isAnnotationPresent(Lazy.class), message);
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.dao.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.dao.impl.PSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
+import com.percussion.pagemanagement.dao.impl.PSPageDaoHelper;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pagemanagement.service.IPSTemplateService;
+import com.percussion.pagemanagement.service.impl.PSPageService;
+import com.percussion.pagemanagement.service.impl.PSTemplateService;
+import com.percussion.recycle.service.IPSRecycleService;
+import com.percussion.recycle.service.impl.PSRecycleService;
+import com.percussion.searchmanagement.service.IPSPageIndexService;
+import com.percussion.searchmanagement.service.impl.PSPageIndexService;
+import com.percussion.share.dao.IPSContentItemDao;
+import com.percussion.share.dao.IPSFolderHelper;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Protection for the {@link PSWidgetAssetRelationshipService} rank-4 hub on the known folderHelper
+ * cycle path (#2423 residual #2519).
+ *
+ * <p>Static inventory (#2463) ranks {@code PSWidgetAssetRelationshipService} as the fourth-hottest
+ * sitemanage hub (ctor out ~4 / in ~18). It sits <em>on</em> the known creation chain:
+ *
+ * <pre>
+ * folderHelper → recycleService → widgetAssetRelationshipService → assetDao → contentItemDao
+ *       ↑_______________________________ @Lazy break ________________________________/
+ *
+ * folderHelper → recycleService → widgetAssetRelationshipService → pageIndexService
+ *       → pageDaoHelper → folderHelper   (@Lazy on pageDaoHelper)
+ * </pre>
+ *
+ * <p><strong>Disposition (#2519):</strong> class-level {@code @Lazy} on {@link
+ * PSWidgetAssetRelationshipService} (hub alignment with page/template/itemWorkflow) <em>plus</em>
+ * reverse-edge freezes. Class {@code @Lazy} is lazy init only — not a constructor-edge cycle
+ * breaker when an eager consumer forces full construction.
+ *
+ * <p>Forward fan-in into this hub from {@code recycleService} / {@code pageService} / {@code
+ * templateService} is intentional product wiring and is frozen positive below. The dangerous edges
+ * are reverse of known one-ways (assetDao → widgetAsset; widgetAsset → recycle / page / template)
+ * and eager reverse field inject of the hub on cycle-path peers.
+ *
+ * <p>Peers: {@link PSItemWorkflowServiceHubReverseEdgeWiringTest} (#2478), {@code
+ * PSTemplateServiceCycleWiringTest} (#2477), {@link PSAssetServicePageServiceNearCycleWiringTest}.
+ * Inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ *
+ * <p>Out of scope: managedLink path-C ctor inject (#2527).
+ */
+@Tag("UnitTest")
+public class PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest {
+
+  /**
+   * Cycle-path peers that must not reverse-construct-require {@link
+   * IPSWidgetAssetRelationshipService} without param {@code @Lazy}. These are dependents on the
+   * folderHelper creation subgraph (or the known-cycle break peers) — <em>not</em> intentional
+   * product consumers (recycle / page / template / assetService), which inject the hub forward.
+   */
+  private static final Class<?>[] CYCLE_PATH_REVERSE_PEERS = {
+    PSAssetDao.class,
+    PSContentItemDao.class,
+    PSFolderHelper.class,
+    PSPageIndexService.class,
+    PSPageDaoHelper.class
+  };
+
+  @Test
+  public void widgetAssetRelationshipServiceIsClassLevelLazy() {
+    assertTrue(
+        PSWidgetAssetRelationshipService.class.isAnnotationPresent(Lazy.class),
+        "PSWidgetAssetRelationshipService must carry class-level @Lazy (hub alignment with"
+            + " pageService/templateService/itemWorkflow; disposition #2519). Class @Lazy is not a"
+            + " cycle breaker alone — reverse-edge bans below remain required.");
+  }
+
+  @Test
+  public void widgetAssetConstructRequiresAssetDaoAndPageIndex() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSWidgetAssetRelationshipService.class);
+
+    assertNotNull(
+        findParamOfType(ctor, IPSAssetDao.class),
+        "PSWidgetAssetRelationshipService must still construct-require IPSAssetDao — inventory"
+            + " #2463 / #2519 hub model on path A; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSPageIndexService.class),
+        "PSWidgetAssetRelationshipService must still construct-require IPSPageIndexService —"
+            + " inventory #2463 path B; if removed, update inventory and this test");
+  }
+
+  /**
+   * Intentional forward fan-in: product hubs on/near the cycle path construct-require widgetAsset.
+   * Freezing these positive edges documents that recycle/page/template → widgetAsset is <em>not</em>
+   * a reverse edge (see inventory #2463 / #2519).
+   */
+  @Test
+  public void intentionalConsumersStillConstructRequireWidgetAsset() throws NoSuchMethodException {
+    assertNotNull(
+        findParamOfType(
+            singlePublicConstructor(PSRecycleService.class), IPSWidgetAssetRelationshipService.class),
+        "PSRecycleService must still construct-require IPSWidgetAssetRelationshipService"
+            + " (known-cycle path A/B forward edge)");
+    assertNotNull(
+        findParamOfType(
+            singlePublicConstructor(PSPageService.class), IPSWidgetAssetRelationshipService.class),
+        "PSPageService must still construct-require IPSWidgetAssetRelationshipService"
+            + " (rank-1 hub fan-in; inventory #2463)");
+    assertNotNull(
+        findParamOfType(
+            singlePublicConstructor(PSTemplateService.class),
+            IPSWidgetAssetRelationshipService.class),
+        "PSTemplateService must still construct-require IPSWidgetAssetRelationshipService"
+            + " (rank-3 hub fan-in; #2477)");
+  }
+
+  @Test
+  public void cyclePathPeersMustNotConstructRequireWidgetAssetWithoutLazy()
+      throws NoSuchMethodException {
+    for (Class<?> peer : CYCLE_PATH_REVERSE_PEERS) {
+      Constructor<?> ctor = singlePublicConstructor(peer);
+      Parameter widgetAsset = findParamOfType(ctor, IPSWidgetAssetRelationshipService.class);
+      if (widgetAsset == null) {
+        continue; // desired: no reverse ctor edge
+      }
+      assertTrue(
+          widgetAsset.isAnnotationPresent(Lazy.class),
+          peer.getSimpleName()
+              + " construct-requires IPSWidgetAssetRelationshipService without @Lazy — that"
+              + " closes a reverse cycle with the widgetAsset hub on the folderHelper path (see"
+              + " #2519). Prefer method-level lookup, setter injection, or @Lazy on the injection"
+              + " point; document intentional @Lazy reverse edges in"
+              + " sitemanage-injection-cycle-inventory.md.");
+    }
+  }
+
+  /**
+   * Eager {@code @Autowired} field inject of the hub on a cycle-path peer is the same class of
+   * reverse edge as a constructor param (class-level {@code @Lazy} on either bean does not break an
+   * eager field edge from a bean already under construction).
+   */
+  @Test
+  public void cyclePathPeersMustNotEagerFieldInjectWidgetAsset() {
+    List<String> violations = new ArrayList<>();
+    for (Class<?> peer : CYCLE_PATH_REVERSE_PEERS) {
+      for (Class<?> type = peer; type != null && type != Object.class; type = type.getSuperclass()) {
+        for (Field field : type.getDeclaredFields()) {
+          if (!IPSWidgetAssetRelationshipService.class.isAssignableFrom(field.getType())
+              && !PSWidgetAssetRelationshipService.class.isAssignableFrom(field.getType())) {
+            continue;
+          }
+          if (field.isAnnotationPresent(Lazy.class)) {
+            continue; // documented intentional reverse edge
+          }
+          boolean autowired = field.isAnnotationPresent(Autowired.class);
+          String owner =
+              type.equals(peer)
+                  ? peer.getSimpleName()
+                  : peer.getSimpleName() + ":" + type.getSimpleName();
+          violations.add(
+              owner
+                  + "."
+                  + field.getName()
+                  + (autowired ? " (@Autowired)" : " (field type)")
+                  + " — reverse field edge without @Lazy");
+        }
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Cycle-path peers must not eagerly field-inject IPSWidgetAssetRelationshipService (use"
+            + " @Lazy or remove the edge). Violations: "
+            + String.join("; ", violations));
+  }
+
+  /** Named assertion: reverse of widgetAsset → assetDao would skip the contentItemDao @Lazy break. */
+  @Test
+  public void assetDaoMustNotConstructRequireWidgetAsset() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSAssetDao.class,
+        IPSWidgetAssetRelationshipService.class,
+        "assetDao → widgetAsset would reverse widgetAsset→assetDao and skip the contentItemDao"
+            + " @Lazy break (#2519 / inventory path A)");
+  }
+
+  /** Named assertion: reverse of recycle → widgetAsset closes the mid-chain. */
+  @Test
+  public void widgetAssetMustNotConstructRequireRecycleService() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSWidgetAssetRelationshipService.class,
+        IPSRecycleService.class,
+        "widgetAsset → recycleService would reverse recycle→widgetAsset and close a mid-chain"
+            + " cycle (#2519)");
+  }
+
+  /** Named assertion: reverse of pageService → widgetAsset closes a hub↔hub cycle branch. */
+  @Test
+  public void widgetAssetMustNotConstructRequirePageService() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSWidgetAssetRelationshipService.class,
+        IPSPageService.class,
+        "widgetAsset → pageService would reverse pageService→widgetAsset (#2519 / #2514)");
+  }
+
+  /** Named assertion: reverse of templateService → widgetAsset closes a hub↔hub cycle branch. */
+  @Test
+  public void widgetAssetMustNotConstructRequireTemplateService() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSWidgetAssetRelationshipService.class,
+        IPSTemplateService.class,
+        "widgetAsset → templateService would reverse templateService→widgetAsset (#2519 /"
+            + " #2477)");
+  }
+
+  @Test
+  public void pageIndexServiceMustNotConstructRequireWidgetAsset() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSPageIndexService.class,
+        IPSWidgetAssetRelationshipService.class,
+        "pageIndexService → widgetAsset would reverse widgetAsset→pageIndex (path B)");
+  }
+
+  @Test
+  public void contentItemDaoStillHasNoWidgetAssetConstructorEdge() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSContentItemDao.class,
+        IPSWidgetAssetRelationshipService.class,
+        "contentItemDao → widgetAsset would couple the cycle-break peer to the hub");
+  }
+
+  @Test
+  public void folderHelperStillHasNoWidgetAssetConstructorEdge() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSFolderHelper.class,
+        IPSWidgetAssetRelationshipService.class,
+        "folderHelper → widgetAsset would short-circuit recycle on the known cycle path");
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    if (p == null) {
+      return;
+    }
+    assertTrue(
+        p.isAnnotationPresent(Lazy.class),
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + " without @Lazy: "
+            + why);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
@@ -154,22 +154,23 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
   }
 
   @Test
-  public void cyclePeersAndPageItemHubsMustNotConstructRequireSiteDataService()
-      throws NoSuchMethodException {
+  public void cyclePeersAndPageItemHubsMustNotConstructRequireSiteDataService() {
     for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
-      Constructor<?> ctor = singlePublicConstructor(peer);
-      Parameter siteData = findParamOfType(ctor, IPSSiteDataService.class);
-      if (siteData == null) {
-        continue; // desired: no reverse ctor edge
+      // Scan all declared constructors so a non-public @Autowired wiring ctor is not missed.
+      for (Constructor<?> ctor : peer.getDeclaredConstructors()) {
+        Parameter siteData = findParamOfType(ctor, IPSSiteDataService.class);
+        if (siteData == null) {
+          continue; // desired: no reverse ctor edge on this ctor
+        }
+        // Intentional exception path: only allowed with parameter @Lazy
+        assertTrue(
+            siteData.isAnnotationPresent(Lazy.class),
+            peer.getSimpleName()
+                + " construct-requires IPSSiteDataService without @Lazy — that closes a reverse"
+                + " cycle with the siteDataService hub (see #2516). Prefer method-level lookup,"
+                + " setter injection, or @Lazy on the injection point; document intentional @Lazy"
+                + " reverse edges in sitemanage-injection-cycle-inventory.md.");
       }
-      // Intentional exception path: only allowed with parameter @Lazy
-      assertTrue(
-          siteData.isAnnotationPresent(Lazy.class),
-          peer.getSimpleName()
-              + " construct-requires IPSSiteDataService without @Lazy — that closes a reverse"
-              + " cycle with the siteDataService hub (see #2516). Prefer method-level lookup,"
-              + " setter injection, or @Lazy on the injection point; document intentional @Lazy"
-              + " reverse edges in sitemanage-injection-cycle-inventory.md.");
     }
   }
 
@@ -189,7 +190,8 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
   public void cyclePeersAndPageItemHubsMustNotEagerFieldInjectSiteDataService() {
     List<String> violations = new ArrayList<>();
     for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
-      for (Field field : peer.getDeclaredFields()) {
+      // Walk hierarchy so inherited reverse edges are not silently skipped (#2516 review).
+      for (Field field : declaredFieldsIncludingInherited(peer)) {
         if (!IPSSiteDataService.class.isAssignableFrom(field.getType())
             && !PSSiteDataService.class.isAssignableFrom(field.getType())) {
           continue;
@@ -239,16 +241,44 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
         "itemWorkflow → siteDataService would reverse siteData→itemWorkflow forward edge");
   }
 
+  /**
+   * Prefer a single {@code @Autowired} declared constructor (Spring wiring ctor), then fall back
+   * to the single public constructor. Avoids missing a non-public wiring ctor when a public
+   * no-arg also exists (#2516 review).
+   */
   private static Constructor<?> singlePublicConstructor(Class<?> type)
       throws NoSuchMethodException {
-    Constructor<?>[] ctors = type.getConstructors();
-    if (ctors.length != 1) {
+    List<Constructor<?>> autowired = new ArrayList<>();
+    for (Constructor<?> ctor : type.getDeclaredConstructors()) {
+      if (ctor.isAnnotationPresent(Autowired.class)) {
+        autowired.add(ctor);
+      }
+    }
+    if (autowired.size() == 1) {
+      return autowired.get(0);
+    }
+    if (autowired.size() > 1) {
       fail(
           type.getSimpleName()
-              + " expected exactly one public constructor for wiring inspection, found "
-              + ctors.length);
+              + " expected at most one @Autowired constructor for wiring inspection, found "
+              + autowired.size());
     }
-    return ctors[0];
+    Constructor<?>[] publicCtors = type.getConstructors();
+    if (publicCtors.length == 1) {
+      return publicCtors[0];
+    }
+    Constructor<?>[] declared = type.getDeclaredConstructors();
+    if (declared.length == 1) {
+      return declared[0];
+    }
+    fail(
+        type.getSimpleName()
+            + " expected exactly one public (or single declared / @Autowired) constructor for"
+            + " wiring inspection, found public="
+            + publicCtors.length
+            + " declared="
+            + declared.length);
+    return null; // unreachable
   }
 
   private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
@@ -260,8 +290,21 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
     return null;
   }
 
+  /** Declared fields on {@code bean} and all superclasses (stops at {@link Object}). */
+  private static List<Field> declaredFieldsIncludingInherited(Class<?> bean) {
+    List<Field> fields = new ArrayList<>();
+    Class<?> current = bean;
+    while (current != null && current != Object.class) {
+      for (Field field : current.getDeclaredFields()) {
+        fields.add(field);
+      }
+      current = current.getSuperclass();
+    }
+    return fields;
+  }
+
   private static boolean hasFieldOfType(Class<?> bean, Class<?> fieldType) {
-    for (Field field : bean.getDeclaredFields()) {
+    for (Field field : declaredFieldsIncludingInherited(bean)) {
       if (fieldType.isAssignableFrom(field.getType())) {
         return true;
       }
@@ -269,19 +312,19 @@ public class PSSiteDataServiceHubReverseEdgeWiringTest {
     return false;
   }
 
-  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
-      throws NoSuchMethodException {
-    Constructor<?> ctor = singlePublicConstructor(bean);
-    Parameter p = findParamOfType(ctor, forbidden);
-    if (p == null) {
-      return;
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why) {
+    for (Constructor<?> ctor : bean.getDeclaredConstructors()) {
+      Parameter p = findParamOfType(ctor, forbidden);
+      if (p == null) {
+        continue;
+      }
+      assertTrue(
+          p.isAnnotationPresent(Lazy.class),
+          bean.getSimpleName()
+              + " must not construct-require "
+              + forbidden.getSimpleName()
+              + " without @Lazy: "
+              + why);
     }
-    assertTrue(
-        p.isAnnotationPresent(Lazy.class),
-        bean.getSimpleName()
-            + " must not construct-require "
-            + forbidden.getSimpleName()
-            + " without @Lazy: "
-            + why);
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/service/impl/PSSiteDataServiceHubReverseEdgeWiringTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.sitemanage.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.dao.impl.PSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.impl.PSAssetService;
+import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.impl.PSItemWorkflowService;
+import com.percussion.pagemanagement.dao.impl.PSPageDaoHelper;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pagemanagement.service.impl.PSPageService;
+import com.percussion.pagemanagement.service.impl.PSTemplateService;
+import com.percussion.pathmanagement.service.impl.PSPathService;
+import com.percussion.recycle.service.impl.PSRecycleService;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.dao.impl.PSContentItemDao;
+import com.percussion.share.dao.impl.PSFolderHelper;
+import com.percussion.sitemanage.service.IPSSiteDataService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Protection for the {@link PSSiteDataService} wide sitemanage hub (#2423 residual #2516).
+ *
+ * <p>Static inventory (#2463) ranked {@code PSSiteDataService} as the sixth-hottest sitemanage hub
+ * (ctor out ~15 / in ~12). It is class-{@code @Lazy} and construct-requires known-cycle peers /
+ * page-item hubs:
+ *
+ * <pre>
+ * siteDataService
+ *   → folderHelper
+ *   → widgetAssetRelationshipService
+ *   → assetDao
+ *   → itemWorkflowService
+ *   (+ field: pageService, pathService)
+ * </pre>
+ *
+ * <p>Those peers sit on or next to the known {@code folderHelper → … → contentItemDao →
+ * folderHelper} chain (broken by {@code @Lazy} on {@link PSContentItemDao}). A reverse constructor
+ * (or eager field) edge from any of those peers / page-item hubs back to {@link
+ * IPSSiteDataService} would form a new creation cycle independent of the contentItemDao {@code
+ * @Lazy} break:
+ *
+ * <pre>
+ * folderHelper → recycle → widgetAsset → assetDao → contentItemDao → folderHelper
+ *       ↑______________________ siteDataService _______________________________/
+ * </pre>
+ *
+ * <p>This test freezes the one-way hub edges and forbids reverse ctor / non-{@code @Lazy} field
+ * inject of {@code IPSSiteDataService} on the cycle peers and rank-1/2 page/item hubs. Intentional
+ * reverse edges must use parameter/field {@link Lazy @Lazy} and be documented in the inventory
+ * note.
+ *
+ * <p>Scan snapshot (2026-08-08 / #2516): none of the listed peers currently inject {@code
+ * IPSSiteDataService} (ctor or field). Downstream consumers (path items, REST adaptors, publish
+ * handlers) remain allowed — they are not cycle fuel.
+ *
+ * <p>Peers: {@link
+ * com.percussion.share.dao.impl.PSItemWorkflowServiceHubReverseEdgeWiringTest}, {@code
+ * PSPageServiceCycleWiringTest}, {@code PSContentItemDaoCycleLazyWiringTest}. Inventory: {@code
+ * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
+ */
+@Tag("UnitTest")
+public class PSSiteDataServiceHubReverseEdgeWiringTest {
+
+  /**
+   * Cycle peers that siteData construct-requires (or that sit on the folderHelper creation path)
+   * plus rank-1/2 page/item hubs that must not reverse-require siteData without {@code @Lazy}.
+   */
+  private static final Class<?>[] CYCLE_PEERS_AND_PAGE_ITEM_HUBS = {
+    PSFolderHelper.class,
+    PSContentItemDao.class,
+    PSWidgetAssetRelationshipService.class,
+    PSRecycleService.class,
+    PSAssetDao.class,
+    PSPageDaoHelper.class,
+    PSPageService.class,
+    PSItemWorkflowService.class,
+    PSAssetService.class,
+    PSTemplateService.class
+  };
+
+  @Test
+  public void siteDataServiceIsClassLevelLazy() {
+    assertTrue(
+        PSSiteDataService.class.isAnnotationPresent(Lazy.class),
+        "PSSiteDataService must carry class-level @Lazy to harden against cycle formation"
+            + " (#2423 residual #2516 / #2463 inventory). Class @Lazy defers the bean until first"
+            + " use; it is not a constructor-cycle breaker once creation starts.");
+  }
+
+  @Test
+  public void siteDataServiceConstructRequiresCyclePeers() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSSiteDataService.class);
+
+    assertNotNull(
+        findParamOfType(ctor, IPSFolderHelper.class),
+        "PSSiteDataService must still construct-require IPSFolderHelper — inventory #2463 / #2516"
+            + " hub model; if removed, update inventory and this test");
+    assertNotNull(
+        findParamOfType(ctor, IPSWidgetAssetRelationshipService.class),
+        "PSSiteDataService must still construct-require IPSWidgetAssetRelationshipService");
+    assertNotNull(
+        findParamOfType(ctor, IPSAssetDao.class),
+        "PSSiteDataService must still construct-require IPSAssetDao");
+    assertNotNull(
+        findParamOfType(ctor, IPSItemWorkflowService.class),
+        "PSSiteDataService must still construct-require IPSItemWorkflowService");
+  }
+
+  /**
+   * Documented forward field edges (not reverse-cycle fuel): siteData → pageService / pathService.
+   * These are intentional consumer edges from the hub; the reverse (page/path → siteData) is banned
+   * via the peer scan for {@link PSPageService} (path service is not a cycle peer).
+   */
+  @Test
+  public void siteDataServiceFieldInjectsPageAndPathServices() {
+    assertTrue(
+        hasFieldOfType(PSSiteDataService.class, IPSPageService.class)
+            || hasFieldOfType(PSSiteDataService.class, PSPageService.class),
+        "PSSiteDataService should still field-inject pageService (inventory #2463 / #2516); if"
+            + " moved to ctor without @Lazy on a reverse partner, re-scan");
+    assertTrue(
+        hasFieldOfType(PSSiteDataService.class, PSPathService.class),
+        "PSSiteDataService should still field-inject pathService (inventory #2463 / #2516)");
+  }
+
+  @Test
+  public void cyclePeersAndPageItemHubsMustNotConstructRequireSiteDataService()
+      throws NoSuchMethodException {
+    for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
+      Constructor<?> ctor = singlePublicConstructor(peer);
+      Parameter siteData = findParamOfType(ctor, IPSSiteDataService.class);
+      if (siteData == null) {
+        continue; // desired: no reverse ctor edge
+      }
+      // Intentional exception path: only allowed with parameter @Lazy
+      assertTrue(
+          siteData.isAnnotationPresent(Lazy.class),
+          peer.getSimpleName()
+              + " construct-requires IPSSiteDataService without @Lazy — that closes a reverse"
+              + " cycle with the siteDataService hub (see #2516). Prefer method-level lookup,"
+              + " setter injection, or @Lazy on the injection point; document intentional @Lazy"
+              + " reverse edges in sitemanage-injection-cycle-inventory.md.");
+    }
+  }
+
+  /**
+   * Eager {@code @Autowired} field inject of {@link IPSSiteDataService} on a cycle peer / page-item
+   * hub is the same class of reverse edge as a constructor param (class-level {@code @Lazy} on the
+   * peer does not break an eager field edge from a bean already under construction).
+   *
+   * <p>Also flags unannotated fields of that type (legacy XML/setter surfaces) unless marked {@code
+   * @Lazy}.
+   *
+   * <p><strong>Intentional exceptions:</strong> none among {@link #CYCLE_PEERS_AND_PAGE_ITEM_HUBS}
+   * as of #2516. If a peer later needs a reverse edge, add field/param {@code @Lazy} and document
+   * it in the inventory (same pattern as {@code PSAssetService → IPSPageService} for #2476).
+   */
+  @Test
+  public void cyclePeersAndPageItemHubsMustNotEagerFieldInjectSiteDataService() {
+    List<String> violations = new ArrayList<>();
+    for (Class<?> peer : CYCLE_PEERS_AND_PAGE_ITEM_HUBS) {
+      for (Field field : peer.getDeclaredFields()) {
+        if (!IPSSiteDataService.class.isAssignableFrom(field.getType())
+            && !PSSiteDataService.class.isAssignableFrom(field.getType())) {
+          continue;
+        }
+        if (field.isAnnotationPresent(Lazy.class)) {
+          continue; // documented intentional reverse edge
+        }
+        boolean autowired = field.isAnnotationPresent(Autowired.class);
+        violations.add(
+            peer.getSimpleName()
+                + "."
+                + field.getName()
+                + (autowired ? " (@Autowired)" : " (field type)")
+                + " — reverse field edge without @Lazy");
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Cycle peers / page-item hubs must not eagerly field-inject IPSSiteDataService (use @Lazy"
+            + " or remove the edge). Violations: "
+            + String.join("; ", violations));
+  }
+
+  @Test
+  public void contentItemDaoStillHasNoSiteDataConstructorEdge() throws NoSuchMethodException {
+    // Explicit named assertion for the known-cycle break peer (contentItemDao is the @Lazy site)
+    assertNoEagerCtorParam(
+        PSContentItemDao.class,
+        IPSSiteDataService.class,
+        "contentItemDao → siteDataService would couple the cycle-break peer to the hub");
+  }
+
+  @Test
+  public void pageServiceStillHasNoSiteDataConstructorEdge() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSPageService.class,
+        IPSSiteDataService.class,
+        "pageService → siteDataService would reverse siteData→page field edge and form a hub↔hub"
+            + " cycle");
+  }
+
+  @Test
+  public void itemWorkflowStillHasNoSiteDataConstructorEdge() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSItemWorkflowService.class,
+        IPSSiteDataService.class,
+        "itemWorkflow → siteDataService would reverse siteData→itemWorkflow forward edge");
+  }
+
+  private static Constructor<?> singlePublicConstructor(Class<?> type)
+      throws NoSuchMethodException {
+    Constructor<?>[] ctors = type.getConstructors();
+    if (ctors.length != 1) {
+      fail(
+          type.getSimpleName()
+              + " expected exactly one public constructor for wiring inspection, found "
+              + ctors.length);
+    }
+    return ctors[0];
+  }
+
+  private static Parameter findParamOfType(Constructor<?> ctor, Class<?> paramType) {
+    for (Parameter p : ctor.getParameters()) {
+      if (paramType.isAssignableFrom(p.getType())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  private static boolean hasFieldOfType(Class<?> bean, Class<?> fieldType) {
+    for (Field field : bean.getDeclaredFields()) {
+      if (fieldType.isAssignableFrom(field.getType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void assertNoEagerCtorParam(Class<?> bean, Class<?> forbidden, String why)
+      throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(bean);
+    Parameter p = findParamOfType(ctor, forbidden);
+    if (p == null) {
+      return;
+    }
+    assertTrue(
+        p.isAnnotationPresent(Lazy.class),
+        bean.getSimpleName()
+            + " must not construct-require "
+            + forbidden.getSimpleName()
+            + " without @Lazy: "
+            + why);
+  }
+}


### PR DESCRIPTION
## Summary

Overnight **same-file thrash absorption** for parent epic **#2423** / inventory **#2463**.

Four owned PRs all edited the shared thrash file:

- `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md`

…while delivering independent sitemanage hub freezes. Rebasing them one-by-one forces repeated inventory conflict resolution and leaves residual **CONFLICTING** state (e.g. #2572). This cluster PR unions all four onto `main` with **union semantics** on the inventory (no unique disposition/test reference dropped).

### Thrash files

- `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md`

(Product/test sources per PR are mostly non-overlapping; the inventory is the thrash hub.)

### Absorbed content

| Hub / slice | Issue | Key artifacts |
|-------------|-------|---------------|
| templateService param `@Lazy` | #2520 | `PSTemplateService`, `PSTemplateServiceParamLazyWiringTest` |
| pageService reverse-edge freeze | #2514 | `PSPageServiceCycleWiringTest` expansion; dead `pageService` field removed from `PSItemWorkflowService` |
| siteDataService reverse-edge freeze | #2516 | `PSSiteDataServiceHubReverseEdgeWiringTest` |
| widgetAsset class `@Lazy` + reverse freezes | #2519 | `@Lazy` on `PSWidgetAssetRelationshipService`, `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` |

### Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #2563 | `fix/2520-templateService-param-lazy` | yes | templateService forward param `@Lazy` |
| yes | #2566 | `fix/issue-2514-pageservice-reverse-edge` | yes | pageService reverse-edge freeze |
| yes | #2568 | `fix/issue-2516-sitedataservice-reverse-edge-freezes` | yes | siteData reverse-edge freeze |
| yes | #2572 | `fix/issue-2519-widget-asset-hub-lazy` | yes | was CONFLICTING vs main; widgetAsset hub |

**Do not merge** the superseded PRs; close them in favor of this cluster.

## Test plan / gates

- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Surefire aggregate: **Tests run: 803, Failures: 0, Errors: 0, Skipped: 128**
- [x] Inventory union retains #2514 / #2516 / #2519 / #2520 sections and reflection peers
- [ ] Human review of inventory disposition table (union may be denser than any single PR)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Code using grok-4.5 with agent night-issue-prs-cluster.
