### PR TITLE
fix(perc-system): editor mapper serial-field companions (#2452)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSActionLinkList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSActionLinkList.java
@@ -24,6 +24,10 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXActionLinkList DTD in BasicObjects.dtd. */
 public class PSActionLinkList extends PSCollectionComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates a new action link collection of PSAcionLink objects.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
@@ -1047,7 +1047,10 @@ public class PSContentEditor extends PSDataSet {
     ICON_SOURCE_NONE, ICON_SOURCE_SPECIFIED, ICON_SOURCE_FROMFILEEXT
   };
 
-  /** A collection of PSUrlRequest objects, never <code>null</code>. */
+  /**
+   * A collection of PSUrlRequest objects, never <code>null</code>. Typed as {@link PSCollection}
+   * which is {@link java.io.Serializable} (utils #2450 / #2452 serial-field residual).
+   */
   private PSCollection m_sectionLinkList = new PSCollection(PSUrlRequest.class);
 
   /** The command handler stylesheets, never <code>null</code> after construction. */
@@ -1062,13 +1065,23 @@ public class PSContentEditor extends PSDataSet {
    */
   private PSWorkflowInfo m_workflowInfo = null;
 
-  /** The group validation rules, never <code>null</code> might be empty. */
+  /**
+   * The group validation rules, never <code>null</code> might be empty. {@link PSValidationRules}
+   * extends {@link PSCollectionComponent} and is Serializable (#2450 / #2452).
+   */
   private PSValidationRules m_validationRules = new PSValidationRules();
 
-  /** The group input translations, never <code>null</code> might be empty. */
+  /**
+   * The group input translations, never <code>null</code> might be empty. {@link
+   * PSInputTranslations} extends {@link PSCollectionComponent} and is Serializable (#2450 / #2452).
+   */
   private PSInputTranslations m_inputTranslations = new PSInputTranslations();
 
-  /** The group output translations, never <code>null</code> might be empty. */
+  /**
+   * The group output translations, never <code>null</code> might be empty. {@link
+   * PSOutputTranslations} extends {@link PSCollectionComponent} and is Serializable (#2450 /
+   * #2452).
+   */
   private PSOutputTranslations m_outputTranslations = new PSOutputTranslations();
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
@@ -315,11 +315,15 @@ public class PSCustomActionGroup extends PSComponent {
 
   /**
    * A list of action link references (String objects) to be removed, never <code>null</code>, might
-   * be empty.
+   * be empty. Typed as {@link PSCollection} which is {@link java.io.Serializable} (utils #2450 /
+   * #2452 serial-field residual).
    */
   private PSCollection m_removeActions = new PSCollection(String.class);
 
-  /** A list of new action links, may be <code>null</code>. Not empty if valid. */
+  /**
+   * A list of new action links, may be <code>null</code>. Not empty if valid. {@link
+   * PSActionLinkList} extends {@link PSCollectionComponent} and is Serializable (#2450 / #2452).
+   */
   private PSActionLinkList m_actionLinkList = null;
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
@@ -269,7 +269,10 @@ public class PSDisplayMapping extends PSComponent {
   /** The UI set, never <code>null</code> after construction. */
   private PSUISet m_uiSet;
 
-  /** The display mapper, may be <code>null</code>. */
+  /**
+   * The display mapper, may be <code>null</code>. {@link PSDisplayMapper} extends {@link
+   * PSCollectionComponent} / {@link PSCollection} and is Serializable (#2450 / #2452 serial-field).
+   */
   private PSDisplayMapper m_displayMapper = null;
 
   /*

--- a/system/src/main/java/com/percussion/design/objectstore/PSLocation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLocation.java
@@ -413,9 +413,11 @@ public class PSLocation extends PSComponent {
    * If <code>m_page</code> is <code>PAGE_SUMMARY_VIEW</code> or it's <code>
    * PAGE_ROW_EDIT</code> and the type is TYPE_FIELD, then this list contains the names of the field
    * sets to which the action applies, otherwise it is empty. Each entry is a String. Never <code>
-   * null</code>.
+   * null</code>. Declared as {@link ArrayList} (not {@link List}) so the field type is {@link
+   * java.io.Serializable} under {@code -Xlint:serial} (mapper companion of {@link
+   * PSCustomActionGroup}, #2452).
    */
-  private List m_fieldRefs = new ArrayList();
+  private ArrayList m_fieldRefs = new ArrayList();
 
   /**
    * What's the position of this button relative to the existing buttons. A value of 1 indicates

--- a/system/src/main/java/com/percussion/design/objectstore/PSOutputTranslations.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSOutputTranslations.java
@@ -23,6 +23,10 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXOutputTranslations DTD in BasicObjects.dtd. */
 public class PSOutputTranslations extends PSCollectionComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /** Creates a new collection of PSConditionalExit objects. */
   public PSOutputTranslations() {
     super((new PSConditionalExit()).getClass());

--- a/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
@@ -509,11 +509,15 @@ public class PSUIDefinition extends PSComponent {
   /**
    * A collection of PSUISet objects, gets initialized when this object is read from xml, may be
    * <code>null</code> if the xml does not define this element. If it is not <code>null</code> it is
-   * never empty.
+   * never empty. Typed as {@link PSCollection} which is {@link java.io.Serializable} (utils #2450 /
+   * #2452 serial-field residual).
    */
   private PSCollection m_defaultUI = null;
 
-  /** The display mapper, never <code>null</code> after construction. */
+  /**
+   * The display mapper, never <code>null</code> after construction. {@link PSDisplayMapper} extends
+   * {@link PSCollectionComponent} / {@link PSCollection} and is Serializable (#2450 / #2452).
+   */
   private PSDisplayMapper m_displayMapper = null;
 
   /*

--- a/system/src/main/java/com/percussion/design/objectstore/PSValidationRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSValidationRules.java
@@ -24,6 +24,10 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXValidationRules DTD in BasicObjects.dtd. */
 public class PSValidationRules extends PSCollectionComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /** Create a new collection of PSConditionalExit objects. */
   public PSValidationRules() {
     super((new PSConditionalExit()).getClass());

--- a/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialFieldEditorsTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSObjectStoreSerialFieldEditorsTest.java
@@ -18,6 +18,7 @@ package com.percussion.design.objectstore;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.percussion.util.PSCollection;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -26,13 +27,15 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 
 /**
  * Java serialization surface checks for design.objectstore serial-field cleanup on hottest content
- * editor types (#2405 / parent #2022). Field declared types use concrete {@link Serializable}
- * collections/maps; companion holders implement {@link Serializable}.
+ * editor types (#2405) and editor mapper companions (#2452 / parent #2022). Field declared types use
+ * concrete {@link Serializable} collections/maps or Serializable {@link PSCollection} hierarchy
+ * (utils #2450); companion holders implement {@link Serializable}.
  */
 public class PSObjectStoreSerialFieldEditorsTest {
 
@@ -107,5 +110,130 @@ public class PSObjectStoreSerialFieldEditorsTest {
     assertEquals(
         HashMap.class,
         PSControlDependencyMap.class.getDeclaredField("m_controlDependencies").getType());
+  }
+
+  /**
+   * Mapper companions (#2452): declared field types must remain Serializable concrete types after
+   * PSCollection/PSConcurrentList became Serializable (#2450).
+   */
+  @Test
+  public void testMapperCompanionFieldTypesAreSerializable() throws Exception {
+    assertEquals(
+        PSCollection.class, PSUIDefinition.class.getDeclaredField("m_defaultUI").getType());
+    assertEquals(
+        PSDisplayMapper.class, PSUIDefinition.class.getDeclaredField("m_displayMapper").getType());
+    assertEquals(
+        PSCollection.class, PSCustomActionGroup.class.getDeclaredField("m_removeActions").getType());
+    assertEquals(
+        PSActionLinkList.class,
+        PSCustomActionGroup.class.getDeclaredField("m_actionLinkList").getType());
+    assertEquals(
+        PSLocation.class, PSCustomActionGroup.class.getDeclaredField("m_location").getType());
+    assertEquals(
+        PSFormAction.class, PSCustomActionGroup.class.getDeclaredField("m_formAction").getType());
+    assertEquals(
+        PSDisplayMapper.class,
+        PSDisplayMapping.class.getDeclaredField("m_displayMapper").getType());
+    assertEquals(PSUISet.class, PSDisplayMapping.class.getDeclaredField("m_uiSet").getType());
+    assertEquals(
+        ArrayList.class, PSLocation.class.getDeclaredField("m_fieldRefs").getType());
+
+    assertEquals(
+        PSCollection.class, PSContentEditor.class.getDeclaredField("m_sectionLinkList").getType());
+    assertEquals(
+        PSValidationRules.class,
+        PSContentEditor.class.getDeclaredField("m_validationRules").getType());
+    assertEquals(
+        PSInputTranslations.class,
+        PSContentEditor.class.getDeclaredField("m_inputTranslations").getType());
+    assertEquals(
+        PSOutputTranslations.class,
+        PSContentEditor.class.getDeclaredField("m_outputTranslations").getType());
+
+    // Direct field types must be Serializable for -Xlint:serial serial-field.
+    assertTrue(Serializable.class.isAssignableFrom(PSCollection.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSDisplayMapper.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSActionLinkList.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSLocation.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSFormAction.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSUISet.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSValidationRules.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSInputTranslations.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSOutputTranslations.class));
+    assertTrue(Serializable.class.isAssignableFrom(ArrayList.class));
+  }
+
+  @Test
+  public void testUiDefinitionJavaSerializationRoundTrip() throws Exception {
+    PSDisplayMapper mapper = new PSDisplayMapper("main");
+    PSUISet uiSet = new PSUISet();
+    mapper.add(new PSDisplayMapping("sys_title", uiSet));
+    PSCollection defaultUI = new PSCollection(PSUISet.class);
+    defaultUI.add(new PSUISet());
+    PSUIDefinition def = new PSUIDefinition(mapper, defaultUI);
+
+    PSUIDefinition ser = roundTrip(def);
+    assertEquals(def, ser);
+    assertEquals("main", ser.getDisplayMapper().getFieldSetRef());
+    assertNotNull(ser.getDefaultUI());
+    assertTrue(ser.getDefaultUI().hasNext());
+  }
+
+  @Test
+  public void testDisplayMappingJavaSerializationRoundTrip() throws Exception {
+    PSUISet uiSet = new PSUISet();
+    PSDisplayMapping mapping = new PSDisplayMapping("body", uiSet);
+    mapping.setDisplayMapper(new PSDisplayMapper("childSet"));
+
+    PSDisplayMapping ser = roundTrip(mapping);
+    assertEquals(mapping, ser);
+    assertEquals("body", ser.getFieldRef());
+    assertNotNull(ser.getDisplayMapper());
+    assertEquals("childSet", ser.getDisplayMapper().getFieldSetRef());
+  }
+
+  @Test
+  public void testCustomActionGroupJavaSerializationRoundTrip() throws Exception {
+    PSParam param = new PSParam("pssessionid", new PSUserContext("/User/SessionId"));
+    PSCollection parameters = new PSCollection(param.getClass());
+    parameters.add(param);
+
+    PSActionLink actionLink = new PSActionLink(new PSDisplayText("Go"));
+    actionLink.setParameters(parameters);
+    PSActionLinkList actions = new PSActionLinkList(actionLink);
+
+    PSLocation location = new PSLocation(PSLocation.PAGE_SUMMARY_VIEW, PSLocation.TYPE_ROW);
+    location.setFieldRefs(Collections.singletonList("testField").iterator());
+
+    PSCustomActionGroup group = new PSCustomActionGroup(location, actions);
+    PSCollection removeActions = new PSCollection(String.class);
+    removeActions.add("remove1");
+    removeActions.add("remove2");
+    group.setRemoveActions(removeActions);
+
+    PSCustomActionGroup ser = roundTrip(group);
+    assertEquals(group, ser);
+
+    Iterator removeIt = ser.getRemoveActions();
+    assertTrue(removeIt.hasNext());
+    assertEquals("remove1", removeIt.next());
+    assertEquals("remove2", removeIt.next());
+    assertFalse(removeIt.hasNext());
+
+    assertTrue(ser.getActionLinkList().hasNext());
+    assertEquals(PSLocation.PAGE_SUMMARY_VIEW, ser.getLocation().getPage());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(value);
+      bytes = bos.toByteArray();
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      return (T) ois.readObject();
+    }
   }
 }


### PR DESCRIPTION
## Summary
Clears residual `-Xlint:serial` **serial-field** on content-editor mapper UI companions left after hottest-editor batch (#2405 / PR #2449). Root cause for `PSCollection`-typed fields was fixed in utils (#2450 / PR #2543); this slice finishes the mapper companion surface and locks it with tests.

**Parent epic:** #2022  
**Grandparent:** #2200  
**Prior:** #2405 / #2450

### Changes
- `PSLocation`: `List m_fieldRefs` → `ArrayList` (Serializable concrete type; companion of `PSCustomActionGroup`)
- `PSActionLinkList` / `PSValidationRules` / `PSOutputTranslations`: explicit `serialVersionUID`
- Field docs on `PSUIDefinition`, `PSCustomActionGroup`, `PSDisplayMapping`, `PSContentEditor` noting Serializable `PSCollection` / `PSCollectionComponent` field types after #2450
- `PSObjectStoreSerialFieldEditorsTest`: mapper companion field-type gates + Java ser/deser round-trips for `PSUIDefinition`, `PSDisplayMapping`, `PSCustomActionGroup`

No wire/XML behavior change.

### Out of scope residual
- `PSDataSet.m_results` (`IPSResults` non-Serializable) — design.objectstore non-editor residual (#2451)
- `PSItemDefinition` cms.objectstore serial-field — separate track

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **1394**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] `PSObjectStoreSerialFieldEditorsTest` (8 tests) green, including new mapper companion cases
- [x] No new serial-field on target types (`PSUIDefinition`, `PSCustomActionGroup`, `PSDisplayMapping`, `PSContentEditor` PSCollection fields)

## Gates evidence
- Erlang self-review: no behavioral wire change; `List`→`ArrayList` preserves runtime type already used; portable paths N/A; companions + tests complete
- Pre-PR Maven: standalone `cd system && ../mvnw.cmd clean install` green; no new warnings attributable to this change on changed files
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2452