### PR TITLE
feat(rest): POST /searches/{idOrName}/execute design-search façade (#2505)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -144,9 +144,8 @@ public class SearchAdaptor implements ISearchAdaptor {
       result.setSearchName(design.getName());
       result.setDisplayFormatId(design.getDisplayFormatId());
       return result;
-    } catch (IllegalArgumentException e) {
-      throw e;
     } catch (RuntimeException e) {
+      // IllegalArgumentException (400) and other runtime errors propagate to JAX-RS as-is
       throw e;
     } catch (Exception e) {
       log.error("Failed to execute search {}", idOrName, e);
@@ -303,8 +302,13 @@ public class SearchAdaptor implements ISearchAdaptor {
       log.debug("Skipping non-numeric content id from search row: {}", contentId);
       return null;
     } catch (Exception e) {
-      // Keep partial row so execute still returns engine hits when enrichment fails
-      log.debug("Could not enrich search result for content id {}: {}", contentId, e.toString());
+      // Keep partial row so execute still returns engine hits when enrichment fails.
+      // Expected gaps (checked/service) stay DEBUG; unexpected runtime at WARN for ops.
+      if (e instanceof RuntimeException) {
+        log.warn("Could not enrich search result for content id {}: {}", contentId, e.toString());
+      } else {
+        log.debug("Could not enrich search result for content id {}: {}", contentId, e.toString());
+      }
       item.setId(contentId);
     }
     return item;
@@ -342,8 +346,13 @@ public class SearchAdaptor implements ISearchAdaptor {
           return s;
         }
         if (s.getGUID() != null) {
+          // IPSGuid has no Optional string; guard blank/sentinel toString before match
           String gsv = s.getGUID().toString();
-          if (key.equalsIgnoreCase(gsv)) {
+          if (StringUtils.isNotBlank(gsv) && key.equalsIgnoreCase(gsv)) {
+            return s;
+          }
+          String untyped = s.getGUID().toStringUntyped();
+          if (StringUtils.isNotBlank(untyped) && key.equalsIgnoreCase(untyped)) {
             return s;
           }
         }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -10,26 +10,49 @@ import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.rest.Guid;
 import com.percussion.rest.searches.ISearchAdaptor;
 import com.percussion.rest.searches.SearchDef;
+import com.percussion.rest.searches.SearchExecuteRequest;
+import com.percussion.rest.searches.SearchExecuteResult;
 import com.percussion.rest.searches.SearchFieldSummary;
+import com.percussion.rest.searches.SearchResultItem;
+import com.percussion.search.IPSExecutableSearch;
+import com.percussion.search.IPSSearchResultRow;
+import com.percussion.search.PSExecutableSearchFactory;
+import com.percussion.search.PSWSSearchResponse;
 import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.PSGuidUtils;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.data.PSItemProperties;
+import com.percussion.share.data.PSPagedObjectList;
+import com.percussion.share.service.IPSIdMapper;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
-/** Read-only CX search definition catalog (UI-06). */
+/**
+ * Read-only CX search definition catalog (UI-06) plus design-search execute façade for Explorer
+ * (#2505 / #2409 slice B).
+ */
 @PSSiteManageBean
 @Lazy
 public class SearchAdaptor implements ISearchAdaptor {
 
   private static final Logger log = LogManager.getLogger(SearchAdaptor.class);
+
+  /** Product default page size when design max is unset/unlimited and client omits maxResults. */
+  static final int DEFAULT_PAGE_SIZE = 25;
 
   private static final List<String> DESIGN_GAPS =
       List.of(
@@ -37,39 +60,29 @@ public class SearchAdaptor implements ISearchAdaptor {
           "Search field criterion editing not supported via this API",
           "Views are a separate catalog (Developer Views / UI-07)");
 
+  private static final List<String> RESULT_COLUMNS =
+      List.of("sys_contentid", "sys_title", "sys_contenttypename");
+
   private final IPSUiDesignWs designWs;
+  private final IPSFolderHelper folderHelper;
+  private final IPSIdMapper idMapper;
 
   @Autowired
-  public SearchAdaptor(IPSUiDesignWs designWs) {
+  public SearchAdaptor(
+      IPSUiDesignWs designWs, IPSFolderHelper folderHelper, IPSIdMapper idMapper) {
     this.designWs = designWs;
+    this.folderHelper = folderHelper;
+    this.idMapper = idMapper;
   }
 
   @Override
   public List<SearchDef> listSearches() {
     try {
-      List<IPSCatalogSummary> summaries = designWs.findSearches(null, null);
-      if (summaries == null || summaries.isEmpty()) {
-        return List.of();
-      }
-      List<IPSGuid> guids = new ArrayList<>();
-      for (IPSCatalogSummary sum : summaries) {
-        if (sum != null && sum.getGUID() != null) {
-          guids.add(sum.getGUID());
-        }
-      }
-      if (guids.isEmpty()) {
-        return List.of();
-      }
-      String currentUser = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
-      String currentSession = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
-      List<PSSearch> loaded =
-          designWs.loadSearches(guids, false, false, currentSession, currentUser);
+      List<PSSearch> loaded = loadAllSearches();
       List<SearchDef> out = new ArrayList<>();
-      if (loaded != null) {
-        for (PSSearch s : loaded) {
-          if (s != null) {
-            out.add(toDef(s));
-          }
+      for (PSSearch s : loaded) {
+        if (s != null) {
+          out.add(toDef(s));
         }
       }
       out.sort(
@@ -87,17 +100,249 @@ public class SearchAdaptor implements ISearchAdaptor {
     if (!isSafeSearchKey(idOrName)) {
       return null;
     }
-    String key = idOrName.trim();
     try {
-      for (SearchDef s : listSearches()) {
+      PSSearch found = findPsSearchByKey(idOrName.trim());
+      return found != null ? toDef(found) : null;
+    } catch (RuntimeException e) {
+      // list failures already wrap; propagate for 500
+      throw e;
+    }
+  }
+
+  @Override
+  public SearchExecuteResult executeSearch(String idOrName, SearchExecuteRequest request) {
+    if (!isSafeSearchKey(idOrName)) {
+      return null;
+    }
+    SearchExecuteRequest effective = normalizeRequest(request);
+    try {
+      PSSearch design = findPsSearchByKey(idOrName.trim());
+      if (design == null) {
+        return null;
+      }
+      if (design.isCustomSearch()) {
+        throw new IllegalArgumentException(
+            "Custom URL searches cannot be executed via this endpoint");
+      }
+
+      // Clone so folder/max overrides do not dirty a shared design instance
+      PSSearch search = (PSSearch) design.clone();
+      applyExecuteOverrides(search, effective);
+
+      List<SearchResultItem> allItems = runDesignSearch(search);
+      sortItems(allItems, effective.getSortColumn(), effective.getSortOrder());
+
+      int startIndex = effective.getStartIndex() != null ? effective.getStartIndex() : 1;
+      Integer maxResults = effective.getMaxResults();
+      PSPagedObjectList<SearchResultItem> page =
+          PSPagedObjectList.getPage(allItems, startIndex, maxResults);
+
+      SearchExecuteResult result = new SearchExecuteResult();
+      result.setChildren(new ArrayList<>(page.getChildrenInPage()));
+      result.setTotalCount(page.getChildrenCount() != null ? page.getChildrenCount() : allItems.size());
+      result.setStartIndex(page.getStartIndex() != null ? page.getStartIndex() : startIndex);
+      result.setSearchName(design.getName());
+      result.setDisplayFormatId(design.getDisplayFormatId());
+      return result;
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to execute search {}", idOrName, e);
+      throw new IllegalStateException("Failed to execute search", e);
+    }
+  }
+
+  /**
+   * Normalize and validate optional execute overrides. Returns a non-null request with defaults
+   * applied where needed for validation only (maxResults default applied later from design when
+   * client omits it).
+   */
+  static SearchExecuteRequest normalizeRequest(SearchExecuteRequest request) {
+    SearchExecuteRequest out = request != null ? request : new SearchExecuteRequest();
+    Integer start = out.getStartIndex();
+    if (start != null && start < 1) {
+      throw new IllegalArgumentException("startIndex must be >= 1");
+    }
+    Integer max = out.getMaxResults();
+    if (max != null && max < 1) {
+      throw new IllegalArgumentException("maxResults must be >= 1");
+    }
+    String sortOrder = out.getSortOrder();
+    if (StringUtils.isNotBlank(sortOrder)) {
+      String trimmed = sortOrder.trim().toLowerCase(Locale.ROOT);
+      if (!"asc".equals(trimmed) && !"desc".equals(trimmed)) {
+        throw new IllegalArgumentException("sortOrder must be asc or desc");
+      }
+      out.setSortOrder(trimmed);
+    }
+    if (StringUtils.isNotBlank(out.getSortColumn())) {
+      out.setSortColumn(out.getSortColumn().trim());
+    }
+    if (StringUtils.isNotBlank(out.getFolderPath())) {
+      out.setFolderPath(out.getFolderPath().trim());
+    }
+    return out;
+  }
+
+  static void applyExecuteOverrides(PSSearch search, SearchExecuteRequest req) {
+    if (req == null || search == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(req.getFolderPath())) {
+      search.setProperty(PSSearch.PROP_FOLDER_PATH, req.getFolderPath().trim());
+      // Default recurse when client scopes by folder (Explorer parity)
+      if (StringUtils.isBlank(search.getProperty(PSSearch.PROP_FOLDER_PATH_RECURSE))) {
+        search.setProperty(PSSearch.PROP_FOLDER_PATH_RECURSE, "true");
+      }
+    }
+    if (req.getMaxResults() != null && req.getMaxResults() >= 1) {
+      search.setMaximumNumber(req.getMaxResults());
+    } else if (search.getMaximumResultSize() <= 0) {
+      // Unlimited / unset design max → product default page size for execute
+      search.setMaximumNumber(DEFAULT_PAGE_SIZE);
+    }
+  }
+
+  static void sortItems(List<SearchResultItem> items, String sortColumn, String sortOrder) {
+    if (items == null || items.isEmpty() || StringUtils.isBlank(sortColumn)) {
+      return;
+    }
+    String col = sortColumn.trim().toLowerCase(Locale.ROOT);
+    int dir = "desc".equalsIgnoreCase(StringUtils.defaultString(sortOrder)) ? -1 : 1;
+    Comparator<String> nullSafe = Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER);
+    Comparator<SearchResultItem> cmp;
+    if ("sys_title".equals(col) || "title".equals(col) || "name".equals(col)) {
+      cmp =
+          Comparator.comparing(
+              i -> StringUtils.defaultIfBlank(i.getTitle(), i.getName()), nullSafe);
+    } else if ("type".equals(col) || "sys_contenttypename".equals(col)) {
+      cmp = Comparator.comparing(SearchResultItem::getType, nullSafe);
+    } else if ("folderpath".equals(col) || "path".equals(col)) {
+      cmp = Comparator.comparing(SearchResultItem::getFolderPath, nullSafe);
+    } else {
+      // Unsupported sort column: leave natural order (engine order)
+      return;
+    }
+    if (dir < 0) {
+      cmp = cmp.reversed();
+    }
+    items.sort(cmp);
+  }
+
+  /**
+   * Execute the design {@link PSSearch} via the local executable search path (operators preserved).
+   * Package-visible for unit tests that subclass/spy can override.
+   */
+  List<SearchResultItem> runDesignSearch(PSSearch search) throws Exception {
+    var request = PSWebserviceUtils.getRequest();
+    if (request == null) {
+      throw new IllegalStateException("No active request context for search execute");
+    }
+    IPSExecutableSearch executable =
+        PSExecutableSearchFactory.createExecutableSearch(request, RESULT_COLUMNS, search);
+    PSWSSearchResponse response = executable.executeSearch();
+    return mapSearchResponse(response);
+  }
+
+  List<SearchResultItem> mapSearchResponse(PSWSSearchResponse response) {
+    List<SearchResultItem> out = new ArrayList<>();
+    if (response == null) {
+      return out;
+    }
+    Iterator<IPSSearchResultRow> rows = response.getRows();
+    while (rows != null && rows.hasNext()) {
+      IPSSearchResultRow row = rows.next();
+      if (row == null) {
+        continue;
+      }
+      SearchResultItem item = mapResultRow(row);
+      if (item != null) {
+        out.add(item);
+      }
+    }
+    return out;
+  }
+
+  SearchResultItem mapResultRow(IPSSearchResultRow row) {
+    String contentId = row.getColumnValue("sys_contentid");
+    if (StringUtils.isBlank(contentId)) {
+      return null;
+    }
+    SearchResultItem item = new SearchResultItem();
+    String title = row.getColumnValue("sys_title");
+    String type = row.getColumnValue("sys_contenttypename");
+    item.setName(title);
+    item.setTitle(title);
+    item.setType(type);
+
+    try {
+      var myGuid = PSGuidUtils.makeGuid(Integer.parseInt(contentId.trim()), PSTypeEnum.LEGACY_CONTENT);
+      String stringId = idMapper.getString(myGuid);
+      item.setId(stringId);
+      if (folderHelper.getParentFolderId(myGuid, false) == null) {
+        log.debug(
+            "Item (id = {}) is not in a folder. It will not be included in the search results.",
+            contentId);
+        return null;
+      }
+      PSItemProperties props = folderHelper.findItemPropertiesById(stringId);
+      if (props != null) {
+        item.setId(props.getId() != null ? props.getId() : stringId);
+        item.setName(StringUtils.defaultIfBlank(props.getName(), title));
+        item.setTitle(
+            StringUtils.defaultIfBlank(
+                props.getSummary(), StringUtils.defaultIfBlank(props.getName(), title)));
+        item.setFolderPath(props.getPath());
+        if (StringUtils.isNotBlank(props.getType())) {
+          item.setType(props.getType());
+        }
+      }
+    } catch (NumberFormatException nfe) {
+      log.debug("Skipping non-numeric content id from search row: {}", contentId);
+      return null;
+    } catch (Exception e) {
+      // Keep partial row so execute still returns engine hits when enrichment fails
+      log.debug("Could not enrich search result for content id {}: {}", contentId, e.toString());
+      item.setId(contentId);
+    }
+    return item;
+  }
+
+  private List<PSSearch> loadAllSearches() throws Exception {
+    List<IPSCatalogSummary> summaries = designWs.findSearches(null, null);
+    if (summaries == null || summaries.isEmpty()) {
+      return List.of();
+    }
+    List<IPSGuid> guids = new ArrayList<>();
+    for (IPSCatalogSummary sum : summaries) {
+      if (sum != null && sum.getGUID() != null) {
+        guids.add(sum.getGUID());
+      }
+    }
+    if (guids.isEmpty()) {
+      return List.of();
+    }
+    String currentUser = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+    String currentSession = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+    List<PSSearch> loaded = designWs.loadSearches(guids, false, false, currentSession, currentUser);
+    return loaded != null ? loaded : List.of();
+  }
+
+  /** Resolve design search by name, GUID string, or numeric id. */
+  PSSearch findPsSearchByKey(String key) {
+    try {
+      List<PSSearch> loaded = loadAllSearches();
+      for (PSSearch s : loaded) {
         if (s == null) {
           continue;
         }
         if (key.equalsIgnoreCase(s.getName())) {
           return s;
         }
-        if (s.getGuid() != null) {
-          String gsv = s.getGuid().getStringValue().orElse(null);
+        if (s.getGUID() != null) {
+          String gsv = s.getGUID().toString();
           if (key.equalsIgnoreCase(gsv)) {
             return s;
           }
@@ -107,9 +352,9 @@ public class SearchAdaptor implements ISearchAdaptor {
         }
       }
       return null;
-    } catch (RuntimeException e) {
-      // list failures already wrap; propagate for 500
-      throw e;
+    } catch (Exception e) {
+      log.error("Failed to resolve search {}", key, e);
+      throw new IllegalStateException("Failed to resolve search", e);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
@@ -233,6 +233,32 @@ class SearchAdaptorExecuteTest {
     assertFalse(SearchAdaptor.isSafeSearchKey("a\\b"));
   }
 
+  @Test
+  void findPsSearchByKey_matchesGuidStringAndUntyped() throws Exception {
+    PSSearch s = mockSearch("ByGuid", false, true);
+    stubLoadedSearches(List.of(s));
+    // stubLoadedSearches attaches GUID "0-301-0"; add untyped for dual-key match
+    IPSGuid g = s.getGUID();
+    when(g.toStringUntyped()).thenReturn("42");
+
+    assertEquals(s, adaptor.findPsSearchByKey("0-301-0"));
+    assertEquals(s, adaptor.findPsSearchByKey("42"));
+  }
+
+  @Test
+  void findPsSearchByKey_skipsBlankGuidString() throws Exception {
+    PSSearch s = mockSearch("BlankGuid", false, true);
+    stubLoadedSearches(List.of(s));
+    IPSGuid g = s.getGUID();
+    when(g.toString()).thenReturn("   ");
+    when(g.toStringUntyped()).thenReturn("");
+    when(s.getId()).thenReturn(99);
+
+    // blank GUID tokens must not match; numeric id still works
+    assertNull(adaptor.findPsSearchByKey("   "));
+    assertEquals(s, adaptor.findPsSearchByKey("99"));
+  }
+
   private static SearchResultItem item(String id, String title) {
     SearchResultItem i = new SearchResultItem();
     i.setId(id);

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.rest.searches.SearchExecuteRequest;
+import com.percussion.rest.searches.SearchExecuteResult;
+import com.percussion.rest.searches.SearchResultItem;
+import com.percussion.search.IPSSearchResultRow;
+import com.percussion.search.PSWSSearchResponse;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class SearchAdaptorExecuteTest {
+
+  private IPSUiDesignWs designWs;
+  private IPSFolderHelper folderHelper;
+  private IPSIdMapper idMapper;
+  private SearchAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() {
+    designWs = mock(IPSUiDesignWs.class);
+    folderHelper = mock(IPSFolderHelper.class);
+    idMapper = mock(IPSIdMapper.class);
+    adaptor = spy(new SearchAdaptor(designWs, folderHelper, idMapper));
+  }
+
+  @Test
+  void normalizeRequest_nullBecomesEmpty() {
+    SearchExecuteRequest n = SearchAdaptor.normalizeRequest(null);
+    assertNotNull(n);
+    assertNull(n.getStartIndex());
+    assertNull(n.getMaxResults());
+  }
+
+  @Test
+  void normalizeRequest_rejectsBadStartIndex() {
+    SearchExecuteRequest r = new SearchExecuteRequest();
+    r.setStartIndex(0);
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.normalizeRequest(r));
+  }
+
+  @Test
+  void normalizeRequest_rejectsBadMaxResults() {
+    SearchExecuteRequest r = new SearchExecuteRequest();
+    r.setMaxResults(0);
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.normalizeRequest(r));
+  }
+
+  @Test
+  void normalizeRequest_rejectsBadSortOrder() {
+    SearchExecuteRequest r = new SearchExecuteRequest();
+    r.setSortOrder("sideways");
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.normalizeRequest(r));
+  }
+
+  @Test
+  void normalizeRequest_normalizesSortOrderCase() {
+    SearchExecuteRequest r = new SearchExecuteRequest();
+    r.setSortOrder("DESC");
+    assertEquals("desc", SearchAdaptor.normalizeRequest(r).getSortOrder());
+  }
+
+  @Test
+  void applyExecuteOverrides_folderAndMax() {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getMaximumResultSize()).thenReturn(100);
+    when(s.getProperty(PSSearch.PROP_FOLDER_PATH_RECURSE)).thenReturn(null);
+
+    SearchExecuteRequest r = new SearchExecuteRequest();
+    r.setFolderPath("//Sites/Demo");
+    r.setMaxResults(10);
+    SearchAdaptor.applyExecuteOverrides(s, r);
+
+    verify(s).setProperty(PSSearch.PROP_FOLDER_PATH, "//Sites/Demo");
+    verify(s).setProperty(PSSearch.PROP_FOLDER_PATH_RECURSE, "true");
+    verify(s).setMaximumNumber(10);
+  }
+
+  @Test
+  void applyExecuteOverrides_defaultsUnlimitedMax() {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getMaximumResultSize()).thenReturn(0);
+    SearchAdaptor.applyExecuteOverrides(s, new SearchExecuteRequest());
+    verify(s).setMaximumNumber(SearchAdaptor.DEFAULT_PAGE_SIZE);
+  }
+
+  @Test
+  void sortItems_byTitleDesc() {
+    List<SearchResultItem> items = new ArrayList<>();
+    items.add(item("1", "Alpha"));
+    items.add(item("2", "Charlie"));
+    items.add(item("3", "Bravo"));
+    SearchAdaptor.sortItems(items, "sys_title", "desc");
+    assertEquals("Charlie", items.get(0).getTitle());
+    assertEquals("Bravo", items.get(1).getTitle());
+    assertEquals("Alpha", items.get(2).getTitle());
+  }
+
+  @Test
+  void executeSearch_unsafeKeyReturnsNull() {
+    assertNull(adaptor.executeSearch("../x", new SearchExecuteRequest()));
+    assertNull(adaptor.executeSearch("a/b", null));
+    assertNull(adaptor.executeSearch(null, null));
+  }
+
+  @Test
+  void executeSearch_missingReturnsNull() throws Exception {
+    when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
+    assertNull(adaptor.executeSearch("Missing", new SearchExecuteRequest()));
+  }
+
+  @Test
+  void executeSearch_customUrlThrows400Style() throws Exception {
+    PSSearch custom = mockSearch("Custom", true, false);
+    stubLoadedSearches(List.of(custom));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.executeSearch("Custom", new SearchExecuteRequest()));
+    assertTrue(ex.getMessage().toLowerCase().contains("custom"));
+  }
+
+  @Test
+  void executeSearch_happyPathPagesAndMaps() throws Exception {
+    PSSearch design = mockSearch("All Content", false, true);
+    when(design.getDisplayFormatId()).thenReturn("0-1-1");
+    when(design.getMaximumResultSize()).thenReturn(100);
+    when(design.clone()).thenReturn(design);
+    stubLoadedSearches(List.of(design));
+
+    SearchResultItem a = item("id-a", "A");
+    SearchResultItem b = item("id-b", "B");
+    SearchResultItem c = item("id-c", "C");
+    doReturn(List.of(a, b, c)).when(adaptor).runDesignSearch(any(PSSearch.class));
+
+    SearchExecuteRequest req = new SearchExecuteRequest();
+    req.setStartIndex(2);
+    req.setMaxResults(1);
+    SearchExecuteResult result = adaptor.executeSearch("All Content", req);
+
+    assertNotNull(result);
+    assertEquals("All Content", result.getSearchName());
+    assertEquals("0-1-1", result.getDisplayFormatId());
+    assertEquals(3, result.getTotalCount());
+    assertEquals(2, result.getStartIndex());
+    assertEquals(1, result.getChildren().size());
+    assertEquals("B", result.getChildren().get(0).getTitle());
+  }
+
+  @Test
+  void executeSearch_emptyResults() throws Exception {
+    PSSearch design = mockSearch("Empty", false, true);
+    when(design.getDisplayFormatId()).thenReturn("0-1-1");
+    when(design.getMaximumResultSize()).thenReturn(25);
+    when(design.clone()).thenReturn(design);
+    stubLoadedSearches(List.of(design));
+    doReturn(List.of()).when(adaptor).runDesignSearch(any(PSSearch.class));
+
+    SearchExecuteResult result = adaptor.executeSearch("Empty", null);
+    assertNotNull(result);
+    assertEquals(0, result.getTotalCount());
+    assertTrue(result.getChildren().isEmpty());
+    assertEquals(1, result.getStartIndex());
+  }
+
+  @Test
+  void mapSearchResponse_skipsNullMappedRowsAndKeepsItems() {
+    IPSSearchResultRow blank = mock(IPSSearchResultRow.class);
+    IPSSearchResultRow ok = mock(IPSSearchResultRow.class);
+
+    // Stub row mapping so this unit test does not depend on PSGuidUtils/static CMS context
+    doReturn(null).when(adaptor).mapResultRow(blank);
+    SearchResultItem kept = item("guid-42", "Title");
+    kept.setFolderPath("/Sites/Demo");
+    kept.setType("Page");
+    doReturn(kept).when(adaptor).mapResultRow(ok);
+
+    PSWSSearchResponse response = mock(PSWSSearchResponse.class);
+    when(response.getRows()).thenReturn(List.of(blank, ok).iterator());
+
+    List<SearchResultItem> mapped = adaptor.mapSearchResponse(response);
+    assertEquals(1, mapped.size());
+    assertEquals("guid-42", mapped.get(0).getId());
+    assertEquals("/Sites/Demo", mapped.get(0).getFolderPath());
+    assertEquals("Page", mapped.get(0).getType());
+  }
+
+  @Test
+  void mapResultRow_blankContentIdReturnsNull() {
+    IPSSearchResultRow blank = mock(IPSSearchResultRow.class);
+    when(blank.getColumnValue("sys_contentid")).thenReturn("  ");
+    assertNull(adaptor.mapResultRow(blank));
+  }
+
+  @Test
+  void mapSearchResponse_nullSafe() {
+    assertTrue(adaptor.mapSearchResponse(null).isEmpty());
+  }
+
+  @Test
+  void isSafeSearchKey_stillHoldsForExecutePath() {
+    assertTrue(SearchAdaptor.isSafeSearchKey("All Content"));
+    assertFalse(SearchAdaptor.isSafeSearchKey("a\\b"));
+  }
+
+  private static SearchResultItem item(String id, String title) {
+    SearchResultItem i = new SearchResultItem();
+    i.setId(id);
+    i.setName(title);
+    i.setTitle(title);
+    return i;
+  }
+
+  private PSSearch mockSearch(String name, boolean custom, boolean standard) {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getName()).thenReturn(name);
+    when(s.isCustomSearch()).thenReturn(custom);
+    when(s.isStandardSearch()).thenReturn(standard);
+    when(s.getId()).thenReturn(10);
+    when(s.getGUID()).thenReturn(null);
+    return s;
+  }
+
+  private void stubLoadedSearches(List<PSSearch> searches) throws Exception {
+    List<IPSCatalogSummary> summaries = new ArrayList<>();
+    List<IPSGuid> guids = new ArrayList<>();
+    for (int i = 0; i < searches.size(); i++) {
+      IPSGuid g = mock(IPSGuid.class);
+      when(g.toString()).thenReturn("0-301-" + i);
+      IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+      when(sum.getGUID()).thenReturn(g);
+      summaries.add(sum);
+      guids.add(g);
+      PSSearch s = searches.get(i);
+      when(s.getGUID()).thenReturn(g);
+    }
+    when(designWs.findSearches(isNull(), isNull())).thenReturn(summaries);
+    when(designWs.loadSearches(anyList(), eq(false), eq(false), isNull(), isNull()))
+        .thenReturn(searches);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/searches/ISearchAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/searches/ISearchAdaptor.java
@@ -6,11 +6,23 @@ package com.percussion.rest.searches;
 
 import java.util.List;
 
-/** Adaptor for CX search design catalog (UI-06 read). */
+/** Adaptor for CX search design catalog (UI-06 read) and design-search execute façade. */
 public interface ISearchAdaptor {
 
   List<SearchDef> listSearches();
 
   /** Resolve by name or GUID string. Returns null if missing/unsafe. */
   SearchDef findSearchByKey(String idOrName);
+
+  /**
+   * Execute a design search by name, GUID string, or numeric id with optional scope/paging
+   * overrides. Preserves design field operators (unlike equality-only searchmanagement criteria).
+   *
+   * @param idOrName search key (same rules as {@link #findSearchByKey})
+   * @param request optional overrides; {@code null} treated as empty defaults by implementations
+   * @return paged results, or {@code null} when the search is missing/unsafe
+   * @throws IllegalArgumentException when the body is invalid or the search type cannot be executed
+   *     (e.g. custom URL searches)
+   */
+  SearchExecuteResult executeSearch(String idOrName, SearchExecuteRequest request);
 }

--- a/rest/src/main/java/com/percussion/rest/searches/SearchExecuteRequest.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchExecuteRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Optional overrides for {@code POST /rest/searches/{idOrName}/execute}.
+ *
+ * <p>v1 does not accept a full field-criteria rewrite — design operators live on the loaded {@code
+ * PSSearch}. Clients may only scope, page, and sort.
+ */
+@XmlRootElement(name = "SearchExecuteRequest")
+@Schema(description = "Optional overrides when executing a CX design search by id or name")
+public class SearchExecuteRequest {
+
+  private String folderPath;
+  private Integer startIndex;
+  private Integer maxResults;
+  private String sortColumn;
+  private String sortOrder;
+
+  public String getFolderPath() {
+    return folderPath;
+  }
+
+  public void setFolderPath(String folderPath) {
+    this.folderPath = folderPath;
+  }
+
+  public Integer getStartIndex() {
+    return startIndex;
+  }
+
+  public void setStartIndex(Integer startIndex) {
+    this.startIndex = startIndex;
+  }
+
+  public Integer getMaxResults() {
+    return maxResults;
+  }
+
+  public void setMaxResults(Integer maxResults) {
+    this.maxResults = maxResults;
+  }
+
+  public String getSortColumn() {
+    return sortColumn;
+  }
+
+  public void setSortColumn(String sortColumn) {
+    this.sortColumn = sortColumn;
+  }
+
+  public String getSortOrder() {
+    return sortOrder;
+  }
+
+  public void setSortOrder(String sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/searches/SearchExecuteResult.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchExecuteResult.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Paged result envelope for {@code POST /rest/searches/{idOrName}/execute}. */
+@XmlRootElement(name = "SearchExecuteResult")
+@Schema(description = "Paged Explorer-ready results from executing a CX design search")
+public class SearchExecuteResult {
+
+  private List<SearchResultItem> children = new ArrayList<>();
+  private int totalCount;
+  private int startIndex = 1;
+  private String searchName;
+  private String displayFormatId;
+
+  public List<SearchResultItem> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<SearchResultItem> children) {
+    this.children = children != null ? children : new ArrayList<>();
+  }
+
+  public int getTotalCount() {
+    return totalCount;
+  }
+
+  public void setTotalCount(int totalCount) {
+    this.totalCount = totalCount;
+  }
+
+  public int getStartIndex() {
+    return startIndex;
+  }
+
+  public void setStartIndex(int startIndex) {
+    this.startIndex = startIndex;
+  }
+
+  public String getSearchName() {
+    return searchName;
+  }
+
+  public void setSearchName(String searchName) {
+    this.searchName = searchName;
+  }
+
+  public String getDisplayFormatId() {
+    return displayFormatId;
+  }
+
+  public void setDisplayFormatId(String displayFormatId) {
+    this.displayFormatId = displayFormatId;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -23,14 +25,14 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only CX search catalog for the Developer module (UI-06 list/detail).
+ * CX search design catalog (UI-06 list/detail) plus design-search execute façade for Explorer.
  *
- * <p>Views (UI-07) remain a separate later slice.
+ * <p>Views (UI-07) remain a separate catalog.
  */
 @PSSiteManageBean(value = "restSearchResource")
 @Path("/searches")
 @XmlRootElement
-@Tag(name = "Searches", description = "CX search design catalog (read-only)")
+@Tag(name = "Searches", description = "CX search design catalog and design-search execute")
 public class SearchResource {
 
   private final ISearchAdaptor adaptor;
@@ -98,6 +100,49 @@ public class SearchResource {
     } catch (WebApplicationException e) {
       // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Execute a saved/standard design search with full field operators. Path is multi-segment so it
+   * does not collide with {@code GET /{idOrName}} catalog detail.
+   */
+  @POST
+  @Path("/{idOrName}/execute")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Execute a design search",
+      description =
+          "Loads the CX search design by name, GUID, or id and executes it server-side with"
+              + " design field operators, display format, max results, and case sensitivity."
+              + " Optional body may override folder scope, paging, and sort. Custom URL searches"
+              + " return 400.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = SearchExecuteResult.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid body or unsupported search type"),
+        @ApiResponse(responseCode = "404", description = "Search not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SearchExecuteResult executeSearch(
+      @PathParam("idOrName") String idOrName, SearchExecuteRequest body) {
+    try {
+      SearchExecuteResult result = requireAdaptor().executeSearch(idOrName, body);
+      if (result == null) {
+        throw new WebApplicationException("Search not found", 404);
+      }
+      return result;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid execute request", 400);
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }

--- a/rest/src/main/java/com/percussion/rest/searches/SearchResultItem.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchResultItem.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * One result row from design-search execute, shaped for Explorer open/reveal (id, title/name,
+ * folderPath, type).
+ */
+@XmlRootElement(name = "SearchResultItem")
+@Schema(description = "Explorer-ready item row from a design search execute")
+public class SearchResultItem {
+
+  private String id;
+  private String name;
+  private String title;
+  private String folderPath;
+  private String type;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getFolderPath() {
+    return folderPath;
+  }
+
+  public void setFolderPath(String folderPath) {
+    this.folderPath = folderPath;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
@@ -8,7 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -113,5 +115,76 @@ public class SearchResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getSearch("All Content"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void executeSearchSuccess() {
+    SearchExecuteRequest req = new SearchExecuteRequest();
+    req.setStartIndex(1);
+    req.setMaxResults(10);
+    SearchExecuteResult expected = new SearchExecuteResult();
+    expected.setSearchName("All Content");
+    expected.setTotalCount(0);
+    when(adaptor.executeSearch(eq("All Content"), eq(req))).thenReturn(expected);
+
+    SearchExecuteResult out = resource.executeSearch("All Content", req);
+    assertSame(expected, out);
+    assertEquals("All Content", out.getSearchName());
+    verify(adaptor).executeSearch("All Content", req);
+  }
+
+  @Test
+  public void executeSearchNullBodyDelegates() {
+    SearchExecuteResult expected = new SearchExecuteResult();
+    expected.setSearchName("All Content");
+    when(adaptor.executeSearch(eq("All Content"), isNull())).thenReturn(expected);
+
+    assertEquals("All Content", resource.executeSearch("All Content", null).getSearchName());
+    verify(adaptor).executeSearch("All Content", null);
+  }
+
+  @Test
+  public void executeSearchNotFoundIsGeneric404() {
+    when(adaptor.executeSearch(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.executeSearch("missing", new SearchExecuteRequest()));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertEquals("Search not found", ex.getMessage());
+  }
+
+  @Test
+  public void executeSearchMapsIllegalArgumentTo400() {
+    when(adaptor.executeSearch(eq("Custom"), any()))
+        .thenThrow(new IllegalArgumentException("Custom URL searches cannot be executed"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.executeSearch("Custom", new SearchExecuteRequest()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("Custom URL"));
+  }
+
+  @Test
+  public void executeSearchWrapsUnexpectedAs500() {
+    IllegalStateException boom = new IllegalStateException("engine down");
+    when(adaptor.executeSearch(eq("All Content"), any())).thenThrow(boom);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.executeSearch("All Content", new SearchExecuteRequest()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnExecute() {
+    SearchResource bare = new SearchResource();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> bare.executeSearch("any", new SearchExecuteRequest()));
+    assertEquals(503, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
@@ -19,6 +19,8 @@ package com.percussion.rest.test.apibridge;
 
 import com.percussion.rest.searches.ISearchAdaptor;
 import com.percussion.rest.searches.SearchDef;
+import com.percussion.rest.searches.SearchExecuteRequest;
+import com.percussion.rest.searches.SearchExecuteResult;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -34,5 +36,14 @@ public class TestSearchAdaptor implements ISearchAdaptor {
   @Override
   public SearchDef findSearchByKey(String idOrName) {
     return null;
+  }
+
+  @Override
+  public SearchExecuteResult executeSearch(String idOrName, SearchExecuteRequest request) {
+    SearchExecuteResult empty = new SearchExecuteResult();
+    empty.setChildren(List.of());
+    empty.setTotalCount(0);
+    empty.setStartIndex(1);
+    return empty;
   }
 }


### PR DESCRIPTION
## Summary

Implements **#2409 slice B** (grandparent **#2400**): public design-search execute façade per `specs/2400-dce-explorer-parity/research/saved-search-execute-disposition.md` (**Disposition: Façade**).

### Public contract

`POST /rest/searches/{idOrName}/execute` with optional JSON body:

- `folderPath`, `startIndex`, `maxResults`, `sortColumn`, `sortOrder`

Returns `SearchExecuteResult` (`children`, `totalCount`, `startIndex`, `searchName`, `displayFormatId`) with Explorer-ready `SearchResultItem` rows (`id`, `name`, `title`, `folderPath`, `type`).

### Companion closure

| Layer | Change |
|-------|--------|
| rest DTOs | `SearchExecuteRequest`, `SearchExecuteResult`, `SearchResultItem` |
| rest interface | `ISearchAdaptor.executeSearch` |
| rest resource | `SearchResource` POST `/{idOrName}/execute` (400/404/503/500) |
| rest tests | Mockito `SearchResourceTest` (15 tests) |
| rest Spring stub | `TestSearchAdaptor.executeSearch` |
| sitemanage | `SearchAdaptor.executeSearch` via `PSExecutableSearchFactory` (operators preserved) |
| sitemanage tests | `SearchAdaptorExecuteTest` (17 tests) + existing map/safe-key |

Safe key handling reuses `isSafeSearchKey`. Custom URL searches return **400**. Missing/unsafe keys → **404**.

### Out of scope (siblings)

- Explorer picker UI → **#2506**
- Playwright → **#2507**

## Test plan

- [x] `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (Tests run: 887, Failures: 0)
- [x] `SearchResourceTest` — Tests run: 15, Failures: 0
- [x] `SearchAdaptorExecuteTest` — Tests run: 17, Failures: 0
- [x] No new compiler/surefire warnings attributable to this change
- [ ] CI green on PR

## Gates evidence

- Erlang-style self-review: no path I/O; no secrets; companion closure complete; key injection hygiene retained
- Standalone module clean installs only (no reactor `-am`)
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2505  
Parent tracker: #2409

> Co-Authored by Grok Build using grok-4.5 with agent main.
