### PR TITLE
feat(audit-log): system-wide audit API Phase 1 dual-write (#2614)

### DIFF
--- a/docs/ai-generated/code-reviews/2614-system-audit-log-phase1-erlang.md
+++ b/docs/ai-generated/code-reviews/2614-system-audit-log-phase1-erlang.md
@@ -1,0 +1,150 @@
+# Erlang Code Review — #2614 System-Wide Audit Log Phase 1
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-09 |
+| **Reviewer** | Erlang (strict independent) |
+| **Scope** | Uncommitted / local Phase 1 work for system-wide audit log |
+| **Ticket** | [#2614](https://github.com/intersoftdatalabs-in/percussioncms/issues/2614) |
+| **Design** | `docs/ai-generated/tasks/system-audit-log/design.md` |
+| **Base note** | Reviewed artifact contents under the listed paths (full file context). Git CLI was not available in this review session for a unified `git diff` dump; inventory was taken from the working tree files matching the Phase 1 design checklist. |
+
+## Summary
+
+Phase 1 introduces a clean `com.intsof.percussioncms.auditlog` API (error codes with `isAuditable`, dual-write service, redaction, template formatting), a `PSX_SYSTEM_AUDIT_LOG` table definition, JPA entity + Spring repository, login/logout smoke hooks in `PSLoginServlet`, and a retention job skeleton. Core library tests cover dual-write identity, non-auditable skip, sink isolation, and redaction; system tests cover entity mapping and login logger smoke via the memory repository.
+
+**Dominant risk:** `PSSystemAuditLogRepository.afterPropertiesSet()` registers the **raw Spring bean** (`this`) into `DefaultAuditLogService.Holder` *before* AOP creates the transactional proxy. Production dual-write to the DB will almost certainly hit `TransactionRequiredException` (or equivalent), get swallowed as `AUDIT_SINK_FAILURE`, and leave only Log4j — silently defeating Phase 1 durable dual-write. That is a hard **bug**.
+
+Secondary gaps: incomplete JSON escaping for attributes, login-success audit ordered after `sendRedirect`, thin coverage for retention/registration, and a vacuous redaction assertion in one service test.
+
+**Cross-platform path checklist:** N/A — no new filesystem path construction, install path joins, or path assertions in this change set. **Outcome: clean.**
+
+**Memory patterns hit:** empty catch / swallowed failures (sink failures are logged — good); missing behavioral proof for integration wiring; Spring transactional proxy / shared-context companion awareness.
+
+## Recommendation
+
+**request-changes**
+
+## Gate
+
+| Gate | Result |
+|------|--------|
+| Bugs open | **yes** (transactional dual-write registration) |
+| Missing behavioral tests (non-trivial) | partial — core API OK; repository TX/wiring not proven |
+| Non-portable paths | **pass** |
+| May commit/push | **no** |
+
+## Issues
+
+### Issue 1 -- Severity: bug
+- File: `system/services/src/com/percussion/services/audit/impl/PSSystemAuditLogRepository.java:42-45` (and `save` at 47-52)
+- Description: `afterPropertiesSet()` does `DefaultAuditLogService.Holder.set(DefaultAuditLogService.create(this))`. Spring invokes `InitializingBean.afterPropertiesSet` **before** `BeanPostProcessors` create the AOP transactional proxy. The `AuditLogRepository` held by `RepositoryAuditLogSink` is therefore the raw target. `@Transactional` on `save` / `deleteOlderThan` does not apply to those external calls. Login/logout (and any other `Holder.get()` path) will call `entityManager.persist(...)` with no active transaction → runtime failure, caught by `DefaultAuditLogService` sink loop → only Log4j dual-write path remains. Design and README claim JPA durable store when Spring wires; production behavior will not match.
+- Suggestion: Do **not** pass `this` from `afterPropertiesSet`. Prefer one of:
+  1. Inject `PlatformTransactionManager` / `TransactionTemplate` and open a transaction **inside** `save` / `deleteOlderThan` (works regardless of caller), or
+  2. Implement `SmartInitializingSingleton` / `ApplicationContextAware` and register `applicationContext.getBean("sys_systemAuditLogRepository", AuditLogRepository.class)` (the proxy) after singletons are ready, or
+  3. Self-inject the repository via `@Lazy @Autowired` proxy field and register that field in a late init hook.
+  Add a unit/integration test that proves `save` runs under a transaction (or that `TransactionTemplate.execute` is invoked) when called through `DefaultAuditLogService.Holder`, not only through a Spring-injected client.
+- Status: open
+
+### Issue 2 -- Severity: bug
+- File: `system/src/main/java/com/percussion/servlets/PSLoginServlet.java:523` (relative to authenticate success path)
+- Description: `PSSystemAuditLogger.loginSuccess` runs **after** `response.sendRedirect(safeRedirect)`. If redirect throws, or the success path aborts between auth and redirect, a successful authentication may never produce an audit row. Security audit trails should record successful login when authentication succeeds, independent of subsequent redirect mechanics. Logout correctly audits before session teardown; success is inconsistent.
+- Suggestion: Call `PSSystemAuditLogger.loginSuccess(request, uid)` immediately after successful `PSSecurityFilter.authenticate(...)` (and still wrap in try/catch like logout so audit sink issues cannot break login). Keep failure audit in the `LoginException` catch as today.
+- Status: open
+
+### Issue 3 -- Severity: suggestion
+- File: `system/services/src/com/percussion/services/audit/data/PSSystemAuditLogEntry.java:114-132`
+- Description: `attributesToJson` / `jsonEscape` only escape `\` and `"`. Newlines, tabs, and other control characters produce **invalid JSON**. Phase 1 login path rarely sets attributes, but any call site that puts free-text attributes into the map will persist unreadable/broken `ATTRIBUTES_JSON` for Admin UI / REST consumers (later phases).
+- Suggestion: Escape control characters (`\n`, `\r`, `\t`, other `\u0000-\u001F`) or use an existing Jackson/JSON utility already on the system classpath. Add a unit test with a value containing quotes and a newline.
+- Status: open
+
+### Issue 4 -- Severity: suggestion
+- File: `system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java:87-92`
+- Description: Client IP is only `request.getRemoteAddr()`. Behind Jetty reverse-proxy / load balancer deployments, durable audit rows will record the proxy address, not the end client — weak for AUTH_FAILURE / AUTH_LOGIN forensics (AU-2/AU-3 intent).
+- Suggestion: Document Phase 1 limitation; later use an existing product trusted-proxy / remote-IP helper if one exists, or a documented `server.properties` allowlist for `X-Forwarded-For`. Do not blindly trust arbitrary headers without an allowlist.
+- Status: open
+
+### Issue 5 -- Severity: suggestion
+- File: `modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/DefaultAuditLogServiceTest.java:77-96`
+- Description: `sinkFailureDoesNotPreventOtherSinks` asserts  
+  `logMessage.contains(REDACTED) || logMessage.contains("jdoe")`. The reason param is `"bad password"` (no `password=` form), so redaction usually does not fire and the assertion passes solely because actor `jdoe` is always present — vacuous for redaction/sink-failure interaction.
+- Suggestion: Assert `sinkFailureCount == 1`, `bad` wrote nothing, `ok` has one record, and (if redaction is intended) use a reason like `password=hunter2` with `assertFalse(logMessage.contains("hunter2"))` — or drop the redaction clause from this test and rely on `redactsSecretsInMessages`.
+- Status: open
+
+### Issue 6 -- Severity: suggestion
+- File: `system/business/src/com/percussion/rx/audit/PSSystemAuditLogRetentionJob.java` (class-level); tests absent
+- Description: Retention skeleton is intentionally unwired (no Spring bean / schedule) — acceptable for Phase 1 “skeleton” per design. Still, `runOnce` / disable (`retentionDays <= 0`) / null repository branches have no unit tests with a mock repository.
+- Suggestion: Add a small pure unit test with a mock `PSSystemAuditLogRepository` verifying disable path returns 0, null repo returns 0, and happy path forwards cutoff and returns deleted count. Schedule/config can remain a follow-on issue.
+- Status: open
+
+### Issue 7 -- Severity: suggestion
+- File: `system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java`
+- Description: Covers login success and failure into memory repository; no logout test; no assertion that failure outcome is `FAILURE` / event type `AUTH_FAILURE`; no test that `Holder` registration replaces the repository sink (would have caught Issue 1 earlier if paired with a transactional mock).
+- Suggestion: Add logout smoke; assert outcomes/event types; add a focused test for repository registration once Issue 1 is fixed.
+- Status: open
+
+### Issue 8 -- Severity: nit
+- File: `system/src/main/java/com/percussion/servlets/PSLoginServlet.java:157-161` vs success path ~523
+- Description: Logout wraps audit in try/catch; login success/failure do not. `DefaultAuditLogService` already swallows sink `RuntimeException`s, so risk is low, but inconsistency remains if future changes throw outside sinks.
+- Suggestion: Mirror the logout try/catch (or a shared private `safeAudit(Runnable)`) on login success/failure for defense in depth.
+- Status: open
+
+## What looks sound
+
+- Intersoft 2026 copyright headers on new sources.
+- `isAuditable` gate and null `eventType` guard in `DefaultAuditLogService`.
+- Sink isolation + failure logging without failing the business call (API design).
+- SLF4J-style `{}` formatter and canonical `[MOD-####]-[uuid]` line form.
+- Redactor coverage (password KV, URL credentials, JWT, sensitive attribute keys) with dedicated tests.
+- Table def columns/indexes align with entity fields; `packagesToScan=com.percussion` will pick up the entity.
+- `system` module already depends on `audit-log` artifact.
+- Login failure logs exception class name, not password material.
+- Memory repository + Holder reset used correctly in `PSSystemAuditLoggerTest`.
+
+## Change-class closure (Phase 1)
+
+| Companion | Present? |
+|-----------|----------|
+| Core API + unit tests (`perc-auditlog`) | yes |
+| Table def (`cmsTableDef.xml` → install lockstep copies) | yes (single source) |
+| JPA entity + repository bean | yes (TX wiring incomplete — Issue 1) |
+| Login smoke call sites | yes |
+| Retention skeleton | yes (unscheduled — intentional) |
+| Role property / REST / Admin UI | out of scope (later issues) |
+| CADF removal | out of scope (later) |
+
+## Recommendation detail
+
+Do **not** commit or open/update a PR until **Issue 1** is fixed and re-tested. Prefer fixing **Issue 2** in the same pack (correct success-audit timing). Issues 3–7 may ship as follow-ups if explicitly deferred in the PR body, but Issue 1 is not deferrable if the PR claims dual-write to `PSX_SYSTEM_AUDIT_LOG`.
+
+## Re-review (2026-08-09, post-fix)
+
+### Mitigations
+
+| Issue | Status | Mitigation |
+|-------|--------|------------|
+| 1 TX proxy / raw `this` | **fixed** | `TransactionTemplate` for `save` / `deleteOlderThan` / `countAll`; unit test verifies `persist` under TX manager |
+| 2 loginSuccess after redirect | **fixed** | Audit immediately after `authenticate`; try/catch like logout |
+| 3 JSON escape | **fixed** | Control-char escape in `jsonEscape` + unit test |
+| 5 vacuous redaction assert | **fixed** | `password=hunter2` + assert no secret in message |
+| 6 retention tests | **fixed** | `PSSystemAuditLogRetentionJobTest` |
+| 7 logout / outcomes | **fixed** | logout smoke + FAILURE outcome assert |
+| 4 client IP | deferred | documented Phase 1 limitation (proxy-blind) |
+
+### Gate (re-review)
+
+**Recommendation:** approve  
+**May commit/push:** yes (after focused clean install evidence)
+
+---
+
+## Handoff
+
+- **Reviewed:** Phase 1 system audit log API, dual-write service, entity/repository, login hooks, table def, retention skeleton, related unit tests, design note.
+- **Top finding:** Spring raw-bean registration kills `@Transactional` for Holder dual-write path.
+- **Recommendation:** `request-changes`; **May commit/push: no**.
+- **Next:** Hephaestus fixes Issue 1 (+ preferably 2); Erlang re-review; then module standalone `mvnw clean install` for `modules/perc-auditlog` and `system` per Pre-PR Maven gate.
+
+---
+
+> Co-Authored by Grok (xAI) using agent Erlang (strict independent code review).

--- a/docs/ai-generated/tasks/system-audit-log/design.md
+++ b/docs/ai-generated/tasks/system-audit-log/design.md
@@ -1,0 +1,56 @@
+# System-Wide Audit Log — Design Note (Phase 0)
+
+**Status:** Active  
+**Date:** 2026-08-09  
+**Package:** `com.intsof.percussioncms.auditlog`  
+**Module:** `modules/perc-auditlog` (artifact `audit-log`)
+
+## Decisions (locked)
+
+| Topic | Decision |
+|-------|----------|
+| Dual write | `server.log` (Log4j) + `PSX_SYSTEM_AUDIT_LOG` (DB); no CADF third sink |
+| Error catalog | Unified `SystemErrorCode` with **`isAuditable`**; package `*ErrorCodes` enums |
+| Placeholders | Sequential `{}` (SLF4J-style) |
+| Permission | Rhythmyx Role model; Role property `sys_securityAuditLogViewer`; Admin always allowed |
+| Log id | UUID string, same id on both sinks |
+| CADF / jcadf | Remove after call-site migration |
+
+## Architecture
+
+See session plan and root implementation under `com.intsof.percussioncms.auditlog`.
+
+```text
+SystemErrorCode (*ErrorCodes) → AuditLogService
+  → redact + format [MOD-####]-[logId] message
+  → Log4j sink (server.log)
+  → AuditLogRepository SPI (DB impl in system — later phase)
+```
+
+## Phase 1 status (2026-08-09)
+
+- [x] Core API `com.intsof.percussioncms.auditlog` + unit tests
+- [x] Dual-write: Log4j + repository SPI (memory default; JPA when Spring wires)
+- [x] Table `PSX_SYSTEM_AUDIT_LOG` in `cmsTableDef.xml`
+- [x] Entity `PSSystemAuditLogEntry` + `PSSystemAuditLogRepository` (`@PSBaseBean`)
+- [x] Login/logout smoke path via `PSSystemAuditLogger` in `PSLoginServlet`
+- [x] Retention job skeleton `PSSystemAuditLogRetentionJob`
+- [ ] PR merge for #2614
+
+## Phase tracking (GitHub)
+
+| Phase | Issue |
+|-------|-------|
+| 0+1 Core API | [#2614](https://github.com/intersoftdatalabs-in/percussioncms/issues/2614) |
+| 2a Call-site migrate | [#2615](https://github.com/intersoftdatalabs-in/percussioncms/issues/2615) |
+| 2b ErrorCodes unification | [#2616](https://github.com/intersoftdatalabs-in/percussioncms/issues/2616) |
+| 2c Design auditor + retire CADF | [#2617](https://github.com/intersoftdatalabs-in/percussioncms/issues/2617) |
+| 3 Role property + REST | [#2618](https://github.com/intersoftdatalabs-in/percussioncms/issues/2618) |
+| 4 Admin UI + Playwright | [#2619](https://github.com/intersoftdatalabs-in/percussioncms/issues/2619) |
+| 5 Hardening | [#2620](https://github.com/intersoftdatalabs-in/percussioncms/issues/2620) |
+
+## References
+
+* Rhythmyx 7.3 Implementation Guide — Roles, communities, folder ACLs  
+* Rhythmyx 7.3 Administration Manual — Role properties (`sys_defaultCommunity`, …)  
+* NIST SP 800-53 Rev. 5 AU family  

--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -1,11 +1,57 @@
-# perc-auditlog
+# perc-auditlog (`audit-log`)
 
-This module contains all Classes and configurations required for Percussion CMS internal Audit Logging
-including Workflow Events, User Management,Authentication, Content Management
+System-wide Percussion CMS audit logging and unified error-code support.
+
+## Package
+
+**New (preferred):** `com.intsof.percussioncms.auditlog`
+
+* `SystemErrorCode` / package `*ErrorCodes` with explicit **`isAuditable`**
+* `AuditLogService` dual-writes auditable events to Log4j (`server.log`) and an `AuditLogRepository` SPI
+* Message form: `[AUTH-1001]-[<uuid>] …` with separate user/log message templates and redaction
+
+**Legacy (to be removed after migration):** `com.percussion.auditlog` + IBM CADF (`auditlogger` module)
+
+## Usage (Phase 1)
+
+```java
+import com.intsof.percussioncms.auditlog.*;
+import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+
+AuditLogService audit = DefaultAuditLogService.Holder.get();
+audit.log(
+    AuthenticationErrorCodes.LOGIN_SUCCESS,
+    AuditContext.builder().actor("jdoe").sourceIp("10.0.0.1").build(),
+    AuditOutcome.SUCCESS,
+    "jdoe",
+    "10.0.0.1");
+```
+
+Non-auditable codes (`isAuditable() == false`) never create audit rows.
+
+Default dual-write: Log4j + in-process `ConcurrentMemoryAuditLogRepository` until Spring starts.
+
+Production durable store: table `PSX_SYSTEM_AUDIT_LOG` with JPA entity
+`com.percussion.services.audit.data.PSSystemAuditLogEntry` and
+`PSSystemAuditLogRepository` (`sys_systemAuditLogRepository`), which registers itself on the
+`DefaultAuditLogService.Holder` at Spring init.
+
+Login smoke path: `PSSystemAuditLogger` / `PSLoginServlet` (success, failure, logout).
 
 ## Building
 
-```
-mvn clean install
+```bash
+cd modules/perc-auditlog
+../../mvnw clean install
 ```
 
+Windows:
+
+```bat
+cd modules\perc-auditlog
+..\..\mvnw.cmd clean install
+```
+
+## Design
+
+See `docs/ai-generated/tasks/system-audit-log/design.md`.

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditContext.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditContext.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Contextual metadata for an audit / error emit (actor, target, network origin, correlation).
+ *
+ * <p>Values may still contain sensitive data; {@link com.intsof.percussioncms.auditlog.redact.AuditRedactor}
+ * runs before sinks.
+ */
+public final class AuditContext {
+
+  private final String actor;
+  private final String target;
+  private final String sourceIp;
+  private final String sourceHost;
+  private final String sessionIdHash;
+  private final String correlationId;
+  private final Map<String, String> attributes;
+
+  private AuditContext(Builder builder) {
+    this.actor = builder.actor;
+    this.target = builder.target;
+    this.sourceIp = builder.sourceIp;
+    this.sourceHost = builder.sourceHost;
+    this.sessionIdHash = builder.sessionIdHash;
+    this.correlationId = builder.correlationId;
+    this.attributes = Collections.unmodifiableMap(new LinkedHashMap<>(builder.attributes));
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static AuditContext empty() {
+    return builder().build();
+  }
+
+  public Optional<String> actor() {
+    return Optional.ofNullable(actor);
+  }
+
+  public Optional<String> target() {
+    return Optional.ofNullable(target);
+  }
+
+  public Optional<String> sourceIp() {
+    return Optional.ofNullable(sourceIp);
+  }
+
+  public Optional<String> sourceHost() {
+    return Optional.ofNullable(sourceHost);
+  }
+
+  public Optional<String> sessionIdHash() {
+    return Optional.ofNullable(sessionIdHash);
+  }
+
+  public Optional<String> correlationId() {
+    return Optional.ofNullable(correlationId);
+  }
+
+  public Map<String, String> attributes() {
+    return attributes;
+  }
+
+  public static final class Builder {
+    private String actor;
+    private String target;
+    private String sourceIp;
+    private String sourceHost;
+    private String sessionIdHash;
+    private String correlationId;
+    private final Map<String, String> attributes = new LinkedHashMap<>();
+
+    public Builder actor(String actor) {
+      this.actor = actor;
+      return this;
+    }
+
+    public Builder target(String target) {
+      this.target = target;
+      return this;
+    }
+
+    public Builder sourceIp(String sourceIp) {
+      this.sourceIp = sourceIp;
+      return this;
+    }
+
+    public Builder sourceHost(String sourceHost) {
+      this.sourceHost = sourceHost;
+      return this;
+    }
+
+    public Builder sessionIdHash(String sessionIdHash) {
+      this.sessionIdHash = sessionIdHash;
+      return this;
+    }
+
+    public Builder correlationId(String correlationId) {
+      this.correlationId = correlationId;
+      return this;
+    }
+
+    public Builder attribute(String key, String value) {
+      Objects.requireNonNull(key, "key");
+      if (value != null) {
+        attributes.put(key, value);
+      }
+      return this;
+    }
+
+    public AuditContext build() {
+      return new AuditContext(this);
+    }
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditEventType.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditEventType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+/**
+ * Catalog of auditable event classes (NIST SP 800-53 AU-2 oriented).
+ *
+ * <p>Only used when {@link SystemErrorCode#isAuditable()} is {@code true}.
+ */
+public enum AuditEventType {
+  AUTH_LOGIN,
+  AUTH_LOGOUT,
+  AUTH_FAILURE,
+  AUTH_SESSION_TIMEOUT,
+  ACCESS_ALLOWED,
+  ACCESS_DENIED,
+  USER_CREATE,
+  USER_UPDATE,
+  USER_DELETE,
+  USER_DISABLE,
+  ROLE_ASSIGN,
+  ROLE_REMOVE,
+  CONFIG_CHANGE,
+  ACL_CHANGE,
+  CONTENT_CREATE,
+  CONTENT_UPDATE,
+  CONTENT_DELETE,
+  CONTENT_RECYCLE,
+  CONTENT_PUBLISH,
+  WORKFLOW_TRANSITION,
+  DESIGN_CREATE,
+  DESIGN_UPDATE,
+  DESIGN_DELETE,
+  AUDIT_VIEW,
+  AUDIT_EXPORT,
+  AUDIT_RETENTION,
+  AUDIT_SINK_FAILURE,
+  OTHER
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditLogId.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditLogId.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Stable identifier for an audit record, shared across dual sinks ({@code server.log} and durable
+ * store).
+ */
+public final class AuditLogId {
+
+  private final String value;
+
+  private AuditLogId(String value) {
+    this.value = Objects.requireNonNull(value, "value");
+  }
+
+  /** Generates a new random UUID-based log id. */
+  public static AuditLogId generate() {
+    return new AuditLogId(UUID.randomUUID().toString());
+  }
+
+  /**
+   * Wraps an existing id string (e.g. when replaying or testing).
+   *
+   * @param value non-blank id
+   */
+  public static AuditLogId of(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Audit log id must not be blank");
+    }
+    return new AuditLogId(value.trim());
+  }
+
+  public String value() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AuditLogId that)) {
+      return false;
+    }
+    return value.equals(that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditLogService.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditLogService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+/**
+ * System-wide audit log entry point. Dual-writes auditable events to {@code server.log} and the
+ * durable repository. Non-auditable codes are ignored for sinks (no audit row).
+ */
+public interface AuditLogService {
+
+  /**
+   * Log using the code's {@link SystemErrorCode#defaultOutcome()} and empty context when omitted.
+   *
+   * @return log id if an audit write was performed; empty id sentinel when skipped (not auditable)
+   */
+  AuditLogId log(SystemErrorCode code, Object... params);
+
+  /** Log with context and default outcome from the code. */
+  AuditLogId log(SystemErrorCode code, AuditContext context, Object... params);
+
+  /** Log with explicit outcome. */
+  AuditLogId log(
+      SystemErrorCode code, AuditContext context, AuditOutcome outcome, Object... params);
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditMessageCode.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditMessageCode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+/**
+ * Alias for {@link SystemErrorCode} emphasizing audit usage. Package {@code *ErrorCodes} enums
+ * implement {@link SystemErrorCode}; this interface exists for call-site clarity.
+ */
+public interface AuditMessageCode extends SystemErrorCode {}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditModule.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditModule.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Short-code registry for CMS modules that emit system error / audit codes.
+ *
+ * <p>Used in the canonical message form {@code [PUB-1001]-[<logId>] …}.
+ */
+public enum AuditModule {
+  SYS("SYS", "System"),
+  AUTH("AUTH", "Authentication"),
+  USER("USER", "User management"),
+  CONT("CONT", "Content"),
+  WF("WF", "Workflow"),
+  PUB("PUB", "Publishing"),
+  DESN("DESN", "Design objects"),
+  SEC("SEC", "Security"),
+  CFG("CFG", "Configuration"),
+  AUDIT("AUDIT", "Audit subsystem");
+
+  private final String code;
+  private final String displayName;
+
+  AuditModule(String code, String displayName) {
+    this.code = code;
+    this.displayName = displayName;
+  }
+
+  /** Short module code used in {@code [PUB-1001]} prefixes. */
+  public String code() {
+    return code;
+  }
+
+  /** Human-readable English display name (i18n keys may override in UI). */
+  public String displayName() {
+    return displayName;
+  }
+
+  /**
+   * Resolve a module from its short code (case-insensitive).
+   *
+   * @param code short code such as {@code PUB}
+   * @return matching module
+   * @throws IllegalArgumentException if unknown
+   */
+  public static AuditModule fromCode(String code) {
+    Objects.requireNonNull(code, "code");
+    String normalized = code.trim().toUpperCase(Locale.ROOT);
+    for (AuditModule m : values()) {
+      if (m.code.equals(normalized)) {
+        return m;
+      }
+    }
+    throw new IllegalArgumentException("Unknown audit module code: " + code);
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditOutcome.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditOutcome.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+/** Outcome of an auditable action. */
+public enum AuditOutcome {
+  SUCCESS,
+  FAILURE,
+  ERROR,
+  UNKNOWN
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditRecord.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/AuditRecord.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Immutable audit record ready for dual sinks (already redacted messages). */
+public final class AuditRecord {
+
+  private final AuditLogId logId;
+  private final Instant eventTime;
+  private final SystemErrorCode code;
+  private final AuditOutcome outcome;
+  private final String actor;
+  private final String target;
+  private final String sourceIp;
+  private final String sourceHost;
+  private final String sessionIdHash;
+  private final String correlationId;
+  private final String userMessage;
+  private final String logMessage;
+  private final String formattedLine;
+  private final Map<String, String> attributes;
+  private final String serverNode;
+
+  private AuditRecord(Builder builder) {
+    this.logId = Objects.requireNonNull(builder.logId, "logId");
+    this.eventTime = Objects.requireNonNull(builder.eventTime, "eventTime");
+    this.code = Objects.requireNonNull(builder.code, "code");
+    this.outcome = Objects.requireNonNull(builder.outcome, "outcome");
+    this.actor = builder.actor;
+    this.target = builder.target;
+    this.sourceIp = builder.sourceIp;
+    this.sourceHost = builder.sourceHost;
+    this.sessionIdHash = builder.sessionIdHash;
+    this.correlationId = builder.correlationId;
+    this.userMessage = Objects.requireNonNull(builder.userMessage, "userMessage");
+    this.logMessage = Objects.requireNonNull(builder.logMessage, "logMessage");
+    this.formattedLine = Objects.requireNonNull(builder.formattedLine, "formattedLine");
+    this.attributes = Collections.unmodifiableMap(new LinkedHashMap<>(builder.attributes));
+    this.serverNode = builder.serverNode;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public AuditLogId logId() {
+    return logId;
+  }
+
+  public Instant eventTime() {
+    return eventTime;
+  }
+
+  public SystemErrorCode code() {
+    return code;
+  }
+
+  public AuditOutcome outcome() {
+    return outcome;
+  }
+
+  public Optional<String> actor() {
+    return Optional.ofNullable(actor);
+  }
+
+  public Optional<String> target() {
+    return Optional.ofNullable(target);
+  }
+
+  public Optional<String> sourceIp() {
+    return Optional.ofNullable(sourceIp);
+  }
+
+  public Optional<String> sourceHost() {
+    return Optional.ofNullable(sourceHost);
+  }
+
+  public Optional<String> sessionIdHash() {
+    return Optional.ofNullable(sessionIdHash);
+  }
+
+  public Optional<String> correlationId() {
+    return Optional.ofNullable(correlationId);
+  }
+
+  public String userMessage() {
+    return userMessage;
+  }
+
+  public String logMessage() {
+    return logMessage;
+  }
+
+  /** Canonical line: {@code [PUB-1001]-[uuid] message…} */
+  public String formattedLine() {
+    return formattedLine;
+  }
+
+  public Map<String, String> attributes() {
+    return attributes;
+  }
+
+  public Optional<String> serverNode() {
+    return Optional.ofNullable(serverNode);
+  }
+
+  public static final class Builder {
+    private AuditLogId logId;
+    private Instant eventTime;
+    private SystemErrorCode code;
+    private AuditOutcome outcome;
+    private String actor;
+    private String target;
+    private String sourceIp;
+    private String sourceHost;
+    private String sessionIdHash;
+    private String correlationId;
+    private String userMessage;
+    private String logMessage;
+    private String formattedLine;
+    private Map<String, String> attributes = Map.of();
+    private String serverNode;
+
+    public Builder logId(AuditLogId logId) {
+      this.logId = logId;
+      return this;
+    }
+
+    public Builder eventTime(Instant eventTime) {
+      this.eventTime = eventTime;
+      return this;
+    }
+
+    public Builder code(SystemErrorCode code) {
+      this.code = code;
+      return this;
+    }
+
+    public Builder outcome(AuditOutcome outcome) {
+      this.outcome = outcome;
+      return this;
+    }
+
+    public Builder actor(String actor) {
+      this.actor = actor;
+      return this;
+    }
+
+    public Builder target(String target) {
+      this.target = target;
+      return this;
+    }
+
+    public Builder sourceIp(String sourceIp) {
+      this.sourceIp = sourceIp;
+      return this;
+    }
+
+    public Builder sourceHost(String sourceHost) {
+      this.sourceHost = sourceHost;
+      return this;
+    }
+
+    public Builder sessionIdHash(String sessionIdHash) {
+      this.sessionIdHash = sessionIdHash;
+      return this;
+    }
+
+    public Builder correlationId(String correlationId) {
+      this.correlationId = correlationId;
+      return this;
+    }
+
+    public Builder userMessage(String userMessage) {
+      this.userMessage = userMessage;
+      return this;
+    }
+
+    public Builder logMessage(String logMessage) {
+      this.logMessage = logMessage;
+      return this;
+    }
+
+    public Builder formattedLine(String formattedLine) {
+      this.formattedLine = formattedLine;
+      return this;
+    }
+
+    public Builder attributes(Map<String, String> attributes) {
+      this.attributes = attributes == null ? Map.of() : attributes;
+      return this;
+    }
+
+    public Builder serverNode(String serverNode) {
+      this.serverNode = serverNode;
+      return this;
+    }
+
+    public AuditRecord build() {
+      return new AuditRecord(this);
+    }
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/DefaultAuditLogService.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/DefaultAuditLogService.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import com.intsof.percussioncms.auditlog.format.MessageTemplateFormatter;
+import com.intsof.percussioncms.auditlog.redact.AuditRedactor;
+import com.intsof.percussioncms.auditlog.sink.AuditLogSink;
+import com.intsof.percussioncms.auditlog.sink.Log4jAuditLogSink;
+import com.intsof.percussioncms.auditlog.sink.RepositoryAuditLogSink;
+import com.intsof.percussioncms.auditlog.spi.AuditLogRepository;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Default dual-write implementation: prepare messages, redact, then write to all configured sinks
+ * (Log4j + repository by default). Business requests never fail solely because a sink failed.
+ */
+public final class DefaultAuditLogService implements AuditLogService {
+
+  private static final Logger FAILURE_LOG =
+      LogManager.getLogger("com.intsof.percussioncms.auditlog.sink-failure");
+
+  private static final AuditLogId SKIPPED = AuditLogId.of("00000000-0000-0000-0000-000000000000");
+
+  private final AuditRedactor redactor;
+  private final Clock clock;
+  private final Supplier<AuditLogId> idSupplier;
+  private final List<AuditLogSink> sinks;
+  private final AtomicLong sinkFailureCount = new AtomicLong();
+  private final String serverNode;
+
+  private DefaultAuditLogService(Builder builder) {
+    this.redactor = Objects.requireNonNull(builder.redactor, "redactor");
+    this.clock = Objects.requireNonNull(builder.clock, "clock");
+    this.idSupplier = Objects.requireNonNull(builder.idSupplier, "idSupplier");
+    this.sinks = List.copyOf(builder.sinks);
+    this.serverNode = builder.serverNode;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Process-wide default: Log4j + in-process memory repository until Spring wires the JPA
+   * repository for {@code PSX_SYSTEM_AUDIT_LOG}.
+   */
+  public static DefaultAuditLogService createDefault() {
+    return builder()
+        .addSink(new Log4jAuditLogSink())
+        .addSink(new RepositoryAuditLogSink(ConcurrentMemoryAuditLogRepository.INSTANCE))
+        .build();
+  }
+
+  public static DefaultAuditLogService create(AuditLogRepository repository) {
+    return builder()
+        .addSink(new Log4jAuditLogSink())
+        .addSink(new RepositoryAuditLogSink(repository))
+        .build();
+  }
+
+  public long sinkFailureCount() {
+    return sinkFailureCount.get();
+  }
+
+  @Override
+  public AuditLogId log(SystemErrorCode code, Object... params) {
+    return log(code, AuditContext.empty(), code.defaultOutcome(), params);
+  }
+
+  @Override
+  public AuditLogId log(SystemErrorCode code, AuditContext context, Object... params) {
+    return log(code, context, code.defaultOutcome(), params);
+  }
+
+  @Override
+  public AuditLogId log(
+      SystemErrorCode code, AuditContext context, AuditOutcome outcome, Object... params) {
+    Objects.requireNonNull(code, "code");
+    Objects.requireNonNull(context, "context");
+    Objects.requireNonNull(outcome, "outcome");
+
+    // Authoritative gate: never write audit for non-auditable codes
+    if (!code.isAuditable()) {
+      return SKIPPED;
+    }
+    if (code.eventType() == null) {
+      FAILURE_LOG.error(
+          "AUDIT_SINK_FAILURE auditable code {} missing eventType; skipping dual write",
+          code.qualifiedCode());
+      sinkFailureCount.incrementAndGet();
+      return SKIPPED;
+    }
+
+    Object[] safeParams = redactor.redactParams(params == null ? new Object[0] : params);
+    String userBody =
+        redactor.redact(
+            MessageTemplateFormatter.format(code.userMessageTemplate(), safeParams));
+    String logBody =
+        redactor.redact(MessageTemplateFormatter.format(code.logMessageTemplate(), safeParams));
+
+    AuditLogId logId = idSupplier.get();
+    String formattedLine = MessageTemplateFormatter.formatLine(code, logId, logBody);
+
+    AuditRecord record =
+        AuditRecord.builder()
+            .logId(logId)
+            .eventTime(Instant.now(clock))
+            .code(code)
+            .outcome(outcome)
+            .actor(context.actor().map(redactor::redact).orElse(null))
+            .target(context.target().map(redactor::redact).orElse(null))
+            .sourceIp(context.sourceIp().orElse(null))
+            .sourceHost(context.sourceHost().orElse(null))
+            .sessionIdHash(context.sessionIdHash().orElse(null))
+            .correlationId(context.correlationId().orElse(null))
+            .userMessage(userBody)
+            .logMessage(logBody)
+            .formattedLine(formattedLine)
+            .attributes(redactor.redactAttributes(context.attributes()))
+            .serverNode(serverNode)
+            .build();
+
+    for (AuditLogSink sink : sinks) {
+      try {
+        sink.write(record);
+      } catch (RuntimeException ex) {
+        sinkFailureCount.incrementAndGet();
+        FAILURE_LOG.error(
+            "AUDIT_SINK_FAILURE sink={} logId={} code={}: {}",
+            sink.name(),
+            logId.value(),
+            code.qualifiedCode(),
+            ex.toString());
+        FAILURE_LOG.debug("AUDIT_SINK_FAILURE details", ex);
+      }
+    }
+    return logId;
+  }
+
+  public static final class Builder {
+    private AuditRedactor redactor = new AuditRedactor();
+    private Clock clock = Clock.systemUTC();
+    private Supplier<AuditLogId> idSupplier = AuditLogId::generate;
+    private final List<AuditLogSink> sinks = new ArrayList<>();
+    private String serverNode;
+
+    public Builder redactor(AuditRedactor redactor) {
+      this.redactor = redactor;
+      return this;
+    }
+
+    public Builder clock(Clock clock) {
+      this.clock = clock;
+      return this;
+    }
+
+    public Builder idSupplier(Supplier<AuditLogId> idSupplier) {
+      this.idSupplier = idSupplier;
+      return this;
+    }
+
+    public Builder addSink(AuditLogSink sink) {
+      this.sinks.add(Objects.requireNonNull(sink, "sink"));
+      return this;
+    }
+
+    public Builder serverNode(String serverNode) {
+      this.serverNode = serverNode;
+      return this;
+    }
+
+    public DefaultAuditLogService build() {
+      if (sinks.isEmpty()) {
+        throw new IllegalStateException("At least one AuditLogSink is required");
+      }
+      return new DefaultAuditLogService(this);
+    }
+  }
+
+  /** Holder for a process-wide instance that system wiring may replace. */
+  public static final class Holder {
+    private static volatile AuditLogService instance = createDefault();
+
+    private Holder() {}
+
+    public static AuditLogService get() {
+      return instance;
+    }
+
+    public static void set(AuditLogService service) {
+      instance = Objects.requireNonNull(service, "service");
+    }
+
+    public static void resetToDefault() {
+      instance = createDefault();
+    }
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/SystemErrorCode.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/SystemErrorCode.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+/**
+ * System-wide error / message code implemented by package-local {@code *ErrorCodes} enums.
+ *
+ * <p>Unifies product error reporting and audit logging. When {@link #isAuditable()} is {@code true},
+ * reporting this code dual-writes to {@code server.log} and the durable audit store. When {@code
+ * false}, the code is operational only (exception text / app log) and must not create an audit row.
+ *
+ * <p>Message templates use sequential {@code {}} placeholders (SLF4J-style).
+ */
+public interface SystemErrorCode {
+
+  /** Module that owns this code (drives the {@code [PUB-…]} prefix). */
+  AuditModule module();
+
+  /** Numeric code within the module (e.g. {@code 1001}). */
+  int numericCode();
+
+  /**
+   * User-facing message template with {@code {}} placeholders. Prepared and sanitized for end
+   * users / Admin UI.
+   */
+  String userMessageTemplate();
+
+  /**
+   * Forensic message template with {@code {}} placeholders. Prepared and sanitized for {@code
+   * server.log} and the durable audit store (may include more detail than the user message).
+   */
+  String logMessageTemplate();
+
+  /**
+   * When {@code true}, dual-write an audit record via {@link AuditLogService}. When {@code false},
+   * operational error only — no audit row.
+   */
+  boolean isAuditable();
+
+  /**
+   * Event type for audit catalog (AU-2). Required when {@link #isAuditable()} is {@code true}; may
+   * return {@code null} when not auditable.
+   */
+  AuditEventType eventType();
+
+  /**
+   * Default outcome when not overridden at the call site. Auditable failures typically use {@link
+   * AuditOutcome#FAILURE}; success-path codes use {@link AuditOutcome#SUCCESS}.
+   */
+  default AuditOutcome defaultOutcome() {
+    return isAuditable() ? AuditOutcome.FAILURE : AuditOutcome.UNKNOWN;
+  }
+
+  /** Optional TMX / bundle key for the user message. */
+  default String userMessageKey() {
+    return "audit." + module().code() + "." + numericCode() + ".user";
+  }
+
+  /** Optional TMX / bundle key for the log message. */
+  default String logMessageKey() {
+    return "audit." + module().code() + "." + numericCode() + ".log";
+  }
+
+  /** Qualified code such as {@code PUB-1001}. */
+  default String qualifiedCode() {
+    return module().code() + "-" + numericCode();
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/** Self-codes for the audit subsystem (viewer access, retention, sink failures). */
+public enum AuditSubsystemErrorCodes implements SystemErrorCode {
+  VIEWER_ACCESS(
+      1,
+      true,
+      AuditEventType.AUDIT_VIEW,
+      AuditOutcome.SUCCESS,
+      "Audit log viewed by {}",
+      "Audit log viewed actor={} filters={}"),
+
+  SINK_FAILURE(
+      2,
+      true,
+      AuditEventType.AUDIT_SINK_FAILURE,
+      AuditOutcome.ERROR,
+      "Audit sink failure",
+      "Audit sink failure sink={} logId={} detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  AuditSubsystemErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.AUDIT;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuthenticationErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuthenticationErrorCodes.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Reference package-local error codes for authentication (Phase 1 sample). Production auth codes
+ * should eventually live under {@code com.percussion.security} once call sites migrate.
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly.
+ */
+public enum AuthenticationErrorCodes implements SystemErrorCode {
+  LOGIN_SUCCESS(
+      1001,
+      true,
+      AuditEventType.AUTH_LOGIN,
+      AuditOutcome.SUCCESS,
+      "User {} logged in successfully",
+      "Login success actor={} sourceIp={}"),
+
+  LOGIN_FAILURE(
+      1002,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Login failed for user {}",
+      "Login failure actor={} reason={} sourceIp={}"),
+
+  LOGOUT(
+      1003,
+      true,
+      AuditEventType.AUTH_LOGOUT,
+      AuditOutcome.SUCCESS,
+      "User {} logged out",
+      "Logout actor={} sourceIp={}"),
+
+  /** Non-auditable operational noise example. */
+  SESSION_CACHE_MISS(
+      1099,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Session cache miss for key {}",
+      "Session cache miss key={} detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  AuthenticationErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.AUTH;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/format/MessageTemplateFormatter.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/format/MessageTemplateFormatter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.format;
+
+import com.intsof.percussioncms.auditlog.AuditLogId;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Formats sequential {@code {}} placeholders (SLF4J-style) and builds the canonical audit line
+ * {@code [MOD-####]-[logId] message}.
+ */
+public final class MessageTemplateFormatter {
+
+  private MessageTemplateFormatter() {}
+
+  /**
+   * Replace sequential {@code {}} placeholders with string forms of {@code params}. Extra params
+   * are ignored; missing params leave {@code {}} intact.
+   */
+  public static String format(String template, Object... params) {
+    if (template == null) {
+      return "";
+    }
+    if (params == null || params.length == 0) {
+      return template;
+    }
+    StringBuilder out = new StringBuilder(template.length() + 32);
+    int paramIndex = 0;
+    int i = 0;
+    while (i < template.length()) {
+      if (i + 1 < template.length() && template.charAt(i) == '{' && template.charAt(i + 1) == '}') {
+        if (paramIndex < params.length) {
+          out.append(stringify(params[paramIndex++]));
+        } else {
+          out.append("{}");
+        }
+        i += 2;
+      } else {
+        out.append(template.charAt(i));
+        i++;
+      }
+    }
+    return out.toString();
+  }
+
+  /** Canonical presentation: {@code [PUB-1001]-[uuid] body}. */
+  public static String formatLine(SystemErrorCode code, AuditLogId logId, String messageBody) {
+    String body = messageBody == null ? "" : messageBody;
+    return "[" + code.qualifiedCode() + "]-[" + logId.value() + "] " + body;
+  }
+
+  private static String stringify(Object value) {
+    if (value == null) {
+      return "null";
+    }
+    return String.valueOf(value);
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/redact/AuditRedactor.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/redact/AuditRedactor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.redact;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Redacts sensitive material from user and log messages (and attribute maps) before dual-write.
+ *
+ * <p>Applied to <em>both</em> userMessage and logMessage channels.
+ */
+public final class AuditRedactor {
+
+  public static final String REDACTED = "[REDACTED]";
+
+  private static final int MAX_FIELD_LENGTH = 4000;
+
+  private static final Pattern PASSWORD_KV =
+      Pattern.compile(
+          "(?i)(password|passwd|pwd|secret|token|api[_-]?key|authorization|bearer)\\s*([:=])\\s*([^\\s,;]+)");
+
+  private static final Pattern JWT =
+      Pattern.compile("\\beyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\b");
+
+  private static final Pattern BASIC_AUTH =
+      Pattern.compile("(?i)(basic)\\s+[A-Za-z0-9+/=]{8,}");
+
+  private static final Pattern URL_CREDENTIALS =
+      Pattern.compile("(?i)(://)([^/@\\s:]+):([^/@\\s]+)@");
+
+  private static final Pattern CONNECTION_PASSWORD =
+      Pattern.compile("(?i)(password|pwd)=([^;&\\s]+)");
+
+  /**
+   * Redact a single string value. {@code null} becomes empty string after redaction pipeline.
+   */
+  public String redact(String input) {
+    if (input == null || input.isEmpty()) {
+      return input == null ? "" : input;
+    }
+    String s = input;
+    s = PASSWORD_KV.matcher(s).replaceAll("$1$2" + REDACTED);
+    s = CONNECTION_PASSWORD.matcher(s).replaceAll("$1=" + REDACTED);
+    s = URL_CREDENTIALS.matcher(s).replaceAll("$1" + REDACTED + ":" + REDACTED + "@");
+    s = JWT.matcher(s).replaceAll(REDACTED);
+    s = BASIC_AUTH.matcher(s).replaceAll("$1 " + REDACTED);
+    if (s.length() > MAX_FIELD_LENGTH) {
+      s = s.substring(0, MAX_FIELD_LENGTH) + "…";
+    }
+    return s;
+  }
+
+  /** Redact each value in a map; keys are preserved as-is. */
+  public Map<String, String> redactAttributes(Map<String, String> attributes) {
+    if (attributes == null || attributes.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, String> out = new LinkedHashMap<>();
+    for (Map.Entry<String, String> e : attributes.entrySet()) {
+      String key = Objects.requireNonNull(e.getKey(), "attribute key");
+      if (isSensitiveKey(key)) {
+        out.put(key, REDACTED);
+      } else {
+        out.put(key, redact(e.getValue()));
+      }
+    }
+    return out;
+  }
+
+  /** Redact params used for template substitution (passwords never enter messages). */
+  public Object[] redactParams(Object... params) {
+    if (params == null || params.length == 0) {
+      return params == null ? new Object[0] : params;
+    }
+    Object[] out = new Object[params.length];
+    for (int i = 0; i < params.length; i++) {
+      Object p = params[i];
+      if (p == null) {
+        out[i] = null;
+      } else if (p instanceof String s) {
+        out[i] = redact(s);
+      } else {
+        out[i] = redact(String.valueOf(p));
+      }
+    }
+    return out;
+  }
+
+  private static boolean isSensitiveKey(String key) {
+    String k = key.toLowerCase();
+    return k.contains("password")
+        || k.contains("passwd")
+        || k.contains("secret")
+        || k.contains("token")
+        || k.contains("apikey")
+        || k.contains("api_key")
+        || k.contains("authorization")
+        || k.contains("credential");
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/sink/AuditLogSink.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/sink/AuditLogSink.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.sink;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+
+/** Destination for a prepared audit record (Log4j, repository, test capture, …). */
+public interface AuditLogSink {
+
+  /** Sink name for diagnostics (e.g. {@code log4j}, {@code repository}). */
+  String name();
+
+  /**
+   * Write the record. Implementations should avoid throwing; if they throw, the service logs an
+   * {@code AUDIT_SINK_FAILURE} marker and continues.
+   */
+  void write(AuditRecord record);
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/sink/Log4jAuditLogSink.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/sink/Log4jAuditLogSink.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.sink;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Writes the canonical formatted audit line to Log4j (configured into {@code server.log} /
+ * operational logs).
+ */
+public final class Log4jAuditLogSink implements AuditLogSink {
+
+  /** Dedicated logger name so operators can filter or dual-bind appenders. */
+  public static final String LOGGER_NAME = "com.intsof.percussioncms.auditlog";
+
+  private final Logger logger;
+
+  public Log4jAuditLogSink() {
+    this(LogManager.getLogger(LOGGER_NAME));
+  }
+
+  /** Package-visible for tests. */
+  Log4jAuditLogSink(Logger logger) {
+    this.logger = Objects.requireNonNull(logger, "logger");
+  }
+
+  @Override
+  public String name() {
+    return "log4j";
+  }
+
+  @Override
+  public void write(AuditRecord record) {
+    Objects.requireNonNull(record, "record");
+    logger.info(
+        "{} outcome={} actor={} target={}",
+        record.formattedLine(),
+        record.outcome(),
+        record.actor().orElse("-"),
+        record.target().orElse("-"));
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/sink/RepositoryAuditLogSink.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/sink/RepositoryAuditLogSink.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.sink;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import com.intsof.percussioncms.auditlog.spi.AuditLogRepository;
+import java.util.Objects;
+
+/** Forwards records to the durable {@link AuditLogRepository} SPI. */
+public final class RepositoryAuditLogSink implements AuditLogSink {
+
+  private final AuditLogRepository repository;
+
+  public RepositoryAuditLogSink(AuditLogRepository repository) {
+    this.repository = Objects.requireNonNull(repository, "repository");
+  }
+
+  @Override
+  public String name() {
+    return "repository";
+  }
+
+  @Override
+  public void write(AuditRecord record) {
+    repository.save(Objects.requireNonNull(record, "record"));
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/spi/AuditLogRepository.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/spi/AuditLogRepository.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.spi;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+
+/**
+ * SPI for durable audit storage (DB implementation lives in the {@code system} module).
+ *
+ * <p>Implementations must never throw in a way that fails the business request; the service
+ * catches failures and emits {@code AUDIT_SINK_FAILURE} markers.
+ */
+public interface AuditLogRepository {
+
+  /**
+   * Persist an audit record. May block briefly; async wrappers are the caller's / service's
+   * concern.
+   *
+   * @param record redacted, fully prepared record
+   */
+  void save(AuditRecord record);
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/spi/ConcurrentMemoryAuditLogRepository.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/spi/ConcurrentMemoryAuditLogRepository.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.spi;
+
+import com.intsof.percussioncms.auditlog.AuditLogId;
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Process-local durable structure used until a DB {@link AuditLogRepository} is wired (and useful in
+ * unit tests). Not a substitute for {@code PSX_SYSTEM_AUDIT_LOG} in production multi-node installs.
+ */
+public final class ConcurrentMemoryAuditLogRepository implements AuditLogRepository {
+
+  public static final ConcurrentMemoryAuditLogRepository INSTANCE =
+      new ConcurrentMemoryAuditLogRepository();
+
+  private final ConcurrentMap<String, AuditRecord> byId = new ConcurrentHashMap<>();
+
+  public ConcurrentMemoryAuditLogRepository() {}
+
+  @Override
+  public void save(AuditRecord record) {
+    Objects.requireNonNull(record, "record");
+    byId.put(record.logId().value(), record);
+  }
+
+  public Optional<AuditRecord> find(AuditLogId id) {
+    return Optional.ofNullable(byId.get(id.value()));
+  }
+
+  public List<AuditRecord> findAll() {
+    return new ArrayList<>(byId.values());
+  }
+
+  public void clear() {
+    byId.clear();
+  }
+
+  public int size() {
+    return byId.size();
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/spi/NoOpAuditLogRepository.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/spi/NoOpAuditLogRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.spi;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+
+/** Default repository when no DB implementation is wired (tests / early boot). */
+public final class NoOpAuditLogRepository implements AuditLogRepository {
+
+  public static final NoOpAuditLogRepository INSTANCE = new NoOpAuditLogRepository();
+
+  private NoOpAuditLogRepository() {}
+
+  @Override
+  public void save(AuditRecord record) {
+    // intentionally empty
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/DefaultAuditLogServiceTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/DefaultAuditLogServiceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class DefaultAuditLogServiceTest {
+
+  @Test
+  void dualWritesSameLogIdToAllSinks() {
+    CapturingAuditLogSink log4j = new CapturingAuditLogSink("log4j");
+    CapturingAuditLogSink repo = new CapturingAuditLogSink("repository");
+    AuditLogId fixed = AuditLogId.of("11111111-2222-3333-4444-555555555555");
+    DefaultAuditLogService svc =
+        DefaultAuditLogService.builder()
+            .clock(Clock.fixed(Instant.parse("2026-08-09T12:00:00Z"), ZoneOffset.UTC))
+            .idSupplier(() -> fixed)
+            .addSink(log4j)
+            .addSink(repo)
+            .build();
+
+    AuditLogId id =
+        svc.log(
+            AuthenticationErrorCodes.LOGIN_SUCCESS,
+            AuditContext.builder().actor("jdoe").sourceIp("10.0.0.1").build(),
+            AuditOutcome.SUCCESS,
+            "jdoe",
+            "10.0.0.1");
+
+    assertEquals(fixed, id);
+    assertEquals(1, log4j.records().size());
+    assertEquals(1, repo.records().size());
+    assertEquals(fixed, log4j.records().get(0).logId());
+    assertEquals(fixed, repo.records().get(0).logId());
+    assertTrue(
+        log4j.records()
+            .get(0)
+            .formattedLine()
+            .startsWith("[AUTH-1001]-[11111111-2222-3333-4444-555555555555]"));
+    assertEquals(AuditOutcome.SUCCESS, log4j.records().get(0).outcome());
+  }
+
+  @Test
+  void nonAuditableCodesDoNotWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id = svc.log(AuthenticationErrorCodes.SESSION_CACHE_MISS, "key1");
+
+    assertEquals("00000000-0000-0000-0000-000000000000", id.value());
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void sinkFailureDoesNotPreventOtherSinks() {
+    CapturingAuditLogSink ok = new CapturingAuditLogSink("ok");
+    CapturingAuditLogSink bad = new CapturingAuditLogSink("bad", true);
+    DefaultAuditLogService svc =
+        DefaultAuditLogService.builder().addSink(bad).addSink(ok).build();
+
+    AuditLogId id =
+        svc.log(
+            AuthenticationErrorCodes.LOGIN_FAILURE,
+            AuditContext.builder().actor("jdoe").build(),
+            "jdoe",
+            "password=hunter2",
+            "1.2.3.4");
+
+    assertEquals(1, ok.records().size());
+    assertEquals(0, bad.records().size());
+    assertEquals(id, ok.records().get(0).logId());
+    assertEquals(1, svc.sinkFailureCount());
+    assertTrue(
+        !ok.records().get(0).logMessage().contains("hunter2"),
+        "secret must be redacted even when one sink fails");
+  }
+
+  @Test
+  void redactsSecretsInMessages() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    svc.log(
+        AuthenticationErrorCodes.LOGIN_FAILURE,
+        AuditContext.builder().actor("jdoe").build(),
+        "jdoe",
+        "password=hunter2",
+        "10.0.0.1");
+
+    String logMsg = sink.records().get(0).logMessage();
+    assertTrue(logMsg.contains("[REDACTED]") || !logMsg.contains("hunter2"));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/format/MessageTemplateFormatterTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/format/MessageTemplateFormatterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.format;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.intsof.percussioncms.auditlog.AuditLogId;
+import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import org.junit.jupiter.api.Test;
+
+class MessageTemplateFormatterTest {
+
+  @Test
+  void formatReplacesSequentialPlaceholders() {
+    assertEquals(
+        "User jdoe logged in successfully",
+        MessageTemplateFormatter.format("User {} logged in successfully", "jdoe"));
+  }
+
+  @Test
+  void formatLeavesPlaceholderWhenParamMissing() {
+    assertEquals("a {} c", MessageTemplateFormatter.format("a {} c"));
+  }
+
+  @Test
+  void formatLineBuildsCanonicalForm() {
+    AuditLogId id = AuditLogId.of("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    String line =
+        MessageTemplateFormatter.formatLine(
+            AuthenticationErrorCodes.LOGIN_SUCCESS, id, "User jdoe logged in successfully");
+    assertEquals(
+        "[AUTH-1001]-[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee] User jdoe logged in successfully",
+        line);
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/redact/AuditRedactorTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/redact/AuditRedactorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.redact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AuditRedactorTest {
+
+  private final AuditRedactor redactor = new AuditRedactor();
+
+  @Test
+  void redactsPasswordKeyValue() {
+    String out = redactor.redact("password=secret123 user=jdoe");
+    assertTrue(out.contains(AuditRedactor.REDACTED));
+    assertFalse(out.contains("secret123"));
+  }
+
+  @Test
+  void redactsUrlCredentials() {
+    String out = redactor.redact("jdbc:mysql://user:pass@host/db");
+    assertFalse(out.contains("user:pass@"));
+    assertTrue(out.contains(AuditRedactor.REDACTED));
+  }
+
+  @Test
+  void redactsSensitiveAttributeKeys() {
+    Map<String, String> out =
+        redactor.redactAttributes(Map.of("password", "x", "username", "jdoe"));
+    assertEquals(AuditRedactor.REDACTED, out.get("password"));
+    assertEquals("jdoe", out.get("username"));
+  }
+
+  @Test
+  void redactsJwtLikeToken() {
+    String jwt =
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    String out = redactor.redact("token=" + jwt);
+    assertFalse(out.contains("eyJhbGciOiJIUzI1NiJ9"));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/sink/CapturingAuditLogSink.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/sink/CapturingAuditLogSink.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.sink;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Test sink that captures written records. */
+public final class CapturingAuditLogSink implements AuditLogSink {
+
+  private final String name;
+  private final List<AuditRecord> records = new ArrayList<>();
+  private final boolean fail;
+
+  public CapturingAuditLogSink(String name) {
+    this(name, false);
+  }
+
+  public CapturingAuditLogSink(String name, boolean fail) {
+    this.name = name;
+    this.fail = fail;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public void write(AuditRecord record) {
+    if (fail) {
+      throw new IllegalStateException("forced sink failure");
+    }
+    records.add(record);
+  }
+
+  public List<AuditRecord> records() {
+    return Collections.unmodifiableList(records);
+  }
+
+  public void clear() {
+    records.clear();
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/spi/ConcurrentMemoryAuditLogRepositoryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/spi/ConcurrentMemoryAuditLogRepositoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditLogId;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ConcurrentMemoryAuditLogRepositoryTest {
+
+  @Test
+  void saveAndFind() {
+    ConcurrentMemoryAuditLogRepository repo = new ConcurrentMemoryAuditLogRepository();
+    AuditLogId id = AuditLogId.of("11111111-1111-1111-1111-111111111111");
+    AuditRecord rec =
+        AuditRecord.builder()
+            .logId(id)
+            .eventTime(Instant.parse("2026-08-09T00:00:00Z"))
+            .code(AuthenticationErrorCodes.LOGIN_SUCCESS)
+            .outcome(AuditOutcome.SUCCESS)
+            .userMessage("u")
+            .logMessage("l")
+            .formattedLine("[AUTH-1001]-[" + id.value() + "] l")
+            .build();
+    repo.save(rec);
+    assertTrue(repo.find(id).isPresent());
+    assertEquals(1, repo.size());
+  }
+}

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableDef.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableDef.xml
@@ -5633,6 +5633,108 @@
             <name>AUDIT_ID</name>
         </primarykey>
     </table>
+    <!-- System-wide security / operational audit log (com.intsof.percussioncms.auditlog dual-write store) -->
+    <table name="PSX_SYSTEM_AUDIT_LOG" allowSchemaChanges="y" alter="y" delolddata="n" isView="n">
+        <row>
+            <column name="AUDIT_ID">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>36</size>
+                <allowsnull>no</allowsnull>
+            </column>
+            <column name="EVENT_TIME">
+                <jdbctype>TIMESTAMP</jdbctype>
+                <allowsnull>no</allowsnull>
+            </column>
+            <column name="MODULE_CODE">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>16</size>
+                <allowsnull>no</allowsnull>
+            </column>
+            <column name="MESSAGE_CODE">
+                <jdbctype>INTEGER</jdbctype>
+                <allowsnull>no</allowsnull>
+            </column>
+            <column name="EVENT_TYPE">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>64</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="OUTCOME">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>32</size>
+                <allowsnull>no</allowsnull>
+            </column>
+            <column name="ACTOR">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>255</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="TARGET">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>512</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="SOURCE_IP">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>64</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="SOURCE_HOST">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>255</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="SESSION_ID_HASH">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>128</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="USER_MESSAGE">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>4000</size>
+                <allowsnull>no</allowsnull>
+            </column>
+            <column name="LOG_MESSAGE">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>4000</size>
+                <allowsnull>no</allowsnull>
+            </column>
+            <column name="CORRELATION_ID">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>128</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="ATTRIBUTES_JSON">
+                <jdbctype>CLOB</jdbctype>
+                <allowsnull>yes</allowsnull>
+            </column>
+            <column name="SERVER_NODE">
+                <jdbctype>VARCHAR</jdbctype>
+                <size>255</size>
+                <allowsnull>yes</allowsnull>
+            </column>
+        </row>
+        <primarykey>
+            <name>AUDIT_ID</name>
+        </primarykey>
+        <indexdefinitions>
+            <index name="IX_SYS_AUDIT_EVENT_TIME" isUnique="n">
+                <name>EVENT_TIME</name>
+            </index>
+            <index name="IX_SYS_AUDIT_MODULE" isUnique="n">
+                <name>MODULE_CODE</name>
+            </index>
+            <index name="IX_SYS_AUDIT_ACTOR" isUnique="n">
+                <name>ACTOR</name>
+            </index>
+            <index name="IX_SYS_AUDIT_EVENT_TYPE" isUnique="n">
+                <name>EVENT_TYPE</name>
+            </index>
+            <index name="IX_SYS_AUDIT_OUTCOME" isUnique="n">
+                <name>OUTCOME</name>
+            </index>
+        </indexdefinitions>
+    </table>
     <table name="PSX_BINARY" allowSchemaChanges="y" alter="y"  delolddata="n" isView="n">
         <row>
             <column name="ID">

--- a/system/business/src/com/percussion/rx/audit/PSSystemAuditLogRetentionJob.java
+++ b/system/business/src/com/percussion/rx/audit/PSSystemAuditLogRetentionJob.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rx.audit;
+
+import com.percussion.services.audit.impl.PSSystemAuditLogRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Retention skeleton for {@code PSX_SYSTEM_AUDIT_LOG} (NIST AU-11).
+ *
+ * <p>Phase 1 provides the delete-by-age API; scheduling / config wiring (days from
+ * server.properties) is a follow-on to the design-object reaper generalization.
+ */
+public class PSSystemAuditLogRetentionJob {
+
+  private static final Logger log = LogManager.getLogger(PSSystemAuditLogRetentionJob.class);
+
+  private PSSystemAuditLogRepository repository;
+  private int retentionDays = 365;
+
+  public void setRepository(PSSystemAuditLogRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * @param retentionDays days to keep; {@code <= 0} disables deletion
+   */
+  public void setRetentionDays(int retentionDays) {
+    this.retentionDays = retentionDays;
+  }
+
+  public int getRetentionDays() {
+    return retentionDays;
+  }
+
+  /**
+   * Deletes entries older than the configured retention window.
+   *
+   * @return deleted row count, or {@code 0} if disabled / not wired
+   */
+  public int runOnce() {
+    if (retentionDays <= 0) {
+      log.debug("System audit log retention disabled (retentionDays={})", retentionDays);
+      return 0;
+    }
+    if (repository == null) {
+      log.warn("System audit log retention skipped: repository not set");
+      return 0;
+    }
+    Instant cutoff = Instant.now().minus(retentionDays, ChronoUnit.DAYS);
+    int deleted = repository.deleteOlderThan(cutoff);
+    log.info(
+        "System audit log retention deleted {} row(s) older than {} days (before {})",
+        deleted,
+        retentionDays,
+        cutoff);
+    return deleted;
+  }
+
+  /** Test helper: run with explicit cutoff. */
+  public int deleteOlderThan(Instant before) {
+    Objects.requireNonNull(repository, "repository");
+    Objects.requireNonNull(before, "before");
+    return repository.deleteOlderThan(before);
+  }
+}

--- a/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
+++ b/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit;
+
+import com.intsof.percussioncms.auditlog.AuditContext;
+import com.intsof.percussioncms.auditlog.AuditLogService;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Thin facade for system code to emit system-wide audit events without depending on Spring at the
+ * call site. Uses {@link DefaultAuditLogService.Holder} (Log4j + memory until JPA repository
+ * registers).
+ */
+public final class PSSystemAuditLogger {
+
+  private PSSystemAuditLogger() {}
+
+  public static AuditLogService service() {
+    return DefaultAuditLogService.Holder.get();
+  }
+
+  public static void log(
+      SystemErrorCode code, AuditContext context, AuditOutcome outcome, Object... params) {
+    service().log(code, context == null ? AuditContext.empty() : context, outcome, params);
+  }
+
+  public static void loginSuccess(HttpServletRequest request, String username) {
+    String actor = nullToEmpty(username);
+    String ip = clientIp(request);
+    log(
+        AuthenticationErrorCodes.LOGIN_SUCCESS,
+        context(request, actor),
+        AuditOutcome.SUCCESS,
+        actor,
+        ip);
+  }
+
+  public static void loginFailure(HttpServletRequest request, String username, String reason) {
+    String actor = nullToEmpty(username);
+    String ip = clientIp(request);
+    log(
+        AuthenticationErrorCodes.LOGIN_FAILURE,
+        context(request, actor),
+        AuditOutcome.FAILURE,
+        actor,
+        nullToEmpty(reason),
+        ip);
+  }
+
+  public static void logout(HttpServletRequest request, String username) {
+    String actor = nullToEmpty(username);
+    String ip = clientIp(request);
+    log(
+        AuthenticationErrorCodes.LOGOUT,
+        context(request, actor),
+        AuditOutcome.SUCCESS,
+        actor,
+        ip);
+  }
+
+  private static AuditContext context(HttpServletRequest request, String actor) {
+    AuditContext.Builder b = AuditContext.builder().actor(actor);
+    if (request != null) {
+      b.sourceIp(clientIp(request)).sourceHost(request.getRemoteHost());
+    }
+    return b.build();
+  }
+
+  private static String clientIp(HttpServletRequest request) {
+    if (request == null) {
+      return "";
+    }
+    return nullToEmpty(request.getRemoteAddr());
+  }
+
+  private static String nullToEmpty(String s) {
+    return s == null ? "" : s;
+  }
+}

--- a/system/services/src/com/percussion/services/audit/data/PSSystemAuditLogEntry.java
+++ b/system/services/src/com/percussion/services/audit/data/PSSystemAuditLogEntry.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit.data;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/** JPA entity for {@code PSX_SYSTEM_AUDIT_LOG} (system-wide dual-write durable store). */
+@Entity
+@Table(name = "PSX_SYSTEM_AUDIT_LOG")
+public class PSSystemAuditLogEntry implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final int MSG_MAX = 4000;
+
+  @Id
+  @Column(name = "AUDIT_ID", nullable = false, length = 36)
+  private String auditId;
+
+  @Column(name = "EVENT_TIME", nullable = false)
+  private Date eventTime;
+
+  @Column(name = "MODULE_CODE", nullable = false, length = 16)
+  private String moduleCode;
+
+  @Column(name = "MESSAGE_CODE", nullable = false)
+  private int messageCode;
+
+  @Column(name = "EVENT_TYPE", length = 64)
+  private String eventType;
+
+  @Column(name = "OUTCOME", nullable = false, length = 32)
+  private String outcome;
+
+  @Column(name = "ACTOR", length = 255)
+  private String actor;
+
+  @Column(name = "TARGET", length = 512)
+  private String target;
+
+  @Column(name = "SOURCE_IP", length = 64)
+  private String sourceIp;
+
+  @Column(name = "SOURCE_HOST", length = 255)
+  private String sourceHost;
+
+  @Column(name = "SESSION_ID_HASH", length = 128)
+  private String sessionIdHash;
+
+  @Column(name = "USER_MESSAGE", nullable = false, length = MSG_MAX)
+  private String userMessage;
+
+  @Column(name = "LOG_MESSAGE", nullable = false, length = MSG_MAX)
+  private String logMessage;
+
+  @Column(name = "CORRELATION_ID", length = 128)
+  private String correlationId;
+
+  @Lob
+  @Column(name = "ATTRIBUTES_JSON")
+  private String attributesJson;
+
+  @Column(name = "SERVER_NODE", length = 255)
+  private String serverNode;
+
+  public static PSSystemAuditLogEntry from(AuditRecord record) {
+    Objects.requireNonNull(record, "record");
+    PSSystemAuditLogEntry e = new PSSystemAuditLogEntry();
+    e.auditId = record.logId().value();
+    e.eventTime = Date.from(record.eventTime());
+    e.moduleCode = record.code().module().code();
+    e.messageCode = record.code().numericCode();
+    e.eventType =
+        record.code().eventType() == null ? null : record.code().eventType().name();
+    e.outcome = record.outcome().name();
+    e.actor = truncate(record.actor().orElse(null), 255);
+    e.target = truncate(record.target().orElse(null), 512);
+    e.sourceIp = truncate(record.sourceIp().orElse(null), 64);
+    e.sourceHost = truncate(record.sourceHost().orElse(null), 255);
+    e.sessionIdHash = truncate(record.sessionIdHash().orElse(null), 128);
+    e.userMessage = truncate(record.userMessage(), MSG_MAX);
+    e.logMessage = truncate(record.logMessage(), MSG_MAX);
+    e.correlationId = truncate(record.correlationId().orElse(null), 128);
+    e.attributesJson = attributesToJson(record.attributes());
+    e.serverNode = truncate(record.serverNode().orElse(null), 255);
+    return e;
+  }
+
+  static String attributesToJson(Map<String, String> attributes) {
+    if (attributes == null || attributes.isEmpty()) {
+      return null;
+    }
+    // Minimal JSON object without pulling Jackson into this mapping path
+    return attributes.entrySet().stream()
+        .map(
+            en ->
+                "\""
+                    + jsonEscape(en.getKey())
+                    + "\":\""
+                    + jsonEscape(en.getValue() == null ? "" : en.getValue())
+                    + "\"")
+        .collect(Collectors.joining(",", "{", "}"));
+  }
+
+  static String jsonEscape(String s) {
+    if (s == null) {
+      return "";
+    }
+    StringBuilder out = new StringBuilder(s.length() + 8);
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      switch (c) {
+        case '\\' -> out.append("\\\\");
+        case '"' -> out.append("\\\"");
+        case '\b' -> out.append("\\b");
+        case '\f' -> out.append("\\f");
+        case '\n' -> out.append("\\n");
+        case '\r' -> out.append("\\r");
+        case '\t' -> out.append("\\t");
+        default -> {
+          if (c < 0x20) {
+            out.append(String.format("\\u%04x", (int) c));
+          } else {
+            out.append(c);
+          }
+        }
+      }
+    }
+    return out.toString();
+  }
+
+  static String truncate(String value, int max) {
+    if (value == null) {
+      return null;
+    }
+    if (value.length() <= max) {
+      return value;
+    }
+    return value.substring(0, max);
+  }
+
+  public String getAuditId() {
+    return auditId;
+  }
+
+  public void setAuditId(String auditId) {
+    this.auditId = auditId;
+  }
+
+  public Date getEventTime() {
+    return eventTime;
+  }
+
+  public Instant getEventTimeInstant() {
+    return eventTime == null ? null : eventTime.toInstant();
+  }
+
+  public void setEventTime(Date eventTime) {
+    this.eventTime = eventTime;
+  }
+
+  public String getModuleCode() {
+    return moduleCode;
+  }
+
+  public void setModuleCode(String moduleCode) {
+    this.moduleCode = moduleCode;
+  }
+
+  public int getMessageCode() {
+    return messageCode;
+  }
+
+  public void setMessageCode(int messageCode) {
+    this.messageCode = messageCode;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(String eventType) {
+    this.eventType = eventType;
+  }
+
+  public String getOutcome() {
+    return outcome;
+  }
+
+  public void setOutcome(String outcome) {
+    this.outcome = outcome;
+  }
+
+  public String getActor() {
+    return actor;
+  }
+
+  public void setActor(String actor) {
+    this.actor = actor;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(String target) {
+    this.target = target;
+  }
+
+  public String getSourceIp() {
+    return sourceIp;
+  }
+
+  public void setSourceIp(String sourceIp) {
+    this.sourceIp = sourceIp;
+  }
+
+  public String getSourceHost() {
+    return sourceHost;
+  }
+
+  public void setSourceHost(String sourceHost) {
+    this.sourceHost = sourceHost;
+  }
+
+  public String getSessionIdHash() {
+    return sessionIdHash;
+  }
+
+  public void setSessionIdHash(String sessionIdHash) {
+    this.sessionIdHash = sessionIdHash;
+  }
+
+  public String getUserMessage() {
+    return userMessage;
+  }
+
+  public void setUserMessage(String userMessage) {
+    this.userMessage = userMessage;
+  }
+
+  public String getLogMessage() {
+    return logMessage;
+  }
+
+  public void setLogMessage(String logMessage) {
+    this.logMessage = logMessage;
+  }
+
+  public String getCorrelationId() {
+    return correlationId;
+  }
+
+  public void setCorrelationId(String correlationId) {
+    this.correlationId = correlationId;
+  }
+
+  public String getAttributesJson() {
+    return attributesJson;
+  }
+
+  public void setAttributesJson(String attributesJson) {
+    this.attributesJson = attributesJson;
+  }
+
+  public String getServerNode() {
+    return serverNode;
+  }
+
+  public void setServerNode(String serverNode) {
+    this.serverNode = serverNode;
+  }
+}

--- a/system/services/src/com/percussion/services/audit/impl/PSSystemAuditLogRepository.java
+++ b/system/services/src/com/percussion/services/audit/impl/PSSystemAuditLogRepository.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit.impl;
+
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.spi.AuditLogRepository;
+import com.percussion.services.audit.data.PSSystemAuditLogEntry;
+import com.percussion.system.utils.PSBaseBean;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Objects;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * JPA durable sink for system-wide audit records ({@code PSX_SYSTEM_AUDIT_LOG}).
+ *
+ * <p>Uses {@link TransactionTemplate} for writes so dual-write from {@link
+ * DefaultAuditLogService.Holder} works without relying on a Spring AOP proxy (the Holder cannot
+ * hold {@code this} from {@link #afterPropertiesSet()} and expect {@code @Transactional} to apply).
+ */
+@PSBaseBean("sys_systemAuditLogRepository")
+public class PSSystemAuditLogRepository implements AuditLogRepository, InitializingBean {
+
+  @PersistenceContext private EntityManager entityManager;
+
+  private TransactionTemplate transactionTemplate;
+
+  @Autowired
+  public void setTransactionManager(PlatformTransactionManager transactionManager) {
+    Objects.requireNonNull(transactionManager, "transactionManager");
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+  }
+
+  /** Package-visible for unit tests. */
+  void setTransactionTemplate(TransactionTemplate transactionTemplate) {
+    this.transactionTemplate = transactionTemplate;
+  }
+
+  /** Package-visible for unit tests. */
+  void setEntityManager(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+    Objects.requireNonNull(entityManager, "entityManager");
+    DefaultAuditLogService.Holder.set(DefaultAuditLogService.create(this));
+  }
+
+  @Override
+  public void save(AuditRecord record) {
+    Objects.requireNonNull(record, "record");
+    Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+    transactionTemplate.executeWithoutResult(
+        status -> entityManager.persist(PSSystemAuditLogEntry.from(record)));
+  }
+
+  /**
+   * Retention helper (AU-11 skeleton): delete rows older than {@code before}.
+   *
+   * @param before exclusive upper bound (UTC instant)
+   * @return number of deleted rows
+   */
+  public int deleteOlderThan(Instant before) {
+    Objects.requireNonNull(before, "before");
+    Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+    Integer deleted =
+        transactionTemplate.execute(
+            status ->
+                entityManager
+                    .createQuery("DELETE FROM PSSystemAuditLogEntry e WHERE e.eventTime < :before")
+                    .setParameter("before", Date.from(before))
+                    .executeUpdate());
+    return deleted == null ? 0 : deleted;
+  }
+
+  /** Test / ops helper: count all rows. */
+  public long countAll() {
+    Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+    Long count =
+        transactionTemplate.execute(
+            status -> {
+              TypedQuery<Long> q =
+                  entityManager.createQuery(
+                      "SELECT COUNT(e) FROM PSSystemAuditLogEntry e", Long.class);
+              return q.getSingleResult();
+            });
+    return count == null ? 0L : count;
+  }
+}

--- a/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
+++ b/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
@@ -22,10 +22,8 @@ import static com.percussion.utils.request.PSRequestInfoBase.KEY_PSREQUEST;
 import static com.percussion.utils.request.PSRequestInfoBase.getRequestInfo;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSAuthenticationEvent;
 import com.percussion.content.IPSMimeContentTypes;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.i18n.PSI18nUtils;
 import com.percussion.security.IPSSecurityErrors;
 import com.percussion.security.PSAuthenticationFailedException;
@@ -72,8 +70,6 @@ import org.apache.logging.log4j.Logger;
 public class PSLoginServlet extends HttpServlet {
   /** Serial version id */
   private static final long serialVersionUID = 1L;
-
-  private final PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
 
   /**
    * Handles requests to login and logout. Initial GET requests to "/login" are returned an include
@@ -158,13 +154,7 @@ public class PSLoginServlet extends HttpServlet {
   private void logout(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
     try {
-      PSAuthenticationEvent psAuthenticationEvent =
-          new PSAuthenticationEvent(
-              PSActionOutcome.SUCCESS.name(),
-              PSAuthenticationEvent.AuthenticationEventActions.logout,
-              request,
-              request.getRemoteUser());
-      psAuditLogService.logAuthenticationEvent(psAuthenticationEvent);
+      PSSystemAuditLogger.logout(request, request.getRemoteUser());
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -524,27 +514,28 @@ public class PSLoginServlet extends HttpServlet {
 
       request = PSSecurityFilter.authenticate(request, response, uid, pwd);
 
+      // Audit immediately after successful authentication (before redirect), so a redirect
+      // failure cannot drop the security audit record.
+      try {
+        PSSystemAuditLogger.loginSuccess(request, uid);
+      } catch (Exception auditEx) {
+        log.error(PSExceptionUtils.getMessageForLog(auditEx));
+        log.debug(PSExceptionUtils.getDebugMessageForLog(auditEx));
+      }
+
       // Jetty 12 UriCompliance: normalize separators; then PSRedirectValidation + URI rebuild
       // before sendRedirect (java/unvalidated-url-redirection residual on session redirect).
       String safeRedirect = resolveSafePostLoginRedirect(request, redirect);
       response.sendRedirect(safeRedirect); // codeql[java/unvalidated-url-redirection]
 
       sess.removeAttribute(REDIRECT_URL);
-      PSAuthenticationEvent psAuthenticationEvent =
-          new PSAuthenticationEvent(
-              PSActionOutcome.SUCCESS.name(),
-              PSAuthenticationEvent.AuthenticationEventActions.login,
-              request,
-              uid);
-      psAuditLogService.logAuthenticationEvent(psAuthenticationEvent);
     } catch (LoginException e) {
-      PSAuthenticationEvent psAuthenticationEvent =
-          new PSAuthenticationEvent(
-              PSActionOutcome.FAILURE.name(),
-              PSAuthenticationEvent.AuthenticationEventActions.login,
-              request,
-              uid);
-      psAuditLogService.logAuthenticationEvent(psAuthenticationEvent);
+      try {
+        PSSystemAuditLogger.loginFailure(request, uid, e.getClass().getSimpleName());
+      } catch (Exception auditEx) {
+        log.error(PSExceptionUtils.getMessageForLog(auditEx));
+        log.debug(PSExceptionUtils.getDebugMessageForLog(auditEx));
+      }
       Exception ex;
 
       if (e instanceof PSMissingRoleException) {

--- a/system/src/test/java/com/percussion/rx/audit/PSSystemAuditLogRetentionJobTest.java
+++ b/system/src/test/java/com/percussion/rx/audit/PSSystemAuditLogRetentionJobTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rx.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.audit.impl.PSSystemAuditLogRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class PSSystemAuditLogRetentionJobTest {
+
+  @Test
+  void disabledWhenRetentionDaysNonPositive() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    PSSystemAuditLogRetentionJob job = new PSSystemAuditLogRetentionJob();
+    job.setRepository(repo);
+    job.setRetentionDays(0);
+    assertEquals(0, job.runOnce());
+    verify(repo, never()).deleteOlderThan(any());
+  }
+
+  @Test
+  void skipsWhenRepositoryMissing() {
+    PSSystemAuditLogRetentionJob job = new PSSystemAuditLogRetentionJob();
+    job.setRetentionDays(30);
+    assertEquals(0, job.runOnce());
+  }
+
+  @Test
+  void happyPathDelegatesDelete() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    when(repo.deleteOlderThan(any(Instant.class))).thenReturn(3);
+    PSSystemAuditLogRetentionJob job = new PSSystemAuditLogRetentionJob();
+    job.setRepository(repo);
+    job.setRetentionDays(30);
+    assertEquals(3, job.runOnce());
+    verify(repo).deleteOlderThan(any(Instant.class));
+  }
+}

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PSSystemAuditLoggerTest {
+
+  @BeforeEach
+  void setUp() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @Test
+  void loginSuccessWritesAuditableRecord() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn("203.0.113.10");
+    when(request.getRemoteHost()).thenReturn("client.example");
+
+    PSSystemAuditLogger.loginSuccess(request, "jdoe");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals("AUTH", rec.code().module().code());
+    assertEquals(1001, rec.code().numericCode());
+    assertTrue(rec.formattedLine().contains("[AUTH-1001]-"));
+    assertEquals("jdoe", rec.actor().orElse(""));
+  }
+
+  @Test
+  void loginFailureIsAuditable() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn("203.0.113.11");
+    when(request.getRemoteHost()).thenReturn("client.example");
+
+    PSSystemAuditLogger.loginFailure(request, "baduser", "LoginException");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(1002, rec.code().numericCode());
+    assertEquals(com.intsof.percussioncms.auditlog.AuditOutcome.FAILURE, rec.outcome());
+  }
+
+  @Test
+  void logoutIsAuditable() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn("203.0.113.12");
+    when(request.getRemoteHost()).thenReturn("client.example");
+
+    PSSystemAuditLogger.logout(request, "jdoe");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(1003, rec.code().numericCode());
+    assertEquals(com.intsof.percussioncms.auditlog.AuditOutcome.SUCCESS, rec.outcome());
+  }
+}

--- a/system/src/test/java/com/percussion/services/audit/data/PSSystemAuditLogEntryTest.java
+++ b/system/src/test/java/com/percussion/services/audit/data/PSSystemAuditLogEntryTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditLogId;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PSSystemAuditLogEntryTest {
+
+  @Test
+  void fromMapsAuditRecordFields() {
+    AuditRecord record =
+        AuditRecord.builder()
+            .logId(AuditLogId.of("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+            .eventTime(Instant.parse("2026-08-09T12:00:00Z"))
+            .code(AuthenticationErrorCodes.LOGIN_SUCCESS)
+            .outcome(AuditOutcome.SUCCESS)
+            .actor("jdoe")
+            .sourceIp("10.0.0.1")
+            .userMessage("User jdoe logged in successfully")
+            .logMessage("Login success actor=jdoe sourceIp=10.0.0.1")
+            .formattedLine(
+                "[AUTH-1001]-[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee] Login success actor=jdoe"
+                    + " sourceIp=10.0.0.1")
+            .attributes(Map.of("k", "v"))
+            .build();
+
+    PSSystemAuditLogEntry e = PSSystemAuditLogEntry.from(record);
+    assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", e.getAuditId());
+    assertEquals("AUTH", e.getModuleCode());
+    assertEquals(1001, e.getMessageCode());
+    assertEquals("AUTH_LOGIN", e.getEventType());
+    assertEquals("SUCCESS", e.getOutcome());
+    assertEquals("jdoe", e.getActor());
+    assertEquals("10.0.0.1", e.getSourceIp());
+    assertTrue(e.getAttributesJson().contains("\"k\":\"v\""));
+  }
+
+  @Test
+  void truncateHonorsMax() {
+    assertNull(PSSystemAuditLogEntry.truncate(null, 10));
+    assertEquals("abc", PSSystemAuditLogEntry.truncate("abc", 10));
+    assertEquals("0123456789", PSSystemAuditLogEntry.truncate("0123456789ABCDEF", 10));
+  }
+
+  @Test
+  void attributesToJsonEscapesQuotesAndNewlines() {
+    String json =
+        PSSystemAuditLogEntry.attributesToJson(Map.of("note", "line1\nline2 \"quoted\""));
+    assertTrue(json.contains("\\n"));
+    assertTrue(json.contains("\\\""));
+    assertTrue(json.startsWith("{"));
+    assertTrue(json.endsWith("}"));
+  }
+}

--- a/system/src/test/java/com/percussion/services/audit/impl/PSSystemAuditLogRepositoryTest.java
+++ b/system/src/test/java/com/percussion/services/audit/impl/PSSystemAuditLogRepositoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.intsof.percussioncms.auditlog.AuditLogId;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.AuditRecord;
+import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import com.percussion.services.audit.data.PSSystemAuditLogEntry;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Proves durable save runs inside a TransactionTemplate (Holder dual-write safe without AOP
+ * proxy).
+ */
+class PSSystemAuditLogRepositoryTest {
+
+  @Test
+  void saveUsesTransactionTemplateAndPersistsEntity() {
+    EntityManager em = mock(EntityManager.class);
+    PlatformTransactionManager tm = mock(PlatformTransactionManager.class);
+    TransactionStatus status = new SimpleTransactionStatus();
+    when(tm.getTransaction(any(TransactionDefinition.class))).thenReturn(status);
+
+    TransactionTemplate tt = new TransactionTemplate(tm);
+
+    PSSystemAuditLogRepository repo = new PSSystemAuditLogRepository();
+    repo.setEntityManager(em);
+    repo.setTransactionTemplate(tt);
+
+    AuditRecord record =
+        AuditRecord.builder()
+            .logId(AuditLogId.of("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+            .eventTime(Instant.parse("2026-08-09T12:00:00Z"))
+            .code(AuthenticationErrorCodes.LOGIN_SUCCESS)
+            .outcome(AuditOutcome.SUCCESS)
+            .userMessage("u")
+            .logMessage("l")
+            .formattedLine("[AUTH-1001]-[aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee] l")
+            .build();
+
+    repo.save(record);
+
+    verify(em).persist(any(PSSystemAuditLogEntry.class));
+    verify(tm).getTransaction(any(TransactionDefinition.class));
+    verify(tm).commit(status);
+  }
+}


### PR DESCRIPTION
## Summary
Phase 0+1 of the system-wide audit log program ([#2614](https://github.com/intersoftdatalabs-in/percussioncms/issues/2614)).

- New package `com.intsof.percussioncms.auditlog` with `SystemErrorCode` (explicit **`isAuditable`**), dual-write `AuditLogService` (Log4j + repository SPI), redaction, and `[MOD-####]-[logId]` formatting.
- Durable table `PSX_SYSTEM_AUDIT_LOG` (tablefactory), JPA entity, and `PSSystemAuditLogRepository` using **TransactionTemplate** so Holder dual-write works without AOP proxy.
- Login smoke path: `PSSystemAuditLogger` on `PSLoginServlet` (success after auth, before redirect; failure; logout).
- Retention job skeleton `PSSystemAuditLogRetentionJob`.
- Follow-on P1 stack: #2615–#2620.

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw clean install` — BUILD SUCCESS
- [x] `cd system && ../mvnw clean install -Dtest=PSSystemAuditLogEntryTest,PSSystemAuditLoggerTest,PSSystemAuditLogRepositoryTest,PSSystemAuditLogRetentionJobTest` — tests green (module install completes; pre-existing javadoc noise on system remains)
- [x] Erlang review: `docs/ai-generated/code-reviews/2614-system-audit-log-phase1-erlang.md` (bugs fixed; re-review approve)

## Notes
- Legacy `com.percussion.auditlog` + CADF remain until Phase 2a/2c.
- Default dual-write uses in-process memory repository until Spring registers JPA repo.
- Client IP is `getRemoteAddr` only in Phase 1 (proxy XFF deferred).

> Co-Authored by Grok using grok-4.5 with agent thesmith.