### PR TITLE
test(qa): Editor/Contributor My profile menu click path (#2497)

### DIFF
--- a/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
@@ -15,7 +15,8 @@
  */
 
 /**
- * Profile hub shell smoke + axe WCAG gate (#2393 / #2425 / #2427 / parent #2374).
+ * Profile hub shell smoke + axe WCAG gate
+ * (#2393 / #2425 / #2427 / #2497 / parent #2374).
  *
  * Surface-filtered only — not full suite:
  *   npm run test:surface -- --path tests/profile-shell.spec.js
@@ -23,11 +24,15 @@
  * Axe-only subset (serious/critical zero on hub after deep link + menu entry):
  *   npm run test:surface -- --path tests/profile-shell.spec.js --grep "axe-core"
  *
+ * Non-admin menu click only (#2497 residual):
+ *   npm run test:surface -- --path tests/profile-shell.spec.js --grep "menu entry"
+ *
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* / EDITOR_* / CONTRIBUTOR_*
  * → test:surface → qa-down.
  *
- * Covers Admin deep link + UserMenu entry, plus non-admin (Editor, Contributor)
- * deep-link access so profile is not admin-only (#2374 acceptance).
+ * Covers Admin deep link + UserMenu entry, non-admin (Editor, Contributor)
+ * deep-link access, and non-admin UserMenu → My profile click path (#2497)
+ * so profile is not admin-only (#2374 acceptance).
  */
 
 const { test, expect } = require("@playwright/test");
@@ -162,6 +167,48 @@ test.describe("Profile shell @profile @smoke", () => {
     await loginAsContributor(page);
 
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectProfileShellMounted(page);
+  });
+
+  /**
+   * #2497 residual of #2425 — non-admin UserMenu → My profile click path.
+   * Deep link alone is not enough; menu entry must navigate for Editor/Contributor.
+   */
+  test("Editor My profile menu entry navigates to profile shell (#2497)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsEditor(page);
+
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const menuLink = page.getByTestId("perc-spa-my-profile");
+    await expect(menuLink).toBeVisible();
+    await expect(menuLink).toBeEnabled();
+    await menuLink.click();
+
+    await expectProfileShellMounted(page);
+  });
+
+  test("Contributor My profile menu entry navigates to profile shell (#2497)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsContributor(page);
+
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const menuLink = page.getByTestId("perc-spa-my-profile");
+    await expect(menuLink).toBeVisible();
+    await expect(menuLink).toBeEnabled();
+    await menuLink.click();
+
     await expectProfileShellMounted(page);
   });
 });


### PR DESCRIPTION
## Summary
Closes residual **#2497** of profile-shell Playwright coverage from #2425 / PR #2496 (parent epic **#2374**).

PR #2496 already covered Admin UserMenu → My profile and deep-link profile shell for Admin/Editor/Contributor. **Non-admin menu click** navigation was still missing.

This PR extends `modules/perc-qa-automation/frontend/tests/profile-shell.spec.js` with:

- **Editor** home SPA → click `perc-spa-my-profile` → assert `perc-profile-shell` + URL `/profile/`
- **Contributor** same path

Reuses existing `expectProfileShellMounted` and Admin menu pattern.

## Test plan
1. `python docker/scripts/perc-devctl.py qa-up` (H2; capture `TEST_CMS_URL` + passwords)
2. From `modules/perc-qa-automation/frontend`:
   ```
   set TEST_CMS_URL=http://127.0.0.1:<port>
   set ADMIN_*/EDITOR_*/CONTRIBUTOR_* from qa-up
   npm run test:surface -- --path tests/profile-shell.spec.js
   ```
3. Expect 8 passed (includes 2 new #2497 menu tests)
4. Optional subset: `--grep "menu entry"`
5. `python docker/scripts/perc-devctl.py qa-down`

## Gates evidence
- **Change class:** Playwright surface residual only (no product code)
- **Erlang self-review:** mirrors Admin menu test; stable `data-testid`; portable URL builders via `BASE_URL`; no path I/O
- **Maven:** `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS (module has no Java sources; compiler skipped)
- **Playwright (live H2):** `npm run test:surface -- --path tests/profile-shell.spec.js` → **8 passed** (including Editor/Contributor menu #2497)
- **No full suite**

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2374

Fixes #2497

> Co-Authored by Grok Build using grok-4.5 with agent main.
