### PR TITLE
feat(auditlog): Phase 2b content/workflow ErrorCodes + isAuditable (#2635)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -9,8 +9,9 @@ System-wide Percussion CMS audit logging and unified error-code support.
 * `SystemErrorCode` / package `*ErrorCodes` with explicit **`isAuditable`**
 * `AuditLogService` dual-writes auditable events to Log4j (`server.log`) and an `AuditLogRepository` SPI
 * Message form: `[AUTH-1001]-[<uuid>] …` with separate user/log message templates and redaction
-* **Phase 2b:** `SecurityErrorCodes` + `LegacyErrorCodeRegistry` bridge legacy `IPSSecurityErrors` ints
-  (auth/security first slice). Non-auditable / unregistered ints never dual-write.
+* **Phase 2b:** `SecurityErrorCodes`, `ContentErrorCodes`, `WorkflowErrorCodes` + `LegacyErrorCodeRegistry`
+  bridge legacy `IPS*Errors` ints (auth/security, content conversion + lifecycle, workflow service).
+  Non-auditable / unregistered ints never dual-write.
 
 **Legacy (to be removed after migration):** `com.percussion.auditlog` + IBM CADF (`auditlogger` module)
 
@@ -29,19 +30,31 @@ audit.log(
     "10.0.0.1");
 ```
 
-## Legacy IPS*Errors bridge (Phase 2b auth/security)
+## Legacy IPS*Errors bridge (Phase 2b)
 
 ```java
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 
 // Prefer enum when available:
 audit.log(SecurityErrorCodes.AUTHENTICATION_FAILED, ctx, "Directory", "ldap1", "jdoe");
+audit.log(ContentErrorCodes.CREATE, ctx, AuditOutcome.SUCCESS, "guid", "42", "/Sites/demo");
+audit.log(WorkflowErrorCodes.ACCESS_DENIED, ctx, "5", "jdoe");
 
 // Central handlers with only a legacy int (e.g. PSException.getErrorCode()):
-LegacyErrorCodeRegistry.logIfAuditable(audit, 9002, ctx, "Directory", "ldap1", "jdoe");
-// Provider config noise (isAuditable=false) and unknown ints → no dual-write
+LegacyErrorCodeRegistry.logIfAuditable(audit, 9002, ctx, "Directory", "ldap1", "jdoe"); // SEC
+LegacyErrorCodeRegistry.logIfAuditable(audit, 17001, ctx); // CONT conversion — non-auditable skip
+LegacyErrorCodeRegistry.logIfAuditable(audit, 6, ctx, "5", "jdoe"); // WF access denied
+// Provider/config/conversion noise (isAuditable=false) and unknown ints → no dual-write
 ```
+
+| Catalog | Ranges | Notes |
+|---------|--------|-------|
+| `SecurityErrorCodes` | 9001–9026, dir-auth 9801+ | Auth/security exception bridge |
+| `ContentErrorCodes` | 2001–2006 lifecycle; 17001–17010 conversion | Aligns Phase 2a lifecycle numbering |
+| `WorkflowErrorCodes` | 4001 transition; 1–10 service | Aligns Phase 2a transition numbering |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -16,7 +16,9 @@
  */
 package com.intsof.percussioncms.auditlog;
 
+import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,8 +29,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Maps legacy {@code IPS*Errors} integer codes to {@link SystemErrorCode} until catalogs are fully
  * migrated. Unregistered codes are treated as <strong>not auditable</strong> (no dual-write).
  *
- * <p>Phase 2b first slice registers {@link SecurityErrorCodes} (auth/security). Later slices
- * register content/workflow/design catalogs via {@link #register(int, SystemErrorCode)}.
+ * <p>Phase 2b registers {@link SecurityErrorCodes} (auth/security), {@link ContentErrorCodes}
+ * (content lifecycle + conversion), and {@link WorkflowErrorCodes} (workflow transition + service
+ * errors). Residual slices may register design/path catalogs via {@link #register(int,
+ * SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -41,12 +45,14 @@ public final class LegacyErrorCodeRegistry {
   private LegacyErrorCodeRegistry() {}
 
   /**
-   * Ensure Phase 2b auth/security catalog is loaded. Safe to call repeatedly; catalogs register
-   * themselves in their own static initializers.
+   * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow). Safe to call
+   * repeatedly; catalogs register themselves in their own static initializers.
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
       SecurityErrorCodes.ensureRegistered();
+      ContentErrorCodes.ensureRegistered();
+      WorkflowErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodes.java
@@ -19,13 +19,34 @@ package com.intsof.percussioncms.auditlog.codes;
 import com.intsof.percussioncms.auditlog.AuditEventType;
 import com.intsof.percussioncms.auditlog.AuditModule;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 
 /**
- * Content lifecycle audit codes (create / update / delete / recycle / schedule). Outcome is set at
- * the call site when success and failure share the same code.
+ * Content error / audit catalog for Phase 2a high-level lifecycle events and Phase 2b legacy {@code
+ * IPSContentErrors} bridges.
+ *
+ * <p><strong>Numbering (aligned with Phase 2a call-site migrate):</strong>
+ *
+ * <ul>
+ *   <li>{@code 2001–2006} — intentional content lifecycle audit events (create/update/delete/…)
+ *   <li>{@code 17001–17010} — legacy {@code com.percussion.content.IPSContentErrors} conversion /
+ *       extraction ints (globally unique per {@code IPSGlobalErrorsMap})
+ * </ul>
+ *
+ * <p>{@link #numericCode()} for the legacy conversion range preserves historical ints so exception
+ * constructors and bundles stay stable. Every constant sets {@link #isAuditable()} explicitly:
+ * lifecycle events dual-write; conversion/config noise does not.
+ *
+ * <p>Package-local {@code com.percussion.services.content.IPSContentErrors.MISSING_KEYWORD} uses
+ * package-local int {@code 1} and is <strong>not</strong> registered in the flat {@link
+ * LegacyErrorCodeRegistry} (would collide with other package-local catalogs). Prefer this enum (or
+ * a future composite-key registry) for dual-write decisions on that code.
  */
 public enum ContentErrorCodes implements SystemErrorCode {
+
+  // --- Phase 2a high-level content lifecycle audit events (CONT-200x) ---
+
   CREATE(
       2001,
       true,
@@ -72,7 +93,89 @@ public enum ContentErrorCodes implements SystemErrorCode {
       AuditEventType.CONTENT_PUBLISH,
       AuditOutcome.SUCCESS,
       "Page removal scheduled for {}",
-      "Page removal schedule guid={} contentId={} path={}");
+      "Page removal schedule guid={} contentId={} path={}"),
+
+  // --- legacy com.percussion.content.IPSContentErrors (17001–17010) ---
+
+  UNSUPPORTED_FILE_TYPE(
+      17001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported file type for content conversion",
+      "Unsupported file type for conversion"),
+
+  CONTENT_CONVERSION_FAILED_NO_MESSAGE(
+      17002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content conversion failed",
+      "Content conversion failed errorCode={} fileType={}"),
+
+  CONTENT_CONVERSION_FAILED_WITH_MESSAGE(
+      17003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content conversion failed: {}",
+      "Content conversion failed errorCode={} fileType={} message={}"),
+
+  CONTENT_CONVERSION_UNEXPECTED_ERROR(
+      17004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content conversion unexpected error",
+      "Content conversion unexpected exceptionClass={} message={}"),
+
+  INVALID_SEARCH_CONFIG_PARAM(
+      17005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid search configuration parameter",
+      "Invalid search config param={} value={}"),
+
+  CONTENT_CONVERSION_INCOMPLETE(
+      17006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content conversion incomplete",
+      "Content conversion incomplete"),
+
+  UNSUPPORTED_MIMETYPE(
+      17007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported MIME type for conversion",
+      "Unsupported MIME type for conversion"),
+
+  UNSUPPORTED_CONVERT_METHOD(
+      17008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported content convert method",
+      "Unsupported content convert method"),
+
+  UNSUPPORTED_EXTRACTION_EXIT(
+      17009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported text extraction exit",
+      "Unsupported text extraction exit"),
+
+  UNSUPPORTED_CONVERT_CONSTRUCTOR(
+      17010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported content converter constructor",
+      "Unsupported content converter constructor");
 
   private final int numericCode;
   private final boolean auditable;
@@ -94,6 +197,20 @@ public enum ContentErrorCodes implements SystemErrorCode {
     this.defaultOutcome = defaultOutcome;
     this.userMessageTemplate = userMessageTemplate;
     this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ContentErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
   }
 
   @Override

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WorkflowErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WorkflowErrorCodes.java
@@ -19,17 +19,124 @@ package com.intsof.percussioncms.auditlog.codes;
 import com.intsof.percussioncms.auditlog.AuditEventType;
 import com.intsof.percussioncms.auditlog.AuditModule;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 
-/** Workflow transition audit codes. */
+/**
+ * Workflow error / audit catalog for Phase 2a high-level transition events and Phase 2b legacy
+ * {@code com.percussion.services.workflow.IPSWorkflowErrors} bridges.
+ *
+ * <p><strong>Numbering (aligned with Phase 2a call-site migrate):</strong>
+ *
+ * <ul>
+ *   <li>{@code 4001} — intentional workflow transition audit event
+ *   <li>{@code 1–10} — package-local {@code IPSWorkflowErrors} ints (preserved for exception /
+ *       bundle lockstep). These package-local ints are registered in the flat {@link
+ *       LegacyErrorCodeRegistry} for this slice because no other Phase 2b catalog claims the same
+ *       bare ints; residual slices must not re-register colliding package-local codes without a
+ *       composite-key registry.
+ * </ul>
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: access-denied and invalid-transition
+ * security-relevant failures dual-write; load/config operational noise does not.
+ */
 public enum WorkflowErrorCodes implements SystemErrorCode {
+
+  // --- Phase 2a high-level workflow audit event (WF-4001) ---
+
   TRANSITION(
       4001,
       true,
       AuditEventType.WORKFLOW_TRANSITION,
       AuditOutcome.SUCCESS,
       "Workflow transition for content {}",
-      "Workflow transition contentId={} guid={} from={} to={}");
+      "Workflow transition contentId={} guid={} from={} to={}"),
+
+  // --- legacy com.percussion.services.workflow.IPSWorkflowErrors (1–10) ---
+
+  WORKFLOW_NOT_FOUND(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Workflow not found: {}",
+      "Workflow not found workflowId={}"),
+
+  /**
+   * Workflow state not found. Legacy alias {@code IPSWorkflowErrors.ERROR_LOADING_WORKFLOW_STATE}
+   * uses the same int ({@code 2}).
+   */
+  STATE_NOT_FOUND(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Workflow state not found",
+      "Workflow state not found stateId={} workflowId={}"),
+
+  INVALID_STATE(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid workflow state operation",
+      "Invalid workflow state stateId={} workflowId={} reason={}"),
+
+  OPERATION_FAILED(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Workflow operation failed: {}",
+      "Workflow operation failed operation={} detail={}"),
+
+  VALIDATION_FAILED(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Workflow validation failed",
+      "Workflow validation failed workflowId={} message={}"),
+
+  ACCESS_DENIED(
+      6,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Access denied to workflow {}",
+      "Workflow access denied workflowId={} user={}"),
+
+  TRANSITION_NOT_FOUND(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Workflow transition not found",
+      "Workflow transition not found transitionId={} stateId={} workflowId={}"),
+
+  INVALID_TRANSITION(
+      8,
+      true,
+      AuditEventType.WORKFLOW_TRANSITION,
+      AuditOutcome.FAILURE,
+      "Invalid workflow transition",
+      "Invalid workflow transition transitionId={} currentStateId={} reason={}"),
+
+  CONFIGURATION_ERROR(
+      9,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Workflow configuration error",
+      "Workflow configuration error detail={}"),
+
+  ASSIGNMENT_ERROR(
+      10,
+      true,
+      AuditEventType.OTHER,
+      AuditOutcome.FAILURE,
+      "Content workflow assignment error",
+      "Workflow assignment error contentId={} workflowId={} detail={}");
 
   private final int numericCode;
   private final boolean auditable;
@@ -51,6 +158,20 @@ public enum WorkflowErrorCodes implements SystemErrorCode {
     this.defaultOutcome = defaultOutcome;
     this.userMessageTemplate = userMessageTemplate;
     this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (WorkflowErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
   }
 
   @Override

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,5 +115,121 @@ class LegacyErrorCodeRegistryTest {
   @Test
   void registryContainsAuthSecuritySlice() {
     assertTrue(LegacyErrorCodeRegistry.size() >= 30);
+  }
+
+  @Test
+  void contentLifecycleLegacyCodeIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(2001));
+    assertSame(
+        ContentErrorCodes.CREATE, LegacyErrorCodeRegistry.find(2001).orElseThrow());
+    assertTrue(ContentErrorCodes.CREATE.isAuditable());
+  }
+
+  @Test
+  void contentConversionLegacyCodeIsNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(17001));
+    assertSame(
+        ContentErrorCodes.UNSUPPORTED_FILE_TYPE,
+        LegacyErrorCodeRegistry.find(17001).orElseThrow());
+    assertFalse(ContentErrorCodes.UNSUPPORTED_FILE_TYPE.isAuditable());
+  }
+
+  @Test
+  void contentConversionNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ContentErrorCodes.UNSUPPORTED_MIMETYPE.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void contentCreateAuditableDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ContentErrorCodes.CREATE.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "guid-1",
+            "42",
+            "/Sites/demo");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(ContentErrorCodes.CREATE, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[CONT-2001]-"));
+  }
+
+  @Test
+  void workflowAccessDeniedIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(6));
+    assertSame(
+        WorkflowErrorCodes.ACCESS_DENIED, LegacyErrorCodeRegistry.find(6).orElseThrow());
+    assertTrue(WorkflowErrorCodes.ACCESS_DENIED.isAuditable());
+  }
+
+  @Test
+  void workflowNotFoundIsNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(1));
+    assertSame(
+        WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertFalse(WorkflowErrorCodes.WORKFLOW_NOT_FOUND.isAuditable());
+  }
+
+  @Test
+  void workflowNotFoundNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WorkflowErrorCodes.WORKFLOW_NOT_FOUND.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "99");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void workflowAccessDeniedDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WorkflowErrorCodes.ACCESS_DENIED.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "5",
+            "jdoe");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(WorkflowErrorCodes.ACCESS_DENIED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[WF-6]-"));
+  }
+
+  @Test
+  void workflowTransitionHighLevelIsAuditable() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(4001));
+    assertSame(
+        WorkflowErrorCodes.TRANSITION, LegacyErrorCodeRegistry.find(4001).orElseThrow());
+  }
+
+  @Test
+  void registryContainsContentAndWorkflowSlice() {
+    // SEC (~30) + CONT (16) + WF (11) — allow headroom for residual growth
+    assertTrue(LegacyErrorCodeRegistry.size() >= 50);
   }
 }

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ContentErrorCodesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ContentErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleContAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ContentErrorCodes code : ContentErrorCodes.values()) {
+      assertEquals(AuditModule.CONT, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("CONT-"));
+    }
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (ContentErrorCodes code : ContentErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void lifecycleEventsAreAuditable() {
+    assertTrue(ContentErrorCodes.CREATE.isAuditable());
+    assertEquals(AuditEventType.CONTENT_CREATE, ContentErrorCodes.CREATE.eventType());
+    assertTrue(ContentErrorCodes.UPDATE.isAuditable());
+    assertTrue(ContentErrorCodes.DELETE.isAuditable());
+    assertTrue(ContentErrorCodes.RECYCLE.isAuditable());
+    assertTrue(ContentErrorCodes.PAGE_PUBLISH_SCHEDULE.isAuditable());
+    assertTrue(ContentErrorCodes.PAGE_REMOVAL_SCHEDULE.isAuditable());
+  }
+
+  @Test
+  void conversionOperationalNoiseIsNotAuditable() {
+    assertFalse(ContentErrorCodes.UNSUPPORTED_FILE_TYPE.isAuditable());
+    assertFalse(ContentErrorCodes.CONTENT_CONVERSION_FAILED_NO_MESSAGE.isAuditable());
+    assertFalse(ContentErrorCodes.UNSUPPORTED_MIMETYPE.isAuditable());
+    assertFalse(ContentErrorCodes.UNSUPPORTED_CONVERT_METHOD.isAuditable());
+  }
+
+  @Test
+  void preservesPhase2aAndLegacyNumericRanges() {
+    assertEquals(2001, ContentErrorCodes.CREATE.numericCode());
+    assertEquals(2003, ContentErrorCodes.DELETE.numericCode());
+    assertEquals(2006, ContentErrorCodes.PAGE_REMOVAL_SCHEDULE.numericCode());
+    assertEquals(17001, ContentErrorCodes.UNSUPPORTED_FILE_TYPE.numericCode());
+    assertEquals(17010, ContentErrorCodes.UNSUPPORTED_CONVERT_CONSTRUCTOR.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WorkflowErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WorkflowErrorCodesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class WorkflowErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleWfAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (WorkflowErrorCodes code : WorkflowErrorCodes.values()) {
+      assertEquals(AuditModule.WF, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("WF-"));
+    }
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (WorkflowErrorCodes code : WorkflowErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void securityRelevantWorkflowFailuresAreAuditable() {
+    assertTrue(WorkflowErrorCodes.ACCESS_DENIED.isAuditable());
+    assertEquals(AuditEventType.ACCESS_DENIED, WorkflowErrorCodes.ACCESS_DENIED.eventType());
+    assertTrue(WorkflowErrorCodes.INVALID_TRANSITION.isAuditable());
+    assertEquals(
+        AuditEventType.WORKFLOW_TRANSITION, WorkflowErrorCodes.INVALID_TRANSITION.eventType());
+    assertTrue(WorkflowErrorCodes.ASSIGNMENT_ERROR.isAuditable());
+    assertTrue(WorkflowErrorCodes.TRANSITION.isAuditable());
+  }
+
+  @Test
+  void loadAndConfigOperationalNoiseIsNotAuditable() {
+    assertFalse(WorkflowErrorCodes.WORKFLOW_NOT_FOUND.isAuditable());
+    assertFalse(WorkflowErrorCodes.STATE_NOT_FOUND.isAuditable());
+    assertFalse(WorkflowErrorCodes.OPERATION_FAILED.isAuditable());
+    assertFalse(WorkflowErrorCodes.CONFIGURATION_ERROR.isAuditable());
+    assertFalse(WorkflowErrorCodes.TRANSITION_NOT_FOUND.isAuditable());
+  }
+
+  @Test
+  void preservesPhase2aAndLegacyIpsWorkflowNumericValues() {
+    assertEquals(4001, WorkflowErrorCodes.TRANSITION.numericCode());
+    assertEquals(1, WorkflowErrorCodes.WORKFLOW_NOT_FOUND.numericCode());
+    assertEquals(2, WorkflowErrorCodes.STATE_NOT_FOUND.numericCode());
+    assertEquals(6, WorkflowErrorCodes.ACCESS_DENIED.numericCode());
+    assertEquals(8, WorkflowErrorCodes.INVALID_TRANSITION.numericCode());
+    assertEquals(10, WorkflowErrorCodes.ASSIGNMENT_ERROR.numericCode());
+  }
+}

--- a/system/services/src/com/percussion/services/content/IPSContentErrors.java
+++ b/system/services/src/com/percussion/services/content/IPSContentErrors.java
@@ -17,8 +17,15 @@
 package com.percussion.services.content;
 
 /**
- * Error numbers for use with the bundle 
- * <code>PSContentErrorStringBundle.properties</code>
+ * Error numbers for use with the bundle
+ * <code>PSContentErrorStringBundle.properties</code>.
+ *
+ * <p><strong>Phase 2b note:</strong> {@link #MISSING_KEYWORD} is package-local ({@code 1}) and is
+ * <em>not</em> registered in the flat {@code LegacyErrorCodeRegistry} (would collide with other
+ * package-local catalogs such as workflow). Prefer typed {@code ContentErrorCodes} high-level
+ * lifecycle codes for intentional content audit emits. Conversion-range content errors live on
+ * {@code com.percussion.content.IPSContentErrors} (17001+) and are bridged in {@code
+ * ContentErrorCodes}.
  */
 public interface IPSContentErrors
 {

--- a/system/services/src/com/percussion/services/workflow/IPSWorkflowErrors.java
+++ b/system/services/src/com/percussion/services/workflow/IPSWorkflowErrors.java
@@ -23,6 +23,13 @@ import java.util.Set;
  * An enumeration of possible error conditions for the workflow service with Java 11 modernization.
  * Each message code enumerated here must correspond to a message in the bundle for this package.
  *
+ * <p><strong>Phase 2b bridge:</strong> package-local ints (1–10) are cataloged in {@code
+ * com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes} with explicit {@code isAuditable}
+ * (access-denied / invalid-transition / assignment dual-write; load/config noise does not). Int
+ * literals remain here so they stay <em>compile-time constants</em>. Prefer {@code
+ * WorkflowErrorCodes} / {@code LegacyErrorCodeRegistry} for dual-write decisions; keep this
+ * interface for legacy exception constructors and message bundles.
+ *
  * <h2>Java 11 Features</h2>
  * <ul>
  * <li>Immutable collections for error metadata</li>

--- a/system/src/main/java/com/percussion/content/IPSContentErrors.java
+++ b/system/src/main/java/com/percussion/content/IPSContentErrors.java
@@ -26,6 +26,13 @@ package com.percussion.content;
  * <TR><TD>17001 - 17100</TD><TD>conversion errors</TD></TR>
  * <TR><TD>17101 - 17500</TD><TD>general errors</TD></TR>
  * </TABLE>
+ *
+ * <p><strong>Phase 2b bridge:</strong> conversion ints (17001–17010) are cataloged in {@code
+ * com.intsof.percussioncms.auditlog.codes.ContentErrorCodes} with explicit {@code isAuditable}
+ * (operational conversion noise is not auditable). Int literals remain here so they stay
+ * <em>compile-time constants</em>. Prefer {@code ContentErrorCodes} / {@code
+ * LegacyErrorCodeRegistry} for dual-write decisions; keep this interface for legacy exception
+ * constructors and message bundles.
  */
 public interface IPSContentErrors {
   /**

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
@@ -25,9 +25,13 @@ import com.intsof.percussioncms.auditlog.AuditContext;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import com.percussion.content.IPSContentErrors;
 import com.percussion.security.IPSSecurityErrors;
+import com.percussion.services.workflow.IPSWorkflowErrors;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -263,5 +267,77 @@ class PSSystemAuditLoggerTest {
     assertEquals(
         SecurityErrorCodes.SESS_NOT_AUTHORIZED.numericCode(),
         IPSSecurityErrors.SESS_NOT_AUTHORIZED);
+  }
+
+  @Test
+  void legacyContentConversionNoiseSkipsDualWrite() {
+    var id =
+        PSSystemAuditLogger.logLegacyIfAuditable(
+            IPSContentErrors.UNSUPPORTED_FILE_TYPE,
+            AuditContext.builder().actor("jdoe").build());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void legacyContentCreateDualWritesViaBridge() {
+    var id =
+        PSSystemAuditLogger.logLegacyIfAuditable(
+            ContentErrorCodes.CREATE.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "guid-1",
+            "42",
+            "/Sites/demo");
+
+    assertTrue(!id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(ContentErrorCodes.CREATE, rec.code());
+    assertTrue(rec.formattedLine().startsWith("[CONT-2001]-"));
+  }
+
+  @Test
+  void legacyWorkflowAccessDeniedDualWritesViaBridge() {
+    var id =
+        PSSystemAuditLogger.logLegacyIfAuditable(
+            IPSWorkflowErrors.ACCESS_DENIED,
+            AuditContext.builder().actor("jdoe").build(),
+            "5",
+            "jdoe");
+
+    assertTrue(!id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(WorkflowErrorCodes.ACCESS_DENIED, rec.code());
+    assertTrue(rec.formattedLine().startsWith("[WF-6]-"));
+  }
+
+  @Test
+  void legacyWorkflowNotFoundSkipsDualWrite() {
+    var id =
+        PSSystemAuditLogger.logLegacyIfAuditable(
+            IPSWorkflowErrors.WORKFLOW_NOT_FOUND,
+            AuditContext.builder().actor("jdoe").build(),
+            "99");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void ipsContentAndWorkflowErrorsIntsMatchCatalogs() {
+    assertEquals(
+        ContentErrorCodes.UNSUPPORTED_FILE_TYPE.numericCode(),
+        IPSContentErrors.UNSUPPORTED_FILE_TYPE);
+    assertEquals(
+        ContentErrorCodes.UNSUPPORTED_CONVERT_CONSTRUCTOR.numericCode(),
+        IPSContentErrors.UNSUPPORTED_CONVERT_CONSTRUCTOR);
+    assertEquals(
+        WorkflowErrorCodes.WORKFLOW_NOT_FOUND.numericCode(), IPSWorkflowErrors.WORKFLOW_NOT_FOUND);
+    assertEquals(
+        WorkflowErrorCodes.ACCESS_DENIED.numericCode(), IPSWorkflowErrors.ACCESS_DENIED);
+    assertEquals(
+        WorkflowErrorCodes.INVALID_TRANSITION.numericCode(), IPSWorkflowErrors.INVALID_TRANSITION);
   }
 }


### PR DESCRIPTION
## Summary
Phase **2b residual** after auth/security (#2637): migrate content + workflow legacy `IPS*Errors` catalogs into `ContentErrorCodes` / `WorkflowErrorCodes` (`SystemErrorCode` + explicit `isAuditable`) and register them in `LegacyErrorCodeRegistry` so non-auditable codes never dual-write.

**Parent:** #2616 (Phase 2b ErrorCodes unification)  
**Issue:** #2635  
**Coordinates with:** open Phase 2a PR #2633 (CONT-200x / WF-4001 high-level audit-event numbering) without depending on it.

### What changed
- **`ContentErrorCodes`** — CONT-2001–2006 lifecycle (align Phase 2a) + legacy conversion ints 17001–17010 (`com.percussion.content.IPSContentErrors`); conversion noise `isAuditable=false`
- **`WorkflowErrorCodes`** — WF-4001 transition (align Phase 2a) + package-local `IPSWorkflowErrors` 1–10 with explicit auditable flags (ACCESS_DENIED / INVALID_TRANSITION / ASSIGNMENT_ERROR dual-write; load/config skip)
- **`LegacyErrorCodeRegistry`** — bootstrap registers content + workflow catalogs alongside security
- Unit tests: catalog integrity, registry resolve, auditable dual-write, non-auditable skip
- **`PSSystemAuditLoggerTest`** — content/workflow legacy bridge via `logLegacyIfAuditable`
- IPS javadoc bridge notes (ints remain compile-time constants)

### Out of scope
- Remaining SEC ranges + design/path + central exception-handler wiring → #2636
- Package-local `services.content.IPSContentErrors.MISSING_KEYWORD` (int 1) not registered in flat registry (would collide with workflow package-local ints)

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw clean install` — BUILD SUCCESS
  - `LegacyErrorCodeRegistryTest` Tests run: 18, Failures: 0
  - `ContentErrorCodesTest` Tests run: 5, Failures: 0
  - `WorkflowErrorCodesTest` Tests run: 5, Failures: 0
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS
  - `PSSystemAuditLoggerTest` Tests run: 11, Failures: 0
- [x] Erlang-style self-review: no bugs found; package-local workflow ints documented for flat registry; portable paths N/A; Intersoft 2026 headers on new files

## Gates
- Change-class: content/workflow ErrorCodes bridge companions (enums + registry bootstrap + tests + IPS javadoc)
- Copyright: Intersoft 2026 on new sources
- No mega-PR: content/workflow residual only

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2635

> Co-Authored by Grok Build using grok-4.5 with agent main.