### PR TITLE
feat(rest): create-variant / item-locale translations façade (#2429)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTranslationsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTranslationsAdaptor.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.cms.objectstore.PSComponentSummary;
+import com.percussion.cms.objectstore.PSCoreItem;
+import com.percussion.cms.objectstore.PSItemField;
+import com.percussion.cms.objectstore.PSRelationshipFilter;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.rest.translations.CreateTranslationsRequest;
+import com.percussion.rest.translations.CreateTranslationsResult;
+import com.percussion.rest.translations.IContentTranslationsAdaptor;
+import com.percussion.rest.translations.ItemTranslationVariants;
+import com.percussion.rest.translations.TranslationVariant;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.content.data.PSAutoTranslation;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
+import com.percussion.services.legacy.PSCmsObjectMgrLocator;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.content.PSContentWsLocator;
+import com.percussion.webservices.system.IPSSystemWs;
+import com.percussion.webservices.system.PSSystemWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Public REST create-variant / item-locale façade (#2429).
+ *
+ * <p>Thin apibridge over {@link IPSContentWs#newTranslations(List, List, String, boolean)} — the
+ * same domain path SOAP {@code content.NewTranslations} uses. Item-locale listing uses component
+ * summaries plus translation-category dependents.
+ *
+ * <p><strong>Out of scope:</strong> in-flight translation queue filter and session content-locale
+ * context (product disposition on #2411 / #2428).
+ */
+@PSSiteManageBean
+public class ContentTranslationsAdaptor implements IContentTranslationsAdaptor {
+
+  private static final Logger log = LogManager.getLogger(ContentTranslationsAdaptor.class);
+
+  static final String ROLE_SOURCE = "source";
+  static final String ROLE_TRANSLATION = "translation";
+
+  private final IPSContentWs contentWs;
+  private final IPSSystemWs systemWs;
+  private final IPSIdMapper idMapper;
+  private final Supplier<IPSCmsObjectMgr> objectMgr;
+  private final Function<String, IPSGuid> guidResolver;
+
+  @Autowired
+  public ContentTranslationsAdaptor(IPSIdMapper idMapper) {
+    this(
+        PSContentWsLocator.getContentWebservice(),
+        PSSystemWsLocator.getSystemWebservice(),
+        idMapper,
+        PSCmsObjectMgrLocator::getObjectManager,
+        idMapper::getGuid);
+  }
+
+  /** Package-visible for unit tests. */
+  ContentTranslationsAdaptor(
+      IPSContentWs contentWs,
+      IPSSystemWs systemWs,
+      IPSIdMapper idMapper,
+      Supplier<IPSCmsObjectMgr> objectMgr,
+      Function<String, IPSGuid> guidResolver) {
+    this.contentWs = contentWs;
+    this.systemWs = systemWs;
+    this.idMapper = idMapper;
+    this.objectMgr = objectMgr;
+    this.guidResolver = guidResolver;
+  }
+
+  @Override
+  public CreateTranslationsResult createTranslations(
+      URI baseUri, CreateTranslationsRequest request) {
+    if (request == null) {
+      throw new IllegalArgumentException("request is required");
+    }
+    List<Long> itemIds = request.getItemIds();
+    if (itemIds == null || itemIds.isEmpty()) {
+      throw new IllegalArgumentException("itemIds is required and must not be empty");
+    }
+
+    List<IPSGuid> guids = new ArrayList<>();
+    for (Long id : itemIds) {
+      if (id == null || id <= 0) {
+        throw new IllegalArgumentException("itemIds must contain positive content ids");
+      }
+      if (id > Integer.MAX_VALUE) {
+        throw new IllegalArgumentException("itemIds content id out of range: " + id);
+      }
+      // content id + undefined revision — same shape SOAP NewTranslations uses via legacy guids
+      guids.add(new PSLegacyGuid(id.intValue(), -1));
+    }
+
+    List<PSAutoTranslation> settings = toAutoTranslations(request.getLocales());
+    String relationshipType = StringUtils.trimToNull(request.getRelationshipType());
+    boolean enableRevisions = Boolean.TRUE.equals(request.getEnableRevisions());
+
+    try {
+      List<PSCoreItem> created =
+          contentWs.newTranslations(guids, settings, relationshipType, enableRevisions);
+      return new CreateTranslationsResult(mapCreated(created, itemIds));
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      log.warn("newTranslations partial/error results: {}", e.getAllErrorString());
+      throw new WebApplicationException(
+          "Failed to create one or more translations: " + e.getAllErrorString(),
+          e,
+          Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (PSErrorException e) {
+      log.error("newTranslations failed: {}", e.getMessage(), e);
+      throw new WebApplicationException(
+          "Failed to create translations.", e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.error("newTranslations unexpected failure: {}", e.getMessage(), e);
+      throw e;
+    }
+  }
+
+  @Override
+  public ItemTranslationVariants listItemVariants(URI baseUri, String itemId) {
+    if (StringUtils.isBlank(itemId)) {
+      throw new IllegalArgumentException("itemId is required");
+    }
+    if (!isSafeItemKey(itemId)) {
+      throw new IllegalArgumentException("itemId contains invalid characters");
+    }
+
+    IPSGuid guid;
+    try {
+      guid = guidResolver.apply(itemId.trim());
+    } catch (RuntimeException e) {
+      log.debug("Could not resolve item id {}: {}", itemId, e.getMessage());
+      return null;
+    }
+    if (guid == null) {
+      return null;
+    }
+
+    int contentId = contentIdFromGuid(guid);
+    PSComponentSummary sourceSummary = loadSummary(contentId);
+    if (sourceSummary == null) {
+      return null;
+    }
+
+    ItemTranslationVariants out = new ItemTranslationVariants();
+    out.setItemId(contentId);
+    out.setLocale(sourceSummary.getLocale());
+
+    List<TranslationVariant> variants = new ArrayList<>();
+    variants.add(fromSummary(sourceSummary, ROLE_SOURCE, null));
+
+    try {
+      List<IPSGuid> dependents = findTranslationDependents(guid);
+      for (IPSGuid dep : dependents) {
+        int depId = contentIdFromGuid(dep);
+        if (depId <= 0 || depId == contentId) {
+          continue;
+        }
+        PSComponentSummary depSum = loadSummary(depId);
+        if (depSum == null) {
+          continue;
+        }
+        variants.add(fromSummary(depSum, ROLE_TRANSLATION, (long) contentId));
+      }
+    } catch (RuntimeException e) {
+      // AuthZ / infrastructure — surface as 403-style security failure when message suggests
+      // access denial; otherwise rethrow for 500.
+      if (isAuthzFailure(e)) {
+        throw new SecurityException("Cannot list translation variants for " + itemId, e);
+      }
+      throw e;
+    }
+
+    out.setVariants(variants);
+    return out;
+  }
+
+  private List<IPSGuid> findTranslationDependents(IPSGuid guid) {
+    PSRelationshipFilter filter = new PSRelationshipFilter();
+    filter.setCategory(PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION);
+    PSLocator owner = idMapper.getLocator(guid);
+    if (owner != null) {
+      filter.setOwner(owner);
+    }
+    List<IPSGuid> rows = systemWs.findDependents(guid, filter);
+    return rows != null ? rows : List.of();
+  }
+
+  private PSComponentSummary loadSummary(int contentId) {
+    if (contentId <= 0) {
+      return null;
+    }
+    try {
+      return objectMgr.get().loadComponentSummary(contentId);
+    } catch (RuntimeException e) {
+      log.debug("loadComponentSummary({}) failed: {}", contentId, e.getMessage());
+      return null;
+    }
+  }
+
+  static List<PSAutoTranslation> toAutoTranslations(List<String> locales) {
+    if (locales == null || locales.isEmpty()) {
+      // SOAP parity: null means use all system auto-translations
+      return null;
+    }
+    List<PSAutoTranslation> out = new ArrayList<>();
+    for (String locale : locales) {
+      if (StringUtils.isBlank(locale)) {
+        throw new IllegalArgumentException("locales must not contain blank entries");
+      }
+      String normalized = locale.trim();
+      if (!isSafeLocaleKey(normalized)) {
+        throw new IllegalArgumentException("invalid locale: " + locale);
+      }
+      PSAutoTranslation at = new PSAutoTranslation();
+      at.setLocale(normalized);
+      out.add(at);
+    }
+    return out;
+  }
+
+  static List<TranslationVariant> mapCreated(List<PSCoreItem> items, List<Long> sourceIds) {
+    List<TranslationVariant> out = new ArrayList<>();
+    if (items == null) {
+      return out;
+    }
+    Long singleSource =
+        sourceIds != null && sourceIds.size() == 1 ? sourceIds.get(0) : null;
+    for (PSCoreItem item : items) {
+      if (item == null) {
+        continue;
+      }
+      TranslationVariant v = new TranslationVariant();
+      v.setContentId(item.getContentId());
+      int rev = item.getRevision();
+      if (rev > 0) {
+        v.setRevision(rev);
+      } else {
+        int cur = item.getCurrentRevision();
+        if (cur > 0) {
+          v.setRevision(cur);
+        }
+      }
+      v.setLocale(readLocaleField(item));
+      v.setRole(ROLE_TRANSLATION);
+      v.setSourceContentId(singleSource);
+      out.add(v);
+    }
+    return out;
+  }
+
+  static String readLocaleField(PSCoreItem item) {
+    if (item == null) {
+      return null;
+    }
+    try {
+      PSItemField field = item.getFieldByName("sys_lang");
+      if (field == null || field.getValue() == null) {
+        return null;
+      }
+      return field.getValue().getValueAsString();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  static TranslationVariant fromSummary(
+      PSComponentSummary summary, String role, Long sourceContentId) {
+    TranslationVariant v = new TranslationVariant();
+    v.setContentId(summary.getContentId());
+    v.setLocale(summary.getLocale());
+    v.setRole(role);
+    v.setSourceContentId(sourceContentId);
+    if (summary.getCurrentLocator() != null) {
+      int rev = summary.getCurrentLocator().getRevision();
+      if (rev > 0) {
+        v.setRevision(rev);
+      }
+    }
+    return v;
+  }
+
+  static int contentIdFromGuid(IPSGuid guid) {
+    if (guid == null) {
+      return -1;
+    }
+    if (guid instanceof PSLegacyGuid legacy) {
+      return legacy.getContentId();
+    }
+    // Untyped / typed guids: UUID portion is content id for item type
+    if (guid.getType() == PSTypeEnum.ITEM.getOrdinal() || guid.getType() == 0) {
+      return guid.getUUID();
+    }
+    return guid.getUUID();
+  }
+
+  static boolean isSafeItemKey(String key) {
+    if (StringUtils.isBlank(key)) {
+      return false;
+    }
+    return !key.contains("..")
+        && key.indexOf('/') < 0
+        && key.indexOf('\\') < 0
+        && key.indexOf('\0') < 0;
+  }
+
+  static boolean isSafeLocaleKey(String key) {
+    if (StringUtils.isBlank(key)) {
+      return false;
+    }
+    return !key.contains("..")
+        && key.indexOf('/') < 0
+        && key.indexOf('\\') < 0
+        && key.indexOf('\0') < 0
+        && key.length() <= 64;
+  }
+
+  private static boolean isAuthzFailure(RuntimeException e) {
+    String msg = e.getMessage();
+    if (msg == null) {
+      return false;
+    }
+    String lower = msg.toLowerCase();
+    return lower.contains("access")
+        || lower.contains("denied")
+        || lower.contains("permission")
+        || lower.contains("not authorized")
+        || lower.contains("forbidden");
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTranslationsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTranslationsAdaptor.java
@@ -27,7 +27,6 @@ import com.percussion.rest.translations.CreateTranslationsResult;
 import com.percussion.rest.translations.IContentTranslationsAdaptor;
 import com.percussion.rest.translations.ItemTranslationVariants;
 import com.percussion.rest.translations.TranslationVariant;
-import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.content.data.PSAutoTranslation;
 import com.percussion.services.guidmgr.data.PSLegacyGuid;
 import com.percussion.services.legacy.IPSCmsObjectMgr;
@@ -227,10 +226,11 @@ public class ContentTranslationsAdaptor implements IContentTranslationsAdaptor {
       return null;
     }
     try {
+      // null = not found → resource 404; RuntimeException = infrastructure → 500
       return objectMgr.get().loadComponentSummary(contentId);
     } catch (RuntimeException e) {
-      log.debug("loadComponentSummary({}) failed: {}", contentId, e.getMessage());
-      return null;
+      log.warn("loadComponentSummary({}) failed: {}", contentId, e.getMessage());
+      throw e;
     }
   }
 
@@ -296,6 +296,10 @@ public class ContentTranslationsAdaptor implements IContentTranslationsAdaptor {
       }
       return field.getValue().getValueAsString();
     } catch (Exception e) {
+      log.warn(
+          "Could not read sys_lang locale from content id {}: {}",
+          item.getContentId(),
+          e.toString());
       return null;
     }
   }
@@ -323,15 +327,16 @@ public class ContentTranslationsAdaptor implements IContentTranslationsAdaptor {
     if (guid instanceof PSLegacyGuid legacy) {
       return legacy.getContentId();
     }
-    // Untyped / typed guids: UUID portion is content id for item type
-    if (guid.getType() == PSTypeEnum.ITEM.getOrdinal() || guid.getType() == 0) {
-      return guid.getUUID();
-    }
+    // Non-legacy guids: UUID is the best available numeric id for any type (item or
+    // untyped). Callers still validate via loadComponentSummary (null → not found).
     return guid.getUUID();
   }
 
+  /** Max path token length for content id / guid string (path-injection surface). */
+  static final int MAX_ITEM_KEY_LENGTH = 128;
+
   static boolean isSafeItemKey(String key) {
-    if (StringUtils.isBlank(key)) {
+    if (StringUtils.isBlank(key) || key.length() > MAX_ITEM_KEY_LENGTH) {
       return false;
     }
     return !key.contains("..")
@@ -351,16 +356,23 @@ public class ContentTranslationsAdaptor implements IContentTranslationsAdaptor {
         && key.length() <= 64;
   }
 
-  private static boolean isAuthzFailure(RuntimeException e) {
-    String msg = e.getMessage();
-    if (msg == null) {
-      return false;
+  /**
+   * Prefer exception type hierarchy over message keywords so unrelated errors that mention
+   * "access"/"permission" are not mis-mapped to 403.
+   */
+  static boolean isAuthzFailure(Throwable e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      if (t instanceof SecurityException) {
+        return true;
+      }
+      String simple = t.getClass().getSimpleName();
+      if (simple.contains("Authorization")
+          || simple.contains("AccessDenied")
+          || simple.contains("NotAuthorized")
+          || simple.contains("Forbidden")) {
+        return true;
+      }
     }
-    String lower = msg.toLowerCase();
-    return lower.contains("access")
-        || lower.contains("denied")
-        || lower.contains("permission")
-        || lower.contains("not authorized")
-        || lower.contains("forbidden");
+    return false;
   }
 }

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -84,6 +84,7 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="restContextResource" />
             <ref bean="restDeliveryTypesResource" />
             <ref bean="restRelationshipSummaryResource" />
+            <ref bean="restContentTranslationsResource" />
             <ref bean="restEditionsResource" />
             <ref bean="restExtensionsResource" />
             <ref bean="restItemFilterResource" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
@@ -46,7 +46,14 @@ import com.percussion.utils.guid.IPSGuid;
 import com.percussion.webservices.content.IPSContentWs;
 import com.percussion.webservices.system.IPSSystemWs;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -65,12 +72,32 @@ class ContentTranslationsAdaptorTest {
   @Mock private IPSCmsObjectMgr objectMgr;
 
   private ContentTranslationsAdaptor adaptor;
+  private CapturingAppender logAppender;
+  private Logger logger;
+  private Level previousLevel;
 
   @BeforeEach
   void init() {
     adaptor =
         new ContentTranslationsAdaptor(
             contentWs, systemWs, idMapper, () -> objectMgr, idMapper::getGuid);
+    logAppender = new CapturingAppender("ContentTranslationsAdaptorTest");
+    logAppender.start();
+    logger = (Logger) LogManager.getLogger(ContentTranslationsAdaptor.class);
+    previousLevel = logger.getLevel();
+    logger.addAppender(logAppender);
+    logger.setLevel(Level.WARN);
+  }
+
+  @AfterEach
+  void tearDownLogs() {
+    if (logger != null) {
+      logger.removeAppender(logAppender);
+      logger.setLevel(previousLevel);
+    }
+    if (logAppender != null) {
+      logAppender.stop();
+    }
   }
 
   @Test
@@ -229,5 +256,75 @@ class ContentTranslationsAdaptorTest {
     RuntimeException wrapped =
         new RuntimeException("outer", new SecurityException("not allowed"));
     assertTrue(ContentTranslationsAdaptor.isAuthzFailure(wrapped));
+  }
+
+  @Test
+  void listPropagatesLoadSummaryInfrastructureErrors() {
+    // loadSummary used to swallow RuntimeException as null (404). Infrastructure failures must
+    // now surface so the REST layer can map them to 500 instead of a false 404.
+    PSLegacyGuid sourceGuid = new PSLegacyGuid(100L);
+    when(idMapper.getGuid("100")).thenReturn(sourceGuid);
+    when(objectMgr.loadComponentSummary(100))
+        .thenThrow(new IllegalStateException("cms object manager unavailable"));
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> adaptor.listItemVariants(URI.create("http://localhost/rest"), "100"));
+    assertTrue(ex.getMessage().contains("unavailable"));
+    assertTrue(
+        logAppender.getEvents().stream()
+            .anyMatch(
+                event ->
+                    event.getLevel() == Level.WARN
+                        && event
+                            .getMessage()
+                            .getFormattedMessage()
+                            .contains("loadComponentSummary(100) failed")),
+        "loadSummary must warn before rethrowing infrastructure failures");
+  }
+
+  @Test
+  void readLocaleFieldLogsWarnAndReturnsNullOnException() {
+    PSCoreItem item = mock(PSCoreItem.class);
+    when(item.getContentId()).thenReturn(42);
+    when(item.getFieldByName("sys_lang")).thenThrow(new RuntimeException("sys_lang unreadable"));
+
+    assertNull(ContentTranslationsAdaptor.readLocaleField(item));
+    assertTrue(
+        logAppender.getEvents().stream()
+            .anyMatch(
+                event ->
+                    event.getLevel() == Level.WARN
+                        && event
+                            .getMessage()
+                            .getFormattedMessage()
+                            .contains("Could not read sys_lang locale from content id 42")),
+        "readLocaleField must log a warning when sys_lang cannot be read");
+  }
+
+  /**
+   * Minimal log4j2 appender that captures emitted {@link LogEvent}s (same approach as {@code
+   * PSCategoryLockInfoLocationTest} — sitemanage does not depend on log4j-core-test).
+   */
+  static final class CapturingAppender extends AbstractAppender {
+    private final List<LogEvent> events = new ArrayList<>();
+
+    CapturingAppender(String name) {
+      super(name, null, null, true);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      synchronized (events) {
+        events.add(event.toImmutable());
+      }
+    }
+
+    List<LogEvent> getEvents() {
+      synchronized (events) {
+        return new ArrayList<>(events);
+      }
+    }
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
@@ -211,4 +211,23 @@ class ContentTranslationsAdaptorTest {
     assertTrue(!ContentTranslationsAdaptor.isSafeItemKey("../etc"));
     assertTrue(!ContentTranslationsAdaptor.isSafeItemKey("a/b"));
   }
+
+  @Test
+  void isSafeItemKeyRejectsOverlong() {
+    String ok = "x".repeat(ContentTranslationsAdaptor.MAX_ITEM_KEY_LENGTH);
+    String tooLong = ok + "y";
+    assertTrue(ContentTranslationsAdaptor.isSafeItemKey(ok));
+    assertTrue(!ContentTranslationsAdaptor.isSafeItemKey(tooLong));
+  }
+
+  @Test
+  void isAuthzFailurePrefersTypeOverMessageKeywords() {
+    assertTrue(ContentTranslationsAdaptor.isAuthzFailure(new SecurityException("x")));
+    assertTrue(
+        !ContentTranslationsAdaptor.isAuthzFailure(
+            new IllegalStateException("access to cache denied by config")));
+    RuntimeException wrapped =
+        new RuntimeException("outer", new SecurityException("not allowed"));
+    assertTrue(ContentTranslationsAdaptor.isAuthzFailure(wrapped));
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTranslationsAdaptorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSComponentSummary;
+import com.percussion.cms.objectstore.PSCoreItem;
+import com.percussion.cms.objectstore.PSRelationshipFilter;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.rest.translations.CreateTranslationsRequest;
+import com.percussion.rest.translations.CreateTranslationsResult;
+import com.percussion.rest.translations.ItemTranslationVariants;
+import com.percussion.rest.translations.TranslationVariant;
+import com.percussion.services.content.data.PSAutoTranslation;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.system.IPSSystemWs;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("UnitTest")
+class ContentTranslationsAdaptorTest {
+
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSSystemWs systemWs;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSCmsObjectMgr objectMgr;
+
+  private ContentTranslationsAdaptor adaptor;
+
+  @BeforeEach
+  void init() {
+    adaptor =
+        new ContentTranslationsAdaptor(
+            contentWs, systemWs, idMapper, () -> objectMgr, idMapper::getGuid);
+  }
+
+  @Test
+  void createRequiresItemIds() {
+    CreateTranslationsRequest req = new CreateTranslationsRequest();
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.createTranslations(URI.create("http://localhost/rest"), req));
+    assertTrue(ex.getMessage().contains("itemIds"));
+  }
+
+  @Test
+  void createNullRequestFails() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.createTranslations(URI.create("http://localhost/rest"), null));
+  }
+
+  @Test
+  void createDelegatesToContentWsWithLocales() throws Exception {
+    CreateTranslationsRequest req = new CreateTranslationsRequest();
+    req.setItemIds(List.of(100L));
+    req.setLocales(List.of("fr-fr", "es-es"));
+    req.setEnableRevisions(true);
+
+    PSCoreItem item = mock(PSCoreItem.class);
+    when(item.getContentId()).thenReturn(200);
+    when(item.getRevision()).thenReturn(1);
+    when(item.getFieldByName("sys_lang")).thenReturn(null);
+
+    when(contentWs.newTranslations(any(), any(), isNull(), eq(true))).thenReturn(List.of(item));
+
+    CreateTranslationsResult out =
+        adaptor.createTranslations(URI.create("http://localhost/rest"), req);
+
+    assertEquals(1, out.getCreated().size());
+    assertEquals(200L, out.getCreated().get(0).getContentId());
+    assertEquals(Integer.valueOf(1), out.getCreated().get(0).getRevision());
+    assertEquals(ContentTranslationsAdaptor.ROLE_TRANSLATION, out.getCreated().get(0).getRole());
+    assertEquals(Long.valueOf(100L), out.getCreated().get(0).getSourceContentId());
+
+    ArgumentCaptor<List<IPSGuid>> guidsCap = ArgumentCaptor.forClass(List.class);
+    ArgumentCaptor<List<PSAutoTranslation>> settingsCap = ArgumentCaptor.forClass(List.class);
+    verify(contentWs)
+        .newTranslations(guidsCap.capture(), settingsCap.capture(), isNull(), eq(true));
+
+    assertEquals(1, guidsCap.getValue().size());
+    assertEquals(2, settingsCap.getValue().size());
+    assertEquals("fr-fr", settingsCap.getValue().get(0).getLocale());
+    assertEquals("es-es", settingsCap.getValue().get(1).getLocale());
+  }
+
+  @Test
+  void createWithEmptyLocalesPassesNullSettings() throws Exception {
+    CreateTranslationsRequest req = new CreateTranslationsRequest();
+    req.setItemIds(List.of(55L));
+    req.setLocales(List.of());
+
+    when(contentWs.newTranslations(any(), isNull(), isNull(), eq(false))).thenReturn(List.of());
+
+    CreateTranslationsResult out =
+        adaptor.createTranslations(URI.create("http://localhost/rest"), req);
+    assertNotNull(out.getCreated());
+    assertTrue(out.getCreated().isEmpty());
+    verify(contentWs).newTranslations(any(), isNull(), isNull(), eq(false));
+  }
+
+  @Test
+  void createRejectsBlankLocale() {
+    CreateTranslationsRequest req = new CreateTranslationsRequest();
+    req.setItemIds(List.of(1L));
+    req.setLocales(List.of("fr-fr", "  "));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.createTranslations(URI.create("http://localhost/rest"), req));
+  }
+
+  @Test
+  void toAutoTranslationsNullMeansSystemDefault() {
+    assertNull(ContentTranslationsAdaptor.toAutoTranslations(null));
+    assertNull(ContentTranslationsAdaptor.toAutoTranslations(List.of()));
+  }
+
+  @Test
+  void listItemVariantsIncludesSourceAndDependents() {
+    PSLegacyGuid sourceGuid = new PSLegacyGuid(100L);
+    when(idMapper.getGuid("100")).thenReturn(sourceGuid);
+    when(idMapper.getLocator(sourceGuid)).thenReturn(new PSLocator(100, 1));
+
+    PSComponentSummary source = mock(PSComponentSummary.class);
+    when(source.getContentId()).thenReturn(100);
+    when(source.getLocale()).thenReturn("en-us");
+    when(source.getCurrentLocator()).thenReturn(new PSLocator(100, 1));
+    when(objectMgr.loadComponentSummary(100)).thenReturn(source);
+
+    PSLegacyGuid depGuid = new PSLegacyGuid(200L);
+    when(systemWs.findDependents(eq(sourceGuid), any(PSRelationshipFilter.class)))
+        .thenReturn(List.of(depGuid));
+
+    PSComponentSummary dep = mock(PSComponentSummary.class);
+    when(dep.getContentId()).thenReturn(200);
+    when(dep.getLocale()).thenReturn("fr-fr");
+    when(dep.getCurrentLocator()).thenReturn(new PSLocator(200, 1));
+    when(objectMgr.loadComponentSummary(200)).thenReturn(dep);
+
+    ItemTranslationVariants out =
+        adaptor.listItemVariants(URI.create("http://localhost/rest"), "100");
+
+    assertEquals(100L, out.getItemId());
+    assertEquals("en-us", out.getLocale());
+    assertEquals(2, out.getVariants().size());
+    TranslationVariant src = out.getVariants().get(0);
+    assertEquals(ContentTranslationsAdaptor.ROLE_SOURCE, src.getRole());
+    assertEquals("en-us", src.getLocale());
+    TranslationVariant tr = out.getVariants().get(1);
+    assertEquals(ContentTranslationsAdaptor.ROLE_TRANSLATION, tr.getRole());
+    assertEquals("fr-fr", tr.getLocale());
+    assertEquals(Long.valueOf(100L), tr.getSourceContentId());
+  }
+
+  @Test
+  void listBlankItemIdFails() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.listItemVariants(URI.create("http://localhost/rest"), "  "));
+  }
+
+  @Test
+  void listUnresolvedIdReturnsNull() {
+    when(idMapper.getGuid("missing")).thenThrow(new RuntimeException("not found"));
+    assertNull(adaptor.listItemVariants(URI.create("http://localhost/rest"), "missing"));
+  }
+
+  @Test
+  void isSafeItemKeyRejectsTraversal() {
+    assertTrue(ContentTranslationsAdaptor.isSafeItemKey("123"));
+    assertTrue(!ContentTranslationsAdaptor.isSafeItemKey("../etc"));
+    assertTrue(!ContentTranslationsAdaptor.isSafeItemKey("a/b"));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -47,6 +47,8 @@ class CatalogRestJaxrsRegistrationTest {
     "restSharedFieldsResource",
     "restSystemDefResource",
     "restExtensionsResource",
+    // #2429 P-Trans create-variant / item-locale façade
+    "restContentTranslationsResource",
   };
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/translations/ContentTranslationsResource.java
+++ b/rest/src/main/java/com/percussion/rest/translations/ContentTranslationsResource.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.translations;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.net.URI;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Public REST façade for content-item translation (P-Trans / #2429).
+ *
+ * <pre>
+ *   POST /Rhythmyx/rest/content-explorer/translations
+ *   GET  /Rhythmyx/rest/content-explorer/translations/{itemId}
+ * </pre>
+ *
+ * <p>Thin HTTP layer over the same domain path SOAP {@code content.NewTranslations} uses. Does
+ * <strong>not</strong> call SOAP from the SPA path — apibridge invokes {@code
+ * IPSContentWs#newTranslations} in-process.
+ *
+ * <p><strong>Not exposed (product disposition pending on #2411/#2428):</strong> in-flight
+ * translation queue filter, session content-locale context switch.
+ */
+@PSSiteManageBean(value = "restContentTranslationsResource")
+@Path("/content-explorer/translations")
+@Tag(
+    name = "Content Explorer Translations",
+    description =
+        "Create and list content-item locale variants (NewTranslations public REST façade)")
+public class ContentTranslationsResource {
+
+  static Logger log = LogManager.getLogger(ContentTranslationsResource.class);
+
+  private final IContentTranslationsAdaptor adaptor;
+
+  @Context private UriInfo uriInfo;
+
+  public ContentTranslationsResource() {
+    this.adaptor = null;
+  }
+
+  @Autowired
+  public ContentTranslationsResource(IContentTranslationsAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
+
+  /** Package-private test hook so unit tests need not reflect on {@code uriInfo}. */
+  void setUriInfo(UriInfo uriInfo) {
+    this.uriInfo = uriInfo;
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Create content-item locale variants",
+      description =
+          "Creates new locale variants for the supplied source content ids. Same domain path as"
+              + " SOAP content.NewTranslations / IPSContentWs.newTranslations. When locales is"
+              + " omitted, all system auto-translations are used.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK — created variants returned",
+            content =
+                @Content(schema = @Schema(implementation = CreateTranslationsResult.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request body / contract"),
+        @ApiResponse(responseCode = "403", description = "Not allowed"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error creating translations")
+      })
+  public CreateTranslationsResult createTranslations(CreateTranslationsRequest body) {
+    if (body == null) {
+      throw new WebApplicationException("Request body is required.", 400);
+    }
+    try {
+      return requireAdaptor().createTranslations(baseUri(), body);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), e, 400);
+    } catch (SecurityException e) {
+      throw new WebApplicationException(e.getMessage(), e, 403);
+    } catch (Exception e) {
+      log.error(
+          "Failed to create translations ({}): {}", e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException("Failed to create translations.", e, 500);
+    }
+  }
+
+  @GET
+  @Path("/{itemId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "List locale variants for a content item",
+      description =
+          "Returns the item's current locale plus translation-category dependents. Does not include"
+              + " in-flight queue status or session content-locale context (product disposition).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content =
+                @Content(schema = @Schema(implementation = ItemTranslationVariants.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid item id"),
+        @ApiResponse(responseCode = "403", description = "Caller cannot read the item"),
+        @ApiResponse(responseCode = "404", description = "Item not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public ItemTranslationVariants listItemVariants(
+      @Parameter(name = "itemId", required = true, description = "Legacy content id or guid string")
+          @PathParam("itemId")
+          String itemId) {
+    try {
+      ItemTranslationVariants out = requireAdaptor().listItemVariants(baseUri(), itemId);
+      if (out == null) {
+        throw new WebApplicationException("Item not found", 404);
+      }
+      return out;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), e, 400);
+    } catch (SecurityException e) {
+      throw new WebApplicationException(e.getMessage(), e, 403);
+    } catch (Exception e) {
+      log.error(
+          "Failed to list translation variants for {} ({}): {}",
+          itemId,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException("Failed to list translation variants.", e, 500);
+    }
+  }
+
+  private URI baseUri() {
+    return uriInfo == null ? null : uriInfo.getBaseUri();
+  }
+
+  private IContentTranslationsAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      throw new WebApplicationException(
+          "Content translations adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
+    }
+    return adaptor;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/translations/ContentTranslationsResource.java
+++ b/rest/src/main/java/com/percussion/rest/translations/ContentTranslationsResource.java
@@ -105,20 +105,29 @@ public class ContentTranslationsResource {
       })
   public CreateTranslationsResult createTranslations(CreateTranslationsRequest body) {
     if (body == null) {
-      throw new WebApplicationException("Request body is required.", 400);
+      throw new WebApplicationException(
+          Response.status(Response.Status.BAD_REQUEST)
+              .entity("Request body is required.")
+              .build());
     }
     try {
       return requireAdaptor().createTranslations(baseUri(), body);
     } catch (WebApplicationException e) {
       throw e;
     } catch (IllegalArgumentException e) {
-      throw new WebApplicationException(e.getMessage(), e, 400);
+      throw new WebApplicationException(
+          e, Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build());
     } catch (SecurityException e) {
-      throw new WebApplicationException(e.getMessage(), e, 403);
+      throw new WebApplicationException(
+          e, Response.status(Response.Status.FORBIDDEN).entity(e.getMessage()).build());
     } catch (Exception e) {
       log.error(
           "Failed to create translations ({}): {}", e.getClass().getName(), e.getMessage(), e);
-      throw new WebApplicationException("Failed to create translations.", e, 500);
+      throw new WebApplicationException(
+          e,
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+              .entity("Failed to create translations.")
+              .build());
     }
   }
 
@@ -149,15 +158,18 @@ public class ContentTranslationsResource {
     try {
       ItemTranslationVariants out = requireAdaptor().listItemVariants(baseUri(), itemId);
       if (out == null) {
-        throw new WebApplicationException("Item not found", 404);
+        throw new WebApplicationException(
+            Response.status(Response.Status.NOT_FOUND).entity("Item not found").build());
       }
       return out;
     } catch (WebApplicationException e) {
       throw e;
     } catch (IllegalArgumentException e) {
-      throw new WebApplicationException(e.getMessage(), e, 400);
+      throw new WebApplicationException(
+          e, Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build());
     } catch (SecurityException e) {
-      throw new WebApplicationException(e.getMessage(), e, 403);
+      throw new WebApplicationException(
+          e, Response.status(Response.Status.FORBIDDEN).entity(e.getMessage()).build());
     } catch (Exception e) {
       log.error(
           "Failed to list translation variants for {} ({}): {}",
@@ -165,7 +177,11 @@ public class ContentTranslationsResource {
           e.getClass().getName(),
           e.getMessage(),
           e);
-      throw new WebApplicationException("Failed to list translation variants.", e, 500);
+      throw new WebApplicationException(
+          e,
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+              .entity("Failed to list translation variants.")
+              .build());
     }
   }
 

--- a/rest/src/main/java/com/percussion/rest/translations/CreateTranslationsRequest.java
+++ b/rest/src/main/java/com/percussion/rest/translations/CreateTranslationsRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.translations;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Wire request for public create-variant (content-item translation) — SOAP {@code
+ * content.NewTranslations} parity.
+ *
+ * <p>When {@link #locales} is null or empty, the server uses all currently defined system auto
+ * translations (same default as SOAP). When provided, only those target locales are created.
+ */
+@XmlRootElement(name = "CreateTranslationsRequest")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Create content-item locale variants (NewTranslations façade)")
+public class CreateTranslationsRequest {
+
+  @Schema(
+      description = "Legacy content ids of source items to translate",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private List<Long> itemIds = new ArrayList<>();
+
+  @Schema(
+      description =
+          "Target locale language strings (e.g. fr-fr). Empty/null = all system auto-translations.")
+  private List<String> locales;
+
+  @Schema(
+      description =
+          "Translation relationship type name; must be Translation category. Defaults to"
+              + " System/Translation when omitted.")
+  private String relationshipType;
+
+  @Schema(
+      description =
+          "When true, turn on revisions for new items immediately. Defaults to false (SOAP"
+              + " parity).")
+  private Boolean enableRevisions;
+
+  public CreateTranslationsRequest() {}
+
+  public List<Long> getItemIds() {
+    return itemIds;
+  }
+
+  public void setItemIds(List<Long> itemIds) {
+    this.itemIds = itemIds != null ? itemIds : new ArrayList<>();
+  }
+
+  public List<String> getLocales() {
+    return locales;
+  }
+
+  public void setLocales(List<String> locales) {
+    this.locales = locales;
+  }
+
+  public String getRelationshipType() {
+    return relationshipType;
+  }
+
+  public void setRelationshipType(String relationshipType) {
+    this.relationshipType = relationshipType;
+  }
+
+  public Boolean getEnableRevisions() {
+    return enableRevisions;
+  }
+
+  public void setEnableRevisions(Boolean enableRevisions) {
+    this.enableRevisions = enableRevisions;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/translations/CreateTranslationsResult.java
+++ b/rest/src/main/java/com/percussion/rest/translations/CreateTranslationsResult.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.translations;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Result envelope for create-variant (NewTranslations façade). */
+@XmlRootElement(name = "CreateTranslationsResult")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Newly created content-item locale variants")
+public class CreateTranslationsResult {
+
+  @Schema(description = "Created translation items (persisted, read-only mode)")
+  private List<TranslationVariant> created = new ArrayList<>();
+
+  public CreateTranslationsResult() {}
+
+  public CreateTranslationsResult(List<TranslationVariant> created) {
+    this.created = created != null ? created : new ArrayList<>();
+  }
+
+  public List<TranslationVariant> getCreated() {
+    return created;
+  }
+
+  public void setCreated(List<TranslationVariant> created) {
+    this.created = created != null ? created : new ArrayList<>();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/translations/IContentTranslationsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/translations/IContentTranslationsAdaptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.translations;
+
+import java.net.URI;
+
+/**
+ * Adaptor for public content-item translation (P-Trans / #2429).
+ *
+ * <p>HTTP lives on {@link ContentTranslationsResource}; production impl is sitemanage apibridge
+ * wrapping the same domain path as SOAP {@code content.NewTranslations} / {@code
+ * IPSContentWs#newTranslations}.
+ *
+ * <p><strong>Out of scope here:</strong> in-flight translation queue filter and session
+ * content-locale context (product disposition on #2411 / #2428).
+ */
+public interface IContentTranslationsAdaptor {
+
+  /**
+   * Create locale variants for the supplied source items.
+   *
+   * @param baseUri request base URI (HATEOAS reserved; may be null)
+   * @param request create request; must include at least one item id
+   * @return created variants; never null
+   * @throws IllegalArgumentException for contract violations
+   * @throws SecurityException when the caller cannot create translations
+   */
+  CreateTranslationsResult createTranslations(URI baseUri, CreateTranslationsRequest request);
+
+  /**
+   * List the requested item's locale plus translation-category dependents.
+   *
+   * @param baseUri request base URI (may be null)
+   * @param itemId legacy content id or guid string
+   * @return variants envelope; never null when the item is readable
+   * @throws SecurityException / not-found mapped by the resource as 403/404
+   */
+  ItemTranslationVariants listItemVariants(URI baseUri, String itemId);
+}

--- a/rest/src/main/java/com/percussion/rest/translations/ItemTranslationVariants.java
+++ b/rest/src/main/java/com/percussion/rest/translations/ItemTranslationVariants.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.translations;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Per-item locale variant listing for Explorer P-Trans.
+ *
+ * <p>Includes the requested item (role {@code source}) and translation-category dependents (role
+ * {@code translation}). In-flight translation queue / session content-locale context remain product
+ * disposition (not exposed here).
+ */
+@XmlRootElement(name = "ItemTranslationVariants")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Locale variants related to a content item")
+public class ItemTranslationVariants {
+
+  @Schema(description = "Requested content id")
+  private long itemId;
+
+  @Schema(description = "Locale of the requested item")
+  private String locale;
+
+  @Schema(description = "Source item plus related translation variants")
+  private List<TranslationVariant> variants = new ArrayList<>();
+
+  public ItemTranslationVariants() {}
+
+  public long getItemId() {
+    return itemId;
+  }
+
+  public void setItemId(long itemId) {
+    this.itemId = itemId;
+  }
+
+  public String getLocale() {
+    return locale;
+  }
+
+  public void setLocale(String locale) {
+    this.locale = locale;
+  }
+
+  public List<TranslationVariant> getVariants() {
+    return variants;
+  }
+
+  public void setVariants(List<TranslationVariant> variants) {
+    this.variants = variants != null ? variants : new ArrayList<>();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/translations/TranslationVariant.java
+++ b/rest/src/main/java/com/percussion/rest/translations/TranslationVariant.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.translations;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** One content-item locale variant (source or translation copy). */
+@XmlRootElement(name = "TranslationVariant")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Content-item locale variant summary")
+public class TranslationVariant {
+
+  @Schema(description = "Legacy content id of this variant")
+  private long contentId;
+
+  @Schema(description = "Current revision when known")
+  private Integer revision;
+
+  @Schema(description = "Locale language string (e.g. en-us, fr-fr)")
+  private String locale;
+
+  @Schema(
+      description =
+          "Role of this row relative to the requested item: source (the item itself) or"
+              + " translation (related locale copy).")
+  private String role;
+
+  @Schema(description = "Source content id that this translation was created from, when known")
+  private Long sourceContentId;
+
+  public TranslationVariant() {}
+
+  public long getContentId() {
+    return contentId;
+  }
+
+  public void setContentId(long contentId) {
+    this.contentId = contentId;
+  }
+
+  public Integer getRevision() {
+    return revision;
+  }
+
+  public void setRevision(Integer revision) {
+    this.revision = revision;
+  }
+
+  public String getLocale() {
+    return locale;
+  }
+
+  public void setLocale(String locale) {
+    this.locale = locale;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public void setRole(String role) {
+    this.role = role;
+  }
+
+  public Long getSourceContentId() {
+    return sourceContentId;
+  }
+
+  public void setSourceContentId(Long sourceContentId) {
+    this.sourceContentId = sourceContentId;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTranslationsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTranslationsAdaptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.translations.CreateTranslationsRequest;
+import com.percussion.rest.translations.CreateTranslationsResult;
+import com.percussion.rest.translations.IContentTranslationsAdaptor;
+import com.percussion.rest.translations.ItemTranslationVariants;
+import java.net.URI;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring test stub for {@link IContentTranslationsAdaptor}. Required for ApplicationContext load
+ * after constructor injection on {@code ContentTranslationsResource}.
+ *
+ * <p>HTTP-layer behavior is covered by {@link
+ * com.percussion.rest.translations.ContentTranslationsResourceTest}; domain path by sitemanage
+ * apibridge tests.
+ */
+@Component
+@Lazy
+public class TestContentTranslationsAdaptor implements IContentTranslationsAdaptor {
+
+  @Override
+  public CreateTranslationsResult createTranslations(
+      URI baseUri, CreateTranslationsRequest request) {
+    return new CreateTranslationsResult(List.of());
+  }
+
+  @Override
+  public ItemTranslationVariants listItemVariants(URI baseUri, String itemId) {
+    ItemTranslationVariants out = new ItemTranslationVariants();
+    out.setItemId(0L);
+    out.setVariants(List.of());
+    return out;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/translations/ContentTranslationsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/translations/ContentTranslationsResourceTest.java
@@ -94,7 +94,7 @@ class ContentTranslationsResourceTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.createTranslations(body));
     assertEquals(400, ex.getResponse().getStatus());
-    assertEquals("itemIds is required", ex.getMessage());
+    assertEquals("itemIds is required", String.valueOf(ex.getResponse().getEntity()));
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/translations/ContentTranslationsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/translations/ContentTranslationsResourceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.translations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * HTTP-layer tests for {@link ContentTranslationsResource} (#2429). Domain behaviour is covered by
+ * sitemanage apibridge unit tests.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("UnitTest")
+class ContentTranslationsResourceTest {
+
+  @Mock private IContentTranslationsAdaptor adaptor;
+
+  @Mock private UriInfo uriInfo;
+
+  private ContentTranslationsResource resource;
+
+  @BeforeEach
+  void init() {
+    resource = new ContentTranslationsResource(adaptor);
+    resource.setUriInfo(uriInfo);
+    org.mockito.Mockito.lenient()
+        .when(uriInfo.getBaseUri())
+        .thenReturn(UriBuilder.fromUri("http://localhost/rest").build());
+  }
+
+  @Test
+  void createDelegatesToAdaptor() {
+    CreateTranslationsRequest body = new CreateTranslationsRequest();
+    body.setItemIds(List.of(100L));
+    body.setLocales(List.of("fr-fr"));
+
+    TranslationVariant created = new TranslationVariant();
+    created.setContentId(200L);
+    created.setLocale("fr-fr");
+    created.setRole("translation");
+    CreateTranslationsResult expected = new CreateTranslationsResult(List.of(created));
+    when(adaptor.createTranslations(any(), eq(body))).thenReturn(expected);
+
+    CreateTranslationsResult out = resource.createTranslations(body);
+
+    assertEquals(1, out.getCreated().size());
+    assertEquals(200L, out.getCreated().get(0).getContentId());
+    verify(adaptor).createTranslations(any(), eq(body));
+  }
+
+  @Test
+  void createNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createTranslations(null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void createIllegalArgumentMapsTo400() {
+    CreateTranslationsRequest body = new CreateTranslationsRequest();
+    when(adaptor.createTranslations(any(), any()))
+        .thenThrow(new IllegalArgumentException("itemIds is required"));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createTranslations(body));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertEquals("itemIds is required", ex.getMessage());
+  }
+
+  @Test
+  void createSecurityMapsTo403() {
+    CreateTranslationsRequest body = new CreateTranslationsRequest();
+    body.setItemIds(List.of(1L));
+    when(adaptor.createTranslations(any(), any()))
+        .thenThrow(new SecurityException("not allowed"));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createTranslations(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void listDelegatesToAdaptor() {
+    ItemTranslationVariants expected = new ItemTranslationVariants();
+    expected.setItemId(100L);
+    expected.setLocale("en-us");
+    when(adaptor.listItemVariants(any(), eq("100"))).thenReturn(expected);
+
+    ItemTranslationVariants out = resource.listItemVariants("100");
+
+    assertEquals(100L, out.getItemId());
+    assertEquals("en-us", out.getLocale());
+    verify(adaptor).listItemVariants(any(), eq("100"));
+  }
+
+  @Test
+  void listNullFromAdaptorIs404() {
+    when(adaptor.listItemVariants(any(), eq("missing"))).thenReturn(null);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listItemVariants("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void listSecurityMapsTo403() {
+    when(adaptor.listItemVariants(any(), eq("private")))
+        .thenThrow(new SecurityException("denied"));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listItemVariants("private"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void missingAdaptorIs503() {
+    ContentTranslationsResource bare = new ContentTranslationsResource();
+    bare.setUriInfo(uriInfo);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> bare.createTranslations(new CreateTranslationsRequest()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+}


### PR DESCRIPTION
## Summary

Implements **#2429** (slice B of **#2411** / grandparent **#2400**): public REST create-variant + item-locale list façade for content-item translation (P-Trans).

Inventory (`specs/2400-dce-explorer-parity/research/p-trans-api-inventory.md`) concluded create-variant was **Missing/Legacy-only** (SOAP `NewTranslations` / CX only). This PR adds a thin public contract that wraps the **same domain path** as SOAP — not SPA→SOAP.

### API

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/rest/content-explorer/translations` | Create locale variants (`itemIds`, optional `locales`, `relationshipType`, `enableRevisions`) |
| `GET` | `/rest/content-explorer/translations/{itemId}` | Item locale + translation-category dependents |

### Companion closure

| Layer | Artifact |
|-------|----------|
| rest resource + DTOs + `IContentTranslationsAdaptor` | `rest/.../translations/` |
| sitemanage apibridge | `ContentTranslationsAdaptor` → `IPSContentWs.newTranslations` |
| Mockito resource tests | `ContentTranslationsResourceTest` (8) |
| Spring test stub | `TestContentTranslationsAdaptor` |
| sitemanage adaptor tests | `ContentTranslationsAdaptorTest` (10) |
| CXF registration | `restContentTranslationsResource` in `sitemanage-beans.xml` + registration lock |

### Explicitly OUT (product disposition on #2411/#2428)

- In-flight translation queue filter
- Session content-locale context switch
- Explorer UI (#2430)

## Test plan

- [x] `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**; `ContentTranslationsResourceTest` 8/0; `MainTest` green (Spring stub present)
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**; `ContentTranslationsAdaptorTest` 10/0
- [ ] Optional live H2: `POST /Rhythmyx/rest/content-explorer/translations` with a known content id + target locale (after deploy)

## Gates evidence

- Standalone per-module clean install (not reactor `-am`)
- No new path hardcoding / platform-only I/O
- OpenAPI annotations on resource methods

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2429  
Parent: #2411  
Grandparent: #2400

> Co-Authored by Grok Build using grok-4.5 with agent main.