### PR TITLE
fix(perc-toolkit): clear main-source Xlint residual 26→0 (#2419)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2419-perc-toolkit-xlint-residual-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2419-perc-toolkit-xlint-residual-erlang.md
@@ -1,0 +1,53 @@
+# Erlang review — issue #2419 perc-toolkit Xlint residual
+
+**Date:** 2026-08-09  
+**Branch:** `fix/issue-2419-perc-toolkit-xlint-residual`  
+**Module:** `modules/perc-toolkit`  
+**Parent:** #2200 / slice of #2030  
+
+## Change class
+
+Main-source `-Xlint` residual cleanup (constructors / serial field / parent-API cascade).
+
+## Summary of approach
+
+| Category | Fix | Suppress? |
+|----------|-----|-----------|
+| `this-escape` on `Error` / `Field` | Direct field assignment + private `applyStringValue` | No |
+| `this-escape` on `Http*Response` | Package-visible `headers` field assignment | No |
+| `this-escape` on AA relationship builders | `super(boolean)` on `PSRelationshipBuilder` / intermediate; classes `final` | No |
+| `this-escape` on `PSOExtensionParamsHelper` | `doLog` / `doParameters` made `private` | No |
+| `this-escape` on `FolderTools` | `init` made `final` (matches `PSOFolderTools`) | No |
+| `PSORequestContext` parent raw→generic cascade | Class `@SuppressWarnings({"unchecked","rawtypes"})` until perc-system types `PSRequestContext`; class `final` | Yes (documented) |
+| `PSORequestContext(String)` this-escape | `@SuppressWarnings("this-escape")` on ctor (`setPrivateObject` overridable on parent) | Yes (documented) |
+| `PropertyData` serial field | Field type `ArrayList<ValueData>` + defensive copy in `setValues` | No |
+
+## Hard-gate checklist
+
+- [x] No bugs in constructor semantics (tests cover Error/Field/Http*/AA orientation/PropertyData/params helper)
+- [x] Cross-platform: no path I/O changes
+- [x] Unit tests for behavioral ctor paths (new test classes)
+- [x] Standalone `cd modules/perc-toolkit && ../../mvnw clean install` green
+- [x] Main-source project `-Xlint` diagnostics **26 → 0**
+- [x] No monorepo reformat / unrelated churn
+- [x] Intentional suppressions documented in code + this review
+
+## Verification
+
+```
+cd modules/perc-toolkit
+../../mvnw.cmd clean install
+# BUILD SUCCESS
+# Tests run: 245, Failures: 0, Errors: 0, Skipped: 16
+# Main-source [WARNING] *.java: count = 0
+```
+
+## Residual
+
+- **Main-source:** none remaining for this module under project `-Xlint` (deprecation still excluded via parent `-Xlint:-deprecation`).
+- **Test-source:** pre-existing rawtypes/unchecked in tests remain (out of #2419 main-source inventory). Optional follow-up under #2030 if full module zero is required.
+- **perc-system:** typing `PSRequestContext` return types would allow removing the PSORequestContext class-level suppress.
+
+## Verdict
+
+**PASS** — ready to commit / open PR.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaDependentRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaDependentRelationshipBuilder.java
@@ -27,9 +27,9 @@ package com.percussion.pso.relationshipbuilder;
  * @see PSAaOwnerRelationshipBuilder
  * @see #retrieve(int)
  */
-public class PSAaDependentRelationshipBuilder extends PSActiveAssemblyRelationshipBuilder {
+public final class PSAaDependentRelationshipBuilder extends PSActiveAssemblyRelationshipBuilder {
 
   public PSAaDependentRelationshipBuilder() {
-    setParent(false);
+    super(false);
   }
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaOwnerRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaOwnerRelationshipBuilder.java
@@ -27,9 +27,9 @@ package com.percussion.pso.relationshipbuilder;
  * @see PSAaDependentRelationshipBuilder
  * @see #retrieve(int)
  */
-public class PSAaOwnerRelationshipBuilder extends PSActiveAssemblyRelationshipBuilder {
+public final class PSAaOwnerRelationshipBuilder extends PSActiveAssemblyRelationshipBuilder {
 
   public PSAaOwnerRelationshipBuilder() {
-    setParent(true);
+    super(true);
   }
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSActiveAssemblyRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSActiveAssemblyRelationshipBuilder.java
@@ -46,6 +46,14 @@ public abstract class PSActiveAssemblyRelationshipBuilder extends PSRelationship
 
   public PSActiveAssemblyRelationshipBuilder() {}
 
+  /**
+   * @param isParent {@code true} when the updated item is the relationship owner
+   * @see PSRelationshipBuilder#PSRelationshipBuilder(boolean)
+   */
+  protected PSActiveAssemblyRelationshipBuilder(boolean isParent) {
+    super(isParent);
+  }
+
   public void init() {
     if (m_assemblyService == null) {
       m_assemblyService = PSAssemblyServiceLocator.getAssemblyService();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipBuilder.java
@@ -70,11 +70,27 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     filter = new PSRelationshipFilter();
   }
 
+  /**
+   * Subclass constructors that know owner/dependent orientation at construction time assign the
+   * field here (no overridable setter call → no this-escape).
+   *
+   * @param isParent {@code true} when the updated item is the relationship owner
+   */
+  protected PSRelationshipBuilder(boolean isParent) {
+    this();
+    this.isParent = isParent;
+  }
+
   public boolean isParent() {
     return isParent;
   }
 
-  public void setParent(boolean isParent) {
+  /**
+   * Final so subclass constructors may call without this-escape (no further override).
+   *
+   * @param isParent {@code true} when the updated item is the relationship owner
+   */
+  public final void setParent(boolean isParent) {
     this.isParent = isParent;
   }
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/BaseHttpResponse.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/BaseHttpResponse.java
@@ -22,13 +22,15 @@ import org.apache.commons.lang3.StringUtils;
 public abstract class BaseHttpResponse {
 
   private Item existingItem;
-  private HttpHeaders headers;
+
+  /** Package-visible for subclass single-shot constructors (avoids this-escape). */
+  HttpHeaders headers;
 
   /***
    * Sets the HTTP Headers collection for this response.
    * @param headers
    */
-  public void setHeaders(HttpHeaders headers) {
+  public final void setHeaders(HttpHeaders headers) {
     this.headers = headers;
   }
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Error.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Error.java
@@ -36,22 +36,23 @@ public class Error {
   private Integer contentId;
 
   public Error() {
-    setErrorCode(ErrorCode.UNKNOWN_ERROR);
+    // Direct field assignment avoids this-escape from overridable setters in ctor.
+    this.errorCode = ErrorCode.UNKNOWN_ERROR;
   }
 
   public Error(ErrorCode errorCode, String message) {
-    setErrorCode(errorCode);
-    setErrorMessage(message);
+    this.errorCode = errorCode;
+    this.errorMessage = message;
   }
 
   public Error(ErrorCode errorCode, Integer contentId, String message) {
-    setErrorCode(errorCode);
-    setErrorMessage(message);
-    setContentId(contentId);
+    this.errorCode = errorCode;
+    this.errorMessage = message;
+    this.contentId = contentId;
   }
 
   public Error(ErrorCode errorCode) {
-    setErrorCode(errorCode);
+    this.errorCode = errorCode;
   }
 
   @XmlAttribute

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Field.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Field.java
@@ -85,6 +85,16 @@ public class Field {
    * @param value String
    */
   public void setStringValue(String value) {
+    applyStringValue(value);
+  }
+
+  /**
+   * Applies string value representation without calling overridable setters (safe from
+   * constructors).
+   *
+   * @param value string content; may be {@code null}
+   */
+  private void applyStringValue(String value) {
     if (value == null) {
       this.valueAtt = null;
       this.values = null;
@@ -94,13 +104,19 @@ public class Field {
     if (value.contains("<div class=\"rxbodyfield\">")) {
       Value newVal = new XhtmlValue();
       newVal.setStringValue(value);
-      setValue(newVal);
+      this.valueAtt = null;
+      this.values = null;
+      this.value = newVal;
     } else if (value.length() > 50) {
-      setValueAtt(value);
+      this.value = null;
+      this.values = null;
+      this.valueAtt = value;
     } else {
       Value newVal = new StringValue();
       newVal.setStringValue(value);
-      setValue(newVal);
+      this.valueAtt = null;
+      this.values = null;
+      this.value = newVal;
     }
   }
 
@@ -172,8 +188,9 @@ public class Field {
    */
   public Field(String name, String value) {
     super();
-    this.setName(name);
-    this.setStringValue(value);
+    // Direct field / private helper — avoids this-escape from overridable setters in ctor.
+    this.name = name;
+    applyStringValue(value);
   }
 
   /** Field name. */

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpDOMResponse.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpDOMResponse.java
@@ -55,7 +55,8 @@ public class HttpDOMResponse extends BaseHttpResponse {
    * @param head
    */
   public HttpDOMResponse(Document doc, HttpHeaders head) {
-    this.setHeaders(head);
+    // Direct field assignment (headers is package-visible on base) — no this-escape.
+    this.headers = head;
     this.document = doc;
   }
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpHtmlResponse.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpHtmlResponse.java
@@ -39,7 +39,8 @@ public class HttpHtmlResponse extends BaseHttpResponse {
    * @param head
    */
   public HttpHtmlResponse(Document doc, HttpHeaders head) {
-    this.setHeaders(head);
+    // Direct field assignment (headers is package-visible on base) — no this-escape.
+    this.headers = head;
     this.document = doc;
   }
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOExtensionParamsHelper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOExtensionParamsHelper.java
@@ -259,11 +259,13 @@ public class PSOExtensionParamsHelper {
     return this.extensionParameters;
   }
 
-  protected void doLog(Logger log) {
+  /** Private: ctor-only; must not be overridable (this-escape). */
+  private void doLog(Logger log) {
     this.log = log == null ? PSOExtensionParamsHelper.defaultLog : log;
   }
 
-  protected void doParameters() {
+  /** Private: ctor-only; must not be overridable (this-escape). */
+  private void doParameters() {
     extensionParameters = new HashMap<>();
 
     if (params != null) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSORequestContext.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSORequestContext.java
@@ -22,7 +22,6 @@
  */
 package com.percussion.pso.utils;
 
-import com.percussion.server.IPSRequestContext;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSRequestContext;
 import com.percussion.system.utils.IPSHtmlParameters;
@@ -31,9 +30,15 @@ import com.percussion.system.utils.IPSHtmlParameters;
  * A system request that overrides the PSRequestContext. Use this class to obtain an
  * IPSRequestContext for the system user (RxServer).
  *
+ * <p>{@link PSRequestContext} still exposes several raw-typed methods that implement generic
+ * {@code IPSRequestContext} methods. Compiling any subclass under {@code -Xlint} re-emits those
+ * unchecked conversion diagnostics here; they are suppressed until perc-system types the parent
+ * API. Prefer fixing {@code PSRequestContext} in a dedicated perc-system change.
+ *
  * @author DavidBenua
  */
-public class PSORequestContext extends PSRequestContext implements IPSRequestContext {
+@SuppressWarnings({"unchecked", "rawtypes"}) // parent PSRequestContext raw → IPSRequestContext
+public final class PSORequestContext extends PSRequestContext {
   /**
    * Gets a the system user request. This system request is always forced to be local to the server,
    * even if the original user request came from elsewhere.
@@ -45,11 +50,12 @@ public class PSORequestContext extends PSRequestContext implements IPSRequestCon
   /**
    * Gets the system user request, specifying a community.
    *
-   * @param CommunityId
+   * @param CommunityId community id to set on the system request
    */
+  @SuppressWarnings("this-escape") // setPrivateObject on parent is overridable; no typed API
   public PSORequestContext(String CommunityId) {
-    this();
-    this.setCommunity(CommunityId);
+    super(PSRequest.getContextForRequest(true));
+    super.setPrivateObject(IPSHtmlParameters.SYS_COMMUNITY, CommunityId);
   }
 
   /**
@@ -58,6 +64,7 @@ public class PSORequestContext extends PSRequestContext implements IPSRequestCon
    *
    * @see com.percussion.server.IPSRequestContext#isTraceEnabled()
    */
+  @Override
   public boolean isTraceEnabled() {
     return false;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/PropertyData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/PropertyData.java
@@ -17,9 +17,8 @@
 
 package com.percussion.soln.jcr.data;
 
-import static java.util.Collections.singletonList;
-
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 public class PropertyData implements Serializable {
@@ -27,7 +26,11 @@ public class PropertyData implements Serializable {
   /** Safe to serialize */
   private static final long serialVersionUID = 428038730570607863L;
 
-  private List<ValueData> values;
+  /**
+   * Concrete {@link ArrayList} (not bare {@link List}) so the field type is serializable under
+   * {@code -Xlint:serial}.
+   */
+  private ArrayList<ValueData> values;
 
   private boolean multiple;
 
@@ -44,7 +47,8 @@ public class PropertyData implements Serializable {
   public PropertyData(ValueData data) {
     if ((data) == null) throw new IllegalArgumentException("Value Data cannot be null");
     multiple = false;
-    values = singletonList(data);
+    values = new ArrayList<>(1);
+    values.add(data);
   }
 
   public boolean isMultiple() {
@@ -60,7 +64,7 @@ public class PropertyData implements Serializable {
   }
 
   public void setValues(List<ValueData> values) {
-    this.values = values;
+    this.values = values == null ? null : new ArrayList<>(values);
   }
 
   public String getName() {

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/FolderTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/FolderTools.java
@@ -83,7 +83,8 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
     init(contentWs, guidManager);
   }
 
-  protected void init(IPSContentWs contentWs, IPSGuidManager guidManager) {
+  /** Final so the preferred constructor may call without this-escape. */
+  protected final void init(IPSContentWs contentWs, IPSGuidManager guidManager) {
     this.contentWs = contentWs;
     this.guidManager = guidManager;
   }

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/relationshipbuilder/PSAaRelationshipBuilderOrientationTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/relationshipbuilder/PSAaRelationshipBuilderOrientationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.pso.relationshipbuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.pso.relationshipbuilder.PSAaDependentRelationshipBuilder;
+import com.percussion.pso.relationshipbuilder.PSAaOwnerRelationshipBuilder;
+import org.junit.jupiter.api.Test;
+
+/** Owner/dependent orientation set via super(boolean) constructors (this-escape free). */
+public class PSAaRelationshipBuilderOrientationTest {
+
+  @Test
+  void ownerBuilderIsParent() {
+    assertTrue(new PSAaOwnerRelationshipBuilder().isParent());
+  }
+
+  @Test
+  void dependentBuilderIsNotParent() {
+    assertFalse(new PSAaDependentRelationshipBuilder().isParent());
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/restservice/model/ErrorTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/restservice/model/ErrorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.pso.restservice.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.pso.restservice.model.Error;
+import com.percussion.pso.restservice.model.Error.ErrorCode;
+import org.junit.jupiter.api.Test;
+
+/** Constructor field-assignment coverage for {@link Error} (this-escape free ctors). */
+public class ErrorTest {
+
+  @Test
+  void defaultConstructorUsesUnknownError() {
+    Error e = new Error();
+    assertEquals(ErrorCode.UNKNOWN_ERROR, e.getErrorCode());
+    assertNull(e.getErrorMessage());
+    assertNull(e.getContentId());
+  }
+
+  @Test
+  void codeAndMessageConstructor() {
+    Error e = new Error(ErrorCode.NOT_FOUND, "missing");
+    assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
+    assertEquals("missing", e.getErrorMessage());
+  }
+
+  @Test
+  void codeContentIdAndMessageConstructor() {
+    Error e = new Error(ErrorCode.ASSEMBLY_ERROR, 99, "boom");
+    assertEquals(ErrorCode.ASSEMBLY_ERROR, e.getErrorCode());
+    assertEquals(Integer.valueOf(99), e.getContentId());
+    assertEquals("boom", e.getErrorMessage());
+  }
+
+  @Test
+  void codeOnlyConstructor() {
+    Error e = new Error(ErrorCode.SKIP);
+    assertEquals(ErrorCode.SKIP, e.getErrorCode());
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/restservice/model/FieldConstructorTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/restservice/model/FieldConstructorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.pso.restservice.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.pso.restservice.model.Field;
+import com.percussion.pso.restservice.model.StringValue;
+import com.percussion.pso.restservice.model.XhtmlValue;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral coverage for {@link Field#Field(String, String)} string-value routing. */
+public class FieldConstructorTest {
+
+  @Test
+  void shortStringBecomesStringValue() {
+    Field f = new Field("title", "hello");
+    assertEquals("title", f.getName());
+    assertEquals("hello", f.getStringValue());
+    assertInstanceOf(StringValue.class, f.getValue());
+  }
+
+  @Test
+  void longStringUsesValueAttribute() {
+    String longVal = "x".repeat(51);
+    Field f = new Field("body", longVal);
+    assertEquals("body", f.getName());
+    assertEquals(longVal, f.getStringValue());
+    assertEquals(longVal, f.getValueAtt());
+    assertNull(f.getValue());
+  }
+
+  @Test
+  void rxbodyfieldMarkupBecomesXhtmlValue() {
+    String html = "<div class=\"rxbodyfield\"><p>hi</p></div>";
+    Field f = new Field("rich", html);
+    assertEquals("rich", f.getName());
+    assertInstanceOf(XhtmlValue.class, f.getValue());
+    assertEquals(html, f.getStringValue());
+  }
+
+  @Test
+  void setStringValueMatchesConstructorRouting() {
+    Field f = new Field();
+    f.setName("n");
+    f.setStringValue("short");
+    assertEquals("short", f.getStringValue());
+    assertInstanceOf(StringValue.class, f.getValue());
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/restservice/model/HttpResponseConstructorTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/restservice/model/HttpResponseConstructorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.pso.restservice.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.pso.restservice.model.HttpDOMResponse;
+import com.percussion.pso.restservice.model.HttpHtmlResponse;
+import java.net.http.HttpHeaders;
+import java.util.List;
+import java.util.Map;
+import org.dom4j.DocumentHelper;
+import org.jsoup.Jsoup;
+import org.junit.jupiter.api.Test;
+
+/** Single-shot constructor coverage for HTTP response models. */
+public class HttpResponseConstructorTest {
+
+  private static HttpHeaders sampleHeaders() {
+    return HttpHeaders.of(
+        Map.of("ETag", List.of("\"abc\""), "Last-Modified", List.of("Wed, 01 Jan 2020 00:00:00 GMT")),
+        (n, v) -> true);
+  }
+
+  @Test
+  void domResponseConstructorSetsDocumentAndHeaders() {
+    org.dom4j.Document doc = DocumentHelper.createDocument();
+    doc.addElement("root").addText("ok");
+    HttpHeaders headers = sampleHeaders();
+
+    HttpDOMResponse response = new HttpDOMResponse(doc, headers);
+
+    assertSame(doc, response.getDocument());
+    assertSame(headers, response.getHeaders());
+    assertEquals("\"abc\"", response.getETag());
+  }
+
+  @Test
+  void htmlResponseConstructorSetsDocumentAndHeaders() {
+    org.jsoup.nodes.Document doc = Jsoup.parse("<html><body>hi</body></html>");
+    HttpHeaders headers = sampleHeaders();
+
+    HttpHtmlResponse response = new HttpHtmlResponse(doc, headers);
+
+    assertSame(doc, response.getDocument());
+    assertSame(headers, response.getHeaders());
+    assertTrue(response.getLastModified().contains("2020"));
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOExtensionParamsHelperTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/PSOExtensionParamsHelperTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.pso.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.pso.utils.PSOExtensionParamsHelper;
+import com.percussion.server.IPSRequestContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+/** Coverage for map/slot constructors and parameter resolution after private init helpers. */
+public class PSOExtensionParamsHelperTest {
+
+  private static PSOExtensionParamsHelper mapHelper(Map<String, String> params) {
+    return new PSOExtensionParamsHelper(params, (IPSRequestContext) null, (Logger) null);
+  }
+
+  @Test
+  void mapConstructorReturnsExtensionParameters() {
+    Map<String, String> params = new HashMap<>();
+    params.put("sys_contentid", "42");
+    PSOExtensionParamsHelper helper = mapHelper(params);
+    assertEquals("42", helper.getParameter("sys_contentid"));
+    assertEquals("42", helper.getRequiredParameter("sys_contentid"));
+  }
+
+  @Test
+  void optionalParameterFallsBackToDefault() {
+    PSOExtensionParamsHelper helper = mapHelper(Map.of());
+    assertEquals("fallback", helper.getOptionalParameter("missing", "fallback"));
+  }
+
+  @Test
+  void requiredParameterThrowsWhenMissing() {
+    PSOExtensionParamsHelper helper = mapHelper(Map.of());
+    assertThrows(IllegalArgumentException.class, () -> helper.getRequiredParameter("nope"));
+  }
+
+  @Test
+  void slotConstructorReadsSelectorsFirst() {
+    Map<String, Object> args = Map.of("fromArgs", "a");
+    Map<String, Object> selectors = new HashMap<>();
+    selectors.put("fromArgs", "selectorWins");
+    selectors.put("onlySelector", "s");
+    PSOExtensionParamsHelper helper =
+        new PSOExtensionParamsHelper(args, selectors, (Logger) null);
+    assertEquals("selectorWins", helper.getParameter("fromArgs"));
+    assertEquals("s", helper.getParameter("onlySelector"));
+  }
+
+  @Test
+  void paramToNumberAndBoolean() {
+    PSOExtensionParamsHelper helper = mapHelper(Map.of("n", "7", "b", "true"));
+    assertEquals(7, helper.getRequiredParameterAsNumber("n").intValue());
+    assertTrue(helper.getRequiredParameterAsBoolean("b"));
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/soln/jcr/data/PropertyDataTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/soln/jcr/data/PropertyDataTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.soln.jcr.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.soln.jcr.data.PropertyData;
+import com.percussion.soln.jcr.data.ValueData;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Serial field hygiene + single-value constructor coverage for {@link PropertyData}. */
+public class PropertyDataTest {
+
+  @Test
+  void singleValueConstructorStoresValue() {
+    ValueData vd = new ValueData("hello");
+    PropertyData pd = new PropertyData(vd);
+    assertFalse(pd.isMultiple());
+    assertEquals(1, pd.getValues().size());
+    assertSame(vd, pd.getValues().get(0));
+  }
+
+  @Test
+  void singleValueConstructorRejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> new PropertyData(null));
+  }
+
+  @Test
+  void setValuesCopiesIntoSerializableArrayList() {
+    PropertyData pd = new PropertyData();
+    List<ValueData> input = List.of(new ValueData("a"), new ValueData("b"));
+    pd.setValues(input);
+    pd.setMultiple(true);
+    assertEquals(2, pd.getValues().size());
+    assertInstanceOf(ArrayList.class, pd.getValues());
+    // defensive copy
+    assertNotSame(input, pd.getValues());
+  }
+
+  @Test
+  void roundTripSerialization() throws Exception {
+    PropertyData original = new PropertyData(new ValueData("serial-me"));
+    original.setName("prop");
+
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(original);
+      bytes = bos.toByteArray();
+    }
+
+    PropertyData restored;
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      restored = (PropertyData) ois.readObject();
+    }
+
+    assertEquals("prop", restored.getName());
+    assertEquals(1, restored.getValues().size());
+    assertEquals("serial-me", restored.getValues().get(0).getStringData());
+  }
+}

--- a/modules/perc-toolkit/src/test/java/test/percussion/soln/listbuilder/FolderToolsConstructorTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/soln/listbuilder/FolderToolsConstructorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.percussion.soln.listbuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.soln.listbuilder.FolderTools;
+import com.percussion.webservices.content.IPSContentWs;
+import org.junit.jupiter.api.Test;
+
+/** Preferred constructor wires contentWs/guidManager via final init (this-escape free). */
+public class FolderToolsConstructorTest {
+
+  @Test
+  void preferredConstructorAcceptsDependencies() {
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    IPSGuidManager guidManager = mock(IPSGuidManager.class);
+    FolderTools tools = new FolderTools(contentWs, guidManager);
+    assertNotNull(tools);
+  }
+}


### PR DESCRIPTION
## Summary

Clears remaining **main-source** project `-Xlint` diagnostics for **perc-toolkit** after batch 1 (#2030 / PR #2420).

**Live main-source diagnostics: 26 → 0.**

Parent tracker: #2200  
Slice of: #2030  
Fixes #2419

### Approach (prefer real patterns)

| Area | Fix |
|------|-----|
| `Error` / `Field` this-escape | Direct field assignment; private `applyStringValue` |
| `HttpDOMResponse` / `HttpHtmlResponse` | Package-visible `headers` field assignment |
| `PSAa*RelationshipBuilder` | `super(boolean)` via `PSRelationshipBuilder` / intermediate; classes `final` |
| `PSOExtensionParamsHelper` | `doLog` / `doParameters` private |
| `FolderTools` | `init` final (matches `PSOFolderTools`) |
| `PropertyData` serial field | `ArrayList<ValueData>` + defensive copy |
| `PSORequestContext` cascade | Documented `@SuppressWarnings({"unchecked","rawtypes"})` until perc-system types `PSRequestContext`; class `final`; intentional `this-escape` suppress on community ctor only |

### Tests

- `ErrorTest`, `FieldConstructorTest`, `HttpResponseConstructorTest`
- `PSAaRelationshipBuilderOrientationTest`
- `PropertyDataTest` (incl. serialization round-trip)
- `PSOExtensionParamsHelperTest`, `FolderToolsConstructorTest`

## Test plan

- [x] `cd modules/perc-toolkit && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **245**, Failures: **0**, Errors: **0**, Skipped: **16**
- [x] Main-source `[WARNING] *.java:` count **0** (was 26)
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-2419-perc-toolkit-xlint-residual-erlang.md`

## Residual

- Main-source: **none** under project `-Xlint` for this module.
- Test-source: pre-existing rawtypes/unchecked remain (out of #2419 inventory). Optional under #2030 if full module zero is required.
- perc-system typing of `PSRequestContext` would remove the PSORequestContext class suppress.

## Gates

- Erlang pre-commit: PASS
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.