### PR TITLE
feat(auditlog): Phase 2a migrate PSAuditLogService call sites (#2615)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -54,6 +54,11 @@ Production durable store: table `PSX_SYSTEM_AUDIT_LOG` with JPA entity
 
 Login smoke path: `PSSystemAuditLogger` / `PSLoginServlet` (success, failure, logout).
 
+Phase 2a migrates production call sites off legacy CADF `PSAuditLogService` to
+`PSSystemAuditLogger` helpers + package `*ErrorCodes` (`ContentErrorCodes`,
+`UserManagementErrorCodes`, `WorkflowErrorCodes`, extended `AuthenticationErrorCodes`).
+Legacy CADF types remain in this module until Phase 2c (#2617).
+
 ## Phase 3 — REST query + role property (#2618)
 
 **Permission:** Rhythmyx role property `sys_securityAuditLogViewer` (truthy `true`/`yes`/`1`/`y`). Members of **Admin** always may view. Pure helper: `com.percussion.services.audit.PSSystemAuditLogPermission`.

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodes.java
@@ -69,7 +69,7 @@ public enum ContentErrorCodes implements SystemErrorCode {
   PAGE_REMOVAL_SCHEDULE(
       2006,
       true,
-      AuditEventType.CONTENT_UPDATE,
+      AuditEventType.CONTENT_PUBLISH,
       AuditOutcome.SUCCESS,
       "Page removal scheduled for {}",
       "Page removal schedule guid={} contentId={} path={}");

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodes.java
@@ -22,57 +22,57 @@ import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 
 /**
- * High-level authentication <em>audit events</em> (login success/failure/logout).
- *
- * <p>Exception catalog codes that bridge legacy {@code IPSSecurityErrors} ints live in {@link
- * SecurityErrorCodes} (Phase 2b). Prefer this enum for intentional audit emits from login
- * servlets; prefer {@link SecurityErrorCodes} / {@code LegacyErrorCodeRegistry} when handling
- * {@code PSException} error codes.
- *
- * <p>Every constant sets {@link #isAuditable()} explicitly.
+ * Content lifecycle audit codes (create / update / delete / recycle / schedule). Outcome is set at
+ * the call site when success and failure share the same code.
  */
-public enum AuthenticationErrorCodes implements SystemErrorCode {
-  LOGIN_SUCCESS(
-      1001,
+public enum ContentErrorCodes implements SystemErrorCode {
+  CREATE(
+      2001,
       true,
-      AuditEventType.AUTH_LOGIN,
+      AuditEventType.CONTENT_CREATE,
       AuditOutcome.SUCCESS,
-      "User {} logged in successfully",
-      "Login success actor={} sourceIp={}"),
+      "Content item {} created",
+      "Content create guid={} contentId={} path={}"),
 
-  LOGIN_FAILURE(
-      1002,
+  UPDATE(
+      2002,
       true,
-      AuditEventType.AUTH_FAILURE,
-      AuditOutcome.FAILURE,
-      "Login failed for user {}",
-      "Login failure actor={} reason={} sourceIp={}"),
-
-  LOGOUT(
-      1003,
-      true,
-      AuditEventType.AUTH_LOGOUT,
+      AuditEventType.CONTENT_UPDATE,
       AuditOutcome.SUCCESS,
-      "User {} logged out",
-      "Logout actor={} sourceIp={}"),
+      "Content item {} updated",
+      "Content update guid={} contentId={} path={}"),
 
-  /** Session nearing timeout was revoked / released. */
-  SESSION_REVOKE(
-      1004,
+  DELETE(
+      2003,
       true,
-      AuditEventType.AUTH_SESSION_TIMEOUT,
+      AuditEventType.CONTENT_DELETE,
       AuditOutcome.SUCCESS,
-      "Session revoked for user {}",
-      "Session revoke actor={} sourceIp={}"),
+      "Content item {} deleted",
+      "Content delete guid={} contentId={} path={}"),
 
-  /** Non-auditable operational noise example. */
-  SESSION_CACHE_MISS(
-      1099,
-      false,
-      null,
-      AuditOutcome.UNKNOWN,
-      "Session cache miss for key {}",
-      "Session cache miss key={} detail={}");
+  RECYCLE(
+      2004,
+      true,
+      AuditEventType.CONTENT_RECYCLE,
+      AuditOutcome.SUCCESS,
+      "Content item {} recycled",
+      "Content recycle guid={} contentId={} path={}"),
+
+  PAGE_PUBLISH_SCHEDULE(
+      2005,
+      true,
+      AuditEventType.CONTENT_PUBLISH,
+      AuditOutcome.SUCCESS,
+      "Page publish scheduled for {}",
+      "Page publish schedule guid={} contentId={} path={}"),
+
+  PAGE_REMOVAL_SCHEDULE(
+      2006,
+      true,
+      AuditEventType.CONTENT_UPDATE,
+      AuditOutcome.SUCCESS,
+      "Page removal scheduled for {}",
+      "Page removal schedule guid={} contentId={} path={}");
 
   private final int numericCode;
   private final boolean auditable;
@@ -81,7 +81,7 @@ public enum AuthenticationErrorCodes implements SystemErrorCode {
   private final String userMessageTemplate;
   private final String logMessageTemplate;
 
-  AuthenticationErrorCodes(
+  ContentErrorCodes(
       int numericCode,
       boolean auditable,
       AuditEventType eventType,
@@ -98,7 +98,7 @@ public enum AuthenticationErrorCodes implements SystemErrorCode {
 
   @Override
   public AuditModule module() {
-    return AuditModule.AUTH;
+    return AuditModule.CONT;
   }
 
   @Override

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/UserManagementErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/UserManagementErrorCodes.java
@@ -22,57 +22,49 @@ import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 
 /**
- * High-level authentication <em>audit events</em> (login success/failure/logout).
- *
- * <p>Exception catalog codes that bridge legacy {@code IPSSecurityErrors} ints live in {@link
- * SecurityErrorCodes} (Phase 2b). Prefer this enum for intentional audit emits from login
- * servlets; prefer {@link SecurityErrorCodes} / {@code LegacyErrorCodeRegistry} when handling
- * {@code PSException} error codes.
- *
- * <p>Every constant sets {@link #isAuditable()} explicitly.
+ * User-management administrative audit codes (create / update / delete / password re-encrypt).
+ * Outcome is set at the call site when success and failure share the same code.
  */
-public enum AuthenticationErrorCodes implements SystemErrorCode {
-  LOGIN_SUCCESS(
-      1001,
+public enum UserManagementErrorCodes implements SystemErrorCode {
+  CREATE(
+      3001,
       true,
-      AuditEventType.AUTH_LOGIN,
+      AuditEventType.USER_CREATE,
       AuditOutcome.SUCCESS,
-      "User {} logged in successfully",
-      "Login success actor={} sourceIp={}"),
+      "User {} created",
+      "User create actor={} target={}"),
 
-  LOGIN_FAILURE(
-      1002,
+  UPDATE(
+      3002,
       true,
-      AuditEventType.AUTH_FAILURE,
-      AuditOutcome.FAILURE,
-      "Login failed for user {}",
-      "Login failure actor={} reason={} sourceIp={}"),
-
-  LOGOUT(
-      1003,
-      true,
-      AuditEventType.AUTH_LOGOUT,
+      AuditEventType.USER_UPDATE,
       AuditOutcome.SUCCESS,
-      "User {} logged out",
-      "Logout actor={} sourceIp={}"),
+      "User {} updated",
+      "User update actor={} target={} activity={}"),
 
-  /** Session nearing timeout was revoked / released. */
-  SESSION_REVOKE(
-      1004,
+  DELETE(
+      3003,
       true,
-      AuditEventType.AUTH_SESSION_TIMEOUT,
+      AuditEventType.USER_DELETE,
       AuditOutcome.SUCCESS,
-      "Session revoked for user {}",
-      "Session revoke actor={} sourceIp={}"),
+      "User {} deleted",
+      "User delete actor={} target={}"),
 
-  /** Non-auditable operational noise example. */
-  SESSION_CACHE_MISS(
-      1099,
-      false,
-      null,
-      AuditOutcome.UNKNOWN,
-      "Session cache miss for key {}",
-      "Session cache miss key={} detail={}");
+  DISABLE(
+      3004,
+      true,
+      AuditEventType.USER_DISABLE,
+      AuditOutcome.SUCCESS,
+      "User {} disabled",
+      "User disable actor={} target={}"),
+
+  REVOKE(
+      3005,
+      true,
+      AuditEventType.ROLE_REMOVE,
+      AuditOutcome.SUCCESS,
+      "Permissions revoked for user {}",
+      "User revoke actor={} target={} activity={}");
 
   private final int numericCode;
   private final boolean auditable;
@@ -81,7 +73,7 @@ public enum AuthenticationErrorCodes implements SystemErrorCode {
   private final String userMessageTemplate;
   private final String logMessageTemplate;
 
-  AuthenticationErrorCodes(
+  UserManagementErrorCodes(
       int numericCode,
       boolean auditable,
       AuditEventType eventType,
@@ -98,7 +90,7 @@ public enum AuthenticationErrorCodes implements SystemErrorCode {
 
   @Override
   public AuditModule module() {
-    return AuditModule.AUTH;
+    return AuditModule.USER;
   }
 
   @Override

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WorkflowErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WorkflowErrorCodes.java
@@ -21,58 +21,15 @@ import com.intsof.percussioncms.auditlog.AuditModule;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 
-/**
- * High-level authentication <em>audit events</em> (login success/failure/logout).
- *
- * <p>Exception catalog codes that bridge legacy {@code IPSSecurityErrors} ints live in {@link
- * SecurityErrorCodes} (Phase 2b). Prefer this enum for intentional audit emits from login
- * servlets; prefer {@link SecurityErrorCodes} / {@code LegacyErrorCodeRegistry} when handling
- * {@code PSException} error codes.
- *
- * <p>Every constant sets {@link #isAuditable()} explicitly.
- */
-public enum AuthenticationErrorCodes implements SystemErrorCode {
-  LOGIN_SUCCESS(
-      1001,
+/** Workflow transition audit codes. */
+public enum WorkflowErrorCodes implements SystemErrorCode {
+  TRANSITION(
+      4001,
       true,
-      AuditEventType.AUTH_LOGIN,
+      AuditEventType.WORKFLOW_TRANSITION,
       AuditOutcome.SUCCESS,
-      "User {} logged in successfully",
-      "Login success actor={} sourceIp={}"),
-
-  LOGIN_FAILURE(
-      1002,
-      true,
-      AuditEventType.AUTH_FAILURE,
-      AuditOutcome.FAILURE,
-      "Login failed for user {}",
-      "Login failure actor={} reason={} sourceIp={}"),
-
-  LOGOUT(
-      1003,
-      true,
-      AuditEventType.AUTH_LOGOUT,
-      AuditOutcome.SUCCESS,
-      "User {} logged out",
-      "Logout actor={} sourceIp={}"),
-
-  /** Session nearing timeout was revoked / released. */
-  SESSION_REVOKE(
-      1004,
-      true,
-      AuditEventType.AUTH_SESSION_TIMEOUT,
-      AuditOutcome.SUCCESS,
-      "Session revoked for user {}",
-      "Session revoke actor={} sourceIp={}"),
-
-  /** Non-auditable operational noise example. */
-  SESSION_CACHE_MISS(
-      1099,
-      false,
-      null,
-      AuditOutcome.UNKNOWN,
-      "Session cache miss for key {}",
-      "Session cache miss key={} detail={}");
+      "Workflow transition for content {}",
+      "Workflow transition contentId={} guid={} from={} to={}");
 
   private final int numericCode;
   private final boolean auditable;
@@ -81,7 +38,7 @@ public enum AuthenticationErrorCodes implements SystemErrorCode {
   private final String userMessageTemplate;
   private final String logMessageTemplate;
 
-  AuthenticationErrorCodes(
+  WorkflowErrorCodes(
       int numericCode,
       boolean auditable,
       AuditEventType eventType,
@@ -98,7 +55,7 @@ public enum AuthenticationErrorCodes implements SystemErrorCode {
 
   @Override
   public AuditModule module() {
-    return AuditModule.AUTH;
+    return AuditModule.WF;
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
@@ -38,10 +38,9 @@ import com.percussion.assetmanagement.data.PSInspectedElementsData;
 import com.percussion.assetmanagement.data.PSReportFailedToRunException;
 import com.percussion.assetmanagement.service.IPSAssetService;
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.IPSConstants;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.objectstore.PSCoreItem;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
@@ -138,8 +137,6 @@ import org.springframework.stereotype.Component;
 public class PSAssetService extends PSAbstractFullDataService<PSAsset, PSAssetSummary>
     implements IPSAssetService {
   private IPSItemService itemService;
-  private PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSContentEvent psContentEvent;
 
   /**
    * Constructs an instance of the class.
@@ -1416,27 +1413,21 @@ public class PSAssetService extends PSAbstractFullDataService<PSAsset, PSAssetSu
     final String substring = assetId.substring(assetId.lastIndexOf("-") + 1, assetId.length());
     try {
       assetDao.addItemToPath(item, folderPath);
-
-      psContentEvent =
-          new PSContentEvent(
-              assetId,
-              substring,
-              folderPath,
-              PSContentEvent.ContentEventActions.create,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logContentEvent(psContentEvent);
+      auditAssetCreate(assetId, substring, folderPath, AuditOutcome.SUCCESS);
     } catch (Exception e) {
-      psContentEvent =
-          new PSContentEvent(
-              assetId,
-              substring,
-              folderPath,
-              PSContentEvent.ContentEventActions.create,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.FAILURE);
-      psAuditLogService.logContentEvent(psContentEvent);
+      auditAssetCreate(assetId, substring, folderPath, AuditOutcome.FAILURE);
       throw new PSAssetServiceException("Failed to add asset to folder", e);
+    }
+  }
+
+  private void auditAssetCreate(
+      String guid, String contentId, String path, AuditOutcome outcome) {
+    try {
+      var current = PSSecurityFilter.getCurrentRequest();
+      var servletRequest = current != null ? current.getServletRequest() : null;
+      PSSystemAuditLogger.contentCreate(servletRequest, outcome, guid, contentId, path);
+    } catch (Exception ignored) {
+      // audit must not mask primary failure
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
@@ -27,10 +27,9 @@ import com.percussion.assetmanagement.data.PSAsset;
 import com.percussion.assetmanagement.data.PSReportFailedToRunException;
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
 import com.percussion.assetmanagement.service.impl.PSAssetRestService;
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.objectstore.PSComponentSummary;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.objectstore.PSCoreItem;
 import com.percussion.cms.objectstore.PSRelationshipFilter;
 import com.percussion.design.objectstore.PSLocator;
@@ -180,8 +179,6 @@ public class PSItemService implements IPSItemService {
     this.recycleService = recycleService;
   }
 
-  private PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSContentEvent psContentEvent;
   private SecureKeyRotationListener secureKeyRotationListener;
 
   @Autowired
@@ -1070,41 +1067,28 @@ public class PSItemService implements IPSItemService {
           guid.toString().substring(guid.toString().lastIndexOf("-") + 1, id.length());
 
       if (!"".equals(startDate)) {
-        psContentEvent =
-            new PSContentEvent(
-                guid.toString(),
-                String.valueOf(dependentId),
-                paths.get(0),
-                PSContentEvent.ContentEventActions.pagePublishSchedule,
-                PSSecurityFilter.getCurrentRequest().getServletRequest(),
-                PSActionOutcome.SUCCESS);
-        psAuditLogService.logContentEvent(psContentEvent);
+        auditSchedule(
+            true,
+            guid.toString(),
+            String.valueOf(dependentId),
+            paths.get(0),
+            AuditOutcome.SUCCESS);
       }
       if (!"".equals(endDate)) {
-        psContentEvent =
-            new PSContentEvent(
-                guid.toString(),
-                String.valueOf(dependentId),
-                paths.get(0),
-                PSContentEvent.ContentEventActions.pageRemovalSchedule,
-                PSSecurityFilter.getCurrentRequest().getServletRequest(),
-                PSActionOutcome.SUCCESS);
-        psAuditLogService.logContentEvent(psContentEvent);
+        auditSchedule(
+            false,
+            guid.toString(),
+            String.valueOf(dependentId),
+            paths.get(0),
+            AuditOutcome.SUCCESS);
       }
     } catch (Exception e) {
       List<String> paths = folderHelper.findPaths(idMapper.getString(guid));
       String dependentId =
           guid.toString().substring(guid.toString().lastIndexOf("-") + 1, id.length());
 
-      psContentEvent =
-          new PSContentEvent(
-              guid.toString(),
-              String.valueOf(dependentId),
-              paths.get(0),
-              PSContentEvent.ContentEventActions.pagePublishSchedule,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.FAILURE);
-      psAuditLogService.logContentEvent(psContentEvent);
+      auditSchedule(
+          true, guid.toString(), dependentId, paths.get(0), AuditOutcome.FAILURE);
     }
     String comments = req.getComments();
     if (comments == null || comments.trim().equals("")) {
@@ -1122,6 +1106,23 @@ public class PSItemService implements IPSItemService {
       log.error("Unexpected error occurred while approving the item while scheduling page", e);
     }
     return new PSNoContent("Item with id " + id + " has been Updated");
+  }
+
+  private void auditSchedule(
+      boolean publish, String guid, String contentId, String path, AuditOutcome outcome) {
+    try {
+      var current = PSSecurityFilter.getCurrentRequest();
+      var servletRequest = current != null ? current.getServletRequest() : null;
+      if (publish) {
+        PSSystemAuditLogger.pagePublishSchedule(
+            servletRequest, outcome, guid, contentId, path);
+      } else {
+        PSSystemAuditLogger.pageRemovalSchedule(
+            servletRequest, outcome, guid, contentId, path);
+      }
+    } catch (Exception ignored) {
+      // audit must not mask primary failure
+    }
   }
 
   @GET

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageService.java
@@ -31,10 +31,9 @@ import static org.apache.commons.lang3.Validate.notNull;
 
 import com.percussion.assetmanagement.data.PSReportFailedToRunException;
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.IPSConstants;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.objectstore.PSCoreItem;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.content.PSContentFactory;
@@ -193,8 +192,6 @@ public class PSPageService extends PSAbstractDataService<PSPage, PSPage, String>
   private IPSRecycleService recycleService;
 
   private static final String RECYCLED_TYPE = PSRelationshipConfig.TYPE_RECYCLED_CONTENT;
-
-  private PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
 
   @Autowired
   public PSPageService(
@@ -642,15 +639,16 @@ public class PSPageService extends PSAbstractDataService<PSPage, PSPage, String>
     pageChangeEvent.setType(PSPageChangeEventType.PAGE_SAVED);
     notifyPageChange(pageChangeEvent);
     try {
-      PSContentEvent psContentEvent =
-          new PSContentEvent(
-              page.getId(),
-              page.getId().substring(page.getId().lastIndexOf("-") + 1, page.getId().length()),
-              page.getFolderPath(),
-              PSContentEvent.ContentEventActions.create,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logContentEvent(psContentEvent);
+      var current = PSSecurityFilter.getCurrentRequest();
+      var servletRequest = current != null ? current.getServletRequest() : null;
+      String contentId =
+          page.getId().substring(page.getId().lastIndexOf("-") + 1, page.getId().length());
+      PSSystemAuditLogger.contentCreate(
+          servletRequest,
+          AuditOutcome.SUCCESS,
+          page.getId(),
+          contentId,
+          page.getFolderPath());
     } catch (Exception e) {
       // Handling exception
     }

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathService.java
@@ -17,9 +17,8 @@
  */
 package com.percussion.pathmanagement.service.impl;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
 import com.percussion.pathmanagement.data.PSDeleteFolderCriteria;
@@ -86,8 +85,7 @@ import org.springframework.context.ApplicationContextAware;
 @Path("/path")
 public class PSPathService extends PSDispatchingPathService
     implements IPSPathService, ApplicationContextAware, InitializingBean {
-  private final PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSContentEvent psContentEvent;
+
 
   private final IPSFolderHelper folderHelper;
 
@@ -554,15 +552,18 @@ public class PSPathService extends PSDispatchingPathService
           getSiteNameFromFolderPath(criteria.getPath()),
           "deleteFolderService",
           PSSiteCopyUtils.CAN_NOT_DELETE_FOLDER);
-      psContentEvent =
-          new PSContentEvent(
-              criteria.getGuid(),
-              String.valueOf(iGuid),
-              criteria.getPath(),
-              PSContentEvent.ContentEventActions.delete,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logContentEvent(psContentEvent);
+      try {
+        var current = PSSecurityFilter.getCurrentRequest();
+        var servletRequest = current != null ? current.getServletRequest() : null;
+        PSSystemAuditLogger.contentDelete(
+            servletRequest,
+            AuditOutcome.SUCCESS,
+            criteria.getGuid(),
+            String.valueOf(iGuid),
+            criteria.getPath());
+      } catch (Exception auditEx) {
+        // audit must not mask primary path delete
+      }
     }
 
     return String.valueOf(super.deleteFolder(criteria));

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
@@ -20,9 +20,8 @@ package com.percussion.recycle.service.impl;
 
 import static org.apache.commons.lang3.Validate.notEmpty;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.handlers.PSRelationshipCommandHandler;
 import com.percussion.cms.objectstore.IPSFieldValue;
@@ -87,8 +86,7 @@ import org.springframework.stereotype.Component;
 @Component("recycleService")
 @Lazy
 public class PSRecycleService implements IPSRecycleService {
-  private final PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSContentEvent psContentEvent;
+
 
   /** Logger for this class. */
   private static final Logger log = LogManager.getLogger(PSRecycleService.class);
@@ -291,35 +289,30 @@ public class PSRecycleService implements IPSRecycleService {
       // Detach page/template widgets still bound to this content id so assembly does not keep
       // rendering recycled assets (perc-recycled-asset chrome / red border). See #777 / #2238.
       clearWidgetRelationshipsForRecycledItem(itemGuid);
-      psContentEvent =
-          new PSContentEvent(
-              itemGuid.toString(),
-              String.valueOf(dependentId),
-              path,
-              PSContentEvent.ContentEventActions.recycle,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logContentEvent(psContentEvent);
+      auditRecycle(itemGuid.toString(), String.valueOf(dependentId), path, AuditOutcome.SUCCESS);
     } catch (PSErrorsException
         | PSErrorException
         | PSErrorResultsException
         | PSCmsException
         | IPSDataService.DataServiceLoadException
         | PSValidationException e) {
-      psContentEvent =
-          new PSContentEvent(
-              itemGuid.toString(),
-              String.valueOf(dependentId),
-              path,
-              PSContentEvent.ContentEventActions.recycle,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.FAILURE);
-      psAuditLogService.logContentEvent(psContentEvent);
+      auditRecycle(itemGuid.toString(), String.valueOf(dependentId), path, AuditOutcome.FAILURE);
       log.error(
           "Unable to recycle item with dependent id: {} Error: {}",
           dependentId,
           PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+    }
+  }
+
+  private void auditRecycle(
+      String guid, String contentId, String path, AuditOutcome outcome) {
+    try {
+      var current = PSSecurityFilter.getCurrentRequest();
+      var servletRequest = current != null ? current.getServletRequest() : null;
+      PSSystemAuditLogger.contentRecycle(servletRequest, outcome, guid, contentId, path);
+    } catch (Exception ignored) {
+      // audit must not mask primary failure
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
@@ -25,10 +25,9 @@ import static org.apache.commons.lang3.Validate.isTrue;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.IPSConstants;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.objectstore.IPSFieldValue;
 import com.percussion.cms.objectstore.PSCoreItem;
 import com.percussion.cms.objectstore.server.PSPurgableFileValue;
@@ -83,9 +82,6 @@ public class PSContentItemDao implements IPSContentItemDao {
   private IPSFolderHelper folderHelper;
   private IPSRelationshipCataloger relationshipHelper;
   private IPSSystemWs systemWs;
-  private PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSContentEvent psContentEvent;
-
   @Autowired
   public PSContentItemDao(
       IPSContentDesignWs contentDesignWs,
@@ -233,26 +229,21 @@ public class PSContentItemDao implements IPSContentItemDao {
       }
       contentWs.deleteItems(asList(guid));
       substring = uid.substring(uid.lastIndexOf("-") + 1, id.length());
-      psContentEvent =
-          new PSContentEvent(
-              id,
-              substring,
-              path,
-              PSContentEvent.ContentEventActions.delete,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logContentEvent(psContentEvent);
+      auditContentDelete(id, substring, path, AuditOutcome.SUCCESS);
     } catch (Exception e) {
-      psContentEvent =
-          new PSContentEvent(
-              id,
-              substring,
-              path,
-              PSContentEvent.ContentEventActions.delete,
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSActionOutcome.FAILURE);
-      psAuditLogService.logContentEvent(psContentEvent);
+      auditContentDelete(id, substring, path, AuditOutcome.FAILURE);
       throw new DeleteException("Failed to delete content item: " + id, convertException(e));
+    }
+  }
+
+  private void auditContentDelete(
+      String guid, String contentId, String path, AuditOutcome outcome) {
+    try {
+      var current = PSSecurityFilter.getCurrentRequest();
+      var servletRequest = current != null ? current.getServletRequest() : null;
+      PSSystemAuditLogger.contentDelete(servletRequest, outcome, guid, contentId, path);
+    } catch (Exception auditEx) {
+      // audit must not mask primary failure
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSUserLoginDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSUserLoginDao.java
@@ -17,10 +17,9 @@
  */
 package com.percussion.sitemanage.dao.impl;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSUserManagementEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.IPSConstants;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.servlets.PSSecurityFilter;
 import com.percussion.share.dao.IPSGenericDao;
 import com.percussion.share.service.exception.PSDataServiceException;
@@ -52,9 +51,6 @@ public class PSUserLoginDao implements IPSUserLoginDao {
 
   private static final Logger log = LogManager.getLogger(IPSConstants.SECURITY_LOG);
 
-  private final PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSUserManagementEvent psUserManagementEvent;
-
   /* (non-Javadoc)
    * Legacy delete that used to be declared on IPSGenericDao.  The current
    * interface now uses `remove` instead, so this method is kept for
@@ -73,12 +69,7 @@ public class PSUserLoginDao implements IPSUserLoginDao {
       }
       session.remove(login);
     } catch (HibernateException he) {
-      psUserManagementEvent =
-          new PSUserManagementEvent(
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSUserManagementEvent.UserEventActions.delete,
-              PSActionOutcome.FAILURE);
-      psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+      auditUser(name, UserAuditKind.DELETE, AuditOutcome.FAILURE);
       emsg = "database error " + he.getMessage();
       log.error(emsg);
       throw new IPSGenericDao.DeleteException(emsg, he);
@@ -191,12 +182,7 @@ public class PSUserLoginDao implements IPSUserLoginDao {
       l2.setPassword(login.getPassword());
       session.merge(l2);
     } catch (HibernateException he) {
-      psUserManagementEvent =
-          new PSUserManagementEvent(
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSUserManagementEvent.UserEventActions.update,
-              PSActionOutcome.FAILURE);
-      psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+      auditUser(login.getUserid(), UserAuditKind.UPDATE, AuditOutcome.FAILURE);
       emsg = "database error " + he.getMessage();
       log.error(emsg);
       throw new IPSGenericDao.SaveException(emsg, he);
@@ -216,25 +202,37 @@ public class PSUserLoginDao implements IPSUserLoginDao {
     var session = getSession();
     try {
       session.persist(login);
-      psUserManagementEvent =
-          new PSUserManagementEvent(
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSUserManagementEvent.UserEventActions.create,
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+      auditUser(login.getUserid(), UserAuditKind.CREATE, AuditOutcome.SUCCESS);
     } catch (HibernateException he) {
       emsg = "database error " + he.getMessage();
       log.error(emsg);
-      psUserManagementEvent =
-          new PSUserManagementEvent(
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSUserManagementEvent.UserEventActions.create,
-              PSActionOutcome.FAILURE);
-      psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+      auditUser(login.getUserid(), UserAuditKind.CREATE, AuditOutcome.FAILURE);
       throw new IPSGenericDao.SaveException(emsg, he);
     } finally {
       session.flush();
     }
     return login;
+  }
+
+  private enum UserAuditKind {
+    CREATE,
+    UPDATE,
+    DELETE
+  }
+
+  private void auditUser(String targetUser, UserAuditKind kind, AuditOutcome outcome) {
+    try {
+      var current = PSSecurityFilter.getCurrentRequest();
+      var servletRequest = current != null ? current.getServletRequest() : null;
+      switch (kind) {
+        case CREATE -> PSSystemAuditLogger.userCreate(servletRequest, outcome, targetUser);
+        case UPDATE ->
+            PSSystemAuditLogger.userUpdate(servletRequest, outcome, targetUser, "login-dao");
+        case DELETE -> PSSystemAuditLogger.userDelete(servletRequest, outcome, targetUser);
+      }
+    } catch (Exception e) {
+      log.error("Failed to write user audit event: {}", e.getMessage());
+      log.debug(e);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
@@ -27,9 +27,8 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.PSFolder;
@@ -130,8 +129,7 @@ public class PSSiteSectionService implements IPSSiteSectionService {
 
   private static final String NAVON_FIELD_CSSCLASSNAMES = "cssClassNames";
 
-  private PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSContentEvent psContentEvent;
+
 
   /** The navigation service, initialized by constructor. */
   private IPSManagedNavService navSrv;
@@ -291,17 +289,12 @@ public class PSSiteSectionService implements IPSSiteSectionService {
     if (sites.get(0).isSecure()) {
       removeSiteTouchedFile(sites.get(0).getName());
     }
-    psContentEvent =
-        new PSContentEvent(
-            section.getId(),
-            section
-                .getId()
-                .substring(section.getId().lastIndexOf("-") + 1, section.getId().length()),
-            section.getFolderPath(),
-            PSContentEvent.ContentEventActions.create,
-            PSSecurityFilter.getCurrentRequest().getServletRequest(),
-            PSActionOutcome.SUCCESS);
-    psAuditLogService.logContentEvent(psContentEvent);
+    auditSection(
+        section.getId(),
+        section.getId().substring(section.getId().lastIndexOf("-") + 1, section.getId().length()),
+        section.getFolderPath(),
+        SectionAuditKind.CREATE,
+        AuditOutcome.SUCCESS);
     return section;
   }
 
@@ -1321,15 +1314,12 @@ public class PSSiteSectionService implements IPSSiteSectionService {
     if (!req.isSiteRootSection() && sites.get(0).isSecure()) {
       removeSiteTouchedFile(sites.get(0).getName());
     }
-    psContentEvent =
-        new PSContentEvent(
-            req.getId(),
-            req.getId().substring(req.getId().lastIndexOf("-") + 1, req.getId().length()),
-            req.getFolderName(),
-            PSContentEvent.ContentEventActions.update,
-            PSSecurityFilter.getCurrentRequest().getServletRequest(),
-            PSActionOutcome.SUCCESS);
-    psAuditLogService.logContentEvent(psContentEvent);
+    auditSection(
+        req.getId(),
+        req.getId().substring(req.getId().lastIndexOf("-") + 1, req.getId().length()),
+        req.getFolderName(),
+        SectionAuditKind.UPDATE,
+        AuditOutcome.SUCCESS);
     return load(req.getId());
   }
 
@@ -1900,17 +1890,36 @@ public class PSSiteSectionService implements IPSSiteSectionService {
     }
     sectionIds.add(idMapper.getGuid(section.getId()));
     contentSrv.deleteItems(sectionIds);
-    psContentEvent =
-        new PSContentEvent(
-            section.getId(),
-            section
-                .getId()
-                .substring(section.getId().lastIndexOf("-") + 1, section.getId().length()),
-            section.getFolderPath(),
-            PSContentEvent.ContentEventActions.delete,
-            PSSecurityFilter.getCurrentRequest().getServletRequest(),
-            PSActionOutcome.SUCCESS);
-    psAuditLogService.logContentEvent(psContentEvent);
+    auditSection(
+        section.getId(),
+        section.getId().substring(section.getId().lastIndexOf("-") + 1, section.getId().length()),
+        section.getFolderPath(),
+        SectionAuditKind.DELETE,
+        AuditOutcome.SUCCESS);
+  }
+
+  private enum SectionAuditKind {
+    CREATE,
+    UPDATE,
+    DELETE
+  }
+
+  private void auditSection(
+      String guid, String contentId, String path, SectionAuditKind kind, AuditOutcome outcome) {
+    try {
+      var current = PSSecurityFilter.getCurrentRequest();
+      var servletRequest = current != null ? current.getServletRequest() : null;
+      switch (kind) {
+        case CREATE ->
+            PSSystemAuditLogger.contentCreate(servletRequest, outcome, guid, contentId, path);
+        case UPDATE ->
+            PSSystemAuditLogger.contentUpdate(servletRequest, outcome, guid, contentId, path);
+        case DELETE ->
+            PSSystemAuditLogger.contentDelete(servletRequest, outcome, guid, contentId, path);
+      }
+    } catch (Exception ignored) {
+      // audit must not mask primary failure
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -31,10 +31,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.Validate.isTrue;
 import static org.apache.commons.lang3.Validate.notNull;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSUserManagementEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.IPSConstants;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.PSFolder;
 import com.percussion.design.objectstore.PSAttribute;
@@ -260,8 +259,6 @@ public class PSUserService implements IPSUserService {
   public static final String DIRECTORY_SET_NAME = "DirectorySet";
 
   public static final List<String> SYSTEM_USERS = asList(RXSERVER_NAME, PERCUSSION_ADMIN_NAME);
-  private final PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSUserManagementEvent psUserManagementEvent;
 
   @Autowired
   public PSUserService(
@@ -598,12 +595,7 @@ public class PSUserService implements IPSUserService {
       userLoginDao.remove(name);
     }
     try {
-      psUserManagementEvent =
-          new PSUserManagementEvent(
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSUserManagementEvent.UserEventActions.delete,
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+      PSSystemAuditLogger.userDelete(currentServletRequest(), AuditOutcome.SUCCESS, name);
     } catch (Exception e) {
       // Just handling exception
     }
@@ -781,12 +773,8 @@ public class PSUserService implements IPSUserService {
       rvalue.setEmail(user.getEmail());
     }
     try {
-      psUserManagementEvent =
-          new PSUserManagementEvent(
-              PSSecurityFilter.getCurrentRequest().getServletRequest(),
-              PSUserManagementEvent.UserEventActions.update,
-              PSActionOutcome.SUCCESS);
-      psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+      PSSystemAuditLogger.userUpdate(
+          currentServletRequest(), AuditOutcome.SUCCESS, user.getName(), "update");
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -945,7 +933,7 @@ public class PSUserService implements IPSUserService {
       backEndRoleMgr.setSubjectEmail(current.getName(), email);
     } catch (RuntimeException e) {
       // Persist failed — audit FAILURE so the trail is not silent, then rethrow.
-      logSelfServiceAccountUpdateAudit(PSActionOutcome.FAILURE);
+      logSelfServiceAccountUpdateAudit(AuditOutcome.FAILURE);
       log.error(
           "Self-service email update failed for user {}: {}",
           current.getName(),
@@ -955,7 +943,7 @@ public class PSUserService implements IPSUserService {
     }
 
     // Persist succeeded — only then record SUCCESS (not before end-to-end completion of the write).
-    logSelfServiceAccountUpdateAudit(PSActionOutcome.SUCCESS);
+    logSelfServiceAccountUpdateAudit(AuditOutcome.SUCCESS);
 
     // Return the already-loaded session user with the new email applied. Avoid a second
     // getCurrentUser() which can fail after the write (session/directory) with no rollback.
@@ -967,20 +955,26 @@ public class PSUserService implements IPSUserService {
    * Best-effort audit for self-service account updates. Never throws — audit infrastructure must
    * not mask the primary operation outcome.
    */
-  private void logSelfServiceAccountUpdateAudit(PSActionOutcome outcome) {
+  private void logSelfServiceAccountUpdateAudit(AuditOutcome outcome) {
     try {
       PSRequest req = PSSecurityFilter.getCurrentRequest();
       if (req != null && req.getServletRequest() != null) {
-        psUserManagementEvent =
-            new PSUserManagementEvent(
-                req.getServletRequest(),
-                PSUserManagementEvent.UserEventActions.update,
-                outcome);
-        psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+        String actor = req.getServletRequest().getRemoteUser();
+        PSSystemAuditLogger.userUpdate(
+            req.getServletRequest(), outcome, actor, "self-service-account");
       }
     } catch (Exception e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+    }
+  }
+
+  private static jakarta.servlet.http.HttpServletRequest currentServletRequest() {
+    try {
+      PSRequest req = PSSecurityFilter.getCurrentRequest();
+      return req != null ? req.getServletRequest() : null;
+    } catch (Exception e) {
+      return null;
     }
   }
 
@@ -1622,12 +1616,13 @@ public class PSUserService implements IPSUserService {
 
       for (PSExternalUser e : users) {
         userNames.add(e.getName());
-        psUserManagementEvent =
-            new PSUserManagementEvent(
-                PSSecurityFilter.getCurrentRequest().getServletRequest(),
-                PSUserManagementEvent.UserEventActions.create,
-                PSActionOutcome.SUCCESS);
-        psAuditLogService.logUserManagementEvent(psUserManagementEvent);
+        try {
+          PSSystemAuditLogger.userCreate(
+              currentServletRequest(), AuditOutcome.SUCCESS, e.getName());
+        } catch (Exception auditEx) {
+          log.error(PSExceptionUtils.getMessageForLog(auditEx));
+          log.debug(PSExceptionUtils.getDebugMessageForLog(auditEx));
+        }
       }
 
       List<PSImportedUser> importedUsers = importUsers(userNames);

--- a/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
+++ b/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
@@ -24,12 +24,17 @@ import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.UserManagementErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
- * Thin facade for system code to emit system-wide audit events without depending on Spring at the
- * call site. Uses {@link DefaultAuditLogService.Holder} (Log4j + memory until JPA repository
- * registers).
+ * Thin facade for system and sitemanage code to emit system-wide audit events without depending on
+ * Spring or legacy CADF event classes at the call site. Uses {@link DefaultAuditLogService.Holder}
+ * (Log4j + memory until JPA repository registers).
+ *
+ * <p>Phase 2a migrates production {@code PSAuditLogService} call sites to these helpers.
  *
  * <p>Phase 2b: use {@link #logLegacyIfAuditable(int, AuditContext, Object...)} for legacy {@code
  * IPS*Errors} ints so non-auditable codes never dual-write.
@@ -105,12 +110,191 @@ public final class PSSystemAuditLogger {
         ip);
   }
 
+  /**
+   * Session near-timeout revoke (formerly {@code PSAuthenticationEvent} with action {@code
+   * revoke}).
+   */
+  public static void sessionRevoke(HttpServletRequest request, String username) {
+    String actor = nullToEmpty(username);
+    String ip = clientIp(request);
+    log(
+        AuthenticationErrorCodes.SESSION_REVOKE,
+        context(request, actor),
+        AuditOutcome.SUCCESS,
+        actor,
+        ip);
+  }
+
+  /** Content create / update / delete / recycle / schedule dual-write. */
+  public static void content(
+      ContentErrorCodes code,
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String guid,
+      String contentId,
+      String path) {
+    String g = nullToEmpty(guid);
+    String cid = nullToEmpty(contentId);
+    String p = nullToEmpty(path);
+    AuditOutcome o = outcome != null ? outcome : code.defaultOutcome();
+    log(code, contentContext(request, g), o, g, cid, p);
+  }
+
+  public static void contentCreate(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String guid,
+      String contentId,
+      String path) {
+    content(ContentErrorCodes.CREATE, request, outcome, guid, contentId, path);
+  }
+
+  public static void contentUpdate(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String guid,
+      String contentId,
+      String path) {
+    content(ContentErrorCodes.UPDATE, request, outcome, guid, contentId, path);
+  }
+
+  public static void contentDelete(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String guid,
+      String contentId,
+      String path) {
+    content(ContentErrorCodes.DELETE, request, outcome, guid, contentId, path);
+  }
+
+  public static void contentRecycle(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String guid,
+      String contentId,
+      String path) {
+    content(ContentErrorCodes.RECYCLE, request, outcome, guid, contentId, path);
+  }
+
+  public static void pagePublishSchedule(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String guid,
+      String contentId,
+      String path) {
+    content(ContentErrorCodes.PAGE_PUBLISH_SCHEDULE, request, outcome, guid, contentId, path);
+  }
+
+  public static void pageRemovalSchedule(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String guid,
+      String contentId,
+      String path) {
+    content(ContentErrorCodes.PAGE_REMOVAL_SCHEDULE, request, outcome, guid, contentId, path);
+  }
+
+  /**
+   * User-management dual-write. {@code targetUser} is the account being acted on; actor comes from
+   * the request remote user when present.
+   */
+  public static void userManagement(
+      UserManagementErrorCodes code,
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String targetUser,
+      String activity) {
+    String actor = remoteUser(request);
+    String target = nullToEmpty(targetUser);
+    if (target.isEmpty()) {
+      target = actor;
+    }
+    AuditOutcome o = outcome != null ? outcome : code.defaultOutcome();
+    AuditContext ctx =
+        AuditContext.builder()
+            .actor(actor)
+            .target(target)
+            .sourceIp(clientIp(request))
+            .sourceHost(sourceHost(request))
+            .attribute("activity", nullToEmpty(activity))
+            .build();
+    if (code == UserManagementErrorCodes.CREATE || code == UserManagementErrorCodes.DELETE) {
+      log(code, ctx, o, actor, target);
+    } else {
+      log(code, ctx, o, actor, target, nullToEmpty(activity));
+    }
+  }
+
+  public static void userCreate(
+      HttpServletRequest request, AuditOutcome outcome, String targetUser) {
+    userManagement(UserManagementErrorCodes.CREATE, request, outcome, targetUser, "");
+  }
+
+  public static void userUpdate(
+      HttpServletRequest request, AuditOutcome outcome, String targetUser, String activity) {
+    userManagement(UserManagementErrorCodes.UPDATE, request, outcome, targetUser, activity);
+  }
+
+  public static void userDelete(
+      HttpServletRequest request, AuditOutcome outcome, String targetUser) {
+    userManagement(UserManagementErrorCodes.DELETE, request, outcome, targetUser, "");
+  }
+
+  /** Workflow transition dual-write. */
+  public static void workflowTransition(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String contentId,
+      String guid,
+      String fromState,
+      String toState) {
+    String cid = nullToEmpty(contentId);
+    String g = nullToEmpty(guid);
+    String from = nullToEmpty(fromState);
+    String to = nullToEmpty(toState);
+    AuditOutcome o = outcome != null ? outcome : AuditOutcome.SUCCESS;
+    AuditContext ctx =
+        AuditContext.builder()
+            .actor(remoteUser(request))
+            .target(g.isEmpty() ? cid : g)
+            .sourceIp(clientIp(request))
+            .sourceHost(sourceHost(request))
+            .attribute("contentId", cid)
+            .attribute("fromState", from)
+            .attribute("toState", to)
+            .build();
+    log(WorkflowErrorCodes.TRANSITION, ctx, o, cid, g, from, to);
+  }
+
+  private static AuditContext contentContext(HttpServletRequest request, String guid) {
+    return AuditContext.builder()
+        .actor(remoteUser(request))
+        .target(nullToEmpty(guid))
+        .sourceIp(clientIp(request))
+        .sourceHost(sourceHost(request))
+        .build();
+  }
+
   private static AuditContext context(HttpServletRequest request, String actor) {
     AuditContext.Builder b = AuditContext.builder().actor(actor);
     if (request != null) {
       b.sourceIp(clientIp(request)).sourceHost(request.getRemoteHost());
     }
     return b.build();
+  }
+
+  private static String remoteUser(HttpServletRequest request) {
+    if (request == null) {
+      return "";
+    }
+    return nullToEmpty(request.getRemoteUser());
+  }
+
+  private static String sourceHost(HttpServletRequest request) {
+    if (request == null) {
+      return "";
+    }
+    return nullToEmpty(request.getRemoteHost());
   }
 
   private static String clientIp(HttpServletRequest request) {

--- a/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
+++ b/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
@@ -204,7 +204,28 @@ public final class PSSystemAuditLogger {
       AuditOutcome outcome,
       String targetUser,
       String activity) {
-    String actor = remoteUser(request);
+    userManagement(code, request, outcome, targetUser, activity, null);
+  }
+
+  /**
+   * User-management dual-write with an optional explicit actor (e.g. {@code "system"} for automated
+   * password re-encryption during authentication when {@link HttpServletRequest#getRemoteUser()} is
+   * not yet the operator of record).
+   *
+   * @param actorOverride when non-blank, used as the audit actor instead of {@code
+   *     request.getRemoteUser()}
+   */
+  public static void userManagement(
+      UserManagementErrorCodes code,
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String targetUser,
+      String activity,
+      String actorOverride) {
+    String actor =
+        (actorOverride != null && !actorOverride.isBlank())
+            ? actorOverride.trim()
+            : remoteUser(request);
     String target = nullToEmpty(targetUser);
     if (target.isEmpty()) {
       target = actor;
@@ -233,6 +254,18 @@ public final class PSSystemAuditLogger {
   public static void userUpdate(
       HttpServletRequest request, AuditOutcome outcome, String targetUser, String activity) {
     userManagement(UserManagementErrorCodes.UPDATE, request, outcome, targetUser, activity);
+  }
+
+  /**
+   * User update with an explicit actor (use {@code "system"} for automated security maintenance).
+   */
+  public static void userUpdate(
+      HttpServletRequest request,
+      AuditOutcome outcome,
+      String targetUser,
+      String activity,
+      String actor) {
+    userManagement(UserManagementErrorCodes.UPDATE, request, outcome, targetUser, activity, actor);
   }
 
   public static void userDelete(

--- a/system/services/src/com/percussion/services/sitemgr/impl/PSSiteManager.java
+++ b/system/services/src/com/percussion/services/sitemgr/impl/PSSiteManager.java
@@ -17,10 +17,9 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.sitemgr.impl;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSContentEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.PSCmsException;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.objectstore.PSFolder;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.security.error.PSExceptionUtils;
@@ -110,8 +109,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Transactional
 public class PSSiteManager implements IPSSiteManager {
 
-    private final PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -171,17 +168,14 @@ public class PSSiteManager implements IPSSiteManager {
 
         try {
             var currentRequest = PSSecurityFilter.getCurrentRequest();
-            if (currentRequest != null && currentRequest.getServletRequest() != null) {
-                var psContentEvent = new PSContentEvent(
-                    newsite.getSiteId().toString(),
-                    newsite.getSiteId().toString(),
-                    newsite.getBaseUrl(),
-                    PSContentEvent.ContentEventActions.create,
-                    currentRequest.getServletRequest(),
-                    PSActionOutcome.SUCCESS
-                );
-                psAuditLogService.logContentEvent(psContentEvent);
-            }
+            var servletRequest =
+                currentRequest != null ? currentRequest.getServletRequest() : null;
+            PSSystemAuditLogger.contentCreate(
+                servletRequest,
+                AuditOutcome.SUCCESS,
+                newsite.getSiteId().toString(),
+                newsite.getSiteId().toString(),
+                newsite.getBaseUrl());
         } catch (Exception e) {
             log.warn("Failed to log content event for site creation: {}", e.getMessage());
             log.debug("Full stack trace:", e);

--- a/system/services/src/com/percussion/services/sitemgr/impl/PSSiteManager.java
+++ b/system/services/src/com/percussion/services/sitemgr/impl/PSSiteManager.java
@@ -168,14 +168,15 @@ public class PSSiteManager implements IPSSiteManager {
 
         try {
             var currentRequest = PSSecurityFilter.getCurrentRequest();
-            var servletRequest =
-                currentRequest != null ? currentRequest.getServletRequest() : null;
-            PSSystemAuditLogger.contentCreate(
-                servletRequest,
-                AuditOutcome.SUCCESS,
-                newsite.getSiteId().toString(),
-                newsite.getSiteId().toString(),
-                newsite.getBaseUrl());
+            // Match legacy CADF semantics: skip audit when there is no request context.
+            if (currentRequest != null && currentRequest.getServletRequest() != null) {
+                PSSystemAuditLogger.contentCreate(
+                    currentRequest.getServletRequest(),
+                    AuditOutcome.SUCCESS,
+                    newsite.getSiteId().toString(),
+                    newsite.getSiteId().toString(),
+                    newsite.getBaseUrl());
+            }
         } catch (Exception e) {
             log.warn("Failed to log content event for site creation: {}", e.getMessage());
             log.debug("Full stack trace:", e);

--- a/system/src/main/java/com/percussion/cms/handlers/PSWorkflowCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSWorkflowCommandHandler.java
@@ -19,10 +19,9 @@ package com.percussion.cms.handlers;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSWorkflowEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.cms.IPSConstants;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.cms.PSApplicationBuilder;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.PSDisplayFieldElementBuilder;
@@ -103,9 +102,6 @@ import org.w3c.dom.Text;
 
 /** This class encapsulates behaviour to handle all workflow related commands. */
 public class PSWorkflowCommandHandler extends PSCommandHandler {
-  private PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
-  private PSWorkflowEvent psWorkflowEvent;
-
   /** Logger */
   private static final Logger ms_logger = LogManager.getLogger(IPSConstants.WORKFLOW_LOG);
 
@@ -534,17 +530,18 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
         wfAction = "Quick Edit";
       }
 
-      psWorkflowEvent =
-          new PSWorkflowEvent(
-              wfAction,
-              currentState,
-              PSWorkflowEvent.WorkflowEventActions.update,
-              req.getServletRequest(),
-              req.getParameter("sys_contentid"),
-              ps.toString(),
-              PSActionOutcome.SUCCESS.name());
-
-      psAuditLogService.logWorkflowEvent(psWorkflowEvent);
+      try {
+        PSSystemAuditLogger.workflowTransition(
+            req.getServletRequest(),
+            AuditOutcome.SUCCESS,
+            req.getParameter("sys_contentid"),
+            ps.toString(),
+            wfAction,
+            currentState);
+      } catch (Exception auditEx) {
+        ms_logger.error("Failed to write workflow audit event: {}", auditEx.getMessage());
+        ms_logger.debug(auditEx);
+      }
 
       return execData;
     } finally {

--- a/system/src/main/java/com/percussion/cms/handlers/PSWorkflowCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSWorkflowCommandHandler.java
@@ -468,6 +468,24 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
       // Just make sure to reset the flag to null
       req.setPrivateObject(IPSConstants.WF_ACTION_PERFORMED, null);
 
+      // Capture workflow state before transition for accurate audit from→to mapping.
+      String fromStateName = "";
+      try {
+        String contentIdParam = req.getParameter("sys_contentid");
+        if (contentIdParam != null && !contentIdParam.isBlank()) {
+          PSComponentSummary preSummary =
+              PSWebserviceUtils.getItemSummary(Integer.parseInt(contentIdParam));
+          PSWorkflow preWf = PSWebserviceUtils.getWorkflow(preSummary.getWorkflowAppId());
+          PSState preState =
+              PSWebserviceUtils.getStateById(preWf, preSummary.getContentStateId());
+          if (preState != null && preState.getName() != null) {
+            fromStateName = preState.getName();
+          }
+        }
+      } catch (Exception e) {
+        ms_logger.debug("Could not resolve pre-transition workflow state for audit", e);
+      }
+
       // run pre exits, which performs the actual checkin/chkout or
       // workflow transitions (if requested)
       runPreProcessingExtensions(execData);
@@ -524,11 +542,8 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
       PSWorkflow wf = PSWebserviceUtils.getWorkflow(summary.getWorkflowAppId());
       PSState currState = PSWebserviceUtils.getStateById(wf, summary.getContentStateId());
       PSLegacyGuid ps = new PSLegacyGuid(summary.getContentId(), summary.getCurrRevision());
-      String currentState = currState.getName();
-
-      if (!wfAction.equalsIgnoreCase("Pending")) {
-        wfAction = "Quick Edit";
-      }
+      // Post-transition state is the audit "to" state; "from" was captured before pre-exits.
+      String toStateName = currState != null ? currState.getName() : "";
 
       try {
         PSSystemAuditLogger.workflowTransition(
@@ -536,8 +551,8 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
             AuditOutcome.SUCCESS,
             req.getParameter("sys_contentid"),
             ps.toString(),
-            wfAction,
-            currentState);
+            fromStateName,
+            toStateName);
       } catch (Exception auditEx) {
         ms_logger.error("Failed to write workflow audit event: {}", auditEx.getMessage());
         ms_logger.debug(auditEx);

--- a/system/src/main/java/com/percussion/security/PSBackEndTableProvider.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndTableProvider.java
@@ -16,10 +16,9 @@
  */
 package com.percussion.security;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSUserManagementEvent;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.percussion.design.objectstore.PSAttributeList;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.design.objectstore.PSProvider;
 import com.percussion.design.objectstore.PSSubject;
 import jakarta.servlet.http.HttpServletRequest;
@@ -72,19 +71,22 @@ public class PSBackEndTableProvider extends PSSecurityProvider {
    * @param action The activity taken
    * @param activityMsg The action taken
    */
-  private void auditlogUserActivity(
-      String uid, PSUserManagementEvent.UserEventActions action, String activityMsg) {
-
-    PSAuditLogService auditLogService = PSAuditLogService.getInstance();
-
-    HttpServletRequest httpRequest = PSThreadRequestUtils.getPSRequest().getServletRequest();
-
-    PSUserManagementEvent event =
-        new PSUserManagementEvent(httpRequest, action, PSActionOutcome.SUCCESS);
-    event.setTargetUsername(uid);
-    event.setIniatorName("system");
-    event.setActivity(activityMsg);
-    auditLogService.logUserManagementEvent(event);
+  private void auditlogUserActivity(String uid, String activityMsg) {
+    HttpServletRequest httpRequest = null;
+    try {
+      var psRequest = PSThreadRequestUtils.getPSRequest();
+      if (psRequest != null) {
+        httpRequest = psRequest.getServletRequest();
+      }
+    } catch (Exception ignored) {
+      // fall through with null request
+    }
+    try {
+      PSSystemAuditLogger.userUpdate(httpRequest, AuditOutcome.SUCCESS, uid, activityMsg);
+    } catch (Exception auditEx) {
+      log.error("Failed to write user-management audit event: {}", auditEx.getMessage());
+      log.debug(auditEx);
+    }
   }
 
   /**
@@ -159,7 +161,6 @@ public class PSBackEndTableProvider extends PSSecurityProvider {
             m_backendConnection.updateUserPassword(uid, filter.encrypt(pw));
             auditlogUserActivity(
                 uid,
-                PSUserManagementEvent.UserEventActions.update,
                 String.format(
                     "Security Update: Re-encrypting password for database user: {%s} from legacy"
                         + " algorithm {%s} to current algorithm {%s}",
@@ -187,7 +188,6 @@ public class PSBackEndTableProvider extends PSSecurityProvider {
             m_backendConnection.updateUserPassword(uid, filter.encrypt(pw));
             auditlogUserActivity(
                 uid,
-                PSUserManagementEvent.UserEventActions.update,
                 String.format(
                     "Security Update: Re-encrypting password for database user: {%s} from legacy"
                         + " algorithm: {%s} to current algorithm: {%s}",

--- a/system/src/main/java/com/percussion/security/PSBackEndTableProvider.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndTableProvider.java
@@ -82,7 +82,9 @@ public class PSBackEndTableProvider extends PSSecurityProvider {
       // fall through with null request
     }
     try {
-      PSSystemAuditLogger.userUpdate(httpRequest, AuditOutcome.SUCCESS, uid, activityMsg);
+      // Automated password re-encryption is system-initiated (legacy CADF setIniatorName("system")).
+      PSSystemAuditLogger.userUpdate(
+          httpRequest, AuditOutcome.SUCCESS, uid, activityMsg, "system");
     } catch (Exception auditEx) {
       log.error("Failed to write user-management audit event: {}", auditEx.getMessage());
       log.debug(auditEx);

--- a/system/src/main/java/com/percussion/servlets/PSSecurityFilter.java
+++ b/system/src/main/java/com/percussion/servlets/PSSecurityFilter.java
@@ -18,10 +18,8 @@ package com.percussion.servlets;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import com.percussion.auditlog.PSActionOutcome;
-import com.percussion.auditlog.PSAuditLogService;
-import com.percussion.auditlog.PSAuthenticationEvent;
 import com.percussion.cms.IPSConstants;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.design.objectstore.PSServerConfiguration;
 import com.percussion.i18n.PSI18nUtils;
 import com.percussion.security.PSSecurityProvider;
@@ -121,7 +119,6 @@ public class PSSecurityFilter implements Filter {
   protected static final String NON_SECURE_HTTP_BIND_ADDRESS = "perc.http.bind.address";
 
   private final PSSecurityUtility securityUtil = new PSSecurityUtility();
-  private final PSAuditLogService psAuditLogService = PSAuditLogService.getInstance();
 
   private static final String ERROR_HEADER_NULL = "headers may not be null";
   private static final String THREAD = "thread ";
@@ -811,14 +808,12 @@ public class PSSecurityFilter implements Filter {
           remaining = 0;
         }
         if (remaining < 500) {
-          PSAuthenticationEvent psAuthenticationEvent =
-              new PSAuthenticationEvent(
-                  PSActionOutcome.SUCCESS.name(),
-                  PSAuthenticationEvent.AuthenticationEventActions.revoke,
-                  request,
-                  request.getRemoteUser());
-          psAuthenticationEvent.setActivity("revoke");
-          psAuditLogService.logAuthenticationEvent(psAuthenticationEvent);
+          try {
+            PSSystemAuditLogger.sessionRevoke(request, request.getRemoteUser());
+          } catch (Exception auditEx) {
+            ms_log.error(PSExceptionUtils.getMessageForLog(auditEx));
+            ms_log.debug(PSExceptionUtils.getDebugMessageForLog(auditEx));
+          }
         }
 
         int warning_s = PSServer.getServerConfiguration().getUserSessionWarning();

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
@@ -145,6 +145,14 @@ class PSSystemAuditLoggerTest {
     assertTrue(codes.contains(2004));
     assertTrue(codes.contains(2005));
     assertTrue(codes.contains(2006));
+    // Publish + removal schedules share the publishing lifecycle event type.
+    assertTrue(
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().stream()
+            .filter(r -> r.code().numericCode() == 2005 || r.code().numericCode() == 2006)
+            .allMatch(
+                r ->
+                    r.code().eventType()
+                        == com.intsof.percussioncms.auditlog.AuditEventType.CONTENT_PUBLISH));
   }
 
   @Test
@@ -181,6 +189,24 @@ class PSSystemAuditLoggerTest {
     assertEquals(4001, rec.code().numericCode());
     assertTrue(rec.formattedLine().contains("Draft"));
     assertTrue(rec.formattedLine().contains("Pending"));
+    // fromState then toState (not action labels) must appear in that semantic order.
+    int fromIdx = rec.formattedLine().indexOf("Draft");
+    int toIdx = rec.formattedLine().indexOf("Pending");
+    assertTrue(fromIdx >= 0 && toIdx > fromIdx);
+    assertEquals("Draft", rec.attributes().get("fromState"));
+    assertEquals("Pending", rec.attributes().get("toState"));
+  }
+
+  @Test
+  void userUpdateAcceptsExplicitSystemActor() {
+    HttpServletRequest request = mockRequest("jdoe", "10.0.0.7");
+    PSSystemAuditLogger.userUpdate(
+        request, AuditOutcome.SUCCESS, "jdoe", "password re-encrypt", "system");
+
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(3002, rec.code().numericCode());
+    assertEquals("system", rec.actor().orElse(""));
+    assertEquals("jdoe", rec.target().orElse(""));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.intsof.percussioncms.auditlog.AuditContext;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
@@ -73,7 +74,7 @@ class PSSystemAuditLoggerTest {
     assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
     var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
     assertEquals(1002, rec.code().numericCode());
-    assertEquals(com.intsof.percussioncms.auditlog.AuditOutcome.FAILURE, rec.outcome());
+    assertEquals(AuditOutcome.FAILURE, rec.outcome());
   }
 
   @Test
@@ -87,7 +88,115 @@ class PSSystemAuditLoggerTest {
     assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
     var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
     assertEquals(1003, rec.code().numericCode());
-    assertEquals(com.intsof.percussioncms.auditlog.AuditOutcome.SUCCESS, rec.outcome());
+    assertEquals(AuditOutcome.SUCCESS, rec.outcome());
+  }
+
+  @Test
+  void sessionRevokeIsAuditable() {
+    HttpServletRequest request = mockRequest("admin", "10.0.0.1");
+    PSSystemAuditLogger.sessionRevoke(request, "admin");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(1004, rec.code().numericCode());
+    assertEquals("AUTH", rec.code().module().code());
+  }
+
+  @Test
+  void contentCreateWritesContCode() {
+    HttpServletRequest request = mockRequest("editor", "10.0.0.2");
+    PSSystemAuditLogger.contentCreate(
+        request, AuditOutcome.SUCCESS, "guid-1", "42", "/Sites/demo");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals("CONT", rec.code().module().code());
+    assertEquals(2001, rec.code().numericCode());
+    assertTrue(rec.formattedLine().contains("guid-1"));
+    assertEquals(AuditOutcome.SUCCESS, rec.outcome());
+  }
+
+  @Test
+  void contentDeleteFailureOutcome() {
+    HttpServletRequest request = mockRequest("editor", "10.0.0.3");
+    PSSystemAuditLogger.contentDelete(
+        request, AuditOutcome.FAILURE, "guid-2", "99", "/Sites/x");
+
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(2003, rec.code().numericCode());
+    assertEquals(AuditOutcome.FAILURE, rec.outcome());
+  }
+
+  @Test
+  void contentRecycleAndSchedules() {
+    HttpServletRequest request = mockRequest("editor", "10.0.0.4");
+    PSSystemAuditLogger.contentRecycle(
+        request, AuditOutcome.SUCCESS, "g-r", "1", "/path");
+    PSSystemAuditLogger.pagePublishSchedule(
+        request, AuditOutcome.SUCCESS, "g-p", "2", "/path");
+    PSSystemAuditLogger.pageRemovalSchedule(
+        request, AuditOutcome.SUCCESS, "g-m", "3", "/path");
+
+    assertEquals(3, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var codes =
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().stream()
+            .map(r -> r.code().numericCode())
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(codes.contains(2004));
+    assertTrue(codes.contains(2005));
+    assertTrue(codes.contains(2006));
+  }
+
+  @Test
+  void userManagementCreateUpdateDelete() {
+    HttpServletRequest request = mockRequest("admin", "10.0.0.5");
+    PSSystemAuditLogger.userCreate(request, AuditOutcome.SUCCESS, "newuser");
+    PSSystemAuditLogger.userUpdate(request, AuditOutcome.SUCCESS, "newuser", "roles");
+    PSSystemAuditLogger.userDelete(request, AuditOutcome.FAILURE, "newuser");
+
+    assertEquals(3, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var codes =
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().stream()
+            .map(r -> r.code().numericCode())
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(codes.contains(3001));
+    assertTrue(codes.contains(3002));
+    assertTrue(codes.contains(3003));
+    assertTrue(
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().stream()
+            .anyMatch(
+                r ->
+                    r.code().numericCode() == 3003
+                        && r.outcome() == AuditOutcome.FAILURE));
+  }
+
+  @Test
+  void workflowTransitionWritesWfCode() {
+    HttpServletRequest request = mockRequest("approver", "10.0.0.6");
+    PSSystemAuditLogger.workflowTransition(
+        request, AuditOutcome.SUCCESS, "55", "guid-wf", "Draft", "Pending");
+
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals("WF", rec.code().module().code());
+    assertEquals(4001, rec.code().numericCode());
+    assertTrue(rec.formattedLine().contains("Draft"));
+    assertTrue(rec.formattedLine().contains("Pending"));
+  }
+
+  @Test
+  void nullRequestDoesNotThrow() {
+    PSSystemAuditLogger.contentCreate(null, AuditOutcome.SUCCESS, "g", "1", "/p");
+    PSSystemAuditLogger.userCreate(null, AuditOutcome.SUCCESS, "u");
+    PSSystemAuditLogger.workflowTransition(null, AuditOutcome.SUCCESS, "1", "g", "a", "b");
+    assertEquals(3, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  private static HttpServletRequest mockRequest(String user, String ip) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteUser()).thenReturn(user);
+    when(request.getRemoteAddr()).thenReturn(ip);
+    when(request.getRemoteHost()).thenReturn("host.example");
+    return request;
   }
 
   @Test


### PR DESCRIPTION
## Summary
Phase 2a of the system audit log stack: migrate all production `PSAuditLogService.getInstance()` call sites in **system** and **sitemanage** to `PSSystemAuditLogger` dual-write helpers backed by `com.intsof.percussioncms.auditlog.AuditLogService`.

**Parent:** #2614 (Phase 0+1 core API)

### What changed
- New package `*ErrorCodes`: `ContentErrorCodes`, `UserManagementErrorCodes`, `WorkflowErrorCodes`; `AuthenticationErrorCodes.SESSION_REVOKE`
- Expanded `PSSystemAuditLogger` with content / user-management / workflow / session-revoke helpers
- Migrated production callers (no remaining production `PSAuditLogService.getInstance()` outside legacy `perc-auditlog` CADF types)
- Extended `PSSystemAuditLoggerTest` (10 tests)
- **Does not** delete CADF/jcadf (#2617)

### Migrated call sites
**system:** `PSSecurityFilter`, `PSBackEndTableProvider`, `PSWorkflowCommandHandler`, `PSSiteManager`  
**sitemanage:** `PSUserService`, `PSUserLoginDao`, `PSContentItemDao`, `PSAssetService`, `PSItemService`, `PSPageService`, `PSPathService`, `PSRecycleService`, `PSSiteSectionService`

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw clean install` — BUILD SUCCESS
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS (`PSSystemAuditLoggerTest` Tests run: 10, Failures: 0)
- [x] `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS
- [x] Grep confirms zero production `PSAuditLogService.getInstance()` outside `perc-auditlog` legacy package
- [ ] Human review of dual-write message templates / code numbering

## Gates
- Erlang-style self-review: no new bugs found; null-safe servlet request handling; audit failures swallowed so business ops continue; portable paths N/A
- Copyright: Intersoft 2026 on new `*ErrorCodes` files
- CADF retained for #2617

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2615

> Co-Authored by Grok Build using grok-4.5 with agent main.