### PR TITLE
test(#2499): locale-aware profile shell title Playwright assert

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -562,13 +562,19 @@ npm run test:surface:list -- --tag explorer-recycle-restore
 class as #2464; Admin login that remains on `/Rhythmyx/login` fails with an
 explicit #2542 / #2423 message — do not soft-skip.
 
-#### Profile shell + axe WCAG (#2393 / #2425 / #2427 / #2497 / #2498 / #2501 / parent #2374)
+#### Profile shell + axe WCAG + locale title (#2393 / #2425 / #2427 / #2497 / #2498 / #2499 / #2501 / parent #2374)
 
 Smoke opens the **My profile** hub via deep link and user-menu entry (Admin,
-Editor, Contributor); axe-core gates assert **zero serious/critical** WCAG 2.1
-A/AA violations on `[data-testid="perc-profile-shell"]` for **Admin, Editor,
+Editor, Contributor); English smoke keeps `/my profile/i` on
+`perc-profile-title`. Locale residual (**#2499**): login with **de** or **es**
+(prefer `de-de`/`de`, then `es`) and assert the title via TMX
+`perc.ui.profile.modern@My profile` (`Mein Profil` / `mi perfil`) — not
+English-only. Axe-core gates assert **zero serious/critical** WCAG 2.1 A/AA
+violations on `[data-testid="perc-profile-shell"]` for **Admin, Editor,
 and Contributor** (helper: `tests/helpers/a11y.js`). #2501 extends the #2427
 Admin-only axe residual to non-admin roles (deep link + My profile menu).
+Title map helper: `tests/helpers/profile-shell-title.js`
+(unit: `npm run test:unit` → `profile-shell-title.test.js`).
 
 **Unattended matrix:** `@profile` is on the **extended** golden multi-path set
 (`npm run test:golden-extended`) so overnight/CI reference gates do not miss
@@ -580,6 +586,8 @@ Baseline `test:golden` stays login + Explorer only.
 | Spec | `frontend/tests/profile-shell.spec.js` |
 | Tags | `@profile` `@smoke` |
 | Golden inventory id | `profile-shell` (tier `extended`) |
+| Locale residual | `#2499` — `--grep "locale"` |
+| Title helper | `tests/helpers/profile-shell-title.js` |
 | Axe helper | `tests/helpers/a11y.js` → `expectNoSeriousA11yViolations` |
 
 ```bash
@@ -594,6 +602,9 @@ TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
 # Extended golden multi-path (baseline + folder-recycle + profile)
 npm run test:golden-extended
 npm run test:golden-extended:list
+
+# Locale title residual only (#2499)
+npm run test:surface -- --path tests/profile-shell.spec.js --grep "locale"
 
 # Axe gates only (Admin + Editor + Contributor)
 npm run test:surface -- --path tests/profile-shell.spec.js --grep "axe-core"

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/golden-unattended-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/explorer-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/profile-shell-title.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/golden-unattended-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/explorer-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:golden-extended": "playwright test tests/golden-unattended-smoke.spec.js tests/folder-recycle-smoke.spec.js tests/profile-shell.spec.js",

--- a/modules/perc-qa-automation/frontend/tests/helpers/profile-shell-title.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/profile-shell-title.js
@@ -1,0 +1,74 @@
+/**
+ * Pure helpers for profile hub title assertions under modern-locale TMX
+ * ({@code perc.ui.profile.modern@My profile} in CmsUi.tmx).
+ *
+ * <p>No Playwright dependency — unit-tested via node:test. Used by
+ * {@code tests/profile-shell.spec.js} locale residual (#2499 / parent #2374).</p>
+ *
+ * @see modules/perc-i18n/.../CmsUi.tmx tu tuid="perc.ui.profile.modern@My profile"
+ */
+
+"use strict";
+
+const { localeLanguageFamily } = require("./pick-locale-tag");
+
+/**
+ * Preferred login tags for profile-title locale residual (#2499).
+ * Prefer German (best modern-locale coverage) then Spanish — matches issue
+ * acceptance ("es or de after #2426").
+ */
+const PROFILE_TITLE_PREFERRED_LOCALES = Object.freeze(["de-de", "de", "es"]);
+
+/**
+ * Expected title text for language family, matching ship TMX segs after #2426.
+ * Values must stay in lockstep with CmsUi.tmx (not en-us fallback after @).
+ */
+const PROFILE_TITLE_BY_FAMILY = Object.freeze({
+  en: "My profile",
+  de: "Mein Profil",
+  es: "mi perfil",
+});
+
+/**
+ * Resolve expected profile title for a login tag or language family.
+ *
+ * @param {string|null|undefined} localeTagOrFamily e.g. de-de, de, es, en-us
+ * @returns {string|null} expected title, or null when family has no sample map
+ */
+function expectedProfileTitle(localeTagOrFamily) {
+  const family = localeLanguageFamily(localeTagOrFamily);
+  if (!Object.prototype.hasOwnProperty.call(PROFILE_TITLE_BY_FAMILY, family)) {
+    return null;
+  }
+  return PROFILE_TITLE_BY_FAMILY[family];
+}
+
+/**
+ * Case-insensitive exact-title matcher for Playwright {@code toContainText}
+ * / {@code toHaveText}. Escapes metacharacters in the TMX string.
+ *
+ * @param {string|null|undefined} localeTagOrFamily
+ * @returns {RegExp|null}
+ */
+function profileTitleMatcher(localeTagOrFamily) {
+  const title = expectedProfileTitle(localeTagOrFamily);
+  if (!title) {
+    return null;
+  }
+  const escaped = String(title).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^\\s*${escaped}\\s*$`, "i");
+}
+
+/**
+ * English title matcher used by default (en-us) smoke cases.
+ * Kept as a shared constant so English and locale tests stay aligned.
+ */
+const ENGLISH_PROFILE_TITLE_MATCHER = /my profile/i;
+
+module.exports = {
+  PROFILE_TITLE_BY_FAMILY,
+  PROFILE_TITLE_PREFERRED_LOCALES,
+  expectedProfileTitle,
+  profileTitleMatcher,
+  ENGLISH_PROFILE_TITLE_MATCHER,
+};

--- a/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-shell.spec.js
@@ -15,11 +15,14 @@
  */
 
 /**
- * Profile hub shell smoke + axe WCAG gate
- * (#2393 / #2425 / #2427 / #2497 / #2498 / #2501 / parent #2374).
+ * Profile hub shell smoke + axe WCAG gate + locale title residual
+ * (#2393 / #2425 / #2427 / #2497 / #2498 / #2499 / #2501 / parent #2374).
  *
  * Surface-filtered only — not full suite:
  *   npm run test:surface -- --path tests/profile-shell.spec.js
+ *
+ * Locale title residual only (#2499):
+ *   npm run test:surface -- --path tests/profile-shell.spec.js --grep "locale"
  *
  * Axe-only subset (serious/critical zero on hub after deep link + menu entry):
  *   npm run test:surface -- --path tests/profile-shell.spec.js --grep "axe-core"
@@ -41,6 +44,8 @@
  * deep-link smoke + axe, non-admin UserMenu → My profile click path (#2497),
  * and non-admin UserMenu → My profile axe (#2501) so profile is not admin-only
  * (#2374 acceptance / #2427 residual).
+ * Locale residual: login with de or es and assert perc-profile-title via TMX
+ * string — not English-only /my profile/i.
  * Inventory: helpers/golden-unattended-smoke-set.js (id profile-shell, tier extended).
  */
 
@@ -49,9 +54,20 @@ const {
   loginAsAdmin,
   loginAsEditor,
   loginAsContributor,
+  listModernLoginLocales,
   BASE_URL,
 } = require("./helpers/auth");
 const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+const {
+  pickPreferredLocaleTag,
+  localeLanguageFamily,
+} = require("./helpers/pick-locale-tag");
+const {
+  expectedProfileTitle,
+  profileTitleMatcher,
+  PROFILE_TITLE_PREFERRED_LOCALES,
+  ENGLISH_PROFILE_TITLE_MATCHER,
+} = require("./helpers/profile-shell-title");
 
 /** Stable CSS scope for axe — matches data-testid on ProfileShell root. */
 const PROFILE_SHELL_SCOPE = '[data-testid="perc-profile-shell"]';
@@ -69,8 +85,11 @@ function homeUrl() {
  * Shared by smoke and axe tests so a11y scans run only after React paint.
  *
  * @param {import('@playwright/test').Page} page
+ * @param {object} [opts]
+ * @param {RegExp|string} [opts.titleMatcher] title text match; default English smoke
  */
-async function expectProfileShellMounted(page) {
+async function expectProfileShellMounted(page, opts = {}) {
+  const titleMatcher = opts.titleMatcher || ENGLISH_PROFILE_TITLE_MATCHER;
   await expect(page.getByTestId("perc-spa-app")).toBeVisible({
     timeout: 30_000,
   });
@@ -78,7 +97,7 @@ async function expectProfileShellMounted(page) {
     timeout: 30_000,
   });
   await expect(page.getByTestId("perc-profile-title")).toContainText(
-    /my profile/i,
+    titleMatcher,
   );
   await expect(page.getByTestId("perc-profile-section-account")).toBeVisible();
   await expect(page.getByTestId("perc-profile-section-security")).toBeVisible();
@@ -88,6 +107,53 @@ async function expectProfileShellMounted(page) {
   await expect(page.getByTestId("perc-profile-section-avatar")).toBeVisible();
   // Client path after entry handoff (or still query — accept either)
   await expect(page).toHaveURL(/profile/i, { timeout: 15_000 });
+}
+
+/**
+ * Pick de-de/de/es from the live login locale list (modern or legacy).
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{ tag: string, family: string, title: string, titleRe: RegExp }>}
+ */
+async function resolveProfileTitleLocale(page) {
+  await page.goto(`${BASE_URL}/Rhythmyx/login`);
+  await page.waitForLoadState("domcontentloaded");
+  // Both root + page may be present; .first() avoids strict-mode dual match.
+  await expect(
+    page
+      .getByTestId("perc-login-page")
+      .or(page.getByTestId("perc-login-root"))
+      .first(),
+  ).toBeVisible({ timeout: 20_000 });
+
+  let available = await listModernLoginLocales(page);
+  if (available.length === 0) {
+    const native = page.locator('select[name="j_locale"]');
+    if ((await native.count()) > 0) {
+      available = await native
+        .locator("option")
+        .evaluateAll((opts) => opts.map((o) => o.value).filter(Boolean));
+    }
+  }
+
+  const tag = pickPreferredLocaleTag(
+    available,
+    PROFILE_TITLE_PREFERRED_LOCALES,
+  );
+  expect(
+    tag,
+    `install must expose de-de, de, or es for profile title locale residual (available=${JSON.stringify(available)})`,
+  ).toBeTruthy();
+
+  const family = localeLanguageFamily(tag);
+  const title = expectedProfileTitle(family);
+  const titleRe = profileTitleMatcher(family);
+  expect(
+    title && titleRe,
+    `no profile title map for language family ${family} (tag=${tag})`,
+  ).toBeTruthy();
+
+  return { tag, family, title, titleRe };
 }
 
 test.describe("Profile shell @profile @smoke", () => {
@@ -307,5 +373,34 @@ test.describe("Profile shell @profile @smoke", () => {
     await expectNoSeriousA11yViolations(page, {
       scope: PROFILE_SHELL_SCOPE,
     });
+  });
+
+  /**
+   * #2499 / parent #2374 — after modern-locale TMX (#2426), non-English
+   * login must render perc-profile-title from CmsUi.tmx (de: Mein Profil,
+   * es: mi perfil), not English-only /my profile/i.
+   *
+   * Surface filter:
+   *   npm run test:surface -- --path tests/profile-shell.spec.js --grep "locale"
+   */
+  test("non-English locale shows localized profile title (#2499)", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { tag, family, title, titleRe } =
+      await resolveProfileTitleLocale(page);
+
+    await loginAsAdmin(page, { locale: tag });
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectProfileShellMounted(page, { titleMatcher: titleRe });
+
+    const titleEl = page.getByTestId("perc-profile-title");
+    await expect(titleEl).toHaveText(titleRe, { timeout: 15_000 });
+    // Guard against English fallback when session locale is de/es.
+    if (family !== "en") {
+      await expect(titleEl).not.toHaveText(/^\s*My profile\s*$/i);
+      await expect(titleEl).toContainText(title, { ignoreCase: true });
+    }
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/profile-shell-title.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/profile-shell-title.test.js
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for profile hub title i18n helpers (no live CMS).
+ * Residual #2499 / parent #2374 — CmsUi.tmx perc.ui.profile.modern@My profile.
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  expectedProfileTitle,
+  profileTitleMatcher,
+  PROFILE_TITLE_BY_FAMILY,
+  PROFILE_TITLE_PREFERRED_LOCALES,
+  ENGLISH_PROFILE_TITLE_MATCHER,
+} = require("../helpers/profile-shell-title");
+
+describe("expectedProfileTitle", () => {
+  it("returns English source for en / en-us", () => {
+    assert.equal(expectedProfileTitle("en"), "My profile");
+    assert.equal(expectedProfileTitle("en-us"), "My profile");
+  });
+
+  it("returns German TMX seg for de / de-de", () => {
+    assert.equal(expectedProfileTitle("de"), "Mein Profil");
+    assert.equal(expectedProfileTitle("de-de"), "Mein Profil");
+  });
+
+  it("returns Spanish TMX seg for es (lowercase as shipped)", () => {
+    assert.equal(expectedProfileTitle("es"), "mi perfil");
+  });
+
+  it("returns null for families without a sample map", () => {
+    assert.equal(expectedProfileTitle("fr"), null);
+    assert.equal(expectedProfileTitle("hi-in"), null);
+  });
+});
+
+describe("profileTitleMatcher", () => {
+  it("matches German title case-insensitively and rejects English", () => {
+    const re = profileTitleMatcher("de-de");
+    assert.ok(re);
+    assert.ok(re.test("Mein Profil"));
+    assert.ok(re.test("mein profil"));
+    assert.equal(re.test("My profile"), false);
+  });
+
+  it("matches Spanish TMX seg and rejects English", () => {
+    const re = profileTitleMatcher("es");
+    assert.ok(re);
+    assert.ok(re.test("mi perfil"));
+    assert.ok(re.test("Mi Perfil"));
+    assert.equal(re.test("My profile"), false);
+  });
+
+  it("matches English source", () => {
+    const re = profileTitleMatcher("en-us");
+    assert.ok(re);
+    assert.ok(re.test("My profile"));
+  });
+
+  it("returns null for unmapped family", () => {
+    assert.equal(profileTitleMatcher("fr-fr"), null);
+  });
+});
+
+describe("constants", () => {
+  it("exports preferred de then es order", () => {
+    assert.deepEqual([...PROFILE_TITLE_PREFERRED_LOCALES], ["de-de", "de", "es"]);
+  });
+
+  it("ships de and es sample titles", () => {
+    assert.equal(PROFILE_TITLE_BY_FAMILY.de, "Mein Profil");
+    assert.equal(PROFILE_TITLE_BY_FAMILY.es, "mi perfil");
+  });
+
+  it("English smoke matcher matches My profile", () => {
+    assert.ok(ENGLISH_PROFILE_TITLE_MATCHER.test("My profile"));
+    assert.ok(ENGLISH_PROFILE_TITLE_MATCHER.test("my profile"));
+  });
+});


### PR DESCRIPTION
## Summary
Profile shell Playwright residual of #2425 / parent epic **#2374**.

After modern-locale TMX fill (#2426), English-only `/my profile/i` on `perc-profile-title` gives false confidence for non-English sessions. This PR:

- Keeps **English smoke** cases (default `/my profile/i`)
- Adds **locale residual**: login with preferred `de-de`/`de` (else `es`), open profile hub deep link, assert title via TMX segs (`Mein Profil` / `mi perfil`) and reject English fallback
- Pure helper `tests/helpers/profile-shell-title.js` + unit tests
- Documents surface path/grep in module README

**Fixes #2499**  
Parent tracker: #2374

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
```bash
# Unit (no live CMS)
cd modules/perc-qa-automation/frontend
npm run test:unit

# Surface list
npm run test:surface:list -- --path tests/profile-shell.spec.js

# QA mode (agent path)
# python docker/scripts/perc-devctl.py qa-up
cd modules/perc-qa-automation/frontend
TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
  EDITOR_* CONTRIBUTOR_* \
  npm run test:surface -- --path tests/profile-shell.spec.js

# Locale residual only
npm run test:surface -- --path tests/profile-shell.spec.js --grep "locale"

# python docker/scripts/perc-devctl.py qa-down
```

## Gates evidence
| Gate | Result |
|------|--------|
| `npm run test:unit` | **188 pass** (incl. profile-shell-title) |
| Surface list | 7 tests in profile-shell.spec.js |
| Surface live QA H2 (`TEST_CMS_URL=http://127.0.0.1:9993`) | **7 passed** (English smoke + axe + Editor/Contributor + locale #2499) |
| Locale-only surface | **1 passed** |
| `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` | **BUILD SUCCESS** |
| Erlang self-review | No bugs; portable paths; no WebUI product change (TMX already shipped #2426); pure helper unit-tested |
| Human QA | Not required — pure Playwright residual; agent-proven on QA H2 |

## Out of scope
- Product WebUI / TMX copy fixes (human MT residual remains #2493 for casing etc.)
- Full multi-locale matrix beyond de/es sample