### PR TITLE
fix(sitemanage): widgetAsset managedLink path-C reverse-edge hardening (#2527)

### DIFF
--- a/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
+++ b/docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md
@@ -1,9 +1,9 @@
 # Sitemanage Spring constructor-injection cycle inventory
 
-**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514** / **#2519**; itemWorkflow param `@Lazy` **#2515**; templateService param `@Lazy` **#2520**; siteData reverse-edge freeze **#2516**  
+**Issue:** #2463 (residual of #2423); reverse-edge inventory refresh **#2485**; hub freezes **#2477** / **#2514** / **#2519**; itemWorkflow param `@Lazy` **#2515**; templateService param `@Lazy` **#2520**; siteData reverse-edge freeze **#2516**; widgetAsset managedLink path-C **#2527**  
 **Module:** `projects/sitemanage`  
-**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2520 / #2521 / #2525 / #2514 / #2516 / #2519)  
-**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525), `PSTemplateServiceCycleWiringTest` (#2477), `PSTemplateServiceParamLazyWiringTest` (#2520), `PSPageServiceCycleWiringTest` (#2514 — ctor + field reverse-edge freeze, mirrors #2478), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSSiteDataServiceHubReverseEdgeWiringTest` (#2516), `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` (#2519), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
+**Date:** 2026-08-08 (updated 2026-08-09 for #2485 / #2515 / #2520 / #2521 / #2525 / #2514 / #2516 / #2519 / #2527)  
+**Method:** Static scan of `@Autowired` constructors + field `@Autowired` among high-fan-in sitemanage beans (interfaces mapped to primary impls). Reflection peers: `PSContentItemDaoCycleLazyWiringTest`, `PSPageDaoHelperCycleLazyWiringTest`, `PSFolderHelperRecycleLazyWiringTest`, `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485), `PSFolderHelperFieldInjectionInventoryWiringTest` (#2525), `PSTemplateServiceCycleWiringTest` (#2477), `PSTemplateServiceParamLazyWiringTest` (#2520), `PSPageServiceCycleWiringTest` (#2514 — ctor + field reverse-edge freeze, mirrors #2478), `PSItemWorkflowServiceHubReverseEdgeWiringTest` (#2478), `PSItemWorkflowServiceCycleLazyWiringTest` (#2515), `PSSiteDataServiceHubReverseEdgeWiringTest` (#2516), `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` (#2519 + path-C #2527), `PSAssetServicePageServiceNearCycleWiringTest`, `PSAssetServiceTemplateServiceNearCycleWiringTest` (#2521), `FolderHelperCycleContextTest` (#2436).
 
 This is an analysis note for humans/agents ΓÇö **not** an agent rule file.
 
@@ -28,6 +28,11 @@ folderHelper
 
 Forward deferral (also #2437):
 folderHelper ΓåÆ recycleService   ΓåÉ @Lazy on PSFolderHelper ctor param
+
+Path C (latent / banned — #2527; not a live ctor cycle):
+widgetAsset ↛ managedLinkService   ΓåÉ application-context lookup only
+managedLinkService ΓåÆ pageService ΓåÆ folderHelper
+  (would re-enter folderHelper while paths A/B may still be constructing)
 ```
 
 | Edge | Type | Breaker |
@@ -40,6 +45,8 @@ folderHelper ΓåÆ recycleService   ΓåÉ @Lazy on PSFolderHelper ctor param
 | `PSWidgetAssetRelationshipService` ΓåÆ `IPSPageIndexService` | ctor | none (forward) |
 | `PSPageIndexService` ΓåÆ `IPSPageDaoHelper` | ctor | none (forward) |
 | `PSPageDaoHelper` ΓåÆ `IPSFolderHelper` | ctor | **`@Lazy`** (#2437) |
+| `PSWidgetAssetRelationshipService` ΓåÆ `IPSManagedLinkService` | **banned** (context lookup) | **Ban** (#2527 path C) |
+| `PSManagedLinkService` ΓåÆ `IPSPageService` | ctor | none (forward consumer; hazard only if widgetAsset ctor-pulls managedLink) |
 
 Class-level `@Lazy` is present on `folderHelper` and `recycleService` but is **not** sufficient alone: an eager consumer (e.g. field inject on `pSRedirectService`) still forces full construction and re-enters the cycle without a parameter-level `@Lazy` proxy.
 
@@ -69,7 +76,7 @@ These sit on path A/B. Adding a ctor edge to `IPSFolderHelper` would short-circu
 | `PSPageIndexService` | pageDao, pageDaoHelper, ΓÇª | **Ban** ctor ΓåÆ folderHelper |
 | `PSPageDao` | contentItemDao, ΓÇª | **Ban** ctor ΓåÆ folderHelper |
 
-`managedLinkService` is resolved by `PSWidgetAssetRelationshipService` via application-context lookup (not ctor) ΓÇö keep it that way; a ctor inject of `IPSManagedLinkService` would pull `pageService` ΓåÆ `folderHelper` and form path C.
+`managedLinkService` is resolved by `PSWidgetAssetRelationshipService` via application-context lookup (not ctor) — **hardened #2527** (keep it that way; freezes in hub reverse-edge test). A ctor inject of `IPSManagedLinkService` would pull `pageService` → `folderHelper` and form path C.
 
 ### Consumer-only injectors of `IPSFolderHelper` (no param `@Lazy` required)
 
@@ -182,7 +189,7 @@ These sit on path A/B. Adding a ctor edge to `IPSFolderHelper` would short-circu
 | `PSPageIndexService` | pageDao, pageDaoHelper, ΓÇª | **Ban** ctor ΓåÆ folderHelper |
 | `PSPageDao` | contentItemDao, ΓÇª | **Ban** ctor ΓåÆ folderHelper |
 
-`managedLinkService` is resolved by `PSWidgetAssetRelationshipService` via application-context lookup (not ctor) ΓÇö keep it that way; a ctor inject of `IPSManagedLinkService` would pull `pageService` ΓåÆ `folderHelper` and form path C.
+`managedLinkService` is resolved by `PSWidgetAssetRelationshipService` via application-context lookup (not ctor) — **hardened #2527** (keep it that way; freezes in hub reverse-edge test). A ctor inject of `IPSManagedLinkService` would pull `pageService` → `folderHelper` and form path C.
 
 ### Consumer-only injectors of `IPSFolderHelper` (no param `@Lazy` required)
 
@@ -347,9 +354,25 @@ Protection test: `PSSiteDataServiceHubReverseEdgeWiringTest` (forward freeze + r
 | Forward edges kept | widgetAsset → `IPSAssetDao` / `IPSPageIndexService` (path A/B); recycle / page / template still construct-require the hub (intentional fan-in) |
 | Reverse edge ban | **Hard** — cycle-path peers (`assetDao`, `contentItemDao`, `folderHelper`, `pageIndexService`, `pageDaoHelper`) must not construct-require or eagerly field-inject `IPSWidgetAssetRelationshipService` without param/field `@Lazy`. Hub must not reverse-require `IPSRecycleService` / `IPSPageService` / `IPSTemplateService` (would reverse known fan-in / mid-chain edges) |
 | Param `@Lazy` on forward cycle edges | **Not** added here — contentItemDao / pageDaoHelper already carry the cycle breaks; optional belt-and-braces on consumers remains separate residual territory |
-| managedLink path C | **Out of scope** — remains #2527 (do not ctor-inject `IPSManagedLinkService` onto this hub) |
+| managedLink path C | **Hardened (#2527)** — see section below |
 
-Protection test: `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` (class `@Lazy` + forward freezes + reverse ctor/field bans + named assetDao/recycle/page/template assertions).
+Protection test: `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` (class `@Lazy` + forward freezes + reverse ctor/field bans + named assetDao/recycle/page/template assertions + path-C managedLink freezes).
+
+### WidgetAsset managedLink path C (#2527)
+
+**Hazard:** `PSManagedLinkService` construct-requires `IPSPageService`, which construct-requires `folderHelper`. If `PSWidgetAssetRelationshipService` (on paths A/B) gained a ctor or eager field inject of `IPSManagedLinkService`, Spring would force `managedLink → pageService → folderHelper` while folderHelper may still be under construction → third reverse path (**path C**).
+
+| Aspect | Disposition |
+|--------|-------------|
+| Production wiring | **Keep application-context lookup** (`getManagedLinkService()`); field is post-lookup cache only — not `@Autowired` |
+| Class `@Lazy` on hub | Already present (#2519); **not** a substitute for keeping managedLink off the ctor |
+| Ctor inject of managedLink | **Hard ban** — do not add `IPSManagedLinkService` to widgetAsset ctor (even "cleanup"); if DI is preferred later, use param `@Lazy` + inventory update |
+| Eager field `@Autowired` of managedLink | **Hard ban** without field `@Lazy` |
+| managedLink reverse freezes | managedLink must not construct-require `folderHelper` / `widgetAsset` / `recycleService` |
+| Force-chain witness | managedLink still construct-requires `pageService` (documents why path C is dangerous) |
+| Seed ban | Also covered by `PSFolderHelperReverseEdgeInventoryWiringTest` (#2485) |
+
+Protection test: `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` path-C methods (`widgetAssetMustNotConstructRequireManagedLinkService`, field non-eager autowire, managedLink pageService force-chain + reverse bans).
 
 
 ### assetServiceΓåötemplateService near-cycle (protected ΓÇö #2521)
@@ -494,9 +517,10 @@ listed in the original inventory and is out of scope for #2526.
 8. ~~assetService↔templateService one-way freeze.~~ **Done (#2521)** — `PSAssetServiceTemplateServiceNearCycleWiringTest`.
 9. Keep Docker `qa-up` / Rhythmyx health smoke (#2437) as the production-level gate.
 10. When adding new `@Autowired` constructors on cycle peers, re-run this inventory method (or extend the reflection tests).
-11. ~~Optional next hubs: siteData reverse-edge freeze.~~ **Done (#2516)** — `PSSiteDataServiceHubReverseEdgeWiringTest`. ~~widgetAsset class `@Lazy`.~~ **Done (#2519)** — class `@Lazy` + `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` (path C managedLink left to #2527).
+11. ~~Optional next hubs: siteData reverse-edge freeze.~~ **Done (#2516)** — `PSSiteDataServiceHubReverseEdgeWiringTest`. ~~widgetAsset class `@Lazy`.~~ **Done (#2519)** — class `@Lazy` + `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest`.
 12. ~~Optional residual: field-injection inventory for `IPSFolderHelper` / recycle subgraph (ctor inventory complete under #2485).~~ **Done (#2525)** — `PSFolderHelperFieldInjectionInventoryWiringTest`; cycle subgraph is fully ctor-injected, no live reverse field edges.
 13. Optional residual: belt-and-braces param `@Lazy` on other high-fan-in consumer hubs (e.g. pageService / siteData) that inject cycle peers ΓÇö only if product risk warrants; do not treat class `@Lazy` as the fix.
+14. ~~widgetAsset managedLink path-C reverse-edge hardening.~~ **Done (#2527)** — keep context lookup; freezes in `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` + inventory note.
 
 ## Related
 
@@ -516,5 +540,6 @@ listed in the original inventory and is out of scope for #2526.
 - #2520 — templateService forward-edge param `@Lazy` (`PSTemplateServiceParamLazyWiringTest`)
 - #2521 — assetService↔templateService one-way freeze + reverse ban  
 - #2526 — emptyRecycle / pathService near-cycle belt-and-braces (`PSEmptyRecycleServiceCycleLazyWiringTest`)
+- #2527 — widgetAsset managedLink path-C reverse-edge hardening (context lookup freeze + managedLink reverse bans)
 
 - #2457 / PR #2469 ΓÇö JDK 21 lambda compile fix often needed to build sitemanage tests

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipService.java
@@ -99,6 +99,12 @@ import org.springframework.stereotype.Component;
  * page/template/itemWorkflow; #2519). Class {@code @Lazy} is <em>not</em> a constructor-edge cycle
  * breaker when an eager consumer forces full construction — reverse-edge freezes live in {@code
  * PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest}.
+ *
+ * <p><strong>Path C (managedLink — #2527):</strong> {@link IPSManagedLinkService} is resolved via
+ * application-context lookup ({@link #getManagedLinkService()}), <em>not</em> constructor or
+ * field {@code @Autowired}. A ctor inject would force {@code managedLink → pageService →
+ * folderHelper} while {@code folderHelper} may still be creating on paths A/B. Do not "clean up"
+ * this lookup into eager DI without a param/field {@code @Lazy} break and inventory update.
  */
 @Component("widgetAssetRelationshipService")
 @Lazy
@@ -111,6 +117,10 @@ public class PSWidgetAssetRelationshipService implements IPSWidgetAssetRelations
 
   private IPSAssetDao assetDao;
 
+  /**
+   * Cached after first {@link #getManagedLinkService()} context lookup. Intentionally <em>not</em>
+   * constructor- or field-injected — path C cycle risk (#2527 / inventory).
+   */
   private IPSManagedLinkService managedLinkService;
 
   private IPSNameGenerator nameGenerator;
@@ -990,6 +1000,13 @@ public class PSWidgetAssetRelationshipService implements IPSWidgetAssetRelations
     return relIds;
   }
 
+  /**
+   * Lazy application-context lookup for {@link IPSManagedLinkService} (path C — #2527).
+   *
+   * <p>Must remain a post-construction lookup (or, if converted to DI, must use param/field {@code
+   * @Lazy}). Eager ctor inject of managedLink forces {@code pageService → folderHelper} while this
+   * hub can still be under construction on the folderHelper cycle path.
+   */
   private IPSManagedLinkService getManagedLinkService() {
     if (managedLinkService != null) return managedLinkService;
 

--- a/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/dao/impl/PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest.java
@@ -16,7 +16,9 @@
  */
 package com.percussion.share.dao.impl;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -24,6 +26,8 @@ import com.percussion.assetmanagement.dao.IPSAssetDao;
 import com.percussion.assetmanagement.dao.impl.PSAssetDao;
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
 import com.percussion.assetmanagement.service.impl.PSWidgetAssetRelationshipService;
+import com.percussion.linkmanagement.service.IPSManagedLinkService;
+import com.percussion.linkmanagement.service.impl.PSManagedLinkService;
 import com.percussion.pagemanagement.dao.impl.PSPageDaoHelper;
 import com.percussion.pagemanagement.service.IPSPageService;
 import com.percussion.pagemanagement.service.IPSTemplateService;
@@ -47,7 +51,7 @@ import org.springframework.context.annotation.Lazy;
 
 /**
  * Protection for the {@link PSWidgetAssetRelationshipService} rank-4 hub on the known folderHelper
- * cycle path (#2423 residual #2519).
+ * cycle path (#2423 residual #2519; path-C managedLink #2527).
  *
  * <p>Static inventory (#2463) ranks {@code PSWidgetAssetRelationshipService} as the fourth-hottest
  * sitemanage hub (ctor out ~4 / in ~18). It sits <em>on</em> the known creation chain:
@@ -58,6 +62,10 @@ import org.springframework.context.annotation.Lazy;
  *
  * folderHelper → recycleService → widgetAssetRelationshipService → pageIndexService
  *       → pageDaoHelper → folderHelper   (@Lazy on pageDaoHelper)
+ *
+ * Path C (latent — keep off ctor):
+ *   widgetAsset ↛ managedLinkService  (context lookup only; #2527)
+ *   managedLinkService → pageService → folderHelper
  * </pre>
  *
  * <p><strong>Disposition (#2519):</strong> class-level {@code @Lazy} on {@link
@@ -65,17 +73,20 @@ import org.springframework.context.annotation.Lazy;
  * reverse-edge freezes. Class {@code @Lazy} is lazy init only — not a constructor-edge cycle
  * breaker when an eager consumer forces full construction.
  *
+ * <p><strong>Path C (#2527):</strong> {@link IPSManagedLinkService} must remain application-context
+ * lookup (or, if converted to DI, param/field {@code @Lazy} with inventory update). A plain ctor
+ * inject forces {@code managedLink → pageService → folderHelper} while folderHelper may still be
+ * creating on paths A/B.
+ *
  * <p>Forward fan-in into this hub from {@code recycleService} / {@code pageService} / {@code
  * templateService} is intentional product wiring and is frozen positive below. The dangerous edges
  * are reverse of known one-ways (assetDao → widgetAsset; widgetAsset → recycle / page / template)
  * and eager reverse field inject of the hub on cycle-path peers.
  *
  * <p>Peers: {@link PSItemWorkflowServiceHubReverseEdgeWiringTest} (#2478), {@code
- * PSTemplateServiceCycleWiringTest} (#2477), {@link PSAssetServicePageServiceNearCycleWiringTest}.
- * Inventory: {@code
+ * PSTemplateServiceCycleWiringTest} (#2477), {@link PSAssetServicePageServiceNearCycleWiringTest},
+ * {@link PSFolderHelperReverseEdgeInventoryWiringTest} (#2485 path-C seed ban). Inventory: {@code
  * docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md}.
- *
- * <p>Out of scope: managedLink path-C ctor inject (#2527).
  */
 @Tag("UnitTest")
 public class PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest {
@@ -262,6 +273,85 @@ public class PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest {
         PSFolderHelper.class,
         IPSWidgetAssetRelationshipService.class,
         "folderHelper → widgetAsset would short-circuit recycle on the known cycle path");
+  }
+
+  // -------------------------------------------------------------------------
+  // Path C — managedLink (#2527)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Hard ban: widgetAsset must not construct-require {@link IPSManagedLinkService}. Prefer keep
+   * application-context lookup ({@code getManagedLinkService()}). If DI is introduced later, it
+   * must use param {@code @Lazy} and this test must be updated with inventory.
+   */
+  @Test
+  public void widgetAssetMustNotConstructRequireManagedLinkService() throws NoSuchMethodException {
+    Constructor<?> ctor = singlePublicConstructor(PSWidgetAssetRelationshipService.class);
+    Parameter managedLink = findParamOfType(ctor, IPSManagedLinkService.class);
+    assertNull(
+        managedLink,
+        "PSWidgetAssetRelationshipService must not construct-require IPSManagedLinkService"
+            + " (path C: managedLink→pageService→folderHelper while folderHelper may still be"
+            + " creating; keep application-context lookup — #2527 / inventory). If converting to"
+            + " DI, use param @Lazy and update this freeze + inventory.");
+  }
+
+  /**
+   * The {@code managedLinkService} field is a post-lookup cache only. Eager field {@code
+   * @Autowired} (without {@code @Lazy}) is the same class of reverse edge as a ctor param.
+   */
+  @Test
+  public void widgetAssetManagedLinkFieldIsNotEagerAutowired() throws NoSuchFieldException {
+    Field field = PSWidgetAssetRelationshipService.class.getDeclaredField("managedLinkService");
+    assertTrue(
+        IPSManagedLinkService.class.isAssignableFrom(field.getType()),
+        "Expected managedLinkService field type IPSManagedLinkService");
+    assertFalse(
+        field.isAnnotationPresent(Autowired.class) && !field.isAnnotationPresent(Lazy.class),
+        "PSWidgetAssetRelationshipService.managedLinkService must not be eagerly @Autowired"
+            + " without @Lazy (path C; keep context lookup cache — #2527)");
+  }
+
+  /**
+   * Documents the force chain that makes path C dangerous: managedLink construct-requires
+   * pageService (which construct-requires folderHelper).
+   */
+  @Test
+  public void managedLinkServiceStillConstructRequiresPageService() throws NoSuchMethodException {
+    assertNotNull(
+        findParamOfType(singlePublicConstructor(PSManagedLinkService.class), IPSPageService.class),
+        "PSManagedLinkService must still construct-require IPSPageService — path C hazard chain"
+            + " (managedLink→pageService→folderHelper); if removed, reassess path C and inventory"
+            + " #2527");
+  }
+
+  /** managedLink must not gain a direct folderHelper reverse edge (would amplify path C). */
+  @Test
+  public void managedLinkServiceMustNotConstructRequireFolderHelper() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSManagedLinkService.class,
+        IPSFolderHelper.class,
+        "managedLink → folderHelper would be a direct reverse into the cycle hub (#2527 path C)");
+  }
+
+  /** managedLink must not reverse-require the widgetAsset hub (closes path C both ways). */
+  @Test
+  public void managedLinkServiceMustNotConstructRequireWidgetAsset() throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSManagedLinkService.class,
+        IPSWidgetAssetRelationshipService.class,
+        "managedLink → widgetAsset would reverse the path-C dependency direction (#2527)");
+  }
+
+  /** managedLink must not construct-require recycle (mid-chain peer on paths A/B). */
+  @Test
+  public void managedLinkServiceMustNotConstructRequireRecycleService()
+      throws NoSuchMethodException {
+    assertNoEagerCtorParam(
+        PSManagedLinkService.class,
+        IPSRecycleService.class,
+        "managedLink → recycleService would couple managedLink into the folderHelper mid-chain"
+            + " (#2527)");
   }
 
   private static Constructor<?> singlePublicConstructor(Class<?> type)


### PR DESCRIPTION
## Summary
Hardens **path C** residual of parent #2423 / #2485: keep `IPSManagedLinkService` off the `PSWidgetAssetRelationshipService` constructor so Spring never forces `managedLink → pageService → folderHelper` while folderHelper may still be creating on paths A/B.

- Production: document path-C context-lookup disposition on `PSWidgetAssetRelationshipService` (`getManagedLinkService()` + field cache). **No** eager ctor DI; does **not** re-do #2519 hub `@Lazy`.
- Tests: extend `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` with path-C freezes (hard ban on managedLink ctor param; non-eager field; managedLink→pageService force-chain witness; reverse bans for folderHelper/widgetAsset/recycle).
- Inventory: update `docs/ai-generated/tasks/2423-spring-injection-cycle/sitemanage-injection-cycle-inventory.md` with path-C disposition (#2527).

Parent: #2423  
Related: #2485, #2519

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] `PSWidgetAssetRelationshipServiceHubReverseEdgeWiringTest` — Tests run: 18, Failures: 0
- [x] Module surefire totals: Tests run: 809, Failures: 0, Errors: 0
- [x] No new compiler/surefire warnings attributable to this change

## Gates
- Erlang-style self-review: freeze-only + docs; no path I/O; no eager DI re-introducing cycle
- Change-class companions: hub reverse-edge peer tests + inventory (product wiring unchanged)
- Pre-PR Maven: standalone sitemanage clean install green

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2527

> Co-Authored by Grok Build using grok-4.5 with agent main.
