### PR TITLE
feat(WebUI): Object ACL editor mounts on design-object peers (B4 / #2604)

### DIFF
--- a/WebUI/src/main/ts/developer/ActionMenuDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ActionMenuDetailPanel.tsx
@@ -8,6 +8,7 @@ import type { ActionMenu } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { ObjectAclSection } from "./ObjectAclSection";
 
 export function ActionMenuDetailPanel({
   idOrName,
@@ -155,6 +156,12 @@ export function ActionMenuDetailPanel({
               </div>
             )}
           </section>
+
+          <ObjectAclSection
+            objectGuid={detail.guid?.stringValue}
+            objectKind="action-menu"
+            testIdPrefix="developer-am-acl"
+          />
 
           <section style={{ marginTop: "16px" }} data-testid="developer-am-gaps">
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.AM_GAPS}</h3>

--- a/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
@@ -24,6 +24,7 @@ import type { DisplayFormat } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { ObjectAclSection } from "./ObjectAclSection";
 
 export function DisplayFormatDetailPanel({
   idOrName,
@@ -155,6 +156,12 @@ export function DisplayFormatDetailPanel({
               </div>
             )}
           </section>
+
+          <ObjectAclSection
+            objectGuid={detail.guid?.stringValue}
+            objectKind="display-format"
+            testIdPrefix="developer-df-acl"
+          />
 
           <section style={{ marginTop: "16px" }} data-testid="developer-df-gaps">
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.DF_GAPS}</h3>

--- a/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
@@ -8,6 +8,7 @@ import type { SearchDef } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { ObjectAclSection } from "./ObjectAclSection";
 
 export function SearchDetailPanel({
   idOrName,
@@ -120,6 +121,12 @@ export function SearchDetailPanel({
               </div>
             )}
           </section>
+
+          <ObjectAclSection
+            objectGuid={detail.guid?.stringValue}
+            objectKind="search"
+            testIdPrefix="developer-sr-acl"
+          />
 
           <section style={{ marginTop: "16px" }} data-testid="developer-sr-gaps">
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.SR_GAPS}</h3>

--- a/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import type { SiteDef } from "../api/developer/types";
 import { catalogColors, backButton, metaGrid, monoCell } from "./catalogStyles";
 import { DEV_MSG } from "./messages";
+import { ObjectAclSection } from "./ObjectAclSection";
 
 export function SiteDetailPanel({
   site,
@@ -49,6 +50,12 @@ export function SiteDetailPanel({
           </dd>
         </dl>
       </header>
+
+      <ObjectAclSection
+        objectGuid={site.guid?.stringValue}
+        objectKind="site"
+        testIdPrefix="developer-site-acl"
+      />
 
       <section data-testid="developer-site-gaps">
         <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.SITE_GAPS}</h3>

--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -8,6 +8,7 @@ import type { ViewDef } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { ObjectAclSection } from "./ObjectAclSection";
 
 export function ViewDetailPanel({
   idOrName,
@@ -120,6 +121,12 @@ export function ViewDetailPanel({
               </div>
             )}
           </section>
+
+          <ObjectAclSection
+            objectGuid={detail.guid?.stringValue}
+            objectKind="view"
+            testIdPrefix="developer-vw-acl"
+          />
 
           <section style={{ marginTop: "16px" }} data-testid="developer-vw-gaps">
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.VW_GAPS}</h3>

--- a/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
@@ -15,6 +15,21 @@ vi.mock("../../../main/ts/api/developer/actionMenusApi", () => ({
   getActionMenuDetail: vi.fn(),
 }));
 
+// ObjectAclSection loads ACL via separate API; stub to isolate detail load + assert wiring.
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
+}));
+
 const getActionMenuDetail = actionMenusApi.getActionMenuDetail as ReturnType<typeof vi.fn>;
 
 const sampleDetail = {
@@ -26,6 +41,7 @@ const sampleDetail = {
   handler: "CLIENT",
   url: "/Rhythmyx/edit",
   sortRank: 10,
+  guid: { stringValue: "0-11-42" },
   parameters: [{ name: "sys_contentid", value: "0" }],
   properties: [{ name: "AcceleratorKey", value: "E" }],
 };
@@ -48,6 +64,9 @@ describe("ActionMenuDetailPanel", () => {
     expect(screen.getByTestId("developer-am-detail-title").textContent).toContain("Edit Item");
     expect(screen.getByTestId("developer-am-params-table")).toBeTruthy();
     expect(screen.getByTestId("developer-am-props-table")).toBeTruthy();
+    const acl = screen.getByTestId("developer-am-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("action-menu");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-11-42");
     expect(screen.getByTestId("developer-am-gaps")).toBeTruthy();
     expect(getActionMenuDetail).toHaveBeenCalledWith("Edit");
     fireEvent.click(screen.getByTestId("developer-am-back"));

--- a/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
@@ -16,6 +16,21 @@ vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
   normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
 }));
 
+// ObjectAclSection loads ACL via separate API; stub to isolate detail load + assert wiring.
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
+}));
+
 const getDisplayFormatDetail = displayFormatsApi.getDisplayFormatDetail as ReturnType<
   typeof vi.fn
 >;
@@ -54,6 +69,17 @@ describe("DisplayFormatDetailPanel", () => {
     expect(getDisplayFormatDetail).toHaveBeenCalledWith("Default");
     fireEvent.click(screen.getByTestId("developer-df-back"));
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("mounts ObjectAclSection with display-format kind and object guid", async () => {
+    getDisplayFormatDetail.mockResolvedValue(sampleDetail);
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-stub")).toBeTruthy();
+    });
+    const acl = screen.getByTestId("developer-df-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("display-format");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-1-100");
   });
 
   it("shows empty columns section when detail has none", async () => {

--- a/WebUI/src/test/ts/developer/ObjectAclSection.createTemplate.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.createTemplate.test.tsx
@@ -179,4 +179,93 @@ describe("ObjectAclSection create + default template apply", () => {
     );
     expect(saveObjectAcl).not.toHaveBeenCalled();
   });
+
+  /**
+   * B4 peer mount evidence: default-template apply path works when objectKind is a
+   * runtime-relevant design-object peer (display-format), not only content-type/template.
+   */
+  it("applies default template for display-format peer kind with runtime columns", async () => {
+    const mergedAfterSave = {
+      id: 60,
+      name: "df-acl",
+      guid: { stringValue: "0-4-60", uuid: 60 },
+      aclEntries: [
+        {
+          id: 600,
+          name: "admin",
+          type: { type: "USER", name: "admin" },
+          permissions: [{ permission: "OWNER" }],
+        },
+        {
+          id: 601,
+          name: "Default",
+          type: { type: "USER", name: "Default" },
+          permissions: [
+            { permission: "READ" },
+            { permission: "UPDATE" },
+            { permission: "DELETE" },
+            { permission: "OWNER" },
+          ],
+        },
+        {
+          id: 602,
+          name: "AnyCommunity",
+          type: { type: "COMMUNITY", name: "AnyCommunity" },
+          permissions: [{ permission: "RUNTIME_VISIBLE" }],
+        },
+      ],
+    };
+    vi.mocked(getAclForObject)
+      .mockRejectedValueOnce({ status: 404, statusText: "Not Found", body: null })
+      .mockResolvedValueOnce(mergedAfterSave);
+    vi.mocked(createObjectAcl).mockImplementation(async (_guid, owner) => ({
+      id: 60,
+      name: "df-acl",
+      guid: { stringValue: "0-4-60", uuid: 60 },
+      aclEntries: [
+        {
+          id: 600,
+          name: owner.name,
+          type: { type: owner.type, name: owner.name },
+          permissions: [{ permission: "OWNER" }],
+        },
+      ],
+    }));
+
+    render(
+      <ObjectAclSection
+        objectGuid="0-1-100"
+        objectKind="display-format"
+        testIdPrefix="developer-df-acl"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-empty")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-df-acl-owner-name"), {
+      target: { value: "admin" },
+    });
+    fireEvent.click(screen.getByTestId("developer-df-acl-create"));
+
+    await waitFor(() => {
+      expect(createObjectAcl).toHaveBeenCalledWith("0-1-100", {
+        name: "admin",
+        type: "USER",
+      });
+    });
+    await waitFor(() => {
+      expect(saveObjectAcl).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-notice").textContent).toMatch(
+        /template applied/i,
+      );
+    });
+    const table = screen.getByTestId("developer-df-acl-table");
+    expect(table.getAttribute("data-acl-object-kind")).toBe("display-format");
+    expect(table.getAttribute("data-acl-show-runtime")).toBe("true");
+    expect(screen.getByTestId("developer-df-acl-special-badge-default")).toBeTruthy();
+    expect(screen.getByTestId("developer-df-acl-special-badge-any-community")).toBeTruthy();
+  });
 });

--- a/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
+++ b/WebUI/src/test/ts/developer/ObjectAclSection.test.tsx
@@ -108,6 +108,30 @@ describe("ObjectAclSection special Default / AnyCommunity UX", () => {
     expect(screen.queryByTestId("t-acl-add-default")).toBeNull();
   });
 
+  it("shows specials and runtime columns for display-format peer kind (B4)", async () => {
+    getAclForObject.mockResolvedValue(aclWithBothSpecials);
+    render(
+      <ObjectAclSection
+        objectGuid="0-1-100"
+        objectKind="display-format"
+        testIdPrefix="df-acl"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("df-acl-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("df-acl-table").getAttribute("data-acl-object-kind")).toBe(
+      "display-format",
+    );
+    expect(screen.getByTestId("df-acl-table").getAttribute("data-acl-show-runtime")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("df-acl-special-badge-default")).toBeTruthy();
+    expect(screen.getByTestId("df-acl-special-badge-any-community")).toBeTruthy();
+    expect(screen.getByTestId("df-acl-layer-runtime")).toBeTruthy();
+  });
+
   it("groups permission columns under Design access and Runtime visibility (CD-19)", async () => {
     getAclForObject.mockResolvedValue(aclWithBothSpecials);
     render(

--- a/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
@@ -15,6 +15,21 @@ vi.mock("../../../main/ts/api/developer/searchesApi", () => ({
   getSearchDetail: vi.fn(),
 }));
 
+// ObjectAclSection loads ACL via separate API; stub to isolate detail load + assert wiring.
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
+}));
+
 const getSearchDetail = searchesApi.getSearchDetail as ReturnType<typeof vi.fn>;
 
 const sampleDetail = {
@@ -24,6 +39,7 @@ const sampleDetail = {
   displayFormatId: "Default",
   maximumResultSize: 100,
   caseSensitive: false,
+  guid: { stringValue: "0-26-7" },
   fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*", fieldType: "text" }],
   designGaps: ["gap-a"],
 };
@@ -47,6 +63,9 @@ describe("SearchDetailPanel", () => {
     expect(screen.getByTestId("developer-sr-fields-table")).toBeTruthy();
     expect(screen.getByTestId("developer-sr-gaps").textContent).toContain("gap-a");
     expect(getSearchDetail).toHaveBeenCalledWith("All Content");
+    const acl = screen.getByTestId("developer-sr-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("search");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-26-7");
     fireEvent.click(screen.getByTestId("developer-sr-back"));
     expect(onBack).toHaveBeenCalled();
   });

--- a/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
@@ -9,6 +9,21 @@ import type { SiteDef } from "../../../main/ts/api/developer/types";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { SiteDetailPanel } from "../../../main/ts/developer/SiteDetailPanel";
 
+// ObjectAclSection loads ACL via separate API; stub to isolate detail render + assert wiring.
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
+}));
+
 /**
  * SiteDetailPanel is prop-driven from the Sites list payload (no separate detail GET).
  * panelErrMsg ladders for load failures live on SitesPanel; this suite covers success +
@@ -22,6 +37,7 @@ const sampleSite: SiteDef = {
   defaultDocument: "index.html",
   defaultFileExtention: "html",
   pageBasedSite: true,
+  guid: { stringValue: "0-10-1" },
   designGaps: ["gap-a"],
 };
 
@@ -39,6 +55,9 @@ describe("SiteDetailPanel", () => {
     expect(screen.getByTestId("developer-site-detail-title").textContent).toContain("Corporate");
     expect(screen.getByTestId("developer-site-gaps").textContent).toContain("gap-a");
     expect(screen.getByText("https://example.com")).toBeTruthy();
+    const acl = screen.getByTestId("developer-site-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("site");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-10-1");
     fireEvent.click(screen.getByTestId("developer-site-back"));
     expect(onBack).toHaveBeenCalled();
   });

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -15,6 +15,21 @@ vi.mock("../../../main/ts/api/developer/viewsApi", () => ({
   getViewDetail: vi.fn(),
 }));
 
+// ObjectAclSection loads ACL via separate API; stub to isolate detail load + assert wiring.
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
+}));
+
 const getViewDetail = viewsApi.getViewDetail as ReturnType<typeof vi.fn>;
 
 const sampleDetail = {
@@ -24,6 +39,7 @@ const sampleDetail = {
   displayFormatId: "Default",
   maximumResultSize: 50,
   caseSensitive: true,
+  guid: { stringValue: "0-27-3" },
   fields: [{ fieldName: "sys_contentid", operator: "=", fieldValue: "1", fieldType: "number" }],
   designGaps: ["gap-a"],
 };
@@ -47,6 +63,9 @@ describe("ViewDetailPanel", () => {
     expect(screen.getByTestId("developer-vw-fields-table")).toBeTruthy();
     expect(screen.getByTestId("developer-vw-gaps").textContent).toContain("gap-a");
     expect(getViewDetail).toHaveBeenCalledWith("My View");
+    const acl = screen.getByTestId("developer-vw-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("view");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-27-3");
     fireEvent.click(screen.getByTestId("developer-vw-back"));
     expect(onBack).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
Parent epic **#2274** slice **B4** (also #2262 / #1690). Mounts the existing `ObjectAclSection` (B1 specials + B2 default-template apply + B3 design/runtime columns) on remaining Workbench design-object detail peers that already expose an object GUID.

### Mounts added
| Panel | `objectKind` | `testIdPrefix` | GUID source |
|-------|--------------|----------------|-------------|
| `DisplayFormatDetailPanel` | `display-format` | `developer-df-acl` | `detail.guid.stringValue` |
| `ActionMenuDetailPanel` | `action-menu` | `developer-am-acl` | `detail.guid.stringValue` |
| `SearchDetailPanel` | `search` | `developer-sr-acl` | `detail.guid.stringValue` |
| `SiteDetailPanel` | `site` | `developer-site-acl` | `site.guid.stringValue` |
| `ViewDetailPanel` | `view` | `developer-vw-acl` | `detail.guid.stringValue` |

Existing mounts unchanged: Content Type (`developer-ct-acl`), Template (`developer-tpl-acl`).

### Intentionally not mounted
- **Workflow** — `WorkflowDef` / workflow REST catalog has **no `guid` field**. B4 forbids REST invent; mount deferred until a guid is available.
- Slot / Keyword / Locale / etc. — not in the prioritized FR §5.4 runtime set for this PR (Slot has guid but is design-only kind).

### REST
No REST / sitemanage changes. Inventory reconfirmed: `IAclAdaptor` load/create/bulk already sufficient; peer DTOs already carry `guid` for the five mounts above.

## Test plan
- [x] Vitest peer mount wiring (stubbed `ObjectAclSection` asserts `objectKind` + `objectGuid` + prefix) on DF / AM / Search / Site / View
- [x] Vitest specials + runtime columns for `objectKind="display-format"` (`ObjectAclSection.test.tsx`)
- [x] Vitest default-template apply-on-create for display-format peer prefix (`ObjectAclSection.createTemplate.test.tsx`)
- [x] `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS** (Java surefire + frontend Vitest in module build)
- [x] Focused Vitest re-run: 7 files / 40 tests passed

## Gates evidence
- **Change class:** WebUI Developer detail panel ACL section mounts (companions: peer panel tests with ObjectAclSection stub; existing ObjectAclSection unit/create-template suites extended for peer kind)
- **Erlang-style review:** no path I/O; no REST invent; portable; no new product bugs identified
- **Spotless:** not required by AGENTS.md
- **Playwright / B5:** out of scope (explicit for this slice)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2604  
Refs #2274 #2262 #1690 (builds on #2281 #2282 / PR #2293 #2294)

> Co-Authored by Grok Build using grok-4.5 with agent main.
