### PR TITLE
fix(DesktopContentExplorer): PSDesktopExplorerWindow this-escape (#2444)

### DIFF
--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/javafx/PSDesktopExplorerWindow.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/javafx/PSDesktopExplorerWindow.java
@@ -57,8 +57,11 @@ public abstract class PSDesktopExplorerWindow extends JFrame {
   /**
    * State provider for the embedded JavaFX web view debugger, exposing a JSON-serializable state
    * blob to the page so it can be restored on reload.
+   *
+   * <p>Declared {@code static} so construction of the provider does not capture the enclosing
+   * window instance (javac {@code this-escape}).
    */
-  public class PSDesktopExplorerStateProvider implements JfxScriptStateProvider {
+  public static class PSDesktopExplorerStateProvider implements JfxScriptStateProvider {
     /** Default constructor. Initializes the state to an empty boxed JSON object. */
     public PSDesktopExplorerStateProvider() {
       // no-op
@@ -77,14 +80,22 @@ public abstract class PSDesktopExplorerWindow extends JFrame {
     }
   }
 
-  /** State provider for the embedded web view, one per window instance. */
-  protected PSDesktopExplorerStateProvider myStateProvider = new PSDesktopExplorerStateProvider();
+  /**
+   * State provider for the embedded web view, one per window instance. Initialized with a static
+   * nested type so the window constructor does not publish {@code this}.
+   */
+  protected transient PSDesktopExplorerStateProvider myStateProvider =
+      new PSDesktopExplorerStateProvider();
 
   /** Logger for this class. */
   static Logger log = LogManager.getLogger(PSDesktopExplorerWindow.class);
 
-  /** The Java bridge exposed to the page's JavaScript as {@code java}. */
-  protected PSJavaBridge bridge = new PSJavaBridge(this);
+  /**
+   * The Java bridge exposed to the page's JavaScript as {@code java}. Lazily created by {@link
+   * #getBridge()} so field initializers and constructors do not publish {@code this} (javac {@code
+   * this-escape}).
+   */
+  protected transient volatile PSJavaBridge bridge;
 
   /** This window's target identifier used by the window manager. */
   protected String target;
@@ -147,6 +158,29 @@ public abstract class PSDesktopExplorerWindow extends JFrame {
    */
   public PSDesktopExplorerWindow(String string) {
     super(string);
+  }
+
+  /**
+   * Returns the {@link PSJavaBridge} for this window, creating it on first use.
+   *
+   * <p>Lazy initialization avoids publishing {@code this} from instance field initializers during
+   * construction (javac {@code this-escape}). Safe to call after the window instance is fully
+   * constructed; used when installing the bridge on the page's JavaScript {@code window}.
+   *
+   * @return the bridge for this window, never {@code null}
+   */
+  protected PSJavaBridge getBridge() {
+    PSJavaBridge existing = bridge;
+    if (existing == null) {
+      synchronized (this) {
+        existing = bridge;
+        if (existing == null) {
+          existing = new PSJavaBridge(this);
+          bridge = existing;
+        }
+      }
+    }
+    return existing;
   }
 
   /**
@@ -404,7 +438,7 @@ public abstract class PSDesktopExplorerWindow extends JFrame {
 
       Object currJava = (Object) window.getMember("java");
       if (currJava == null || currJava.toString().equals("undefined")) {
-        window.setMember("java", this.bridge);
+        window.setMember("java", getBridge());
         if (applet != null) window.setMember("contentexplorer", applet);
 
         getEngine()

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/javafx/PSDesktopExplorerWindowTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/javafx/PSDesktopExplorerWindowTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx.javafx;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cx.PSJavaBridge;
+import com.percussion.cx.PSSelection;
+import com.percussion.cx.objectstore.PSMenuAction;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import javax.swing.JFrame;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Coverage for {@link PSDesktopExplorerWindow} this-escape remediation (#2444): static nested state
+ * provider and lazy {@link PSJavaBridge} so constructors do not publish {@code this}.
+ */
+public class PSDesktopExplorerWindowTest {
+
+  /** Minimal concrete window for construction and bridge lazy-init tests. */
+  private static final class TestExplorerWindow extends PSDesktopExplorerWindow {
+    @Override
+    public boolean validateOpen(
+        String mi_actionurl,
+        String mi_target,
+        String mi_style,
+        PSSelection selection,
+        PSMenuAction action) {
+      return true;
+    }
+
+    @Override
+    public JFrame instanceOpen() {
+      return this;
+    }
+  }
+
+  @Test
+  public void stateProviderIsStaticNestedClass() {
+    assertTrue(
+        Modifier.isStatic(
+            PSDesktopExplorerWindow.PSDesktopExplorerStateProvider.class.getModifiers()),
+        "PSDesktopExplorerStateProvider must be static to avoid this-escape on outer construction");
+  }
+
+  @Test
+  public void stateProviderCanBeConstructedWithoutOuterWindow() {
+    PSDesktopExplorerWindow.PSDesktopExplorerStateProvider provider =
+        new PSDesktopExplorerWindow.PSDesktopExplorerStateProvider();
+    assertNotNull(provider.getState());
+  }
+
+  @Test
+  public void windowConstructionDoesNotCreateBridge() throws Exception {
+    TestExplorerWindow window = new TestExplorerWindow();
+    Field bridgeField = PSDesktopExplorerWindow.class.getDeclaredField("bridge");
+    bridgeField.setAccessible(true);
+    assertNull(
+        bridgeField.get(window),
+        "bridge must remain null after construction (lazy-init, no this-escape)");
+  }
+
+  @Test
+  public void getBridgeLazilyCreatesStableInstance() {
+    TestExplorerWindow window = new TestExplorerWindow();
+    PSJavaBridge first = window.getBridge();
+    assertNotNull(first);
+    assertSame(first, window.getBridge(), "getBridge must return the same instance");
+  }
+
+  @Test
+  public void myStateProviderIsInitializedOnConstruction() {
+    TestExplorerWindow window = new TestExplorerWindow();
+    assertNotNull(window.myStateProvider);
+    assertNotNull(window.myStateProvider.getState());
+  }
+
+  @Test
+  public void bridgeAndStateProviderFieldsAreTransient() throws Exception {
+    Field bridgeField = PSDesktopExplorerWindow.class.getDeclaredField("bridge");
+    Field stateField = PSDesktopExplorerWindow.class.getDeclaredField("myStateProvider");
+    assertTrue(
+        Modifier.isTransient(bridgeField.getModifiers()),
+        "bridge must be transient (non-serializable collaborator)");
+    assertTrue(
+        Modifier.isTransient(stateField.getModifiers()),
+        "myStateProvider must be transient (non-serializable collaborator)");
+  }
+}


### PR DESCRIPTION
## Summary
Eliminates javac `this-escape` on `PSDesktopExplorerWindow` (residual of #2384 under parent #2045 / #2200).

### Changes
- `PSDesktopExplorerStateProvider` is now a **static** nested class (does not capture outer `this`).
- `PSJavaBridge` is **lazy-init** via `getBridge()` (double-checked locking) so constructors/field initializers do not publish `this`.
- `setJavaBridge()` installs the bridge through `getBridge()`.
- Non-serializable collaborators (`bridge`, `myStateProvider`) marked `transient`.
- Unit tests for static provider, post-ctor null bridge, stable lazy bridge, and transient fields.

No product behavior change — bridge is still created before install on the page `window`.

Fixes #2444  
Parent trackers: #2045, #2200  
Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **86**, Failures: 0, Errors: 0, Skipped: 0 (includes 6 new `PSDesktopExplorerWindowTest`)
- [x] No new compiler warnings attributable to this change
- [x] Erlang-style self-review: no path I/O; change-class companions (unit tests); lazy init preserves install-time bridge identity

## Gates evidence
| Gate | Result |
|------|--------|
| Module standalone clean install | BUILD SUCCESS |
| Unit tests | 86 / 0 fail |
| this-escape mitigation | static nested + lazy bridge |
| Human QA | Not required (pure tech-debt, no UI/install behavior change) |

> Co-Authored by Grok Build using grok-4.5 with agent main.