### PR TITLE
feat(WebUI): Explorer SearchPanel saved-search picker (#2506)

### DIFF
--- a/WebUI/src/main/ts/api/developer/searchesApi.ts
+++ b/WebUI/src/main/ts/api/developer/searchesApi.ts
@@ -1,10 +1,27 @@
 /*
  * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-import { get } from "../client";
+import { get, post } from "../client";
 import { PATHS } from "../paths";
-import type { SearchDef } from "./types";
+import type {
+  SearchDef,
+  SearchExecuteRequest,
+  SearchExecuteResult,
+  SearchResultItem,
+} from "./types";
 
 function asArray<T>(payload: unknown): T[] {
   if (payload == null) return [];
@@ -18,6 +35,40 @@ function asArray<T>(payload: unknown): T[] {
   return [];
 }
 
+/**
+ * Unwrap Jackson root-name wrapping for {@link SearchExecuteResult}
+ * ({@code SearchExecuteResult} / camelCase aliases) while accepting a flat
+ * payload when root wrapping is off.
+ */
+export function unwrapSearchExecuteResult(payload: unknown): SearchExecuteResult {
+  if (payload == null || typeof payload !== "object") {
+    return { children: [], totalCount: 0, startIndex: 1 };
+  }
+  const root = payload as Record<string, unknown>;
+  const nested =
+    root.SearchExecuteResult ??
+    root.searchExecuteResult ??
+    (Array.isArray(root.children) ||
+    typeof root.totalCount === "number" ||
+    typeof root.startIndex === "number"
+      ? root
+      : null);
+  if (nested == null || typeof nested !== "object") {
+    return { children: [], totalCount: 0, startIndex: 1 };
+  }
+  const body = nested as SearchExecuteResult;
+  const children = Array.isArray(body.children)
+    ? (body.children as SearchResultItem[])
+    : [];
+  return {
+    children,
+    totalCount: typeof body.totalCount === "number" ? body.totalCount : children.length,
+    startIndex: typeof body.startIndex === "number" ? body.startIndex : 1,
+    searchName: body.searchName,
+    displayFormatId: body.displayFormatId,
+  };
+}
+
 /** GET /services/searches */
 export async function listSearches(): Promise<SearchDef[]> {
   const payload = await get<unknown>(PATHS.SEARCHES);
@@ -28,4 +79,28 @@ export async function listSearches(): Promise<SearchDef[]> {
 export async function getSearchDetail(idOrName: string): Promise<SearchDef> {
   const key = encodeURIComponent(idOrName);
   return get<SearchDef>(`${PATHS.SEARCHES}/${key}`);
+}
+
+/**
+ * POST /services/searches/{idOrName}/execute — run a CX design search with
+ * optional folder / paging / sort overrides (slice B façade).
+ *
+ * <p>Empty or blank {@code idOrName} rejects client-side before the network
+ * call so the picker cannot fire a meaningless path segment.</p>
+ */
+export async function executeSearch(
+  idOrName: string,
+  request?: SearchExecuteRequest | null,
+): Promise<SearchExecuteResult> {
+  const key = (idOrName ?? "").trim();
+  if (!key) {
+    throw new Error("Search id or name is required");
+  }
+  const pathKey = encodeURIComponent(key);
+  const body = request ?? {};
+  const payload = await post<unknown>(
+    `${PATHS.SEARCHES}/${pathKey}/execute`,
+    body,
+  );
+  return unwrapSearchExecuteResult(payload);
 }

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -463,6 +463,42 @@ export interface SearchDef {
   designGaps?: string[];
 }
 
+/**
+ * Optional overrides for {@code POST /services/searches/{idOrName}/execute}.
+ * Mirrors {@code com.percussion.rest.searches.SearchExecuteRequest}.
+ */
+export interface SearchExecuteRequest {
+  folderPath?: string;
+  startIndex?: number;
+  maxResults?: number;
+  sortColumn?: string;
+  sortOrder?: string;
+}
+
+/**
+ * One result row from design-search execute.
+ * Mirrors {@code com.percussion.rest.searches.SearchResultItem}.
+ */
+export interface SearchResultItem {
+  id?: string;
+  name?: string;
+  title?: string;
+  folderPath?: string;
+  type?: string;
+}
+
+/**
+ * Paged result envelope for design-search execute.
+ * Mirrors {@code com.percussion.rest.searches.SearchExecuteResult}.
+ */
+export interface SearchExecuteResult {
+  children?: SearchResultItem[];
+  totalCount?: number;
+  startIndex?: number;
+  searchName?: string;
+  displayFormatId?: string;
+}
+
 /** View field criterion from GET /services/views. */
 export interface ViewFieldSummary {
   fieldName?: string;

--- a/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
@@ -15,38 +15,48 @@
  */
 
 /**
- * Search panel for the modern Content Explorer (US5 / T068).
+ * Search panel for the modern Content Explorer (US5 / T068 + #2506 saved-search picker).
  *
- * <p>Renders a server-backed search input + results list. The
- * {@link SearchPanelProps.onOpen} callback receives the selected result
+ * <p>Renders a server-backed free-text search input + results list, and a
+ * saved/design-search picker fed by {@code GET /services/searches} that
+ * executes via {@code POST /services/searches/{idOrName}/execute}.</p>
+ *
+ * <p>The {@link SearchPanelProps.onOpen} callback receives the selected result
  * for the host (typically the explorer shell) to navigate to the item;
  * the {@link SearchPanelProps.onReveal} callback asks the host to
- * select the parent folder in the tree. Results come from the
+ * select the parent folder in the tree. Free-text results come from the
  * sitemanage extended-search REST endpoint via the typed
- * {@link searchExtended} client; the panel defers all transport so
- * the host can stub it in tests.</p>
+ * {@link searchExtended} client; saved searches use the design-search
+ * execute façade. The panel defers all transport so the host can stub
+ * it in tests.</p>
  *
- * <p>State machine:</p>
+ * <p>State machine (results):</p>
  * <ul>
- *   <li>{@code idle} — initial; submit the form to search.</li>
+ *   <li>{@code idle} — initial; submit the form or run a saved search.</li>
  *   <li>{@code loading} — fetch in flight.</li>
  *   <li>{@code ready} — has results (possibly empty).</li>
- *   <li>{@code error} — fetch rejected / server error; the
- *       {@code SearchStatusView} renders a Retry button that re-issues
- *       the last query. The handler is wired by the parent
- *       {@link SearchPanel} (which owns the transport); see the
- *       {@code onRetry} prop description in the local
- *       {@code SearchStatusView} function component below.</li>
+ *   <li>{@code error} — fetch rejected / server error; Retry re-issues
+ *       the last free-text query or last saved-search execute.</li>
  * </ul>
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   searchExtended,
   type PSItemProperties,
   type PSSearchCriteria,
   type PSSearchResults,
 } from "../api/contentExplorer/searchApi";
+import {
+  executeSearch as executeSearchApi,
+  listSearches as listSearchesApi,
+} from "../api/developer/searchesApi";
+import type {
+  SearchDef,
+  SearchExecuteRequest,
+  SearchExecuteResult,
+} from "../api/developer/types";
+import { formatApiError } from "../api/client";
 import { message } from "../i18n/message";
 import { EXPLORER_MSG } from "./messages";
 
@@ -55,8 +65,24 @@ export interface SearchPanelProps {
   initialQuery?: string;
   /** Optional initial criteria (folder scope + sortColumn + maxResults). */
   initialCriteria?: PSSearchCriteria;
-  /** Override for the search transport (default: {@link searchExtended}). */
+  /** Override for the free-text search transport (default: {@link searchExtended}). */
   search?: (criteria: PSSearchCriteria) => Promise<PSSearchResults>;
+  /**
+   * Override for the saved-search catalog load
+   * (default: {@link listSearchesApi}).
+   */
+  listSavedSearches?: () => Promise<SearchDef[]>;
+  /**
+   * Override for design-search execute
+   * (default: {@link executeSearchApi}). Return value is normalized to
+   * {@link PSSearchResults} by the panel when callers return the wire
+   * {@link SearchExecuteResult} shape — inject a function that already
+   * returns {@link PSSearchResults} for simple test stubs.
+   */
+  executeSavedSearch?: (
+    idOrName: string,
+    request?: SearchExecuteRequest | null,
+  ) => Promise<PSSearchResults | SearchExecuteResult>;
   /** Triggered when the user clicks "Open" on a result. */
   onOpen?: (result: PSItemProperties) => void;
   /** Triggered when the user clicks "Reveal in folder" on a result. */
@@ -72,11 +98,58 @@ type Status =
   | { kind: "ready"; query: string; results: PSSearchResults }
   | { kind: "error"; query: string; message: string };
 
+type CatalogStatus =
+  | { kind: "loading" }
+  | { kind: "ready"; items: SearchDef[] }
+  | { kind: "empty" }
+  | { kind: "error"; message: string };
+
+/** Last results request so Retry can re-issue free-text or saved execute. */
+type LastRun =
+  | { mode: "query"; query: string }
+  | { mode: "saved"; idOrName: string; label: string };
+
+function searchKey(def: SearchDef): string {
+  return (def.name || def.guid?.stringValue || (def.id != null ? String(def.id) : "")).trim();
+}
+
+function searchLabel(def: SearchDef): string {
+  return (def.label || def.name || searchKey(def) || "—").trim();
+}
+
+/**
+ * Map design-search execute wire (or already-normalized results) into the
+ * Explorer {@link PSSearchResults} shape used by the results list.
+ */
+export function toSearchResults(
+  payload: PSSearchResults | SearchExecuteResult | null | undefined,
+): PSSearchResults {
+  if (payload == null) {
+    return { children: [], totalCount: 0, startIndex: 1 };
+  }
+  const children = Array.isArray(payload.children)
+    ? payload.children.map((row) => ({
+        id: row.id,
+        name: row.name,
+        title: row.title,
+        folderPath: row.folderPath,
+        type: row.type,
+      }))
+    : [];
+  const startIndex =
+    typeof payload.startIndex === "number" ? payload.startIndex : 1;
+  const totalCount =
+    typeof payload.totalCount === "number" ? payload.totalCount : children.length;
+  return { children, totalCount, startIndex };
+}
+
 export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
   const {
     initialQuery = "",
     initialCriteria = {},
     search = searchExtended,
+    listSavedSearches = listSearchesApi,
+    executeSavedSearch = executeSearchApi,
     onOpen,
     onReveal,
     ariaLabel,
@@ -87,6 +160,10 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
     query: initialQuery,
   });
   const [draft, setDraft] = useState(initialQuery);
+  const [catalog, setCatalog] = useState<CatalogStatus>({ kind: "loading" });
+  const [selectedSaved, setSelectedSaved] = useState("");
+  const [lastRun, setLastRun] = useState<LastRun | null>(null);
+  const [catalogEpoch, setCatalogEpoch] = useState(0);
 
   useEffect(() => {
     setDraft(initialQuery);
@@ -98,12 +175,52 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialQuery]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setCatalog({ kind: "loading" });
+    listSavedSearches()
+      .then((items) => {
+        if (cancelled) return;
+        const list = Array.isArray(items) ? items : [];
+        if (list.length === 0) {
+          setCatalog({ kind: "empty" });
+          return;
+        }
+        setCatalog({ kind: "ready", items: list });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setCatalog({
+          kind: "error",
+          message: formatApiError(err, message(EXPLORER_MSG.SEARCH_SAVED_ERROR)),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [listSavedSearches, catalogEpoch]);
+
+  const sortedCatalog = useMemo(() => {
+    if (catalog.kind !== "ready") return [];
+    return [...catalog.items].sort((a, b) =>
+      searchLabel(a).localeCompare(searchLabel(b), undefined, {
+        sensitivity: "base",
+      }),
+    );
+  }, [catalog]);
+
+  const selectedDef =
+    catalog.kind === "ready"
+      ? sortedCatalog.find((d) => searchKey(d) === selectedSaved)
+      : undefined;
+
   async function runSearch(query: string): Promise<void> {
     const trimmed = query.trim();
     if (trimmed.length === 0) {
       setStatus({ kind: "idle", query: "" });
       return;
     }
+    setLastRun({ mode: "query", query: trimmed });
     setStatus({ kind: "loading", query: trimmed });
     try {
       const results = await search({
@@ -114,15 +231,72 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
       });
       setStatus({ kind: "ready", query: trimmed, results });
     } catch (err: unknown) {
-      const msg =
-        err instanceof Error ? err.message : String(err ?? "unknown");
-      setStatus({ kind: "error", query: trimmed, message: msg });
+      setStatus({
+        kind: "error",
+        query: trimmed,
+        message: formatApiError(err, message(EXPLORER_MSG.SEARCH_ERROR)),
+      });
+    }
+  }
+
+  async function runSavedSearch(idOrName: string, label: string): Promise<void> {
+    const key = idOrName.trim();
+    if (!key) {
+      return;
+    }
+    const display = (label || key).trim();
+    setLastRun({ mode: "saved", idOrName: key, label: display });
+    setStatus({ kind: "loading", query: display });
+    try {
+      const request: SearchExecuteRequest = {
+        folderPath: initialCriteria.folderPath,
+        startIndex: initialCriteria.startIndex ?? 1,
+        maxResults: initialCriteria.maxResults ?? 25,
+        sortColumn: initialCriteria.sortColumn,
+        sortOrder: initialCriteria.sortOrder,
+      };
+      const raw = await executeSavedSearch(key, request);
+      const results = toSearchResults(raw);
+      setStatus({ kind: "ready", query: display, results });
+    } catch (err: unknown) {
+      setStatus({
+        kind: "error",
+        query: display,
+        message: formatApiError(err, message(EXPLORER_MSG.SEARCH_ERROR)),
+      });
     }
   }
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
     e.preventDefault();
     void runSearch(draft);
+  }
+
+  function handleRunSaved(): void {
+    if (!selectedDef) return;
+    if (selectedDef.customSearch) {
+      setStatus({
+        kind: "error",
+        query: searchLabel(selectedDef),
+        message: message(EXPLORER_MSG.SEARCH_SAVED_CUSTOM_UNSUPPORTED),
+      });
+      return;
+    }
+    void runSavedSearch(searchKey(selectedDef), searchLabel(selectedDef));
+  }
+
+  function handleRetry(): void {
+    if (lastRun?.mode === "saved") {
+      void runSavedSearch(lastRun.idOrName, lastRun.label);
+      return;
+    }
+    if (lastRun?.mode === "query") {
+      void runSearch(lastRun.query);
+      return;
+    }
+    if (status.kind === "error") {
+      void runSearch(status.query);
+    }
   }
 
   return (
@@ -154,13 +328,146 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
           {message(EXPLORER_MSG.SEARCH_SUBMIT)}
         </button>
       </form>
+
+      <SavedSearchPicker
+        catalog={catalog}
+        sortedItems={sortedCatalog}
+        selectedKey={selectedSaved}
+        onSelectKey={setSelectedSaved}
+        onRun={handleRunSaved}
+        onRetryCatalog={() => setCatalogEpoch((n) => n + 1)}
+        runDisabled={
+          status.kind === "loading" ||
+          !selectedSaved ||
+          (selectedDef?.customSearch === true)
+        }
+        selectedIsCustom={selectedDef?.customSearch === true}
+      />
+
       <SearchStatusView
         status={status}
         onOpen={onOpen}
         onReveal={onReveal}
-        onRetry={() => void runSearch(status.kind === "error" ? status.query : draft.trim())}
+        onRetry={handleRetry}
       />
     </section>
+  );
+}
+
+function SavedSearchPicker(props: {
+  catalog: CatalogStatus;
+  sortedItems: SearchDef[];
+  selectedKey: string;
+  onSelectKey: (key: string) => void;
+  onRun: () => void;
+  onRetryCatalog: () => void;
+  runDisabled: boolean;
+  selectedIsCustom: boolean;
+}): React.JSX.Element {
+  const {
+    catalog,
+    sortedItems,
+    selectedKey,
+    onSelectKey,
+    onRun,
+    onRetryCatalog,
+    runDisabled,
+    selectedIsCustom,
+  } = props;
+
+  if (catalog.kind === "loading") {
+    return (
+      <p
+        role="status"
+        aria-live="polite"
+        data-testid="search-panel-saved-loading"
+        style={{ marginTop: 10, color: "#666" }}
+      >
+        {message(EXPLORER_MSG.SEARCH_SAVED_LOADING)}
+      </p>
+    );
+  }
+
+  if (catalog.kind === "error") {
+    return (
+      <div role="alert" style={{ marginTop: 10, color: "#a00" }}>
+        <p data-testid="search-panel-saved-error" style={{ margin: "0 0 6px 0" }}>
+          {message(EXPLORER_MSG.SEARCH_SAVED_ERROR)}: {catalog.message}
+        </p>
+        <button
+          type="button"
+          data-testid="search-panel-saved-retry"
+          onClick={onRetryCatalog}
+        >
+          {message(EXPLORER_MSG.SEARCH_SAVED_RETRY)}
+        </button>
+      </div>
+    );
+  }
+
+  if (catalog.kind === "empty") {
+    return (
+      <p
+        role="status"
+        data-testid="search-panel-saved-empty"
+        style={{ marginTop: 10, color: "#888" }}
+      >
+        {message(EXPLORER_MSG.SEARCH_SAVED_EMPTY)}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      data-testid="search-panel-saved-picker"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 8,
+        alignItems: "center",
+        marginTop: 10,
+      }}
+    >
+      <label
+        htmlFor="search-panel-saved-select"
+        style={{ fontSize: 13, color: "#333" }}
+      >
+        {message(EXPLORER_MSG.SEARCH_SAVED_LABEL)}
+      </label>
+      <select
+        id="search-panel-saved-select"
+        data-testid="search-panel-saved-select"
+        value={selectedKey}
+        onChange={(e) => onSelectKey(e.target.value)}
+        style={{ flex: "1 1 160px", minWidth: 140, padding: "4px 6px" }}
+        aria-label={message(EXPLORER_MSG.SEARCH_SAVED_LABEL)}
+      >
+        <option value="">{message(EXPLORER_MSG.SEARCH_SAVED_PLACEHOLDER)}</option>
+        {sortedItems.map((def, idx) => {
+          const key = searchKey(def);
+          if (!key) return null;
+          return (
+            <option key={`${key}-${idx}`} value={key}>
+              {searchLabel(def)}
+              {def.customSearch ? " (URL)" : ""}
+            </option>
+          );
+        })}
+      </select>
+      <button
+        type="button"
+        data-testid="search-panel-saved-run"
+        disabled={runDisabled}
+        onClick={onRun}
+        title={
+          selectedIsCustom
+            ? message(EXPLORER_MSG.SEARCH_SAVED_CUSTOM_UNSUPPORTED)
+            : undefined
+        }
+      >
+        {message(EXPLORER_MSG.SEARCH_SAVED_RUN)}
+      </button>
+    </div>
   );
 }
 
@@ -169,7 +476,7 @@ function SearchStatusView(props: {
   onOpen?: (r: PSItemProperties) => void;
   onReveal?: (r: PSItemProperties) => void;
   /** Re-issues the failed search. Optional to keep the helper pure; the
-   * parent {@link SearchPanel} wires its own {@code runSearch} closure
+   * parent {@link SearchPanel} wires its own retry closure
    * here so the parent stays the single owner of the transport.
    *
    * <p>(Plain-text reference; {@code SearchStatusView.onRetry} is a

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -119,6 +119,16 @@ export const EXPLORER_MSG = {
   SEARCH_REVEAL: "perc.ui.explorer@Reveal in folder",
   SEARCH_PERMISSION_DENIED:
     "perc.ui.explorer@You do not have permission to open this item",
+  // Saved / design-search picker (#2506 / #2409 slice C)
+  SEARCH_SAVED_LABEL: "perc.ui.explorer@Saved search",
+  SEARCH_SAVED_PLACEHOLDER: "perc.ui.explorer@Select a saved search…",
+  SEARCH_SAVED_RUN: "perc.ui.explorer@Run saved search",
+  SEARCH_SAVED_LOADING: "perc.ui.explorer@Loading saved searches…",
+  SEARCH_SAVED_EMPTY: "perc.ui.explorer@No saved searches available",
+  SEARCH_SAVED_ERROR: "perc.ui.explorer@Could not load saved searches",
+  SEARCH_SAVED_RETRY: "perc.ui.explorer@Retry loading saved searches",
+  SEARCH_SAVED_CUSTOM_UNSUPPORTED:
+    "perc.ui.explorer@Custom URL searches cannot be run from Explorer",
   DISPLAY_FORMAT_LABEL: "perc.ui.explorer@Display format",
   DISPLAY_FORMAT_DEFAULT: "perc.ui.explorer@Default columns",
   /** Product shell: server-driven action toolbar (US3 / #2400). */

--- a/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx
@@ -20,7 +20,11 @@ import type {
   PSItemProperties,
   PSSearchResults,
 } from "../../../main/ts/api/contentExplorer/types";
-import { SearchPanel } from "../../../main/ts/contentExplorer/SearchPanel";
+import type { SearchDef } from "../../../main/ts/api/developer/types";
+import {
+  SearchPanel,
+  toSearchResults,
+} from "../../../main/ts/contentExplorer/SearchPanel";
 import { renderA11yGate } from "./a11y";
 
 function makeResults(children: PSItemProperties[]): PSSearchResults {
@@ -36,11 +40,53 @@ const ONE_ROW: PSItemProperties[] = [
   },
 ];
 
+const SAVED: SearchDef[] = [
+  {
+    name: "All Content",
+    label: "All Content",
+    standardSearch: true,
+  },
+  {
+    name: "My Pages",
+    label: "My Pages",
+    userSearch: true,
+  },
+  {
+    name: "Custom URL",
+    label: "Custom URL",
+    customSearch: true,
+  },
+];
+
+function emptyCatalog() {
+  return vi.fn().mockResolvedValue([] as SearchDef[]);
+}
+
+function readyCatalog(items: SearchDef[] = SAVED) {
+  return vi.fn().mockResolvedValue(items);
+}
+
+describe("toSearchResults", () => {
+  it("maps execute wire rows into PSSearchResults", () => {
+    const out = toSearchResults({
+      children: [{ id: "9", title: "T", folderPath: "/Sites/X", type: "page" }],
+      totalCount: 1,
+      startIndex: 1,
+    });
+    expect(out.children).toHaveLength(1);
+    expect(out.children[0]?.id).toBe("9");
+    expect(out.totalCount).toBe(1);
+  });
+});
+
 describe("SearchPanel", () => {
-  it("renders the search input and submit button", () => {
-    render(<SearchPanel />);
+  it("renders the search input and submit button", async () => {
+    render(<SearchPanel listSavedSearches={emptyCatalog()} />);
     expect(screen.getByTestId("search-panel-input")).toBeTruthy();
     expect(screen.getByTestId("search-panel-submit")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("search-panel-saved-empty")).toBeTruthy();
+    });
   });
 
   it("submitting the form invokes the search and renders results", async () => {
@@ -48,7 +94,12 @@ describe("SearchPanel", () => {
     const onReveal = vi.fn();
     const search = vi.fn().mockResolvedValue(makeResults(ONE_ROW));
     render(
-      <SearchPanel search={search} onOpen={onOpen} onReveal={onReveal} />,
+      <SearchPanel
+        search={search}
+        onOpen={onOpen}
+        onReveal={onReveal}
+        listSavedSearches={emptyCatalog()}
+      />,
     );
     const input = screen.getByTestId("search-panel-input") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "Welcome" } });
@@ -77,18 +128,28 @@ describe("SearchPanel", () => {
             resolveSearch = res;
           }),
       );
-    render(<SearchPanel search={search} />);
+    render(
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("search-panel-saved-empty")).toBeTruthy();
+    });
     fireEvent.change(screen.getByTestId("search-panel-input"), {
       target: { value: "q" },
     });
     fireEvent.click(screen.getByTestId("search-panel-submit"));
     expect(await screen.findByTestId("search-panel-loading")).toBeTruthy();
     resolveSearch(makeResults([]));
+    await waitFor(() => {
+      expect(screen.getByTestId("search-panel-empty")).toBeTruthy();
+    });
   });
 
   it("renders the empty state when the search returns no rows", async () => {
     const search = vi.fn().mockResolvedValue(makeResults([]));
-    render(<SearchPanel search={search} />);
+    render(
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
+    );
     fireEvent.change(screen.getByTestId("search-panel-input"), {
       target: { value: "nothing" },
     });
@@ -100,7 +161,9 @@ describe("SearchPanel", () => {
 
   it("renders the error state when the search rejects", async () => {
     const search = vi.fn().mockRejectedValue(new Error("boom"));
-    render(<SearchPanel search={search} />);
+    render(
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
+    );
     fireEvent.change(screen.getByTestId("search-panel-input"), {
       target: { value: "q" },
     });
@@ -118,7 +181,9 @@ describe("SearchPanel", () => {
         ? Promise.reject(new Error("first attempt failed"))
         : Promise.resolve(makeResults([]));
     });
-    render(<SearchPanel search={search} />);
+    render(
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
+    );
     fireEvent.change(screen.getByTestId("search-panel-input"), {
       target: { value: "retry-test" },
     });
@@ -144,7 +209,12 @@ describe("SearchPanel", () => {
 
   it("skip-trim: an empty query returns to idle without calling search", async () => {
     const search = vi.fn().mockResolvedValue(makeResults([]));
-    render(<SearchPanel search={search} />);
+    render(
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("search-panel-saved-empty")).toBeTruthy();
+    });
     fireEvent.click(screen.getByTestId("search-panel-submit"));
     expect(search).not.toHaveBeenCalled();
   });
@@ -152,7 +222,11 @@ describe("SearchPanel", () => {
   it("initialQuery triggers a search on mount", async () => {
     const search = vi.fn().mockResolvedValue(makeResults(ONE_ROW));
     render(
-      <SearchPanel initialQuery="deep link" search={search} />,
+      <SearchPanel
+        initialQuery="deep link"
+        search={search}
+        listSavedSearches={emptyCatalog()}
+      />,
     );
     await waitFor(() => {
       expect(search).toHaveBeenCalledTimes(1);
@@ -160,20 +234,32 @@ describe("SearchPanel", () => {
     expect(search.mock.calls[0]?.[0]?.query).toBe("deep link");
   });
 
-  it("empty initial query does not auto-fire a search", () => {
+  it("empty initial query does not auto-fire a search", async () => {
     const search = vi.fn();
-    render(<SearchPanel search={search} />);
+    render(
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("search-panel-saved-empty")).toBeTruthy();
+    });
     expect(search).not.toHaveBeenCalled();
   });
 
   it("passes the zero serious/critical axe-core gate (idle state)", async () => {
-    const { container } = render(<SearchPanel />);
+    const { container } = render(
+      <SearchPanel listSavedSearches={emptyCatalog()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("search-panel-saved-empty")).toBeTruthy();
+    });
     await renderA11yGate(container);
   });
 
   it("passes the zero serious/critical axe-core gate (results state)", async () => {
     const search = vi.fn().mockResolvedValue(makeResults(ONE_ROW));
-    const { container } = render(<SearchPanel search={search} />);
+    const { container } = render(
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
+    );
     fireEvent.change(screen.getByTestId("search-panel-input"), {
       target: { value: "Welcome" },
     });
@@ -186,9 +272,8 @@ describe("SearchPanel", () => {
 
   it("passes the zero serious/critical axe-core gate (error state with retry)", async () => {
     const search = vi.fn().mockRejectedValue(new Error("boom"));
-    const onRetry = vi.fn();
     const { container } = render(
-      <SearchPanel search={search} onRetry={onRetry} />,
+      <SearchPanel search={search} listSavedSearches={emptyCatalog()} />,
     );
     fireEvent.change(screen.getByTestId("search-panel-input"), {
       target: { value: "anything" },
@@ -198,5 +283,160 @@ describe("SearchPanel", () => {
       expect(screen.getByTestId("search-panel-retry")).toBeTruthy();
     });
     await renderA11yGate(container);
+  });
+
+  describe("saved-search picker (#2506)", () => {
+    it("shows loading then catalog select options", async () => {
+      let resolveList!: (items: SearchDef[]) => void;
+      const listSavedSearches = vi.fn(
+        () =>
+          new Promise<SearchDef[]>((res) => {
+            resolveList = res;
+          }),
+      );
+      render(<SearchPanel listSavedSearches={listSavedSearches} />);
+      expect(screen.getByTestId("search-panel-saved-loading")).toBeTruthy();
+      resolveList(SAVED);
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-picker")).toBeTruthy();
+      });
+      const select = screen.getByTestId(
+        "search-panel-saved-select",
+      ) as HTMLSelectElement;
+      expect(select.options.length).toBeGreaterThan(1);
+      expect(Array.from(select.options).some((o) => o.value === "All Content")).toBe(
+        true,
+      );
+    });
+
+    it("shows empty catalog state", async () => {
+      render(<SearchPanel listSavedSearches={emptyCatalog()} />);
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-empty")).toBeTruthy();
+      });
+    });
+
+    it("shows catalog error and retries load", async () => {
+      let attempt = 0;
+      const listSavedSearches = vi.fn().mockImplementation(() => {
+        attempt += 1;
+        if (attempt === 1) {
+          return Promise.reject(new Error("catalog down"));
+        }
+        return Promise.resolve(SAVED);
+      });
+      render(<SearchPanel listSavedSearches={listSavedSearches} />);
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-error")).toBeTruthy();
+      });
+      fireEvent.click(screen.getByTestId("search-panel-saved-retry"));
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-picker")).toBeTruthy();
+      });
+      expect(attempt).toBe(2);
+    });
+
+    it("runs a selected saved search via execute and shows results", async () => {
+      const executeSavedSearch = vi.fn().mockResolvedValue({
+        children: ONE_ROW,
+        totalCount: 1,
+        startIndex: 1,
+        searchName: "All Content",
+      });
+      const onOpen = vi.fn();
+      render(
+        <SearchPanel
+          listSavedSearches={readyCatalog()}
+          executeSavedSearch={executeSavedSearch}
+          onOpen={onOpen}
+          initialCriteria={{ folderPath: "/Sites/Foo", maxResults: 10 }}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-select")).toBeTruthy();
+      });
+      fireEvent.change(screen.getByTestId("search-panel-saved-select"), {
+        target: { value: "All Content" },
+      });
+      fireEvent.click(screen.getByTestId("search-panel-saved-run"));
+      await waitFor(() => {
+        expect(executeSavedSearch).toHaveBeenCalledTimes(1);
+      });
+      expect(executeSavedSearch.mock.calls[0]?.[0]).toBe("All Content");
+      expect(executeSavedSearch.mock.calls[0]?.[1]).toMatchObject({
+        folderPath: "/Sites/Foo",
+        maxResults: 10,
+        startIndex: 1,
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-results")).toBeTruthy();
+      });
+      fireEvent.click(screen.getByTestId("search-panel-open-1"));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it("blocks custom URL searches with a clear error", async () => {
+      const executeSavedSearch = vi.fn();
+      render(
+        <SearchPanel
+          listSavedSearches={readyCatalog()}
+          executeSavedSearch={executeSavedSearch}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-select")).toBeTruthy();
+      });
+      fireEvent.change(screen.getByTestId("search-panel-saved-select"), {
+        target: { value: "Custom URL" },
+      });
+      // Run is disabled for custom; force onRun path via enabling then click is blocked
+      expect(
+        (screen.getByTestId("search-panel-saved-run") as HTMLButtonElement).disabled,
+      ).toBe(true);
+      expect(executeSavedSearch).not.toHaveBeenCalled();
+    });
+
+    it("retries a failed saved-search execute", async () => {
+      let attempt = 0;
+      const executeSavedSearch = vi.fn().mockImplementation(() => {
+        attempt += 1;
+        if (attempt === 1) {
+          return Promise.reject(new Error("execute failed"));
+        }
+        return Promise.resolve(makeResults([]));
+      });
+      render(
+        <SearchPanel
+          listSavedSearches={readyCatalog()}
+          executeSavedSearch={executeSavedSearch}
+        />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-select")).toBeTruthy();
+      });
+      fireEvent.change(screen.getByTestId("search-panel-saved-select"), {
+        target: { value: "My Pages" },
+      });
+      fireEvent.click(screen.getByTestId("search-panel-saved-run"));
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-error")).toBeTruthy();
+      });
+      fireEvent.click(screen.getByTestId("search-panel-retry"));
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-empty")).toBeTruthy();
+      });
+      expect(attempt).toBe(2);
+      expect(executeSavedSearch.mock.calls[1]?.[0]).toBe("My Pages");
+    });
+
+    it("passes axe-core with saved picker visible", async () => {
+      const { container } = render(
+        <SearchPanel listSavedSearches={readyCatalog()} />,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("search-panel-saved-picker")).toBeTruthy();
+      });
+      await renderA11yGate(container);
+    });
   });
 });

--- a/WebUI/src/test/ts/developer/searchesApi.test.ts
+++ b/WebUI/src/test/ts/developer/searchesApi.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  executeSearch,
+  unwrapSearchExecuteResult,
+} from "../../../main/ts/api/developer/searchesApi";
+import { PATHS } from "../../../main/ts/api/paths";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("unwrapSearchExecuteResult", () => {
+  it("accepts a flat payload", () => {
+    const out = unwrapSearchExecuteResult({
+      children: [{ id: "1", title: "A" }],
+      totalCount: 1,
+      startIndex: 1,
+      searchName: "All Content",
+    });
+    expect(out.children).toHaveLength(1);
+    expect(out.children?.[0]?.title).toBe("A");
+    expect(out.totalCount).toBe(1);
+    expect(out.searchName).toBe("All Content");
+  });
+
+  it("unwraps Jackson root name SearchExecuteResult", () => {
+    const out = unwrapSearchExecuteResult({
+      SearchExecuteResult: {
+        children: [{ id: "2", name: "b" }],
+        totalCount: 2,
+        startIndex: 1,
+      },
+    });
+    expect(out.children).toHaveLength(1);
+    expect(out.totalCount).toBe(2);
+  });
+
+  it("returns empty shape for null / non-object", () => {
+    expect(unwrapSearchExecuteResult(null).children).toEqual([]);
+    expect(unwrapSearchExecuteResult("x").children).toEqual([]);
+  });
+});
+
+describe("executeSearch", () => {
+  it("POSTs to /searches/{id}/execute with optional overrides", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          children: [
+            {
+              id: "10",
+              title: "Welcome",
+              folderPath: "/Sites/Foo",
+              type: "page",
+            },
+          ],
+          totalCount: 1,
+          startIndex: 1,
+          searchName: "All Content",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await executeSearch("All Content", {
+      folderPath: "/Sites/Foo",
+      startIndex: 1,
+      maxResults: 25,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe(
+      `${PATHS.SEARCHES}/${encodeURIComponent("All Content")}/execute`,
+    );
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      folderPath: "/Sites/Foo",
+      startIndex: 1,
+      maxResults: 25,
+    });
+    expect(result.children).toHaveLength(1);
+    expect(result.children?.[0]?.title).toBe("Welcome");
+    expect(result.searchName).toBe("All Content");
+  });
+
+  it("rejects blank idOrName without calling the network", async () => {
+    const fetchMock = vi.spyOn(global, "fetch");
+    await expect(executeSearch("   ")).rejects.toThrow(/required/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("encodes special characters in the path segment", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ children: [], totalCount: 0, startIndex: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await executeSearch("A/B Search");
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe(
+      `${PATHS.SEARCHES}/${encodeURIComponent("A/B Search")}/execute`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#2506** — parent **#2409** / grandparent **#2400** slice **C**: Explorer **SearchPanel** saved-search picker + Vitest.

Operators can:
1. Open Explorer search panel
2. Pick a design/saved search from `GET /services/searches`
3. Run it via `POST /services/searches/{idOrName}/execute` (slice B façade from #2505 / PR #2592)
4. See results on the existing SearchPanel results path (Open / Reveal)

Also handles catalog **loading / empty / error** (with catalog retry), execute **loading / empty / error** (with retry), and blocks **custom URL** searches client-side.

### Changes
- `searchesApi.executeSearch` + `unwrapSearchExecuteResult` + execute DTOs
- `SearchPanel` saved-search `<select>` + Run wiring (injectable transports for tests)
- Explorer message keys for picker chrome
- Vitest: `searchesApi.test.ts` + extended `SearchPanel.test.tsx`

### Out of scope
- Playwright E2E → **#2507**
- Search design authoring UI

## Parent trackers
- Parent: #2409
- Grandparent: #2400

## Test plan
1. `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**
2. Java Surefire: Tests run: 31, Failures: 0
3. Vitest: Test Files 231 passed; Tests 1569 passed
4. Manual / QA H2 (follow-up QA issue): open Explorer → Search → pick saved search → Run → open/reveal a result

## Gates evidence
- **Module clean install:** `cd WebUI` → `..\mvnw.cmd clean install` → BUILD SUCCESS
- **No new warnings** attributable to this change (pre-existing dependency-analyze / javadoc noise only)
- **Erlang-style self-review:** injectable transports, formatApiError for ApiError objects, encodeURIComponent path keys, no OS path hardcoding, custom URL blocked, retry re-issues last free-text or saved execute
- Playwright intentionally deferred to #2507

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2506
Partial for #2409
Partial for #2400

> Co-Authored by Grok Build using grok-4.5 with agent main.