### PR TITLE
fix(system): complete PSObjectAcl typed set surface (#2442)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSFolderObjectDependencyHandler.java
@@ -285,9 +285,9 @@ public abstract class PSFolderObjectDependencyHandler extends PSCmsObjectDepende
         // get roles
         PSDependencyHandler roleHandler =
             getDependencyHandler(PSRoleDefDependencyHandler.DEPENDENCY_TYPE);
-        Iterator aclEntries = folder.getAcl().iterator();
+        Iterator<PSObjectAclEntry> aclEntries = folder.getAcl().iterator();
         while (aclEntries.hasNext()) {
-          PSObjectAclEntry aclEntry = (PSObjectAclEntry) aclEntries.next();
+          PSObjectAclEntry aclEntry = aclEntries.next();
           if (aclEntry.isRole()) {
             PSDependency roleDep = roleHandler.getDependency(tok, aclEntry.getName());
             if (roleDep != null) childDeps.add(roleDep);

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderSecurityPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderSecurityPanel.java
@@ -232,13 +232,9 @@ public class PSFolderSecurityPanel extends JPanel implements ActionListener {
         // additional calculation is necessary
         permissions = objectAclEntry.getPermissions();
       } else {
-        Iterator<?> it = acl.iterator();
+        Iterator<PSObjectAclEntry> it = acl.iterator();
         while (it.hasNext()) {
-          Object next = it.next();
-          if (!(next instanceof PSObjectAclEntry)) {
-            continue;
-          }
-          PSObjectAclEntry aclEntry = (PSObjectAclEntry) next;
+          PSObjectAclEntry aclEntry = it.next();
           switch (aclEntry.getType()) {
               case PSObjectAclEntry.ACL_ENTRY_TYPE_USER:
                 // already processed the user.
@@ -542,15 +538,12 @@ public class PSFolderSecurityPanel extends JPanel implements ActionListener {
   private void loadAclList(PSObjectAcl acl) {
     if (acl == null) throw new IllegalArgumentException("acl must not be null");
 
-    Iterator<?> acls = acl.iterator();
+    Iterator<PSObjectAclEntry> acls = acl.iterator();
 
     List<PSObjectAclEntry> listCurEntries = new ArrayList<>();
 
     while (acls.hasNext()) {
-      Object next = acls.next();
-      if (next instanceof PSObjectAclEntry) {
-        listCurEntries.add((PSObjectAclEntry) next);
-      }
+      listCurEntries.add(acls.next());
     }
 
     addUniqueListAclEntries(listCurEntries);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSObjectAcl.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSObjectAcl.java
@@ -146,7 +146,7 @@ public class PSObjectAcl extends PSDbComponentSet<PSObjectAclEntry> {
    * @return An iterator with zero or more <code>PSObjectAclEntry</code> objects. Never <code>null
    *     </code>, but may be empty.
    */
-  public Iterator getDeletedAclEntries() {
+  public Iterator<PSObjectAclEntry> getDeletedAclEntries() {
     return getDeleteCollection().iterator();
   }
 

--- a/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSServerFolderProcessor.java
@@ -690,9 +690,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     child = fItem.getChildByName(CHILD_NAME_ACL);
 
     // set the inserted and modified properties
-    Iterator it = folder.getAcl().iterator();
+    Iterator<PSObjectAclEntry> it = folder.getAcl().iterator();
     while (it.hasNext()) {
-      PSObjectAclEntry aclEntry = (PSObjectAclEntry) it.next();
+      PSObjectAclEntry aclEntry = it.next();
       if (aclEntry.getState() == IPSDbComponent.DBSTATE_UNMODIFIED) continue;
 
       PSItemChildEntry childEntry = child.createChildEntry();
@@ -725,7 +725,7 @@ public class PSServerFolderProcessor extends PSProcessorCommon
     // take care the deleted ACL entries
     it = folder.getAcl().getDeletedAclEntries();
     while (it.hasNext()) {
-      PSObjectAclEntry aclEntry = (PSObjectAclEntry) it.next();
+      PSObjectAclEntry aclEntry = it.next();
 
       PSItemChildEntry childEntry = child.createChildEntry();
       childEntry.setAction(PSItemChildEntry.CHILD_ACTION_DELETE);
@@ -3276,9 +3276,9 @@ public class PSServerFolderProcessor extends PSProcessorCommon
         // folder will fail, resulting in an orphaned folder.
         PSFolderAcl folderAcl = new PSFolderAcl(locator.getId(), folder.getCommunityId());
 
-        Iterator it = folder.getAcl().iterator();
+        Iterator<PSObjectAclEntry> it = folder.getAcl().iterator();
         while (it.hasNext()) {
-          PSObjectAclEntry aclEntry = (PSObjectAclEntry) it.next();
+          PSObjectAclEntry aclEntry = it.next();
           if (aclEntry != null) folderAcl.add(aclEntry);
         }
 

--- a/system/src/test/java/com/percussion/cms/objectstore/PSObjectAclTypedTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSObjectAclTypedTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed {@link PSObjectAcl} as {@link
+ * PSDbComponentSet}{@code <PSObjectAclEntry>} (#2442). Verifies typed iterators, lookup helpers, and
+ * delete-list set ops without casts.
+ */
+public class PSObjectAclTypedTest {
+
+  private static PSObjectAclEntry userEntry(String name, int permissions) {
+    return new PSObjectAclEntry(PSObjectAclEntry.ACL_ENTRY_TYPE_USER, name, permissions);
+  }
+
+  private static PSObjectAclEntry persistedUserEntry(int id, String name, int permissions) {
+    return new PSObjectAclEntry(id, PSObjectAclEntry.ACL_ENTRY_TYPE_USER, name, permissions);
+  }
+
+  private static PSObjectAclEntry roleEntry(String name, int permissions) {
+    return new PSObjectAclEntry(PSObjectAclEntry.ACL_ENTRY_TYPE_ROLE, name, permissions);
+  }
+
+  @Test
+  public void typedIteratorYieldsAclEntriesWithoutCast() {
+    PSObjectAcl acl = new PSObjectAcl();
+    PSObjectAclEntry alice = userEntry("alice", PSObjectAclEntry.ACCESS_READ);
+    PSObjectAclEntry editors = roleEntry("Editors", PSObjectAclEntry.ACCESS_WRITE);
+    assertTrue(acl.add(alice));
+    assertTrue(acl.add(editors));
+    assertEquals(2, acl.size());
+
+    int count = 0;
+    Iterator<PSObjectAclEntry> it = acl.iterator();
+    while (it.hasNext()) {
+      PSObjectAclEntry entry = it.next();
+      assertNotNull(entry.getName());
+      assertTrue(
+          entry.getType() == PSObjectAclEntry.ACL_ENTRY_TYPE_USER
+              || entry.getType() == PSObjectAclEntry.ACL_ENTRY_TYPE_ROLE);
+      count++;
+    }
+    assertEquals(2, count);
+  }
+
+  @Test
+  public void getAclEntryLookupIsCaseInsensitiveAndTyped() {
+    PSObjectAcl acl = new PSObjectAcl();
+    PSObjectAclEntry alice = userEntry("Alice", PSObjectAclEntry.ACCESS_ADMIN);
+    acl.add(alice);
+    acl.add(roleEntry("Editors", PSObjectAclEntry.ACCESS_READ));
+
+    assertSame(alice, acl.getAclEntry("alice", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+    assertSame(alice, acl.getAclEntry("ALICE", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+    assertNull(acl.getAclEntry("alice", PSObjectAclEntry.ACL_ENTRY_TYPE_ROLE));
+    assertNull(acl.getAclEntry("missing", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+  }
+
+  @Test
+  public void addRejectsDuplicateUserRoleVirtualIdentity() {
+    PSObjectAcl acl = new PSObjectAcl();
+    PSObjectAclEntry first = userEntry("bob", PSObjectAclEntry.ACCESS_READ);
+    PSObjectAclEntry duplicate = userEntry("bob", PSObjectAclEntry.ACCESS_WRITE);
+
+    assertTrue(acl.add(first));
+    assertFalse(acl.add(duplicate));
+    assertEquals(1, acl.size());
+    assertEquals(
+        PSObjectAclEntry.ACCESS_READ,
+        acl.getAclEntry("bob", PSObjectAclEntry.ACL_ENTRY_TYPE_USER).getPermissions());
+  }
+
+  @Test
+  public void removePersistedEntryAppearsInTypedDeletedIterator() {
+    PSObjectAcl acl = new PSObjectAcl();
+    PSObjectAclEntry persisted =
+        persistedUserEntry(42, "admin1", PSObjectAclEntry.ACCESS_ADMIN);
+    PSObjectAclEntry other = userEntry("qa1", PSObjectAclEntry.ACCESS_READ);
+    assertTrue(acl.add(persisted));
+    assertTrue(acl.add(other));
+    assertTrue(persisted.isPersisted());
+
+    assertTrue(acl.remove(persisted));
+    assertEquals(1, acl.size());
+    assertNull(acl.getAclEntry("admin1", PSObjectAclEntry.ACL_ENTRY_TYPE_USER));
+    assertEquals(1, acl.getDeleteCollection().size());
+
+    Iterator<PSObjectAclEntry> deleted = acl.getDeletedAclEntries();
+    assertTrue(deleted.hasNext());
+    PSObjectAclEntry removed = deleted.next();
+    assertEquals("admin1", removed.getName());
+    assertEquals(PSObjectAclEntry.ACL_ENTRY_TYPE_USER, removed.getType());
+    assertFalse(deleted.hasNext());
+  }
+
+  @Test
+  public void removeNewEntryDoesNotEnterDeleteList() {
+    PSObjectAcl acl = new PSObjectAcl();
+    PSObjectAclEntry draft = userEntry("temp", PSObjectAclEntry.ACCESS_READ);
+    assertTrue(acl.add(draft));
+    assertFalse(draft.isPersisted());
+
+    assertTrue(acl.remove(draft));
+    assertEquals(0, acl.size());
+    assertFalse(acl.getDeletedAclEntries().hasNext());
+    assertEquals(0, acl.getDeleteCollection().size());
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/transformation/converter/PSFolderConverter.java
+++ b/system/webservices/src/com/percussion/webservices/transformation/converter/PSFolderConverter.java
@@ -301,13 +301,13 @@ public class PSFolderConverter extends PSConverter
       List<PSFolderSecurityAclEntry> tgtAclEntries =
          new ArrayList<PSFolderSecurityAclEntry>();
 
-      java.util.Iterator<?> sourceAcls = source.getAcl().iterator();
+      java.util.Iterator<PSObjectAclEntry> sourceAcls = source.getAcl().iterator();
       PSObjectAclEntry srcAcl;
       PSFolderSecurityAclEntry tgtAcl;
       PSFolderSecurityAclEntryType tgtType;
       while (sourceAcls.hasNext())
       {
-         srcAcl = (PSObjectAclEntry) sourceAcls.next();
+         srcAcl = sourceAcls.next();
 
          // get the ACL type
          if (srcAcl.getType() == PSObjectAclEntry.ACL_ENTRY_TYPE_ROLE)


### PR DESCRIPTION
## Summary
Completes issue #2442 residual typing for `PSObjectAcl` as `PSDbComponentSet<PSObjectAclEntry>`.

- `PSObjectAcl` already extended the typed component set (from #2456 / PR #2456). This PR finishes the typed surface:
  - `getDeletedAclEntries()` now returns `Iterator<PSObjectAclEntry>`
  - Call sites stop casting ACL iterators (`PSServerFolderProcessor`, `PSFolderConverter`, DCE `PSFolderSecurityPanel`, deployer folder dependency handler)
- No product behavior change — generics / cast removal only
- Does **not** touch `PSFolderAclEditorDialog` (left to #2439)

**Parent trackers:** #2045 (consumer pain) / #2200 (monorepo)

## Test plan
- [x] New `PSObjectAclTypedTest` (typed iterator, `getAclEntry`, duplicate add, delete-list ops)
- [x] Existing `PSFolderTest` still green
- [x] Standalone clean installs:
  - `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 1349, Failures: 0, Skipped: 240)
  - `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 93, Failures: 0)
  - `cd deployer && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] No new warnings attributable to this change (baseline dependency-analyze / shade warnings only)

## Gates
- Erlang-style self-review: no behavior change, portable paths N/A, companions (tests + call sites) complete
- Avoided overlapping #2439 rawtypes work on `PSFolderAclEditorDialog`

## Fixes
Fixes #2442

Operator: Grok: night-issue-prs (model grok-4.5)
