### PR TITLE
feat(auditlog): Phase 3 role property + REST audit query API (#2618)

### DIFF
--- a/docs/ai-generated/tasks/system-audit-log/design.md
+++ b/docs/ai-generated/tasks/system-audit-log/design.md
@@ -37,6 +37,34 @@ SystemErrorCode (*ErrorCodes) → AuditLogService
 - [x] Retention job skeleton `PSSystemAuditLogRetentionJob`
 - [ ] PR merge for #2614
 
+## Phase 3 — Role property + REST query (#2618)
+
+### Operator notes (Admin Manual style)
+
+**Role property:** `sys_securityAuditLogViewer`
+
+| Setting | Meaning |
+|---------|---------|
+| Role **Admin** | Always allowed to query the system security audit log (even without the property) |
+| Role property `sys_securityAuditLogViewer=true` | Grants query access to members of that role |
+| Truthy values | `true`, `yes`, `y`, `1` (case-insensitive) |
+| Falsy / absent | No access for non-Admin roles |
+
+**Fresh install seed:** installer data registers the property name under `PSX_ADMINLOOKUP` (so Server Admin can assign it) and seeds `true` on the **Admin** role (`PSX_ATTRIBUTE_*` / `PSX_ROLE_ATTRIBUTES`). Existing sites may add the property on Admin or other roles via Server Admin → Roles.
+
+**Public REST (read-only):**
+
+| Method | Path | AuthZ |
+|--------|------|-------|
+| `GET` | `/Rhythmyx/rest/auditlog/entries` | Admin or property |
+| `GET` | `/Rhythmyx/rest/auditlog/entries/{auditId}` | Admin or property |
+
+Query parameters on list: `from`, `to` (ISO-8601 instants), `module`, `eventType`, `outcome`, `actor`, `offset`, `limit` (default 50, max 200).
+
+Responses: `200` page/entry, `403` without permission, `404` missing id, `400` bad dates.
+
+**Not in Phase 3:** Admin WebUI viewer / Playwright (#2619).
+
 ## Phase tracking (GitHub)
 
 | Phase | Issue |

--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -38,6 +38,19 @@ Production durable store: table `PSX_SYSTEM_AUDIT_LOG` with JPA entity
 
 Login smoke path: `PSSystemAuditLogger` / `PSLoginServlet` (success, failure, logout).
 
+## Phase 3 — REST query + role property (#2618)
+
+**Permission:** Rhythmyx role property `sys_securityAuditLogViewer` (truthy `true`/`yes`/`1`/`y`). Members of **Admin** always may view. Pure helper: `com.percussion.services.audit.PSSystemAuditLogPermission`.
+
+**REST** (public adaptor pattern):
+
+* Resource: `com.percussion.rest.auditlog.AuditLogResource` → `/auditlog/entries`
+* Interface: `IAuditLogAdaptor`
+* Impl: `com.percussion.apibridge.AuditLogAdaptor` (sitemanage) → `PSSystemAuditLogRepository` query helpers
+* Seed: installer `cmsTableData.xml` registers the property and seeds Admin=`true`
+
+Unauthorized callers receive HTTP **403**. Admin UI for browsing is Phase 4 (#2619).
+
 ## Building
 
 ```bash

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
@@ -1681,6 +1681,15 @@
             <column name="LIMITTOLIST"/>
             <column name="CATALOGURL"/>
         </row>
+        <!-- System security audit log viewer (#2618): Admin always allowed; property grants non-Admin roles -->
+        <row onTableCreateOnly="no" action="i">
+            <column name="ID">6</column>
+            <column name="TYPE">role</column>
+            <column name="CATEGORY">SYS_ATTRIBUTENAME</column>
+            <column name="NAME">sys_securityAuditLogViewer</column>
+            <column name="LIMITTOLIST"/>
+            <column name="CATALOGURL"/>
+        </row>
     </table>
     <table name="PSX_ATTRIBUTE_NAMES" onCreateOnly="no">
             <row action="i" onTableCreateOnly="no">
@@ -1700,6 +1709,13 @@
             <column name="NAME">sys_defaultCommunity</column>
             <column name="COMPONENTID">0</column>
             <column name="NORMALNAME">sys_defaultcommunity</column>
+        </row>
+        <!-- Seed sys_securityAuditLogViewer=true on Admin (ROLEID 1); Admin is always allowed without this row -->
+        <row action="i" onTableCreateOnly="no">
+            <column name="ID">30</column>
+            <column name="NAME">sys_securityAuditLogViewer</column>
+            <column name="COMPONENTID">0</column>
+            <column name="NORMALNAME">sys_securityauditlogviewer</column>
         </row>
 
     </table>
@@ -1722,11 +1738,21 @@
             <column name="VALUE">Default</column>
             <column name="COMPONENTID">0</column>
         </row>
+        <row action="i" onTableCreateOnly="no">
+            <column name="ID">30</column>
+            <column name="ATTRIBUTEID">30</column>
+            <column name="VALUE">true</column>
+            <column name="COMPONENTID">0</column>
+        </row>
     </table>
     <table name="PSX_ROLE_ATTRIBUTES" onCreateOnly="no">
             <row action="i" onTableCreateOnly="no">
             <column name="ROLEID">1</column>
             <column name="ATTRIBUTEID">7</column>
+        </row>
+            <row action="i" onTableCreateOnly="no">
+            <column name="ROLEID">1</column>
+            <column name="ATTRIBUTEID">30</column>
         </row>
             <row action="i" onTableCreateOnly="no">
             <column name="ROLEID">4</column>

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.apibridge;
+
+import static com.percussion.webservices.PSWebserviceUtils.getUserRoles;
+
+import com.percussion.rest.auditlog.IAuditLogAdaptor;
+import com.percussion.rest.auditlog.SystemAuditLogEntry;
+import com.percussion.rest.auditlog.SystemAuditLogPage;
+import com.percussion.security.IPSPrincipalAttribute;
+import com.percussion.services.audit.PSSystemAuditLogPermission;
+import com.percussion.services.audit.data.PSSystemAuditLogEntry;
+import com.percussion.services.audit.impl.PSSystemAuditLogRepository;
+import com.percussion.services.security.IPSRoleMgr;
+import com.percussion.services.security.PSRoleMgrLocator;
+import com.percussion.system.utils.PSSiteManageBean;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * sitemanage apibridge for system audit log query API (#2618).
+ *
+ * <p>AuthZ: {@link PSSystemAuditLogPermission} — Admin always allowed, otherwise role property
+ * {@code sys_securityAuditLogViewer}.
+ */
+@PSSiteManageBean
+@Lazy
+public class AuditLogAdaptor implements IAuditLogAdaptor {
+
+  private static final Logger log = LogManager.getLogger(AuditLogAdaptor.class);
+
+  private final PSSystemAuditLogRepository repository;
+  private final Supplier<List<String>> userRolesSupplier;
+  private final Function<String, Boolean> roleHasViewerProperty;
+
+  @Autowired
+  public AuditLogAdaptor(PSSystemAuditLogRepository repository) {
+    this(
+        repository,
+        () -> getUserRoles(),
+        AuditLogAdaptor::roleHasViewerPropertyFromRoleMgr);
+  }
+
+  /** Package-visible test constructor. */
+  AuditLogAdaptor(
+      PSSystemAuditLogRepository repository,
+      Supplier<List<String>> userRolesSupplier,
+      Function<String, Boolean> roleHasViewerProperty) {
+    this.repository = Objects.requireNonNull(repository, "repository");
+    this.userRolesSupplier = Objects.requireNonNull(userRolesSupplier, "userRolesSupplier");
+    this.roleHasViewerProperty =
+        Objects.requireNonNull(roleHasViewerProperty, "roleHasViewerProperty");
+  }
+
+  @Override
+  public SystemAuditLogPage query(
+      String fromIso,
+      String toIso,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor,
+      int offset,
+      int limit) {
+    requireViewer();
+    Instant from = parseInstant(fromIso, "from");
+    Instant to = parseInstant(toIso, "to");
+    int safeOffset = Math.max(0, offset);
+    int safeLimit = PSSystemAuditLogRepository.clampLimit(limit);
+
+    List<PSSystemAuditLogEntry> rows =
+        repository.findEntries(
+            from, to, moduleCode, eventType, outcome, actor, safeOffset, safeLimit);
+    long total = repository.countEntries(from, to, moduleCode, eventType, outcome, actor);
+
+    List<SystemAuditLogEntry> entries = new ArrayList<>(rows.size());
+    for (PSSystemAuditLogEntry row : rows) {
+      entries.add(toDto(row));
+    }
+    return new SystemAuditLogPage(entries, total, safeOffset, safeLimit);
+  }
+
+  @Override
+  public SystemAuditLogEntry findById(String auditId) {
+    requireViewer();
+    if (StringUtils.isBlank(auditId)) {
+      throw new IllegalArgumentException("auditId is required");
+    }
+    Optional<PSSystemAuditLogEntry> found = repository.findById(auditId.trim());
+    return found.map(AuditLogAdaptor::toDto).orElse(null);
+  }
+
+  private void requireViewer() {
+    List<String> roles;
+    try {
+      roles = userRolesSupplier.get();
+    } catch (Exception e) {
+      log.debug("Could not resolve user roles for audit log access", e);
+      throw new SecurityException("Unable to resolve user roles for audit log access");
+    }
+    boolean allowed =
+        PSSystemAuditLogPermission.allows(
+            roles, role -> Boolean.TRUE.equals(roleHasViewerProperty.apply(role)));
+    if (!allowed) {
+      throw new SecurityException(
+          "Not authorized to view the system security audit log (Admin role or "
+              + PSSystemAuditLogPermission.ROLE_PROPERTY
+              + " required)");
+    }
+  }
+
+  static Instant parseInstant(String raw, String fieldName) {
+    if (StringUtils.isBlank(raw)) {
+      return null;
+    }
+    try {
+      return Instant.parse(raw.trim());
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException(
+          fieldName + " is not a valid ISO-8601 instant: " + raw, e);
+    }
+  }
+
+  static SystemAuditLogEntry toDto(PSSystemAuditLogEntry e) {
+    SystemAuditLogEntry dto = new SystemAuditLogEntry();
+    dto.setAuditId(e.getAuditId());
+    dto.setEventTime(e.getEventTimeInstant());
+    dto.setModuleCode(e.getModuleCode());
+    dto.setMessageCode(e.getMessageCode());
+    dto.setEventType(e.getEventType());
+    dto.setOutcome(e.getOutcome());
+    dto.setActor(e.getActor());
+    dto.setTarget(e.getTarget());
+    dto.setSourceIp(e.getSourceIp());
+    dto.setSourceHost(e.getSourceHost());
+    dto.setUserMessage(e.getUserMessage());
+    dto.setLogMessage(e.getLogMessage());
+    dto.setCorrelationId(e.getCorrelationId());
+    dto.setAttributesJson(e.getAttributesJson());
+    dto.setServerNode(e.getServerNode());
+    return dto;
+  }
+
+  static boolean roleHasViewerPropertyFromRoleMgr(String roleName) {
+    try {
+      IPSRoleMgr roleMgr = PSRoleMgrLocator.getRoleManager();
+      Set<IPSPrincipalAttribute> attrs = roleMgr.getRoleAttributes(roleName);
+      if (attrs == null || attrs.isEmpty()) {
+        return false;
+      }
+      for (IPSPrincipalAttribute attr : attrs) {
+        if (attr == null || attr.getName() == null) {
+          continue;
+        }
+        if (PSSystemAuditLogPermission.ROLE_PROPERTY.equalsIgnoreCase(attr.getName())) {
+          return PSSystemAuditLogPermission.isTruthyPropertyValue(attr.getValues());
+        }
+      }
+      return false;
+    } catch (Exception e) {
+      LogManager.getLogger(AuditLogAdaptor.class)
+          .debug("Failed to load role attributes for {}", roleName, e);
+      return false;
+    }
+  }
+}

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -107,6 +107,7 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="restViewResource" />
             <ref bean="restControlsResource" />
             <ref bean="restServerConfigsResource" />
+            <ref bean="restAuditLogResource" />
         </jaxrs:serviceBeans>
         <jaxrs:extensionMappings>
             <entry key="json" value="application/json" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.auditlog.SystemAuditLogEntry;
+import com.percussion.rest.auditlog.SystemAuditLogPage;
+import com.percussion.services.audit.data.PSSystemAuditLogEntry;
+import com.percussion.services.audit.impl.PSSystemAuditLogRepository;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class AuditLogAdaptorTest {
+
+  @Test
+  void adminCanQuery() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    PSSystemAuditLogEntry row = sampleRow();
+    when(repo.findEntries(
+            isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(0), eq(50)))
+        .thenReturn(List.of(row));
+    when(repo.countEntries(isNull(), isNull(), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(1L);
+
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+
+    SystemAuditLogPage page =
+        adaptor.query(null, null, null, null, null, null, 0, 50);
+    assertEquals(1, page.getEntries().size());
+    assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", page.getEntries().get(0).getAuditId());
+    assertEquals(1L, page.getTotal());
+    assertEquals(50, page.getLimit());
+  }
+
+  @Test
+  void propertyHolderCanQuery() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    when(repo.findEntries(
+            any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(List.of());
+    when(repo.countEntries(any(), any(), any(), any(), any(), any())).thenReturn(0L);
+
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Editor"), role -> "Editor".equals(role));
+
+    SystemAuditLogPage page =
+        adaptor.query(null, null, null, null, null, null, 0, 10);
+    assertNotNull(page);
+    assertEquals(0, page.getEntries().size());
+  }
+
+  @Test
+  void unauthorizedThrowsSecurityExceptionWithoutTouchingRepo() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false);
+
+    assertThrows(
+        SecurityException.class,
+        () -> adaptor.query(null, null, null, null, null, null, 0, 50));
+    verify(repo, never())
+        .findEntries(any(), any(), any(), any(), any(), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  void invalidFromIsIllegalArgument() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.query("not-an-instant", null, null, null, null, null, 0, 50));
+  }
+
+  @Test
+  void findByIdMapsAndReturnsNullWhenMissing() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    when(repo.findById(eq("missing"))).thenReturn(Optional.empty());
+    when(repo.findById(eq("id-1"))).thenReturn(Optional.of(sampleRow()));
+
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+
+    assertNull(adaptor.findById("missing"));
+    SystemAuditLogEntry found = adaptor.findById("id-1");
+    assertNotNull(found);
+    assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", found.getAuditId());
+    assertEquals("AUTH", found.getModuleCode());
+  }
+
+  @Test
+  void findByIdUnauthorized() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false);
+    assertThrows(SecurityException.class, () -> adaptor.findById("id-1"));
+    verify(repo, never()).findById(anyString());
+  }
+
+  private static PSSystemAuditLogEntry sampleRow() {
+    PSSystemAuditLogEntry e = new PSSystemAuditLogEntry();
+    e.setAuditId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    e.setEventTime(Date.from(Instant.parse("2026-08-09T12:00:00Z")));
+    e.setModuleCode("AUTH");
+    e.setMessageCode(1001);
+    e.setEventType("LOGIN");
+    e.setOutcome("SUCCESS");
+    e.setActor("admin");
+    e.setUserMessage("login ok");
+    e.setLogMessage("login ok");
+    return e;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/rest/ServerConfigsRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/ServerConfigsRestJaxrsRegistrationTest.java
@@ -37,6 +37,7 @@ class ServerConfigsRestJaxrsRegistrationTest {
   /** Peers already registered (#1714) stay locked so they cannot regress silently. */
   private static final String[] REQUIRED_REFS = {
     "restServerConfigsResource",
+    "restAuditLogResource",
     "restKeywordsResource",
     "restLocalesResource",
     "restSlotsResource",

--- a/rest/src/main/java/com/percussion/rest/auditlog/AuditLogResource.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/AuditLogResource.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Public REST surface for querying {@code PSX_SYSTEM_AUDIT_LOG} (Phase 3 / #2618).
+ *
+ * <pre>
+ *   GET /Rhythmyx/rest/auditlog/entries
+ *   GET /Rhythmyx/rest/auditlog/entries/{auditId}
+ * </pre>
+ *
+ * <p>AuthZ is enforced in the sitemanage apibridge: Admin role or role property {@code
+ * sys_securityAuditLogViewer}. Unauthorized callers receive HTTP 403.
+ *
+ * <p>Bean id {@code restAuditLogResource} is registered on the {@code rest-jax-rs} CXF server in
+ * {@code sitemanage-beans.xml}.
+ */
+@PSSiteManageBean(value = "restAuditLogResource")
+@Path("/auditlog")
+@Tag(name = "Audit Log", description = "System security audit log query API")
+public class AuditLogResource {
+
+  private static final Logger log = LogManager.getLogger(AuditLogResource.class);
+
+  private final IAuditLogAdaptor adaptor;
+
+  public AuditLogResource() {
+    this.adaptor = null;
+  }
+
+  @Autowired
+  public AuditLogResource(IAuditLogAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
+
+  @GET
+  @Path("/entries")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Query system audit log entries",
+      description =
+          "Returns a page of durable system audit log rows. Requires Admin role or role property"
+              + " sys_securityAuditLogViewer=true.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = SystemAuditLogPage.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid query parameters"),
+        @ApiResponse(responseCode = "403", description = "Caller not allowed to view audit log"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public SystemAuditLogPage queryEntries(
+      @Parameter(description = "Inclusive lower bound (ISO-8601 instant)") @QueryParam("from")
+          String from,
+      @Parameter(description = "Exclusive upper bound (ISO-8601 instant)") @QueryParam("to")
+          String to,
+      @Parameter(description = "Module code filter (e.g. AUTH)") @QueryParam("module")
+          String module,
+      @Parameter(description = "Event type filter") @QueryParam("eventType") String eventType,
+      @Parameter(description = "Outcome filter (SUCCESS, FAILURE, …)") @QueryParam("outcome")
+          String outcome,
+      @Parameter(description = "Actor (user name) filter, case-insensitive") @QueryParam("actor")
+          String actor,
+      @Parameter(description = "Zero-based offset") @QueryParam("offset") @DefaultValue("0")
+          int offset,
+      @Parameter(description = "Page size (server clamps to max)")
+          @QueryParam("limit")
+          @DefaultValue("50")
+          int limit) {
+    try {
+      return requireAdaptor()
+          .query(from, to, module, eventType, outcome, actor, offset, limit);
+    } catch (SecurityException e) {
+      throw new WebApplicationException(e.getMessage(), e, Response.Status.FORBIDDEN);
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), e, Response.Status.BAD_REQUEST);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Audit log query failed", e);
+      throw new WebApplicationException("Failed to query audit log", e, 500);
+    }
+  }
+
+  @GET
+  @Path("/entries/{auditId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Get one system audit log entry",
+      description =
+          "Loads a single durable audit row by AUDIT_ID (UUID). Requires Admin role or role"
+              + " property sys_securityAuditLogViewer=true.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = SystemAuditLogEntry.class))),
+        @ApiResponse(responseCode = "403", description = "Caller not allowed to view audit log"),
+        @ApiResponse(responseCode = "404", description = "Entry not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public SystemAuditLogEntry getEntry(
+      @Parameter(name = "auditId", required = true) @PathParam("auditId") String auditId) {
+    try {
+      SystemAuditLogEntry entry = requireAdaptor().findById(auditId);
+      if (entry == null) {
+        throw new WebApplicationException("Audit log entry not found", Response.Status.NOT_FOUND);
+      }
+      return entry;
+    } catch (SecurityException e) {
+      throw new WebApplicationException(e.getMessage(), e, Response.Status.FORBIDDEN);
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), e, Response.Status.BAD_REQUEST);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Audit log get failed for id={}", auditId, e);
+      throw new WebApplicationException("Failed to load audit log entry", e, 500);
+    }
+  }
+
+  private IAuditLogAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      throw new WebApplicationException(
+          "Audit log adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
+    }
+    return adaptor;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/auditlog/IAuditLogAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/IAuditLogAdaptor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+/**
+ * Adaptor contract for the system security audit log query API (Phase 3 / #2618).
+ *
+ * <p>Implementations enforce AuthZ (Admin role or role property {@code
+ * sys_securityAuditLogViewer}) and map domain rows to wire DTOs. Unauthorized callers must surface
+ * as {@link SecurityException} (resource maps to HTTP 403).
+ */
+public interface IAuditLogAdaptor {
+
+  /**
+   * Query durable audit rows.
+   *
+   * @param fromIso optional inclusive lower bound (ISO-8601 instant); null/blank ignored
+   * @param toIso optional exclusive upper bound (ISO-8601 instant); null/blank ignored
+   * @param moduleCode optional module filter (e.g. AUTH)
+   * @param eventType optional event type filter
+   * @param outcome optional outcome filter (SUCCESS / FAILURE / …)
+   * @param actor optional actor (user name) filter; case-insensitive
+   * @param offset zero-based row offset (negative treated as 0)
+   * @param limit page size (clamped server-side)
+   */
+  SystemAuditLogPage query(
+      String fromIso,
+      String toIso,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor,
+      int offset,
+      int limit);
+
+  /**
+   * Load one entry by audit id.
+   *
+   * @return entry when present
+   * @throws SecurityException when the caller is not allowed
+   * @throws java.util.NoSuchElementException or return null when missing — implementations should
+   *     return null so the resource can map 404
+   */
+  SystemAuditLogEntry findById(String auditId);
+}

--- a/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogEntry.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogEntry.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.time.Instant;
+
+/** Wire DTO for one row from {@code PSX_SYSTEM_AUDIT_LOG}. */
+@XmlRootElement(name = "SystemAuditLogEntry")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "System security audit log entry")
+public class SystemAuditLogEntry {
+
+  private String auditId;
+  private Instant eventTime;
+  private String moduleCode;
+  private Integer messageCode;
+  private String eventType;
+  private String outcome;
+  private String actor;
+  private String target;
+  private String sourceIp;
+  private String sourceHost;
+  private String userMessage;
+  private String logMessage;
+  private String correlationId;
+  private String attributesJson;
+  private String serverNode;
+
+  public SystemAuditLogEntry() {}
+
+  public String getAuditId() {
+    return auditId;
+  }
+
+  public void setAuditId(String auditId) {
+    this.auditId = auditId;
+  }
+
+  public Instant getEventTime() {
+    return eventTime;
+  }
+
+  public void setEventTime(Instant eventTime) {
+    this.eventTime = eventTime;
+  }
+
+  public String getModuleCode() {
+    return moduleCode;
+  }
+
+  public void setModuleCode(String moduleCode) {
+    this.moduleCode = moduleCode;
+  }
+
+  public Integer getMessageCode() {
+    return messageCode;
+  }
+
+  public void setMessageCode(Integer messageCode) {
+    this.messageCode = messageCode;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(String eventType) {
+    this.eventType = eventType;
+  }
+
+  public String getOutcome() {
+    return outcome;
+  }
+
+  public void setOutcome(String outcome) {
+    this.outcome = outcome;
+  }
+
+  public String getActor() {
+    return actor;
+  }
+
+  public void setActor(String actor) {
+    this.actor = actor;
+  }
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(String target) {
+    this.target = target;
+  }
+
+  public String getSourceIp() {
+    return sourceIp;
+  }
+
+  public void setSourceIp(String sourceIp) {
+    this.sourceIp = sourceIp;
+  }
+
+  public String getSourceHost() {
+    return sourceHost;
+  }
+
+  public void setSourceHost(String sourceHost) {
+    this.sourceHost = sourceHost;
+  }
+
+  public String getUserMessage() {
+    return userMessage;
+  }
+
+  public void setUserMessage(String userMessage) {
+    this.userMessage = userMessage;
+  }
+
+  public String getLogMessage() {
+    return logMessage;
+  }
+
+  public void setLogMessage(String logMessage) {
+    this.logMessage = logMessage;
+  }
+
+  public String getCorrelationId() {
+    return correlationId;
+  }
+
+  public void setCorrelationId(String correlationId) {
+    this.correlationId = correlationId;
+  }
+
+  public String getAttributesJson() {
+    return attributesJson;
+  }
+
+  public void setAttributesJson(String attributesJson) {
+    this.attributesJson = attributesJson;
+  }
+
+  public String getServerNode() {
+    return serverNode;
+  }
+
+  public void setServerNode(String serverNode) {
+    this.serverNode = serverNode;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogPage.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogPage.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Paged query result for system audit log entries. */
+@XmlRootElement(name = "SystemAuditLogPage")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Paged system security audit log query result")
+public class SystemAuditLogPage {
+
+  private List<SystemAuditLogEntry> entries = new ArrayList<>();
+  private long total;
+  private int offset;
+  private int limit;
+
+  public SystemAuditLogPage() {}
+
+  public SystemAuditLogPage(List<SystemAuditLogEntry> entries, long total, int offset, int limit) {
+    this.entries = entries != null ? entries : new ArrayList<>();
+    this.total = total;
+    this.offset = offset;
+    this.limit = limit;
+  }
+
+  public List<SystemAuditLogEntry> getEntries() {
+    return entries;
+  }
+
+  public void setEntries(List<SystemAuditLogEntry> entries) {
+    this.entries = entries != null ? entries : new ArrayList<>();
+  }
+
+  public long getTotal() {
+    return total;
+  }
+
+  public void setTotal(long total) {
+    this.total = total;
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+
+  public void setOffset(int offset) {
+    this.offset = offset;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public void setLimit(int limit) {
+    this.limit = limit;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/auditlog/AuditLogResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/auditlog/AuditLogResourceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class AuditLogResourceTest {
+
+  private IAuditLogAdaptor adaptor;
+  private AuditLogResource resource;
+
+  @BeforeEach
+  public void setUp() {
+    adaptor = mock(IAuditLogAdaptor.class);
+    resource = new AuditLogResource(adaptor);
+  }
+
+  @Test
+  public void queryDelegates() {
+    SystemAuditLogPage page = new SystemAuditLogPage(List.of(), 0, 0, 50);
+    when(adaptor.query(
+            isNull(), isNull(), eq("AUTH"), isNull(), isNull(), isNull(), eq(0), eq(50)))
+        .thenReturn(page);
+
+    SystemAuditLogPage out =
+        resource.queryEntries(null, null, "AUTH", null, null, null, 0, 50);
+    assertSame(page, out);
+    verify(adaptor)
+        .query(isNull(), isNull(), eq("AUTH"), isNull(), isNull(), isNull(), eq(0), eq(50));
+  }
+
+  @Test
+  public void queryMapsSecurityExceptionTo403() {
+    when(adaptor.query(
+            isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(0), eq(50)))
+        .thenThrow(new SecurityException("not allowed"));
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.queryEntries(null, null, null, null, null, null, 0, 50));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void queryMapsIllegalArgumentTo400() {
+    when(adaptor.query(
+            eq("bad"), isNull(), isNull(), isNull(), isNull(), isNull(), eq(0), eq(50)))
+        .thenThrow(new IllegalArgumentException("from is not a valid ISO-8601 instant"));
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.queryEntries("bad", null, null, null, null, null, 0, 50));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getEntryDelegates() {
+    SystemAuditLogEntry entry = new SystemAuditLogEntry();
+    entry.setAuditId("id-1");
+    when(adaptor.findById(eq("id-1"))).thenReturn(entry);
+    assertEquals("id-1", resource.getEntry("id-1").getAuditId());
+  }
+
+  @Test
+  public void getEntryMissingIs404() {
+    when(adaptor.findById(eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getEntry("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getEntryForbiddenIs403() {
+    when(adaptor.findById(eq("id-1"))).thenThrow(new SecurityException("denied"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getEntry("id-1"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorIs503() {
+    AuditLogResource bare = new AuditLogResource();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> bare.queryEntries(null, null, null, null, null, null, 0, 50));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestAuditLogAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestAuditLogAdaptor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.auditlog.IAuditLogAdaptor;
+import com.percussion.rest.auditlog.SystemAuditLogEntry;
+import com.percussion.rest.auditlog.SystemAuditLogPage;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Spring test stub for {@link IAuditLogAdaptor} (MainTest / shared rest context). */
+@Component
+public class TestAuditLogAdaptor implements IAuditLogAdaptor {
+
+  @Override
+  public SystemAuditLogPage query(
+      String fromIso,
+      String toIso,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor,
+      int offset,
+      int limit) {
+    return new SystemAuditLogPage(List.of(), 0, Math.max(0, offset), limit <= 0 ? 50 : limit);
+  }
+
+  @Override
+  public SystemAuditLogEntry findById(String auditId) {
+    return null;
+  }
+}

--- a/system/services/src/com/percussion/services/audit/PSSystemAuditLogPermission.java
+++ b/system/services/src/com/percussion/services/audit/PSSystemAuditLogPermission.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Authorization for the system security audit log viewer (Phase 3).
+ *
+ * <p>Access is granted when the caller is in the {@link #ADMIN_ROLE} <strong>or</strong> any of
+ * their roles has the Rhythmyx role property {@link #ROLE_PROPERTY} set to a truthy value.
+ *
+ * <p>Operators assign {@code sys_securityAuditLogViewer=true} on non-Admin roles via Server Admin /
+ * role properties. Admin is always allowed even without the property row.
+ */
+public final class PSSystemAuditLogPermission {
+
+  /** Role property name (Rhythmyx role attribute). */
+  public static final String ROLE_PROPERTY = "sys_securityAuditLogViewer";
+
+  /** Built-in role that always may view the security audit log. */
+  public static final String ADMIN_ROLE = "Admin";
+
+  private PSSystemAuditLogPermission() {}
+
+  /**
+   * @param userRoles role names for the authenticated principal; null treated as empty
+   * @param roleHasViewerProperty for each role name, whether that role has a truthy {@link
+   *     #ROLE_PROPERTY} value
+   * @return true when Admin or any role carries the property
+   */
+  public static boolean allows(
+      Collection<String> userRoles, Predicate<String> roleHasViewerProperty) {
+    Objects.requireNonNull(roleHasViewerProperty, "roleHasViewerProperty");
+    if (userRoles == null || userRoles.isEmpty()) {
+      return false;
+    }
+    for (String role : userRoles) {
+      if (role == null || role.isBlank()) {
+        continue;
+      }
+      if (ADMIN_ROLE.equalsIgnoreCase(role.trim())) {
+        return true;
+      }
+      if (roleHasViewerProperty.test(role.trim())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether a role property value collection grants viewer access.
+   *
+   * <p>Truthy: {@code true}, {@code yes}, {@code y}, {@code 1} (case-insensitive). Empty/null is
+   * false. Explicit negatives ({@code false}, {@code no}, {@code n}, {@code 0}) are false.
+   */
+  public static boolean isTruthyPropertyValue(Collection<String> values) {
+    if (values == null || values.isEmpty()) {
+      return false;
+    }
+    for (String raw : values) {
+      if (raw == null) {
+        continue;
+      }
+      String v = raw.trim().toLowerCase(Locale.ROOT);
+      if (v.isEmpty()) {
+        continue;
+      }
+      if ("false".equals(v) || "no".equals(v) || "n".equals(v) || "0".equals(v)) {
+        continue;
+      }
+      if ("true".equals(v) || "yes".equals(v) || "y".equals(v) || "1".equals(v)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Single-value convenience for unit tests and simple maps. */
+  public static boolean isTruthyPropertyValue(String value) {
+    if (value == null) {
+      return false;
+    }
+    return isTruthyPropertyValue(java.util.List.of(value));
+  }
+}

--- a/system/services/src/com/percussion/services/audit/impl/PSSystemAuditLogRepository.java
+++ b/system/services/src/com/percussion/services/audit/impl/PSSystemAuditLogRepository.java
@@ -26,7 +26,12 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import java.time.Instant;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -108,5 +113,156 @@ public class PSSystemAuditLogRepository implements AuditLogRepository, Initializ
               return q.getSingleResult();
             });
     return count == null ? 0L : count;
+  }
+
+  /**
+   * Load one durable audit row by primary key.
+   *
+   * @param auditId UUID string (AUDIT_ID); may not be blank
+   * @return entry if present
+   */
+  public Optional<PSSystemAuditLogEntry> findById(String auditId) {
+    Objects.requireNonNull(auditId, "auditId");
+    if (auditId.isBlank()) {
+      throw new IllegalArgumentException("auditId may not be blank");
+    }
+    Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+    return Optional.ofNullable(
+        transactionTemplate.execute(status -> entityManager.find(PSSystemAuditLogEntry.class, auditId)));
+  }
+
+  /**
+   * Query durable audit rows with optional filters, newest first.
+   *
+   * <p>Null/blank filter arguments are ignored. {@code offset} defaults to 0 when negative; {@code
+   * limit} is clamped to {@code 1..MAX_PAGE_SIZE}.
+   */
+  public List<PSSystemAuditLogEntry> findEntries(
+      Instant fromInclusive,
+      Instant toExclusive,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor,
+      int offset,
+      int limit) {
+    Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+    int safeOffset = Math.max(0, offset);
+    int safeLimit = clampLimit(limit);
+    List<PSSystemAuditLogEntry> rows =
+        transactionTemplate.execute(
+            status -> {
+              QueryParts qp =
+                  buildWhere(
+                      fromInclusive, toExclusive, moduleCode, eventType, outcome, actor);
+              String jpql =
+                  "SELECT e FROM PSSystemAuditLogEntry e"
+                      + qp.where
+                      + " ORDER BY e.eventTime DESC, e.auditId DESC";
+              TypedQuery<PSSystemAuditLogEntry> q =
+                  entityManager.createQuery(jpql, PSSystemAuditLogEntry.class);
+              qp.apply(q);
+              q.setFirstResult(safeOffset);
+              q.setMaxResults(safeLimit);
+              return q.getResultList();
+            });
+    return rows == null ? List.of() : rows;
+  }
+
+  /**
+   * Count rows matching the same filters as {@link #findEntries(Instant, Instant, String, String,
+   * String, String, int, int)} (offset/limit ignored).
+   */
+  public long countEntries(
+      Instant fromInclusive,
+      Instant toExclusive,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor) {
+    Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+    Long count =
+        transactionTemplate.execute(
+            status -> {
+              QueryParts qp =
+                  buildWhere(
+                      fromInclusive, toExclusive, moduleCode, eventType, outcome, actor);
+              String jpql = "SELECT COUNT(e) FROM PSSystemAuditLogEntry e" + qp.where;
+              TypedQuery<Long> q = entityManager.createQuery(jpql, Long.class);
+              qp.apply(q);
+              return q.getSingleResult();
+            });
+    return count == null ? 0L : count;
+  }
+
+  /** Maximum page size for REST / ops queries (hard cap). */
+  public static final int MAX_PAGE_SIZE = 200;
+
+  /** Default page size when caller omits or passes non-positive limit. */
+  public static final int DEFAULT_PAGE_SIZE = 50;
+
+  public static int clampLimit(int limit) {
+    if (limit <= 0) {
+      return DEFAULT_PAGE_SIZE;
+    }
+    return Math.min(limit, MAX_PAGE_SIZE);
+  }
+
+  private static QueryParts buildWhere(
+      Instant fromInclusive,
+      Instant toExclusive,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor) {
+    StringBuilder where = new StringBuilder();
+    Map<String, Object> params = new LinkedHashMap<>();
+    if (fromInclusive != null) {
+      where.append(where.isEmpty() ? " WHERE " : " AND ");
+      where.append("e.eventTime >= :fromTime");
+      params.put("fromTime", Date.from(fromInclusive));
+    }
+    if (toExclusive != null) {
+      where.append(where.isEmpty() ? " WHERE " : " AND ");
+      where.append("e.eventTime < :toTime");
+      params.put("toTime", Date.from(toExclusive));
+    }
+    if (moduleCode != null && !moduleCode.isBlank()) {
+      where.append(where.isEmpty() ? " WHERE " : " AND ");
+      where.append("e.moduleCode = :moduleCode");
+      params.put("moduleCode", moduleCode.trim());
+    }
+    if (eventType != null && !eventType.isBlank()) {
+      where.append(where.isEmpty() ? " WHERE " : " AND ");
+      where.append("e.eventType = :eventType");
+      params.put("eventType", eventType.trim());
+    }
+    if (outcome != null && !outcome.isBlank()) {
+      where.append(where.isEmpty() ? " WHERE " : " AND ");
+      where.append("e.outcome = :outcome");
+      params.put("outcome", outcome.trim());
+    }
+    if (actor != null && !actor.isBlank()) {
+      where.append(where.isEmpty() ? " WHERE " : " AND ");
+      where.append("LOWER(e.actor) = :actor");
+      params.put("actor", actor.trim().toLowerCase(Locale.ROOT));
+    }
+    return new QueryParts(where.toString(), params);
+  }
+
+  private static final class QueryParts {
+    final String where;
+    final Map<String, Object> params;
+
+    QueryParts(String where, Map<String, Object> params) {
+      this.where = where;
+      this.params = params;
+    }
+
+    void apply(TypedQuery<?> q) {
+      for (Map.Entry<String, Object> e : params.entrySet()) {
+        q.setParameter(e.getKey(), e.getValue());
+      }
+    }
   }
 }

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLogPermissionTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLogPermissionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.audit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class PSSystemAuditLogPermissionTest {
+
+  @Test
+  void adminAlwaysAllowedEvenWithoutProperty() {
+    assertTrue(
+        PSSystemAuditLogPermission.allows(List.of("Admin"), role -> false));
+    assertTrue(
+        PSSystemAuditLogPermission.allows(List.of("admin"), role -> false));
+  }
+
+  @Test
+  void grantedRoleWithTruthyPropertyAllowed() {
+    assertTrue(
+        PSSystemAuditLogPermission.allows(
+            List.of("Editor"), role -> "Editor".equals(role)));
+  }
+
+  @Test
+  void nonAdminWithoutPropertyDenied() {
+    assertFalse(
+        PSSystemAuditLogPermission.allows(List.of("Editor", "Author"), role -> false));
+  }
+
+  @Test
+  void emptyOrNullRolesDenied() {
+    assertFalse(PSSystemAuditLogPermission.allows(null, role -> true));
+    assertFalse(PSSystemAuditLogPermission.allows(List.of(), role -> true));
+  }
+
+  @Test
+  void truthyPropertyValues() {
+    assertTrue(PSSystemAuditLogPermission.isTruthyPropertyValue("true"));
+    assertTrue(PSSystemAuditLogPermission.isTruthyPropertyValue("YES"));
+    assertTrue(PSSystemAuditLogPermission.isTruthyPropertyValue("1"));
+    assertTrue(PSSystemAuditLogPermission.isTruthyPropertyValue(List.of("y")));
+    assertFalse(PSSystemAuditLogPermission.isTruthyPropertyValue("false"));
+    assertFalse(PSSystemAuditLogPermission.isTruthyPropertyValue("0"));
+    assertFalse(PSSystemAuditLogPermission.isTruthyPropertyValue(""));
+    assertFalse(PSSystemAuditLogPermission.isTruthyPropertyValue((String) null));
+    assertFalse(PSSystemAuditLogPermission.isTruthyPropertyValue(Set.of("maybe")));
+  }
+}

--- a/system/src/test/java/com/percussion/services/audit/impl/PSSystemAuditLogRepositoryTest.java
+++ b/system/src/test/java/com/percussion/services/audit/impl/PSSystemAuditLogRepositoryTest.java
@@ -16,7 +16,11 @@
  */
 package com.percussion.services.audit.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,7 +31,11 @@ import com.intsof.percussioncms.auditlog.AuditRecord;
 import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
 import com.percussion.services.audit.data.PSSystemAuditLogEntry;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -37,7 +45,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Proves durable save runs inside a TransactionTemplate (Holder dual-write safe without AOP
- * proxy).
+ * proxy) and that Phase 3 query helpers clamp paging and bind filters.
  */
 class PSSystemAuditLogRepositoryTest {
 
@@ -70,5 +78,76 @@ class PSSystemAuditLogRepositoryTest {
     verify(em).persist(any(PSSystemAuditLogEntry.class));
     verify(tm).getTransaction(any(TransactionDefinition.class));
     verify(tm).commit(status);
+  }
+
+  @Test
+  void clampLimitDefaultsAndCaps() {
+    assertEquals(
+        PSSystemAuditLogRepository.DEFAULT_PAGE_SIZE, PSSystemAuditLogRepository.clampLimit(0));
+    assertEquals(
+        PSSystemAuditLogRepository.DEFAULT_PAGE_SIZE, PSSystemAuditLogRepository.clampLimit(-5));
+    assertEquals(10, PSSystemAuditLogRepository.clampLimit(10));
+    assertEquals(
+        PSSystemAuditLogRepository.MAX_PAGE_SIZE,
+        PSSystemAuditLogRepository.clampLimit(PSSystemAuditLogRepository.MAX_PAGE_SIZE + 50));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findEntriesAppliesFiltersOffsetAndLimit() {
+    EntityManager em = mock(EntityManager.class);
+    PlatformTransactionManager tm = mock(PlatformTransactionManager.class);
+    TransactionStatus status = new SimpleTransactionStatus();
+    when(tm.getTransaction(any(TransactionDefinition.class))).thenReturn(status);
+    TypedQuery<PSSystemAuditLogEntry> q = mock(TypedQuery.class);
+    when(em.createQuery(anyString(), eq(PSSystemAuditLogEntry.class))).thenReturn(q);
+    when(q.setParameter(anyString(), any())).thenReturn(q);
+    when(q.setFirstResult(any(Integer.class))).thenReturn(q);
+    when(q.setMaxResults(any(Integer.class))).thenReturn(q);
+    when(q.getResultList()).thenReturn(List.of());
+
+    PSSystemAuditLogRepository repo = new PSSystemAuditLogRepository();
+    repo.setEntityManager(em);
+    repo.setTransactionTemplate(new TransactionTemplate(tm));
+
+    Instant from = Instant.parse("2026-08-01T00:00:00Z");
+    Instant to = Instant.parse("2026-08-10T00:00:00Z");
+    repo.findEntries(from, to, "AUTH", "LOGIN", "SUCCESS", "Admin", 5, 10);
+
+    verify(em)
+        .createQuery(
+            eq(
+                "SELECT e FROM PSSystemAuditLogEntry e WHERE e.eventTime >= :fromTime AND"
+                    + " e.eventTime < :toTime AND e.moduleCode = :moduleCode AND e.eventType ="
+                    + " :eventType AND e.outcome = :outcome AND LOWER(e.actor) = :actor ORDER BY"
+                    + " e.eventTime DESC, e.auditId DESC"),
+            eq(PSSystemAuditLogEntry.class));
+    verify(q).setParameter(eq("fromTime"), eq(Date.from(from)));
+    verify(q).setParameter(eq("toTime"), eq(Date.from(to)));
+    verify(q).setParameter(eq("moduleCode"), eq("AUTH"));
+    verify(q).setParameter(eq("eventType"), eq("LOGIN"));
+    verify(q).setParameter(eq("outcome"), eq("SUCCESS"));
+    verify(q).setParameter(eq("actor"), eq("admin"));
+    verify(q).setFirstResult(5);
+    verify(q).setMaxResults(10);
+  }
+
+  @Test
+  void findByIdDelegatesToEntityManager() {
+    EntityManager em = mock(EntityManager.class);
+    PlatformTransactionManager tm = mock(PlatformTransactionManager.class);
+    TransactionStatus status = new SimpleTransactionStatus();
+    when(tm.getTransaction(any(TransactionDefinition.class))).thenReturn(status);
+    PSSystemAuditLogEntry entry = new PSSystemAuditLogEntry();
+    entry.setAuditId("id-1");
+    when(em.find(PSSystemAuditLogEntry.class, "id-1")).thenReturn(entry);
+
+    PSSystemAuditLogRepository repo = new PSSystemAuditLogRepository();
+    repo.setEntityManager(em);
+    repo.setTransactionTemplate(new TransactionTemplate(tm));
+
+    Optional<PSSystemAuditLogEntry> found = repo.findById("id-1");
+    assertTrue(found.isPresent());
+    assertEquals("id-1", found.get().getAuditId());
   }
 }


### PR DESCRIPTION
## Summary

Phase 3 of the system audit log stack (**Parent: #2614**): wire the **Security Audit Log Viewer** permission and public REST query API over `PSX_SYSTEM_AUDIT_LOG`.

- Role property `sys_securityAuditLogViewer` (Admin always allowed via code path; installer seeds property name + Admin=`true`)
- REST: `GET /rest/auditlog/entries` and `GET /rest/auditlog/entries/{auditId}`
- Full rest companion closure: wire DTOs, `IAuditLogAdaptor`, Mockito resource test, Spring `TestAuditLogAdaptor`, sitemanage `AuditLogAdaptor` + unit tests, CXF `restAuditLogResource` registration
- AuthZ: **403** without Admin or truthy role property
- Repository query helpers on `PSSystemAuditLogRepository` (filters, paging, findById)
- Operator docs in design note + `perc-auditlog` README

**Out of scope:** Admin UI / Playwright (#2619). No CADF retire (#2617).

Fixes #2618

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Unit: `PSSystemAuditLogPermissionTest` (Admin / property / deny / truthy values)
- [x] Unit: `PSSystemAuditLogRepositoryTest` (save tx, clamp, filter bind, findById)
- [x] Unit: `AuditLogResourceTest` (delegate, 403, 400, 404, 503)
- [x] Unit: `AuditLogAdaptorTest` (Admin, property holder, unauthorized no-repo-touch, parse errors)
- [x] `MainTest` / rest suite still green with Spring stub adaptor
- [x] `ServerConfigsRestJaxrsRegistrationTest` includes `restAuditLogResource`
- [ ] Manual (optional post-merge): as Admin `GET /Rhythmyx/rest/auditlog/entries`; as non-Admin without property expect 403; assign property and re-try

## Gates evidence

| Module | Command | Result |
|--------|---------|--------|
| `system` | `cd system && ../mvnw.cmd test -Dtest=PSSystemAuditLogPermissionTest,PSSystemAuditLogRepositoryTest` | BUILD SUCCESS — Tests run: 9, Failures: 0 |
| `system` | install (javadoc skip for pre-existing javadoc errors unrelated to this change) | BUILD SUCCESS |
| `rest` | `cd rest && ../mvnw.cmd clean install` | BUILD SUCCESS — `AuditLogResourceTest` 7/0; `MainTest` 2/0 |
| `projects/sitemanage` | `cd projects/sitemanage && ../../mvnw.cmd clean install` | BUILD SUCCESS — `AuditLogAdaptorTest` 6/0; suite Failures: 0 |

Self-review (Erlang-style): AuthZ checked before repository; limit clamped server-side; no path I/O; rest→sitemanage cycle avoided; companion stubs present.

> Co-Authored by Grok Build using grok-4.5 with agent main.
