### PR TITLE
fix(perc-system): cms.objectstore createKey/Element this-escape residual (#2467)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2467-cms-objectstore-createkey-this-escape-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2467-cms-objectstore-createkey-this-escape-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — #2467 cms.objectstore createKey/Element this-escape residual
+
+**Status:** pass (self-review before commit)  
+**Date:** 2026-08-09  
+**Module:** `system` / perc-system
+
+## Change class
+
+Real `-Xlint:this-escape` reduction in `cms.objectstore` around Element ctors / `createKey` overrides and collection `super(Element)` paths: private/non-virtual helpers, double-load elimination, final leaf `createKey` where no subclasses. **No** blanket `@SuppressWarnings("this-escape")`.
+
+## Findings
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| none | Bugs in Element restore / createKey after full construction | Covered by expanded `PSDbComponentThisEscapeTest` (9 tests) + existing set/summary tests |
+| none | Non-portable paths | N/A (no file I/O changes) |
+| note | Residual cms.objectstore this-escape remains outside this slice (AaRelationship, Action, CoreItem, …) | Parent #2022 may re-file further residual if needed; not suppress |
+| note | Subclass `createKey` still used from public `fromXml` after construction | Intentional — Element super path uses `createKeyDefault` only |
+
+## Tests
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS  
+- Tests run: 1351, Failures: 0, Errors: 0 (Skipped: 240)  
+- Focused: `PSDbComponentThisEscapeTest` 9/9, `PSDbComponentSetSubclassesTypedTest` 5/5, `PSComponentSummaryTest` 5/5  
+
+## Hard gates
+
+- [x] Behavioral unit tests for Element restore / createKey  
+- [x] No suppress-only this-escape  
+- [x] Cross-platform N/A  
+- [x] Module clean install green  

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
@@ -159,10 +159,14 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
    *     defined in the <code>fromXml()</code> method.
    */
   public PSComponentSummary(Element source) throws PSUnknownNodeTypeException {
-    // Avoid PSDbComponent(Element) which virtual-dispatches createKey before subclass init.
-    // Dummy locator is replaced by fromXml (same pattern as the no-arg Hibernate ctor).
+    // Avoid PSDbComponent(Element). Dummy locator replaced with final createKey (PSLocator).
     super(createKey(0, -1));
-    fromXml(source);
+    if (null == source) throw new IllegalArgumentException("sourceNode must be supplied");
+    Element keyEl = PSXMLDomUtil.getFirstElementChild(source);
+    // Package setKey avoids overridable setLocator during construction.
+    setKey(createKey(keyEl));
+    applyStateFromXml(source);
+    loadFieldsFromXml(source);
   }
 
   /**
@@ -944,8 +948,36 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
   public final void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (null == sourceNode) throw new IllegalArgumentException("sourceNode must be supplied");
 
+    // After full construction: super.fromXml uses final createKey (PSLocator).
     super.fromXml(sourceNode);
+    loadFieldsFromXml(sourceNode);
+  }
 
+  /**
+   * Applies the {@code state} attribute via {@link #setState(int)} (safe here: this class is not
+   * subclassed and does not override setState).
+   */
+  private void applyStateFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+    String strState = PSXMLDomUtil.checkAttribute(sourceNode, XML_ATTR_STATE, false);
+    if (strState.length() == 0) {
+      setState(DBSTATE_NEW);
+      return;
+    }
+    boolean found = false;
+    int i = 0;
+    for (; i < STATE_LABELS.length && !found; i++) {
+      if (STATE_LABELS[i].equalsIgnoreCase(strState)) found = true;
+    }
+    if (!found) {
+      String[] args = {"PSXComponentSummary", XML_ATTR_STATE, strState};
+      throw new PSUnknownNodeTypeException(
+          com.percussion.design.objectstore.IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+    }
+    setState(i - 1);
+  }
+
+  /** Loads non-key fields from the summary Element. */
+  private void loadFieldsFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     // Title
     m_name = PSXMLDomUtil.checkAttribute(sourceNode, XML_ATTR_NAME, true);
 
@@ -1199,7 +1231,12 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
   }
 
   /** Override to create our own Key which is {@link PSLocator}. */
-  protected PSKey createKey(Element el) throws PSUnknownNodeTypeException {
+  /**
+   * Final — {@code PSComponentSummary} is not subclassed; Element restore after dummy key uses this
+   * path from public {@link #fromXml(Element)}.
+   */
+  @Override
+  protected final PSKey createKey(Element el) throws PSUnknownNodeTypeException {
     if (el == null) throw new IllegalArgumentException("Source element cannot be null.");
 
     return new PSLocator(el);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSContentType.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSContentType.java
@@ -100,9 +100,10 @@ public class PSContentType extends PSDbComponent {
    *     values.
    */
   public PSContentType(Element source) throws PSUnknownNodeTypeException {
+    // super(Element) restores key/state via createKeyDefault (non-virtual); field load is separate
+    // so we do not double-call super.fromXml / virtual createKey during construction.
     super(source);
-
-    fromXml(source);
+    loadFieldsFromXml(source);
   }
 
   /**
@@ -216,8 +217,16 @@ public class PSContentType extends PSDbComponent {
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (null == sourceNode) throw new IllegalArgumentException("sourceNode must be supplied");
 
+    // After full construction: virtual createKey is honored.
     super.fromXml(sourceNode);
+    loadFieldsFromXml(sourceNode);
+  }
 
+  /**
+   * Loads non-key fields from XML. Used by the Element ctor (after super key/state restore) and by
+   * public {@link #fromXml(Element)} so key restore is not double-applied.
+   */
+  private void loadFieldsFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     m_name = PSXMLDomUtil.checkAttribute(sourceNode, XML_ATTR_name, true);
 
     m_label =
@@ -243,7 +252,8 @@ public class PSContentType extends PSDbComponent {
     if (el != null) m_queryRequest = PSXmlTreeWalker.getElementData(el);
 
     if (!verifyUrlFormat(m_queryRequest)) {
-      Object[] args = {getNodeName(), XML_ELEM_QueryRequest, m_queryRequest};
+      // Fixed node name for error args (loadFieldsFromXml may run from Element ctor).
+      Object[] args = {"PSXContentType", XML_ELEM_QueryRequest, m_queryRequest};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
@@ -277,9 +287,12 @@ public class PSContentType extends PSDbComponent {
     throw new UnsupportedOperationException("PSContentType is read-only.");
   }
 
-  /** Override to create our own Key which is {@link PSLocator}. */
+  /**
+   * Override to create our own Key which is {@link PSKey}. Final — no subclasses; safe for public
+   * {@link #fromXml(Element)} after construction.
+   */
   @Override
-  protected PSKey createKey(Element el) throws PSUnknownNodeTypeException {
+  protected final PSKey createKey(Element el) throws PSUnknownNodeTypeException {
     if (el == null) throw new IllegalArgumentException("Source element cannot be null.");
 
     return new PSKey(el);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeTemplate.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeTemplate.java
@@ -50,8 +50,9 @@ public class PSContentTypeTemplate extends PSDbComponent {
    *     defined in the <code>fromXml</code> method.
    */
   public PSContentTypeTemplate(Element source) throws PSUnknownNodeTypeException {
+    // super(Element) restores key/state via createKeyDefault; fields loaded without re-fromXml.
     super(source);
-    fromXml(source);
+    loadFieldsFromXml(source);
   }
 
   /**
@@ -244,7 +245,13 @@ public class PSContentTypeTemplate extends PSDbComponent {
     if (null == sourceNode) throw new IllegalArgumentException("sourceNode must be supplied");
 
     super.fromXml(sourceNode);
+    loadFieldsFromXml(sourceNode);
+  }
 
+  /**
+   * Loads non-key fields from XML without re-applying key/state (avoids Element double-load).
+   */
+  private void loadFieldsFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     m_outputFormat = PSXMLDomUtil.checkAttributeInt(sourceNode, XML_ATTR_outputFormat, true);
 
     m_aaType = PSXMLDomUtil.checkAttributeInt(sourceNode, XML_ATTR_aaType, false);
@@ -326,8 +333,12 @@ public class PSContentTypeTemplate extends PSDbComponent {
     return copy;
   }
 
-  /** Override to create our own Key which is {@link PSLocator}. */
-  protected PSKey createKey(Element el) throws PSUnknownNodeTypeException {
+  /**
+   * Override to create our own Key which is {@link PSKey}. Final — leaf type; honored from public
+   * {@link #fromXml(Element)} after construction.
+   */
+  @Override
+  protected final PSKey createKey(Element el) throws PSUnknownNodeTypeException {
     if (el == null) throw new IllegalArgumentException("Source element cannot be null.");
 
     return new PSKey(el);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
@@ -83,10 +83,10 @@ public abstract class PSDbComponent implements IPSDbComponent {
    */
   protected PSDbComponent(Element src) throws PSUnknownNodeTypeException {
     if (null == src) throw new IllegalArgumentException("Source element cannot be null.");
-    // Private path avoids virtual dispatch to subclass fromXml during super construction.
-    // Skip node-name check here: custom constants (e.g. PSSFields → PSX_FIELDS) differ from
-    // the PS→PSX class mapping; subclasses re-validate in their fromXml when needed.
-    fromXmlBase(src, false);
+    // Construction-only path: never calls overridable getNodeName/createKey (this-escape free).
+    // Custom node-name constants (e.g. PSSFields → PSX_FIELDS) are re-validated in subclass
+    // fromXml after full construction when needed.
+    fromXmlKeyAndStateDefault(src);
   }
 
   /**
@@ -315,58 +315,60 @@ public abstract class PSDbComponent implements IPSDbComponent {
    *     (see {@link PSKey#fromXml(Element)}) or the state name is not valid.
    */
   public void fromXml(Element source) throws PSUnknownNodeTypeException {
-    fromXmlBase(source, true);
-  }
-
-  /**
-   * Shared implementation for {@link #fromXml(Element)} and the Element constructor. Keeps the
-   * constructor from virtually dispatching to a subclass {@code fromXml} before subclass fields are
-   * initialized. Note: {@link #createKey(Element)} remains overridable so specialized key types
-   * (e.g. {@code PSLocator}) still work when restoring from XML after construction.
-   *
-   * @param checkNodeName when {@code true} (public fromXml), validate against {@link
-   *     #getNodeName()}; when {@code false} (Element super ctor), skip that check to avoid
-   *     this-escape and allow custom node-name constants.
-   */
-  private void fromXmlBase(Element source, boolean checkNodeName)
-      throws PSUnknownNodeTypeException {
     // Threshold
     if (null == source) throw new IllegalArgumentException("Source must be provided.");
 
-    String nodeName = nodeNameFor(getClass());
-    if (checkNodeName) {
-      // Safe after full construction: honor getNodeName overrides (e.g. PSX_FIELDS).
-      if (!getNodeName().equalsIgnoreCase(source.getNodeName())) {
-        String[] args = new String[] {"PSDbComponent.fromXml node: " + getNodeName()};
+    // After full construction: honor getNodeName overrides (e.g. PSX_FIELDS).
+    if (!getNodeName().equalsIgnoreCase(source.getNodeName())) {
+      String[] args = new String[] {"PSDbComponent.fromXml node: " + getNodeName()};
 
-        // @todo change exceptions if needed!!
-        throw new PSUnknownNodeTypeException(IPSCmsErrors.INVALID_CONTENT_TYPE_ID, args);
-      }
-      nodeName = getNodeName();
+      // @todo change exceptions if needed!!
+      throw new PSUnknownNodeTypeException(IPSCmsErrors.INVALID_CONTENT_TYPE_ID, args);
     }
 
     // Must restore key first because it has higher priority than state.
-    // Element super-ctor path uses non-overridable default createKey to avoid
-    // this-escape; public fromXml (after full construction) still uses virtual createKey.
+    // Public fromXml uses virtual createKey so specialized keys (e.g. PSLocator) work.
     Element keyEl = PSXMLDomUtil.getFirstElementChild(source);
-    setLocatorInternal(checkNodeName ? createKey(keyEl) : createKeyDefault(keyEl));
+    setLocatorInternal(createKey(keyEl));
+    restoreStateAttribute(source, getNodeName());
+  }
 
-    // Threshold
+  /**
+   * Element super-ctor path only: restores key via non-overridable {@link #createKeyDefault} and
+   * state via {@link #setStateInternal}. Never calls {@link #getNodeName()} or {@link
+   * #createKey(Element)} so subclass overrides are not dispatched before subclass init.
+   *
+   * @param source never {@code null}
+   */
+  private void fromXmlKeyAndStateDefault(Element source) throws PSUnknownNodeTypeException {
+    Element keyEl = PSXMLDomUtil.getFirstElementChild(source);
+    setLocatorInternal(createKeyDefault(keyEl));
+    restoreStateAttribute(source, nodeNameFor(getClass()));
+  }
+
+  /**
+   * Parses the component {@code state} attribute into {@link #setStateInternal(int)}.
+   *
+   * @param source root element, never {@code null}
+   * @param nodeName for error messages only (not validated here)
+   */
+  private void restoreStateAttribute(Element source, String nodeName)
+      throws PSUnknownNodeTypeException {
     String strState = PSXMLDomUtil.checkAttribute(source, XML_ATTR_STATE, false);
-    if (strState.length() == 0) setStateInternal(DBSTATE_NEW);
-    else {
-      boolean found = false;
-      int i = 0;
-      for (; i < STATE_LABELS.length && !found; i++) {
-        if (STATE_LABELS[i].equalsIgnoreCase(strState)) found = true;
-      }
-      if (!found) {
-        String[] args = {nodeName, XML_ATTR_STATE, strState};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
-      }
-      // Handles validation of state.
-      setStateInternal(i - 1);
+    if (strState.length() == 0) {
+      setStateInternal(DBSTATE_NEW);
+      return;
     }
+    boolean found = false;
+    int i = 0;
+    for (; i < STATE_LABELS.length && !found; i++) {
+      if (STATE_LABELS[i].equalsIgnoreCase(strState)) found = true;
+    }
+    if (!found) {
+      String[] args = {nodeName, XML_ATTR_STATE, strState};
+      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+    }
+    setStateInternal(i - 1);
   }
 
   /**
@@ -387,10 +389,13 @@ public abstract class PSDbComponent implements IPSDbComponent {
    * construction).
    */
   private void setStateInternal(int newState) {
-    if (!isValidState(newState)) throw new IllegalArgumentException("Invalid state.");
-
-    if ((isPersisted() && newState == DBSTATE_NEW)
-        || (!isPersisted()
+    // Inline validity + key.persisted checks — do not call overridable isValidState/isPersisted.
+    if (newState <= 0 || newState >= STATE_LABELS.length) {
+      throw new IllegalArgumentException("Invalid state.");
+    }
+    boolean keyPersisted = m_key != null && m_key.isPersisted();
+    if ((keyPersisted && newState == DBSTATE_NEW)
+        || (!keyPersisted
             && (newState == DBSTATE_UNMODIFIED
                 || newState == DBSTATE_MODIFIED
                 || newState == DBSTATE_MARKEDFORDELETE))) {
@@ -416,8 +421,8 @@ public abstract class PSDbComponent implements IPSDbComponent {
 
   /**
    * Default key restoration used by {@link #createKey(Element)} and by the Element super-ctor path
-   * in {@link #fromXmlBase(Element, boolean)} (non-virtual, this-escape safe). Subclasses may still
-   * override {@link #createKey(Element)}; that override is honored from public {@link
+   * in {@link #fromXmlKeyAndStateDefault(Element)} (non-virtual, this-escape safe). Subclasses may
+   * still override {@link #createKey(Element)}; that override is honored from public {@link
    * #fromXml(Element)} after construction.
    *
    * <p>Resolves the key class from the element node name (PSXFoo → PSFoo) by trying known key
@@ -440,6 +445,9 @@ public abstract class PSDbComponent implements IPSDbComponent {
       "com.percussion.cms.objectstore.", "com.percussion.design.objectstore."
     };
 
+    // Non-virtual type label for error messages (do not call overridable getComponentType()).
+    String typeLabel = getComponentType(getClass());
+
     String lastClassName = keyPackages[0] + simpleName;
     ClassNotFoundException lastCnfe = null;
     for (String pkg : keyPackages) {
@@ -453,20 +461,20 @@ public abstract class PSDbComponent implements IPSDbComponent {
         lastCnfe = cnfe;
         // try next package
       } catch (InstantiationException ie) {
-        String[] args = {strClassName, getComponentType(), ie.getLocalizedMessage()};
+        String[] args = {strClassName, typeLabel, ie.getLocalizedMessage()};
         throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
       } catch (IllegalAccessException iae) {
-        String[] args = {strClassName, getComponentType(), iae.getLocalizedMessage()};
+        String[] args = {strClassName, typeLabel, iae.getLocalizedMessage()};
         throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
       } catch (InvocationTargetException ite) {
         Throwable origException = ite.getTargetException();
         String msg = origException.getLocalizedMessage();
         String[] args = {
-          strClassName, getComponentType(), origException.getClass().getName() + ": " + msg
+          strClassName, typeLabel, origException.getClass().getName() + ": " + msg
         };
         throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
       } catch (NoSuchMethodException nsme) {
-        String[] args = {strClassName, getComponentType(), nsme.getLocalizedMessage()};
+        String[] args = {strClassName, typeLabel, nsme.getLocalizedMessage()};
         throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
       } catch (IllegalArgumentException iae) {
         // this should never happen because we checked ahead of time
@@ -475,7 +483,7 @@ public abstract class PSDbComponent implements IPSDbComponent {
     }
 
     String cnfeMsg = lastCnfe != null ? lastCnfe.getLocalizedMessage() : "class not found";
-    String[] args = {lastClassName, getComponentType(), cnfeMsg};
+    String[] args = {lastClassName, typeLabel, cnfeMsg};
     throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
   }
 
@@ -534,12 +542,13 @@ public abstract class PSDbComponent implements IPSDbComponent {
       throw new IllegalArgumentException("Key type must match existing key.");
 
     m_key = (PSKey) locator.clone();
-    if (isPersisted()) {
-      if (getState() == DBSTATE_NEW || getState() == DBSTATE_MARKEDFORDELETE) {
+    // Use key + m_state directly — not overridable isPersisted()/getState() (this-escape safe).
+    if (m_key.isPersisted()) {
+      if (m_state == DBSTATE_NEW || m_state == DBSTATE_MARKEDFORDELETE) {
         setStateInternal(DBSTATE_MODIFIED);
       }
     } else {
-      if (getState() == DBSTATE_MODIFIED || getState() == DBSTATE_UNMODIFIED) {
+      if (m_state == DBSTATE_MODIFIED || m_state == DBSTATE_UNMODIFIED) {
         setStateInternal(DBSTATE_NEW);
       }
     }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentCollection.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentCollection.java
@@ -133,7 +133,21 @@ public class PSDbComponentCollection extends PSDbComponent {
     the key and db state */
     this();
     if (null == src) throw new IllegalArgumentException("Source element cannot be null.");
-    m_list = new PSDbComponentList(src, getNodeName());
+    // Class-derived node name during construction (no virtual getNodeName / this-escape).
+    m_list = new PSDbComponentList(src, defaultNodeNameFor(getClass()));
+  }
+
+  /**
+   * Default XML root name for a component class without virtual dispatch (PS → PSX).
+   *
+   * @param clazz runtime class, never {@code null}
+   * @return node name, never {@code null} or empty
+   */
+  private static String defaultNodeNameFor(Class<?> clazz) {
+    String name = clazz.getName();
+    name = name.substring(name.lastIndexOf('.') + 1);
+    if (name.startsWith("PS")) name = "PSX" + name.substring(2);
+    return name;
   }
 
   /**
@@ -188,7 +202,11 @@ public class PSDbComponentCollection extends PSDbComponent {
   PSDbComponentCollection(Element src, String nodeName) throws PSUnknownNodeTypeException {
     this();
     if (null == src) throw new IllegalArgumentException("Source element cannot be null.");
-    fromXml(src, nodeName);
+    String effective =
+        (nodeName == null || nodeName.trim().isEmpty())
+            ? defaultNodeNameFor(getClass())
+            : nodeName;
+    fromXml(src, effective);
   }
 
   /** For use when constructing from xml. */
@@ -246,7 +264,8 @@ public class PSDbComponentCollection extends PSDbComponent {
    */
   @Override
   public void fromXml(Element src) throws PSUnknownNodeTypeException {
-    fromXml(src, null);
+    // After full construction: honor getNodeName overrides.
+    fromXml(src, getNodeName());
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentList.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentList.java
@@ -180,16 +180,16 @@ public class PSDbComponentList extends PSDbComponent {
 
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
 
-    // create a root element which name is constructed from the item class
-    Element root = PSXmlDocumentBuilder.createRoot(doc, getNodeName());
+    // Class-derived node name during construction (no virtual getNodeName / this-escape).
+    String rootName = defaultNodeNameFor(getClass());
+    Element root = PSXmlDocumentBuilder.createRoot(doc, rootName);
 
     for (int i = 0; items != null && i < items.length; i++) {
       Node node = doc.importNode(items[i], true);
       root.appendChild(node);
     }
 
-    // now we can reuse existing fromXml to create this List.
-    fromXml(root);
+    fromXmlLoad(root, rootName);
   }
 
   /**
@@ -203,7 +203,32 @@ public class PSDbComponentList extends PSDbComponent {
     the key and db state */
     this();
     if (null == src) throw new IllegalArgumentException("Source element cannot be null.");
-    fromXml(src, nodeName);
+    String effective =
+        (nodeName == null || nodeName.trim().isEmpty())
+            ? defaultNodeNameFor(getClass())
+            : nodeName;
+    fromXmlLoad(src, effective);
+  }
+
+  /**
+   * Default XML root name for a component class without virtual dispatch (PS → PSX).
+   *
+   * @param clazz runtime class, never {@code null}
+   * @return node name, never {@code null} or empty
+   */
+  private static String defaultNodeNameFor(Class<?> clazz) {
+    String name = clazz.getName();
+    name = name.substring(name.lastIndexOf('.') + 1);
+    if (name.startsWith("PS")) name = "PSX" + name.substring(2);
+    return name;
+  }
+
+  /** Non-virtual type label for error messages during Element load. */
+  private String componentTypeLabel() {
+    if (m_memberComponentType != null && !m_memberComponentType.isEmpty()) {
+      return m_memberComponentType;
+    }
+    return getComponentType(getClass());
   }
 
   /**
@@ -313,7 +338,8 @@ public class PSDbComponentList extends PSDbComponent {
    */
   @Override
   public void fromXml(Element src) throws PSUnknownNodeTypeException {
-    fromXml(src, null);
+    // After full construction: honor getNodeName overrides.
+    fromXml(src, getNodeName());
   }
 
   /**
@@ -323,8 +349,23 @@ public class PSDbComponentList extends PSDbComponent {
    * @param nodeName If <code>null</code> or empty, getNodeName() is used.
    */
   void fromXml(Element src, String nodeName) throws PSUnknownNodeTypeException {
+    if (null == nodeName || nodeName.trim().length() == 0) nodeName = getNodeName();
+    fromXmlLoad(src, nodeName);
+  }
+
+  /**
+   * Shared member restore used by public/package {@link #fromXml} and Element construction. Callers
+   * must supply a non-empty expected root node name (no virtual {@link #getNodeName()} here).
+   *
+   * @param src never {@code null}
+   * @param nodeName expected root element name, never {@code null} or empty
+   */
+  private void fromXmlLoad(Element src, String nodeName) throws PSUnknownNodeTypeException {
     // don't call super.fromXml because we don't use the key and state
     if (null == src) throw new IllegalArgumentException("Source element cannot be null.");
+    if (nodeName == null || nodeName.trim().isEmpty()) {
+      throw new IllegalArgumentException("nodeName must be supplied");
+    }
 
     m_list.clear();
     m_deleteList.clear();
@@ -332,8 +373,6 @@ public class PSDbComponentList extends PSDbComponent {
 
     String strClass = null;
     try {
-      if (null == nodeName || nodeName.trim().length() == 0) nodeName = getNodeName();
-
       PSXMLDomUtil.checkNode(src, nodeName);
 
       String seqFlag = src.getAttribute(XML_ATTR_SEQFLAG);
@@ -353,7 +392,7 @@ public class PSDbComponentList extends PSDbComponent {
         if (strClass.length() == 0) {
           strClass = "com.percussion.cms.objectstore.";
           if (!strNodeName.startsWith("PSX")) {
-            String[] args = {strClass, getComponentType()};
+            String[] args = {strClass, componentTypeLabel()};
             throw new PSUnknownNodeTypeException(IPSCmsErrors.INVALID_ENTRY_CLASSNAME, args);
           } else strClass += PSStringOperation.replace(strNodeName, "PSX", "PS");
         }
@@ -376,31 +415,34 @@ public class PSDbComponentList extends PSDbComponent {
           // add to delete list
           m_deleteList.add(aCmp);
         } else {
-          // Add to list
-          add(aCmp);
+          // Append without virtual add() (this-escape); sequencing matches end-append path.
+          m_list.add(aCmp);
+          if (!m_ignoreSequencing && aCmp instanceof IPSSequencedComponent) {
+            ((IPSSequencedComponent) aCmp).setPosition(m_list.size() - 1);
+          }
         }
 
         // Get the next sibling node
         aEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
       }
     } catch (ClassNotFoundException e) {
-      String[] args = {strClass, getComponentType(), e.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), e.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (InstantiationException ie) {
-      String[] args = {strClass, getComponentType(), ie.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), ie.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (IllegalAccessException iae) {
-      String[] args = {strClass, getComponentType(), iae.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), iae.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (InvocationTargetException ite) {
       Throwable origException = ite.getTargetException();
       String msg = origException.getLocalizedMessage();
       String[] args = {
-        strClass, getComponentType(), origException.getClass().getName() + ": " + msg
+        strClass, componentTypeLabel(), origException.getClass().getName() + ": " + msg
       };
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (NoSuchMethodException nsme) {
-      String[] args = {strClass, getComponentType(), nsme.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), nsme.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (IllegalArgumentException iae) {
       // this should never happen because we checked ahead of time

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponentSet.java
@@ -182,14 +182,14 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
     m_class = compClass;
     m_memberComponentType = compType;
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
-    // create a root element which name is constructed from the item class
-    Element root = PSXmlDocumentBuilder.createRoot(doc, getNodeName());
+    // Class-derived node name during construction (no virtual getNodeName / this-escape).
+    Element root = PSXmlDocumentBuilder.createRoot(doc, defaultNodeNameFor(getClass()));
     for (int i = 0; items != null && i < items.length; i++) {
       Node node = doc.importNode(items[i], true);
       root.appendChild(node);
     }
-    // now we can reuse existing fromXml to create this Set.
-    fromXml(root);
+    // Construction-safe load (explicit node name, no virtual getNodeName).
+    fromXmlLoad(root, defaultNodeNameFor(getClass()));
   }
 
   /**
@@ -203,7 +203,34 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
     the key and db state */
     this();
     if (null == src) throw new IllegalArgumentException("Source element cannot be null.");
-    fromXml(src, nodeName);
+    // Prefer supplied node name; else class-derived default (subclass overrides of getNodeName
+    // that match PS→PSX mapping are equivalent; custom constants should pass nodeName explicitly).
+    String effective =
+        (nodeName == null || nodeName.trim().isEmpty())
+            ? defaultNodeNameFor(getClass())
+            : nodeName;
+    fromXmlLoad(src, effective);
+  }
+
+  /**
+   * Default XML root name for a component class without virtual dispatch (PS → PSX).
+   *
+   * @param clazz runtime class, never {@code null}
+   * @return node name, never {@code null} or empty
+   */
+  private static String defaultNodeNameFor(Class<?> clazz) {
+    String name = clazz.getName();
+    name = name.substring(name.lastIndexOf('.') + 1);
+    if (name.startsWith("PS")) name = "PSX" + name.substring(2);
+    return name;
+  }
+
+  /** Non-virtual type label for error messages during Element load. */
+  private String componentTypeLabel() {
+    if (m_memberComponentType != null && !m_memberComponentType.isEmpty()) {
+      return m_memberComponentType;
+    }
+    return getComponentType(getClass());
   }
 
   /** For use when constructing from xml. */
@@ -300,7 +327,8 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
    */
   @Override
   public void fromXml(Element src) throws PSUnknownNodeTypeException {
-    fromXml(src, null);
+    // After full construction: honor getNodeName overrides.
+    fromXml(src, getNodeName());
   }
 
   /**
@@ -310,8 +338,23 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
    * @param nodeName If <code>null</code> or empty, getNodeName() is used.
    */
   void fromXml(Element src, String nodeName) throws PSUnknownNodeTypeException {
+    if ((nodeName == null) || (nodeName.trim().length() < 1)) nodeName = getNodeName();
+    fromXmlLoad(src, nodeName);
+  }
+
+  /**
+   * Shared member restore used by public/package {@link #fromXml} and Element construction. Callers
+   * must supply a non-empty expected root node name (no virtual {@link #getNodeName()} here).
+   *
+   * @param src never {@code null}
+   * @param nodeName expected root element name, never {@code null} or empty
+   */
+  private void fromXmlLoad(Element src, String nodeName) throws PSUnknownNodeTypeException {
     // don't call super.fromXml because we don't use the key and state
     if (src == null) throw new IllegalArgumentException("Source element cannot be null.");
+    if (nodeName == null || nodeName.trim().isEmpty()) {
+      throw new IllegalArgumentException("nodeName must be supplied");
+    }
 
     m_set.clear();
     m_deleteList.clear();
@@ -319,8 +362,6 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
 
     String strClass = null;
     try {
-      if ((nodeName == null) || (nodeName.trim().length() < 1)) nodeName = getNodeName();
-
       PSXMLDomUtil.checkNode(src, nodeName);
 
       // if classname is already set, the xml must match that, otherwise we
@@ -339,7 +380,7 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
         if (strClass.length() == 0) {
           strClass = "com.percussion.cms.objectstore.";
           if (!strNodeName.startsWith("PSX")) {
-            String[] args = {strClass, getComponentType()};
+            String[] args = {strClass, componentTypeLabel()};
             throw new PSUnknownNodeTypeException(IPSCmsErrors.INVALID_ENTRY_CLASSNAME, args);
           } else strClass += PSStringOperation.replace(strNodeName, "PSX", "PS");
         }
@@ -362,30 +403,30 @@ public class PSDbComponentSet<T extends IPSDbComponent> extends PSDbComponent {
           // add to delete list
           m_deleteList.add(aCmp);
         } else {
-          // Add to Set
-          add(aCmp);
+          // Direct set insert during load — avoid overridable add() (this-escape).
+          m_set.add(aCmp);
         }
         // Get the next sibling node
         aEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
       }
     } catch (ClassNotFoundException e) {
-      String[] args = {strClass, getComponentType(), e.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), e.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (InstantiationException ie) {
-      String[] args = {strClass, getComponentType(), ie.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), ie.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (IllegalAccessException iae) {
-      String[] args = {strClass, getComponentType(), iae.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), iae.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (InvocationTargetException ite) {
       Throwable origException = ite.getTargetException();
       String msg = origException.getLocalizedMessage();
       String[] args = {
-        strClass, getComponentType(), origException.getClass().getName() + ": " + msg
+        strClass, componentTypeLabel(), origException.getClass().getName() + ": " + msg
       };
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (NoSuchMethodException nsme) {
-      String[] args = {strClass, getComponentType(), nsme.getLocalizedMessage()};
+      String[] args = {strClass, componentTypeLabel(), nsme.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSCmsErrors.COMPONENT_INSTANTIATION_ERROR, args);
     } catch (IllegalArgumentException iae) {
       // this should never happen because we checked ahead of time

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefSummary.java
@@ -70,12 +70,13 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     if (null == editorUrl) {
       throw new IllegalArgumentException("editorUrl cannot be null");
     }
-    setName(name);
-    setLabel(label);
-    setTypeId(typeId);
-    setEditorUrl(editorUrl);
-    setDescription(description);
-    setHideFromMenu(hideFromMenu);
+    // Direct field assignment during construction — avoid overridable setters (this-escape).
+    m_name = name;
+    m_label = label == null ? "" : label;
+    m_typeId = typeId;
+    m_editorUrl = editorUrl;
+    m_description = description == null ? "" : description;
+    m_hideFromMenu = hideFromMenu;
   }
 
   public PSItemDefSummary(
@@ -109,7 +110,7 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
    *     defined in the <code>fromXml</code> method.
    */
   public PSItemDefSummary(Element source) throws PSUnknownNodeTypeException {
-    fromXml(source, null, null);
+    fromXmlLoad(source);
   }
 
   /**
@@ -268,11 +269,32 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
       @SuppressWarnings("unused") IPSDocument parentDoc,
       @SuppressWarnings("unused") List parentComponents)
       throws PSUnknownNodeTypeException {
+    fromXmlLoad(source);
+  }
+
+  /**
+   * Package helper for {@link PSItemDefinition} Element construction — restores summary fields
+   * without dispatching through overridable public {@link #fromXml}.
+   *
+   * @param source never {@code null}
+   */
+  final void restoreSummaryFromXml(Element source) throws PSUnknownNodeTypeException {
+    fromXmlLoad(source);
+  }
+
+  /**
+   * Shared Element restore for construction and public {@link #fromXml}. Uses static {@link
+   * #getNodeName()} and direct field writes (no overridable setters) for this-escape safety.
+   *
+   * @param source never {@code null}
+   */
+  private void fromXmlLoad(Element source) throws PSUnknownNodeTypeException {
     if (null == source) throw new IllegalArgumentException("sourceNode must be supplied");
 
-    // make sure we got the correct root node tag
-    if (false == getNodeName().equals(source.getNodeName())) {
-      Object[] args = {getNodeName(), source.getNodeName()};
+    // Static getNodeName — no virtual dispatch.
+    final String nodeName = getNodeName();
+    if (false == nodeName.equals(source.getNodeName())) {
+      Object[] args = {nodeName, source.getNodeName()};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
     }
 
@@ -281,7 +303,7 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     String attrName = "name";
     temp = walker.getElementData(attrName);
     if (null == temp || temp.trim().length() == 0) {
-      Object[] args = {getNodeName(), attrName, temp};
+      Object[] args = {nodeName, attrName, temp};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
     } else m_name = temp;
 
@@ -296,13 +318,13 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     attrName = "typeId";
     temp = walker.getElementData(attrName);
     if (null == temp || temp.trim().length() == 0) {
-      Object[] args = {getNodeName(), attrName, temp};
+      Object[] args = {nodeName, attrName, temp};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
     } else {
       try {
-        setTypeId(Integer.parseInt(temp));
+        m_typeId = Integer.parseInt(temp);
       } catch (NumberFormatException nfe) {
-        Object[] args = {getNodeName(), attrName, temp};
+        Object[] args = {nodeName, attrName, temp};
         throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
@@ -310,20 +332,20 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     attrName = "hideFromMenu";
     temp = walker.getElementData(attrName);
     if (null == temp || temp.trim().length() == 0) {
-      setHideFromMenu(false);
+      m_hideFromMenu = false;
     } else {
-      setHideFromMenu(Boolean.getBoolean(temp));
+      m_hideFromMenu = Boolean.getBoolean(temp);
     }
 
     attrName = "editorUrl";
     temp = walker.getElementData(attrName);
     if (null == temp || temp.trim().length() == 0) {
-      Object[] args = {getNodeName(), attrName, temp};
+      Object[] args = {nodeName, attrName, temp};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
     } else m_editorUrl = temp;
 
-    String elemName = "Description";
-    setDescription(walker.getElementData(elemName));
+    String desc = walker.getElementData("Description");
+    m_description = desc == null ? "" : desc;
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
@@ -104,7 +104,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    * @param contentTypeDef
    */
   public PSItemDefinition(Element contentTypeDef) throws PSUnknownNodeTypeException {
-    fromXml(contentTypeDef, null, null);
+    fromXmlLoad(contentTypeDef, null, null, false);
   }
 
   /**
@@ -114,7 +114,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    */
   public PSItemDefinition(Element contentTypeDef, boolean isCopy)
       throws PSUnknownNodeTypeException {
-    fromXml(contentTypeDef, null, null, isCopy);
+    fromXmlLoad(contentTypeDef, null, null, isCopy);
   }
 
   /** Ctor to be used by subclasses */
@@ -592,7 +592,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
   @Override
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
-    fromXml(sourceNode, parentDoc, parentComponents, false);
+    fromXmlLoad(sourceNode, parentDoc, parentComponents, false);
   }
 
   /**
@@ -614,7 +614,7 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
    * @throws PSUnknownNodeTypeException if the XML element node does not represent a type supported
    *     by the class.
    */
-  private void fromXml(
+  private void fromXmlLoad(
       Element sourceNode, IPSDocument parentDoc, List parentComponents, boolean isCopy)
       throws PSUnknownNodeTypeException {
     // validate the root element
@@ -633,7 +633,8 @@ public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, 
     Element el1 = PSXMLDomUtil.getFirstElementChild(sourceNode);
     Element el2 = PSXMLDomUtil.getNextElementSibling(el1);
 
-    super.fromXml(el1, null, null);
+    // Final package helper — no overridable public fromXml during Element construction.
+    restoreSummaryFromXml(el1);
     if (m_contentEditorDef == null) {
       m_contentEditorDef = new PSContentEditor(el2, parentDoc, parentComponents, !isCopy);
     } else {

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSlotType.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSlotType.java
@@ -44,8 +44,9 @@ public class PSSlotType extends PSDbComponent {
    *     defined in the <code>fromXml</code> method.
    */
   public PSSlotType(Element source) throws PSUnknownNodeTypeException {
+    // super(Element) restores key/state via createKeyDefault; fields loaded without re-fromXml.
     super(source);
-    fromXml(source);
+    loadFieldsFromXml(source);
   }
 
   /**
@@ -174,7 +175,13 @@ public class PSSlotType extends PSDbComponent {
     if (null == sourceNode) throw new IllegalArgumentException("sourceNode must be supplied");
 
     super.fromXml(sourceNode);
+    loadFieldsFromXml(sourceNode);
+  }
 
+  /**
+   * Loads non-key fields from XML without re-applying key/state (avoids Element double-load).
+   */
+  private void loadFieldsFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     m_systemSlot = PSXMLDomUtil.checkAttributeInt(sourceNode, XML_ATTR_systemSlot, false);
 
     m_slotType = PSXMLDomUtil.checkAttributeInt(sourceNode, XML_ATTR_slotType, false);
@@ -256,9 +263,11 @@ public class PSSlotType extends PSDbComponent {
   }
 
   /**
-   * Override to create our own Key which is {@link com.percussion.design.objectstore.PSLocator}.
+   * Override to create our own Key which is {@link PSKey}. Final — leaf type; honored from public
+   * {@link #fromXml(Element)} after construction.
    */
-  protected PSKey createKey(Element el) throws PSUnknownNodeTypeException {
+  @Override
+  protected final PSKey createKey(Element el) throws PSUnknownNodeTypeException {
     if (el == null) throw new IllegalArgumentException("Source element cannot be null.");
 
     return new PSKey(el);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSlotTypeContentTypeVariant.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSlotTypeContentTypeVariant.java
@@ -37,8 +37,9 @@ public class PSSlotTypeContentTypeVariant extends PSDbComponent {
    *     defined in the <code>fromXml</code> method.
    */
   public PSSlotTypeContentTypeVariant(Element source) throws PSUnknownNodeTypeException {
+    // super(Element) restores key/state via createKeyDefault; fromXml only re-applies that —
+    // avoid double-load by not calling fromXml from the Element ctor.
     super(source);
-    fromXml(source);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSVariantSlotType.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSVariantSlotType.java
@@ -39,8 +39,9 @@ public class PSVariantSlotType extends PSDbComponent {
    *     defined in the <code>fromXml</code> method.
    */
   public PSVariantSlotType(Element source) throws PSUnknownNodeTypeException {
+    // super(Element) restores key/state via createKeyDefault; no field load needed beyond that.
+    // (fromXml only re-applies key/state — avoid double-load by not calling it from the ctor.)
     super(source);
-    fromXml(source);
   }
 
   /**

--- a/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentThisEscapeTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentThisEscapeTest.java
@@ -17,7 +17,9 @@
 package com.percussion.cms.objectstore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.xml.PSXmlDocumentBuilder;
 import org.junit.jupiter.api.Test;
@@ -25,24 +27,20 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /**
- * Behavioral coverage for {@link PSDbComponent} Element super-ctor / {@code fromXmlBase} + {@code
- * createKeyDefault} path (#2404 review follow-up). Complements design.objectstore coverage in
- * {@code PSDesignObjectStoreThisEscapeTest}.
+ * Behavioral coverage for cms.objectstore Element super-ctor / createKey / collection restore after
+ * this-escape fixes (#2467 / parent #2022). Complements {@code PSDesignObjectStoreThisEscapeTest}.
  *
- * <p>Uses {@link PSVariantSlotType} because it calls {@code super(source)} then {@code
- * fromXml(source)} and stores a multi-part {@link PSKey} (not {@link PSSimpleKey}, whose node name
- * mismatches the PSContentType {@code createKey} override).
+ * <p>Covers: createKeyDefault Element path, double-load elimination (ContentType/SlotType),
+ * collection Element restore, public fromXml still honoring subclass createKey after construction.
  */
 public class PSDbComponentThisEscapeTest {
 
   @Test
-  public void variantSlotTypeElementCtorRoundTripUsesCreateKeyDefaultThenFromXml()
-      throws Exception {
+  public void variantSlotTypeElementCtorRoundTripUsesCreateKeyDefault() throws Exception {
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
     Element source = sampleVariantSlotTypeElement(doc, 42, 7);
 
-    // Element ctor: super(source) → createKeyDefault (non-virtual), then subclass fromXml →
-    // virtual createKey (PSKey(Element)).
+    // Element ctor: super(source) → createKeyDefault only (no double fromXml).
     PSVariantSlotType restored = new PSVariantSlotType(source);
 
     assertEquals(42, restored.getVariantId());
@@ -64,6 +62,127 @@ public class PSDbComponentThisEscapeTest {
     assertEquals(88, target.getSlotId());
   }
 
+  @Test
+  public void contentTypeElementCtorLoadsFieldsWithoutDoubleKeyApply() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element source =
+        sampleContentTypeElement(doc, 15, "percPage", "Page", "../rx_cePage/page.html", false, 1);
+
+    PSContentType restored = new PSContentType(source);
+
+    assertEquals(15, restored.getTypeId());
+    assertEquals("percPage", restored.getName());
+    assertEquals("Page", restored.getLabel());
+    assertEquals("../rx_cePage/page.html", restored.getEditorUrl());
+    assertFalse(restored.isHiddenFromMenu());
+    assertEquals(1, restored.getObjectType());
+    assertEquals(IPSDbComponent.DBSTATE_UNMODIFIED, restored.getState());
+  }
+
+  @Test
+  public void contentTypePublicFromXmlHonorsCreateKeyAfterConstruction() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element first =
+        sampleContentTypeElement(doc, 1, "a", "A", "../rx_ceA/a.html", true, 1);
+    PSContentType target = new PSContentType(first);
+
+    Element second =
+        sampleContentTypeElement(doc, 77, "b", "B", "../rx_ceB/b.html", false, 2);
+    target.fromXml(second);
+
+    assertEquals(77, target.getTypeId());
+    assertEquals("b", target.getName());
+    assertEquals("B", target.getLabel());
+    assertEquals("../rx_ceB/b.html", target.getEditorUrl());
+    assertFalse(target.isHiddenFromMenu());
+    assertEquals(2, target.getObjectType());
+  }
+
+  @Test
+  public void slotTypeElementCtorAndPublicFromXmlRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element source = sampleSlotTypeElement(doc, 9, "sys_content");
+
+    PSSlotType restored = new PSSlotType(source);
+    assertEquals(9, restored.getSlotId());
+    assertEquals("sys_content", restored.getSlotName());
+
+    Element second = sampleSlotTypeElement(doc, 11, "rffList");
+    restored.fromXml(second);
+    assertEquals(11, restored.getSlotId());
+    assertEquals("rffList", restored.getSlotName());
+  }
+
+  @Test
+  public void contentTypeSetElementArrayCtorRestoresMembers() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element a =
+        sampleContentTypeElement(doc, 10, "percPage", "Page", "../rx_cePage/page.html", false, 1);
+    Element b =
+        sampleContentTypeElement(
+            doc, 20, "percFolder", "Folder", "../rx_ceFolder/folder.html", true, 2);
+
+    PSContentTypeSet set = new PSContentTypeSet(new Element[] {a, b});
+    assertEquals(2, set.size());
+    assertEquals("percPage", set.getContentTypeById(10).getName());
+    assertEquals("percFolder", set.getContentTypeByName("PERCFOLDER").getName());
+  }
+
+  @Test
+  public void contentTypeSetElementRootCtorRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element a =
+        sampleContentTypeElement(doc, 3, "t1", "T1", "../rx_ceT1/t1.html", false, 1);
+    Element b =
+        sampleContentTypeElement(doc, 4, "t2", "T2", "../rx_ceT2/t2.html", false, 1);
+    PSContentTypeSet original = new PSContentTypeSet(new Element[] {a, b});
+    Element xml = original.toXml(doc);
+
+    PSContentTypeSet restored = new PSContentTypeSet(xml);
+    assertEquals(2, restored.size());
+    assertNotNull(restored.getContentTypeById(3));
+    assertNotNull(restored.getContentTypeById(4));
+  }
+
+  @Test
+  public void itemDefSummaryElementCtorRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = doc.createElement(PSItemDefSummary.getNodeName());
+    root.setAttribute("id", "0");
+    root.setAttribute("name", "percPage");
+    root.setAttribute("label", "Page");
+    root.setAttribute("typeId", "301");
+    root.setAttribute("editorUrl", "../rx_cePage/page.html");
+    root.setAttribute("hideFromMenu", "false");
+    PSXmlDocumentBuilder.addElement(doc, root, "Description", "A page type");
+
+    PSItemDefSummary restored = new PSItemDefSummary(root);
+    assertEquals("percPage", restored.getName());
+    assertEquals("Page", restored.getLabel());
+    assertEquals(301, restored.getTypeId());
+    assertEquals("../rx_cePage/page.html", restored.getEditorUrl());
+    assertEquals("A page type", restored.getDescription());
+    assertFalse(restored.getHideFromMenu());
+  }
+
+  @Test
+  public void slotTypeContentTypeVariantElementCtorUsesCreateKeyDefault() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSKey key =
+        new PSKey(
+            new String[] {"SLOTID", "CONTENTTYPEID", "VARIANTID"},
+            new String[] {"5", "301", "42"},
+            true);
+    Element root = doc.createElement("PSXSlotTypeContentTypeVariant");
+    root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    root.appendChild(key.toXml(doc));
+
+    PSSlotTypeContentTypeVariant restored = new PSSlotTypeContentTypeVariant(root);
+    assertEquals(5, restored.getSlotId());
+    assertEquals(301L, restored.getContentTypeId());
+    assertEquals(42, restored.getVariantId());
+  }
+
   /**
    * Builds a minimal {@code PSXVariantSlotType} document matching {@link
    * PSVariantSlotType#toXml(Document)} / super key serialization.
@@ -77,6 +196,46 @@ public class PSDbComponentThisEscapeTest {
     Element root = doc.createElement("PSXVariantSlotType");
     root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
     root.appendChild(key.toXml(doc));
+    return root;
+  }
+
+  private static Element sampleContentTypeElement(
+      Document doc,
+      int typeId,
+      String name,
+      String label,
+      String editorUrl,
+      boolean hideFromMenu,
+      int objectType) {
+    // PSContentType.createKey(Element) expects a PSXKey node (new PSKey(el)), not PSXSimpleKey.
+    PSKey key =
+        new PSKey(
+            new String[] {"CONTENTTYPEID"}, new String[] {String.valueOf(typeId)}, true);
+
+    Element root = doc.createElement("PSXContentType");
+    root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    root.setAttribute("name", name);
+    root.setAttribute("label", label);
+    root.setAttribute("hideFromMenu", hideFromMenu ? "1" : "0");
+    root.setAttribute("objectType", String.valueOf(objectType));
+    root.appendChild(key.toXml(doc));
+    PSXmlDocumentBuilder.addElement(doc, root, "QueryRequest", editorUrl);
+    return root;
+  }
+
+  private static Element sampleSlotTypeElement(Document doc, int slotId, String slotName) {
+    // PSSlotType.createKey(Element) expects a PSXKey node (new PSKey(el)).
+    PSKey key =
+        new PSKey(new String[] {"SLOTID"}, new String[] {String.valueOf(slotId)}, true);
+
+    Element root = doc.createElement("PSXSlotType");
+    root.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    root.setAttribute("systemSlot", "0");
+    root.setAttribute("slotType", "0");
+    root.setAttribute("allowedRelationshipName", "ActiveAssembly");
+    root.appendChild(key.toXml(doc));
+    PSXmlDocumentBuilder.addElement(doc, root, "SlotName", slotName);
+    PSXmlDocumentBuilder.addElement(doc, root, "SlotDesc", "desc");
     return root;
   }
 }


### PR DESCRIPTION
## Summary

PR-sized **slice 3j** for **#2467** (parent **#2022** / grandparent **#2200**): reduce residual `-Xlint:this-escape` in **cms.objectstore** around Element ctors / `createKey` overrides with **real** private helpers — **not** suppress-only.

### Real this-escape fixes
- **PSDbComponent**: Element super-ctor uses private `fromXmlKeyAndStateDefault` + `createKeyDefault` only (no virtual `getNodeName`/`createKey`); public `fromXml` still uses virtual `createKey` after full construction; `setLocatorInternal`/`setStateInternal` avoid overridable `isPersisted`/`getState`
- **Double-load elimination**: `PSContentType`, `PSContentTypeTemplate`, `PSSlotType`, `PSVariantSlotType`, `PSSlotTypeContentTypeVariant` — `super(Element)` then private field load (or key-only), not `fromXml` re-entry
- **Collections**: `PSDbComponentSet`/`List`/`Collection` Element paths use class-derived node names + private `fromXmlLoad` (no virtual `getNodeName`/`add` during construction)
- **PSItemDefSummary** / **PSItemDefinition** / **PSComponentSummary**: private/package Element restore helpers; leaf `createKey` marked `final` where no subclasses

### Tests
- Expanded `PSDbComponentThisEscapeTest` — 9 Element restore / public fromXml cases (ContentType, SlotType, VariantSlotType, ContentTypeSet, ItemDefSummary, …)

### Metrics (cms.objectstore `this' escape` messages, `-Xmaxwarns 10000`)
| | Count |
| --- | ---: |
| Before (slice start) | ~98 |
| After this PR | ~82 |
| Δ | **~−16** primary construction sites cleared on named targets |

Residual cms.objectstore this-escape remains outside this slice (AaRelationship, Action, CoreItem, …) — parent epic may re-file further residual under #2022 if needed.

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1351**, Failures: **0**, Errors: **0** (Skipped: 240)
- [x] `PSDbComponentThisEscapeTest` — 9/9 pass
- [x] `PSDbComponentSetSubclassesTypedTest` — 5/5; `PSComponentSummaryTest` — 5/5

## Gates evidence
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2467-cms-objectstore-createkey-this-escape-erlang.md`
- Per-module standalone clean install: pass
- No monorepo-wide reformat; no suppress-only this-escape

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2467  
Refs #2022 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.