### PR TITLE
fix(webui): #2605 B5 prefs Design/Runtime columns + object ACL Playwright product path

### DIFF
--- a/WebUI/src/main/ts/developer/DeveloperPreferencesPanel.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperPreferencesPanel.tsx
@@ -20,7 +20,7 @@ import {
   loadDefaultAclTemplate,
   saveDefaultAclTemplate,
 } from "../api/developer/preferencesApi";
-import { ACL_PERMISSIONS, type AclPermissionName } from "../api/developer/aclApi";
+import { type AclPermissionName } from "../api/developer/aclApi";
 import { isSessionRedirectError, type ApiError } from "../api/client";
 import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
 import { catalogColors, errorAlert } from "./catalogStyles";
@@ -34,6 +34,12 @@ import {
   type DefaultAclTemplateEntryType,
 } from "./defaultAclTemplate";
 import { DEV_MSG } from "./messages";
+import {
+  DESIGN_ACCESS_PERMISSIONS,
+  LAYERED_ACL_PERMISSIONS,
+  RUNTIME_ACCESS_PERMISSIONS,
+  type AclPermissionLayer,
+} from "./objectAclPermissionModel";
 
 const inputStyle: React.CSSProperties = {
   padding: "8px",
@@ -74,9 +80,28 @@ function fromDraft(rows: DraftRow[]): DefaultAclTemplate {
   };
 }
 
+/** Workbench-aligned short labels for permission columns (same as ObjectAclSection). */
+function permissionColumnLabel(perm: AclPermissionName): string {
+  switch (perm) {
+    case "READ":
+      return DEV_MSG.ACL_PERM_READ;
+    case "UPDATE":
+      return DEV_MSG.ACL_PERM_UPDATE;
+    case "DELETE":
+      return DEV_MSG.ACL_PERM_DELETE;
+    case "OWNER":
+      return DEV_MSG.ACL_PERM_OWNER;
+    case "RUNTIME_VISIBLE":
+      return DEV_MSG.ACL_PERM_RUNTIME_VISIBLE;
+    default:
+      return String(perm).replace(/_/g, " ");
+  }
+}
+
 /**
  * Developer Preferences — Security: default ACL template for new object ACLs
  * (Workbench parity FR §5.9 / §5.4 #7).
+ * Permission columns are grouped under Design access / Runtime visibility (CD-19 B5).
  */
 export function DeveloperPreferencesPanel(): React.ReactElement {
   const bootstrap = useSpaBootstrap();
@@ -252,7 +277,10 @@ export function DeveloperPreferencesPanel(): React.ReactElement {
         <h3 style={{ fontSize: "1rem", marginTop: 0 }}>
           {DEV_MSG.PREF_SECURITY_TITLE}
         </h3>
-        <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>
+        <p
+          style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+          data-testid="developer-prefs-acl-hint"
+        >
           {DEV_MSG.PREF_ACL_HINT}
         </p>
         <p
@@ -302,6 +330,8 @@ export function DeveloperPreferencesPanel(): React.ReactElement {
           <div style={{ overflowX: "auto", marginTop: "8px" }}>
             <table
               data-testid="developer-prefs-acl-table"
+              data-acl-show-runtime="true"
+              data-acl-layered="true"
               style={{
                 width: "100%",
                 borderCollapse: "collapse",
@@ -309,27 +339,77 @@ export function DeveloperPreferencesPanel(): React.ReactElement {
               }}
             >
               <thead>
+                {/* Layer group headers — Design access | Runtime visibility (CD-19 B5) */}
                 <tr
                   style={{
                     borderBottom: `1px solid ${catalogColors.headerBorder}`,
                     textAlign: "left",
                   }}
+                  data-testid="developer-prefs-acl-layer-headers"
                 >
-                  <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_ENTRY}</th>
-                  <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_TYPE}</th>
-                  {ACL_PERMISSIONS.map((p) => (
+                  <th style={{ padding: "8px" }} rowSpan={2}>
+                    {DEV_MSG.ACL_COL_ENTRY}
+                  </th>
+                  <th style={{ padding: "8px" }} rowSpan={2}>
+                    {DEV_MSG.ACL_COL_TYPE}
+                  </th>
+                  <th
+                    colSpan={DESIGN_ACCESS_PERMISSIONS.length}
+                    style={{
+                      padding: "6px 8px",
+                      textAlign: "center",
+                      fontSize: "0.8rem",
+                      borderBottom: `1px solid ${catalogColors.softBorder}`,
+                      background: "rgba(0,0,0,0.02)",
+                    }}
+                    title={DEV_MSG.ACL_LAYER_DESIGN_HINT}
+                    data-testid="developer-prefs-acl-layer-design"
+                    data-acl-layer={"design" satisfies AclPermissionLayer}
+                  >
+                    {DEV_MSG.ACL_LAYER_DESIGN}
+                  </th>
+                  <th
+                    colSpan={RUNTIME_ACCESS_PERMISSIONS.length}
+                    style={{
+                      padding: "6px 8px",
+                      textAlign: "center",
+                      fontSize: "0.8rem",
+                      borderBottom: `1px solid ${catalogColors.softBorder}`,
+                      background: "rgba(0,0,0,0.02)",
+                    }}
+                    title={DEV_MSG.ACL_LAYER_RUNTIME_HINT}
+                    data-testid="developer-prefs-acl-layer-runtime"
+                    data-acl-layer={"runtime" satisfies AclPermissionLayer}
+                  >
+                    {DEV_MSG.ACL_LAYER_RUNTIME}
+                  </th>
+                  <th style={{ padding: "8px" }} rowSpan={2}>
+                    {DEV_MSG.ACL_COL_ACTIONS}
+                  </th>
+                </tr>
+                <tr
+                  style={{
+                    borderBottom: `1px solid ${catalogColors.headerBorder}`,
+                    textAlign: "left",
+                  }}
+                  data-testid="developer-prefs-acl-perm-headers"
+                >
+                  {LAYERED_ACL_PERMISSIONS.map((p) => (
                     <th
                       key={p}
                       style={{
                         padding: "8px",
                         textAlign: "center",
                         fontSize: "0.8rem",
+                        fontWeight: 500,
                       }}
+                      data-testid={`developer-prefs-acl-perm-header-${p}`}
+                      data-acl-permission={p}
+                      title={p}
                     >
-                      {p.replace("_", " ")}
+                      {permissionColumnLabel(p)}
                     </th>
                   ))}
-                  <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_ACTIONS}</th>
                 </tr>
               </thead>
               <tbody>
@@ -389,7 +469,7 @@ export function DeveloperPreferencesPanel(): React.ReactElement {
                           ))}
                         </select>
                       </td>
-                      {ACL_PERMISSIONS.map((p) => (
+                      {LAYERED_ACL_PERMISSIONS.map((p) => (
                         <td
                           key={p}
                           style={{ padding: "8px", textAlign: "center" }}
@@ -400,7 +480,7 @@ export function DeveloperPreferencesPanel(): React.ReactElement {
                             checked={chosen.has(p)}
                             disabled={busy}
                             onChange={() => togglePerm(r.clientKey, p)}
-                            aria-label={`${p} for ${r.name || "entry"}`}
+                            aria-label={`${permissionColumnLabel(p)} (${p}) for ${r.name || "entry"}`}
                           />
                         </td>
                       ))}

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -103,7 +103,7 @@ export const DEV_MSG_KEYS = {
     "perc.ui.developer@Workbench-parity preferences for design-time tools. Security preferences control the default ACL template applied when you create an object ACL.",
   PREF_SECURITY_TITLE: "perc.ui.developer@Security",
   PREF_ACL_HINT:
-    "perc.ui.developer@Default object ACL template for newly created ACLs (Workbench Security preferences). Entries are merged onto the owner ACL after Create ACL on an object that has none.",
+    "perc.ui.developer@Default object ACL template for newly created ACLs (Workbench Security preferences). Permission columns are grouped under Design access and Runtime visibility. Entries are merged onto the owner ACL after Create ACL on an object that has none.",
   PREF_ACL_LOADING: "perc.ui.developer@Loading default ACL template...",
   PREF_ACL_LOAD_ERROR: "perc.ui.developer@Could not load default ACL template preference.",
   PREF_ACL_SAVE: "perc.ui.developer@Save default ACL template",

--- a/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
@@ -84,6 +84,49 @@ describe("DeveloperPreferencesPanel", () => {
     expect(loadDefaultAclTemplate).toHaveBeenCalled();
   });
 
+  it("groups permission columns under Design access and Runtime visibility", async () => {
+    renderPanel();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-prefs-acl-table")).toBeTruthy();
+    });
+
+    const table = screen.getByTestId("developer-prefs-acl-table");
+    expect(table.getAttribute("data-acl-show-runtime")).toBe("true");
+    expect(table.getAttribute("data-acl-layered")).toBe("true");
+
+    const designLayer = screen.getByTestId("developer-prefs-acl-layer-design");
+    expect(designLayer.getAttribute("data-acl-layer")).toBe("design");
+    expect(designLayer.textContent).toMatch(/Design access/i);
+
+    const runtimeLayer = screen.getByTestId("developer-prefs-acl-layer-runtime");
+    expect(runtimeLayer.getAttribute("data-acl-layer")).toBe("runtime");
+    expect(runtimeLayer.textContent).toMatch(/Runtime visibility/i);
+
+    expect(
+      screen.getByTestId("developer-prefs-acl-perm-header-READ").textContent,
+    ).toMatch(/Read/i);
+    expect(
+      screen.getByTestId("developer-prefs-acl-perm-header-UPDATE").textContent,
+    ).toMatch(/Update/i);
+    expect(
+      screen.getByTestId("developer-prefs-acl-perm-header-DELETE").textContent,
+    ).toMatch(/Delete/i);
+    expect(
+      screen.getByTestId("developer-prefs-acl-perm-header-OWNER").textContent,
+    ).toMatch(/Modify ACL/i);
+    expect(
+      screen.getByTestId("developer-prefs-acl-perm-header-RUNTIME_VISIBLE")
+        .textContent,
+    ).toMatch(/Visible/i);
+
+    // Layered checkbox still present for Default row
+    expect(
+      screen.getByTestId(
+        "developer-prefs-acl-perm-row:0:Default:USER-RUNTIME_VISIBLE",
+      ),
+    ).toBeTruthy();
+  });
+
   it("saves dirty template via preferences API", async () => {
     renderPanel();
     await waitFor(() => {

--- a/modules/perc-qa-automation/frontend/tests/developer-default-acl-preferences.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-default-acl-preferences.spec.js
@@ -100,6 +100,15 @@ test.describe("Developer default ACL preferences (#2282)", () => {
       await expect(nameInputs.first()).toBeVisible();
       const count = await nameInputs.count();
       expect(count).toBeGreaterThan(0);
+
+      // CD-19 B5 (#2605): Design access / Runtime visibility column groups
+      await expect(table).toHaveAttribute("data-acl-layered", "true");
+      await expect(
+        page.locator('[data-testid="developer-prefs-acl-layer-design"]'),
+      ).toContainText(/Design access/i);
+      await expect(
+        page.locator('[data-testid="developer-prefs-acl-layer-runtime"]'),
+      ).toContainText(/Runtime visibility/i);
     }
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-design-runtime.spec.js
@@ -17,16 +17,20 @@
 /**
  * Developer Object ACL — design vs runtime permission model depth (#2283 / #2274 CD-19).
  *
- * Opens a content-type detail panel and asserts ObjectAclSection exposes
- * Workbench-parity Design access vs Runtime visibility column groups and
- * layered permission toggles (Read / Update / Delete / Modify ACL / Visible).
+ * Opens content-type and template detail panels and asserts ObjectAclSection
+ * exposes Workbench-parity Design access vs Runtime visibility column groups
+ * and layered permission toggles (Read / Update / Delete / Modify ACL / Visible).
+ *
+ * Product path (CT + Template + prefs) lives in
+ * developer-object-acl-product-path.spec.js (#2605 B5).
  *
  * Surface filter (H2 QA / agent path):
  *   cd modules/perc-qa-automation/frontend
  *   npx playwright test tests/developer-object-acl-design-runtime.spec.js
+ *   # or: npm run test:surface -- --path tests/developer-object-acl-design-runtime.spec.js
  *
- * Entry: spa.jsp?entry=developer&section=content-types
- * Refs #2283, #2274, #2262, #1690.
+ * Entry: spa.jsp?entry=developer&section=content-types|templates
+ * Refs #2283, #2605, #2274, #2262, #1690.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -35,10 +39,10 @@ const {
   catalogRowSelector,
 } = require("./helpers/developer-catalog-selectors");
 
-function developerContentTypesUrl() {
+function developerSectionUrl(section) {
   const q = new URLSearchParams({
     entry: "developer",
-    section: "content-types",
+    section,
     _: String(Date.now()),
   });
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
@@ -53,7 +57,9 @@ test.describe("Developer Object ACL design vs runtime permissions (#2283)", () =
   test("content type ACL shows Design access and Runtime visibility columns", async ({
     page,
   }) => {
-    await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+    await page.goto(developerSectionUrl("content-types"), {
+      waitUntil: "networkidle",
+    });
 
     await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
       timeout: 20_000,
@@ -176,5 +182,97 @@ test.describe("Developer Object ACL design vs runtime permissions (#2283)", () =
     // Restore so we leave UI clean if user has dirty state visible
     await firstRead.click();
     await expect(firstRead).toBeChecked({ checked: wasChecked });
+  });
+
+  test("template ACL shows Design access and Runtime visibility columns", async ({
+    page,
+  }) => {
+    await page.goto(developerSectionUrl("templates"), {
+      waitUntil: "networkidle",
+    });
+
+    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-templates"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const error = page.locator('[data-testid="developer-tpl-error"]');
+    const panel = page.locator('[data-testid="developer-tpl-panel"]');
+    const empty = page.locator('[data-testid="developer-tpl-empty"]');
+
+    await expect(panel.or(empty).or(error).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await error.isVisible()) {
+      const msg = (await error.innerText()).trim();
+      throw new Error(`Templates catalog error: ${msg}`);
+    }
+
+    if (await empty.isVisible()) {
+      test.skip(true, "No templates in CMS — cannot open Object ACL");
+      return;
+    }
+
+    const firstRow = page.locator(catalogRowSelector("developer-tpl-row", 0));
+    await expect(firstRow).toBeVisible({ timeout: 15_000 });
+    const openBtn = firstRow.locator("button");
+    await expect(
+      openBtn,
+      "first template row should expose Open when selectionKey is set",
+    ).toBeVisible({ timeout: 5_000 });
+    await openBtn.click();
+
+    await expect(
+      page.locator('[data-testid="developer-tpl-detail"]'),
+    ).toBeVisible({ timeout: 20_000 });
+
+    const aclSection = page.locator(
+      '[data-testid="developer-tpl-acl-section"]',
+    );
+    await expect(aclSection).toBeVisible({ timeout: 15_000 });
+
+    const aclError = page.locator('[data-testid="developer-tpl-acl-error"]');
+    const aclEmpty = page.locator('[data-testid="developer-tpl-acl-empty"]');
+    const aclTable = page.locator('[data-testid="developer-tpl-acl-table"]');
+    const aclLoading = page.locator(
+      '[data-testid="developer-tpl-acl-loading"]',
+    );
+
+    await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+    await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await aclError.isVisible()) {
+      const msg = (await aclError.innerText()).trim();
+      throw new Error(`Template Object ACL load error: ${msg}`);
+    }
+
+    if (await aclEmpty.isVisible()) {
+      test.skip(
+        true,
+        "Template has no ACL — create-first path not required for design/runtime columns",
+      );
+      return;
+    }
+
+    await expect(aclTable).toBeVisible();
+    await expect(aclTable).toHaveAttribute("data-acl-show-runtime", "true");
+    await expect(aclTable).toHaveAttribute("data-acl-object-kind", "template");
+
+    await expect(
+      page.locator('[data-testid="developer-tpl-acl-layer-design"]'),
+    ).toContainText(/Design access/i);
+    await expect(
+      page.locator('[data-testid="developer-tpl-acl-layer-runtime"]'),
+    ).toContainText(/Runtime visibility/i);
+    await expect(
+      page.locator(
+        '[data-testid="developer-tpl-acl-perm-header-RUNTIME_VISIBLE"]',
+      ),
+    ).toContainText(/Visible/i);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Object ACL — product path beyond CT-only smoke (#2605 / #2274 B5).
+ *
+ * Covers:
+ *   - Content type ObjectAclSection: Design access / Runtime visibility + specials
+ *   - Template ObjectAclSection: same layered columns (objectKind=template)
+ *   - Developer Preferences default-ACL template: layered Design / Runtime columns
+ *
+ * Peer mounts beyond CT/Template are B4 (#2604); residual Playwright if B4 lands later.
+ *
+ * Surface filter (H2 QA / agent path):
+ *   cd modules/perc-qa-automation/frontend
+ *   npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js
+ *   # or: npm run test:surface -- --tag object-acl-product
+ *
+ * QA mode:
+ *   perc-devctl qa-up → TEST_CMS_URL=… npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js → qa-down
+ *
+ * Refs #2605, #2274, #2262, #1690 (builds on #2283 / PR #2342).
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  catalogRowSelector,
+} = require("./helpers/developer-catalog-selectors");
+
+function developerSectionUrl(section) {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section,
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/**
+ * Open first catalog row detail and return when detail panel is visible.
+ * @param {import('@playwright/test').Page} page
+ * @param {{ rowBase: string, panel: string, empty: string, error: string, detail: string, catalogLabel: string }} ids
+ */
+async function openFirstCatalogDetail(page, ids) {
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const error = page.locator(`[data-testid="${ids.error}"]`);
+  const panel = page.locator(`[data-testid="${ids.panel}"]`);
+  const empty = page.locator(`[data-testid="${ids.empty}"]`);
+
+  await expect(panel.or(empty).or(error).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await error.isVisible()) {
+    const msg = (await error.innerText()).trim();
+    throw new Error(`${ids.catalogLabel} catalog error: ${msg}`);
+  }
+
+  if (await empty.isVisible()) {
+    test.skip(true, `No ${ids.catalogLabel} in CMS — cannot open Object ACL`);
+    return false;
+  }
+
+  const firstRow = page.locator(catalogRowSelector(ids.rowBase, 0));
+  await expect(firstRow).toBeVisible({ timeout: 15_000 });
+  const openBtn = firstRow.locator("button");
+  await expect(
+    openBtn,
+    `first ${ids.catalogLabel} row should expose Open when selectionKey is set`,
+  ).toBeVisible({ timeout: 5_000 });
+  await openBtn.click();
+
+  await expect(page.locator(`[data-testid="${ids.detail}"]`)).toBeVisible({
+    timeout: 20_000,
+  });
+  return true;
+}
+
+/**
+ * Assert layered design/runtime ACL columns on a mounted ObjectAclSection.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} prefix e.g. developer-ct-acl / developer-tpl-acl
+ * @param {string} objectKind expected data-acl-object-kind
+ */
+async function assertLayeredObjectAcl(page, prefix, objectKind) {
+  const aclSection = page.locator(`[data-testid="${prefix}-section"]`);
+  await expect(aclSection).toBeVisible({ timeout: 15_000 });
+  await expect(aclSection).toContainText(
+    /Design-time and runtime|Design access|Runtime/i,
+  );
+
+  const aclError = page.locator(`[data-testid="${prefix}-error"]`);
+  const aclEmpty = page.locator(`[data-testid="${prefix}-empty"]`);
+  const aclTable = page.locator(`[data-testid="${prefix}-table"]`);
+  const aclLoading = page.locator(`[data-testid="${prefix}-loading"]`);
+
+  await expect(aclLoading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+  await expect(aclTable.or(aclEmpty).or(aclError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await aclError.isVisible()) {
+    const msg = (await aclError.innerText()).trim();
+    throw new Error(`Object ACL load error (${prefix}): ${msg}`);
+  }
+
+  if (await aclEmpty.isVisible()) {
+    test.skip(
+      true,
+      `Object has no ACL on ${prefix} — create-first not required for B5 column groups`,
+    );
+    return false;
+  }
+
+  await expect(aclTable).toBeVisible();
+  await expect(aclTable).toHaveAttribute("data-acl-show-runtime", "true");
+  await expect(aclTable).toHaveAttribute("data-acl-object-kind", objectKind);
+
+  await expect(
+    page.locator(`[data-testid="${prefix}-layer-design"]`),
+  ).toBeVisible();
+  await expect(
+    page.locator(`[data-testid="${prefix}-layer-design"]`),
+  ).toContainText(/Design access/i);
+  await expect(
+    page.locator(`[data-testid="${prefix}-layer-runtime"]`),
+  ).toBeVisible();
+  await expect(
+    page.locator(`[data-testid="${prefix}-layer-runtime"]`),
+  ).toContainText(/Runtime visibility/i);
+
+  await expect(
+    page.locator(`[data-testid="${prefix}-perm-header-READ"]`),
+  ).toContainText(/Read/i);
+  await expect(
+    page.locator(`[data-testid="${prefix}-perm-header-UPDATE"]`),
+  ).toContainText(/Update/i);
+  await expect(
+    page.locator(`[data-testid="${prefix}-perm-header-DELETE"]`),
+  ).toContainText(/Delete/i);
+  await expect(
+    page.locator(`[data-testid="${prefix}-perm-header-OWNER"]`),
+  ).toContainText(/Modify ACL/i);
+  await expect(
+    page.locator(`[data-testid="${prefix}-perm-header-RUNTIME_VISIBLE"]`),
+  ).toContainText(/Visible/i);
+
+  const designRead = page.locator(
+    `input[type="checkbox"][data-testid^="${prefix}-perm-"][data-testid$="-READ"]`,
+  );
+  const runtimeVis = page.locator(
+    `input[type="checkbox"][data-testid^="${prefix}-perm-"][data-testid$="-RUNTIME_VISIBLE"]`,
+  );
+  await expect(designRead.first()).toBeVisible();
+  await expect(runtimeVis.first()).toBeVisible();
+  return true;
+}
+
+test.describe("Developer Object ACL product path (#2605 B5) @object-acl-product", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(120_000);
+    await loginAsAdmin(page);
+  });
+
+  test("content type ACL shows Design/Runtime columns and protected specials", async ({
+    page,
+  }) => {
+    await page.goto(developerSectionUrl("content-types"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-content-types"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const opened = await openFirstCatalogDetail(page, {
+      rowBase: "developer-ct-row",
+      panel: "developer-ct-panel",
+      empty: "developer-ct-empty",
+      error: "developer-ct-error",
+      detail: "developer-ct-detail",
+      catalogLabel: "content types",
+    });
+    if (!opened) return;
+
+    const ok = await assertLayeredObjectAcl(
+      page,
+      "developer-ct-acl",
+      "content-type",
+    );
+    if (!ok) return;
+
+    // Protected specials still present on product path (B1 / #2281)
+    await expect(
+      page.locator('[data-testid="developer-ct-acl-special-hint"]'),
+    ).toBeVisible();
+  });
+
+  test("template ACL shows Design access and Runtime visibility columns", async ({
+    page,
+  }) => {
+    await page.goto(developerSectionUrl("templates"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-templates"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const opened = await openFirstCatalogDetail(page, {
+      rowBase: "developer-tpl-row",
+      panel: "developer-tpl-panel",
+      empty: "developer-tpl-empty",
+      error: "developer-tpl-error",
+      detail: "developer-tpl-detail",
+      catalogLabel: "templates",
+    });
+    if (!opened) return;
+
+    await assertLayeredObjectAcl(page, "developer-tpl-acl", "template");
+  });
+
+  test("preferences default ACL template shows Design/Runtime column groups", async ({
+    page,
+  }) => {
+    await page.goto(developerSectionUrl("preferences"), {
+      waitUntil: "networkidle",
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-preferences"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const prefsPanel = page.locator('[data-testid="developer-prefs-panel"]');
+    await expect(prefsPanel).toBeVisible({ timeout: 20_000 });
+
+    const loading = page.locator('[data-testid="developer-prefs-acl-loading"]');
+    await expect(loading).toBeHidden({ timeout: 30_000 }).catch(() => {});
+
+    const table = page.locator('[data-testid="developer-prefs-acl-table"]');
+    const error = page.locator('[data-testid="developer-prefs-acl-error"]');
+    // Table should still render system default even if preference load fails
+    await expect(table.or(error).first()).toBeVisible({ timeout: 30_000 });
+    await expect(table).toBeVisible({ timeout: 15_000 });
+
+    await expect(table).toHaveAttribute("data-acl-show-runtime", "true");
+    await expect(table).toHaveAttribute("data-acl-layered", "true");
+
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-layer-design"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-layer-design"]'),
+    ).toContainText(/Design access/i);
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-layer-runtime"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-layer-runtime"]'),
+    ).toContainText(/Runtime visibility/i);
+
+    await expect(
+      page.locator('[data-testid="developer-prefs-acl-perm-header-READ"]'),
+    ).toContainText(/Read/i);
+    await expect(
+      page.locator(
+        '[data-testid="developer-prefs-acl-perm-header-RUNTIME_VISIBLE"]',
+      ),
+    ).toContainText(/Visible/i);
+
+    const runtimeBoxes = page.locator(
+      'input[type="checkbox"][data-testid^="developer-prefs-acl-perm-"][data-testid$="-RUNTIME_VISIBLE"]',
+    );
+    await expect(runtimeBoxes.first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

**Parent:** #2274 (B tracker) · **Grandparent residual:** #2262 · **Epic:** #1690  
**Slice:** B5 — CD-19 design/runtime residual + object ACL Playwright product path  
**Fixes:** #2605

### Product
1. **Developer Preferences** default-ACL template table now groups permission columns under **Design access** / **Runtime visibility** (reuses `objectAclPermissionModel`: `DESIGN_ACCESS_PERMISSIONS`, `RUNTIME_ACCESS_PERMISSIONS`, `LAYERED_ACL_PERMISSIONS`).
2. Stable `data-testid`s for layer + permission headers (`developer-prefs-acl-layer-design`, `-runtime`, `perm-header-*`); table attributes `data-acl-layered` / `data-acl-show-runtime`.
3. Hint copy mentions Design/Runtime grouping.

### Playwright (HARD GATE companion)
- **New** `developer-object-acl-product-path.spec.js` (`@object-acl-product`): content-type ACL columns + specials, template ACL columns, prefs layered columns.
- Extended `developer-object-acl-design-runtime.spec.js` with **template** path.
- Extended `developer-default-acl-preferences.spec.js` to assert Design/Runtime groups when table is visible.

Does **not** re-do B4 mounts. Peer mounts still open as PR #2639 (#2604); product path covers CT + Template + prefs (available on `main`).

## Test plan

### Agent evidence (this session)
| Gate | Result |
|------|--------|
| Vitest `src/test/ts/developer/` | **366 passed** (incl. new prefs design/runtime test) |
| `cd WebUI && ../mvnw.cmd clean install` | **BUILD SUCCESS** |
| `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` | **BUILD SUCCESS** |
| `npm run test:unit` (perc-qa-automation frontend) | **189 passed** |
| `npm run test:surface:list -- --path tests/developer-object-acl-product-path.spec.js` | **3 tests listed** |
| `npm run test:surface:list -- --tag object-acl-product` | **3 tests listed** |
| Live H2: `perc-devctl qa-up` | **ENV SKIP** — probe failed `server_log_errors` (~97s, host port 21383); `qa-down` run |

### Live surface (when QA stack healthy)
```bash
python docker/scripts/perc-devctl.py qa-up
# use printed TEST_CMS_URL + ADMIN_PASSWORD
cd modules/perc-qa-automation/frontend
TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
  npm run test:surface -- --path tests/developer-object-acl-product-path.spec.js
python docker/scripts/perc-devctl.py qa-down
```

### Manual / human QA
- Preferences → Security: Design access + Runtime visibility column groups, toggle Visible, save/reset.
- Content type + template detail: Object ACL layered columns; specials still protected on CT.
- After #2639 merges: extend product path to peer kinds (residual).

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

## Gates
- Erlang-style self-review: no bugs found; portable paths (N/A for UI strings); companions delivered (Vitest + Playwright surface specs).
- No REST invent.
- Pre-PR Maven clean install per changed module (standalone).

> Co-Authored by Grok Build using grok-4.5 with agent main.