### PR TITLE
fix(perc-system): design.objectstore security/UI this-escape residual (#2466)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2466-design-objectstore-this-escape-security-ui-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2466-design-objectstore-this-escape-security-ui-erlang.md
@@ -1,0 +1,19 @@
+# Erlang review — #2466 design.objectstore security/UI this-escape
+
+## Scope
+Real this-escape fixes for security/directory/UI-adjacent design.objectstore types after #2404.
+
+## Change class
+Leaf final setters/fromXml + private apply*/fromXmlBase for bases with subclasses (PSSubject, PSSecurityProviderInstance). Shared: final getComponentState on PSDatabaseComponent.
+
+## Findings
+- No bugs found in final/private-helper pattern (matches #2404).
+- Behavioral tests extended: 19 tests green.
+- Residual Element-ctor warnings remain where fromXml publishes `this` via updateParentList or delegates to overridable super.fromXml — same residual class as #2404 peers; not suppress-only.
+- No path I/O / cross-platform issues.
+- Did not thrash #2465 editors/app-config types.
+
+## Verdict
+Pass for PR.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
@@ -285,7 +285,7 @@ public class PSAttribute extends PSDatabaseComponentCollection {
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXRole
    * @see IPSComponent#fromXml(Element, IPSDocument, List) for the interface description
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
@@ -181,7 +181,7 @@ public class PSAttributeList extends PSDatabaseComponentCollection implements IP
    * @see IPSComponent#fromXml(Element, IPSDocument, List) for the interface description
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponent.java
@@ -316,8 +316,10 @@ public abstract class PSDatabaseComponent implements IPSDatabaseComponent {
    * @throws IllegalArgumentException if e is <code>null</code>.
    * @throws PSUnknownNodeTypeException if the provided element does not contain the expected
    *     attributes.
+   *     <p>Final so Element constructors / {@code fromXml} can call this without this-escape
+   *     virtual dispatch. Subclasses must not override component-state load.
    */
-  protected void getComponentState(Element e) throws PSUnknownNodeTypeException {
+  protected final void getComponentState(Element e) throws PSUnknownNodeTypeException {
     if (e == null) throw new IllegalArgumentException("Element may not be null");
 
     /* get the component state, if not found, assume this xml is from the

--- a/system/src/main/java/com/percussion/design/objectstore/PSErrorWebPages.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSErrorWebPages.java
@@ -93,7 +93,7 @@ public class PSErrorWebPages extends PSCollectionComponent {
    * @param returnHtml <code>true</code> to return the error page as HTML, <code>false</code> to
    *     return it as XML
    */
-  public void setHtmlReturned(boolean returnHtml) {
+  public final void setHtmlReturned(boolean returnHtml) {
     m_html = returnHtml;
   }
 
@@ -191,7 +191,7 @@ public class PSErrorWebPages extends PSCollectionComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXErrorWebPages
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
@@ -95,7 +95,7 @@ public class PSLoginWebPage extends PSComponent {
    * @param isSecure <code>true</code> if the login page may only be sent over secure channels (eg,
    *     HTTPS)
    */
-  public void setSecure(boolean isSecure) {
+  public final void setSecure(boolean isSecure) {
     m_isSecure = isSecure;
   }
 
@@ -113,7 +113,7 @@ public class PSLoginWebPage extends PSComponent {
    *
    * @param url the URL of the login page
    */
-  public void setUrl(java.net.URL url) {
+  public final void setUrl(java.net.URL url) {
     m_url = url;
   }
 
@@ -183,7 +183,7 @@ public class PSLoginWebPage extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXLoginWebPage
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSNotifier.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNotifier.java
@@ -98,7 +98,7 @@ public class PSNotifier extends PSComponent {
    *     supported.
    * @exception PSIllegalArgumentException if provider is invalid
    */
-  public void setProviderType(int provider) throws PSIllegalArgumentException {
+  public final void setProviderType(int provider) throws PSIllegalArgumentException {
     PSIllegalArgumentException ex = validateProviderType(provider);
     if (ex != null) throw ex;
 
@@ -131,7 +131,7 @@ public class PSNotifier extends PSComponent {
    * @param name the name of the mail server
    * @exception PSIllegalArgumentException if name is null, empty or exceeds the specified limit
    */
-  public void setServer(java.lang.String name) throws PSIllegalArgumentException {
+  public final void setServer(java.lang.String name) throws PSIllegalArgumentException {
     PSIllegalArgumentException ex = validateServer(name);
     if (ex != null) throw ex;
 
@@ -166,7 +166,7 @@ public class PSNotifier extends PSComponent {
    * @param from the name of the mail originator
    * @exception PSIllegalArgumentException if from exceeds the specified limit
    */
-  public void setFrom(java.lang.String from) throws PSIllegalArgumentException {
+  public final void setFrom(java.lang.String from) throws PSIllegalArgumentException {
     if ((null == from) || (from.length() == 0)) from = DEFAULT_FROM;
 
     PSIllegalArgumentException ex = validateFrom(from);
@@ -206,7 +206,7 @@ public class PSNotifier extends PSComponent {
    * @see #getRecipients
    * @see PSRecipient
    */
-  public void setRecipients(com.percussion.util.PSCollection recipients)
+  public final void setRecipients(com.percussion.util.PSCollection recipients)
       throws PSIllegalArgumentException {
     PSIllegalArgumentException ex = validateRecipients(recipients);
     if (ex != null) throw ex;
@@ -322,7 +322,7 @@ public class PSNotifier extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXNotifier
    */
-  public void fromXml(
+  public final void fromXml(
       Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRole.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRole.java
@@ -268,7 +268,7 @@ public class PSRole extends PSDatabaseComponent implements Comparable, IPSCatalo
    *     MAX_ROLE_NAME_LEN</code> in length.
    * @throws IllegalArgumentException if name is null, empty or exceeds the specified size limit
    */
-  void setName(String name) {
+  final void setName(String name) {
     if ((null == name) || (name.length() == 0))
       throw new IllegalArgumentException("Role name must be specified.");
     else if (name.length() > MAX_ROLE_NAME_LEN)
@@ -360,7 +360,7 @@ public class PSRole extends PSDatabaseComponent implements Comparable, IPSCatalo
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXRole
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
@@ -62,7 +62,8 @@ public class PSSecurityProviderInstance extends PSComponent {
       Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     this();
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private path avoids virtual fromXml dispatch before subclass fields initialize.
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
 
   /** Constructor for serialization, fromXml, etc. */
@@ -80,8 +81,9 @@ public class PSSecurityProviderInstance extends PSComponent {
    */
   public PSSecurityProviderInstance(String name, int type) throws PSIllegalArgumentException {
     super();
-    setName(name);
-    setType(type);
+    // Private helpers avoid virtual setName/setType during construction (this-escape).
+    applyName(name);
+    applyType(type);
   }
 
   @Override
@@ -117,7 +119,12 @@ public class PSSecurityProviderInstance extends PSComponent {
    * @param type the appropriate SP_TYPE_xxx flag
    * @throws PSIllegalArgumentException if type is invalid
    */
-  public void setType(int type) throws PSIllegalArgumentException {
+  public final void setType(int type) throws PSIllegalArgumentException {
+    applyType(type);
+  }
+
+  /** Non-overridable assignment used from constructors and {@link #setType(int)}. */
+  private void applyType(int type) throws PSIllegalArgumentException {
     PSIllegalArgumentException ex = validateType(type);
     if (ex != null) throw ex;
 
@@ -170,7 +177,12 @@ public class PSSecurityProviderInstance extends PSComponent {
    * @param name the unique security provider instance name
    * @throws PSIllegalArgumentException if name exceeds the specified size limit
    */
-  public void setName(java.lang.String name) throws PSIllegalArgumentException {
+  public final void setName(java.lang.String name) throws PSIllegalArgumentException {
+    applyName(name);
+  }
+
+  /** Non-overridable assignment used from constructors and {@link #setName(String)}. */
+  private void applyName(java.lang.String name) throws PSIllegalArgumentException {
     PSIllegalArgumentException ex = validateName(name);
     if (ex != null) throw ex;
 
@@ -298,6 +310,16 @@ public class PSSecurityProviderInstance extends PSComponent {
    */
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Shared load for {@link #fromXml} and the Element constructor. Keeps construction free of
+   * virtual {@code fromXml} dispatch so subclasses (e.g. legacy security provider instances) can
+   * initialize safely while still overriding public {@code fromXml}.
+   */
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
 
@@ -331,7 +353,7 @@ public class PSSecurityProviderInstance extends PSComponent {
     // get the instance name
     sTemp = tree.getElementData("name");
     try {
-      setName(sTemp);
+      applyName(sTemp);
     } catch (PSIllegalArgumentException e) {
       throw new PSUnknownNodeTypeException(ms_NodeType, "name", e);
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
@@ -130,9 +130,10 @@ public abstract class PSSubject extends PSDatabaseComponent {
    *     list will be assigned.
    */
   protected PSSubject(String name, int type, PSAttributeList atts) {
-    setName(name);
-    setType(type);
-    setAttributes(atts);
+    // Private helpers avoid virtual setName/setAttributes during construction (this-escape).
+    applyName(name);
+    applyType(type);
+    applyAttributes(atts);
   }
 
   /**
@@ -149,7 +150,8 @@ public abstract class PSSubject extends PSDatabaseComponent {
       throws PSUnknownNodeTypeException {
     this();
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private path avoids virtual fromXml dispatch before subclass fields initialize.
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
 
   /** Empty constructor for creating from serialization, fromXml() etc */
@@ -186,6 +188,11 @@ public abstract class PSSubject extends PSDatabaseComponent {
    * @throws IllegalArgumentException if name is invalid
    */
   void setName(String name) {
+    applyName(name);
+  }
+
+  /** Non-overridable assignment used from constructors and {@link #setName(String)}. */
+  private void applyName(String name) {
     if ((null == name) || (name.trim().length() == 0)) {
       throw new IllegalArgumentException("Subject name must be specified.");
     } else if (name.length() > SUBJECT_MAX_NAME_LEN)
@@ -205,6 +212,13 @@ public abstract class PSSubject extends PSDatabaseComponent {
    *     empty attribute list will be set.
    */
   void setAttributes(PSAttributeList attributes) {
+    applyAttributes(attributes);
+  }
+
+  /**
+   * Non-overridable assignment used from constructors and {@link #setAttributes(PSAttributeList)}.
+   */
+  private void applyAttributes(PSAttributeList attributes) {
     if (attributes == null) m_attributes = new PSAttributeList();
     else m_attributes = attributes;
   }
@@ -359,6 +373,16 @@ public abstract class PSSubject extends PSDatabaseComponent {
    */
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Shared load for {@link #fromXml} and the Element constructor. Keeps construction free of
+   * virtual {@code fromXml} dispatch so subclasses ({@link PSGlobalSubject}, {@link
+   * PSRelativeSubject}) can initialize safely.
+   */
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
     }
@@ -386,7 +410,7 @@ public abstract class PSSubject extends PSDatabaseComponent {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
     } else {
       try {
-        setType(Integer.valueOf(sTemp).intValue());
+        applyType(Integer.valueOf(sTemp).intValue());
       } catch (NumberFormatException nfe) {
         Object[] args = {ms_NodeType, "type", sTemp};
         throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
@@ -402,7 +426,7 @@ public abstract class PSSubject extends PSDatabaseComponent {
     // Read name element of the Subject
     sTemp = tree.getElementData("name");
     try {
-      setName(sTemp);
+      applyName(sTemp);
     } catch (IllegalArgumentException e) {
       Object[] args = {ms_NodeType, "name", e.toString()};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
@@ -468,6 +492,11 @@ public abstract class PSSubject extends PSDatabaseComponent {
    * @throws IllegalArgumentException if the type is not valid.
    */
   private void setType(int type) {
+    applyType(type);
+  }
+
+  /** Non-overridable assignment used from constructors and {@link #setType(int)}. */
+  private void applyType(int type) {
     if ((type != SUBJECT_TYPE_USER) && (type != SUBJECT_TYPE_GROUP))
       throw new IllegalArgumentException("The subject type supplied is invalid.");
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
@@ -287,7 +287,7 @@ public class PSTraceInfo extends PSComponent {
    * @throws PSUnknownNodeTypeException if the XML element node does not represent a type supported
    *     by the class.
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
 
     if (sourceNode == null) {

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacySecurityProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacySecurityProviderInstance.java
@@ -56,7 +56,8 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
       Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     this();
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private path avoids virtual fromXml dispatch during construction (this-escape).
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
 
   /** Constructor for serialization, fromXml, etc. */
@@ -73,9 +74,8 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
    *     invalid.
    */
   public PSLegacySecurityProviderInstance(String name, int type) throws PSIllegalArgumentException {
-    super();
-    setName(name);
-    setType(type);
+    // Base name/type ctor applies non-virtual helpers (this-escape safe).
+    super(name, type);
   }
 
   @Override
@@ -102,7 +102,15 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndConnection
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
+    fromXmlBase(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Shared load for {@link #fromXml} and the Element constructor (this-escape safe; non-virtual).
+   */
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectStoreThisEscapeTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectStoreThisEscapeTest.java
@@ -141,4 +141,121 @@ public class PSDesignObjectStoreThisEscapeTest {
     assertEquals(original.getName(), restored.getName());
     assertEquals(original.getType(), restored.getType());
   }
+
+  @Test
+  public void relativeSubjectNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSRelativeSubject original =
+        new PSRelativeSubject("alice", PSSubject.SUBJECT_TYPE_USER, null);
+    Element elem = original.toXml(doc);
+
+    PSRelativeSubject restored = new PSRelativeSubject(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getType(), restored.getType());
+    assertTrue(restored.isUser());
+  }
+
+  @Test
+  public void globalSubjectNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSGlobalSubject original =
+        new PSGlobalSubject("editors", PSSubject.SUBJECT_TYPE_GROUP, null);
+    Element elem = original.toXml(doc);
+
+    PSGlobalSubject restored = new PSGlobalSubject(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getType(), restored.getType());
+    assertTrue(restored.isGroup());
+  }
+
+  @Test
+  public void attributeNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSAttribute original = new PSAttribute("department");
+    Element elem = original.toXml(doc);
+
+    PSAttribute restored = new PSAttribute(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+  }
+
+  @Test
+  public void attributeListElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSAttributeList original = new PSAttributeList();
+    original.setAttribute("dept", java.util.List.of("eng"));
+    Element elem = original.toXml(doc);
+
+    PSAttributeList restored = new PSAttributeList(elem);
+    assertEquals("eng", restored.getAttribute("dept").getValues().get(0));
+  }
+
+  @Test
+  public void notifierProviderCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSNotifier original = new PSNotifier(PSNotifier.MP_TYPE_SMTP, "mail.example.intsof");
+    original.setFrom("cms@example.intsof");
+    Element elem = original.toXml(doc);
+
+    PSNotifier restored = new PSNotifier(elem, null, null);
+    assertEquals(original.getServer(), restored.getServer());
+    assertEquals(original.getFrom(), restored.getFrom());
+    assertEquals(PSNotifier.MP_TYPE_SMTP, restored.getProviderType());
+  }
+
+  @Test
+  public void loginWebPageCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSLoginWebPage original =
+        new PSLoginWebPage(new java.net.URL("https://example.intsof/login"), true);
+    Element elem = original.toXml(doc);
+
+    PSLoginWebPage restored = new PSLoginWebPage(elem, null, null);
+    assertEquals(original.getUrl().toExternalForm(), restored.getUrl().toExternalForm());
+    assertTrue(restored.isSecure());
+  }
+
+  @Test
+  public void errorWebPagesElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSErrorWebPages original = new PSErrorWebPages(false);
+    Element elem = original.toXml(doc);
+
+    PSErrorWebPages restored = new PSErrorWebPages(elem, null, null);
+    assertEquals(original.isHtmlReturned(), restored.isHtmlReturned());
+  }
+
+  @Test
+  public void roleNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSRole original = new PSRole("Admin");
+    Element elem = original.toXml(doc);
+
+    PSRole restored = new PSRole(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+  }
+
+  @Test
+  public void securityProviderInstanceNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    // SP_TYPE_WEB_SERVER is a stable supported type used in unit tests
+    PSSecurityProviderInstance original =
+        new PSSecurityProviderInstance(
+            "web1", com.percussion.security.PSSecurityProvider.SP_TYPE_WEB_SERVER);
+    Element elem = original.toXml(doc);
+
+    PSSecurityProviderInstance restored = new PSSecurityProviderInstance(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getType(), restored.getType());
+  }
+
+  @Test
+  public void traceInfoDefaultAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSTraceInfo original = new PSTraceInfo();
+    Element elem = original.toXml(doc);
+
+    PSTraceInfo restored = new PSTraceInfo(elem, null, null);
+    assertEquals(original.getColumnWidth(), restored.getColumnWidth());
+    assertEquals(original.isTraceEnabled(), restored.isTraceEnabled());
+  }
 }


### PR DESCRIPTION
## Summary
Parent #2022 / #2200 slice **3i** — residual design.objectstore **this-escape** on security/directory/UI-adjacent types after #2404.

Real private-helper / `final` fixes only (no suppress-only):

| Area | Change |
|------|--------|
| `PSSubject` | `applyName`/`applyType`/`applyAttributes` + `fromXmlBase` |
| Leaf types | `final` `fromXml`/setters: Attribute(List), Notifier, LoginWebPage, ErrorWebPages, TraceInfo, Role |
| `PSSecurityProviderInstance` (+ legacy) | `applyName`/`applyType` + `fromXmlBase` |
| `PSDatabaseComponent` | `getComponentState` final (shared non-virtual load) |
| Tests | Extended `PSDesignObjectStoreThisEscapeTest` (19 tests) |

Does **not** expand into HTTPClient/server package rawtypes (#2299/#2460/#2461) or #2465 editors/app-config batch files.

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] `PSDesignObjectStoreThisEscapeTest` — Tests run: **19**, Failures: **0**
- [x] Focused `-Xlint:this-escape` probe on batch types (name/type ctor escapes cleared; residual Element paths that publish `this` via `updateParentList`/`super.fromXml` match #2404 residual class)

## Gates
- Erlang self-review: `docs/ai-generated/code-reviews/issue-2466-design-objectstore-this-escape-security-ui-erlang.md`
- No new path I/O / portability issues
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2466  
Refs #2022 #2200 #2404

> Co-Authored by Grok Build using grok-4.5 with agent main.
