### PR TITLE
fix(WebUI): #2410 folder security identities + properties parity

### DIFF
--- a/WebUI/README.md
+++ b/WebUI/README.md
@@ -117,7 +117,7 @@ The legacy Miller-column Finder is hard-cut in 8.2:
 | `ReducedActions`       | inside Shell               | Per-item menu (open/preview/createFolder/rename/move/copy/delete)               |
 | `ContextMenu`          | inside Shell               | Right-click menu driven by server `actions/...` REST                            |
 | `ActionToolbar`        | inside Shell               | Top toolbar driven by the same server action set                                |
-| `FolderSecurityPanel`  | `folderSecurityModern.jsp` | ACL viewer + editor; `aclLockout.ts` client gate                                |
+| `FolderSecurityPanel`  | Explorer shell + `folderSecurityModern.jsp` | ACL + folder properties (community/locale/DF/workflow); `aclLockout.ts` + bootstrap identities |
 | `SearchPanel`          | `searchModern.jsp`         | Extended search with retry / open / reveal                                      |
 | `ClipboardPanel`       | `us7AdvancedModern.jsp`    | Copy / cut / paste to a target folder                                           |
 | `SiteCopyWizard`       | same                       | 5-step site copy wizard                                                         |

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -450,8 +450,14 @@ export function ContentExplorerShell({
         if (!cancelled) setSecurityFolderId(undefined);
         return;
       }
-      const id = await resolveFolderId(path);
-      if (!cancelled) setSecurityFolderId(id);
+      try {
+        const id = await resolveFolderId(path);
+        if (!cancelled) setSecurityFolderId(id);
+      } catch {
+        // Custom injectors may reject; defaultResolveFolderId already swallows.
+        // Treat failure as unresolved so security stays read-only hint, not crash.
+        if (!cancelled) setSecurityFolderId(undefined);
+      }
     }
     void resolve();
     return () => {

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -33,6 +33,7 @@ import {
   normalizeDisplayFormatColumns,
   type DisplayFormat,
 } from "../api/contentExplorer/displayFormatsApi";
+import { findItemByPath } from "../api/contentExplorer/pathApi";
 import type {
   Clipboard,
   ClipboardItem,
@@ -40,11 +41,13 @@ import type {
   PSItemProperties,
   PSPathItem,
 } from "../api/contentExplorer/types";
+import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
 import { message } from "../i18n/message";
 import { ActionToolbar } from "./ActionToolbar";
 import { ClipboardPanel } from "./clipboard/ClipboardPanel";
 import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/model";
 import { ContextMenu } from "./ContextMenu";
+import { resolveCurrentUserIdentities } from "./currentUserIdentities";
 import { DetailList } from "./DetailList";
 import {
   displayFormatOptionKey,
@@ -84,6 +87,17 @@ export interface ContentExplorerShellProps {
   loadDisplayFormats?: () => Promise<DisplayFormat[]>;
   /** Test seam: override action menu load. */
   loadMenuActions?: (item: PSPathItem | null) => Promise<MenuAction[]>;
+  /**
+   * Identities for folder ACL self-lockout (USER name + ROLE names).
+   * When omitted, derived from SPA bootstrap ({@code userName}, admin/designer
+   * flags). Tests inject an explicit list so lockout gates stay deterministic.
+   */
+  currentUserIdentities?: ReadonlyArray<string>;
+  /**
+   * Test seam: resolve a CMS folder id from a path for the security panel.
+   * Default uses pathmanagement {@link findItemByPath}.
+   */
+  resolveFolderId?: (path: string) => Promise<string | undefined>;
 }
 
 type ContextMenuState = {
@@ -162,6 +176,19 @@ async function defaultLoadDisplayFormats(): Promise<DisplayFormat[]> {
   return listDisplayFormats({ validForFolder: true });
 }
 
+async function defaultResolveFolderId(
+  path: string,
+): Promise<string | undefined> {
+  try {
+    const item = await findItemByPath(path);
+    return item?.id != null && String(item.id).length > 0
+      ? String(item.id)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function ContentExplorerShell({
   initialPath = "/",
   onOpenItem = openInEditor,
@@ -169,8 +196,33 @@ export function ContentExplorerShell({
   onFolderActivated,
   loadDisplayFormats = defaultLoadDisplayFormats,
   loadMenuActions = defaultLoadMenuActions,
+  currentUserIdentities: currentUserIdentitiesProp,
+  resolveFolderId = defaultResolveFolderId,
 }: ContentExplorerShellProps): React.ReactElement {
-  const [selection, setSelection] = useState<Selection>(EMPTY_SELECTION);
+  const bootstrap = useSpaBootstrap();
+  const currentUserIdentities = useMemo(() => {
+    if (currentUserIdentitiesProp) {
+      return [...currentUserIdentitiesProp];
+    }
+    return resolveCurrentUserIdentities({
+      userName: bootstrap.userName,
+      isAdmin: bootstrap.isAdmin,
+      isDesigner: bootstrap.isDesigner,
+    });
+  }, [
+    currentUserIdentitiesProp,
+    bootstrap.userName,
+    bootstrap.isAdmin,
+    bootstrap.isDesigner,
+  ]);
+
+  // Seed from initialPath so deep-links and the security/properties panel
+  // resolve a folder without requiring an extra tree click (#2410).
+  const [selection, setSelection] = useState<Selection>(() =>
+    initialPath
+      ? { folderPath: initialPath, item: null }
+      : EMPTY_SELECTION,
+  );
   const [error, setError] = useState<string | null>(null);
   const [showSearch, setShowSearch] = useState(false);
   const [showSecurity, setShowSecurity] = useState(false);
@@ -188,6 +240,10 @@ export function ContentExplorerShell({
   >(() => new Map<string, PSPathItem>());
   const [clipboard, setClipboardState] = useState<Clipboard>(EMPTY_CLIPBOARD);
   const [clipboardMode, setClipboardMode] = useState<"copy" | "cut">("copy");
+  /** Folder content id for security/properties (resolved from selection or path). */
+  const [securityFolderId, setSecurityFolderId] = useState<string | undefined>(
+    undefined,
+  );
 
   const handlers: ReducedActionHandlers = {
     ...defaultReducedActionHandlers(),
@@ -370,7 +426,7 @@ export function ContentExplorerShell({
       ? selection.item
       : selection.folderPath
         ? ({
-            id: undefined,
+            id: securityFolderId,
             path: selection.folderPath,
             name: selection.folderPath,
             type: "folder",
@@ -378,10 +434,30 @@ export function ContentExplorerShell({
           } as PSPathItem)
         : null;
 
-  const securityFolderId =
-    selection.item?.type === "folder"
-      ? selection.item.id
-      : undefined;
+  // Resolve the folder id for security/properties: prefer a selected
+  // folder row, otherwise look up the active folder path (tree navigation
+  // sets item=null and only folderPath). Without path resolution ADMIN
+  // could not open ACL for the folder they are browsing (#2410).
+  useEffect(() => {
+    let cancelled = false;
+    async function resolve(): Promise<void> {
+      if (selection.item?.type === "folder" && selection.item.id) {
+        if (!cancelled) setSecurityFolderId(String(selection.item.id));
+        return;
+      }
+      const path = selection.folderPath;
+      if (!path) {
+        if (!cancelled) setSecurityFolderId(undefined);
+        return;
+      }
+      const id = await resolveFolderId(path);
+      if (!cancelled) setSecurityFolderId(id);
+    }
+    void resolve();
+    return () => {
+      cancelled = true;
+    };
+  }, [selection.item, selection.folderPath, resolveFolderId]);
 
   return (
     <div
@@ -603,7 +679,7 @@ export function ContentExplorerShell({
         >
           <FolderSecurityPanel
             folderId={securityFolderId}
-            currentUserIdentities={[]}
+            currentUserIdentities={currentUserIdentities}
           />
         </section>
       )}

--- a/WebUI/src/main/ts/contentExplorer/FolderSecurityPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/FolderSecurityPanel.tsx
@@ -308,6 +308,11 @@ export function FolderSecurityPanel(
           {message(EXPLORER_MSG.SECURITY_READ_ONLY)}
         </p>
       ) : null}
+      <FolderPropertiesEditor
+        props={current}
+        editable={editable}
+        onChange={(next) => patchProps(() => next)}
+      />
       {drafts.map((d) => (
         <PrincipalListEditor
           key={d.level}
@@ -341,6 +346,89 @@ export function FolderSecurityPanel(
         </span>
       </div>
     </section>
+  );
+}
+
+/**
+ * Community / locale / display-format / workflow fields from
+ * {@link PSFolderProperties} (pathmanagement REST). Editable when the
+ * session has ADMIN on the folder; otherwise read-only display.
+ */
+function FolderPropertiesEditor(props: {
+  props: PSFolderProperties;
+  editable: boolean;
+  onChange: (next: PSFolderProperties) => void;
+}): React.JSX.Element {
+  const { props: folder, editable, onChange } = props;
+
+  function field(
+    testId: string,
+    labelKey: string,
+    value: string,
+    onValue: (v: string) => void,
+  ): React.JSX.Element {
+    const id = `folder-props-${testId}`;
+    return (
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(8rem, 12rem) 1fr",
+          gap: 8,
+          alignItems: "center",
+          marginBottom: 6,
+        }}
+      >
+        <label htmlFor={id}>{message(labelKey)}</label>
+        <input
+          id={id}
+          type="text"
+          value={value}
+          disabled={!editable}
+          onChange={(e) => onValue(e.target.value)}
+          data-testid={`folder-props-${testId}`}
+          style={{ maxWidth: 320 }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <fieldset
+      data-testid="folder-properties"
+      style={{ border: "1px solid #ccc", padding: 8, marginBottom: 12 }}
+    >
+      <legend>{message(EXPLORER_MSG.FOLDER_PROPS_TITLE)}</legend>
+      {field(
+        "community-name",
+        EXPLORER_MSG.FOLDER_PROPS_COMMUNITY,
+        folder.communityName ?? "",
+        (v) => onChange({ ...folder, communityName: v }),
+      )}
+      {field(
+        "community-id",
+        EXPLORER_MSG.FOLDER_PROPS_COMMUNITY_ID,
+        folder.communityId != null ? String(folder.communityId) : "",
+        (v) => onChange({ ...folder, communityId: v }),
+      )}
+      {field(
+        "locale",
+        EXPLORER_MSG.FOLDER_PROPS_LOCALE,
+        folder.locale ?? "",
+        (v) => onChange({ ...folder, locale: v }),
+      )}
+      {field(
+        "display-format",
+        EXPLORER_MSG.FOLDER_PROPS_DISPLAY_FORMAT,
+        folder.displayFormatName ?? "",
+        (v) => onChange({ ...folder, displayFormatName: v }),
+      )}
+      {field(
+        "workflow-id",
+        EXPLORER_MSG.FOLDER_PROPS_WORKFLOW_ID,
+        folder.workflowId != null ? String(folder.workflowId) : "",
+        (v) => onChange({ ...folder, workflowId: v }),
+      )}
+    </fieldset>
   );
 }
 

--- a/WebUI/src/main/ts/contentExplorer/currentUserIdentities.ts
+++ b/WebUI/src/main/ts/contentExplorer/currentUserIdentities.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Resolve the identity set used by folder ACL self-lockout detection
+ * ({@link detectSelfLockout} / {@code FolderSecurityPanel}).
+ *
+ * <p>Principals on {@code PSFolderPermission} lists are matched by name
+ * only (USER and ROLE). The product session bootstrap exposes the
+ * signed-in user name plus coarse role flags ({@code isAdmin} /
+ * {@code isDesigner}); optional role names may be supplied when a richer
+ * catalog is available.</p>
+ *
+ * <p>Pure helper — no DOM / fetch / React — so Vitest can lock the rules
+ * without mounting the shell.</p>
+ */
+
+export interface CurrentUserIdentitySource {
+  /** Signed-in CMS user name (e.g. spa bootstrap {@code userName}). */
+  userName?: string | null;
+  /** True when the session is an Admin user. */
+  isAdmin?: boolean;
+  /** True when the session is a Designer user. */
+  isDesigner?: boolean;
+  /**
+   * Optional explicit role names (e.g. from a roles API). Deduped with
+   * flag-derived role names below.
+   */
+  roles?: ReadonlyArray<string>;
+}
+
+/**
+ * Built-in product role names inferred from SPA bootstrap flags.
+ * Matches common folder ACL principal names used by the CMS seed data.
+ */
+export const BOOTSTRAP_ROLE_ADMIN = "Admin";
+export const BOOTSTRAP_ROLE_DESIGNER = "Designer";
+
+/**
+ * Build a de-duplicated identity list for lockout detection.
+ *
+ * <p>Order: user name first, then flag-derived roles, then any extra
+ * {@link CurrentUserIdentitySource.roles}. Empty / blank strings are
+ * dropped. When nothing is available, returns an empty array (lockout
+ * detection is a no-op — safer than inventing a principal).</p>
+ */
+export function resolveCurrentUserIdentities(
+  source: CurrentUserIdentitySource,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  const push = (raw: string | null | undefined): void => {
+    if (raw == null) return;
+    const name = raw.trim();
+    if (!name || seen.has(name)) return;
+    seen.add(name);
+    out.push(name);
+  };
+
+  push(source.userName);
+  if (source.isAdmin) {
+    push(BOOTSTRAP_ROLE_ADMIN);
+  }
+  if (source.isDesigner) {
+    push(BOOTSTRAP_ROLE_DESIGNER);
+  }
+  for (const role of source.roles ?? []) {
+    push(role);
+  }
+  return out;
+}

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -132,7 +132,7 @@ export const EXPLORER_MSG = {
   // US4 P-ACL / folder security (FR-014–FR-016, SC-004)
   SECURITY_TITLE: "perc.ui.explorer@Folder Security",
   SECURITY_SELECT_FOLDER:
-    "perc.ui.explorer@Select a folder item to edit ACL.",
+    "perc.ui.explorer@Open or select a folder to edit security and properties.",
   SECURITY_LOADING: "perc.ui.explorer@Loading permissions",
   SECURITY_LOAD_ERROR: "perc.ui.explorer@Failed to load folder permissions",
   SECURITY_SAVE_SUCCESS: "perc.ui.explorer@Permissions saved",
@@ -151,6 +151,13 @@ export const EXPLORER_MSG = {
   SECURITY_PRINCIPAL_REMOVE: "perc.ui.explorer@Remove",
   SECURITY_PRINCIPAL_ADD: "perc.ui.explorer@Add principal",
   SECURITY_PRINCIPAL_NAME_LABEL: "perc.ui.explorer@Principal name",
+  /** Folder properties block (community / locale / display format / workflow). */
+  FOLDER_PROPS_TITLE: "perc.ui.explorer@Folder properties",
+  FOLDER_PROPS_COMMUNITY: "perc.ui.explorer@Community",
+  FOLDER_PROPS_COMMUNITY_ID: "perc.ui.explorer@Community id",
+  FOLDER_PROPS_LOCALE: "perc.ui.explorer@Locale",
+  FOLDER_PROPS_DISPLAY_FORMAT: "perc.ui.explorer@Display format",
+  FOLDER_PROPS_WORKFLOW_ID: "perc.ui.explorer@Workflow id",
   // US7 P-Adv / multi-select + clipboard panel (FR-026, #2400 #2408).
   SELECT_COLUMN_HEADER: "perc.ui.explorer@Select",
   SELECT_ROW_LABEL: "perc.ui.explorer@Select item",

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -15,11 +15,32 @@
  */
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { BootstrapProvider } from "../../../main/ts/app/bootstrap/BootstrapContext";
+import type { SpaBootstrap } from "../../../main/ts/app/bootstrap/types";
 import { ContentExplorerShell } from "../../../main/ts/contentExplorer/ContentExplorerShell";
 import { EXPLORER_MSG } from "../../../main/ts/contentExplorer/messages";
 import { renderA11yGate } from "./a11y";
 import { mockFetch } from "./setup";
+
+const adminBootstrap: SpaBootstrap = {
+  userName: "Admin",
+  locale: "en-us",
+  entry: "explorer",
+  isAdmin: true,
+  isDesigner: false,
+  isWidgetBuilderActive: false,
+};
+
+function renderShell(
+  ui: ReactElement,
+  bootstrap: SpaBootstrap = adminBootstrap,
+) {
+  return render(
+    <BootstrapProvider value={bootstrap}>{ui}</BootstrapProvider>,
+  );
+}
 
 function stubPathFetch() {
   mockFetch(async (input) => {
@@ -48,7 +69,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
   it("renders search toggle, display format select, and server action toolbar", async () => {
     stubPathFetch();
 
-    render(
+    renderShell(
       <ContentExplorerShell
         initialPath="/Sites"
         loadDisplayFormats={async () => [
@@ -105,7 +126,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     const loadMenuActions = vi.fn(async () => []);
     stubPathFetch();
 
-    render(
+    renderShell(
       <ContentExplorerShell
         loadDisplayFormats={loadDisplayFormats}
         loadMenuActions={loadMenuActions}
@@ -133,6 +154,9 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       EXPLORER_MSG.SEARCH_PANEL_REGION,
       EXPLORER_MSG.SECURITY_PANEL_REGION,
       EXPLORER_MSG.SECURITY_SELECT_FOLDER,
+      EXPLORER_MSG.FOLDER_PROPS_TITLE,
+      EXPLORER_MSG.FOLDER_PROPS_COMMUNITY,
+      EXPLORER_MSG.FOLDER_PROPS_LOCALE,
     ];
     for (const key of chromeKeys) {
       expect(key.startsWith("perc.ui.explorer@")).toBe(true);
@@ -141,7 +165,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
 
   it("passes the zero serious/critical axe-core gate (T082a / 508)", async () => {
     stubPathFetch();
-    const { container } = render(
+    const { container } = renderShell(
       <ContentExplorerShell
         initialPath="/Sites"
         loadDisplayFormats={async () => []}
@@ -156,7 +180,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
 
   it("passes axe with search panel expanded", async () => {
     stubPathFetch();
-    const { container } = render(
+    const { container } = renderShell(
       <ContentExplorerShell
         loadDisplayFormats={async () => []}
         loadMenuActions={async () => []}
@@ -170,5 +194,82 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       expect(screen.getByTestId("explorer-search-panel")).toBeInTheDocument(),
     );
     await renderA11yGate(container);
+  });
+
+  it("security toggle shows hint when no folder id is available (#2410)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        resolveFolderId={async () => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("explorer-toggle-security"));
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-security-hint")).toBeInTheDocument();
+    });
+  });
+
+  it("security panel mounts with resolved folder id and session identities (#2410)", async () => {
+    stubPathFetch();
+    const resolveFolderId = vi.fn(async () => "folder-42");
+    // FolderSecurityPanel will fetch properties for folder-42 — stub returns empty.
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("folderProperties") || url.includes("folderproperties")) {
+        return new Response(
+          JSON.stringify({
+            id: "folder-42",
+            name: "Sites",
+            permission: {
+              accessLevel: "ADMIN",
+              adminPrincipals: [{ type: "USER", name: "Admin" }],
+            },
+            communityName: "Default",
+            locale: "en-us",
+            displayFormatName: "FolderList",
+            workflowId: "6",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [],
+              childrenCount: 0,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        resolveFolderId={resolveFolderId}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("explorer-toggle-security"));
+    await waitFor(() => {
+      expect(resolveFolderId).toHaveBeenCalled();
+      expect(screen.getByTestId("explorer-security-panel")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("folder-security-panel")).toBeInTheDocument();
+      expect(screen.getByTestId("folder-properties")).toBeInTheDocument();
+    });
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -211,6 +211,25 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("security stays on hint when resolveFolderId rejects (#2410)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+        resolveFolderId={async () => {
+          throw new Error("lookup failed");
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("explorer-toggle-security"));
+    await waitFor(() => {
+      expect(screen.getByTestId("explorer-security-hint")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("folder-security-panel")).toBeNull();
+  });
+
   it("security panel mounts with resolved folder id and session identities (#2410)", async () => {
     stubPathFetch();
     const resolveFolderId = vi.fn(async () => "folder-42");

--- a/WebUI/src/test/ts/contentExplorer/FolderSecurityPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/FolderSecurityPanel.test.tsx
@@ -364,4 +364,84 @@ describe("FolderSecurityPanel", () => {
     });
     await renderA11yGate(container);
   });
+
+  it("renders folder properties (community / locale / display format / workflow) (#2410)", () => {
+    const props = makeProps({
+      permission: permission(["Admin"], [], [], []),
+      communityName: "Default",
+      communityId: "10",
+      locale: "en-us",
+      displayFormatName: "FolderList",
+      workflowId: "6",
+    });
+    render(
+      <FolderSecurityPanel
+        folderId={props.id}
+        currentUserIdentities={["Admin"]}
+        initial={props}
+      />,
+    );
+    expect(screen.getByTestId("folder-properties")).toBeTruthy();
+    expect(
+      (screen.getByTestId("folder-props-community-name") as HTMLInputElement)
+        .value,
+    ).toBe("Default");
+    expect(
+      (screen.getByTestId("folder-props-locale") as HTMLInputElement).value,
+    ).toBe("en-us");
+    expect(
+      (screen.getByTestId("folder-props-display-format") as HTMLInputElement)
+        .value,
+    ).toBe("FolderList");
+    expect(
+      (screen.getByTestId("folder-props-workflow-id") as HTMLInputElement)
+        .value,
+    ).toBe("6");
+  });
+
+  it("editing folder properties flips dirty and is included in save payload (#2410)", async () => {
+    const props = makeProps({
+      permission: permission(["Admin"], [], [], []),
+      locale: "en-us",
+      communityName: "Default",
+    });
+    const saveMock = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FolderSecurityPanel
+        folderId={props.id}
+        currentUserIdentities={["Admin"]}
+        initial={props}
+        save={saveMock}
+      />,
+    );
+    const locale = screen.getByTestId(
+      "folder-props-locale",
+    ) as HTMLInputElement;
+    fireEvent.change(locale, { target: { value: "fr-fr" } });
+    expect(screen.getByTestId("folder-security-dirty").textContent).toBe("●");
+    fireEvent.click(screen.getByTestId("folder-security-save"));
+    await waitFor(() => {
+      expect(saveMock).toHaveBeenCalledTimes(1);
+    });
+    const saved = saveMock.mock.calls[0]![0] as PSFolderProperties;
+    expect(saved.locale).toBe("fr-fr");
+    expect(saved.permission?.adminPrincipals?.[0]?.name).toBe("Admin");
+  });
+
+  it("folder property inputs are disabled in read-only mode (#2410)", () => {
+    const props = makeProps({
+      permission: permission([], [], [], [], "READ"),
+      locale: "en-us",
+    });
+    render(
+      <FolderSecurityPanel
+        folderId={props.id}
+        currentUserIdentities={["Editor"]}
+        initial={props}
+      />,
+    );
+    expect(
+      (screen.getByTestId("folder-props-locale") as HTMLInputElement).disabled,
+    ).toBe(true);
+  });
 });

--- a/WebUI/src/test/ts/contentExplorer/currentUserIdentities.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/currentUserIdentities.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  BOOTSTRAP_ROLE_ADMIN,
+  BOOTSTRAP_ROLE_DESIGNER,
+  resolveCurrentUserIdentities,
+} from "../../../main/ts/contentExplorer/currentUserIdentities";
+
+describe("resolveCurrentUserIdentities", () => {
+  it("returns empty when no session identity is available", () => {
+    expect(resolveCurrentUserIdentities({})).toEqual([]);
+    expect(
+      resolveCurrentUserIdentities({ userName: "   ", roles: ["", "  "] }),
+    ).toEqual([]);
+  });
+
+  it("includes the signed-in user name", () => {
+    expect(resolveCurrentUserIdentities({ userName: "Editor1" })).toEqual([
+      "Editor1",
+    ]);
+  });
+
+  it("adds Admin role when isAdmin is true (does not invent when false)", () => {
+    // Dedup when userName already equals the role name.
+    expect(
+      resolveCurrentUserIdentities({ userName: "Admin", isAdmin: true }),
+    ).toEqual(["Admin"]);
+    expect(
+      resolveCurrentUserIdentities({ userName: "Alice", isAdmin: true }),
+    ).toEqual(["Alice", BOOTSTRAP_ROLE_ADMIN]);
+    expect(
+      resolveCurrentUserIdentities({ userName: "Alice", isAdmin: false }),
+    ).toEqual(["Alice"]);
+  });
+
+  it("adds Designer role when isDesigner is true", () => {
+    expect(
+      resolveCurrentUserIdentities({
+        userName: "Des",
+        isDesigner: true,
+      }),
+    ).toEqual(["Des", BOOTSTRAP_ROLE_DESIGNER]);
+  });
+
+  it("merges explicit roles without duplicates or blanks", () => {
+    expect(
+      resolveCurrentUserIdentities({
+        userName: "Admin",
+        isAdmin: true,
+        roles: ["Admin", "Editor", "  ", "Contributor", "Editor"],
+      }),
+    ).toEqual(["Admin", "Editor", "Contributor"]);
+  });
+
+  it("works with roles-only source (no userName)", () => {
+    expect(
+      resolveCurrentUserIdentities({
+        isAdmin: true,
+        roles: ["Publisher"],
+      }),
+    ).toEqual([BOOTSTRAP_ROLE_ADMIN, "Publisher"]);
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/index.ts
+++ b/WebUI/src/test/ts/contentExplorer/index.ts
@@ -25,7 +25,7 @@
  * <ul>
  *   <li>US1: {@code pathApi.test.ts}, {@code ExplorerTree.test.tsx}, {@code DetailList.test.tsx}, {@code reducedActions.test.tsx}, {@code sc005-perf-regression.test.tsx}</li>
  *   <li>US3: {@code actionMenuMapper.test.ts}, {@code ContextMenu.test.tsx}, {@code ContextMenu.a11y.test.tsx}</li>
- *   <li>US4: {@code aclLockout.test.ts}, {@code FolderSecurityPanel.test.tsx}</li>
+ *   <li>US4: {@code aclLockout.test.ts}, {@code FolderSecurityPanel.test.tsx}, {@code currentUserIdentities.test.ts}</li>
  *   <li>US5: {@code searchApi.test.ts}, {@code SearchPanel.test.tsx}</li>
  *   <li>US7: {@code clipboard.test.ts}, {@code wizards/}, {@code views/}</li>
  * </ul>

--- a/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us4-acl.spec.js
@@ -116,4 +116,36 @@ test.describe("US4 P-ACL — folder security panel (SC-004)", () => {
         '[data-testid="perc-folder-security-root"], [data-testid="folder-security-panel"]',
     });
   });
+
+  test("Explorer shell security toggle opens panel or folder-select hint (#2410)", async ({
+    page,
+  }) => {
+    // Product path: spa.jsp?entry=explorer — ADMIN opens folder security
+    // from view tools. Without a resolved folder id the shell shows a
+    // polite hint; with a tree folder the panel mounts (folderProperties).
+    const explorerUrl = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+    await page.goto(explorerUrl, { waitUntil: "networkidle" });
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 15_000 });
+    const toggle = page.locator('[data-testid="explorer-toggle-security"]');
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+    // Either the security panel region or the select-folder hint is shown.
+    const panelOrHint = page.locator(
+      '[data-testid="explorer-security-panel"], [data-testid="explorer-security-hint"]',
+    );
+    await expect(panelOrHint.first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("Explorer shell security surface has no miller-column chrome (#2410)", async ({
+    page,
+  }) => {
+    const explorerUrl = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+    await page.goto(explorerUrl, { waitUntil: "networkidle" });
+    await expect(
+      page.locator('[data-testid="content-explorer-shell"]'),
+    ).toBeVisible({ timeout: 15_000 });
+    await page.locator('[data-testid="explorer-toggle-security"]').click();
+    await expect(page.locator(".perc-mcol")).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary

Parent tracker: #2400  
Fixes #2410

Polish the product Explorer **Folder Security** path so ADMIN can edit folder ACL and properties from the shell with real session identities (self-lockout) and community / locale / display format / workflow fields from pathmanagement REST.

### Changes
- **`resolveCurrentUserIdentities`** — pure helper from SPA bootstrap (`userName`, `isAdmin` → Admin role, `isDesigner`, optional roles)
- **`ContentExplorerShell`** — wires bootstrap identities into `FolderSecurityPanel`; resolves folder content id from selected folder **or** active folder path via `findItemByPath`; seeds selection from `initialPath` so deep-links work without an extra tree click
- **`FolderSecurityPanel`** — folder properties editor (community name/id, locale, display format, workflow id) saved with existing `saveFolderProperties`
- **Vitest** — identities unit tests; panel properties dirty/save/readonly; shell security panel + folder id resolution
- **Playwright** — `us4-acl.spec.js` extended for Explorer shell security toggle

### Not in this PR
- Multi-select / clipboard (already done #2408)
- Full community/workflow catalog pickers (free-text fields aligned to REST DTOs; richer pickers residual if needed after UAT)

## Test plan
1. `cd WebUI/src/main/frontend && npm test -- --run` (focused: currentUserIdentities, FolderSecurityPanel, ContentExplorerShell) — **31 passed**
2. `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS** (war + Java tests)
3. Playwright surface (when QA H2 available):  
   `npm run test:surface -- --path tests/us4-acl.spec.js` from `modules/perc-qa-automation/frontend`
4. Manual: Admin → Explorer → open folder → Folder Security → edit ACL principal + locale → Save; confirm self-lockout when removing own principal

## Gates evidence
- Erlang-style self-review: no invented REST fields; portable paths N/A (UI only); companions: Vitest + Playwright us4-acl
- Pre-PR Maven: standalone `WebUI` clean install SUCCESS
- Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
