### PR TITLE
test(qa): profile shell axe WCAG for Editor/Contributor (#2501)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -557,12 +557,13 @@ npm run test:surface:list -- --tag explorer-recycle-restore
 class as #2464; Admin login that remains on `/Rhythmyx/login` fails with an
 explicit #2542 / #2423 message — do not soft-skip.
 
-#### Profile shell + axe WCAG (#2393 / #2425 / #2427 / parent #2374)
+#### Profile shell + axe WCAG (#2393 / #2425 / #2427 / #2501 / parent #2374)
 
 Smoke opens the **My profile** hub via deep link and user-menu entry (Admin,
 Editor, Contributor); axe-core gates assert **zero serious/critical** WCAG 2.1
-A/AA violations on `[data-testid="perc-profile-shell"]` (helper:
-`tests/helpers/a11y.js`).
+A/AA violations on `[data-testid="perc-profile-shell"]` for **Admin, Editor,
+and Contributor** (helper: `tests/helpers/a11y.js`). #2501 extends the #2427
+Admin-only axe residual to non-admin roles (deep link + My profile menu).
 
 | Item | Value |
 |------|--------|
@@ -575,10 +576,15 @@ A/AA violations on `[data-testid="perc-profile-shell"]` (helper:
 cd modules/perc-qa-automation/frontend
 TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
   ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  EDITOR_USERNAME=Editor EDITOR_PASSWORD=<from-qa-up> \
+  CONTRIBUTOR_USERNAME=Contributor CONTRIBUTOR_PASSWORD=<from-qa-up> \
   npm run test:surface -- --path tests/profile-shell.spec.js
 
-# Axe gates only
+# Axe gates only (Admin + Editor + Contributor)
 npm run test:surface -- --path tests/profile-shell.spec.js --grep "axe-core"
+
+# Non-admin axe residual (#2501)
+npm run test:surface -- --path tests/profile-shell.spec.js --grep "#2501"
 
 # List only (no live CMS)
 npm run test:surface:list -- --path tests/profile-shell.spec.js

--- a/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
@@ -15,7 +15,8 @@
  */
 
 /**
- * Profile hub shell smoke + axe WCAG gate (#2393 / #2425 / #2427 / parent #2374).
+ * Profile hub shell smoke + axe WCAG gate
+ * (#2393 / #2425 / #2427 / #2501 / parent #2374).
  *
  * Surface-filtered only — not full suite:
  *   npm run test:surface -- --path tests/profile-shell.spec.js
@@ -23,11 +24,15 @@
  * Axe-only subset (serious/critical zero on hub after deep link + menu entry):
  *   npm run test:surface -- --path tests/profile-shell.spec.js --grep "axe-core"
  *
+ * Non-admin axe only (#2501 residual of #2427):
+ *   npm run test:surface -- --path tests/profile-shell.spec.js --grep "Editor|Contributor"
+ *
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* / EDITOR_* / CONTRIBUTOR_*
  * → test:surface → qa-down.
  *
- * Covers Admin deep link + UserMenu entry, plus non-admin (Editor, Contributor)
- * deep-link access so profile is not admin-only (#2374 acceptance).
+ * Covers Admin deep link + UserMenu entry, non-admin (Editor, Contributor)
+ * deep-link smoke + axe, and non-admin UserMenu → My profile axe (#2501)
+ * so profile a11y is not admin-only (#2374 / #2427 residual).
  */
 
 const { test, expect } = require("@playwright/test");
@@ -163,5 +168,93 @@ test.describe("Profile shell @profile @smoke", () => {
 
     await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
     await expectProfileShellMounted(page);
+  });
+
+  /**
+   * #2501 residual of #2427 — axe serious/critical zero for Editor after deep link.
+   * Admin-only axe is insufficient; same shell must pass for non-admin roles.
+   */
+  test("axe-core a11y gate — Editor profile shell via deep link (#2501)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsEditor(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectProfileShellMounted(page);
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: PROFILE_SHELL_SCOPE,
+    });
+  });
+
+  /**
+   * #2501 — axe after Editor UserMenu → My profile (menu tree vs deep link).
+   * Menu smoke for non-admin is #2497; this gates a11y on that path.
+   */
+  test("axe-core a11y gate — Editor profile shell via My profile menu (#2501)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsEditor(page);
+
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const menuLink = page.getByTestId("perc-spa-my-profile");
+    await expect(menuLink).toBeVisible();
+    await expect(menuLink).toBeEnabled();
+    await menuLink.click();
+
+    await expectProfileShellMounted(page);
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: PROFILE_SHELL_SCOPE,
+    });
+  });
+
+  /**
+   * #2501 residual of #2427 — axe serious/critical zero for Contributor after deep link.
+   */
+  test("axe-core a11y gate — Contributor profile shell via deep link (#2501)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsContributor(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectProfileShellMounted(page);
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: PROFILE_SHELL_SCOPE,
+    });
+  });
+
+  /**
+   * #2501 — axe after Contributor UserMenu → My profile.
+   */
+  test("axe-core a11y gate — Contributor profile shell via My profile menu (#2501)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsContributor(page);
+
+    await page.goto(homeUrl(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-spa-user-menu")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const menuLink = page.getByTestId("perc-spa-my-profile");
+    await expect(menuLink).toBeVisible();
+    await expect(menuLink).toBeEnabled();
+    await menuLink.click();
+
+    await expectProfileShellMounted(page);
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: PROFILE_SHELL_SCOPE,
+    });
   });
 });


### PR DESCRIPTION
## Summary
Closes residual **#2501** of profile-shell axe WCAG coverage from #2427 / PR #2500 (parent epic **#2374**).

#2427 gates **Admin only**. This PR extends `expectNoSeriousA11yViolations` (scoped to `[data-testid="perc-profile-shell"]`) to:

- **Editor** deep link + UserMenu → My profile
- **Contributor** deep link + UserMenu → My profile

No product WebUI change required — same shell already passes Admin axe; non-admin paths green on H2 QA.

## Test plan
1. `python docker/scripts/perc-devctl.py qa-up` (H2; capture `TEST_CMS_URL` + passwords)
2. From `modules/perc-qa-automation/frontend`:
   ```
   set TEST_CMS_URL=http://127.0.0.1:<port>
   set ADMIN_*/EDITOR_*/CONTRIBUTOR_* from qa-up
   npm run test:surface -- --path tests/profile-shell.spec.js
   ```
3. Expect **10 passed** (includes 4 new #2501 axe tests)
4. Axe subset: `--grep "axe-core"` → 6 tests; `--grep "#2501"` → 4 tests
5. `python docker/scripts/perc-devctl.py qa-down`
6. No full Playwright suite

## Gates evidence
- **Change class:** Playwright a11y residual only (no product code)
- **Erlang self-review:** mirrors Admin #2427 axe tests; stable `data-testid`; portable `BASE_URL`; no filesystem path I/O
- **Maven:** `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- **Playwright (live H2 QA):** `npm run test:surface -- --path tests/profile-shell.spec.js` → **10 passed** (4 new #2501)
- **List-only:** surface list 10 tests; axe-core grep 6; #2501 grep 4
- **No full suite**

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2374

Fixes #2501

> Co-Authored by Grok Build using grok-4.5 with agent main.