### PR TITLE
fix(a11y): axe serious/critical on landed profile form roots (#2503)

### DIFF
--- a/WebUI/src/main/ts/profile/AccountSection.module.css
+++ b/WebUI/src/main/ts/profile/AccountSection.module.css
@@ -100,7 +100,8 @@
 .fieldError,
 .formError {
   margin: 0;
-  color: var(--color-danger, #b42318);
+  /* Darker than theme --color-danger (#d63637) so axe AA contrast holds on white. */
+  color: #7a1a12;
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -167,14 +168,17 @@
   gap: 0.65rem;
   padding: 0.75rem 0.9rem;
   border-radius: 8px;
-  border: 1px solid var(--color-danger, #b42318);
-  background: #fef3f2;
-  color: var(--color-danger, #b42318);
+  /* Pair matches login error card: solid AA contrast (axe color-contrast). */
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
 }
 
 .errorBox p {
   margin: 0;
   line-height: 1.45;
+  color: #991b1b;
+  word-break: break-word;
 }
 
 .statusRegion {

--- a/WebUI/src/main/ts/profile/AccountSection.module.css
+++ b/WebUI/src/main/ts/profile/AccountSection.module.css
@@ -100,8 +100,8 @@
 .fieldError,
 .formError {
   margin: 0;
-  /* Darker than theme --color-danger (#d63637) so axe AA contrast holds on white. */
-  color: #7a1a12;
+  /* Theme token --color-danger-text is AA on white (darker than --color-danger). */
+  color: var(--color-danger-text, #7a1a12);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -168,16 +168,16 @@
   gap: 0.65rem;
   padding: 0.75rem 0.9rem;
   border-radius: 8px;
-  /* Pair matches login error card: solid AA contrast (axe color-contrast). */
-  border: 1px solid #fecaca;
-  background: #fef2f2;
-  color: #991b1b;
+  /* Theme danger surface tokens (AA contrast on light — axe color-contrast). */
+  border: 1px solid var(--color-danger-border, #fecaca);
+  background: var(--color-danger-surface, #fef2f2);
+  color: var(--color-danger-strong, #991b1b);
 }
 
 .errorBox p {
   margin: 0;
   line-height: 1.45;
-  color: #991b1b;
+  color: var(--color-danger-strong, #991b1b);
   word-break: break-word;
 }
 

--- a/WebUI/src/main/ts/profile/AvatarSection.module.css
+++ b/WebUI/src/main/ts/profile/AvatarSection.module.css
@@ -175,8 +175,8 @@
 
 .formError {
   margin: 0;
-  /* Darker than theme --color-danger (#d63637) so axe AA contrast holds on white. */
-  color: #7a1a12;
+  /* Theme token --color-danger-text is AA on white (darker than --color-danger). */
+  color: var(--color-danger-text, #7a1a12);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -200,15 +200,15 @@
   gap: 0.65rem;
   padding: 0.75rem 0.9rem;
   border-radius: 8px;
-  /* Pair matches login error card: solid AA contrast (axe color-contrast). */
-  border: 1px solid #fecaca;
-  background: #fef2f2;
-  color: #991b1b;
+  /* Theme danger surface tokens (AA contrast on light — axe color-contrast). */
+  border: 1px solid var(--color-danger-border, #fecaca);
+  background: var(--color-danger-surface, #fef2f2);
+  color: var(--color-danger-strong, #991b1b);
 }
 
 .errorBox p {
   margin: 0;
   line-height: 1.45;
-  color: #991b1b;
+  color: var(--color-danger-strong, #991b1b);
   word-break: break-word;
 }

--- a/WebUI/src/main/ts/profile/AvatarSection.module.css
+++ b/WebUI/src/main/ts/profile/AvatarSection.module.css
@@ -175,7 +175,8 @@
 
 .formError {
   margin: 0;
-  color: var(--color-danger, #b42318);
+  /* Darker than theme --color-danger (#d63637) so axe AA contrast holds on white. */
+  color: #7a1a12;
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -199,12 +200,15 @@
   gap: 0.65rem;
   padding: 0.75rem 0.9rem;
   border-radius: 8px;
-  border: 1px solid var(--color-danger, #b42318);
-  background: #fef3f2;
-  color: var(--color-danger, #b42318);
+  /* Pair matches login error card: solid AA contrast (axe color-contrast). */
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
 }
 
 .errorBox p {
   margin: 0;
   line-height: 1.45;
+  color: #991b1b;
+  word-break: break-word;
 }

--- a/WebUI/src/main/ts/profile/PreferencesSection.module.css
+++ b/WebUI/src/main/ts/profile/PreferencesSection.module.css
@@ -118,8 +118,8 @@
 
 .formError {
   margin: 0;
-  /* Darker than theme --color-danger (#d63637) so axe AA contrast holds on white. */
-  color: #7a1a12;
+  /* Theme token --color-danger-text is AA on white (darker than --color-danger). */
+  color: var(--color-danger-text, #7a1a12);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -143,15 +143,15 @@
   gap: 0.65rem;
   padding: 0.75rem 0.9rem;
   border-radius: 8px;
-  /* Pair matches login error card: solid AA contrast (axe color-contrast). */
-  border: 1px solid #fecaca;
-  background: #fef2f2;
-  color: #991b1b;
+  /* Theme danger surface tokens (AA contrast on light — axe color-contrast). */
+  border: 1px solid var(--color-danger-border, #fecaca);
+  background: var(--color-danger-surface, #fef2f2);
+  color: var(--color-danger-strong, #991b1b);
 }
 
 .errorBox p {
   margin: 0;
   line-height: 1.45;
-  color: #991b1b;
+  color: var(--color-danger-strong, #991b1b);
   word-break: break-word;
 }

--- a/WebUI/src/main/ts/profile/PreferencesSection.module.css
+++ b/WebUI/src/main/ts/profile/PreferencesSection.module.css
@@ -118,7 +118,8 @@
 
 .formError {
   margin: 0;
-  color: var(--color-danger, #b42318);
+  /* Darker than theme --color-danger (#d63637) so axe AA contrast holds on white. */
+  color: #7a1a12;
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -142,12 +143,15 @@
   gap: 0.65rem;
   padding: 0.75rem 0.9rem;
   border-radius: 8px;
-  border: 1px solid var(--color-danger, #b42318);
-  background: #fef3f2;
-  color: var(--color-danger, #b42318);
+  /* Pair matches login error card: solid AA contrast (axe color-contrast). */
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
 }
 
 .errorBox p {
   margin: 0;
   line-height: 1.45;
+  color: #991b1b;
+  word-break: break-word;
 }

--- a/WebUI/src/main/ts/ui-themes/intersoft/intersoftTheme.ts
+++ b/WebUI/src/main/ts/ui-themes/intersoft/intersoftTheme.ts
@@ -92,6 +92,11 @@ const SEMANTIC: SemanticColors = {
   surfaceAlt: "#f5f7fb",
   border: "#d8dee9",
   danger: "#d63637",
+  // AA-friendly danger palette for text/cards on light surfaces (profile forms axe gate).
+  dangerText: "#7a1a12",
+  dangerStrong: "#991b1b",
+  dangerBorder: "#fecaca",
+  dangerSurface: "#fef2f2",
   success: "#1f8a4c",
   warning: "#e09a1f",
   info: "#1dc2ef",

--- a/WebUI/src/main/ts/ui-themes/types.ts
+++ b/WebUI/src/main/ts/ui-themes/types.ts
@@ -66,8 +66,19 @@ export type SemanticColors = Readonly<{
   surfaceAlt: string;
   /** Border / divider color. */
   border: string;
-  /** Danger / destructive actions. */
+  /** Danger / destructive actions (iconic red; may be low-contrast on white for body text). */
   danger: string;
+  /**
+   * Darker danger text for body copy on light surfaces (axe AA contrast on white).
+   * Prefer this over {@link SemanticColors.danger} for field/form error messages.
+   */
+  dangerText: string;
+  /** Strong danger text for error cards / emphasis on light surfaces. */
+  dangerStrong: string;
+  /** Soft danger border for error cards. */
+  dangerBorder: string;
+  /** Soft danger surface fill for error cards. */
+  dangerSurface: string;
   /** Success / positive states. */
   success: string;
   /** Warning / attention. */

--- a/WebUI/src/test/ts/ui-themes/intersoft/intersoftTheme.test.ts
+++ b/WebUI/src/test/ts/ui-themes/intersoft/intersoftTheme.test.ts
@@ -72,6 +72,10 @@ describe("intersoftTheme", () => {
     expect(vars["--color-text-inverse"]).toBe("#ffffff");
     expect(vars["--color-border"]).toBe("#d8dee9");
     expect(vars["--color-danger"]).toBe("#d63637");
+    expect(vars["--color-danger-text"]).toBe("#7a1a12");
+    expect(vars["--color-danger-strong"]).toBe("#991b1b");
+    expect(vars["--color-danger-border"]).toBe("#fecaca");
+    expect(vars["--color-danger-surface"]).toBe("#fef2f2");
     expect(vars["--font-font-family"]).toContain("Inter");
     expect(vars["--font-font-family-heading"]).toContain("Rubik");
     expect(vars["--font-font-size-base"]).toBe("14");

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -710,6 +710,53 @@ npm run test:surface:list -- --path tests/profile-shell-keyboard.spec.js
 npm run test:surface:list -- --tag keyboard
 ```
 
+#### Profile form axe WCAG (account / preferences / avatar) (#2503 / residual #2427 / parent #2374)
+
+When profile **form** slices land, extend the shell axe pattern
+(`expectNoSeriousA11yViolations`) to each **form root** testid — not only the
+hub chrome (`perc-profile-shell`).
+
+| Surface | Spec | Form root scope | Product issue |
+|---------|------|-----------------|---------------|
+| Account edit | `tests/profile-account.spec.js` | `[data-testid="perc-profile-account"]` | #2395 |
+| Preferences | `tests/profile-preferences.spec.js` | `[data-testid="perc-profile-preferences"]` | #2396 |
+| Avatar / Gravatar | `tests/profile-avatar.spec.js` | `[data-testid="perc-profile-avatar"]` | #2397 |
+| Password (local auth) | *not on main yet* | — | #2394 (still open) — residual when form lands |
+
+Account also scans after a client email-validation error so `aria-invalid` /
+error live region stay free of serious/critical issues. Password form axe is
+intentionally out of scope until #2394 merges.
+
+```bash
+# After qa-up — path-filtered only (do not run full suite)
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/profile-account.spec.js --grep "axe-core"
+
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/profile-preferences.spec.js --grep "axe-core"
+
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/profile-avatar.spec.js --grep "axe-core"
+
+# Multi-path landed form surfaces (axe only)
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- \
+    --path tests/profile-account.spec.js \
+    --path tests/profile-preferences.spec.js \
+    --path tests/profile-avatar.spec.js \
+    --grep "axe-core"
+
+# List only (no live CMS)
+npm run test:surface:list -- --path tests/profile-account.spec.js
+npm run test:surface:list -- --path tests/profile-preferences.spec.js
+npm run test:surface:list -- --path tests/profile-avatar.spec.js
+```
+
 **`run-surface` refuses the full suite** unless you pass `--allow-full` (agents must
 not use that by default).
 

--- a/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-account.spec.js
@@ -20,14 +20,22 @@
  * Surface-filtered only — not full suite:
  *   npm run test:surface -- --path tests/profile-account.spec.js
  *
+ * Axe form root (#2503 / residual #2427):
+ *   npm run test:surface -- --path tests/profile-account.spec.js --grep "axe-core"
+ *
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
  * Covers: Account identity fields for Admin (internal), email edit happy path
  * + client validation, and self-only REST (no target user on path).
+ * Axe: zero serious/critical on [data-testid="perc-profile-account"].
  */
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+/** Form root for account edit (not the whole profile shell). */
+const ACCOUNT_FORM_SCOPE = '[data-testid="perc-profile-account"]';
 
 function profileDeepLink() {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
@@ -78,6 +86,48 @@ test.describe("Profile account @profile @account @smoke", () => {
     await expect(email).toBeVisible();
     await expect(email).toHaveAttribute("type", "email");
     await expect(page.getByTestId("perc-profile-account-save")).toBeVisible();
+  });
+
+  /**
+   * #2503 residual of #2427 — axe serious/critical zero on account form root
+   * after mount (labels, controls, live region wiring). Scope is the form
+   * section, not perc-profile-shell (shell covered by profile-shell.spec.js).
+   */
+  test("axe-core a11y gate — account form root (#2503)", async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectAccountMounted(page);
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: ACCOUNT_FORM_SCOPE,
+    });
+  });
+
+  /**
+   * #2503 — axe after client validation error so aria-invalid / error live
+   * region on the email field stay free of serious/critical issues.
+   */
+  test("axe-core a11y gate — account form with email error (#2503)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectAccountMounted(page);
+
+    const email = page.getByTestId("perc-profile-account-email");
+    await email.fill("not-a-valid-email");
+    await page.getByTestId("perc-profile-account-save").click();
+    await expect(
+      page.getByTestId("perc-profile-account-email-error"),
+    ).toBeVisible();
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: ACCOUNT_FORM_SCOPE,
+    });
   });
 
   test("email validation and save happy path for Admin", async ({ page }) => {

--- a/modules/perc-qa-automation/frontend/tests/profile-avatar.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-avatar.spec.js
@@ -20,14 +20,20 @@
  * Surface-filtered only — not full suite:
  *   npm run test:surface -- --path tests/profile-avatar.spec.js
  *
+ * Axe form root (#2503 / residual #2427):
+ *   npm run test:surface -- --path tests/profile-avatar.spec.js --grep "axe-core"
+ *
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Axe: zero serious/critical on [data-testid="perc-profile-avatar"].
  */
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
 const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
 
-const PROFILE_SHELL_SCOPE = '[data-testid="perc-profile-shell"]';
+/** Form root for Gravatar / avatar controls (not the whole profile shell). */
+const AVATAR_FORM_SCOPE = '[data-testid="perc-profile-avatar"]';
 const ENGLISH_PROFILE_TITLE = /my profile/i;
 
 function profileDeepLink() {
@@ -82,8 +88,24 @@ test.describe("Profile avatar Gravatar @profile @avatar", () => {
     await expect(
       page.getByTestId("perc-profile-section-avatar-status"),
     ).toHaveCount(0);
+  });
 
-    await expectNoSeriousA11yViolations(page, PROFILE_SHELL_SCOPE);
+  /**
+   * #2503 residual of #2427 — axe serious/critical zero on avatar form root
+   * (preview, use-primary, override email, privacy copy, save). Scope is the
+   * form section; shell-level axe remains in profile-shell.spec.js.
+   * Also fixes a prior call that passed a selector string as opts (scope was
+   * never applied — whole page scanned unintentionally).
+   */
+  test("axe-core a11y gate — avatar form root (#2503)", async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectAvatarSectionMounted(page);
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: AVATAR_FORM_SCOPE,
+    });
   });
 
   test("Admin can set Gravatar override email and save", async ({ page }) => {

--- a/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
@@ -20,13 +20,21 @@
  * Surface-filtered only — not full suite:
  *   npm run test:surface -- --path tests/profile-preferences.spec.js
  *
+ * Axe form root (#2503 / residual #2427):
+ *   npm run test:surface -- --path tests/profile-preferences.spec.js --grep "axe-core"
+ *
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
  * Covers: Preferences form mounts; change default landing; reload persists.
+ * Axe: zero serious/critical on [data-testid="perc-profile-preferences"].
  */
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
+
+/** Form root for preferences edit (not the whole profile shell). */
+const PREFERENCES_FORM_SCOPE = '[data-testid="perc-profile-preferences"]';
 
 function profileDeepLink() {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=profile&_=${Date.now()}`;
@@ -71,6 +79,45 @@ test.describe("Profile preferences @profile @preferences @smoke", () => {
     await expect(
       page.getByTestId("perc-profile-preferences-count"),
     ).toBeVisible();
+  });
+
+  /**
+   * #2503 residual of #2427 — axe serious/critical zero on preferences form
+   * root (landing select, save, live status, or load-error/retry). Scope is the
+   * form section, not perc-profile-shell. Waits for the form root only so a
+   * load-error state (missing preferences API on a partial stack) is still
+   * axe-scanned — functional persist coverage remains in the smoke tests.
+   */
+  test("axe-core a11y gate — preferences form root (#2503)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    await page.goto(profileDeepLink(), { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("perc-profile-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(
+      page.getByTestId("perc-profile-section-preferences"),
+    ).toBeVisible();
+    // Root is present for loading, ready, and error — do not require landing.
+    await expect(page.getByTestId("perc-profile-preferences")).toBeVisible({
+      timeout: 30_000,
+    });
+    // Leave loading (aria-busy) before axe when possible.
+    await expect(page.getByTestId("perc-profile-preferences")).not.toHaveAttribute(
+      "aria-busy",
+      "true",
+      { timeout: 30_000 },
+    );
+
+    await expectNoSeriousA11yViolations(page, {
+      scope: PREFERENCES_FORM_SCOPE,
+    });
   });
 
   test("change landing preference, reload, value persists", async ({


### PR DESCRIPTION
## Summary
**Partial for #2503** (parent epic #2374, residual of #2427).

Extends the shell axe gate (`expectNoSeriousA11yViolations`) to **landed profile form roots**:

| Surface | Form root scope | Spec |
|---------|-----------------|------|
| Account edit | `[data-testid="perc-profile-account"]` | `profile-account.spec.js` |
| Preferences | `[data-testid="perc-profile-preferences"]` | `profile-preferences.spec.js` |
| Avatar / Gravatar | `[data-testid="perc-profile-avatar"]` | `profile-avatar.spec.js` |

Also:
- Account axe after client email validation (aria-invalid / error live region).
- Fix avatar prior call that passed a selector **string** as opts (scope never applied).
- Darken profile form error text/cards so theme `--color-danger` (`#d63637`) no longer fails axe `color-contrast` on load-error boxes (login-card AA pair).
- Document surface-filtered commands in `modules/perc-qa-automation/README.md`.

**Not in this PR:** password change form axe — product slice **#2394** is still open / in progress. Residual child will track form-root axe once that form lands.

## Test plan
```bash
# List only
cd modules/perc-qa-automation/frontend
npm run test:surface:list -- --path tests/profile-account.spec.js
npm run test:surface:print -- --path tests/profile-account.spec.js --path tests/profile-preferences.spec.js --path tests/profile-avatar.spec.js --grep axe-core

# Live QA mode (after perc-devctl qa-up; hot-copy modern assets if dist jar is shell-only)
TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up> \
  npm run test:surface -- \
    --path tests/profile-account.spec.js \
    --path tests/profile-preferences.spec.js \
    --path tests/profile-avatar.spec.js \
    --grep "axe-core"
```

**Live evidence (this run):** 4 passed (account form + account email-error + preferences form + avatar form).

## Gates evidence
- Erlang-style self-review: form scopes only; portable paths; no secrets; companions = Playwright specs + README surface docs + product contrast fix for axe failure.
- Maven standalone:
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- Playwright surface-filtered axe: **4 passed**

## Residual
- Password form axe when #2394 merges (filed as residual child).

Operator: Grok: night-issue-prs (model grok-4.5)

Partial #2503
Parent: #2374

> Co-Authored by Grok Build using grok-4.5 with agent main.