### PR TITLE
feat(pipeline): multi-table join-graph SQL planner (#2391)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2391-join-graph-sql-planner-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2391-join-graph-sql-planner-erlang.md
@@ -1,0 +1,40 @@
+# Erlang review — issue #2391 join-graph SQL planner
+
+| Field | Value |
+|-------|-------|
+| Issue | #2391 |
+| Change class | Pipeline IR join-graph + multi-table SELECT planner |
+| Module | `system` |
+| Date | 2026-08-09 |
+
+## Scope
+
+| Artifact | Role |
+|----------|------|
+| `BackendJoinIr` | IR join edge model |
+| `BackendTankStageIr` | `joins[]` + joinCount inventory |
+| `PSClassicPipelineImporter` | Classic `PSBackEndJoin` → IR edges |
+| `PSPipelineSqlPlanner` | ANSI multi-table FROM/JOIN SELECT |
+| `PSPipelineRuntimeServiceTest` | H2 INNER + LEFT OUTER + limit tests |
+| `docs/developer-module/pipeline-ir-v1.md` | Product docs |
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs | No hard bugs found. Join-type flip when introducing left table preserves OUTER semantics. Disconnected graphs / translators / missing edges rejected with stable messages. |
+| Behavioral tests | Planner SQL shape + H2 INNER/LEFT execute + translator/edge-limit rejection |
+| Cross-platform paths | N/A (SQL/IR only; no filesystem path construction) |
+| Companions | IR model + classic import + planner + H2 tests + docs |
+| Mutations | Still single-table; join edges rejected on INSERT/UPDATE/DELETE |
+| Security | Identifiers validated; values only as JDBC binds; no string-concat user data |
+
+## Residual (not this PR)
+
+- Multi-table mutations
+- Join edges with classic extension translators (native SELECT escape hatch)
+- Designer UI / graph editor
+
+## Verdict
+
+**Pass** — ready to commit/PR after `system` `mvnw clean install` BUILD SUCCESS.

--- a/docs/developer-module/pipeline-ir-v1.md
+++ b/docs/developer-module/pipeline-ir-v1.md
@@ -54,6 +54,7 @@ Slice A part 1 delivers **IR model + load/save + classic import**. Execution, SQ
           "tables": [
             { "alias": "PSX_ADMINLOOKUP", "table": "PSX_ADMINLOOKUP", "datasource": "" }
           ],
+          "joins": [],
           "joinCount": 0
         },
         "mapper": {
@@ -120,14 +121,14 @@ From classic `PSApplication` / `PSDataSet` / pipes:
 | `PSUpdatePipe` | resource `kind=UPDATE` + updater |
 | `PSContentEditor` | resource `kind=CONTENT_EDITOR` (no deep CE pipe expand) |
 | `PSPageDataTank` | `stages.pageTank` |
-| `PSBackEndDataTank` | `stages.backendTank` (tables + join count) |
+| `PSBackEndDataTank` | `stages.backendTank` (tables + `joins[]` edges + join count) |
 | `PSDataMapper` | `stages.mapper` (field inventory) |
 | `PSDataSelector` | `stages.selector` (method + whereClauses IR + counts) |
 | `PSWhereClause` / `PSConditional` | `selector.whereClauses[]` (COLUMN/PARAM/LITERAL/OTHER) |
 | `PSResultPager` | `stages.pager` |
 | `PSDataSynchronizer` | `stages.updater` |
 
-Not imported in v1 (deferred): join graphs (only `joinCount`), exits/hooks, result pages/XSL, ACLs, CE field maps. Unsupported where right-hand kinds stay as `OTHER` (planner requires native SQL for those).
+Not imported in v1 (deferred): join **translators** (edges still import with `translatorPresent=true`; generated planner rejects those edges), exits/hooks, result pages/XSL, ACLs, CE field maps. Unsupported where right-hand kinds stay as `OTHER` (planner requires native SQL for those).
 
 ## Service API
 
@@ -146,8 +147,9 @@ Not imported in v1 (deferred): join graphs (only `joinCount`), exits/hooks, resu
 - `execute(appName, resourceName, request)` — load native IR, run resource
 - `execute(document, resource, request)` — in-memory IR (tests / callers)
 - SQL via `IPSPipelineSqlAdapter` / `PSJdbcPipelineSqlAdapter` (parameterized JDBC only)
-- Planner: `PSPipelineSqlPlanner` (generated single-table SELECT/INSERT/**UPDATE**/**DELETE**, or native SELECT with `:param`)
+- Planner: `PSPipelineSqlPlanner` (generated single-table or **multi-table JOIN** SELECT; single-table INSERT/**UPDATE**/**DELETE**; or native SELECT with `:param`)
 - Generated SELECT **WHERE** prefers `selector.whereClauses` IR when present (COLUMN left; operators `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`, `LIKE`, `NOT LIKE`, `IS NULL`, `IS NOT NULL`; right PARAM/LITERAL/COLUMN; AND/OR; `omitWhenNull`). Otherwise falls back to request-param equality on mapped columns.
+- Generated multi-table SELECT uses `backendTank.joins[]` (`joinType` = `INNER`|`LEFT`|`RIGHT`|`FULL`; `left`/`right` = `alias.column`). ANSI `INNER` / `LEFT OUTER` / `RIGHT OUTER` / `FULL OUTER` JOIN … ON. Join edges with classic translators are rejected (native SELECT escape hatch). Mutations remain single-table.
 - Pre/post hooks: `IPSPipelinePreExecuteHook` / `IPSPipelinePostExecuteHook`
 - JSON I/O: `PipelineExecuteRequest` / `PipelineExecuteResult` + `PSPipelineExecuteJsonCodec`
 - Thin REST: `POST /services/pipelines/{app}/resources/{resource}/execute` (see #2269 / PR #2341)
@@ -201,7 +203,8 @@ Documented + covered by H2 tests in `PSPipelineRuntimeServiceTest` (`transaction
 | Parameterized SQL | Request values bound as JDBC `?` only |
 | Generated identifiers | Table/column must match `[A-Za-z_][A-Za-z0-9_]*` |
 | Native SQL escape hatch | Single `SELECT`/`WITH` only; named `:param`; rejects `;`, DML/DDL keywords |
-| Joins / multi-table | **Product limit:** `joinCount > 0` rejected (`PSPipelineSqlPlanner.JOIN_PRODUCT_LIMIT_MESSAGE`). Multi-table tanks without joins also rejected. Use single table or `nativeStatement` SELECT with hand-authored joins. Residual join-graph planner under parent epic #1690 / #2359 follow-up. |
+| Joins / multi-table QUERY | **Supported** when `backendTank.joins` has edges: ANSI JOIN SELECT with qualified identifiers + parameterized filters. **Rejected** when multi-table / `joinCount > 0` without edges (`JOIN_PRODUCT_LIMIT_MESSAGE`), disconnected graphs, self-joins, or `translatorPresent` edges (`JOIN_TRANSLATOR_LIMIT_MESSAGE`). Use `nativeStatement` for translator joins or exotic SQL. |
+| Joins / multi-table mutations | INSERT/UPDATE/DELETE remain single-table only |
 | Unrestricted DELETE/UPDATE | Rejected (WHERE keys required) |
 
 Manual raw multi-statement SQL is **not** a product surface.
@@ -210,7 +213,7 @@ Manual raw multi-statement SQL is **not** a product surface.
 
 - IR JSON round-trip + file load/save
 - Golden classic fixture `sys_adminCataloger` → IR stage inventory (backend tank, mapper, selector whereClauses, page tank)
-- H2 runtime: generated query + JSON params, **where-clause IR** (PARAM/LIKE), native SELECT, pre/post hooks, INSERT, UPDATE/DELETE flag gates, multi-row `transactionMode` all/row, **joinCount product-limit rejection** (`PSPipelineRuntimeServiceTest`)
+- H2 runtime: generated query + JSON params, **where-clause IR** (PARAM/LIKE), native SELECT, pre/post hooks, INSERT, UPDATE/DELETE flag gates, multi-row `transactionMode` all/row, **multi-table INNER + LEFT OUTER JOIN** generation/execution, joinCount-without-edges rejection (`PSPipelineRuntimeServiceTest`)
 
 ## Evolution
 
@@ -218,5 +221,6 @@ Manual raw multi-statement SQL is **not** a product surface.
 - Slice A2 (#2248): SQL execute + JSON I/O + hooks consume this IR (landed).
 - Residual #2269: thin REST invoke (landed / PR #2341).
 - Residual #2340: richer UPDATE/DELETE + multi-row txn modes (landed / PR #2360).
-- Residual #2359: where-clause IR executable path + documented join product limit (this work); **join-graph SQL generation** remains a further residual under #1690.
+- Residual #2359: where-clause IR executable path + join product limit documentation (landed).
+- Residual #2391: **join-graph SQL generation** (`backendTank.joins` + multi-table SELECT planner; this work). Refs #1690.
 - Slice B: designer writes native IR (`source=NATIVE`).

--- a/system/services/src/com/percussion/services/pipeline/PSClassicPipelineImporter.java
+++ b/system/services/src/com/percussion/services/pipeline/PSClassicPipelineImporter.java
@@ -21,6 +21,7 @@ import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSApplication;
 import com.percussion.design.objectstore.PSBackEndColumn;
 import com.percussion.design.objectstore.PSBackEndDataTank;
+import com.percussion.design.objectstore.PSBackEndJoin;
 import com.percussion.design.objectstore.PSBackEndTable;
 import com.percussion.design.objectstore.PSContentEditor;
 import com.percussion.design.objectstore.PSDataMapper;
@@ -43,6 +44,7 @@ import com.percussion.design.objectstore.PSUpdatePipe;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.design.objectstore.PSWhereClause;
+import com.percussion.services.pipeline.model.BackendJoinIr;
 import com.percussion.services.pipeline.model.BackendTableRefIr;
 import com.percussion.services.pipeline.model.BackendTankStageIr;
 import com.percussion.services.pipeline.model.MapperStageIr;
@@ -224,9 +226,48 @@ public final class PSClassicPipelineImporter {
       }
     }
     stage.setTables(tables);
+    List<BackendJoinIr> joinEdges = new ArrayList<>();
     PSCollection joins = tank.getJoins();
-    stage.setJoinCount(joins != null ? joins.size() : 0);
+    if (joins != null) {
+      for (Object o : joins) {
+        if (o instanceof PSBackEndJoin j) {
+          joinEdges.add(mapJoin(j));
+        }
+      }
+    }
+    stage.setJoins(joinEdges);
+    stage.setJoinCount(joinEdges.size());
     return stage;
+  }
+
+  private static BackendJoinIr mapJoin(PSBackEndJoin join) {
+    BackendJoinIr edge = new BackendJoinIr();
+    if (join.isFullOuterJoin()) {
+      edge.setJoinType(BackendJoinIr.TYPE_FULL);
+    } else if (join.isLeftOuterJoin()) {
+      edge.setJoinType(BackendJoinIr.TYPE_LEFT);
+    } else if (join.isRightOuterJoin()) {
+      edge.setJoinType(BackendJoinIr.TYPE_RIGHT);
+    } else {
+      edge.setJoinType(BackendJoinIr.TYPE_INNER);
+    }
+    edge.setLeft(backendColumnRef(join.getLeftColumn()));
+    edge.setRight(backendColumnRef(join.getRightColumn()));
+    edge.setTranslatorPresent(join.getTranslator() != null);
+    return edge;
+  }
+
+  /** Classic {@link PSBackEndColumn} → {@code alias.column} or bare column name. */
+  private static String backendColumnRef(PSBackEndColumn col) {
+    if (col == null) {
+      return null;
+    }
+    String alias = col.getTable() != null ? col.getTable().getAlias() : null;
+    String column = col.getColumn();
+    if (StringUtils.isNotBlank(alias) && StringUtils.isNotBlank(column)) {
+      return alias + "." + column;
+    }
+    return column;
   }
 
   private static MapperStageIr mapMapper(PSDataMapper mapper) {

--- a/system/services/src/com/percussion/services/pipeline/model/BackendJoinIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/BackendJoinIr.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/**
+ * One join edge in a backend data tank (classic {@code PSBackEndJoin}).
+ *
+ * <p>{@code left} / {@code right} are backend column references in the same form as mapper backends
+ * and where-clause columns: {@code alias.column} or bare {@code column}.
+ *
+ * <p>{@link #joinType} is one of {@link #TYPE_INNER}, {@link #TYPE_LEFT}, {@link #TYPE_RIGHT},
+ * {@link #TYPE_FULL}. Classic extension translators on joins are inventoried via {@link
+ * #translatorPresent} and rejected by the generated SQL planner (use native SELECT).
+ */
+public class BackendJoinIr {
+
+  public static final String TYPE_INNER = "INNER";
+  public static final String TYPE_LEFT = "LEFT";
+  public static final String TYPE_RIGHT = "RIGHT";
+  public static final String TYPE_FULL = "FULL";
+
+  private String joinType = TYPE_INNER;
+  private String left;
+  private String right;
+  private boolean translatorPresent;
+
+  public String getJoinType() {
+    return joinType;
+  }
+
+  public void setJoinType(String joinType) {
+    this.joinType = joinType != null && !joinType.isBlank() ? joinType : TYPE_INNER;
+  }
+
+  public String getLeft() {
+    return left;
+  }
+
+  public void setLeft(String left) {
+    this.left = left;
+  }
+
+  public String getRight() {
+    return right;
+  }
+
+  public void setRight(String right) {
+    this.right = right;
+  }
+
+  public boolean isTranslatorPresent() {
+    return translatorPresent;
+  }
+
+  public void setTranslatorPresent(boolean translatorPresent) {
+    this.translatorPresent = translatorPresent;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BackendJoinIr that)) {
+      return false;
+    }
+    return translatorPresent == that.translatorPresent
+        && Objects.equals(joinType, that.joinType)
+        && Objects.equals(left, that.left)
+        && Objects.equals(right, that.right);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(joinType, left, right, translatorPresent);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/BackendTankStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/BackendTankStageIr.java
@@ -21,11 +21,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/** Backend data tank stage (classic {@code PSBackEndDataTank}). */
+/**
+ * Backend data tank stage (classic {@code PSBackEndDataTank}).
+ *
+ * <p>{@link #joins} holds the join-graph edges used by the multi-table SQL planner. {@link
+ * #joinCount} remains for inventory / legacy IR and should match {@code joins.size()} when edges
+ * were imported.
+ */
 public class BackendTankStageIr {
 
   private boolean present;
   private List<BackendTableRefIr> tables = new ArrayList<>();
+  private List<BackendJoinIr> joins = new ArrayList<>();
   private int joinCount;
 
   public boolean isPresent() {
@@ -42,6 +49,14 @@ public class BackendTankStageIr {
 
   public void setTables(List<BackendTableRefIr> tables) {
     this.tables = tables != null ? tables : new ArrayList<>();
+  }
+
+  public List<BackendJoinIr> getJoins() {
+    return joins;
+  }
+
+  public void setJoins(List<BackendJoinIr> joins) {
+    this.joins = joins != null ? joins : new ArrayList<>();
   }
 
   public int getJoinCount() {
@@ -62,11 +77,12 @@ public class BackendTankStageIr {
     }
     return present == that.present
         && joinCount == that.joinCount
-        && Objects.equals(tables, that.tables);
+        && Objects.equals(tables, that.tables)
+        && Objects.equals(joins, that.joins);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(present, tables, joinCount);
+    return Objects.hash(present, tables, joins, joinCount);
   }
 }

--- a/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
@@ -18,7 +18,9 @@
 package com.percussion.services.pipeline.sql;
 
 import com.percussion.services.pipeline.PSPipelineIrException;
+import com.percussion.services.pipeline.model.BackendJoinIr;
 import com.percussion.services.pipeline.model.BackendTableRefIr;
+import com.percussion.services.pipeline.model.BackendTankStageIr;
 import com.percussion.services.pipeline.model.MapperStageIr;
 import com.percussion.services.pipeline.model.MappingEntryIr;
 import com.percussion.services.pipeline.model.PipelineExecuteRequest;
@@ -28,7 +30,9 @@ import com.percussion.services.pipeline.model.UpdaterStageIr;
 import com.percussion.services.pipeline.model.WhereClauseIr;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -47,8 +51,10 @@ import java.util.regex.Pattern;
  *   <li>Generated identifiers (table/column) are restricted to {@code [A-Za-z_][A-Za-z0-9_]*}.
  *   <li>Native SQL (selector {@code nativeStatement}) is an escape hatch: single {@code SELECT}
  *       only, named {@code :param} placeholders; multi-statement and non-SELECT rejected.
- *   <li>Multi-table joins are a documented product limit: {@code joinCount &gt; 0} is rejected
- *       (use native SELECT escape hatch or a residual join-graph planner).
+ *   <li>QUERY multi-table SELECT uses IR join edges ({@code backendTank.joins}) with ANSI JOIN
+ *       ({@code INNER}/{@code LEFT}/{@code RIGHT}/{@code FULL OUTER}). Join edges with classic
+ *       translators, disconnected graphs, or multi-table tanks without edges are rejected.
+ *   <li>INSERT/UPDATE/DELETE remain single-table only.
  * </ul>
  */
 public final class PSPipelineSqlPlanner {
@@ -63,13 +69,18 @@ public final class PSPipelineSqlPlanner {
   private static final Set<String> UNARY_OPS = Set.of("IS NULL", "IS NOT NULL");
 
   /**
-   * Product-limit message for multi-table backend tanks. Keep stable for tests and API clients.
+   * Rejection message when join inventory is present without executable join edges (legacy IR) or
+   * multi-table tank has no graph. Keep stable for tests and API clients.
    */
   public static final String JOIN_PRODUCT_LIMIT_MESSAGE =
-      "Product limit: multi-table joins are not supported by the pipeline SQL planner"
-          + " (joinCount > 0). Use a single backend table, or the selector nativeStatement"
-          + " escape hatch for hand-authored SELECT with joins. Residual join-graph planner"
-          + " tracked under parent pipeline epic.";
+      "Product limit: multi-table join SQL requires backendTank.joins edges"
+          + " (joinCount alone is not enough). Provide join graph IR, use a single backend table,"
+          + " or the selector nativeStatement escape hatch for hand-authored SELECT with joins.";
+
+  /** Rejection when a join edge carries a classic extension translator. */
+  public static final String JOIN_TRANSLATOR_LIMIT_MESSAGE =
+      "Product limit: join edges with classic translators are not supported by the generated"
+          + " planner; use selector nativeStatement for translated join predicates.";
 
   private PSPipelineSqlPlanner() {}
 
@@ -613,7 +624,32 @@ public final class PSPipelineSqlPlanner {
 
   private static PSPipelineSqlPlan planGeneratedSelect(
       PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
-    String table = requireSingleTable(resource);
+    BackendTankStageIr tank = requireBackendTank(resource);
+    List<BackendTableRefIr> tables = tank.getTables();
+    if (tables == null || tables.isEmpty()) {
+      throw new PSPipelineIrException(
+          "Pipeline SQL planner requires at least one backend table. Resource: "
+              + resource.getName());
+    }
+    List<BackendJoinIr> joins =
+        tank.getJoins() != null ? tank.getJoins() : List.of();
+
+    // Multi-table without edges, or legacy joinCount without edges → reject.
+    if (tables.size() > 1 && joins.isEmpty()) {
+      throw new PSPipelineIrException(
+          JOIN_PRODUCT_LIMIT_MESSAGE + " Resource: " + resource.getName());
+    }
+    if (joins.isEmpty() && tank.getJoinCount() > 0) {
+      throw new PSPipelineIrException(
+          JOIN_PRODUCT_LIMIT_MESSAGE + " Resource: " + resource.getName());
+    }
+    // Single table with stray join edges is invalid.
+    if (tables.size() == 1 && !joins.isEmpty()) {
+      throw new PSPipelineIrException(
+          "Backend tank has join edges but only one table; remove joins or add tables. Resource: "
+              + resource.getName());
+    }
+
     List<ColumnMapping> mappings = columnMappings(resource);
     if (mappings.isEmpty()) {
       throw new PSPipelineIrException(
@@ -623,6 +659,7 @@ public final class PSPipelineSqlPlanner {
     SelectorStageIr selector =
         resource.getStages() != null ? resource.getStages().getSelector() : null;
     boolean distinct = selector != null && selector.isUnique();
+    boolean multiTable = !joins.isEmpty();
 
     StringBuilder sql = new StringBuilder("SELECT ");
     if (distinct) {
@@ -633,9 +670,19 @@ public final class PSPipelineSqlPlanner {
       if (i > 0) {
         sql.append(", ");
       }
-      sql.append(quoteIdent(m.column)).append(" AS ").append(quoteIdent(m.jsonField));
+      sql.append(columnSql(m, multiTable)).append(" AS ").append(quoteIdent(m.jsonField));
     }
-    sql.append(" FROM ").append(quoteIdent(table));
+
+    String planLabel;
+    List<QualifiedColumn> deferredJoinEquals = List.of();
+    if (!multiTable) {
+      String table = tableName(tables.get(0));
+      sql.append(" FROM ").append(quoteIdent(table));
+      planLabel = "generatedSelect:" + table;
+    } else {
+      deferredJoinEquals = appendMultiTableFrom(sql, tables, joins, resource.getName());
+      planLabel = "generatedSelect:join:" + tables.size() + "t/" + joins.size() + "j";
+    }
 
     List<Object> binds = new ArrayList<>();
     Map<String, Object> params =
@@ -645,26 +692,307 @@ public final class PSPipelineSqlPlanner {
         selector != null && selector.getWhereClauses() != null
             ? selector.getWhereClauses()
             : List.of();
+    boolean whereStarted = false;
     if (!irClauses.isEmpty()) {
-      appendWhereFromIr(sql, binds, irClauses, params, resource.getName());
+      whereStarted = appendWhereFromIr(sql, binds, irClauses, params, resource.getName(), multiTable);
     } else if (!params.isEmpty()) {
-      appendWhereFromRequestParams(sql, binds, mappings, params);
+      whereStarted = appendWhereFromRequestParams(sql, binds, mappings, params, multiTable);
+    }
+    appendDeferredJoinEquals(sql, deferredJoinEquals, whereStarted);
+
+    return new PSPipelineSqlPlan(PSPipelineSqlPlan.Kind.QUERY, sql.toString(), binds, planLabel);
+  }
+
+  /**
+   * Emit {@code FROM t0 a0 JOIN t1 a1 ON ...} for a connected join graph. Returns equality
+   * predicates for join edges that connect already-included tables (cycles), to fold into WHERE.
+   */
+  private static List<QualifiedColumn> appendMultiTableFrom(
+      StringBuilder sql,
+      List<BackendTableRefIr> tables,
+      List<BackendJoinIr> joins,
+      String resourceName)
+      throws PSPipelineIrException {
+    Map<String, BackendTableRefIr> byAlias = new LinkedHashMap<>();
+    for (BackendTableRefIr t : tables) {
+      if (t == null) {
+        continue;
+      }
+      String alias = tableAlias(t);
+      String key = alias.toUpperCase(Locale.ROOT);
+      if (byAlias.containsKey(key)) {
+        throw new PSPipelineIrException(
+            "Duplicate backend table alias '" + alias + "' on resource: " + resourceName);
+      }
+      byAlias.put(key, t);
+    }
+    if (byAlias.isEmpty()) {
+      throw new PSPipelineIrException(
+          "Pipeline SQL planner requires at least one backend table. Resource: " + resourceName);
     }
 
-    return new PSPipelineSqlPlan(
-        PSPipelineSqlPlan.Kind.QUERY, sql.toString(), binds, "generatedSelect:" + table);
+    List<ResolvedJoin> resolved = new ArrayList<>();
+    for (BackendJoinIr edge : joins) {
+      if (edge == null) {
+        continue;
+      }
+      if (edge.isTranslatorPresent()) {
+        throw new PSPipelineIrException(
+            JOIN_TRANSLATOR_LIMIT_MESSAGE + " Resource: " + resourceName);
+      }
+      resolved.add(resolveJoin(edge, byAlias, resourceName));
+    }
+    if (resolved.isEmpty()) {
+      throw new PSPipelineIrException(
+          JOIN_PRODUCT_LIMIT_MESSAGE + " Resource: " + resourceName);
+    }
+
+    // Root = first table in tank order.
+    BackendTableRefIr root = byAlias.values().iterator().next();
+    String rootAlias = tableAlias(root);
+    sql.append(" FROM ");
+    appendTableRef(sql, root);
+
+    Set<String> included = new LinkedHashSet<>();
+    included.add(rootAlias.toUpperCase(Locale.ROOT));
+
+    List<ResolvedJoin> remaining = new ArrayList<>(resolved);
+    List<ResolvedJoin> deferred = new ArrayList<>();
+
+    while (!remaining.isEmpty()) {
+      boolean progress = false;
+      Iterator<ResolvedJoin> it = remaining.iterator();
+      while (it.hasNext()) {
+        ResolvedJoin j = it.next();
+        boolean leftIn = included.contains(j.leftAlias.toUpperCase(Locale.ROOT));
+        boolean rightIn = included.contains(j.rightAlias.toUpperCase(Locale.ROOT));
+        if (leftIn && rightIn) {
+          deferred.add(j);
+          it.remove();
+          progress = true;
+        } else if (leftIn && !rightIn) {
+          appendAnsiJoin(sql, j.joinType, byAlias.get(j.rightAlias.toUpperCase(Locale.ROOT)), j);
+          included.add(j.rightAlias.toUpperCase(Locale.ROOT));
+          it.remove();
+          progress = true;
+        } else if (rightIn && !leftIn) {
+          // Introduce left table; flip outer-join direction to preserve semantics.
+          String flipped = flipJoinType(j.joinType);
+          ResolvedJoin flippedJoin =
+              new ResolvedJoin(
+                  flipped, j.rightAlias, j.rightColumn, j.leftAlias, j.leftColumn);
+          appendAnsiJoin(sql, flipped, byAlias.get(j.leftAlias.toUpperCase(Locale.ROOT)), flippedJoin);
+          included.add(j.leftAlias.toUpperCase(Locale.ROOT));
+          it.remove();
+          progress = true;
+        }
+      }
+      if (!progress) {
+        throw new PSPipelineIrException(
+            "Disconnected join graph: cannot attach remaining join edges from root table '"
+                + rootAlias
+                + "' on resource: "
+                + resourceName);
+      }
+    }
+
+    if (included.size() != byAlias.size()) {
+      throw new PSPipelineIrException(
+          "Join graph does not include all backend tables on resource: " + resourceName);
+    }
+
+    // Cycle edges (both tables already in FROM): fold into WHERE as equality pairs.
+    List<QualifiedColumn> deferredMarker = new ArrayList<>();
+    for (ResolvedJoin d : deferred) {
+      deferredMarker.add(new QualifiedColumn(d.leftAlias, d.leftColumn));
+      deferredMarker.add(new QualifiedColumn(d.rightAlias, d.rightColumn));
+    }
+    return deferredMarker;
+  }
+
+  private static void appendDeferredJoinEquals(
+      StringBuilder sql, List<QualifiedColumn> deferredPairs, boolean whereAlreadyStarted) {
+    if (deferredPairs == null || deferredPairs.isEmpty()) {
+      return;
+    }
+    // pairs: (left0, right0, left1, right1, ...)
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i + 1 < deferredPairs.size(); i += 2) {
+      QualifiedColumn left = deferredPairs.get(i);
+      QualifiedColumn right = deferredPairs.get(i + 1);
+      parts.add(qualifiedColumnSql(left) + " = " + qualifiedColumnSql(right));
+    }
+    if (parts.isEmpty()) {
+      return;
+    }
+    if (whereAlreadyStarted) {
+      sql.append(" AND ");
+    } else {
+      sql.append(" WHERE ");
+    }
+    sql.append(String.join(" AND ", parts));
+  }
+
+  private static ResolvedJoin resolveJoin(
+      BackendJoinIr edge, Map<String, BackendTableRefIr> byAlias, String resourceName)
+      throws PSPipelineIrException {
+    QualifiedColumn left = parseBackendColumn(edge.getLeft() != null ? edge.getLeft() : "");
+    QualifiedColumn right = parseBackendColumn(edge.getRight() != null ? edge.getRight() : "");
+    if (left.tableAlias == null || right.tableAlias == null) {
+      throw new PSPipelineIrException(
+          "Join edge columns must be qualified as alias.column on resource: " + resourceName);
+    }
+    String leftKey = left.tableAlias.toUpperCase(Locale.ROOT);
+    String rightKey = right.tableAlias.toUpperCase(Locale.ROOT);
+    if (!byAlias.containsKey(leftKey) || !byAlias.containsKey(rightKey)) {
+      throw new PSPipelineIrException(
+          "Join edge references unknown table alias (left="
+              + left.tableAlias
+              + ", right="
+              + right.tableAlias
+              + ") on resource: "
+              + resourceName);
+    }
+    if (leftKey.equals(rightKey)) {
+      throw new PSPipelineIrException(
+          "Join edge cannot join a table to itself on resource: " + resourceName);
+    }
+    String type = normalizeJoinType(edge.getJoinType());
+    return new ResolvedJoin(type, left.tableAlias, left.column, right.tableAlias, right.column);
+  }
+
+  private static String normalizeJoinType(String raw) throws PSPipelineIrException {
+    if (raw == null || raw.isBlank()) {
+      return BackendJoinIr.TYPE_INNER;
+    }
+    String t = raw.trim().toUpperCase(Locale.ROOT);
+    // Accept classic-style names too.
+    if ("INNER".equals(t) || "INNERJOIN".equals(t)) {
+      return BackendJoinIr.TYPE_INNER;
+    }
+    if ("LEFT".equals(t) || "LEFTOUTER".equals(t) || "LEFT_OUTER".equals(t) || "LEFT OUTER".equals(t)) {
+      return BackendJoinIr.TYPE_LEFT;
+    }
+    if ("RIGHT".equals(t)
+        || "RIGHTOUTER".equals(t)
+        || "RIGHT_OUTER".equals(t)
+        || "RIGHT OUTER".equals(t)) {
+      return BackendJoinIr.TYPE_RIGHT;
+    }
+    if ("FULL".equals(t)
+        || "FULLOUTER".equals(t)
+        || "FULL_OUTER".equals(t)
+        || "FULL OUTER".equals(t)) {
+      return BackendJoinIr.TYPE_FULL;
+    }
+    throw new PSPipelineIrException("Unsupported join type: " + raw);
+  }
+
+  private static String flipJoinType(String type) {
+    if (BackendJoinIr.TYPE_LEFT.equals(type)) {
+      return BackendJoinIr.TYPE_RIGHT;
+    }
+    if (BackendJoinIr.TYPE_RIGHT.equals(type)) {
+      return BackendJoinIr.TYPE_LEFT;
+    }
+    return type; // INNER / FULL are symmetric
+  }
+
+  private static void appendAnsiJoin(
+      StringBuilder sql, String joinType, BackendTableRefIr newTable, ResolvedJoin on)
+      throws PSPipelineIrException {
+    if (newTable == null) {
+      throw new PSPipelineIrException("Join introduces unknown table");
+    }
+    sql.append(' ').append(ansiJoinKeyword(joinType)).append(' ');
+    appendTableRef(sql, newTable);
+    sql.append(" ON ")
+        .append(quoteIdent(on.leftAlias))
+        .append('.')
+        .append(quoteIdent(on.leftColumn))
+        .append(" = ")
+        .append(quoteIdent(on.rightAlias))
+        .append('.')
+        .append(quoteIdent(on.rightColumn));
+  }
+
+  private static String ansiJoinKeyword(String joinType) throws PSPipelineIrException {
+    return switch (joinType) {
+      case BackendJoinIr.TYPE_INNER -> "INNER JOIN";
+      case BackendJoinIr.TYPE_LEFT -> "LEFT OUTER JOIN";
+      case BackendJoinIr.TYPE_RIGHT -> "RIGHT OUTER JOIN";
+      case BackendJoinIr.TYPE_FULL -> "FULL OUTER JOIN";
+      default -> throw new PSPipelineIrException("Unsupported join type: " + joinType);
+    };
+  }
+
+  private static void appendTableRef(StringBuilder sql, BackendTableRefIr t)
+      throws PSPipelineIrException {
+    String table = tableName(t);
+    String alias = tableAlias(t);
+    sql.append(quoteIdent(table)).append(' ').append(quoteIdent(alias));
+  }
+
+  private static String tableName(BackendTableRefIr t) throws PSPipelineIrException {
+    String table = t.getTable();
+    if (table == null || table.isBlank()) {
+      table = t.getAlias();
+    }
+    return requireSafeIdent(table, "table");
+  }
+
+  private static String tableAlias(BackendTableRefIr t) throws PSPipelineIrException {
+    String alias = t.getAlias();
+    if (alias == null || alias.isBlank()) {
+      alias = t.getTable();
+    }
+    return requireSafeIdent(alias, "table alias");
+  }
+
+  private static final class ResolvedJoin {
+    final String joinType;
+    final String leftAlias;
+    final String leftColumn;
+    final String rightAlias;
+    final String rightColumn;
+
+    ResolvedJoin(
+        String joinType,
+        String leftAlias,
+        String leftColumn,
+        String rightAlias,
+        String rightColumn) {
+      this.joinType = joinType;
+      this.leftAlias = leftAlias;
+      this.leftColumn = leftColumn;
+      this.rightAlias = rightAlias;
+      this.rightColumn = rightColumn;
+    }
+  }
+
+  private static final class QualifiedColumn {
+    final String tableAlias; // nullable
+    final String column;
+
+    QualifiedColumn(String tableAlias, String column) {
+      this.tableAlias = tableAlias;
+      this.column = column;
+    }
   }
 
   /**
    * Build WHERE from selector where-clause IR (classic import / native IR). Values are always JDBC
    * binds; identifiers are validated.
+   *
+   * @return true when a WHERE clause was appended
    */
-  private static void appendWhereFromIr(
+  private static boolean appendWhereFromIr(
       StringBuilder sql,
       List<Object> binds,
       List<WhereClauseIr> clauses,
       Map<String, Object> params,
-      String resourceName)
+      String resourceName,
+      boolean multiTable)
       throws PSPipelineIrException {
     List<String> parts = new ArrayList<>();
     // Connector after each emitted part (classic: boolean on a clause joins it to the next).
@@ -673,7 +1001,7 @@ public final class PSPipelineSqlPlanner {
       if (clause == null) {
         continue;
       }
-      PredicateFrag frag = compileWherePredicate(clause, params, resourceName);
+      PredicateFrag frag = compileWherePredicate(clause, params, resourceName, multiTable);
       if (frag == null) {
         // omitWhenNull skipped this predicate — do not consume its boolean either
         continue;
@@ -683,7 +1011,7 @@ public final class PSPipelineSqlPlanner {
       trailingConnectors.add(frag.booleanOpAfter);
     }
     if (parts.isEmpty()) {
-      return;
+      return false;
     }
     sql.append(" WHERE ");
     for (int i = 0; i < parts.size(); i++) {
@@ -693,13 +1021,14 @@ public final class PSPipelineSqlPlanner {
       }
       sql.append(parts.get(i));
     }
+    return true;
   }
 
   /**
    * @return null when predicate should be omitted (omitWhenNull + missing/null param)
    */
   private static PredicateFrag compileWherePredicate(
-      WhereClauseIr clause, Map<String, Object> params, String resourceName)
+      WhereClauseIr clause, Map<String, Object> params, String resourceName, boolean multiTable)
       throws PSPipelineIrException {
     String opRaw = clause.getOperator();
     if (opRaw == null || opRaw.isBlank()) {
@@ -716,8 +1045,8 @@ public final class PSPipelineSqlPlanner {
               + resourceName
               + " — use nativeStatement for non-column predicates");
     }
-    String leftCol = columnFromBackend(clause.getLeft() != null ? clause.getLeft() : "");
-    String leftSql = quoteIdent(leftCol);
+    String leftSql =
+        backendColumnSql(clause.getLeft() != null ? clause.getLeft() : "", multiTable);
 
     String bool =
         clause.getBooleanOp() != null && !clause.getBooleanOp().isBlank()
@@ -746,8 +1075,9 @@ public final class PSPipelineSqlPlanner {
 
     String rightKind = clause.getRightKind() != null ? clause.getRightKind() : WhereClauseIr.KIND_OTHER;
     if (WhereClauseIr.KIND_COLUMN.equals(rightKind)) {
-      String rightCol = columnFromBackend(clause.getRight() != null ? clause.getRight() : "");
-      return new PredicateFrag(leftSql + " " + sqlOp + " " + quoteIdent(rightCol), List.of(), bool);
+      String rightSql =
+          backendColumnSql(clause.getRight() != null ? clause.getRight() : "", multiTable);
+      return new PredicateFrag(leftSql + " " + sqlOp + " " + rightSql, List.of(), bool);
     }
     if (WhereClauseIr.KIND_PARAM.equals(rightKind)) {
       String paramName = clause.getRight();
@@ -797,11 +1127,15 @@ public final class PSPipelineSqlPlanner {
     return upper;
   }
 
-  private static void appendWhereFromRequestParams(
+  /**
+   * @return true when a WHERE clause was appended
+   */
+  private static boolean appendWhereFromRequestParams(
       StringBuilder sql,
       List<Object> binds,
       List<ColumnMapping> mappings,
-      Map<String, Object> params) {
+      Map<String, Object> params,
+      boolean multiTable) {
     List<String> whereParts = new ArrayList<>();
     // Deduplicate by mapped column so case variants of the same param (TYPE vs type) do not
     // produce duplicate WHERE "TYPE" = ? AND "TYPE" = ? with conflicting binds.
@@ -813,17 +1147,21 @@ public final class PSPipelineSqlPlanner {
         // become filters.
         continue;
       }
-      String colKey = match.column.toUpperCase(Locale.ROOT);
+      String colKey =
+          (match.tableAlias != null ? match.tableAlias + "." : "")
+              + match.column.toUpperCase(Locale.ROOT);
       if (!usedColumns.add(colKey)) {
         continue;
       }
-      whereParts.add(quoteIdent(match.column) + " = ?");
+      whereParts.add(columnSql(match, multiTable) + " = ?");
       binds.add(e.getValue());
     }
-    if (!whereParts.isEmpty()) {
-      sql.append(" WHERE ");
-      sql.append(String.join(" AND ", whereParts));
+    if (whereParts.isEmpty()) {
+      return false;
     }
+    sql.append(" WHERE ");
+    sql.append(String.join(" AND ", whereParts));
+    return true;
   }
 
   private static final class PredicateFrag {
@@ -839,17 +1177,29 @@ public final class PSPipelineSqlPlanner {
     }
   }
 
-  private static String requireSingleTable(PipelineResourceIr resource) throws PSPipelineIrException {
+  private static BackendTankStageIr requireBackendTank(PipelineResourceIr resource)
+      throws PSPipelineIrException {
     if (resource.getStages() == null
         || resource.getStages().getBackendTank() == null
         || !resource.getStages().getBackendTank().isPresent()) {
       throw new PSPipelineIrException("Resource missing backend tank: " + resource.getName());
     }
-    if (resource.getStages().getBackendTank().getJoinCount() > 0) {
+    return resource.getStages().getBackendTank();
+  }
+
+  /**
+   * Mutations (INSERT/UPDATE/DELETE) require exactly one backend table and no join graph.
+   */
+  private static String requireSingleTable(PipelineResourceIr resource)
+      throws PSPipelineIrException {
+    BackendTankStageIr tank = requireBackendTank(resource);
+    List<BackendJoinIr> joins = tank.getJoins() != null ? tank.getJoins() : List.of();
+    if (tank.getJoinCount() > 0 || !joins.isEmpty()) {
       throw new PSPipelineIrException(
-          JOIN_PRODUCT_LIMIT_MESSAGE + " Resource: " + resource.getName());
+          "Pipeline SQL planner mutations require a single backend table without joins. Resource: "
+              + resource.getName());
     }
-    List<BackendTableRefIr> tables = resource.getStages().getBackendTank().getTables();
+    List<BackendTableRefIr> tables = tank.getTables();
     if (tables == null || tables.size() != 1) {
       throw new PSPipelineIrException(
           "Pipeline SQL planner requires exactly one backend table (got "
@@ -857,11 +1207,7 @@ public final class PSPipelineSqlPlanner {
               + "); multi-table tanks without joins are also unsupported. Resource: "
               + resource.getName());
     }
-    String table = tables.get(0).getTable();
-    if (table == null || table.isBlank()) {
-      table = tables.get(0).getAlias();
-    }
-    return requireSafeIdent(table, "table");
+    return tableName(tables.get(0));
   }
 
   private static List<ColumnMapping> columnMappings(PipelineResourceIr resource)
@@ -886,18 +1232,53 @@ public final class PSPipelineSqlPlanner {
       if (backend == null || backend.isBlank()) {
         continue;
       }
-      String column = columnFromBackend(backend);
-      String jsonField = jsonFieldFromDocument(entry.getDocumentField(), column);
-      out.add(new ColumnMapping(column, jsonField, entry.getDocumentField()));
+      QualifiedColumn qc = parseBackendColumn(backend);
+      String jsonField = jsonFieldFromDocument(entry.getDocumentField(), qc.column);
+      out.add(new ColumnMapping(qc.tableAlias, qc.column, jsonField, entry.getDocumentField()));
     }
     return out;
   }
 
   static String columnFromBackend(String backend) throws PSPipelineIrException {
+    return parseBackendColumn(backend).column;
+  }
+
+  static QualifiedColumn parseBackendColumn(String backend) throws PSPipelineIrException {
     String b = backend.trim();
     int dot = b.lastIndexOf('.');
-    String col = dot >= 0 ? b.substring(dot + 1) : b;
-    return requireSafeIdent(col, "column");
+    if (dot >= 0) {
+      // Prefer last segment as column; previous segment as table alias (alias.col or *.alias.col).
+      String col = b.substring(dot + 1).trim();
+      String prefix = b.substring(0, dot).trim();
+      int prev = prefix.lastIndexOf('.');
+      String alias = prev >= 0 ? prefix.substring(prev + 1).trim() : prefix;
+      return new QualifiedColumn(
+          requireSafeIdent(alias, "table alias"), requireSafeIdent(col, "column"));
+    }
+    return new QualifiedColumn(null, requireSafeIdent(b, "column"));
+  }
+
+  private static String backendColumnSql(String backend, boolean multiTable)
+      throws PSPipelineIrException {
+    QualifiedColumn qc = parseBackendColumn(backend);
+    if (multiTable && qc.tableAlias != null) {
+      return qualifiedColumnSql(qc);
+    }
+    return quoteIdent(qc.column);
+  }
+
+  private static String columnSql(ColumnMapping m, boolean multiTable) {
+    if (multiTable && m.tableAlias != null) {
+      return quoteIdent(m.tableAlias) + "." + quoteIdent(m.column);
+    }
+    return quoteIdent(m.column);
+  }
+
+  private static String qualifiedColumnSql(QualifiedColumn qc) {
+    if (qc.tableAlias != null) {
+      return quoteIdent(qc.tableAlias) + "." + quoteIdent(qc.column);
+    }
+    return quoteIdent(qc.column);
   }
 
   static String jsonFieldFromDocument(String documentField, String fallbackColumn) {
@@ -1026,11 +1407,13 @@ public final class PSPipelineSqlPlanner {
   }
 
   private static final class ColumnMapping {
+    final String tableAlias; // nullable
     final String column;
     final String jsonField;
     final String documentField;
 
-    ColumnMapping(String column, String jsonField, String documentField) {
+    ColumnMapping(String tableAlias, String column, String jsonField, String documentField) {
+      this.tableAlias = tableAlias;
       this.column = column;
       this.jsonField = jsonField;
       this.documentField = documentField;

--- a/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
+++ b/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.percussion.services.pipeline.hooks.IPSPipelinePostExecuteHook;
 import com.percussion.services.pipeline.hooks.IPSPipelinePreExecuteHook;
+import com.percussion.services.pipeline.model.BackendJoinIr;
 import com.percussion.services.pipeline.model.BackendTableRefIr;
 import com.percussion.services.pipeline.model.BackendTankStageIr;
 import com.percussion.services.pipeline.model.MapperStageIr;
@@ -78,6 +79,13 @@ class PSPipelineRuntimeServiceTest {
               + "('workflow', 'wf1', '1'),"
               + "('workflow', 'wf2', '2'),"
               + "('locale', 'en-us', 'en')");
+      st.execute(
+          "CREATE TABLE \"PSX_LOOKUP_EXTRA\" ("
+              + "\"LOOKUP_NAME\" VARCHAR(128), \"NOTE\" VARCHAR(256))");
+      st.execute(
+          "INSERT INTO \"PSX_LOOKUP_EXTRA\" (\"LOOKUP_NAME\", \"NOTE\") VALUES "
+              + "('wf1', 'note-one'),"
+              + "('wf2', 'note-two')");
     }
     irService = new PSPipelineIrService(tempDir);
     sqlAdapter =
@@ -325,11 +333,12 @@ class PSPipelineRuntimeServiceTest {
   }
 
   @Test
-  @DisplayName("product limit: joinCount > 0 rejected with documented message")
-  void planQuery_rejectsJoins_productLimit() {
+  @DisplayName("product limit: joinCount > 0 without join edges rejected")
+  void planQuery_rejectsJoinCountWithoutEdges() {
     PipelineIrDocument doc = nativeQueryDoc("joinApp", "J1");
     PipelineResourceIr res = doc.findResource("J1");
     res.getStages().getBackendTank().setJoinCount(1);
+    res.getStages().getBackendTank().setJoins(List.of());
 
     PSPipelineIrException ex =
         assertThrows(
@@ -337,13 +346,13 @@ class PSPipelineRuntimeServiceTest {
             () -> PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.empty()));
     assertTrue(
         ex.getMessage().contains(PSPipelineSqlPlanner.JOIN_PRODUCT_LIMIT_MESSAGE)
-            || ex.getMessage().contains("multi-table joins"),
+            || ex.getMessage().contains("backendTank.joins"),
         ex.getMessage());
     assertTrue(ex.getMessage().contains("J1"), ex.getMessage());
   }
 
   @Test
-  @DisplayName("product limit: multi-table tank without join also rejected")
+  @DisplayName("product limit: multi-table tank without join edges rejected")
   void planQuery_rejectsMultiTableWithoutJoin() {
     PipelineIrDocument doc = nativeQueryDoc("mtApp", "M1");
     PipelineResourceIr res = doc.findResource("M1");
@@ -354,12 +363,92 @@ class PSPipelineRuntimeServiceTest {
     tables.add(t2);
     res.getStages().getBackendTank().setTables(tables);
     res.getStages().getBackendTank().setJoinCount(0);
+    res.getStages().getBackendTank().setJoins(List.of());
 
     PSPipelineIrException ex =
         assertThrows(
             PSPipelineIrException.class,
             () -> PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.empty()));
-    assertTrue(ex.getMessage().contains("exactly one backend table"), ex.getMessage());
+    assertTrue(
+        ex.getMessage().contains(PSPipelineSqlPlanner.JOIN_PRODUCT_LIMIT_MESSAGE)
+            || ex.getMessage().contains("joins"),
+        ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("join-graph: INNER JOIN generates parameterized multi-table SELECT")
+  void planQuery_innerJoinSql() throws Exception {
+    PipelineIrDocument doc = nativeJoinQueryDoc("innerPlan", "IJ", BackendJoinIr.TYPE_INNER);
+    PipelineResourceIr res = doc.findResource("IJ");
+
+    PSPipelineSqlPlan plan =
+        PSPipelineSqlPlanner.planQuery(
+            res, PipelineExecuteRequest.ofParams(Map.of("TYPE", "workflow")));
+
+    String sql = plan.getSql();
+    assertTrue(sql.contains("INNER JOIN"), sql);
+    assertTrue(sql.contains("\"PSX_ADMINLOOKUP\" \"L\""), sql);
+    assertTrue(sql.contains("\"PSX_LOOKUP_EXTRA\" \"X\""), sql);
+    assertTrue(sql.contains("ON \"L\".\"NAME\" = \"X\".\"LOOKUP_NAME\""), sql);
+    assertTrue(sql.contains("\"L\".\"TYPE\" = ?") || sql.contains("\"TYPE\" = ?"), sql);
+    assertEquals(List.of("workflow"), plan.getParameters());
+    assertTrue(plan.getDescription().contains("join"), plan.getDescription());
+  }
+
+  @Test
+  @DisplayName("join-graph: INNER JOIN executes against H2")
+  void executeQuery_innerJoinH2() throws Exception {
+    PipelineIrDocument doc = nativeJoinQueryDoc("innerH2", "IJH", BackendJoinIr.TYPE_INNER);
+    irService.save(doc);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    PipelineExecuteResult result =
+        runtime.execute(
+            "innerH2", "IJH", PipelineExecuteRequest.ofParams(Map.of("TYPE", "workflow")));
+
+    assertEquals(2, result.getRowCount());
+    assertTrue(
+        result.getRows().stream()
+            .allMatch(r -> String.valueOf(r.get("Type")).equals("workflow")));
+    assertTrue(
+        result.getRows().stream()
+            .map(r -> String.valueOf(r.get("Note")))
+            .anyMatch(n -> n.startsWith("note-")));
+  }
+
+  @Test
+  @DisplayName("join-graph: LEFT OUTER JOIN executes against H2 (orphan left row kept)")
+  void executeQuery_leftOuterJoinH2() throws Exception {
+    PipelineIrDocument doc = nativeJoinQueryDoc("leftH2", "LJH", BackendJoinIr.TYPE_LEFT);
+    irService.save(doc);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    // locale has no matching PSX_LOOKUP_EXTRA row — INNER would drop it; LEFT keeps it.
+    PipelineExecuteResult result =
+        runtime.execute(
+            "leftH2", "LJH", PipelineExecuteRequest.ofParams(Map.of("TYPE", "locale")));
+
+    assertEquals(1, result.getRowCount());
+    assertEquals("locale", result.getRows().get(0).get("Type"));
+    assertEquals("en-us", result.getRows().get(0).get("Name"));
+    assertNull(result.getRows().get(0).get("Note"));
+  }
+
+  @Test
+  @DisplayName("join-graph: translator edges rejected")
+  void planQuery_rejectsJoinTranslator() {
+    PipelineIrDocument doc = nativeJoinQueryDoc("trApp", "TR", BackendJoinIr.TYPE_INNER);
+    PipelineResourceIr res = doc.findResource("TR");
+    res.getStages().getBackendTank().getJoins().get(0).setTranslatorPresent(true);
+
+    PSPipelineIrException ex =
+        assertThrows(
+            PSPipelineIrException.class,
+            () -> PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.empty()));
+    assertTrue(
+        ex.getMessage().contains(PSPipelineSqlPlanner.JOIN_TRANSLATOR_LIMIT_MESSAGE)
+            || ex.getMessage().contains("translator"),
+        ex.getMessage());
   }
 
   @Test
@@ -775,6 +864,59 @@ class PSPipelineRuntimeServiceTest {
             mapping("Properties/@Type", "PSX_ADMINLOOKUP.TYPE"),
             mapping("Properties/@Name", "PSX_ADMINLOOKUP.NAME"),
             mapping("Properties/@Value", "PSX_ADMINLOOKUP.LOOKUPVALUE")));
+    stages.setMapper(mapper);
+
+    SelectorStageIr selector = new SelectorStageIr();
+    selector.setPresent(true);
+    selector.setMethod(SelectorStageIr.METHOD_WHERE);
+    stages.setSelector(selector);
+
+    res.setStages(stages);
+    doc.getResources().add(res);
+    return doc;
+  }
+
+  /**
+   * Two-table QUERY IR: {@code L} = PSX_ADMINLOOKUP, {@code X} = PSX_LOOKUP_EXTRA, join on
+   * L.NAME = X.LOOKUP_NAME.
+   */
+  private static PipelineIrDocument nativeJoinQueryDoc(
+      String appName, String resourceName, String joinType) {
+    PipelineIrDocument doc = new PipelineIrDocument();
+    doc.setSource(PipelineIrDocument.SOURCE_NATIVE);
+    doc.getApp().setName(appName);
+
+    PipelineResourceIr res = new PipelineResourceIr();
+    res.setName(resourceName);
+    res.setKind(PipelineResourceIr.KIND_QUERY);
+
+    PipelineStagesIr stages = new PipelineStagesIr();
+
+    BackendTankStageIr tank = new BackendTankStageIr();
+    tank.setPresent(true);
+    BackendTableRefIr left = new BackendTableRefIr();
+    left.setTable("PSX_ADMINLOOKUP");
+    left.setAlias("L");
+    BackendTableRefIr right = new BackendTableRefIr();
+    right.setTable("PSX_LOOKUP_EXTRA");
+    right.setAlias("X");
+    tank.setTables(List.of(left, right));
+
+    BackendJoinIr join = new BackendJoinIr();
+    join.setJoinType(joinType);
+    join.setLeft("L.NAME");
+    join.setRight("X.LOOKUP_NAME");
+    tank.setJoins(List.of(join));
+    tank.setJoinCount(1);
+    stages.setBackendTank(tank);
+
+    MapperStageIr mapper = new MapperStageIr();
+    mapper.setPresent(true);
+    mapper.setMappings(
+        List.of(
+            mapping("Properties/@Type", "L.TYPE"),
+            mapping("Properties/@Name", "L.NAME"),
+            mapping("Properties/@Note", "X.NOTE")));
     stages.setMapper(mapper);
 
     SelectorStageIr selector = new SelectorStageIr();


### PR DESCRIPTION
## Summary
Implements multi-table **join-graph SQL generation** for Pipeline IR QUERY resources (issue #2391 residual of #2359 / epic #1690).

- Import classic `PSBackEndJoin` into `BackendTankStageIr.joins` (`BackendJoinIr`: type, left/right `alias.column`, translator flag)
- `PSPipelineSqlPlanner` emits parameterized ANSI `INNER` / `LEFT OUTER` / `RIGHT OUTER` / `FULL OUTER` JOIN SELECT when join edges are present
- Reject incomplete inventory (`joinCount` without edges), disconnected graphs, translator edges; mutations remain single-table
- H2 tests: INNER execute, LEFT OUTER orphan keep, planner SQL shape, limit messages
- Docs: `docs/developer-module/pipeline-ir-v1.md`

## Parent
- Parent epic: #1690
- Residual of: #2359
- Fixes #2391

## Test plan
1. `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
2. Focused: `PSPipelineRuntimeServiceTest` + `PSPipelineIrServiceTest` — 35 tests, 0 failures
3. Verify planner SQL contains `INNER JOIN` / `LEFT OUTER JOIN` with qualified idents and `?` binds

## Gates
- Erlang self-review: `docs/ai-generated/code-reviews/issue-2391-join-graph-sql-planner-erlang.md` — Pass
- Standalone system clean install green
- No Designer UI / where-clause rework

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.