### PR TITLE
feat(auditlog): Phase 2b auth/security SecurityErrorCodes + isAuditable bridge (#2616)

### DIFF
--- a/docs/ai-generated/tasks/system-audit-log/design.md
+++ b/docs/ai-generated/tasks/system-audit-log/design.md
@@ -35,7 +35,15 @@ SystemErrorCode (*ErrorCodes) → AuditLogService
 - [x] Entity `PSSystemAuditLogEntry` + `PSSystemAuditLogRepository` (`@PSBaseBean`)
 - [x] Login/logout smoke path via `PSSystemAuditLogger` in `PSLoginServlet`
 - [x] Retention job skeleton `PSSystemAuditLogRetentionJob`
-- [ ] PR merge for #2614
+- [x] PR merge for #2614
+
+## Phase 2b status (auth/security first slice)
+
+- [x] `SecurityErrorCodes` for `IPSSecurityErrors` general auth (9001–9026) + directory auth login codes
+- [x] `LegacyErrorCodeRegistry` int → `SystemErrorCode` with safe non-auditable default
+- [x] `IPSSecurityErrors` bridged ints for that slice; `PSSystemAuditLogger.logLegacyIfAuditable`
+- [x] Unit tests: non-auditable skip dual-write; auditable SEC-9002 dual-write
+- [ ] Follow-on: content/workflow ErrorCodes batch; share/path/item; design-object; remaining legacy ints; central exception-handler wiring residuals
 
 ## Phase tracking (GitHub)
 

--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -9,6 +9,8 @@ System-wide Percussion CMS audit logging and unified error-code support.
 * `SystemErrorCode` / package `*ErrorCodes` with explicit **`isAuditable`**
 * `AuditLogService` dual-writes auditable events to Log4j (`server.log`) and an `AuditLogRepository` SPI
 * Message form: `[AUTH-1001]-[<uuid>] …` with separate user/log message templates and redaction
+* **Phase 2b:** `SecurityErrorCodes` + `LegacyErrorCodeRegistry` bridge legacy `IPSSecurityErrors` ints
+  (auth/security first slice). Non-auditable / unregistered ints never dual-write.
 
 **Legacy (to be removed after migration):** `com.percussion.auditlog` + IBM CADF (`auditlogger` module)
 
@@ -25,6 +27,20 @@ audit.log(
     AuditOutcome.SUCCESS,
     "jdoe",
     "10.0.0.1");
+```
+
+## Legacy IPS*Errors bridge (Phase 2b auth/security)
+
+```java
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+
+// Prefer enum when available:
+audit.log(SecurityErrorCodes.AUTHENTICATION_FAILED, ctx, "Directory", "ldap1", "jdoe");
+
+// Central handlers with only a legacy int (e.g. PSException.getErrorCode()):
+LegacyErrorCodeRegistry.logIfAuditable(audit, 9002, ctx, "Directory", "ldap1", "jdoe");
+// Provider config noise (isAuditable=false) and unknown ints → no dual-write
 ```
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Maps legacy {@code IPS*Errors} integer codes to {@link SystemErrorCode} until catalogs are fully
+ * migrated. Unregistered codes are treated as <strong>not auditable</strong> (no dual-write).
+ *
+ * <p>Phase 2b first slice registers {@link SecurityErrorCodes} (auth/security). Later slices
+ * register content/workflow/design catalogs via {@link #register(int, SystemErrorCode)}.
+ */
+public final class LegacyErrorCodeRegistry {
+
+  /** Same sentinel used by {@link DefaultAuditLogService} when dual-write is skipped. */
+  public static final AuditLogId SKIPPED = AuditLogId.of("00000000-0000-0000-0000-000000000000");
+
+  private static final Map<Integer, SystemErrorCode> BY_LEGACY = new ConcurrentHashMap<>();
+  private static final AtomicBoolean BOOTSTRAPPED = new AtomicBoolean(false);
+
+  private LegacyErrorCodeRegistry() {}
+
+  /**
+   * Ensure Phase 2b auth/security catalog is loaded. Safe to call repeatedly; catalogs register
+   * themselves in their own static initializers.
+   */
+  public static void bootstrap() {
+    if (BOOTSTRAPPED.compareAndSet(false, true)) {
+      SecurityErrorCodes.ensureRegistered();
+    }
+  }
+
+  /**
+   * Register a legacy int → {@link SystemErrorCode} mapping. Later registration for the same int
+   * replaces the previous mapping (last writer wins) so residual slices can refine catalogs.
+   *
+   * @param legacyCode historical {@code IPS*Errors} constant
+   * @param code modern code with explicit {@link SystemErrorCode#isAuditable()}
+   */
+  public static void register(int legacyCode, SystemErrorCode code) {
+    Objects.requireNonNull(code, "code");
+    BY_LEGACY.put(legacyCode, code);
+  }
+
+  /** Resolve a legacy int to a modern code when this phase (or a later slice) has cataloged it. */
+  public static Optional<SystemErrorCode> find(int legacyCode) {
+    bootstrap();
+    return Optional.ofNullable(BY_LEGACY.get(legacyCode));
+  }
+
+  /**
+   * Whether dual-write should run for this legacy int. Unregistered codes return {@code false}
+   * (safe default — operational only until cataloged).
+   */
+  public static boolean isAuditable(int legacyCode) {
+    bootstrap();
+    SystemErrorCode code = BY_LEGACY.get(legacyCode);
+    return code != null && code.isAuditable();
+  }
+
+  /**
+   * Dual-write when the legacy code is registered and {@link SystemErrorCode#isAuditable()};
+   * otherwise returns {@link #SKIPPED} without writing to sinks.
+   */
+  public static AuditLogId logIfAuditable(
+      AuditLogService service,
+      int legacyCode,
+      AuditContext context,
+      AuditOutcome outcome,
+      Object... params) {
+    Objects.requireNonNull(service, "service");
+    bootstrap();
+    SystemErrorCode code = BY_LEGACY.get(legacyCode);
+    if (code == null || !code.isAuditable()) {
+      return SKIPPED;
+    }
+    return service.log(
+        code,
+        context == null ? AuditContext.empty() : context,
+        outcome == null ? code.defaultOutcome() : outcome,
+        params);
+  }
+
+  /** Convenience when outcome comes from the code default. */
+  public static AuditLogId logIfAuditable(
+      AuditLogService service, int legacyCode, AuditContext context, Object... params) {
+    bootstrap();
+    SystemErrorCode code = BY_LEGACY.get(legacyCode);
+    AuditOutcome outcome = code != null ? code.defaultOutcome() : AuditOutcome.UNKNOWN;
+    return logIfAuditable(service, legacyCode, context, outcome, params);
+  }
+
+  /** Test support: clear all mappings and bootstrap flag (re-register catalogs after). */
+  static void clearForTests() {
+    BY_LEGACY.clear();
+    BOOTSTRAPPED.set(false);
+  }
+
+  /** Number of registered legacy codes (diagnostics / tests). */
+  public static int size() {
+    bootstrap();
+    return BY_LEGACY.size();
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuthenticationErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuthenticationErrorCodes.java
@@ -22,8 +22,12 @@ import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 
 /**
- * Reference package-local error codes for authentication (Phase 1 sample). Production auth codes
- * should eventually live under {@code com.percussion.security} once call sites migrate.
+ * High-level authentication <em>audit events</em> (login success/failure/logout).
+ *
+ * <p>Exception catalog codes that bridge legacy {@code IPSSecurityErrors} ints live in {@link
+ * SecurityErrorCodes} (Phase 2b). Prefer this enum for intentional audit emits from login
+ * servlets; prefer {@link SecurityErrorCodes} / {@code LegacyErrorCodeRegistry} when handling
+ * {@code PSException} error codes.
  *
  * <p>Every constant sets {@link #isAuditable()} explicitly.
  */

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SecurityErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SecurityErrorCodes.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Phase 2b auth/security error catalog bridging legacy {@code IPSSecurityErrors} ints (9001–9026
+ * general range plus directory-auth codes used on login paths).
+ *
+ * <p>{@link #numericCode()} preserves the historical int so legacy exception constructors and
+ * resource bundles remain stable. Every constant sets {@link #isAuditable()} explicitly: only
+ * security-relevant authentication/authorization failures dual-write; operational/provider config
+ * noise does not.
+ *
+ * <p>High-level login success/failure audit events remain on {@link AuthenticationErrorCodes}
+ * (AUTH-100x). This catalog is the exception/error-code bridge for central handlers.
+ */
+public enum SecurityErrorCodes implements SystemErrorCode {
+
+  // --- general security / auth (9001–9026) ---
+
+  AUTHENTICATION_NOT_SUPPORTED(
+      9001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Authentication not supported for provider {}",
+      "Authentication not supported providerType={}"),
+
+  AUTHENTICATION_FAILED(
+      9002,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Authentication failed for user {}",
+      "Authentication failed providerType={} instance={} user={}"),
+
+  PROVIDER_NOT_SUPPORTED_BY_CLASS(
+      9003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Security provider not supported",
+      "Provider not supported class={} requestedType={}"),
+
+  FILTERS_NOT_SUPPORTED(
+      9004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Filters not supported for provider {}",
+      "Filters not supported providerType={}"),
+
+  USERS_NOT_SUPPORTED(
+      9005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Users not supported for provider {}",
+      "Users not supported providerType={}"),
+
+  GROUPS_NOT_SUPPORTED(
+      9006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Groups not supported for provider {}",
+      "Groups not supported providerType={}"),
+
+  AUTHENTICATION_REQUIRED(
+      9007,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Authentication required for {} {}",
+      "Authentication required resourceType={} resourceName={}"),
+
+  SESS_NOT_AUTHORIZED(
+      9008,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Session not authorized for {} {}",
+      "Session not authorized resourceType={} resourceName={} session={}"),
+
+  USER_NOT_AUTHORIZED(
+      9009,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "User not authorized for {} {}",
+      "User not authorized resourceType={} resourceName={} provider={} user={}"),
+
+  PROVIDER_INIT_EXCEPTION(
+      9010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Security provider initialization failed",
+      "Provider init failed type={} instance={} detail={}"),
+
+  PROVIDER_UNKNOWN(
+      9011,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown security provider",
+      "Unknown provider type={} instance={}"),
+
+  AUTHENTICATION_FAILED_WITH_MSG(
+      9012,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Authentication failed for user {}",
+      "Authentication failed providerType={} instance={} user={} reason={}"),
+
+  PROVIDER_INIT_CATALOG_DISABLED(
+      9013,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Security provider catalog disabled",
+      "Provider catalog disabled type={} instance={} detail={}"),
+
+  PROVIDER_INSTANCE_NAME_DUPLICATED(
+      9014,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate security provider instance name",
+      "Duplicate provider instance name={}"),
+
+  NATIVE_AUTHENTICATION_FAILURE(
+      9015,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Native authentication failed",
+      "Native authentication failure"),
+
+  SSL_KEY_STRENGTH_TOO_WEAK(
+      9016,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "SSL key strength too weak",
+      "SSL key strength too weak session={} requiredBits={} suppliedBits={}"),
+
+  DATA_ENCRYPTION_ERROR(
+      9017,
+      true,
+      AuditEventType.OTHER,
+      AuditOutcome.ERROR,
+      "Data encryption error",
+      "Data encryption handler error"),
+
+  SECURITY_NOT_INITIALIZED(
+      9018,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Security subsystem not initialized",
+      "Security subsystem not initialized"),
+
+  SECRET_KEY_INVALID_SIZE(
+      9019,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid secret key size",
+      "Invalid secret key size expected={} actual={}"),
+
+  MULTI_AUTHENTICATION_FAILED(
+      9020,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Authentication failed",
+      "Multi-provider authentication failed detail={}"),
+
+  GENERIC_AUTHENTICATION_FAILED(
+      9021,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Authentication failed",
+      "Generic authentication failed"),
+
+  METADATA_UNAVAILABLE(
+      9022,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Security metadata unavailable",
+      "Security metadata unavailable detail={}"),
+
+  FILTER_WILDCARD_INVALID(
+      9023,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid filter wildcard",
+      "Invalid filter wildcard={} providerType={}"),
+
+  GET_GROUPS_FAILURE(
+      9024,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to get groups",
+      "Get groups failure groupProvider={} directory={} error={}"),
+
+  CHECK_GROUP_MEMBER_FAILURE(
+      9025,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Group membership check failed",
+      "Check group member failure type={} name={} user={} group={} error={}"),
+
+  GROUP_PROVIDER_MISSING(
+      9026,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Group provider missing",
+      "Group provider missing name={}"),
+
+  // --- directory auth used on login paths ---
+
+  DIR_AUTHENTICATION_FAILED(
+      9801,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Directory authentication failed for user {}",
+      "Directory authentication failed user={}"),
+
+  DIR_MULTIPLE_ENTRIES_RETURNED(
+      9802,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Directory authentication failed for user {}",
+      "Directory multiple entries for user={}"),
+
+  DIR_PASSWORD_REQUIRED(
+      9804,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Password required for authentication",
+      "Directory password required providerType={}"),
+
+  DIRECTORY_AUTHENTICATION_FAILED(
+      9862,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Directory authentication failed",
+      "Directory authentication failed directory={} auth={} error={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  SecurityErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (SecurityErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SEC;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LegacyErrorCodeRegistryTest {
+
+  @BeforeEach
+  void rebootstrap() {
+    LegacyErrorCodeRegistry.clearForTests();
+    LegacyErrorCodeRegistry.bootstrap();
+  }
+
+  @Test
+  void authFailureLegacyCodeIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(9002));
+    assertSame(
+        SecurityErrorCodes.AUTHENTICATION_FAILED,
+        LegacyErrorCodeRegistry.find(9002).orElseThrow());
+    assertTrue(SecurityErrorCodes.AUTHENTICATION_FAILED.isAuditable());
+  }
+
+  @Test
+  void providerConfigLegacyCodeIsNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(9011));
+    assertSame(
+        SecurityErrorCodes.PROVIDER_UNKNOWN, LegacyErrorCodeRegistry.find(9011).orElseThrow());
+    assertFalse(SecurityErrorCodes.PROVIDER_UNKNOWN.isAuditable());
+  }
+
+  @Test
+  void unregisteredLegacyCodeIsNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(42));
+    assertTrue(LegacyErrorCodeRegistry.find(42).isEmpty());
+  }
+
+  @Test
+  void nonAuditableLegacyCodeSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SecurityErrorCodes.PROVIDER_UNKNOWN.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "Directory",
+            "ldap1");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void auditableLegacyCodeDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SecurityErrorCodes.AUTHENTICATION_FAILED.numericCode(),
+            AuditContext.builder().actor("jdoe").sourceIp("10.0.0.1").build(),
+            "Directory",
+            "ldap1",
+            "jdoe");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(SecurityErrorCodes.AUTHENTICATION_FAILED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SEC-9002]-"));
+  }
+
+  @Test
+  void genericAuthFailedIsAuditable() {
+    assertTrue(SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED.isAuditable());
+    assertTrue(
+        LegacyErrorCodeRegistry.isAuditable(
+            SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED.numericCode()));
+  }
+
+  @Test
+  void securityNotInitializedIsNotAuditable() {
+    assertFalse(SecurityErrorCodes.SECURITY_NOT_INITIALIZED.isAuditable());
+    assertFalse(
+        LegacyErrorCodeRegistry.isAuditable(
+            SecurityErrorCodes.SECURITY_NOT_INITIALIZED.numericCode()));
+  }
+
+  @Test
+  void registryContainsAuthSecuritySlice() {
+    assertTrue(LegacyErrorCodeRegistry.size() >= 30);
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SecurityErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SecurityErrorCodesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class SecurityErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSecAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (SecurityErrorCodes code : SecurityErrorCodes.values()) {
+      assertEquals(AuditModule.SEC, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertNotNull(code.qualifiedCode());
+      assertTrue(code.qualifiedCode().startsWith("SEC-"));
+    }
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (SecurityErrorCodes code : SecurityErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void loginPathAuthFailuresAreAuditable() {
+    assertTrue(SecurityErrorCodes.AUTHENTICATION_FAILED.isAuditable());
+    assertEquals(AuditEventType.AUTH_FAILURE, SecurityErrorCodes.AUTHENTICATION_FAILED.eventType());
+    assertTrue(SecurityErrorCodes.AUTHENTICATION_FAILED_WITH_MSG.isAuditable());
+    assertTrue(SecurityErrorCodes.MULTI_AUTHENTICATION_FAILED.isAuditable());
+    assertTrue(SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED.isAuditable());
+    assertTrue(SecurityErrorCodes.DIR_AUTHENTICATION_FAILED.isAuditable());
+    assertTrue(SecurityErrorCodes.USER_NOT_AUTHORIZED.isAuditable());
+    assertTrue(SecurityErrorCodes.SESS_NOT_AUTHORIZED.isAuditable());
+  }
+
+  @Test
+  void operationalProviderNoiseIsNotAuditable() {
+    assertFalse(SecurityErrorCodes.AUTHENTICATION_NOT_SUPPORTED.isAuditable());
+    assertFalse(SecurityErrorCodes.PROVIDER_NOT_SUPPORTED_BY_CLASS.isAuditable());
+    assertFalse(SecurityErrorCodes.PROVIDER_INIT_EXCEPTION.isAuditable());
+    assertFalse(SecurityErrorCodes.PROVIDER_UNKNOWN.isAuditable());
+    assertFalse(SecurityErrorCodes.SECURITY_NOT_INITIALIZED.isAuditable());
+    assertFalse(SecurityErrorCodes.GET_GROUPS_FAILURE.isAuditable());
+  }
+
+  @Test
+  void preservesLegacyIpsSecurityErrorsNumericValues() {
+    assertEquals(9002, SecurityErrorCodes.AUTHENTICATION_FAILED.numericCode());
+    assertEquals(9008, SecurityErrorCodes.SESS_NOT_AUTHORIZED.numericCode());
+    assertEquals(9009, SecurityErrorCodes.USER_NOT_AUTHORIZED.numericCode());
+    assertEquals(9021, SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED.numericCode());
+    assertEquals(9801, SecurityErrorCodes.DIR_AUTHENTICATION_FAILED.numericCode());
+  }
+}

--- a/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
+++ b/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
@@ -17,9 +17,11 @@
 package com.percussion.services.audit;
 
 import com.intsof.percussioncms.auditlog.AuditContext;
+import com.intsof.percussioncms.auditlog.AuditLogId;
 import com.intsof.percussioncms.auditlog.AuditLogService;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,6 +30,9 @@ import jakarta.servlet.http.HttpServletRequest;
  * Thin facade for system code to emit system-wide audit events without depending on Spring at the
  * call site. Uses {@link DefaultAuditLogService.Holder} (Log4j + memory until JPA repository
  * registers).
+ *
+ * <p>Phase 2b: use {@link #logLegacyIfAuditable(int, AuditContext, Object...)} for legacy {@code
+ * IPS*Errors} ints so non-auditable codes never dual-write.
  */
 public final class PSSystemAuditLogger {
 
@@ -40,6 +45,30 @@ public final class PSSystemAuditLogger {
   public static void log(
       SystemErrorCode code, AuditContext context, AuditOutcome outcome, Object... params) {
     service().log(code, context == null ? AuditContext.empty() : context, outcome, params);
+  }
+
+  /**
+   * Resolve a legacy {@code IPS*Errors} int via {@link LegacyErrorCodeRegistry} and dual-write only
+   * when the catalog marks the code {@code isAuditable}. Unregistered or non-auditable codes are a
+   * no-op (returns the skipped audit id).
+   */
+  public static AuditLogId logLegacyIfAuditable(
+      int legacyErrorCode, AuditContext context, Object... params) {
+    return LegacyErrorCodeRegistry.logIfAuditable(
+        service(), legacyErrorCode, context == null ? AuditContext.empty() : context, params);
+  }
+
+  /**
+   * Same as {@link #logLegacyIfAuditable(int, AuditContext, Object...)} with an explicit outcome.
+   */
+  public static AuditLogId logLegacyIfAuditable(
+      int legacyErrorCode, AuditContext context, AuditOutcome outcome, Object... params) {
+    return LegacyErrorCodeRegistry.logIfAuditable(
+        service(),
+        legacyErrorCode,
+        context == null ? AuditContext.empty() : context,
+        outcome,
+        params);
   }
 
   public static void loginSuccess(HttpServletRequest request, String username) {

--- a/system/src/main/java/com/percussion/security/IPSSecurityErrors.java
+++ b/system/src/main/java/com/percussion/security/IPSSecurityErrors.java
@@ -19,7 +19,17 @@ package com.percussion.security;
 
 /**
  * The IPSSecurityErrors inteface is provided as a convenient mechanism for accessing the various
- * security related error codes. The error code ranges are:
+ * security related error codes.
+ *
+ * <p><strong>Phase 2b bridge:</strong> general auth/security ints (9001–9026) and directory-auth
+ * login codes are cataloged in {@code
+ * com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes} with explicit {@code isAuditable}.
+ * Int literals remain here so they stay <em>compile-time constants</em> (required for {@code
+ * switch} labels such as {@code case IPSSecurityErrors.SESS_NOT_AUTHORIZED}). Prefer {@code
+ * SecurityErrorCodes} / {@code LegacyErrorCodeRegistry} for dual-write decisions; keep this
+ * interface for legacy {@code PSException} constructors and message bundles.
+ *
+ * <p>The error code ranges are:
  *
  * <TABLE BORDER="1"><CAPTION>Error Arguments</CAPTION>
  * <TR><TH>Range</TH><TH>Component</TH></TR>

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
@@ -21,8 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.intsof.percussioncms.auditlog.AuditContext;
 import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import com.percussion.security.IPSSecurityErrors;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,5 +88,45 @@ class PSSystemAuditLoggerTest {
     var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
     assertEquals(1003, rec.code().numericCode());
     assertEquals(com.intsof.percussioncms.auditlog.AuditOutcome.SUCCESS, rec.outcome());
+  }
+
+  @Test
+  void legacyAuthFailureDualWritesViaBridge() {
+    var id =
+        PSSystemAuditLogger.logLegacyIfAuditable(
+            IPSSecurityErrors.AUTHENTICATION_FAILED,
+            AuditContext.builder().actor("jdoe").sourceIp("10.0.0.1").build(),
+            "Directory",
+            "ldap1",
+            "jdoe");
+
+    assertTrue(!id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(SecurityErrorCodes.AUTHENTICATION_FAILED, rec.code());
+    assertTrue(rec.formattedLine().startsWith("[SEC-9002]-"));
+  }
+
+  @Test
+  void legacyNonAuditableProviderNoiseSkipsDualWrite() {
+    var id =
+        PSSystemAuditLogger.logLegacyIfAuditable(
+            IPSSecurityErrors.PROVIDER_UNKNOWN,
+            AuditContext.builder().actor("system").build(),
+            "Directory",
+            "ldap1");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void ipsSecurityErrorsIntsMatchSecurityErrorCodes() {
+    assertEquals(
+        SecurityErrorCodes.GENERIC_AUTHENTICATION_FAILED.numericCode(),
+        IPSSecurityErrors.GENERIC_AUTHENTICATION_FAILED);
+    assertEquals(
+        SecurityErrorCodes.SESS_NOT_AUTHORIZED.numericCode(),
+        IPSSecurityErrors.SESS_NOT_AUTHORIZED);
   }
 }


### PR DESCRIPTION
## Summary
Phase **2b first slice** of the system audit log stack: unify auth/security legacy `IPSSecurityErrors` ints into `SecurityErrorCodes` (`SystemErrorCode` + explicit `isAuditable`) and a `LegacyErrorCodeRegistry` so non-auditable codes never dual-write.

**Parent:** #2616 (Phase 2b ErrorCodes unification)  
**Stack:** after #2614 (core API); coordinates with #2615 call-site migrate patterns when those files touch.

### What changed
- **`SecurityErrorCodes`** — catalogs `IPSSecurityErrors` general auth (9001–9026) + directory-auth login codes (9801, 9802, 9804, 9862) with explicit `isAuditable` / event types
- **`LegacyErrorCodeRegistry`** — int → `SystemErrorCode`; unregistered ints default to non-auditable; `logIfAuditable` skips dual-write when not auditable
- **`PSSystemAuditLogger.logLegacyIfAuditable`** — system facade for exception/error-code handlers
- **`IPSSecurityErrors` javadoc** — Phase 2b bridge note (ints stay compile-time constants for `switch` labels)
- Unit tests: registry, non-auditable skip, auditable SEC-9002 dual-write, IPS int lockstep

### Out of scope (residuals)
- Content/workflow catalogs → #2635
- Remaining SEC ranges + design/path + central exception-handler wiring → #2636

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw clean install` — BUILD SUCCESS
  - `LegacyErrorCodeRegistryTest` Tests run: 8, Failures: 0
  - `SecurityErrorCodesTest` Tests run: 5, Failures: 0
  - `DefaultAuditLogServiceTest` non-auditable skip still green
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS
  - `PSSystemAuditLoggerTest` Tests run: 6, Failures: 0
- [x] Erlang-style self-review: no bugs found; compile-time constant constraint documented (do not derive IPS ints from enum methods — breaks switch); portable paths N/A; Intersoft 2026 headers on new files

## Gates
- Change-class: auth/security ErrorCodes bridge companions (registry + tests + logger helper + IPS javadoc)
- Copyright: Intersoft 2026 on new sources
- No mega-PR: auth/security only

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2616  
Residuals: #2635 #2636

> Co-Authored by Grok Build using grok-4.5 with agent main.
