### PR TITLE
test(qa): surface-filtered Playwright for Explorer saved searches (#2507)

### DIFF
--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -617,6 +617,42 @@ npm run test:surface:list -- --path tests/profile-shell.spec.js
 npm run test:surface:list -- --tag profile
 ```
 
+#### Explorer saved-search picker (#2507 / parent #2409 / #2400 slice D)
+
+Surface-filtered live-CMS companion to WebUI SearchPanel saved-search picker
+(#2506). Opens modern Content Explorer (`spa.jsp?entry=explorer`) → toggles
+SearchPanel → asserts catalog chrome (picker / empty / error) → when the
+fixture has a runnable design search, selects it and asserts post-execute
+results list, empty, or error region wiring.
+
+**Soft-skip:** if `GET /services/searches` has no non-custom-URL design search,
+the execute-path test soft-skips after catalog UI assertions (documented for
+minimal H2 fixtures). Shell open + catalog settle remain hard.
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/explorer-saved-search.spec.js` |
+| Tags | `@saved-search` `@explorer-saved-search` `@explorer` |
+| Unit (no CMS) | `npm run test:unit` (includes `explorer-saved-search.test.js`) |
+| Helper | `frontend/tests/helpers/explorer-saved-search.js` |
+| Product peer | `WebUI/.../SearchPanel.tsx` + Vitest `SearchPanel.test.tsx` |
+
+```bash
+# After qa-up — path-filtered only (do not run full suite)
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/explorer-saved-search.spec.js
+
+# Tag form
+npm run test:surface -- --tag saved-search
+npm run test:surface -- --tag explorer-saved-search
+
+# List only (no live CMS)
+npm run test:surface:list -- --path tests/explorer-saved-search.spec.js
+npm run test:surface:list -- --tag saved-search
+```
+
 #### Profile shell keyboard section-nav / focus (#2502 / residual #2427)
 
 Beyond axe: keyboard path Tab → `perc-profile-nav-*` → Enter focuses and

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/profile-shell-title.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/golden-unattended-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/explorer-recycle-restore-ui.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/profile-shell-title.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/golden-unattended-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/folder-recycle-smoke.test.js tests/unit/finder-recycle-restore-ui.test.js tests/unit/explorer-recycle-restore-ui.test.js tests/unit/explorer-saved-search.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:golden-extended": "playwright test tests/golden-unattended-smoke.spec.js tests/folder-recycle-smoke.spec.js tests/profile-shell.spec.js",

--- a/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-saved-search.spec.js
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Explorer saved-search picker surface (#2507 / parent #2409 / grandparent #2400).
+ *
+ * <p>Live-CMS companion to WebUI slice C (#2506 / PR #2606): open modern
+ * Content Explorer → SearchPanel → pick a design search from the catalog →
+ * assert results region, empty handling, or error/loading post-execute
+ * wiring.</p>
+ *
+ * <p>Vitest covers mocked catalog/execute in
+ * {@code WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx}; this
+ * spec is the surface-filtered Playwright HARD GATE for overnight agents.</p>
+ *
+ * <h3>Unattended surface (QA mode)</h3>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; \
+ *     npm run test:surface -- --path tests/explorer-saved-search.spec.js
+ *   # tags:
+ *   npm run test:surface -- --tag saved-search
+ *   npm run test:surface -- --tag explorer-saved-search
+ *   # list only (no live CMS):
+ *   npm run test:surface:list -- --path tests/explorer-saved-search.spec.js
+ *   npm run test:surface:list -- --tag saved-search
+ *   python docker/scripts/perc-devctl.py qa-down
+ * </pre>
+ *
+ * <p><strong>Fixture soft-skip:</strong> when GET /services/searches returns
+ * no runnable (non-custom-URL) design search, the execute-path test soft-skips
+ * after asserting catalog empty / picker-only-custom UI. Catalog mount and
+ * shell toggle remain hard assertions.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+const {
+  TEST_IDS,
+  explorerEntryUrl,
+  searchesCatalogUrl,
+  unwrapSearchDefs,
+  pickRunnableSavedSearch,
+  noRunnableSearchSkipMessage,
+  postExecuteRegionSelector,
+  catalogSettledSelector,
+  isCustomUrlSearch,
+} = require("./helpers/explorer-saved-search");
+
+// Tags live on individual test() titles only — Playwright ignores @tags on describe names.
+test.describe("Explorer saved-search picker (#2507 / #2409)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("Explorer shell opens SearchPanel with saved-search catalog chrome @saved-search @explorer-saved-search @explorer", async ({
+    page,
+  }) => {
+    const url = explorerEntryUrl(BASE_URL);
+    await page.goto(url, { waitUntil: "networkidle" });
+
+    const shell = page.locator(`[data-testid="${TEST_IDS.shell}"]`);
+    await expect(shell).toBeVisible({ timeout: 20_000 });
+
+    await page.locator(`[data-testid="${TEST_IDS.toggleSearch}"]`).click();
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.searchPanelHost}"]`),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.searchPanel}"]`),
+    ).toBeVisible();
+
+    // Catalog settles to empty, error, or picker (loading may flash first).
+    await expect(page.locator(catalogSettledSelector()).first()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const picker = page.locator(`[data-testid="${TEST_IDS.savedPicker}"]`);
+    const empty = page.locator(`[data-testid="${TEST_IDS.savedEmpty}"]`);
+    const err = page.locator(`[data-testid="${TEST_IDS.savedError}"]`);
+
+    if (await picker.isVisible()) {
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.savedSelect}"]`),
+      ).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.savedRun}"]`),
+      ).toBeVisible();
+      // Run stays disabled until a non-placeholder option is chosen.
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.savedRun}"]`),
+      ).toBeDisabled();
+    } else if (await empty.isVisible()) {
+      await expect(empty).toBeVisible();
+    } else {
+      await expect(err).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.savedRetry}"]`),
+      ).toBeVisible();
+    }
+  });
+
+  test("pick known saved search and assert results / empty / error region @saved-search @explorer-saved-search", async ({
+    page,
+    request,
+  }) => {
+    // Probe REST catalog so we know a runnable key before UI drive; soft-skip
+    // when QA H2 fixture has no design searches (documented acceptance).
+    const headers = adminBasicAuthHeaders();
+    const catalogUrl = searchesCatalogUrl(BASE_URL);
+    let restStatus = 0;
+    let restBody = null;
+    try {
+      const res = await request.get(catalogUrl, {
+        headers: { ...headers, Accept: "application/json" },
+      });
+      restStatus = res.status();
+      if (res.ok()) {
+        restBody = await res.json().catch(() => null);
+      }
+    } catch (e) {
+      // Network failure against a dead stack should fail hard below on shell.
+      restBody = null;
+    }
+
+    const runnable = pickRunnableSavedSearch(restBody);
+    const defs = unwrapSearchDefs(restBody);
+    const onlyCustom =
+      defs.length > 0 && defs.every((d) => isCustomUrlSearch(d));
+
+    const url = explorerEntryUrl(BASE_URL);
+    await page.goto(url, { waitUntil: "networkidle" });
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+    ).toBeVisible({ timeout: 20_000 });
+    await page.locator(`[data-testid="${TEST_IDS.toggleSearch}"]`).click();
+    await expect(
+      page.locator(`[data-testid="${TEST_IDS.searchPanel}"]`),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(catalogSettledSelector()).first()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    if (!runnable) {
+      // Soft path: empty catalog or custom-only — still prove UI state.
+      const empty = page.locator(`[data-testid="${TEST_IDS.savedEmpty}"]`);
+      const picker = page.locator(`[data-testid="${TEST_IDS.savedPicker}"]`);
+      if (await empty.isVisible()) {
+        await expect(empty).toBeVisible();
+      } else if (await picker.isVisible()) {
+        await expect(
+          page.locator(`[data-testid="${TEST_IDS.savedSelect}"]`),
+        ).toBeVisible();
+      }
+      test.skip(
+        true,
+        noRunnableSearchSkipMessage({
+          empty: defs.length === 0,
+          onlyCustom,
+          restStatus,
+        }),
+      );
+      return;
+    }
+
+    const select = page.locator(`[data-testid="${TEST_IDS.savedSelect}"]`);
+    await expect(select).toBeVisible({ timeout: 10_000 });
+
+    // Prefer REST-known key; fall back to first non-empty option value.
+    const optionValues = await select.locator("option").evaluateAll((opts) =>
+      opts.map((o) => /** @type {HTMLOptionElement} */ (o).value).filter(Boolean),
+    );
+    const keyToPick = optionValues.includes(runnable.key)
+      ? runnable.key
+      : optionValues[0];
+    expect(
+      keyToPick,
+      "saved-search select should expose at least one design search option",
+    ).toBeTruthy();
+
+    await select.selectOption(keyToPick);
+    const runBtn = page.locator(`[data-testid="${TEST_IDS.savedRun}"]`);
+    await expect(runBtn).toBeEnabled({ timeout: 5_000 });
+    await runBtn.click();
+
+    // Post-execute: loading may flash; settle on results, empty, or error.
+    await expect(page.locator(postExecuteRegionSelector()).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const results = page.locator(`[data-testid="${TEST_IDS.resultsList}"]`);
+    const emptyResults = page.locator(
+      `[data-testid="${TEST_IDS.resultsEmpty}"]`,
+    );
+    const errResults = page.locator(`[data-testid="${TEST_IDS.resultsError}"]`);
+    const loading = page.locator(`[data-testid="${TEST_IDS.resultsLoading}"]`);
+
+    // Wait out loading if it is still visible.
+    if (await loading.isVisible().catch(() => false)) {
+      await expect(loading).toBeHidden({ timeout: 30_000 });
+    }
+
+    await expect(page.locator(postExecuteRegionSelector()).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    if (await results.isVisible()) {
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.resultRow}"]`).first(),
+      ).toBeVisible();
+    } else if (await emptyResults.isVisible()) {
+      await expect(emptyResults).toBeVisible();
+    } else {
+      // Execute may 500 on minimal H2 without search index — error region is
+      // valid wiring evidence (same contract as us5-search free-text path).
+      await expect(errResults).toBeVisible();
+      await expect(
+        page.locator(`[data-testid="search-panel-retry"]`),
+      ).toBeVisible();
+    }
+  });
+
+  test("REST: GET /services/searches answers for Admin @saved-search @explorer-saved-search", async ({
+    request,
+  }) => {
+    test.setTimeout(45_000);
+    const headers = adminBasicAuthHeaders();
+    const res = await request.get(searchesCatalogUrl(BASE_URL), {
+      headers: { ...headers, Accept: "application/json" },
+    });
+    // 200 = catalog; 401/403 still prove webapp auth surface; 5xx is hard fail.
+    expect(
+      res.status(),
+      `GET searches catalog should not 5xx (status=${res.status()})`,
+    ).toBeLessThan(500);
+    expect([200, 401, 403]).toContain(res.status());
+    if (res.status() === 200) {
+      const body = await res.json().catch(() => null);
+      expect(body == null || typeof body === "object" || Array.isArray(body)).toBe(
+        true,
+      );
+      // Structural unwrap never throws on common shapes.
+      const defs = unwrapSearchDefs(body);
+      expect(Array.isArray(defs)).toBe(true);
+    }
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-saved-search.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-saved-search.js
@@ -1,0 +1,260 @@
+/**
+ * Explorer saved-search Playwright helpers (#2507 / parent #2409 / #2400 slice D).
+ *
+ * <p>Pure helpers for surface-filtered E2E: open modern Content Explorer →
+ * SearchPanel → saved-search picker → assert catalog / execute result regions.
+ * No machine hard-coded install paths; base URL comes from auth /
+ * resolve-cms-env ({@code TEST_CMS_URL} or {@code DEV_PERCUSSION_*}).</p>
+ *
+ * <p>Product surface (WebUI #2506): {@code data-testid} values on
+ * {@code SearchPanel} / {@code ContentExplorerShell}.</p>
+ */
+
+"use strict";
+
+/** Stable product test ids for the saved-search surface. */
+const TEST_IDS = Object.freeze({
+  shell: "content-explorer-shell",
+  toggleSearch: "explorer-toggle-search",
+  searchPanelHost: "explorer-search-panel",
+  searchPanel: "search-panel",
+  savedLoading: "search-panel-saved-loading",
+  savedError: "search-panel-saved-error",
+  savedRetry: "search-panel-saved-retry",
+  savedEmpty: "search-panel-saved-empty",
+  savedPicker: "search-panel-saved-picker",
+  savedSelect: "search-panel-saved-select",
+  savedRun: "search-panel-saved-run",
+  resultsLoading: "search-panel-loading",
+  resultsError: "search-panel-error",
+  resultsEmpty: "search-panel-empty",
+  resultsList: "search-panel-results",
+  resultRow: "search-panel-result-row",
+});
+
+/** CX design-search catalog (same path as WebUI {@code PATHS.SEARCHES}). */
+const PATH_SEARCHES = "/Rhythmyx/services/searches";
+
+/**
+ * Build the modern Explorer SPA entry URL with cache-buster.
+ *
+ * @param {string} baseUrl CMS origin (no trailing slash required)
+ * @param {{ cacheBuster?: string | number }} [opts]
+ * @returns {string}
+ */
+function explorerEntryUrl(baseUrl, opts = {}) {
+  const root = String(baseUrl || "")
+    .trim()
+    .replace(/\/+$/, "");
+  const bust =
+    opts.cacheBuster != null ? String(opts.cacheBuster) : String(Date.now());
+  return `${root}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${encodeURIComponent(bust)}`;
+}
+
+/**
+ * Absolute URL for GET design-search catalog.
+ *
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+function searchesCatalogUrl(baseUrl) {
+  const root = String(baseUrl || "")
+    .trim()
+    .replace(/\/+$/, "");
+  return `${root}${PATH_SEARCHES}`;
+}
+
+/**
+ * Absolute URL for POST execute of one design search.
+ *
+ * @param {string} baseUrl
+ * @param {string} idOrName
+ * @returns {string}
+ */
+function searchesExecuteUrl(baseUrl, idOrName) {
+  const root = String(baseUrl || "")
+    .trim()
+    .replace(/\/+$/, "");
+  const key = encodeURIComponent(String(idOrName || "").trim());
+  return `${root}${PATH_SEARCHES}/${key}/execute`;
+}
+
+/**
+ * Unwrap Jackson / list wrappers for {@code SearchDef[]} catalog payloads.
+ *
+ * @param {unknown} payload
+ * @returns {Record<string, unknown>[]}
+ */
+function unwrapSearchDefs(payload) {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload.filter((x) => x != null && typeof x === "object");
+  }
+  if (typeof payload === "object") {
+    const obj = /** @type {Record<string, unknown>} */ (payload);
+    const raw = obj.SearchDef ?? obj.searchDef ?? obj.SearchDefList ?? obj.items;
+    if (raw == null) {
+      return [];
+    }
+    if (Array.isArray(raw)) {
+      return raw.filter((x) => x != null && typeof x === "object");
+    }
+    if (typeof raw === "object") {
+      return [/** @type {Record<string, unknown>} */ (raw)];
+    }
+  }
+  return [];
+}
+
+/**
+ * Stable select option key for a SearchDef (matches WebUI searchKey).
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {string}
+ */
+function searchDefKey(def) {
+  if (def == null || typeof def !== "object") {
+    return "";
+  }
+  const name = def.name != null ? String(def.name).trim() : "";
+  if (name) {
+    return name;
+  }
+  const id = def.id != null ? String(def.id).trim() : "";
+  return id;
+}
+
+/**
+ * Human label for a SearchDef option.
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {string}
+ */
+function searchDefLabel(def) {
+  if (def == null || typeof def !== "object") {
+    return "";
+  }
+  const label =
+    def.label != null
+      ? String(def.label).trim()
+      : def.displayName != null
+        ? String(def.displayName).trim()
+        : "";
+  if (label) {
+    return label;
+  }
+  return searchDefKey(def);
+}
+
+/**
+ * True when the design search is a custom URL search (UI run button disabled).
+ *
+ * @param {Record<string, unknown> | null | undefined} def
+ * @returns {boolean}
+ */
+function isCustomUrlSearch(def) {
+  if (def == null || typeof def !== "object") {
+    return false;
+  }
+  return def.customSearch === true || def.customSearch === "true";
+}
+
+/**
+ * Pick the first runnable (non-custom-URL) design search from a catalog.
+ *
+ * @param {unknown} payload raw REST body or SearchDef[]
+ * @returns {{ key: string, label: string, def: Record<string, unknown> } | null}
+ */
+function pickRunnableSavedSearch(payload) {
+  const defs = unwrapSearchDefs(payload);
+  for (const def of defs) {
+    if (isCustomUrlSearch(def)) {
+      continue;
+    }
+    const key = searchDefKey(def);
+    if (!key) {
+      continue;
+    }
+    return { key, label: searchDefLabel(def) || key, def };
+  }
+  return null;
+}
+
+/**
+ * Classify catalog UI region after SearchPanel mounts.
+ *
+ * @param {"loading"|"error"|"empty"|"picker"|"unknown"} kind
+ * @returns {boolean}
+ */
+function isCatalogSettled(kind) {
+  return kind === "error" || kind === "empty" || kind === "picker";
+}
+
+/**
+ * Soft-skip message when QA fixture has no runnable design searches.
+ *
+ * @param {{ empty?: boolean, onlyCustom?: boolean, restStatus?: number }} [detail]
+ * @returns {string}
+ */
+function noRunnableSearchSkipMessage(detail = {}) {
+  const parts = [
+    "No runnable design search in fixture for Explorer saved-search E2E (#2507).",
+    "Catalog empty or only custom-URL searches — soft skip after asserting catalog UI.",
+  ];
+  if (detail.empty) {
+    parts.push("catalog empty.");
+  }
+  if (detail.onlyCustom) {
+    parts.push("only customSearch=true entries.");
+  }
+  if (detail.restStatus != null) {
+    parts.push(`REST status=${detail.restStatus}.`);
+  }
+  return parts.join(" ");
+}
+
+/**
+ * CSS selector joining post-execute result regions (loading / error / empty / list).
+ *
+ * @returns {string}
+ */
+function postExecuteRegionSelector() {
+  return [
+    `[data-testid="${TEST_IDS.resultsLoading}"]`,
+    `[data-testid="${TEST_IDS.resultsError}"]`,
+    `[data-testid="${TEST_IDS.resultsEmpty}"]`,
+    `[data-testid="${TEST_IDS.resultsList}"]`,
+  ].join(", ");
+}
+
+/**
+ * CSS selector for settled catalog chrome (not still loading).
+ *
+ * @returns {string}
+ */
+function catalogSettledSelector() {
+  return [
+    `[data-testid="${TEST_IDS.savedError}"]`,
+    `[data-testid="${TEST_IDS.savedEmpty}"]`,
+    `[data-testid="${TEST_IDS.savedPicker}"]`,
+  ].join(", ");
+}
+
+module.exports = {
+  TEST_IDS,
+  PATH_SEARCHES,
+  explorerEntryUrl,
+  searchesCatalogUrl,
+  searchesExecuteUrl,
+  unwrapSearchDefs,
+  searchDefKey,
+  searchDefLabel,
+  isCustomUrlSearch,
+  pickRunnableSavedSearch,
+  isCatalogSettled,
+  noRunnableSearchSkipMessage,
+  postExecuteRegionSelector,
+  catalogSettledSelector,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-saved-search.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-saved-search.test.js
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for Explorer saved-search pure helpers (no live CMS).
+ *
+ * Run from modules/perc-qa-automation/frontend:
+ *   npm run test:unit
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  TEST_IDS,
+  PATH_SEARCHES,
+  explorerEntryUrl,
+  searchesCatalogUrl,
+  searchesExecuteUrl,
+  unwrapSearchDefs,
+  searchDefKey,
+  searchDefLabel,
+  isCustomUrlSearch,
+  pickRunnableSavedSearch,
+  isCatalogSettled,
+  noRunnableSearchSkipMessage,
+  postExecuteRegionSelector,
+  catalogSettledSelector,
+} = require("../helpers/explorer-saved-search");
+
+describe("explorer-saved-search helpers (#2507)", () => {
+  it("exports stable test ids used by SearchPanel / shell", () => {
+    assert.equal(TEST_IDS.shell, "content-explorer-shell");
+    assert.equal(TEST_IDS.toggleSearch, "explorer-toggle-search");
+    assert.equal(TEST_IDS.savedSelect, "search-panel-saved-select");
+    assert.equal(TEST_IDS.savedRun, "search-panel-saved-run");
+    assert.equal(TEST_IDS.resultsList, "search-panel-results");
+    assert.equal(PATH_SEARCHES, "/Rhythmyx/services/searches");
+  });
+
+  it("explorerEntryUrl builds spa.jsp explorer entry with cache-buster", () => {
+    assert.equal(
+      explorerEntryUrl("http://127.0.0.1:9993", { cacheBuster: "42" }),
+      "http://127.0.0.1:9993/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=42",
+    );
+    assert.equal(
+      explorerEntryUrl("http://localhost:9992/", { cacheBuster: "a b" }),
+      "http://localhost:9992/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=a%20b",
+    );
+  });
+
+  it("searchesCatalogUrl and searchesExecuteUrl encode idOrName", () => {
+    assert.equal(
+      searchesCatalogUrl("http://127.0.0.1:9993/"),
+      "http://127.0.0.1:9993/Rhythmyx/services/searches",
+    );
+    assert.equal(
+      searchesExecuteUrl("http://cms.example", "All Content"),
+      "http://cms.example/Rhythmyx/services/searches/All%20Content/execute",
+    );
+  });
+
+  it("unwrapSearchDefs handles arrays and Jackson wrappers", () => {
+    assert.deepEqual(unwrapSearchDefs(null), []);
+    assert.deepEqual(unwrapSearchDefs([{ name: "A" }]), [{ name: "A" }]);
+    assert.deepEqual(unwrapSearchDefs({ SearchDef: { name: "B" } }), [
+      { name: "B" },
+    ]);
+    assert.deepEqual(
+      unwrapSearchDefs({ searchDef: [{ name: "C" }, { name: "D" }] }),
+      [{ name: "C" }, { name: "D" }],
+    );
+  });
+
+  it("searchDefKey prefers name then id", () => {
+    assert.equal(searchDefKey(null), "");
+    assert.equal(searchDefKey({ name: "All Content" }), "All Content");
+    assert.equal(searchDefKey({ id: "42" }), "42");
+    assert.equal(searchDefKey({ name: "  n  ", id: "1" }), "n");
+  });
+
+  it("searchDefLabel prefers label/displayName then key", () => {
+    assert.equal(searchDefLabel({ name: "x", label: "Label X" }), "Label X");
+    assert.equal(
+      searchDefLabel({ name: "x", displayName: "Display X" }),
+      "Display X",
+    );
+    assert.equal(searchDefLabel({ name: "fallback" }), "fallback");
+  });
+
+  it("isCustomUrlSearch detects customSearch flags", () => {
+    assert.equal(isCustomUrlSearch({ customSearch: true }), true);
+    assert.equal(isCustomUrlSearch({ customSearch: "true" }), true);
+    assert.equal(isCustomUrlSearch({ customSearch: false }), false);
+    assert.equal(isCustomUrlSearch({}), false);
+  });
+
+  it("pickRunnableSavedSearch skips custom URL entries", () => {
+    assert.equal(pickRunnableSavedSearch([]), null);
+    assert.equal(
+      pickRunnableSavedSearch([{ name: "URL only", customSearch: true }]),
+      null,
+    );
+    const picked = pickRunnableSavedSearch([
+      { name: "Custom", customSearch: true },
+      { name: "All Content", label: "All" },
+      { name: "My Pages" },
+    ]);
+    assert.ok(picked);
+    assert.equal(picked.key, "All Content");
+    assert.equal(picked.label, "All");
+  });
+
+  it("isCatalogSettled and soft-skip message", () => {
+    assert.equal(isCatalogSettled("loading"), false);
+    assert.equal(isCatalogSettled("picker"), true);
+    assert.equal(isCatalogSettled("empty"), true);
+    assert.equal(isCatalogSettled("error"), true);
+    const msg = noRunnableSearchSkipMessage({ empty: true, restStatus: 200 });
+    assert.match(msg, /#2507/);
+    assert.match(msg, /soft skip/i);
+    assert.match(msg, /empty/i);
+    assert.match(msg, /200/);
+  });
+
+  it("region selectors include key test ids", () => {
+    assert.match(postExecuteRegionSelector(), /search-panel-results/);
+    assert.match(postExecuteRegionSelector(), /search-panel-empty/);
+    assert.match(catalogSettledSelector(), /search-panel-saved-picker/);
+    assert.match(catalogSettledSelector(), /search-panel-saved-empty/);
+  });
+});


### PR DESCRIPTION
## Summary
- **Slice D** of parent **#2409** (grandparent **#2400**): surface-filtered Playwright for Explorer saved-search picker (HARD GATE companion to WebUI #2506 / PR #2606).
- Spec: open modern Content Explorer → SearchPanel → pick a known design search when the fixture has one → assert results list / empty / error region wiring.
- Soft-skip when GET /services/searches has no runnable (non-custom-URL) design search after catalog UI assertions.
- Pure helpers + `npm run test:unit` coverage; README documents path/tag for night-issue-prs QA mode.

## Surface filter (night-issue-prs / QA mode)
| Filter | Command |
|--------|---------|
| **Path** | `npm run test:surface -- --path tests/explorer-saved-search.spec.js` |
| **Tag** | `npm run test:surface -- --tag saved-search` (also `@explorer-saved-search`) |
| **List only** | `npm run test:surface:list -- --path tests/explorer-saved-search.spec.js` |

`ash
python docker/scripts/perc-devctl.py qa-up
cd modules/perc-qa-automation/frontend
TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
  npm run test:surface -- --path tests/explorer-saved-search.spec.js
python docker/scripts/perc-devctl.py qa-down
`

## Test plan
- [x] `npm run test:unit` — 199 pass (includes `explorer-saved-search.test.js`)
- [x] `npm run test:surface:list -- --path tests/explorer-saved-search.spec.js` — 3 tests listed
- [x] `npm run test:surface:list -- --tag saved-search` — same 3 tests
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [ ] Live QA mode run (agent `qa-up` hit matrix cell folder-processor probe fail on this host; human/CI against healthy H2 stack)

## Gates
- Erlang-style self-review: portable URL paths only; no host install hardcodes; soft-skip documented for empty fixtures.
- Change class: Playwright surface + helper + unit + README (peers: folder-recycle-smoke / explorer-recycle-restore-ui).
- No product UI/REST code changes (C/B already merged).

## Parent trackers
- Parent epic: #2409
- Grandparent: #2400

Fixes #2507
Partial for #2409
Partial for #2400

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.