### PR TITLE
fix(perc-system): cms.objectstore server handlers rawtypes residual batch 2f (#2453)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2453-objectstore-server-handlers-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2453-objectstore-server-handlers-rawtypes-erlang.md
@@ -1,0 +1,23 @@
+# Erlang-style self-review — issue #2453
+
+**Branch:** fix/issue-2453-objectstore-server-handlers-rawtypes
+**Module:** system / perc-system
+**Change class:** residual rawtypes/unchecked typing in cms.objectstore.server handlers + tightly coupled effect result map
+
+## Scope
+- Parameterized maps/iterators in PSLocalCataloger, PSInlineLinkProcessor, PSRelationshipEffectProcessor, PSRelationshipEffectTestResult, PSExecutionContext, PSCloneFactory, PSFolderSecurityManager, PSItemDefManager residual, PSFieldFinderUtil, caller PSConditionalCloneHandler / PSSearchIndexEventQueue.
+- Behavioral tests for typed effect results, activation endpoint table, inline-link contract.
+
+## Gates
+- [x] No intentional behavior change beyond typing (activation filter pure-static extraction only)
+- [x] Real generics preferred; narrow @SuppressWarnings only at raw design.objectstore iterator boundaries
+- [x] Out of scope: IPSComponent parentComponents (#2455), data.jdbc (#2603)
+- [x] Cross-platform: no path I/O changes
+- [x] Unit tests for changed pure logic
+- [x] `cd system && ../mvnw clean install` green (Tests run: 1362, Failures: 0)
+
+## Residual
+- PSServerItem / PSLoadChildDataExit / PSFieldRetriever / PSAuthTypes / PSCatalogServerObjectHandler still have raw iterators — PR-sized residual after this batch.
+
+## Verdict
+**PASS** for commit/PR.

--- a/system/src/main/java/com/percussion/cms/handlers/PSConditionalCloneHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSConditionalCloneHandler.java
@@ -138,7 +138,7 @@ public class PSConditionalCloneHandler extends PSCloneHandler {
        * No clone exists based on the user effect(s) attached to the
        * relationship type, create clone now.
        */
-      Map childRowMappings = new HashMap();
+      Map<String, String> childRowMappings = new HashMap<>();
       Iterator<PSRelationship> dedupedRels = relationships;
       if (!cloneExists) {
         // see if the target folder for creating the item is present
@@ -523,7 +523,7 @@ public class PSConditionalCloneHandler extends PSCloneHandler {
      * may be empty. See {@link PSCloneFactory#CHILD_ROW_MAPPINGS_PRIVATE_OBJECT} for details of the
      * map.
      */
-    Map mi_childRowMappings;
+    Map<String, String> mi_childRowMappings;
   }
 
   /**
@@ -544,7 +544,7 @@ public class PSConditionalCloneHandler extends PSCloneHandler {
       PSRequest request,
       PSLocator clone,
       List<ProcessedRelationship> psRelationships,
-      Map childRowMappings)
+      Map<String, String> childRowMappings)
       throws PSException {
     List<PSRelationship> createdRels = new ArrayList<>();
     CollectionUtils.addAll(createdRels, request.getRelationships());
@@ -881,7 +881,7 @@ public class PSConditionalCloneHandler extends PSCloneHandler {
       PSRequest request,
       Iterator<PSRelationship> relationships,
       List<ProcessedRelationship> processedRelationships,
-      Map childRowMappings)
+      Map<String, String> childRowMappings)
       throws PSCmsException {
     if (childRowMappings.isEmpty()) return;
 
@@ -897,7 +897,7 @@ public class PSConditionalCloneHandler extends PSCloneHandler {
           PSRelationship relationship = relationships.next();
           String test = relationship.getProperty(PSRelationshipConfig.PDU_INLINERELATIONSHIP);
           if (test != null && test.trim().length() > 0 && originalInlineRsId.equals(test)) {
-            String newInlineRsId = (String) childRowMappings.get(originalInlineRsId);
+            String newInlineRsId = childRowMappings.get(originalInlineRsId);
             if (newInlineRsId != null) {
               relationship.setProperty(PSRelationshipConfig.PDU_INLINERELATIONSHIP, newInlineRsId);
               needModification.add(relationship);

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSCloneFactory.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSCloneFactory.java
@@ -37,7 +37,6 @@ import com.percussion.services.legacy.IPSItemEntry;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.system.utils.PSCms;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -60,7 +59,8 @@ public class PSCloneFactory {
    * @return the locator of the newly created clone, never <code>null</code>.
    * @throws PSCmsException for any error creating the clone.
    */
-  public static PSLocator createClone(PSRequest request, PSLocator source, Map childRowMappings)
+  public static PSLocator createClone(
+      PSRequest request, PSLocator source, Map<String, String> childRowMappings)
       throws PSCmsException {
     try {
       PSLocator clone = null;
@@ -113,14 +113,14 @@ public class PSCloneFactory {
 
     PSFolder tgt = (PSFolder) src[0].clone();
 
-    Map overrides =
-        (Map)
+    @SuppressWarnings("unchecked")
+    Map<String, String> overrides =
+        (Map<String, String>)
             request.getParameterObject(
-                PSCloneCommandHandler.SYS_CLONE_OVERRIDE_FIELDSET, new HashMap());
-    Iterator keys = overrides.keySet().iterator();
-    while (keys.hasNext()) {
-      String name = (String) keys.next();
-      String value = (String) overrides.get(name);
+                PSCloneCommandHandler.SYS_CLONE_OVERRIDE_FIELDSET, new HashMap<String, String>());
+    for (Map.Entry<String, String> entry : overrides.entrySet()) {
+      String name = entry.getKey();
+      String value = entry.getValue();
 
       if (value != null) {
         if (name.equals("sys_title")) tgt.setName(value);
@@ -152,14 +152,13 @@ public class PSCloneFactory {
    * @throws PSCmsException for any error creating the new clone.
    */
   private static PSLocator createItemClone(
-      PSRequest request, PSLocator source, String cloneResource, Map childRowMappings)
+      PSRequest request,
+      PSLocator source,
+      String cloneResource,
+      Map<String, String> childRowMappings)
       throws PSCmsException {
-    // avoid eclipse warning
-    if (childRowMappings == null)
-      ;
-
     try {
-      HashMap cloneParams = new HashMap();
+      Map<String, String> cloneParams = new HashMap<>();
       cloneParams.put(IPSHtmlParameters.SYS_COMMAND, PSCloneCommandHandler.COMMAND_NAME);
       cloneParams.put(IPSHtmlParameters.SYS_CONTENTID, Integer.toString(source.getId()));
       cloneParams.put(IPSHtmlParameters.SYS_REVISION, Integer.toString(source.getRevision()));
@@ -174,8 +173,11 @@ public class PSCloneFactory {
       ir.performUpdate();
 
       Object test = ir.getRequest().getPrivateObject(CHILD_ROW_MAPPINGS_PRIVATE_OBJECT);
-      if (test instanceof Map) {
-        childRowMappings.putAll((Map) test);
+      if (test instanceof Map && childRowMappings != null) {
+        // CHILD_ROW_MAPPINGS_PRIVATE_OBJECT is String → String (see field javadoc)
+        @SuppressWarnings("unchecked")
+        Map<String, String> mappings = (Map<String, String>) test;
+        childRowMappings.putAll(mappings);
       }
 
       // create the locater for the cloned object

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSFolderSecurityManager.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSFolderSecurityManager.java
@@ -93,10 +93,10 @@ public class PSFolderSecurityManager {
     // This method is not normally called directly and folder ACL will be pulled from
     // PSItemSummaryCache through PSServerFolderProcessor and
     // when populating the cache initially.
-    Map params = new HashMap<>();
+    Map<String, Object> params = new HashMap<>();
 
     if (ids != null) {
-      List idList = new ArrayList<>();
+      List<String> idList = new ArrayList<>();
       for (int i = 0; i < ids.length; i++) idList.add(String.valueOf(ids[i]));
       params.put(IPSHtmlParameters.SYS_CONTENTID, idList);
     }
@@ -110,7 +110,7 @@ public class PSFolderSecurityManager {
             null);
     if (ir == null)
       throw new PSCmsException(IPSCmsErrors.REQUIRED_RESOURCE_MISSING, FOLDER_ACL_RESOURCE);
-    List aclList = new ArrayList<>();
+    List<PSFolderAcl> aclList = new ArrayList<>();
     ResultSet rs = null;
     try {
       // to improve the performance, we process the result set directly.
@@ -135,7 +135,7 @@ public class PSFolderSecurityManager {
         folderAcl.add(aclEntry);
       }
 
-      return (PSFolderAcl[]) aclList.toArray(new PSFolderAcl[aclList.size()]);
+      return aclList.toArray(new PSFolderAcl[0]);
     } catch (SQLException e) {
       throw new PSCmsException(IPSServerErrors.CE_SQL_ERRORS, e.toString());
     } catch (PSException e) {

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSInlineLinkProcessor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSInlineLinkProcessor.java
@@ -61,8 +61,8 @@ public class PSInlineLinkProcessor {
    * processInlineLinkItem(request, item, relationships,
    * request.getSecurityToken().getCommunityId())}.
    */
-  public static void processInlineLinkItem(PSRequest request, PSLocator item, Map relationships)
-      throws PSException {
+  public static void processInlineLinkItem(
+      PSRequest request, PSLocator item, Map<?, ?> relationships) throws PSException {
     // convenience methods don't need to validate contract
     processInlineLinkItem(
         request, item, relationships, request.getSecurityToken().getCommunityId());
@@ -72,7 +72,8 @@ public class PSInlineLinkProcessor {
    * Convenience method that calls {@link #processInlineLinkItem(PSRequest, PSLocator, Map, int)}
    */
   public static void processInlineLinkItem(
-      PSRequest request, PSLocator item, Map relationships, int communityId) throws PSException {
+      PSRequest request, PSLocator item, Map<?, ?> relationships, int communityId)
+      throws PSException {
     // convenience methods don't need to validate contract
     processInlineLinkItem(request, item, relationships, communityId, true, true);
   }
@@ -94,7 +95,7 @@ public class PSInlineLinkProcessor {
   public static void processInlineLinkItem(
       PSRequest request,
       PSLocator item,
-      Map relationships,
+      Map<?, ?> relationships,
       int communityId,
       boolean bCheckout,
       boolean checkin)
@@ -186,7 +187,7 @@ public class PSInlineLinkProcessor {
       PSRequest request,
       PSLocator locator,
       PSItemDefinition itemDef,
-      Map relationshipMap,
+      Map<?, ?> relationshipMap,
       Iterator<PSInlineLinkField> fields,
       int communityId,
       boolean bCheckout,
@@ -253,7 +254,7 @@ public class PSInlineLinkProcessor {
    *     empty.
    * @throws PSCmsException if an error occurs.
    */
-  private static void processInlineLinkField(PSItemField itemField, Map relationshipMap)
+  private static void processInlineLinkField(PSItemField itemField, Map<?, ?> relationshipMap)
       throws PSCmsException {
     IPSFieldValue fieldValue = itemField.getValue();
     if (!(fieldValue instanceof PSTextValue)) return;

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSItemDefManager.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSItemDefManager.java
@@ -1053,7 +1053,7 @@ public class PSItemDefManager {
     }
 
     // Check if the content type id supplied is listed for the community.
-    Map params = new HashMap();
+    Map<String, Object> params = new HashMap<>();
     params.put(IPSHtmlParameters.SYS_CONTENTTYPEID, "" + contentTypeId);
     params.put(IPSHtmlParameters.SYS_COMMUNITYID, "" + communityId);
 

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSLocalCataloger.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSLocalCataloger.java
@@ -104,7 +104,7 @@ public class PSLocalCataloger implements IPSCataloger {
    * @return Never <code>null</code>. Each entry is the internal name of a system field that matches
    *     the supplied flags.
    */
-  public Set getSystemFields(int controlFlags) {
+  public Set<String> getSystemFields(int controlFlags) {
     initFieldCatalog();
 
     processSystemOnlyFields(PSServer.getContentEditorSystemDef(), controlFlags);
@@ -182,15 +182,15 @@ public class PSLocalCataloger implements IPSCataloger {
   private void addSharedFields(PSContentEditorSharedDef sharedDef, int controlFlags) {
     if (sharedDef == null) return;
 
-    Iterator entries = m_sharedFields.entrySet().iterator();
-    while (entries.hasNext()) {
-      Map.Entry entry = (Entry) entries.next();
-      String fsName = (String) entry.getKey();
-      Set fieldNameSet = (Set) entry.getValue();
+    for (Entry<String, Set<String>> entry : m_sharedFields.entrySet()) {
+      String fsName = entry.getKey();
+      Set<String> fieldNameSet = entry.getValue();
 
-      Iterator groups = sharedDef.getFieldGroups();
+      // design.objectstore shared-def field groups iterator is raw
+      @SuppressWarnings("unchecked")
+      Iterator<PSSharedFieldGroup> groups = sharedDef.getFieldGroups();
       while (groups.hasNext()) {
-        PSSharedFieldGroup group = (PSSharedFieldGroup) groups.next();
+        PSSharedFieldGroup group = groups.next();
         PSUIDefinition uiDef = group.getUIDefinition();
 
         PSFieldSet fs = group.getFieldSet();
@@ -198,7 +198,7 @@ public class PSLocalCataloger implements IPSCataloger {
         if (!fs.getName().equals(fsName)) {
           // try for child
           Object o = fs.get(fsName);
-          if (o != null && o instanceof PSFieldSet) {
+          if (o instanceof PSFieldSet) {
             fs = (PSFieldSet) o;
             if (!fs.getName().equals(fsName)) continue;
             mapper = uiDef.getDisplayMapper(fsName);
@@ -207,9 +207,7 @@ public class PSLocalCataloger implements IPSCataloger {
 
         if (mapper == null) continue;
 
-        Iterator fields = fieldNameSet.iterator();
-        while (fields.hasNext()) {
-          String fieldName = (String) fields.next();
+        for (String fieldName : fieldNameSet) {
           PSField field = fs.findFieldByName(fieldName);
           PSDisplayMapping mapping = mapper.getMapping(fieldName);
           if (mapping != null && field != null) {
@@ -232,9 +230,10 @@ public class PSLocalCataloger implements IPSCataloger {
   public PSRelationshipInfoSet getRelationshipInfoSet() throws PSCmsException {
     PSRelationshipInfoSet infoSet = new PSRelationshipInfoSet();
 
-    Iterator configs = PSRelationshipCommandHandler.getRelationshipConfigs();
+    Iterator<PSRelationshipConfig> configs =
+        PSRelationshipCommandHandler.getRelationshipConfigs();
     while (configs.hasNext()) {
-      PSRelationshipConfig config = (PSRelationshipConfig) configs.next();
+      PSRelationshipConfig config = configs.next();
       PSRelationshipInfo info = new PSRelationshipInfo(config);
       infoSet.add(info);
     }
@@ -308,12 +307,14 @@ public class PSLocalCataloger implements IPSCataloger {
 
     PSContentEditorSystemDef sysDef = PSServer.getContentEditorSystemDef();
 
-    Iterator mappings = dispMapper.iterator();
+    // PSDisplayMapper extends raw PSCollection; narrow at the boundary
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> mappings = dispMapper.iterator();
     PSDisplayMapping mapping = null;
     PSUISet uiSet = null;
     if (mappings != null) {
       while (mappings.hasNext()) {
-        mapping = (PSDisplayMapping) mappings.next();
+        mapping = mappings.next();
         PSDisplayMapper displayMapper = mapping.getDisplayMapper();
         if (displayMapper != null) {
           recurseMapping(displayMapper, mapper, contentType, controlFlags);
@@ -330,7 +331,7 @@ public class PSLocalCataloger implements IPSCataloger {
                   mapping.getFieldRef(), fieldSet.TYPE_MULTI_PROPERTY_SIMPLE_CHILD);
         }
 
-        if (o != null && o instanceof PSField) {
+        if (o instanceof PSField) {
           PSField field = (PSField) o;
           uiSet = mapping.getUISet();
 
@@ -476,7 +477,7 @@ public class PSLocalCataloger implements IPSCataloger {
             m_request.getUserSession().getSessionObject(PSI18nUtils.USER_SESSION_OBJECT_SYS_LANG);
     if (lang == null) lang = PSI18nUtils.DEFAULT_LANG;
 
-    Map map = null;
+    Map<String, Collection<FieldObject>> map = null;
     if (field.isSystemField()) {
       map = m_systemMap;
       choices = localizeChoices(choices, lang, "psx.ce.system." + field.getSubmitName() + "@");
@@ -529,10 +530,12 @@ public class PSLocalCataloger implements IPSCataloger {
     newChoices.copyFrom(choices);
 
     // build list of translated entries
+    // PSChoices.getLocal() is a raw design.objectstore iterator boundary
+    @SuppressWarnings("unchecked")
+    Iterator<PSEntry> oldChoices = choices.getLocal();
     List<PSEntry> newChoiceList = new ArrayList<>();
-    Iterator oldChoices = choices.getLocal();
     while (oldChoices.hasNext()) {
-      PSEntry entry = (PSEntry) oldChoices.next();
+      PSEntry entry = oldChoices.next();
       PSDisplayText newText =
           new PSDisplayText(PSI18nUtils.getString(keyBase + entry.getLabel().getText()));
       PSEntry newEntry = new PSEntry(entry.getValue(), newText);
@@ -554,10 +557,10 @@ public class PSLocalCataloger implements IPSCataloger {
    * @param f Assumed not <code>null</code>.
    * @param key Assumed not <code>null</code> or empty. Lowercased before performing search on map.
    */
-  private void addToMap(Map map, FieldObject f, String key) {
-    Collection c = (Collection) map.get(key);
+  private void addToMap(Map<String, Collection<FieldObject>> map, FieldObject f, String key) {
+    Collection<FieldObject> c = map.get(key);
     if (null == c) {
-      c = new ArrayList();
+      c = new ArrayList<>();
       map.put(key, c);
     }
 
@@ -591,27 +594,32 @@ public class PSLocalCataloger implements IPSCataloger {
    * @param doc parent document, assumed to be not <code>null</code>.
    * @param controlFlags The control flags supplied to {@link #getCEFieldXml(int)}
    */
-  private void addElement(String type, Element root, Map map, Document doc, int controlFlags) {
+  private void addElement(
+      String type,
+      Element root,
+      Map<String, Collection<FieldObject>> map,
+      Document doc,
+      int controlFlags) {
     Element elem = doc.createElement(type);
-    Iterator itr = map.keySet().iterator();
     String key = null;
     FieldObject value = null;
     Element fieldElem = null;
     String id = null;
     String dataType = null;
     String displayName = null;
-    while (itr.hasNext()) {
+    for (String mapKey : map.keySet()) {
       Element fieldInstancesEl = doc.createElement(SEARCH_FIELD);
-      key = (String) itr.next();
+      key = mapKey;
       fieldInstancesEl.setAttribute(INTERNALNAME, key);
 
-      Iterator fobs = ((Collection) map.get(key)).iterator();
+      Collection<FieldObject> fieldObjects = map.get(key);
+      Iterator<FieldObject> fobs = fieldObjects.iterator();
       boolean firstPass = false;
 
       while (fobs.hasNext()) {
         fieldElem = doc.createElement(FIELD);
 
-        value = (FieldObject) fobs.next();
+        value = fobs.next();
         if (!firstPass) {
           firstPass = true;
           if (value.isReadOnly()) fieldInstancesEl.setAttribute(RESULT_ONLY, RESULT_ONLY_VALUE);
@@ -860,7 +868,7 @@ public class PSLocalCataloger implements IPSCataloger {
    * </code> types, abstracting display name, data type and content type id. Never <code>null</code>
    * .
    */
-  private Map m_systemMap = new HashMap();
+  private final Map<String, Collection<FieldObject>> m_systemMap = new HashMap<>();
 
   /**
    * Shared map for shared content editor fields. The key is the internal name of the field and the
@@ -868,12 +876,12 @@ public class PSLocalCataloger implements IPSCataloger {
    * and content type id. Since any given name could occur in multiple editors, we provide all the
    * data so the client can display the results in different ways. Never <code>null</code>.
    */
-  private Map m_sharedMap = new HashMap();
+  private final Map<String, Collection<FieldObject>> m_sharedMap = new HashMap<>();
 
   /**
    * Local map for local fields. See <code>m_sharedMap</code> for details. Never <code>null</code>.
    */
-  private Map m_localMap = new HashMap();
+  private final Map<String, Collection<FieldObject>> m_localMap = new HashMap<>();
 
   /**
    * Map of shared fields to process in order to use the source field rather than the overriden

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSRelationshipEffectProcessor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSRelationshipEffectProcessor.java
@@ -194,7 +194,7 @@ public class PSRelationshipEffectProcessor {
    *     by the locator), never <code>null</code>, may be empty.
    * @exception PSCmsException if an error occurs.
    */
-  private Iterator getAllRelationships(PSLocator locator) throws PSCmsException {
+  private Iterator<PSRelationship> getAllRelationships(PSLocator locator) throws PSCmsException {
     Collection<PSRelationshipConfig> configs = getReleventRelationships();
     if (configs.isEmpty()) return Collections.emptyIterator();
 
@@ -272,15 +272,17 @@ public class PSRelationshipEffectProcessor {
   private Collection<PSRelationshipConfig> getReleventRelationships() {
     int exeCtx = m_executionContext.getContextType();
     HashSet<PSRelationshipConfig> retConfigs = new HashSet<>();
-    Iterator configs = PSRelationshipCommandHandler.getConfigurationSet().iterator();
-    PSRelationshipConfig config;
-    Iterator cdEffects;
-    PSConditionalEffect cdEffect;
+    // relationship configuration set is a raw PSCollection boundary
+    @SuppressWarnings("unchecked")
+    Iterator<PSRelationshipConfig> configs =
+        PSRelationshipCommandHandler.getConfigurationSet().iterator();
     while (configs.hasNext()) {
-      config = (PSRelationshipConfig) configs.next();
-      cdEffects = config.getEffects();
+      PSRelationshipConfig config = configs.next();
+      // design.objectstore getEffects() is a raw iterator boundary
+      @SuppressWarnings("unchecked")
+      Iterator<PSConditionalEffect> cdEffects = config.getEffects();
       while (cdEffects.hasNext()) {
-        cdEffect = (PSConditionalEffect) cdEffects.next();
+        PSConditionalEffect cdEffect = cdEffects.next();
         if (cdEffect.hasExecutionContext(exeCtx)) retConfigs.add(config);
       }
     }
@@ -320,18 +322,22 @@ public class PSRelationshipEffectProcessor {
    *     configuration, i.e. one of teh {link PSRelationshipConfig} ACTIVATION_ENDPOINT_XXXX
    *     strings. Assumed not <code>null</code>.
    */
-  private boolean isProcessThisEffect(boolean isOwner, String activationEndPoint) {
-    boolean result = false;
+  /**
+   * Pure activation-endpoint filter (package-visible for unit tests).
+   *
+   * @param isOwner <code>true</code> if processing the owner end
+   * @param activationEndPoint one of {@link PSRelationshipConfig} ACTIVATION_ENDPOINT_XXXX values
+   * @return whether the effect should run for this end of the relationship
+   */
+  static boolean isProcessThisEffect(boolean isOwner, String activationEndPoint) {
     if (activationEndPoint.equals(PSRelationshipConfig.ACTIVATION_ENDPOINT_EITHER)) {
-      result = true;
-    } else if (activationEndPoint.equals(PSRelationshipConfig.ACTIVATION_ENDPOINT_OWNER)
-        && isOwner) {
-      result = true;
-    } else if (activationEndPoint.equals(PSRelationshipConfig.ACTIVATION_ENDPOINT_DEPENDENT)
-        && !isOwner) {
-      result = true;
+      return true;
     }
-    return result;
+    if (activationEndPoint.equals(PSRelationshipConfig.ACTIVATION_ENDPOINT_OWNER) && isOwner) {
+      return true;
+    }
+    return activationEndPoint.equals(PSRelationshipConfig.ACTIVATION_ENDPOINT_DEPENDENT)
+        && !isOwner;
   }
 
   /**
@@ -357,9 +363,9 @@ public class PSRelationshipEffectProcessor {
           PSExtensionProcessingException,
           PSParameterMismatchException,
           PSCmsException {
-    Iterator relationships = getAllRelationships(firstEnd);
+    Iterator<PSRelationship> relationships = getAllRelationships(firstEnd);
     while (relationships.hasNext()) {
-      PSRelationship currentRel = (PSRelationship) relationships.next();
+      PSRelationship currentRel = relationships.next();
       runTests(currentRel, isOwner(currentRel, firstEnd));
     }
   }
@@ -438,12 +444,14 @@ public class PSRelationshipEffectProcessor {
       }
       m_execData.setSourceRelationship(sourceRel);
 
-      Iterator effects = currentRel.getConfig().getEffects();
+      // design.objectstore getEffects() is a raw iterator boundary
+      @SuppressWarnings("unchecked")
+      Iterator<PSConditionalEffect> effects = currentRel.getConfig().getEffects();
       PSRelationshipEffectTestResult relEffectResults =
           new PSRelationshipEffectTestResult(currentRel);
 
       while (effects.hasNext()) {
-        PSConditionalEffect effect = (PSConditionalEffect) effects.next();
+        PSConditionalEffect effect = effects.next();
         String activationEndPoint = effect.getActivationEndPoint();
         boolean processThisEffect = isProcessThisEffect(isOwner, activationEndPoint);
         if (!processThisEffect) continue;
@@ -469,9 +477,9 @@ public class PSRelationshipEffectProcessor {
        * @todo: do we test for success or failure here and stop recursing through dependents in case
        *     of failure or walk entire web and then report?
        */
-      Iterator iter = relEffectResults.getResults();
+      Iterator<PSEffectTestResultPair> iter = relEffectResults.getResults();
       while (iter.hasNext()) {
-        PSEffectTestResultPair effectResult = (PSEffectTestResultPair) iter.next();
+        PSEffectTestResultPair effectResult = iter.next();
         if (!effectResult.getResult().getRecurseDependents()) continue;
         PSRelationship rel = relEffectResults.getRelationship();
         PSLocator next = null;
@@ -511,14 +519,13 @@ public class PSRelationshipEffectProcessor {
     IPSExtensionManager manager = PSServer.getExtensionManager(null);
     PSExtensionRunner runner = null;
     PSAttemptResult attemptResult = new PSAttemptResult();
-    Iterator keys = m_relationshipsProcessed.keySet().iterator();
     PSRelationship relationship = null;
     PSRelationshipEffectTestResult result = null;
 
     try {
-      while (keys.hasNext()) {
-        Integer key = (Integer) keys.next();
-        result = (PSRelationshipEffectTestResult) m_relationshipsProcessed.get(key);
+      for (Map.Entry<Integer, PSRelationshipEffectTestResult> entry :
+          m_relationshipsProcessed.entrySet()) {
+        result = entry.getValue();
 
         relationship = result.getRelationship();
 
@@ -538,12 +545,10 @@ public class PSRelationshipEffectProcessor {
         }
         m_execData.setSourceRelationship(sourceRel);
 
-        Iterator iter = result.getResults();
-        PSEffectTestResultPair pair = null;
-        PSConditionalEffect effect = null;
+        Iterator<PSEffectTestResultPair> iter = result.getResults();
         while (iter.hasNext()) {
-          pair = (PSEffectTestResultPair) iter.next();
-          effect = pair.getEffect();
+          PSEffectTestResultPair pair = iter.next();
+          PSConditionalEffect effect = pair.getEffect();
           if (pair.getResult().hasWarning()) continue;
 
           m_executionContext.setActivationEndPoint(pair.getResult().isActivationEndPointOwner());
@@ -588,15 +593,10 @@ public class PSRelationshipEffectProcessor {
    *     null</code> if there was no error processing the test() mthod of the effects.
    */
   private PSException isAllTestsSuccess() {
-    Iterator keys = m_relationshipsProcessed.keySet().iterator();
-    PSRelationshipEffectTestResult result = null;
-    PSEffectTestResultPair effectResultPair = null;
-    while (keys.hasNext()) {
-      Integer key = (Integer) keys.next();
-      result = (PSRelationshipEffectTestResult) m_relationshipsProcessed.get(key);
-      Iterator iter = result.getResults();
+    for (PSRelationshipEffectTestResult result : m_relationshipsProcessed.values()) {
+      Iterator<PSEffectTestResultPair> iter = result.getResults();
       while (iter.hasNext()) {
-        effectResultPair = (PSEffectTestResultPair) iter.next();
+        PSEffectTestResultPair effectResultPair = iter.next();
         if (!effectResultPair.getResult().isSuccess()) {
           return effectResultPair.getResult().getException();
         }
@@ -650,10 +650,11 @@ public class PSRelationshipEffectProcessor {
   }
 
   /**
-   * Map of all relationships processed by the engine. The key is the relationship object. and the
-   * value is the {@link PSRelationshipEffectTestResult} object that contains the test result data.
+   * Map of all relationships processed by the engine. The key is the relationship id, and the value
+   * is the {@link PSRelationshipEffectTestResult} object that contains the test result data.
    */
-  private Map m_relationshipsProcessed = new HashMap();
+  private final Map<Integer, PSRelationshipEffectTestResult> m_relationshipsProcessed =
+      new HashMap<>();
 
   /**
    * Reference to the execution data, set in the constructor, never <code>null</code> after that.

--- a/system/src/main/java/com/percussion/cms/objectstore/server/util/PSFieldFinderUtil.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/util/PSFieldFinderUtil.java
@@ -48,15 +48,19 @@ public class PSFieldFinderUtil {
   private static List<String> getFields(
       PSDisplayMapper mapper, String propertyName, String propertyValue) {
     List<String> fieldNames = new ArrayList<>();
-    Iterator mappings = mapper.iterator();
+    // PSDisplayMapper extends raw PSCollection; narrow at the boundary
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> mappings = mapper.iterator();
     while (mappings.hasNext()) {
-      PSDisplayMapping mapping = (PSDisplayMapping) mappings.next();
+      PSDisplayMapping mapping = mappings.next();
       String name = mapping.getFieldRef();
       PSControlRef controlMeta = mapping.getUISet().getControl();
       if (controlMeta != null) {
-        Iterator params = controlMeta.getParameters();
+        // design.objectstore getParameters() is a raw iterator boundary
+        @SuppressWarnings("unchecked")
+        Iterator<PSParam> params = controlMeta.getParameters();
         while (params.hasNext()) {
-          PSParam param = (PSParam) params.next();
+          PSParam param = params.next();
           if (param.getName().equals(propertyName)
               && param.getValue().getValueDisplayText().equals(propertyValue)) {
             fieldNames.add(name);

--- a/system/src/main/java/com/percussion/relationship/PSExecutionContext.java
+++ b/system/src/main/java/com/percussion/relationship/PSExecutionContext.java
@@ -21,7 +21,6 @@ import com.percussion.design.objectstore.PSRelationship;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.relationship.effect.PSRelationshipEffectTestResult;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,7 +48,10 @@ public class PSExecutionContext implements IPSExecutionContext {
    *     because this type was readily available by the creator of this class and I was trying to
    *     minimize changes.]
    */
-  public PSExecutionContext(int context, PSExecutionData data, Map processedRelationships) {
+  public PSExecutionContext(
+      int context,
+      PSExecutionData data,
+      Map<Integer, PSRelationshipEffectTestResult> processedRelationships) {
     if (data == null) throw new IllegalArgumentException("data must not be null");
 
     if (!isContextValid(context))
@@ -273,12 +275,11 @@ public class PSExecutionContext implements IPSExecutionContext {
   }
 
   // see IPSExecutionContext for documentation
-  public Set getProcessedRelationships() {
-    Set result = new HashSet();
+  public Set<PSRelationship> getProcessedRelationships() {
+    Set<PSRelationship> result = new HashSet<>();
     if (m_processedRelationships != null) {
-      Iterator values = m_processedRelationships.values().iterator();
-      while (values.hasNext()) {
-        result.add(((PSRelationshipEffectTestResult) values.next()).getRelationship());
+      for (PSRelationshipEffectTestResult testResult : m_processedRelationships.values()) {
+        result.add(testResult.getRelationship());
       }
     }
     return result;
@@ -317,5 +318,5 @@ public class PSExecutionContext implements IPSExecutionContext {
   private int m_activationEndPoint = RS_ENDPOINT_OWNER;
 
   /** May be <code>null</code>. */
-  private Map m_processedRelationships;
+  private Map<Integer, PSRelationshipEffectTestResult> m_processedRelationships;
 }

--- a/system/src/main/java/com/percussion/relationship/effect/PSRelationshipEffectTestResult.java
+++ b/system/src/main/java/com/percussion/relationship/effect/PSRelationshipEffectTestResult.java
@@ -69,7 +69,7 @@ public class PSRelationshipEffectTestResult {
    * @return and iterator of <code>EffectTestResultPair</code> objects representing the effect test
    *     results for the relationship, never <code>null</code>
    */
-  public Iterator getResults() {
+  public Iterator<PSEffectTestResultPair> getResults() {
     return m_list.iterator();
   }
 
@@ -89,8 +89,8 @@ public class PSRelationshipEffectTestResult {
   private PSRelationship m_relationship = null;
 
   /**
-   * List of {@link EffectTestResultPair objects} representing all effects and results for the
+   * List of {@link PSEffectTestResultPair} objects representing all effects and results for the
    * relationship.
    */
-  private List m_list = new ArrayList();
+  private final List<PSEffectTestResultPair> m_list = new ArrayList<>();
 }

--- a/system/src/main/java/com/percussion/search/PSSearchIndexEventQueue.java
+++ b/system/src/main/java/com/percussion/search/PSSearchIndexEventQueue.java
@@ -1002,7 +1002,7 @@ public class PSSearchIndexEventQueue implements IPSEditorChangeListener, IPSHand
     // get system field catalog
     PSRequest req = PSRequest.getContextForRequest();
     PSLocalCataloger cat = new PSLocalCataloger(req);
-    Set systemFieldNames =
+    Set<String> systemFieldNames =
         cat.getSystemFields(
             IPSFieldCataloger.FLAG_USER_SEARCH | IPSFieldCataloger.FLAG_INCLUDE_HIDDEN);
 

--- a/system/src/test/java/com/percussion/cms/objectstore/server/PSInlineLinkProcessorContractTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/server/PSInlineLinkProcessorContractTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore.server;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.design.objectstore.PSRelationship;
+import com.percussion.error.PSException;
+import com.percussion.server.PSRequest;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for typed {@link PSInlineLinkProcessor} relationship maps (issue #2453 server
+ * handlers rawtypes residual batch 2f). Full processing requires a live CMS stack; this covers
+ * null/empty map short-circuits on the fully-specified entry point that validates the contract
+ * without reading the request security token.
+ */
+@Tag("UnitTest")
+public class PSInlineLinkProcessorContractTest {
+
+  @Test
+  void nullArgumentsRejected() {
+    PSRequest request = new PSRequest(null, null, null, null);
+    PSLocator item = new PSLocator(1, 1);
+    Map<Integer, PSRelationship> relationships = new HashMap<>();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSInlineLinkProcessor.processInlineLinkItem(
+                null, item, relationships, -1, false, false));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSInlineLinkProcessor.processInlineLinkItem(
+                request, null, relationships, -1, false, false));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PSInlineLinkProcessor.processInlineLinkItem(
+                request, item, null, -1, false, false));
+  }
+
+  @Test
+  void emptyRelationshipMapIsNoOp() throws PSException {
+    PSRequest request = new PSRequest(null, null, null, null);
+    PSLocator item = new PSLocator(1, 1);
+
+    assertDoesNotThrow(
+        () ->
+            PSInlineLinkProcessor.processInlineLinkItem(
+                request, item, Collections.emptyMap(), -1, false, false));
+  }
+}

--- a/system/src/test/java/com/percussion/cms/objectstore/server/PSRelationshipEffectProcessorActivationTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/server/PSRelationshipEffectProcessorActivationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSRelationshipConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for activation-endpoint filtering used by {@link
+ * PSRelationshipEffectProcessor} (issue #2453). Pure decision table — no live relationship/effect
+ * stack required.
+ */
+@Tag("UnitTest")
+public class PSRelationshipEffectProcessorActivationTest {
+
+  @Test
+  void activationEndpointDecisionTable() {
+    assertTrue(
+        PSRelationshipEffectProcessor.isProcessThisEffect(
+            true, PSRelationshipConfig.ACTIVATION_ENDPOINT_EITHER));
+    assertTrue(
+        PSRelationshipEffectProcessor.isProcessThisEffect(
+            false, PSRelationshipConfig.ACTIVATION_ENDPOINT_EITHER));
+
+    assertTrue(
+        PSRelationshipEffectProcessor.isProcessThisEffect(
+            true, PSRelationshipConfig.ACTIVATION_ENDPOINT_OWNER));
+    assertFalse(
+        PSRelationshipEffectProcessor.isProcessThisEffect(
+            false, PSRelationshipConfig.ACTIVATION_ENDPOINT_OWNER));
+
+    assertFalse(
+        PSRelationshipEffectProcessor.isProcessThisEffect(
+            true, PSRelationshipConfig.ACTIVATION_ENDPOINT_DEPENDENT));
+    assertTrue(
+        PSRelationshipEffectProcessor.isProcessThisEffect(
+            false, PSRelationshipConfig.ACTIVATION_ENDPOINT_DEPENDENT));
+  }
+}

--- a/system/src/test/java/com/percussion/relationship/effect/PSRelationshipEffectTestResultGenericsTest.java
+++ b/system/src/test/java/com/percussion/relationship/effect/PSRelationshipEffectTestResultGenericsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.relationship.effect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.data.PSExecutionData;
+import com.percussion.design.objectstore.PSConditionalEffect;
+import com.percussion.design.objectstore.PSExtensionCall;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.design.objectstore.PSRelationship;
+import com.percussion.design.objectstore.PSRelationshipConfig;
+import com.percussion.extension.PSExtensionRef;
+import com.percussion.relationship.IPSExecutionContext;
+import com.percussion.relationship.PSExecutionContext;
+import com.percussion.relationship.PSTestResult;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed relationship-effect result collections (issue #2453 cms.objectstore
+ * server handlers rawtypes residual batch 2f).
+ */
+@Tag("UnitTest")
+public class PSRelationshipEffectTestResultGenericsTest {
+
+  @Test
+  void typedGetResultsReturnsAddedPairsInOrder() {
+    PSRelationship relationship = sampleRelationship(42);
+    PSRelationshipEffectTestResult result = new PSRelationshipEffectTestResult(relationship);
+    assertSame(relationship, result.getRelationship());
+
+    PSConditionalEffect effect1 = sampleEffect("effect1");
+    PSConditionalEffect effect2 = sampleEffect("effect2");
+    PSTestResult test1 = new PSTestResult();
+    test1.setRecurseDependents(true);
+    test1.setActivationEndPoint(true);
+    PSTestResult test2 = new PSTestResult();
+    test2.setRecurseDependents(false);
+    test2.setActivationEndPoint(false);
+
+    result.add(effect1, test1);
+    result.add(effect2, test2);
+
+    Iterator<PSEffectTestResultPair> pairs = result.getResults();
+    assertTrue(pairs.hasNext());
+    PSEffectTestResultPair first = pairs.next();
+    assertSame(effect1, first.getEffect());
+    assertSame(test1, first.getResult());
+    assertTrue(first.getResult().getRecurseDependents());
+    assertTrue(first.getResult().isActivationEndPointOwner());
+
+    assertTrue(pairs.hasNext());
+    PSEffectTestResultPair second = pairs.next();
+    assertSame(effect2, second.getEffect());
+    assertSame(test2, second.getResult());
+    assertFalse(second.getResult().getRecurseDependents());
+    assertFalse(second.getResult().isActivationEndPointOwner());
+
+    assertFalse(pairs.hasNext());
+  }
+
+  @Test
+  void executionContextReturnsTypedProcessedRelationshipsFromMap() {
+    PSRelationship relationship = sampleRelationship(7);
+    PSRelationshipEffectTestResult effectResult = new PSRelationshipEffectTestResult(relationship);
+    effectResult.add(sampleEffect("processed"), new PSTestResult());
+
+    Map<Integer, PSRelationshipEffectTestResult> processed = new HashMap<>();
+    processed.put(relationship.getId(), effectResult);
+
+    PSExecutionData data = new PSExecutionData(null, null, null);
+    PSExecutionContext ctx =
+        new PSExecutionContext(IPSExecutionContext.RS_PRE_WORKFLOW, data, processed);
+
+    Set<PSRelationship> found = ctx.getProcessedRelationships();
+    assertEquals(1, found.size());
+    assertTrue(found.contains(relationship));
+  }
+
+  @Test
+  void executionContextReturnsEmptyWhenProcessedMapIsNull() {
+    PSExecutionData data = new PSExecutionData(null, null, null);
+    PSExecutionContext ctx =
+        new PSExecutionContext(IPSExecutionContext.RS_PRE_WORKFLOW, data, null);
+    assertTrue(ctx.getProcessedRelationships().isEmpty());
+  }
+
+  private static PSRelationship sampleRelationship(int id) {
+    PSRelationshipConfig config =
+        new PSRelationshipConfig(
+            "ActiveAssembly",
+            PSRelationshipConfig.RS_TYPE_SYSTEM,
+            PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY);
+    return new PSRelationship(id, new PSLocator(100, 1), new PSLocator(200, 1), config);
+  }
+
+  private static PSConditionalEffect sampleEffect(String name) {
+    PSExtensionRef ref = new PSExtensionRef("Java", "global/percussion/relationship/", name);
+    return new PSConditionalEffect(new PSExtensionCall(ref, null));
+  }
+}


### PR DESCRIPTION
## Summary
Parent epic: #2022 / grandparent #2200. Slice **2f** residual cms.objectstore **server handlers** rawtypes after #2401 (PR #2456).

Parameterizes the next coherent batch of rawtypes/unchecked in tightly coupled server handlers:

- `PSLocalCataloger` — typed field maps `Map<String, Collection<FieldObject>>`, `Set<String> getSystemFields`, shared-field / display-mapper / relationship config iterators
- `PSInlineLinkProcessor` — `Map<?, ?>` relationship maps aligned with `PSInlineLinkField.modifyField`
- `PSRelationshipEffectProcessor` + `PSRelationshipEffectTestResult` + `PSExecutionContext` — `Map<Integer, PSRelationshipEffectTestResult>`, typed iterators, pure activation-endpoint filter
- `PSCloneFactory` / `PSConditionalCloneHandler` — `Map<String, String>` child-row mappings
- `PSFolderSecurityManager`, `PSItemDefManager` residual params, `PSFieldFinderUtil`, search index queue consumer

Prefer real generics; narrow `@SuppressWarnings` only at raw design.objectstore iterator boundaries.

## Out of scope
- design.objectstore `IPSComponent` parentComponents redesign (#2455)
- data/data.jdbc (open residual #2602 / PR #2603 surface)
- this-escape/serial

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1362**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] New tests: `PSRelationshipEffectTestResultGenericsTest` (3), `PSInlineLinkProcessorContractTest` (2), `PSRelationshipEffectProcessorActivationTest` (1)
- [x] Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2453-objectstore-server-handlers-rawtypes-erlang.md`

## Residual
Remaining server-handler rawtypes after this batch (`PSServerItem`, `PSLoadChildDataExit`, `PSFieldRetriever`, `PSAuthTypes`, `PSCatalogServerObjectHandler`) will be filed as a follow-up child under #2022.

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2453.

> Co-Authored by Grok Build using grok-4.5 with agent main.
