### PR TITLE
feat(profile): Preferences section (landing + PreferenceResource) (#2396)

### DIFF
--- a/WebUI/src/main/ts/api/developer/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/developer/preferencesApi.ts
@@ -15,8 +15,11 @@
  * limitations under the License.
  */
 
-import { get, put, type ApiError } from "../client";
-import { PATHS } from "../paths";
+import {
+  loadUserPreference,
+  saveUserPreference,
+  type UserPreference,
+} from "../preferences/preferencesApi";
 import {
   DEFAULT_ACL_TEMPLATE_PREF_CATEGORY,
   DEFAULT_ACL_TEMPLATE_PREF_CONTEXT,
@@ -27,56 +30,9 @@ import {
   type DefaultAclTemplate,
 } from "../../developer/defaultAclTemplate";
 
-/** REST UserPreference DTO (PreferenceResource). */
-export type UserPreference = {
-  name: string;
-  value: string;
-  category?: string;
-  context?: string;
-  userName?: string;
-  extraParam?: string;
-};
-
-function isNotFound(err: unknown): boolean {
-  const api = err as ApiError;
-  return !!api && typeof api.status === "number" && api.status === 404;
-}
-
-/**
- * GET /services/preferences/{preference}
- *
- * @returns null when the preference is not stored (404)
- */
-export async function loadUserPreference(
-  preferenceName: string,
-): Promise<UserPreference | null> {
-  const key = encodeURIComponent(preferenceName);
-  try {
-    return await get<UserPreference>(`${PATHS.PREFERENCES}/${key}`);
-  } catch (err: unknown) {
-    if (isNotFound(err)) return null;
-    throw err;
-  }
-}
-
-/**
- * PUT /services/preferences/ — save a single preference for the current user.
- *
- * <p>{@code userName} must be set (server requires it on the DTO).
- */
-export async function saveUserPreference(
-  pref: UserPreference,
-): Promise<UserPreference> {
-  // PreferenceResource is @Path("/preferences") with @PUT @Path("/") on save.
-  return put<UserPreference>(PATHS.PREFERENCES, {
-    name: pref.name,
-    value: pref.value ?? "",
-    category: pref.category || DEFAULT_ACL_TEMPLATE_PREF_CATEGORY,
-    context: pref.context || DEFAULT_ACL_TEMPLATE_PREF_CONTEXT,
-    userName: pref.userName ?? "",
-    extraParam: pref.extraParam,
-  });
-}
+/** Re-export shared PreferenceResource DTO + load/save for Developer callers. */
+export type { UserPreference };
+export { loadUserPreference, saveUserPreference };
 
 export type LoadDefaultAclTemplateResult = {
   /** Effective template (system default when no valid stored pref). */

--- a/WebUI/src/main/ts/api/preferences/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/preferences/preferencesApi.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Client for public PreferenceResource ({@code /services/preferences}).
+ *
+ * <p>Shared by Developer ACL preferences and the profile Preferences section
+ * (#2396 / parent #2374). No parallel preference store — name/value prefs go
+ * through this REST + sitemanage {@code IPreferenceAdaptor} stack.</p>
+ *
+ * <p>Default CMS landing page is <em>not</em> stored here; it uses the existing
+ * user homepage REST ({@code /user/user/homepage}) already product-backed.</p>
+ */
+
+import { get, put, type ApiError } from "../client";
+import { PATHS } from "../paths";
+
+/** REST UserPreference DTO (PreferenceResource). */
+export type UserPreference = {
+  name: string;
+  value: string;
+  category?: string;
+  context?: string;
+  userName?: string;
+  extraParam?: string;
+};
+
+/** Default category PreferenceResource applies when omitted on save. */
+export const PREF_CATEGORY_SYS = "sys_preferences";
+
+/** Default private (per-user) context PreferenceResource applies when omitted. */
+export const PREF_CONTEXT_PRIVATE = "private";
+
+function isNotFound(err: unknown): boolean {
+  const api = err as ApiError;
+  return !!api && typeof api.status === "number" && api.status === 404;
+}
+
+function asPreferenceArray(data: unknown): UserPreference[] {
+  if (Array.isArray(data)) {
+    return data.filter(isUserPreferenceShape);
+  }
+  if (data != null && typeof data === "object") {
+    const root = data as Record<string, unknown>;
+    for (const key of [
+      "UserPreferenceList",
+      "userPreferenceList",
+      "list",
+      "items",
+    ]) {
+      const nested = root[key];
+      if (Array.isArray(nested)) {
+        return nested.filter(isUserPreferenceShape);
+      }
+    }
+  }
+  return [];
+}
+
+function isUserPreferenceShape(value: unknown): value is UserPreference {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const o = value as Record<string, unknown>;
+  return typeof o.name === "string";
+}
+
+/**
+ * GET /services/preferences/ — all stored prefs for the current user.
+ *
+ * @returns empty array when none stored (404) or body is empty
+ */
+export async function getAllUserPreferences(): Promise<UserPreference[]> {
+  try {
+    const data = await get<unknown>(PATHS.PREFERENCES);
+    return asPreferenceArray(data);
+  } catch (err: unknown) {
+    if (isNotFound(err)) {
+      return [];
+    }
+    throw err;
+  }
+}
+
+/**
+ * GET /services/preferences/{preference}
+ *
+ * @returns null when the preference is not stored (404)
+ */
+export async function loadUserPreference(
+  preferenceName: string,
+): Promise<UserPreference | null> {
+  const key = encodeURIComponent(preferenceName);
+  try {
+    return await get<UserPreference>(`${PATHS.PREFERENCES}/${key}`);
+  } catch (err: unknown) {
+    if (isNotFound(err)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * PUT /services/preferences/ — save a single preference for the current user.
+ *
+ * <p>{@code userName} should be set (server DTO requires it).</p>
+ */
+export async function saveUserPreference(
+  pref: UserPreference,
+): Promise<UserPreference> {
+  return put<UserPreference>(PATHS.PREFERENCES, {
+    name: pref.name,
+    value: pref.value ?? "",
+    category: pref.category || PREF_CATEGORY_SYS,
+    context: pref.context || PREF_CONTEXT_PRIVATE,
+    userName: pref.userName ?? "",
+    extraParam: pref.extraParam,
+  });
+}

--- a/WebUI/src/main/ts/api/user/userHomepageApi.ts
+++ b/WebUI/src/main/ts/api/user/userHomepageApi.ts
@@ -59,9 +59,10 @@ function asPlainString(data: unknown): string {
 
 /**
  * GET persisted override for a user. Returns {@code ""} when unset/invalid.
+ * Pass blank {@code userName} for the signed-in self endpoint.
  */
 export async function getUserHomepageOverride(
-  userName: string,
+  userName?: string,
 ): Promise<string> {
   const data = await get<unknown>(homepageUrl(userName));
   return asPlainString(data);
@@ -70,9 +71,10 @@ export async function getUserHomepageOverride(
 /**
  * PUT override. Blank {@code homepage} clears (role/Home fallback).
  * Returns the stored canonical type or {@code ""}.
+ * Pass blank {@code userName} for the signed-in self endpoint.
  */
 export async function setUserHomepageOverride(
-  userName: string,
+  userName: string | undefined,
   homepage: string,
 ): Promise<string> {
   const body = homepage == null ? "" : String(homepage).trim();
@@ -84,9 +86,24 @@ export async function setUserHomepageOverride(
   return asPlainString(data) || body;
 }
 
-/** DELETE override for a named user. */
+/** DELETE override for a named user (or self when name omitted). */
 export async function clearUserHomepageOverride(
-  userName: string,
+  userName?: string,
 ): Promise<void> {
   await del(homepageUrl(userName));
+}
+
+/** GET self default landing override (no user name on path — no IDOR). */
+export async function getMyHomepageOverride(): Promise<string> {
+  return getUserHomepageOverride();
+}
+
+/**
+ * PUT self default landing override. Blank clears to role/Home fallback.
+ * No user name on path — always the signed-in session user.
+ */
+export async function setMyHomepageOverride(
+  homepage: string,
+): Promise<string> {
+  return setUserHomepageOverride(undefined, homepage);
 }

--- a/WebUI/src/main/ts/profile/PreferencesSection.module.css
+++ b/WebUI/src/main/ts/profile/PreferencesSection.module.css
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.root {
+  margin-top: 0.25rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 32rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text, #181c2c);
+  line-height: 1.4;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #5b6478);
+  line-height: 1.4;
+}
+
+.select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--color-text, #181c2c);
+  background: var(--color-surface, #fff);
+}
+
+.select:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.85rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.primaryButton {
+  background: var(--color-primary, #4a6aa3);
+  color: #fff;
+  border-color: var(--color-primary, #4a6aa3);
+}
+
+.primaryButton:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.primaryButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.primaryButton:focus-visible,
+.secondaryButton:focus-visible {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 2px;
+}
+
+.secondaryButton {
+  background: var(--color-surface, #fff);
+  color: var(--color-primary, #4a6aa3);
+  border-color: var(--color-border, #d8dee9);
+}
+
+.muted {
+  margin: 0;
+  color: var(--color-text-muted, #5b6478);
+  line-height: 1.5;
+}
+
+.formError {
+  margin: 0;
+  color: var(--color-danger, #b42318);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.success {
+  margin: 0;
+  color: var(--color-success, #067647);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.statusRegion {
+  margin-top: 0.25rem;
+  min-height: 1.25rem;
+}
+
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-danger, #b42318);
+  background: #fef3f2;
+  color: var(--color-danger, #b42318);
+}
+
+.errorBox p {
+  margin: 0;
+  line-height: 1.45;
+}

--- a/WebUI/src/main/ts/profile/PreferencesSection.tsx
+++ b/WebUI/src/main/ts/profile/PreferencesSection.tsx
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useEffect, useId, useMemo, useState } from "react";
+import {
+  formatApiError,
+  isSessionRedirectError,
+} from "../api/client";
+import { getAllUserPreferences } from "../api/preferences/preferencesApi";
+import {
+  getMyHomepageOverride,
+  setMyHomepageOverride,
+} from "../api/user/userHomepageApi";
+import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
+import { i18nKeyAttr } from "../i18n/i18nDom";
+import { message } from "../i18n/message";
+import { profileLandingOptions } from "./landingOptions";
+import { PROFILE_MSG } from "./messages";
+import styles from "./PreferencesSection.module.css";
+
+export interface PreferencesSectionProps {
+  /** Optional test doubles — default to live REST. */
+  loadLanding?: () => Promise<string>;
+  saveLanding?: (landing: string) => Promise<string>;
+  loadPreferenceCount?: () => Promise<number>;
+  isAdmin?: boolean;
+  isDesigner?: boolean;
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; landing: string; preferenceCount: number };
+
+/**
+ * Profile Preferences section (#2396 / parent #2374 slice 4).
+ *
+ * <p>Default CMS landing page uses existing self homepage REST (product-backed).
+ * PreferenceResource is loaded via {@code getAllUserPreferences} so this section
+ * binds the public preference stack without inventing a parallel store or keys
+ * the product ignores (language/density deferred until product persists them).</p>
+ */
+export function PreferencesSection({
+  loadLanding = getMyHomepageOverride,
+  saveLanding = setMyHomepageOverride,
+  loadPreferenceCount = defaultPreferenceCount,
+  isAdmin: isAdminProp,
+  isDesigner: isDesignerProp,
+}: PreferencesSectionProps = {}): React.ReactElement {
+  const reactId = useId();
+  const formId = `perc-profile-preferences-form-${reactId}`;
+  const landingId = `perc-profile-preferences-landing-${reactId}`;
+  const landingHelpId = `perc-profile-preferences-landing-help-${reactId}`;
+  const statusId = `perc-profile-preferences-status-${reactId}`;
+
+  const bootstrap = useSpaBootstrap();
+  const isAdmin = isAdminProp ?? bootstrap.isAdmin;
+  const isDesigner = isDesignerProp ?? bootstrap.isDesigner;
+
+  const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+  const [landingDraft, setLandingDraft] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoadState({ status: "loading" });
+    setFormError(null);
+    setSuccessMessage(null);
+    try {
+      const [landing, preferenceCount] = await Promise.all([
+        loadLanding(),
+        loadPreferenceCount(),
+      ]);
+      const normalized = landing == null ? "" : String(landing).trim();
+      setLandingDraft(normalized);
+      setLoadState({
+        status: "ready",
+        landing: normalized,
+        preferenceCount:
+          typeof preferenceCount === "number" && preferenceCount >= 0
+            ? preferenceCount
+            : 0,
+      });
+    } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setLoadState({
+        status: "error",
+        message: formatApiError(err, message(PROFILE_MSG.PREF_LOAD_ERROR)),
+      });
+    }
+  }, [loadLanding, loadPreferenceCount]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const options = useMemo(
+    () =>
+      profileLandingOptions(
+        { isAdmin, isDesigner },
+        loadState.status === "ready" ? loadState.landing : landingDraft,
+      ),
+    [isAdmin, isDesigner, loadState, landingDraft],
+  );
+
+  const dirty =
+    loadState.status === "ready" && landingDraft !== loadState.landing;
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (loadState.status !== "ready") {
+      return;
+    }
+    setFormError(null);
+    setSuccessMessage(null);
+    setIsSaving(true);
+    try {
+      const saved = await saveLanding(landingDraft);
+      const normalized = saved == null ? "" : String(saved).trim();
+      // Blank clear may return ""; treat empty draft as clear.
+      const effective =
+        landingDraft === "" ? "" : normalized || landingDraft.trim();
+      setLandingDraft(effective);
+      setLoadState({
+        status: "ready",
+        landing: effective,
+        preferenceCount: loadState.preferenceCount,
+      });
+      setSuccessMessage(message(PROFILE_MSG.PREF_SAVE_SUCCESS));
+    } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setFormError(
+        formatApiError(err, message(PROFILE_MSG.PREF_SAVE_ERROR)),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (loadState.status === "loading") {
+    return (
+      <div
+        className={styles.root}
+        data-testid="perc-profile-preferences"
+        aria-busy="true"
+      >
+        <p className={styles.muted} {...i18nKeyAttr(PROFILE_MSG.PREF_LOADING)}>
+          {message(PROFILE_MSG.PREF_LOADING)}
+        </p>
+      </div>
+    );
+  }
+
+  if (loadState.status === "error") {
+    return (
+      <div
+        className={styles.root}
+        data-testid="perc-profile-preferences"
+        role="alert"
+      >
+        <div className={styles.errorBox}>
+          <p data-testid="perc-profile-preferences-load-error">
+            {loadState.message}
+          </p>
+          <button
+            type="button"
+            className={styles.secondaryButton}
+            onClick={() => void load()}
+            data-testid="perc-profile-preferences-retry"
+            {...i18nKeyAttr(PROFILE_MSG.PREF_RETRY)}
+          >
+            {message(PROFILE_MSG.PREF_RETRY)}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.root} data-testid="perc-profile-preferences">
+      <form
+        id={formId}
+        className={styles.form}
+        onSubmit={(e) => void onSubmit(e)}
+        noValidate
+        aria-describedby={statusId}
+      >
+        <div className={styles.field}>
+          <label
+            className={styles.label}
+            htmlFor={landingId}
+            {...i18nKeyAttr(PROFILE_MSG.PREF_LANDING_LABEL)}
+          >
+            {message(PROFILE_MSG.PREF_LANDING_LABEL)}
+          </label>
+          <p
+            id={landingHelpId}
+            className={styles.hint}
+            {...i18nKeyAttr(PROFILE_MSG.PREF_LANDING_HINT)}
+          >
+            {message(PROFILE_MSG.PREF_LANDING_HINT)}
+          </p>
+          <select
+            id={landingId}
+            className={styles.select}
+            value={landingDraft}
+            onChange={(e) => {
+              setLandingDraft(e.target.value);
+              setSuccessMessage(null);
+              setFormError(null);
+            }}
+            disabled={isSaving}
+            aria-describedby={landingHelpId}
+            data-testid="perc-profile-preferences-landing"
+          >
+            {options.map((opt) => (
+              <option key={opt.value || "__role_default__"} value={opt.value}>
+                {message(opt.labelKey)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <p
+          className={styles.hint}
+          data-testid="perc-profile-preferences-stack-note"
+          {...i18nKeyAttr(PROFILE_MSG.PREF_STACK_NOTE)}
+        >
+          {message(PROFILE_MSG.PREF_STACK_NOTE)}
+        </p>
+        <p
+          className={styles.muted}
+          data-testid="perc-profile-preferences-count"
+          aria-live="polite"
+        >
+          {message(PROFILE_MSG.PREF_STORED_COUNT).replace(
+            "{0}",
+            String(loadState.preferenceCount),
+          )}
+        </p>
+
+        <div className={styles.actions}>
+          <button
+            type="submit"
+            className={styles.primaryButton}
+            disabled={isSaving || !dirty}
+            data-testid="perc-profile-preferences-save"
+            {...i18nKeyAttr(PROFILE_MSG.PREF_SAVE)}
+          >
+            {message(
+              isSaving ? PROFILE_MSG.PREF_SAVING : PROFILE_MSG.PREF_SAVE,
+            )}
+          </button>
+        </div>
+
+        <div
+          id={statusId}
+          className={styles.statusRegion}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {formError ? (
+            <p
+              className={styles.formError}
+              data-testid="perc-profile-preferences-error"
+            >
+              {formError}
+            </p>
+          ) : null}
+          {successMessage ? (
+            <p
+              className={styles.success}
+              data-testid="perc-profile-preferences-success"
+            >
+              {successMessage}
+            </p>
+          ) : null}
+        </div>
+      </form>
+    </div>
+  );
+}
+
+async function defaultPreferenceCount(): Promise<number> {
+  const prefs = await getAllUserPreferences();
+  return prefs.length;
+}

--- a/WebUI/src/main/ts/profile/ProfileShell.tsx
+++ b/WebUI/src/main/ts/profile/ProfileShell.tsx
@@ -19,6 +19,7 @@ import React, { useId } from "react";
 import { i18nKeyAttr } from "../i18n/i18nDom";
 import { message } from "../i18n/message";
 import { PROFILE_MSG } from "./messages";
+import { PreferencesSection } from "./PreferencesSection";
 import styles from "./ProfileShell.module.css";
 
 export interface ProfileShellProps {
@@ -64,9 +65,9 @@ const SECTIONS: {
 ];
 
 /**
- * User profile hub shell (slice 1): landmarks, heading hierarchy, and
- * placeholder sections for later account / security / preferences / avatar work.
- * Does not load or mutate account data.
+ * User profile hub shell: landmarks, heading hierarchy, and section content.
+ * Preferences (#2396) is live; account / security / avatar remain placeholders
+ * until their slices land.
  */
 export function ProfileShell(_props: ProfileShellProps = {}): React.ReactElement {
   const reactId = useId();
@@ -126,6 +127,7 @@ export function ProfileShell(_props: ProfileShellProps = {}): React.ReactElement
       <div className={styles.sections}>
         {SECTIONS.map((section) => {
           const headingId = `perc-profile-${section.id}-heading`;
+          const isPreferences = section.id === "preferences";
           return (
             <section
               key={section.id}
@@ -145,13 +147,17 @@ export function ProfileShell(_props: ProfileShellProps = {}): React.ReactElement
               <p className={styles.sectionBody} {...i18nKeyAttr(section.bodyKey)}>
                 {message(section.bodyKey)}
               </p>
-              <p
-                className={styles.comingSoon}
-                data-testid={`${section.testId}-status`}
-                {...i18nKeyAttr(PROFILE_MSG.COMING_SOON)}
-              >
-                {message(PROFILE_MSG.COMING_SOON)}
-              </p>
+              {isPreferences ? (
+                <PreferencesSection />
+              ) : (
+                <p
+                  className={styles.comingSoon}
+                  data-testid={`${section.testId}-status`}
+                  {...i18nKeyAttr(PROFILE_MSG.COMING_SOON)}
+                >
+                  {message(PROFILE_MSG.COMING_SOON)}
+                </p>
+              )}
             </section>
           );
         })}

--- a/WebUI/src/main/ts/profile/index.ts
+++ b/WebUI/src/main/ts/profile/index.ts
@@ -17,4 +17,6 @@
 
 export { ProfileShell } from "./ProfileShell";
 export type { ProfileShellProps } from "./ProfileShell";
+export { PreferencesSection } from "./PreferencesSection";
+export type { PreferencesSectionProps } from "./PreferencesSection";
 export { PROFILE_MSG } from "./messages";

--- a/WebUI/src/main/ts/profile/landingOptions.ts
+++ b/WebUI/src/main/ts/profile/landingOptions.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default landing options for the profile Preferences section (#2396).
+ *
+ * <p>Values are product homepage types (PascalCase) already accepted by
+ * {@code PSUserService} / login landing resolve. Labels reuse nav menu keys.
+ * Options are filtered from SPA bootstrap admin/designer flags (self-service
+ * does not load full role lists).</p>
+ */
+
+import { HOMEPAGE_TYPES, type HomepageType } from "../api/user/userHomepageApi";
+
+export interface ProfileLandingOption {
+  /** Canonical API value, or empty string for "use role default". */
+  value: HomepageType | "";
+  /** TMX message key. */
+  labelKey: string;
+}
+
+/** Product options for the profile landing select. */
+export const PROFILE_LANDING_OPTIONS: readonly ProfileLandingOption[] = [
+  {
+    value: "",
+    labelKey: "perc.ui.profile.modern@Use role default",
+  },
+  {
+    value: HOMEPAGE_TYPES.HOME,
+    labelKey: "perc.ui.navMenu.home@Home",
+  },
+  {
+    value: HOMEPAGE_TYPES.EDITOR,
+    labelKey: "perc.ui.navMenu.webmgt@Editor",
+  },
+  {
+    value: HOMEPAGE_TYPES.DESIGNER,
+    labelKey: "perc.ui.navMenu.design@Design",
+  },
+  {
+    value: HOMEPAGE_TYPES.ARCHITECTURE,
+    labelKey: "perc.ui.navMenu.architecture@Architecture",
+  },
+  {
+    value: HOMEPAGE_TYPES.WORKFLOW,
+    labelKey: "perc.ui.navMenu.admin@Administration",
+  },
+] as const;
+
+export type ProfileLandingGates = {
+  isAdmin?: boolean;
+  isDesigner?: boolean;
+};
+
+/**
+ * Whether the signed-in user may choose a landing type (peer SPA nav gates).
+ */
+export function isProfileLandingAllowed(
+  homepageType: HomepageType | "",
+  gates: ProfileLandingGates,
+): boolean {
+  if (homepageType === "" || homepageType === HOMEPAGE_TYPES.HOME) {
+    return true;
+  }
+  if (homepageType === HOMEPAGE_TYPES.EDITOR) {
+    return true;
+  }
+  const isAdmin = !!gates.isAdmin;
+  const isDesigner = !!gates.isDesigner || isAdmin;
+  switch (homepageType) {
+    case HOMEPAGE_TYPES.DESIGNER:
+    case HOMEPAGE_TYPES.ARCHITECTURE:
+    case HOMEPAGE_TYPES.PUBLISH:
+    case HOMEPAGE_TYPES.WIDGET_BUILDER:
+      return isDesigner;
+    case HOMEPAGE_TYPES.WORKFLOW:
+      return isAdmin;
+    case HOMEPAGE_TYPES.DASHBOARD:
+      return true;
+    default:
+      return isAdmin;
+  }
+}
+
+/**
+ * Options for the select: role-default + allowed product screens.
+ * If the currently stored override is no longer allowed, it is still listed.
+ */
+export function profileLandingOptions(
+  gates: ProfileLandingGates,
+  currentValue?: string | null,
+): ProfileLandingOption[] {
+  const allowed = PROFILE_LANDING_OPTIONS.filter((opt) =>
+    isProfileLandingAllowed(opt.value, gates),
+  );
+  const current = currentValue == null ? "" : String(currentValue).trim();
+  if (
+    current &&
+    !allowed.some((o) => o.value === current) &&
+    PROFILE_LANDING_OPTIONS.some((o) => o.value === current)
+  ) {
+    const extra = PROFILE_LANDING_OPTIONS.find((o) => o.value === current);
+    if (extra) {
+      return [...allowed, extra];
+    }
+  }
+  return allowed;
+}

--- a/WebUI/src/main/ts/profile/messages.ts
+++ b/WebUI/src/main/ts/profile/messages.ts
@@ -33,9 +33,24 @@ export const PROFILE_MSG = {
     "perc.ui.profile.modern@Password and authentication options for your account will appear here.",
   SECTION_PREFERENCES: "perc.ui.profile.modern@Preferences",
   SECTION_PREFERENCES_BODY:
-    "perc.ui.profile.modern@Language and personal UI preferences will appear here.",
+    "perc.ui.profile.modern@Choose your default CMS landing page and view preferences stored for your account.",
   SECTION_AVATAR: "perc.ui.profile.modern@Avatar",
   SECTION_AVATAR_BODY:
     "perc.ui.profile.modern@Avatar and Gravatar email settings will appear here.",
   COMING_SOON: "perc.ui.profile.modern@Coming soon",
+  // Preferences section (#2396)
+  PREF_LOADING: "perc.ui.profile.modern@Loading preferences…",
+  PREF_LOAD_ERROR: "perc.ui.profile.modern@Could not load preferences.",
+  PREF_RETRY: "perc.ui.profile.modern@Try again",
+  PREF_LANDING_LABEL: "perc.ui.profile.modern@Default landing page",
+  PREF_LANDING_HINT:
+    "perc.ui.profile.modern@Where you land after sign-in. Leave as role default to use your role homepage.",
+  PREF_STACK_NOTE:
+    "perc.ui.profile.modern@Personal preferences use the product preference services already available for your account.",
+  PREF_STORED_COUNT:
+    "perc.ui.profile.modern@Stored preference entries: {0}",
+  PREF_SAVE: "perc.ui.profile.modern@Save preferences",
+  PREF_SAVING: "perc.ui.profile.modern@Saving…",
+  PREF_SAVE_SUCCESS: "perc.ui.profile.modern@Preferences saved.",
+  PREF_SAVE_ERROR: "perc.ui.profile.modern@Could not save preferences.",
 } as const;

--- a/WebUI/src/test/ts/api/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/preferencesApi.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAllUserPreferences,
+  loadUserPreference,
+  saveUserPreference,
+} from "../../../main/ts/api/preferences/preferencesApi";
+import * as client from "../../../main/ts/api/client";
+
+describe("preferencesApi (PreferenceResource)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("getAllUserPreferences returns list and treats 404 as empty", async () => {
+    const getSpy = vi.spyOn(client, "get");
+    getSpy.mockResolvedValueOnce([
+      { name: "developer.defaultObjectAclTemplate", value: "{}" },
+    ]);
+    await expect(getAllUserPreferences()).resolves.toHaveLength(1);
+
+    getSpy.mockRejectedValueOnce({ status: 404, statusText: "Not Found", body: null });
+    await expect(getAllUserPreferences()).resolves.toEqual([]);
+  });
+
+  it("loadUserPreference returns null on 404", async () => {
+    vi.spyOn(client, "get").mockRejectedValueOnce({
+      status: 404,
+      statusText: "Not Found",
+      body: null,
+    });
+    await expect(loadUserPreference("missing")).resolves.toBeNull();
+  });
+
+  it("saveUserPreference puts DTO with defaults", async () => {
+    const putSpy = vi.spyOn(client, "put").mockResolvedValueOnce({
+      name: "k",
+      value: "v",
+      category: "sys_preferences",
+      context: "private",
+      userName: "Admin",
+    });
+    await saveUserPreference({ name: "k", value: "v", userName: "Admin" });
+    expect(putSpy).toHaveBeenCalled();
+    const body = putSpy.mock.calls[0][1] as Record<string, string>;
+    expect(body.category).toBe("sys_preferences");
+    expect(body.context).toBe("private");
+    expect(body.userName).toBe("Admin");
+  });
+});

--- a/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
+++ b/WebUI/src/test/ts/profile/PreferencesSection.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PreferencesSection } from "../../../main/ts/profile/PreferencesSection";
+import { BootstrapProvider } from "../../../main/ts/app/bootstrap/BootstrapContext";
+import type { SpaBootstrap } from "../../../main/ts/app/bootstrap/types";
+
+const bootstrap: SpaBootstrap = {
+  userName: "Admin",
+  locale: "en-us",
+  entry: "profile",
+  isAdmin: true,
+  isDesigner: true,
+  isWidgetBuilderActive: false,
+};
+
+function renderPrefs(
+  props: React.ComponentProps<typeof PreferencesSection> = {},
+): ReturnType<typeof render> {
+  return render(
+    <BootstrapProvider value={bootstrap}>
+      <PreferencesSection {...props} />
+    </BootstrapProvider>,
+  );
+}
+
+describe("PreferencesSection", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+  });
+
+  it("loads landing select and preference stack count", async () => {
+    const loadLanding = vi.fn().mockResolvedValue("Home");
+    const loadPreferenceCount = vi.fn().mockResolvedValue(2);
+    renderPrefs({ loadLanding, loadPreferenceCount });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences-landing")).toBeTruthy();
+    });
+    const select = screen.getByTestId(
+      "perc-profile-preferences-landing",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe("Home");
+    expect(screen.getByTestId("perc-profile-preferences-count").textContent).toContain(
+      "2",
+    );
+    expect(loadLanding).toHaveBeenCalled();
+    expect(loadPreferenceCount).toHaveBeenCalled();
+  });
+
+  it("saves dirty landing and shows success", async () => {
+    const loadLanding = vi.fn().mockResolvedValue("");
+    const saveLanding = vi.fn().mockResolvedValue("Editor");
+    const loadPreferenceCount = vi.fn().mockResolvedValue(0);
+    renderPrefs({ loadLanding, saveLanding, loadPreferenceCount });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences-landing")).toBeTruthy();
+    });
+
+    const select = screen.getByTestId(
+      "perc-profile-preferences-landing",
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "Editor" } });
+
+    const save = screen.getByTestId("perc-profile-preferences-save");
+    expect((save as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(save);
+
+    await waitFor(() => {
+      expect(saveLanding).toHaveBeenCalledWith("Editor");
+      expect(screen.getByTestId("perc-profile-preferences-success")).toBeTruthy();
+    });
+    expect(select.value).toBe("Editor");
+  });
+
+  it("shows load error and retries", async () => {
+    const loadLanding = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 500, statusText: "err", body: null })
+      .mockResolvedValueOnce("Home");
+    const loadPreferenceCount = vi.fn().mockResolvedValue(0);
+    renderPrefs({ loadLanding, loadPreferenceCount });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("perc-profile-preferences-load-error"),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("perc-profile-preferences-retry"));
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences-landing")).toBeTruthy();
+    });
+    expect(loadLanding).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables save when not dirty", async () => {
+    const loadLanding = vi.fn().mockResolvedValue("Home");
+    const loadPreferenceCount = vi.fn().mockResolvedValue(1);
+    renderPrefs({ loadLanding, loadPreferenceCount });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences-landing")).toBeTruthy();
+    });
+    const save = screen.getByTestId(
+      "perc-profile-preferences-save",
+    ) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+});

--- a/WebUI/src/test/ts/profile/ProfileShell.test.tsx
+++ b/WebUI/src/test/ts/profile/ProfileShell.test.tsx
@@ -16,20 +16,64 @@
  */
 
 import React from "react";
-import { beforeEach, describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import { ProfileShell } from "../../../main/ts/profile/ProfileShell";
 import { PROFILE_MSG } from "../../../main/ts/profile/messages";
+import { BootstrapProvider } from "../../../main/ts/app/bootstrap/BootstrapContext";
+
+vi.mock("../../../main/ts/api/user/userHomepageApi", () => ({
+  getMyHomepageOverride: vi.fn().mockResolvedValue(""),
+  setMyHomepageOverride: vi.fn().mockResolvedValue(""),
+  HOMEPAGE_TYPES: {
+    HOME: "Home",
+    DASHBOARD: "Dashboard",
+    EDITOR: "Editor",
+    DESIGNER: "Designer",
+    ARCHITECTURE: "Architecture",
+    PUBLISH: "Publish",
+    WORKFLOW: "Workflow",
+    WIDGET_BUILDER: "WidgetBuilder",
+  },
+}));
+
+vi.mock("../../../main/ts/api/preferences/preferencesApi", () => ({
+  getAllUserPreferences: vi.fn().mockResolvedValue([]),
+  loadUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn(),
+  PREF_CATEGORY_SYS: "sys_preferences",
+  PREF_CONTEXT_PRIVATE: "private",
+}));
+
+const bootstrap = {
+  userName: "Admin",
+  locale: "en-us",
+  entry: "profile",
+  isAdmin: true,
+  isDesigner: true,
+  isWidgetBuilderActive: false,
+};
+
+function renderShell() {
+  return render(
+    <BootstrapProvider value={bootstrap}>
+      <ProfileShell embedded />
+    </BootstrapProvider>,
+  );
+}
 
 describe("ProfileShell", () => {
   beforeEach(() => {
     (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
-      message: (key: string) => key,
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
     };
   });
 
-  it("renders title, intro, and four placeholder sections", () => {
-    render(<ProfileShell embedded />);
+  it("renders title, intro, four sections, and live preferences", async () => {
+    renderShell();
     expect(screen.getByTestId("perc-profile-shell")).toBeTruthy();
     expect(screen.getByTestId("perc-profile-title").textContent).toBe("My profile");
     expect(screen.getByTestId("perc-profile-intro").textContent).toContain(
@@ -39,10 +83,16 @@ describe("ProfileShell", () => {
     expect(screen.getByTestId("perc-profile-section-security")).toBeTruthy();
     expect(screen.getByTestId("perc-profile-section-preferences")).toBeTruthy();
     expect(screen.getByTestId("perc-profile-section-avatar")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences")).toBeTruthy();
+    });
   });
 
-  it("exposes landmark heading hierarchy and section jump links", () => {
-    render(<ProfileShell embedded />);
+  it("exposes landmark heading hierarchy and section jump links", async () => {
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences")).toBeTruthy();
+    });
     const h1 = screen.getByRole("heading", { level: 1, name: "My profile" });
     expect(h1).toBeTruthy();
 
@@ -68,15 +118,22 @@ describe("ProfileShell", () => {
     );
   });
 
-  it("marks section status as coming soon via catalog keys", () => {
-    render(<ProfileShell embedded />);
+  it("marks non-preferences sections as coming soon", async () => {
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences")).toBeTruthy();
+    });
     const statuses = screen.getAllByText("Coming soon");
-    expect(statuses.length).toBe(4);
+    expect(statuses.length).toBe(3);
     expect(PROFILE_MSG.COMING_SOON).toContain("Coming soon");
+    expect(screen.queryByTestId("perc-profile-section-preferences-status")).toBeNull();
   });
 
-  it("makes section landmarks focusable skip targets (tabIndex=-1)", () => {
-    render(<ProfileShell embedded />);
+  it("makes section landmarks focusable skip targets (tabIndex=-1)", async () => {
+    renderShell();
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-profile-preferences")).toBeTruthy();
+    });
     for (const id of [
       "perc-profile-section-account",
       "perc-profile-section-security",

--- a/WebUI/src/test/ts/profile/landingOptions.test.ts
+++ b/WebUI/src/test/ts/profile/landingOptions.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  isProfileLandingAllowed,
+  profileLandingOptions,
+} from "../../../main/ts/profile/landingOptions";
+import { HOMEPAGE_TYPES } from "../../../main/ts/api/user/userHomepageApi";
+
+describe("profileLandingOptions", () => {
+  it("allows Home and Editor for any user", () => {
+    expect(isProfileLandingAllowed("", {})).toBe(true);
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.HOME, {})).toBe(true);
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.EDITOR, {})).toBe(true);
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, {})).toBe(false);
+    expect(isProfileLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, {})).toBe(false);
+  });
+
+  it("opens Design for designers and Administration for admins", () => {
+    expect(
+      isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isDesigner: true }),
+    ).toBe(true);
+    expect(
+      isProfileLandingAllowed(HOMEPAGE_TYPES.WORKFLOW, { isAdmin: true }),
+    ).toBe(true);
+    expect(
+      isProfileLandingAllowed(HOMEPAGE_TYPES.DESIGNER, { isAdmin: true }),
+    ).toBe(true);
+  });
+
+  it("keeps current value when no longer allowed", () => {
+    const opts = profileLandingOptions({}, HOMEPAGE_TYPES.DESIGNER);
+    expect(opts.some((o) => o.value === HOMEPAGE_TYPES.DESIGNER)).toBe(true);
+  });
+});

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -26758,6 +26758,46 @@ Niet-opgeslagen wijzigingen in '{1}' kunnen verloren gaan.</seg></tuv>
     <tu tuid="perc.ui.profile.modern@Language and personal UI preferences will appear here.">
       <tuv xml:lang="en-us"><seg>Language and personal UI preferences will appear here.</seg></tuv>
     <tuv xml:lang="ar"><seg>ستظهر هنا تفضيلات اللغة وواجهة المستخدم الشخصية.</seg></tuv><tuv xml:lang="bn"><seg>ভাষা এবং ব্যক্তিগত UI পছন্দগুলি এখানে উপস্থিত হবে৷</seg></tuv><tuv xml:lang="de"><seg>Hier werden Sprach- und persönliche Benutzeroberflächeneinstellungen angezeigt.</seg></tuv><tuv xml:lang="es"><seg>Las preferencias de idioma y de interfaz de usuario personal aparecerán aquí.</seg></tuv><tuv xml:lang="fr"><seg>Les préférences de langue et d’interface utilisateur personnelles apparaîtront ici.</seg></tuv><tuv xml:lang="he"><seg>העדפות שפה וממשק משתמש אישי יופיעו כאן.</seg></tuv><tuv xml:lang="hi"><seg>भाषा और व्यक्तिगत यूआई प्राथमिकताएँ यहाँ दिखाई देंगी।</seg></tuv><tuv xml:lang="it"><seg>La lingua e le preferenze personali dell'interfaccia utente verranno visualizzate qui.</seg></tuv><tuv xml:lang="nl"><seg>Taal- en persoonlijke UI-voorkeuren verschijnen hier.</seg></tuv><tuv xml:lang="pl"><seg>Tutaj pojawią się preferencje dotyczące języka i osobistego interfejsu użytkownika.</seg></tuv><tuv xml:lang="pt"><seg>As preferências de idioma e de interface pessoal aparecerão aqui.</seg></tuv><tuv xml:lang="ru"><seg>Здесь появятся языковые и персональные настройки пользовательского интерфейса.</seg></tuv><tuv xml:lang="sv"><seg>Språk och personliga gränssnittsinställningar visas här.</seg></tuv><tuv xml:lang="te"><seg>భాష మరియు వ్యక్తిగత UI ప్రాధాన్యతలు ఇక్కడ కనిపిస్తాయి.</seg></tuv><tuv xml:lang="tr"><seg>Dil ve kişisel kullanıcı arayüzü tercihleri u200bu200bburada görünecektir.</seg></tuv><tuv xml:lang="uk"><seg>Тут відображатимуться мова та особисті налаштування інтерфейсу користувача.</seg></tuv><tuv xml:lang="zh-cn"><seg>语言和个人 UI 首选项将显示在此处。</seg></tuv><tuv xml:lang="zh-tw"><seg>語言和個人 UI 偏好設定將顯示在此處。</seg></tuv><tuv xml:lang="lou"><seg>Lang épi personal UI preferences will appear here.</seg></tuv></tu>
+    <!-- Issue #2396 / parent #2374 slice 4: profile Preferences section (en-us + lou; other locales fall back) -->
+    <tu tuid="perc.ui.profile.modern@Choose your default CMS landing page and view preferences stored for your account.">
+      <tuv xml:lang="en-us"><seg>Choose your default CMS landing page and view preferences stored for your account.</seg></tuv>
+    <tuv xml:lang="lou"><seg>Choose to default CMS landing page épi view preferences stored pou to account.</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Loading preferences…">
+      <tuv xml:lang="en-us"><seg>Loading preferences…</seg></tuv>
+    <tuv xml:lang="lou"><seg>Loading preferences…</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Could not load preferences.">
+      <tuv xml:lang="en-us"><seg>Could not load preferences.</seg></tuv>
+    <tuv xml:lang="lou"><seg>Could not load preferences.</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Try again">
+      <tuv xml:lang="en-us"><seg>Try again</seg></tuv>
+    <tuv xml:lang="lou"><seg>Try again</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Default landing page">
+      <tuv xml:lang="en-us"><seg>Default landing page</seg></tuv>
+    <tuv xml:lang="lou"><seg>Default landing page</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Where you land after sign-in. Leave as role default to use your role homepage.">
+      <tuv xml:lang="en-us"><seg>Where you land after sign-in. Leave as role default to use your role homepage.</seg></tuv>
+    <tuv xml:lang="lou"><seg>Where you land after sign-in. Leave as role default to use to role homepage.</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Use role default">
+      <tuv xml:lang="en-us"><seg>Use role default</seg></tuv>
+    <tuv xml:lang="lou"><seg>Use role default</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Personal preferences use the product preference services already available for your account.">
+      <tuv xml:lang="en-us"><seg>Personal preferences use the product preference services already available for your account.</seg></tuv>
+    <tuv xml:lang="lou"><seg>Personal preferences use the product preference services already available pou to account.</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Stored preference entries: {0}">
+      <tuv xml:lang="en-us"><seg>Stored preference entries: {0}</seg></tuv>
+    <tuv xml:lang="lou"><seg>Stored preference entries: {0}</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Save preferences">
+      <tuv xml:lang="en-us"><seg>Save preferences</seg></tuv>
+    <tuv xml:lang="lou"><seg>Save preferences</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Saving…">
+      <tuv xml:lang="en-us"><seg>Saving…</seg></tuv>
+    <tuv xml:lang="lou"><seg>Saving…</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Preferences saved.">
+      <tuv xml:lang="en-us"><seg>Preferences saved.</seg></tuv>
+    <tuv xml:lang="lou"><seg>Preferences saved.</seg></tuv></tu>
+    <tu tuid="perc.ui.profile.modern@Could not save preferences.">
+      <tuv xml:lang="en-us"><seg>Could not save preferences.</seg></tuv>
+    <tuv xml:lang="lou"><seg>Could not save preferences.</seg></tuv></tu>
     <tu tuid="perc.ui.profile.modern@Avatar">
       <tuv xml:lang="en-us"><seg>Avatar</seg></tuv>
     <tuv xml:lang="ar"><seg>الصورة الرمزية</seg></tuv><tuv xml:lang="bn"><seg>অবতার</seg></tuv><tuv xml:lang="de"><seg>Avatar</seg></tuv><tuv xml:lang="es"><seg>Avatar</seg></tuv><tuv xml:lang="fr"><seg>Avatar</seg></tuv><tuv xml:lang="he"><seg>גִלגוּל</seg></tuv><tuv xml:lang="hi"><seg>अवतार</seg></tuv><tuv xml:lang="it"><seg>Avatar</seg></tuv><tuv xml:lang="nl"><seg>Avatar</seg></tuv><tuv xml:lang="pl"><seg>Awatara</seg></tuv><tuv xml:lang="pt"><seg>avatar</seg></tuv><tuv xml:lang="ru"><seg>Аватар</seg></tuv><tuv xml:lang="sv"><seg>Avatar</seg></tuv><tuv xml:lang="te"><seg>అవతార్</seg></tuv><tuv xml:lang="tr"><seg>avatar</seg></tuv><tuv xml:lang="uk"><seg>Аватар</seg></tuv><tuv xml:lang="zh-cn"><seg>阿凡达</seg></tuv><tuv xml:lang="zh-tw"><seg>頭像</seg></tuv><tuv xml:lang="lou"><seg>Avatar</seg></tuv></tu>

--- a/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Profile Preferences section (#2396 / parent #2374 slice 4).
+ *
+ * Surface-filtered only — not full suite:
+ *   npm run test:surface -- --path tests/profile-preferences.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Covers: Preferences form mounts; change default landing; reload persists.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function profileDeepLink() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function expectPreferencesMounted(page) {
+  await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByTestId("perc-profile-section-preferences"),
+  ).toBeVisible();
+  await expect(page.getByTestId("perc-profile-preferences")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByTestId("perc-profile-preferences-landing"),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe("Profile preferences @profile @preferences @smoke", () => {
+  test("deep link shows preferences landing control for Admin", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectPreferencesMounted(page);
+
+    const landing = page.getByTestId("perc-profile-preferences-landing");
+    await expect(landing).toBeEnabled();
+    await expect(
+      page.getByTestId("perc-profile-preferences-save"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("perc-profile-preferences-count"),
+    ).toBeVisible();
+  });
+
+  test("change landing preference, reload, value persists", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectPreferencesMounted(page);
+
+    const landing = page.getByTestId("perc-profile-preferences-landing");
+    await expect(landing).toBeVisible();
+
+    const original = await landing.inputValue();
+    // Prefer Home ↔ Editor so both are allowed for Admin and product-backed.
+    const next = original === "Editor" ? "Home" : "Editor";
+
+    await landing.selectOption(next);
+    await page.getByTestId("perc-profile-preferences-save").click();
+    await expect(
+      page.getByTestId("perc-profile-preferences-success"),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(landing).toHaveValue(next);
+
+    // Reload profile hub — value must come back from server
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectPreferencesMounted(page);
+    await expect(
+      page.getByTestId("perc-profile-preferences-landing"),
+    ).toHaveValue(next, { timeout: 30_000 });
+
+    // Best-effort restore original for stable re-runs
+    if (original !== next) {
+      const landing2 = page.getByTestId("perc-profile-preferences-landing");
+      await landing2.selectOption(original);
+      await page.getByTestId("perc-profile-preferences-save").click();
+      await expect(
+        page.getByTestId("perc-profile-preferences-success"),
+      ).toBeVisible({ timeout: 30_000 });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#2396** (parent epic **#2374** slice 4): user-owned Preferences on the Profile hub.

### WebUI
- Shared `api/preferences/preferencesApi` bound to public `PreferenceResource` (`GET/PUT /services/preferences`) — also re-used by Developer ACL prefs (no parallel store)
- `PreferencesSection` on ProfileShell Preferences section:
  - **Default landing page** via existing self homepage REST (`GET/PUT /user/user/homepage`) — product-backed, survives reload
  - PreferenceResource **getAll** count so the prefs stack is live-wired (404 → empty)
  - Role-gated landing options from SPA bootstrap (Admin/Designer)
  - Labels, live regions, focus styles; catalog keys via `PROFILE_MSG`
- Self helpers `getMyHomepageOverride` / `setMyHomepageOverride` (no username on path)

### i18n
- New `perc.ui.profile.modern@…` keys in `CmsUi.tmx` (en-us + lou; other locales fall back / residual)

### Tests
- Vitest: PreferencesSection, landingOptions, preferencesApi, ProfileShell (14 tests)
- Playwright surface: `modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js` (mount + change landing, reload persists)

## Test plan
1. `cd WebUI && ../mvnw clean install` — BUILD SUCCESS; focused Vitest profile/preferences 14/14
2. `cd modules/perc-i18n && ../../mvnw clean install` — BUILD SUCCESS
3. QA mode (when available): `perc-devctl qa-up` → `npm run test:surface -- --path tests/profile-preferences.spec.js` in perc-qa-automation → `qa-down`
4. Manual: My profile → Preferences → change Default landing page → Save → reload hub → value persists

## Gates evidence
- Erlang self-review: no invented parallel store; portable paths N/A for UI/API client; companions (TMX, Vitest, Playwright) included
- No rest/sitemanage Java API changes required (PreferenceResource + homepage self endpoints already public)
- Live Playwright not executed in this agent session (no QA CMS up) — human QA handoff
- Operator: Grok: night-issue-prs (model grok-4.5)

## Partial / residuals
- Multi-locale TMX fill for new preferences keys (peer of #2426 / #2595 pattern)
- Language / density controls deferred until product persists those keys with server support

Fixes #2396  
Parent: #2374

> Co-Authored by Grok Build using grok-4.5 with agent main.
