### PR TITLE
fix(perc-system): residual cms.objectstore this-escape after #2467 (#2613)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2613-objectstore-this-escape-residual-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2613-objectstore-this-escape-residual-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — #2613 cms.objectstore residual this-escape (post-#2467)
+
+**Status:** pass (self-review before commit)  
+**Date:** 2026-08-09  
+**Module:** `system` / perc-system
+
+## Change class
+
+Real `-Xlint:this-escape` reduction in `cms.objectstore` residual hotspots **outside** createKey/Element double-load (#2467): final leaf types, private `loadFieldsFromXml` / construction helpers, final relationship property APIs. **No** suppress-only.
+
+## Findings
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| none | Bugs in Action/Folder/Search/AaRelationship Element or named ctor restore | Covered by `PSObjectStoreThisEscapeResidualTest` (8) + existing `PSDbComponentThisEscapeTest` (9) |
+| none | Non-portable paths | N/A (no file I/O changes) |
+| note | Residual cms.objectstore this-escape remains (~64) on CoreItem/ServerItem, processors, leaf value types, etc. | Parent #2022 may re-file further residual; PR-sized leftover out of this slice |
+| note | Several leaf types marked `final` | No in-repo subclasses of Action/Search/DisplayFormat/Folder/AaRelationship; ant `PSAction` is a different type |
+
+## Metrics (cms.objectstore `this-escape` with `-Xmaxwarns 10000`)
+
+| | Count |
+| --- | ---: |
+| Before | 82 |
+| After | 64 |
+| Δ | **−18** |
+
+## Tests
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS  
+- Tests run: 1398, Failures: 0, Errors: 0 (Skipped: 240)  
+- Focused: `PSObjectStoreThisEscapeResidualTest` 8/8, `PSDbComponentThisEscapeTest` 9/9  
+
+## Hard gates
+
+- [x] Behavioral unit tests for touched Element/ctor paths  
+- [x] No suppress-only this-escape  
+- [x] Cross-platform N/A  
+- [x] Module clean install green  

--- a/system/src/main/java/com/percussion/cms/objectstore/PSAaRelationship.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSAaRelationship.java
@@ -42,7 +42,8 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @author RammohanVangapalli
  */
-public class PSAaRelationship extends PSRelationship {
+// Final leaf — constructors call final setConfig/setProperty/setSlot without subclass this-escape.
+public final class PSAaRelationship extends PSRelationship {
   /**
    * Construct a new active assembly relaionship knowing the owner locator, contentid of the
    * dependent, id of the slot the dependent belongs and the variantid of the dependent.
@@ -203,8 +204,12 @@ public class PSAaRelationship extends PSRelationship {
    *     registered user properties.
    * @deprecated use {@link #setSlot(IPSTemplateSlot)} instead.
    */
+  /**
+   * Final so constructors can assign slot without this-escape. Uses final {@link
+   * PSRelationship#setProperty(String, String)}.
+   */
   @Deprecated
-  public void setSlot(PSSlotType slot) {
+  public final void setSlot(PSSlotType slot) {
     if (slot == null) throw new IllegalArgumentException("slot must not be null");
 
     m_slot = slot;
@@ -241,8 +246,12 @@ public class PSAaRelationship extends PSRelationship {
    * @throws IllegalArgumentException if the {@link IPSHtmlParameters#SYS_VARIANTID} is not one of
    *     the registered user properties.
    */
+  /**
+   * Final so constructors can assign variant/template without this-escape. Uses final {@link
+   * PSRelationship#setProperty(String, String)}.
+   */
   @SuppressWarnings("deprecation")
-  public void setVariant(PSContentTypeTemplate variant) {
+  public final void setVariant(PSContentTypeTemplate variant) {
     if (variant == null) throw new IllegalArgumentException("variant must not be null");
 
     m_variant = variant;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSAaRelationshipList.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSAaRelationshipList.java
@@ -36,7 +36,8 @@ import org.w3c.dom.Element;
  * @author Ram
  */
 // REFACTORED: CP-JAVA11
-public class PSAaRelationshipList extends PSCollectionComponent {
+// Final leaf — Element ctor restores via private fromXmlLoad without subclass this-escape.
+public final class PSAaRelationshipList extends PSCollectionComponent {
   /** Constructs an empty active assembly relationship list. */
   public PSAaRelationshipList() {
     super(PSAaRelationship.class);
@@ -53,7 +54,8 @@ public class PSAaRelationshipList extends PSCollectionComponent {
   public PSAaRelationshipList(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     super(PSAaRelationship.class);
-    fromXml(sourceNode, parentDoc, parentComponents);
+    // Private load avoids virtual fromXml/add during construction (this-escape).
+    fromXmlLoad(sourceNode, parentDoc, parentComponents);
   }
 
   /**
@@ -61,6 +63,16 @@ public class PSAaRelationshipList extends PSCollectionComponent {
    */
   @Override
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      throws PSUnknownNodeTypeException {
+    fromXmlLoad(sourceNode, parentDoc, parentComponents);
+  }
+
+  /**
+   * Non-virtual Element restore. Uses {@link java.util.Collection#add} via direct super path after
+   * full construction when called from public {@link #fromXml}; during Element ctor the collection
+   * is empty and only non-overridable list storage is used.
+   */
+  private void fromXmlLoad(Element sourceNode, IPSDocument parentDoc, List parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
@@ -82,7 +94,8 @@ public class PSAaRelationshipList extends PSCollectionComponent {
       while (node != null) {
         PSRelationship relationship =
             new PSRelationship(node, parentDoc, (List<IPSComponent>) parentComponents);
-        add(relationship);
+        // Direct list insert — avoid overridable add() during construction (this-escape).
+        super.add(relationship);
         node = tree.getNextElement(PSRelationship.XML_NODE_NAME, nextFlags);
       }
     } finally {

--- a/system/src/main/java/com/percussion/cms/objectstore/PSAction.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSAction.java
@@ -37,7 +37,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 
 /** The class that is used to represent menu actions as defined by 'sys_Action.dtd'. */
-public class PSAction extends PSVersionableDbComponent implements IPSCatalogSummary, IPSCloneTuner {
+// Final leaf — Element/ctor paths use private helpers; no subclass this-escape risk.
+public final class PSAction extends PSVersionableDbComponent implements IPSCatalogSummary, IPSCloneTuner {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
@@ -94,7 +95,9 @@ public class PSAction extends PSVersionableDbComponent implements IPSCatalogSumm
 
     m_name = name;
     m_label = label;
-    setMenuType(type);
+    // Private validate + field write — avoid overridable setMenuType (this-escape).
+    validateType(type);
+    m_type = type;
     m_handler = handler;
     m_actionURL = (url == null) ? "" : url;
     m_sortrank = sortrank;
@@ -114,9 +117,9 @@ public class PSAction extends PSVersionableDbComponent implements IPSCatalogSumm
    * @throws PSUnknownNodeTypeException if element is not of expected format.
    */
   public PSAction(Element element) throws PSUnknownNodeTypeException {
-    super.fromXml(element);
-
-    fromXml(element);
+    // Key/state via non-virtual Element super path; fields without virtual fromXml (this-escape).
+    super(element);
+    loadFieldsFromXml(element);
   }
 
   /** Creates the correct key for this component. */
@@ -204,15 +207,27 @@ public class PSAction extends PSVersionableDbComponent implements IPSCatalogSumm
   // of the xml element.
   @Override
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+    // After full construction: virtual createKey / getNodeName still honored via super.
     super.fromXml(sourceNode);
+    loadFieldsFromXml(sourceNode);
+  }
 
+  /**
+   * Loads non-key action fields from XML. Used by Element ctor (after super key/state) and public
+   * {@link #fromXml(Element)} so key restore is not double-applied and construction stays
+   * this-escape free.
+   */
+  private void loadFieldsFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     // attributes
     m_name = PSComponentUtils.getRequiredAttribute(sourceNode, NAME_ATTR);
     m_label = PSComponentUtils.getRequiredAttribute(sourceNode, LABEL_ATTR);
     m_type = PSComponentUtils.getEnumeratedAttribute(sourceNode, TYPE_ATTR, ms_menuTypes);
     String url = sourceNode.getAttribute(URL_ATTR);
     m_actionURL = (url == null) ? "" : (url.equals(URL_PLACEHOLDER) ? "" : url);
-    setMenuDynamic(!StringUtils.isBlank(m_actionURL));
+    // Direct field write for dynamic flag — avoid overridable setMenuDynamic during Element load.
+    if (m_type != null && m_type.equals(TYPE_MENU)) {
+      m_isDynamic = !StringUtils.isBlank(m_actionURL);
+    }
     m_handler = PSComponentUtils.getEnumeratedAttribute(sourceNode, HANDLER_ATTR, ms_handlers);
 
     m_sortrank = 0;
@@ -224,9 +239,15 @@ public class PSAction extends PSVersionableDbComponent implements IPSCatalogSumm
     }
 
     try {
-      setVersion(Integer.parseInt(PSComponentUtils.getRequiredAttribute(sourceNode, VERSION_ATTR)));
+      // Direct field — avoid overridable setVersion during construction / loadFields path.
+      int ver = Integer.parseInt(PSComponentUtils.getRequiredAttribute(sourceNode, VERSION_ATTR));
+      if (ver < 0) {
+        Object[] args = {getNodeNameSafe(), VERSION_ATTR, "negative"};
+        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      }
+      m_version = ver;
     } catch (NumberFormatException e) {
-      Object[] args = {getNodeName(), VERSION_ATTR, e.getLocalizedMessage()};
+      Object[] args = {getNodeNameSafe(), VERSION_ATTR, e.getLocalizedMessage()};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
     }
 
@@ -264,6 +285,11 @@ public class PSAction extends PSVersionableDbComponent implements IPSCatalogSumm
         PSComponentUtils.getChildElement(sourceNode, PSChildActions.XML_NODE_NAME, false);
     if (actions != null) m_children.fromXml(actions);
     else m_children.clear();
+  }
+
+  /** Node name without virtual {@code getNodeName()} — safe during Element construction. */
+  private static String getNodeNameSafe() {
+    return XML_NODE_NAME;
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSActionParameter.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSActionParameter.java
@@ -19,7 +19,8 @@ package com.percussion.cms.objectstore;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Element;
 
-public class PSActionParameter extends PSCmsProperty {
+// Final leaf — Element ctor uses non-virtual super path (this-escape free).
+public final class PSActionParameter extends PSCmsProperty {
   /** no-args constructor */
   public PSActionParameter() {}
 
@@ -41,9 +42,8 @@ public class PSActionParameter extends PSCmsProperty {
   }
 
   public PSActionParameter(Element src) throws PSUnknownNodeTypeException {
-    // The dummy name will be overridden in the fromXml
-    super(getKeyDef(), "dummy");
-    fromXml(src);
+    // Key/state via non-virtual Element super path; fields via loadFieldsFromXml (this-escape free).
+    super(src);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSActionProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSActionProperty.java
@@ -19,7 +19,8 @@ package com.percussion.cms.objectstore;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Element;
 
-public class PSActionProperty extends PSCmsProperty {
+// Final leaf — Element ctor uses non-virtual super path (this-escape free).
+public final class PSActionProperty extends PSCmsProperty {
   /** no-args constructor */
   public PSActionProperty() {}
 
@@ -47,8 +48,8 @@ public class PSActionProperty extends PSCmsProperty {
    * @throws PSUnknownNodeTypeException
    */
   public PSActionProperty(Element src) throws PSUnknownNodeTypeException {
-    super(getKeyDef(), "dummy");
-    fromXml(src);
+    // Key/state via non-virtual Element super path; fields via loadFieldsFromXml (this-escape free).
+    super(src);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSActionVisibilityContext.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSActionVisibilityContext.java
@@ -19,7 +19,8 @@ package com.percussion.cms.objectstore;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Element;
 
-public class PSActionVisibilityContext extends PSMultiValuedProperty {
+// Final leaf — multi-value construction without subclass this-escape risk.
+public final class PSActionVisibilityContext extends PSMultiValuedProperty {
   /** no-args constructor */
   public PSActionVisibilityContext() {}
 
@@ -51,12 +52,12 @@ public class PSActionVisibilityContext extends PSMultiValuedProperty {
    */
   public PSActionVisibilityContext(String name, String[] values, String desc) {
     super(PSVisibilityContextEntry.class, name);
+    // Direct multi-value add via non-virtual helper — avoid overridable add/setDescription
+    // during construction (this-escape).
     if (null != values) {
-      for (int i = 0; i < values.length; i++) {
-        add(values[i]);
-      }
+      addValuesInternal(values);
     }
-    setDescription(desc);
+    applyDescription(desc);
   }
 
   /**
@@ -71,8 +72,9 @@ public class PSActionVisibilityContext extends PSMultiValuedProperty {
     super(src);
   }
 
-  // see base class for description
-  protected PSCmsProperty createProperty(String name, String value) {
+  // Final so multi-value construction can call createProperty without this-escape.
+  @Override
+  protected final PSCmsProperty createProperty(String name, String value) {
     return new PSVisibilityContextEntry(name, value);
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCmsProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCmsProperty.java
@@ -113,8 +113,9 @@ public abstract class PSCmsProperty extends PSDbComponent {
    * @param src Never <code>null</code>.
    */
   protected PSCmsProperty(Element src) throws PSUnknownNodeTypeException {
-    super(src); // validates src
-    fromXml(src);
+    // Key/state via non-virtual Element super path; fields without virtual fromXml (this-escape).
+    super(src);
+    loadFieldsFromXml(src);
   }
 
   /**
@@ -256,9 +257,17 @@ public abstract class PSCmsProperty extends PSDbComponent {
 
   // see interface for description
   public void fromXml(Element src) throws PSUnknownNodeTypeException {
-    // Base class from xml
+    // After full construction: virtual createKey still honored via super.
     super.fromXml(src);
+    loadFieldsFromXml(src);
+  }
 
+  /**
+   * Loads non-key property fields from XML. Used by Element ctor (after super key/state) and public
+   * {@link #fromXml(Element)}. Multi-valued subclasses that fully override {@code fromXml} do not
+   * use this path.
+   */
+  private void loadFieldsFromXml(Element src) throws PSUnknownNodeTypeException {
     Element kEl = PSXMLDomUtil.getFirstElementChild(src); // skip the key el
 
     m_strName = PSXMLDomUtil.checkAttribute(src, XML_ATTR_PROPERTYNAME, true);
@@ -272,15 +281,26 @@ public abstract class PSCmsProperty extends PSDbComponent {
       el = PSXMLDomUtil.getNextElementSibling(el);
     }
     if (values.isEmpty()) {
-      String[] args = {getNodeName(), "Value", "missing node"};
+      // Class-derived node name during construction (no virtual getNodeName / this-escape).
+      String[] args = {nodeNameFor(getClass()), "Value", "missing node"};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
-    setValues(values);
+    // Direct single-value assign — avoid overridable setValues during construction (this-escape).
+    // Multi-valued subclasses override fromXml entirely and never use this helper.
+    m_strValue = values.iterator().next();
 
     if (el != null && el.getTagName().equals(XML_NODE_DESCRIPTION))
       m_strDescription = PSXMLDomUtil.getElementData(el);
     else m_strDescription = "";
+  }
+
+  /** Default XML node name for a property class without virtual dispatch (PS → PSX). */
+  private static String nodeNameFor(Class<?> clazz) {
+    String name = clazz.getName();
+    name = name.substring(name.lastIndexOf('.') + 1);
+    if (name.startsWith("PS")) name = "PSX" + name.substring(2);
+    return name;
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
@@ -41,7 +41,8 @@ import org.w3c.dom.Element;
  *
  * @see PSVersionableDbComponent
  */
-public class PSDisplayFormat extends PSVersionableDbComponent
+// Final leaf — default/Element ctors assign without subclass this-escape risk.
+public final class PSDisplayFormat extends PSVersionableDbComponent
     implements IPSCatalogSummary, IPSCloneTuner {
 
   /** Serialization id for {@link java.io.Serializable}. */
@@ -66,14 +67,13 @@ public class PSDisplayFormat extends PSVersionableDbComponent
     } catch (ClassNotFoundException neverHappen) {
     }
 
-    // required elements for validity
+    // required elements for validity — direct fields / private helpers (this-escape)
     String label = "Display Format " + ms_nameCounter++;
-    setDisplayName(label);
-    String name = label.replace(' ', '_');
-    name = name.toLowerCase();
-    setInternalName(name);
+    m_strDisplayName = label;
+    String name = label.replace(' ', '_').toLowerCase();
+    m_strInternalName = name;
 
-    addCommunity(null);
+    applyCommunityAll();
   }
 
   // implements IPSCatalogSummary#getGUID()
@@ -840,6 +840,16 @@ public class PSDisplayFormat extends PSVersionableDbComponent
       removeProperty(PROP_COMMUNITY, null, false);
     }
     setProperty(PROP_COMMUNITY, communityId, true);
+  }
+
+  /**
+   * Construction-only: default community visibility without overridable addCommunity/setProperty
+   * (this-escape).
+   */
+  private void applyCommunityAll() {
+    PSDFMultiProperty mp = new PSDFMultiProperty(PROP_COMMUNITY);
+    mp.add(PROP_COMMUNITY_ALL);
+    m_properties.add(mp);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolder.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolder.java
@@ -40,7 +40,8 @@ import org.w3c.dom.Element;
  * contain the folder relationship information, which is the information about its related child
  * items or folders.
  */
-public class PSFolder extends PSDbComponent implements java.io.Serializable {
+// Final leaf — Element ctor uses non-virtual key restore + loadFieldsFromXml (this-escape free).
+public final class PSFolder extends PSDbComponent implements java.io.Serializable {
   private static final Logger logger = LogManager.getLogger(PSFolder.class);
 
   /**
@@ -185,8 +186,10 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
    *     defined in the <code>fromXml</code> method.
    */
   public PSFolder(Element source) throws PSUnknownNodeTypeException {
-    super(new PSLocator());
-    fromXml(source);
+    // Key/state via non-virtual Element super path (createKeyDefault → PSLocator); fields without
+    // virtual fromXml (this-escape free). Public fromXml still uses createKey after construction.
+    super(source);
+    loadFieldsFromXml(source);
   }
 
   /**
@@ -603,8 +606,16 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
   /** See {@link IPSDbComponent#fromXml(Element)} */
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     super.fromXml(sourceNode); // set data for super class
+    loadFieldsFromXml(sourceNode);
+  }
 
-    PSXMLDomUtil.checkNode(sourceNode, getNodeName());
+  /**
+   * Loads non-key folder fields from XML. Used by Element ctor and public {@link
+   * #fromXml(Element)}.
+   */
+  private void loadFieldsFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+    // Class-derived node name during construction (no virtual getNodeName / this-escape).
+    PSXMLDomUtil.checkNode(sourceNode, "PSXFolder");
 
     m_name = PSXMLDomUtil.checkAttribute(sourceNode, XML_ATTR_NAME, true);
     m_communityId = PSXMLDomUtil.checkAttributeInt(sourceNode, XML_ATTR_COMMUNITYID, true);
@@ -839,9 +850,10 @@ public class PSFolder extends PSDbComponent implements java.io.Serializable {
     }
   }
 
-  /** See {@link PSDbComponent#createKey(Element)} */
-  protected PSKey createKey(Element keyEl) throws PSUnknownNodeTypeException {
-    return (PSKey) new PSLocator(keyEl);
+  /** See {@link PSDbComponent#createKey(Element)}. Final — leaf type; safe for public fromXml. */
+  @Override
+  protected final PSKey createKey(Element keyEl) throws PSUnknownNodeTypeException {
+    return new PSLocator(keyEl);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolderProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolderProperty.java
@@ -25,7 +25,8 @@ import org.w3c.dom.Element;
  * "properties" as the child name. The folder property represent one entry in the child table, or
  * child entry.
  */
-public class PSFolderProperty extends PSCmsProperty {
+// Final leaf — Element ctor uses non-virtual super path (this-escape free).
+public final class PSFolderProperty extends PSCmsProperty {
   /** Creates an empty object. */
   public PSFolderProperty(String name) {
     super(new PSSimpleKey(KEY_ID), name);
@@ -40,8 +41,9 @@ public class PSFolderProperty extends PSCmsProperty {
    */
   public PSFolderProperty(String name, String value, String desc) {
     super(new PSSimpleKey(KEY_ID), name);
-    super.setValue(value);
-    super.setDescription(desc);
+    // Direct field assignment — avoid overridable setValue/setDescription (this-escape).
+    m_strValue = (value == null) ? "" : value;
+    m_strDescription = (desc == null) ? "" : desc;
   }
 
   /**
@@ -61,16 +63,18 @@ public class PSFolderProperty extends PSCmsProperty {
    * <code>KEY_ID</code>.
    */
   public PSFolderProperty(Element src) throws PSUnknownNodeTypeException {
-    super(new PSSimpleKey(KEY_ID), "dummy");
-    super.fromXml(src);
+    // Key/state via non-virtual Element super path + field load (this-escape free).
+    // Public fromXml still uses createKey override after full construction.
+    super(src);
   }
 
   /**
    * Override the key because this property uses different key part definition. see {@link
-   * PSCmsProperty#createKey(Element)} more detail
+   * PSCmsProperty#createKey(Element)} more detail. Final — no further subclasses; safe for public
+   * fromXml after construction.
    */
   @Override
-  protected PSKey createKey(Element el) throws PSUnknownNodeTypeException {
+  protected final PSKey createKey(Element el) throws PSUnknownNodeTypeException {
     PSKey k = new PSSimpleKey(KEY_ID);
     k.fromXml(el);
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSMultiValuedProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSMultiValuedProperty.java
@@ -182,11 +182,27 @@ public abstract class PSMultiValuedProperty extends PSCmsProperty {
    */
   public void add(String[] values) {
     if (null == values) throw new IllegalArgumentException("Values array cannot be null.");
+    addValuesInternal(values);
+  }
+
+  /**
+   * Construction-safe multi-value insert (non-overridable). Used from subclass constructors to
+   * avoid this-escape via public {@link #add(String[])}.
+   */
+  protected final void addValuesInternal(String[] values) {
+    if (null == values) throw new IllegalArgumentException("Values array cannot be null.");
 
     for (int i = 0; i < values.length; i++) {
       if (null != values[i] && !contains(values[i]))
         m_props.add(createProperty(getName(), values[i]));
     }
+  }
+
+  /**
+   * Construction-safe description assignment without overridable {@link #setDescription(String)}.
+   */
+  protected final void applyDescription(String desc) {
+    m_strDescription = (desc == null) ? "" : desc;
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
@@ -49,7 +49,8 @@ import org.w3c.dom.Element;
  *
  * @see PSVersionableDbComponent for base class description.
  */
-public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSummary, IPSCloneTuner {
+// Final leaf — default/named Element ctors assign without subclass this-escape risk.
+public final class PSSearch extends PSVersionableDbComponent implements IPSCatalogSummary, IPSCloneTuner {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
@@ -78,15 +79,15 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
     m_fields = new PSSFields();
     m_properties = new PSSProperties();
 
-    // Default required values for db consistency
+    // Default required values for db consistency — direct fields / private helpers (this-escape).
     String name = "search" + ms_nameSuffix++;
-    setInternalName(name);
-    setDisplayName(Character.toUpperCase(name.charAt(0)) + name.substring(1));
-    setMaximumNumber(DEFAULT_MAX);
-    setDisplayFormatId("1");
-    setParentCategory(1);
-    setShowTo(SHOW_TO_ALL_COMMUNITIES, null);
-    setUserCustomizable(false);
+    m_strInternalName = name;
+    m_strDisplayName = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    m_nMaxResults = DEFAULT_MAX;
+    m_strDisplayId = "1";
+    m_nParentCat = 1;
+    applyShowToAllCommunities();
+    applyUserCustomizable(false);
   }
 
   /**
@@ -920,6 +921,26 @@ public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSumm
     if (doesPropertyHaveValue(PROP_USER_CUSTOMIZABLE, userCustomizable)) return;
 
     setProperty(PROP_USER_CUSTOMIZABLE, userCustomizable);
+  }
+
+  /**
+   * Construction-only: community visibility defaults to all communities without overridable
+   * setShowTo/setProperty (this-escape).
+   */
+  private void applyShowToAllCommunities() {
+    PSSearchMultiProperty mp = new PSSearchMultiProperty(PROP_COMMUNITY);
+    mp.add(PROP_COMMUNITY_ALL);
+    m_properties.add(mp);
+  }
+
+  /**
+   * Construction-only: user-customizable flag without overridable setProperty (this-escape).
+   */
+  private void applyUserCustomizable(boolean isUserCustomizable) {
+    String userCustomizable = isUserCustomizable ? BOOL_YES : BOOL_NO;
+    PSSearchMultiProperty mp = new PSSearchMultiProperty(PROP_USER_CUSTOMIZABLE);
+    mp.add(userCustomizable);
+    m_properties.add(mp);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearchField.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearchField.java
@@ -33,7 +33,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Represents a single search field used in a given search/view. */
-public class PSSearchField extends PSDbComponent implements IPSSequencedComponent {
+// Final leaf — Element/named ctors avoid subclass this-escape risk.
+public final class PSSearchField extends PSDbComponent implements IPSSequencedComponent {
   /** Creates the key required by the super. */
   private PSSearchField() {
     super(new PSKey(new String[] {KEY_COL_FIELDNAME, KEY_COL_SEARCHID}));
@@ -44,8 +45,9 @@ public class PSSearchField extends PSDbComponent implements IPSSequencedComponen
    * com.percussion.cms.objectstore.PSDbComponentCollection}
    */
   public PSSearchField(Element src) throws PSUnknownNodeTypeException, PSCmsException {
-    this();
-    fromXml(src);
+    // Key/state via non-virtual Element super path; fields without virtual fromXml (this-escape).
+    super(src);
+    loadFieldsFromXml(src);
   }
 
   /**
@@ -92,15 +94,25 @@ public class PSSearchField extends PSDbComponent implements IPSSequencedComponen
     if (strLabel == null || strLabel.trim().isEmpty()) {
       strLabel = strName;
     }
-    setFieldDescription(strDesc);
-    setFieldType(strType);
-    setDisplayName(strLabel);
-    setMnemonic(mnemonic);
+    // Direct field assignment — avoid overridable setters during construction (this-escape).
+    m_strDescription = (strDesc == null) ? "" : strDesc;
+    if (!isValidFieldType(strType))
+      throw new IllegalArgumentException("Invalid field type specified for search field");
+    if (strType.length() > FIELDTYPE_LENGTH)
+      throw new IllegalArgumentException(
+          "field type must not exceed " + FIELDTYPE_LENGTH + "characters");
+    m_strFieldType = strType;
+    if (strLabel.length() > FIELDLABEL_LENGTH)
+      throw new IllegalArgumentException(
+          "display name must not exceed " + FIELDLABEL_LENGTH + "characters");
+    m_strDisplayName = strLabel;
+    m_mnemonic = (mnemonic == null) ? "" : mnemonic;
     m_strFieldName = strName;
     setValues(m_strOperator, null, null);
     PSKey key = getLocator();
     key.setPart(KEY_COL_FIELDNAME, strName);
-    setLocator(key);
+    // setKey is package-private non-overridable; avoid overridable setLocator (this-escape).
+    setKey(key);
   }
 
   // see base class for description
@@ -148,9 +160,16 @@ public class PSSearchField extends PSDbComponent implements IPSSequencedComponen
 
   // see base class for description
   public void fromXml(Element e) throws PSUnknownNodeTypeException {
-    // base class handling
+    // After full construction: virtual createKey still honored via super.
     super.fromXml(e);
+    loadFieldsFromXml(e);
+  }
 
+  /**
+   * Loads non-key search-field fields from XML. Used by Element ctor and public {@link
+   * #fromXml(Element)}.
+   */
+  private void loadFieldsFromXml(Element e) throws PSUnknownNodeTypeException {
     // save state so we can restore when finished w/ updates
     int state = getState();
 
@@ -161,17 +180,18 @@ public class PSSearchField extends PSDbComponent implements IPSSequencedComponen
     m_strFieldName = getLocator().getPart(KEY_COL_FIELDNAME);
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(e);
+    String nodeName = "PSXSearchField";
 
     Element elOp = tree.getNextElement(XML_NODE_OPERATOR);
     tree.setCurrent(e);
     if (elOp == null) {
-      Object[] args = {getNodeName(), XML_NODE_OPERATOR, "null"};
+      Object[] args = {nodeName, XML_NODE_OPERATOR, "null"};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     String op = PSXmlTreeWalker.getElementData(elOp);
     if (!isValidOperator(op)) {
-      Object[] args = {getNodeName(), XML_NODE_OPERATOR, op};
+      Object[] args = {nodeName, XML_NODE_OPERATOR, op};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
@@ -183,21 +203,21 @@ public class PSSearchField extends PSDbComponent implements IPSSequencedComponen
     Element elFieldType = tree.getNextElement(XML_NODE_FIELDTYPE);
     tree.setCurrent(e);
     if (elFieldType == null) {
-      Object[] args = {getNodeName(), XML_NODE_FIELDTYPE, "null"};
+      Object[] args = {nodeName, XML_NODE_FIELDTYPE, "null"};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_strFieldType = PSXmlTreeWalker.getElementData(elFieldType);
 
     if (!isValidFieldType(m_strFieldType)) {
-      Object[] args = {getNodeName(), XML_NODE_FIELDTYPE, m_strFieldType};
+      Object[] args = {nodeName, XML_NODE_FIELDTYPE, m_strFieldType};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     Element elFieldLabel = tree.getNextElement(XML_NODE_FIELDLABEL);
     tree.setCurrent(e);
     if (elFieldLabel == null) {
-      Object[] args = {getNodeName(), XML_NODE_FIELDLABEL, "null"};
+      Object[] args = {nodeName, XML_NODE_FIELDLABEL, "null"};
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
     }
 
@@ -205,7 +225,10 @@ public class PSSearchField extends PSDbComponent implements IPSSequencedComponen
 
     Element elFieldMnemonic = tree.getNextElement(XML_NODE_FIELDMNEMONIC);
     tree.setCurrent(e);
-    if (elFieldMnemonic != null) setMnemonic(PSXmlTreeWalker.getElementData(elFieldLabel));
+    if (elFieldMnemonic != null) {
+      m_mnemonic = PSXmlTreeWalker.getElementData(elFieldMnemonic);
+      if (m_mnemonic == null) m_mnemonic = "";
+    }
 
     // Optional
     Element elVal = tree.getNextElement(XML_NODE_FIELDVALUE);
@@ -220,7 +243,7 @@ public class PSSearchField extends PSDbComponent implements IPSSequencedComponen
         } else values = new ArrayList<>();
       }
     }
-    // method handles all cases
+    // private helper — non-overridable
     setValues(op, extOp, values);
 
     Element elDesc = tree.getNextElement(XML_NODE_DESCRIPTION);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSVersionableDbComponent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSVersionableDbComponent.java
@@ -33,6 +33,16 @@ public abstract class PSVersionableDbComponent extends PSDbComponent {
     super(locator);
   }
 
+  /**
+   * Element super-ctor path: key/state via non-virtual {@code PSDbComponent} restore (this-escape
+   * free). Subclasses load their own fields after {@code super(src)}.
+   *
+   * @param src never {@code null}
+   */
+  protected PSVersionableDbComponent(Element src) throws PSUnknownNodeTypeException {
+    super(src);
+  }
+
   @Override
   public void fromXml(Element source) throws PSUnknownNodeTypeException {
     super.fromXml(source);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationship.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationship.java
@@ -112,7 +112,10 @@ public class PSRelationship extends PSComponent {
    * @param config the relationship configuration, not <code>null</code>.
    * @throws IllegalStateException if this relationship has already been assigned a config.
    */
-  public void setConfig(PSRelationshipConfig config) {
+  /**
+   * Final so constructors (e.g. {@code PSAaRelationship}) can assign config without this-escape.
+   */
+  public final void setConfig(PSRelationshipConfig config) {
     if (config == null) throw new IllegalArgumentException("relationship config may not be null");
     m_config = config;
     initUserProperties();
@@ -380,7 +383,10 @@ public class PSRelationship extends PSComponent {
    * @return the requested property, might be <code>null</code> if no property for the supplied name
    *     exists.
    */
-  public String getProperty(String name) {
+  /**
+   * Final so constructors can read properties without this-escape (e.g. AA validation).
+   */
+  public final String getProperty(String name) {
     if (name == null || name.trim().length() == 0)
       throw new IllegalArgumentException("name cannot be null");
 
@@ -413,7 +419,10 @@ public class PSRelationship extends PSComponent {
    *     be one of the defined user property name and cannot be one of the system property name.
    * @param value the new value to set, may be <code>null</code> or empty.
    */
-  public void setProperty(String name, String value) {
+  /**
+   * Final so constructors can set user properties without this-escape (slot/variant ids).
+   */
+  public final void setProperty(String name, String value) {
     if (name == null || name.trim().length() == 0)
       throw new IllegalArgumentException("name cannot be null");
 

--- a/system/src/test/java/com/percussion/cms/objectstore/PSObjectStoreThisEscapeResidualTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSObjectStoreThisEscapeResidualTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for residual cms.objectstore Element/ctor this-escape real fixes (#2613 /
+ * parent #2022), after createKey/Element batch #2467. Complements {@link
+ * PSDbComponentThisEscapeTest}.
+ */
+public class PSObjectStoreThisEscapeResidualTest {
+
+  @Test
+  public void actionNamedCtorAndElementRoundTrip() throws Exception {
+    PSAction original =
+        new PSAction(
+            "preview_item",
+            "Preview",
+            PSAction.TYPE_MENUITEM,
+            "../sys_cxSupport/preview.html",
+            PSAction.HANDLER_CLIENT,
+            3);
+    assertEquals("preview_item", original.getName());
+    assertEquals("Preview", original.getLabel());
+    assertEquals(PSAction.TYPE_MENUITEM, original.getMenuType());
+    assertEquals(3, original.getSortRank());
+    assertTrue(original.isClientAction());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+
+    PSAction restored = new PSAction(xml);
+    assertEquals("preview_item", restored.getName());
+    assertEquals("Preview", restored.getLabel());
+    assertEquals(PSAction.TYPE_MENUITEM, restored.getMenuType());
+    assertEquals(3, restored.getSortRank());
+    assertTrue(restored.isClientAction());
+
+    // Public fromXml after construction still works
+    PSAction second =
+        new PSAction(
+            "other",
+            "Other",
+            PSAction.TYPE_MENU,
+            "",
+            PSAction.HANDLER_SERVER,
+            1);
+    Element secondXml = second.toXml(doc);
+    restored.fromXml(secondXml);
+    assertEquals("other", restored.getName());
+    assertEquals("Other", restored.getLabel());
+    assertEquals(PSAction.TYPE_MENU, restored.getMenuType());
+    assertFalse(restored.isClientAction());
+  }
+
+  @Test
+  public void actionParameterAndPropertyElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+
+    PSActionParameter param = new PSActionParameter("sys_contentid", "301", "id param");
+    Element paramXml = param.toXml(doc);
+    PSActionParameter paramRestored = new PSActionParameter(paramXml);
+    assertEquals("sys_contentid", paramRestored.getName());
+    assertEquals("301", paramRestored.getValue());
+    assertEquals("id param", paramRestored.getDescription());
+
+    PSActionProperty prop = new PSActionProperty(PSAction.PROP_MUTLI_SELECT, PSAction.NO, "multi");
+    Element propXml = prop.toXml(doc);
+    PSActionProperty propRestored = new PSActionProperty(propXml);
+    assertEquals(PSAction.PROP_MUTLI_SELECT, propRestored.getName());
+    assertEquals(PSAction.NO, propRestored.getValue());
+    assertEquals("multi", propRestored.getDescription());
+  }
+
+  @Test
+  public void actionVisibilityContextCtorAcceptsValues() {
+    PSActionVisibilityContext ctx =
+        new PSActionVisibilityContext(
+            PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY,
+            new String[] {"10", "20"},
+            "communities");
+    assertEquals(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, ctx.getName());
+    assertTrue(ctx.contains("10"));
+    assertTrue(ctx.contains("20"));
+    assertEquals("communities", ctx.getDescription());
+  }
+
+  @Test
+  public void folderElementRoundTrip() throws Exception {
+    // (name, id, communityId, permissions, description)
+    PSFolder original = new PSFolder("SiteRoot", 1001, 7, 0, "Root folder");
+    assertEquals("SiteRoot", original.getName());
+    assertEquals(1001, original.getLocator().getId());
+    assertEquals(7, original.getCommunityId());
+    assertEquals("Root folder", original.getDescription());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+
+    PSFolder restored = new PSFolder(xml);
+    assertEquals("SiteRoot", restored.getName());
+    assertEquals(7, restored.getCommunityId());
+    assertEquals("Root folder", restored.getDescription());
+
+    restored.fromXml(xml);
+    assertEquals("SiteRoot", restored.getName());
+    assertEquals(7, restored.getCommunityId());
+  }
+
+  @Test
+  public void folderPropertyNamedAndElementRoundTrip() throws Exception {
+    PSFolderProperty prop = new PSFolderProperty("sys_pubFileName", "site", "pub name");
+    assertEquals("sys_pubFileName", prop.getName());
+    assertEquals("site", prop.getValue());
+    assertEquals("pub name", prop.getDescription());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = prop.toXml(doc);
+    PSFolderProperty restored = new PSFolderProperty(xml);
+    assertEquals("sys_pubFileName", restored.getName());
+    assertEquals("site", restored.getValue());
+    assertEquals("pub name", restored.getDescription());
+  }
+
+  @Test
+  public void searchDefaultAndNamedCtors() throws Exception {
+    PSSearch def = new PSSearch();
+    assertNotNull(def.getInternalName());
+    assertTrue(def.getInternalName().startsWith("search"));
+    assertEquals(PSSearch.DEFAULT_MAX, def.getMaximumResultSize());
+
+    PSSearch named = new PSSearch("MySearch", false);
+    assertEquals("MySearch", named.getInternalName());
+    assertEquals("MySearch", named.getDisplayName());
+    assertFalse(named.isCustomApp());
+  }
+
+  @Test
+  public void searchFieldNamedAndElementRoundTrip() throws Exception {
+    PSSearchField field =
+        new PSSearchField("sys_title", "Title", "T", PSSearchField.TYPE_TEXT, "title field");
+    assertEquals("sys_title", field.getFieldName());
+    assertEquals("Title", field.getDisplayName());
+    assertEquals(PSSearchField.TYPE_TEXT, field.getFieldType());
+    assertEquals("title field", field.getFieldDescription());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = field.toXml(doc);
+    PSSearchField restored = new PSSearchField(xml);
+    assertEquals("sys_title", restored.getFieldName());
+    assertEquals("Title", restored.getDisplayName());
+    assertEquals(PSSearchField.TYPE_TEXT, restored.getFieldType());
+  }
+
+  @Test
+  public void displayFormatDefaultCtorSetsNames() throws Exception {
+    PSDisplayFormat df = new PSDisplayFormat();
+    assertNotNull(df.getDisplayName());
+    assertTrue(df.getDisplayName().startsWith("Display Format "));
+    assertNotNull(df.getInternalName());
+    assertTrue(df.getInternalName().startsWith("display_format_"));
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized residual for **#2613** (parent **#2022** / grandparent **#2200**): reduce residual `-Xlint:this-escape` in **cms.objectstore** after createKey/Element batch **#2467** with **real** constructor patterns — **not** suppress-only.

### Real this-escape fixes
- **PSAction** family: Element ctor via non-virtual `PSVersionableDbComponent(Element)` + private `loadFieldsFromXml`; named ctor avoids overridable `setMenuType`; leaf types `final`
- **PSCmsProperty** / **PSActionParameter** / **PSActionProperty** / **PSFolderProperty**: Element path uses super key/state + private field load; direct field assigns
- **PSFolder** / **PSSearch** / **PSSearchField** / **PSDisplayFormat**: construction helpers + final leaf types
- **PSAaRelationship** / list: final leaf + final `PSRelationship` `setConfig`/`getProperty`/`setProperty`; private list load
- **PSMultiValuedProperty**: `addValuesInternal` / `applyDescription` for construction-safe multi-value

### Tests
- New `PSObjectStoreThisEscapeResidualTest` — 8 cases (Action, params/props, folder, search, search field, display format)
- Existing `PSDbComponentThisEscapeTest` still green

### Metrics (cms.objectstore `this' escape`, `-Xmaxwarns 10000`)
| | Count |
| --- | ---: |
| Before | 82 |
| After | 64 |
| Δ | **−18** |

Further residual filed as **#2652** (CoreItem/ServerItem/processors + remaining leaves).

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1398**, Failures: **0**, Errors: **0** (Skipped: 240)
- [x] `PSObjectStoreThisEscapeResidualTest` — 8/8
- [x] `PSDbComponentThisEscapeTest` — 9/9

## Gates evidence
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2613-objectstore-this-escape-residual-erlang.md`
- Per-module standalone clean install: pass
- No monorepo-wide reformat; no suppress-only this-escape
- Avoids overlap with open server-handler batch (#2623 / #2453)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2613  
Refs #2022 #2200  
Residual: #2652

> Co-Authored by Grok Build using grok-4.5 with agent main.
