### PR TITLE
fix(perc-system): cms.objectstore server handlers rawtypes residual batch 2h (#2624)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2624-objectstore-server-handlers-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2624-objectstore-server-handlers-rawtypes-erlang.md
@@ -1,0 +1,34 @@
+# Erlang-style self-review — issue #2624
+
+**Branch:** fix/issue-2624-objectstore-server-handlers-rawtypes-2h  
+**Module:** system / perc-system  
+**Change class:** residual rawtypes/unchecked typing in cms.objectstore.server handlers (slice 2h after #2453)
+
+## Scope
+
+- `PSServerItem` — typed field/child/related iterators; `Map<String, Object>` HTML param maps for update paths; `Map<String, ?>` for `makeRequest`; package-visible `populateFieldParams`
+- `PSLoadChildDataExit` — `List<Element>` snapshot of base elements; extracted `snapshotElements` for tests
+- `PSFieldRetriever` — `Map<String, Object>` `prepareParams` / request helpers; package-visible for tests
+- `PSAuthTypes` — `stringPropertyNames()` iteration; extracted `parseAuthTypeProperties`; try-with-resources on config stream
+- `PSCatalogServerObjectHandler` — `Collection<String>` init, `Iterator<String>` request roots, `collectFieldNames` for multi-value field-name params
+
+Prefer real generics; no new `@SuppressWarnings` for rawtypes in this batch.
+
+## Gates
+
+- [x] No intentional behavior change beyond typing (authtype parse key rule preserved; field-name list/scalar semantics preserved)
+- [x] Real generics preferred
+- [x] Out of scope: IPSComponent parentComponents (#2455), data/data.jdbc, this-escape/serial
+- [x] Cross-platform: no path I/O changes (auth config still uses `File.separator` via existing `PSObservableFile` construction)
+- [x] Unit tests for changed pure logic (`PSObjectStoreServerHandlersRawtypesTest`)
+- [x] `cd system && ../mvnw.cmd clean install` green — Tests run: **1441**, Failures: **0**, Errors: **0**, Skipped: 240; BUILD SUCCESS
+
+## Residual
+
+- Named hottest list for this slice (PSServerItem / PSLoadChildDataExit / PSFieldRetriever / PSAuthTypes / PSCatalogServerObjectHandler) is zeroed for the rawtypes in scope.
+- `PSServer.getInternalRequest(..., Map, ...)` remains raw at the server API boundary (out of this slice).
+- Epic #2022 may still track other perc-system javac residual outside this handler batch; no micro residual filed for zeroed slice scope.
+
+## Verdict
+
+**PASS** for commit/PR.

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSAuthTypePropertiesParser.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSAuthTypePropertiesParser.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore.server;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Pure parser for authtype properties files used by {@link PSAuthTypes}.
+ *
+ * <p>Separated from {@link PSAuthTypes} so unit tests can exercise key/value handling without
+ * triggering the singleton's static config-file initialization (issue #2624).
+ */
+final class PSAuthTypePropertiesParser {
+
+  private PSAuthTypePropertiesParser() {}
+
+  /**
+   * Parse an authtype properties file into the authtype → resource map.
+   *
+   * <p>Preserves historical key handling: any property whose name is longer than the {@code
+   * authtype.} prefix contributes a map entry whose key is {@code name.substring("authtype."
+   * .length())} (only non-empty property values are kept).
+   *
+   * @param props never {@code null}
+   * @return never {@code null}; may be empty
+   */
+  static Map<String, String> parse(Properties props) {
+    if (props == null) {
+      throw new IllegalArgumentException("props may not be null");
+    }
+    Map<String, String> result = new HashMap<>();
+    final String AUTHTYPE_PREFIX = "authtype.";
+    for (String name : props.stringPropertyNames()) {
+      String value = props.getProperty(name);
+      if (value != null && !value.isEmpty()) {
+        if (name.length() > AUTHTYPE_PREFIX.length()) {
+          String key = name.substring(AUTHTYPE_PREFIX.length());
+          result.put(key, value);
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSAuthTypes.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSAuthTypes.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
@@ -107,30 +106,10 @@ public class PSAuthTypes implements Observer {
    */
   private synchronized void loadProperties(PSObservableFile configFile) throws IOException {
     m_authTypeMap.clear();
-    InputStream is = null;
-    try {
-      is = new FileInputStream(configFile.getFile());
+    try (InputStream is = new FileInputStream(configFile.getFile())) {
       Properties props = new Properties();
       props.load(is);
-      Iterator iter = props.keySet().iterator();
-      final String AUTHTYPE_PREFIX = "authtype.";
-      while (iter.hasNext()) {
-        String name = (String) iter.next();
-        String value = props.getProperty(name);
-        if (value != null && value.length() > 0) {
-          String key = null;
-          if (name.length() > AUTHTYPE_PREFIX.length())
-            key = name.substring(AUTHTYPE_PREFIX.length());
-          if (key != null) m_authTypeMap.put(key, value);
-        }
-      }
-    } finally {
-      if (is != null) {
-        try {
-          is.close();
-        } catch (Exception e) {
-        }
-      }
+      m_authTypeMap.putAll(PSAuthTypePropertiesParser.parse(props));
     }
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSCatalogServerObjectHandler.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSCatalogServerObjectHandler.java
@@ -57,8 +57,9 @@ import org.xml.sax.SAXException;
 /** Loadable handler for getting shared, system and local content editor fields from the server. */
 public class PSCatalogServerObjectHandler implements IPSLoadableRequestHandler {
   // see the interface.
+  @Override
   @SuppressWarnings("unused")
-  public void init(Collection requestRoots, InputStream cfgFileIn) throws PSServerException {
+  public void init(Collection<String> requestRoots, InputStream cfgFileIn) throws PSServerException {
     // do nothing.
   }
 
@@ -103,16 +104,8 @@ public class PSCatalogServerObjectHandler implements IPSLoadableRequestHandler {
           controlFlags = controlFlags | PSLocalCataloger.FLAG_EXCLUDE_CHOICES;
         }
 
-        Set<String> fieldNames = new HashSet<>();
-        Object obj = request.getParameters().get(IPSHtmlParameters.SYS_CE_FIELD_NAME);
-        if (obj instanceof List) {
-          List names = (List) obj;
-          for (Object name : names) {
-            if (name != null) fieldNames.add(name.toString());
-          }
-        } else if (obj != null) {
-          fieldNames.add(obj.toString());
-        }
+        Set<String> fieldNames = collectFieldNames(
+            request.getParameters().get(IPSHtmlParameters.SYS_CE_FIELD_NAME));
 
         Element ceFieldElem = cataloger.getCEFieldXml(controlFlags, fieldNames);
         responseDoc = ceFieldElem.getOwnerDocument();
@@ -347,8 +340,33 @@ public class PSCatalogServerObjectHandler implements IPSLoadableRequestHandler {
   }
 
   // see {@link com.percussion.server.IPSRootedHandler}
-  public Iterator getRequestRoots() {
+  @Override
+  public Iterator<String> getRequestRoots() {
     return null;
+  }
+
+  /**
+   * Normalize a request parameter value for {@link IPSHtmlParameters#SYS_CE_FIELD_NAME} into a set
+   * of field names. Multi-valued parameters arrive as a {@link List}; a single value is treated as
+   * one name.
+   *
+   * <p>Package-private for unit tests (issue #2624).
+   *
+   * @param obj parameter value from the request map; may be {@code null}
+   * @return never {@code null}; may be empty; never contains {@code null} entries
+   */
+  static Set<String> collectFieldNames(Object obj) {
+    Set<String> fieldNames = new HashSet<>();
+    if (obj instanceof List<?> names) {
+      for (Object name : names) {
+        if (name != null) {
+          fieldNames.add(name.toString());
+        }
+      }
+    } else if (obj != null) {
+      fieldNames.add(obj.toString());
+    }
+    return fieldNames;
   }
 
   /** Name of the custom application for web services. */

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSFieldRetriever.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSFieldRetriever.java
@@ -81,7 +81,7 @@ public class PSFieldRetriever {
   public byte[] getFieldContent(PSRequest req, PSLocator itemId, String fieldName, int childRowId)
       throws PSCmsException, PSInvalidContentTypeException {
     String urlToApp = getRequestUrl(req, itemId, fieldName, childRowId);
-    Map params = prepareParams(itemId, fieldName, childRowId);
+    Map<String, Object> params = prepareParams(itemId, fieldName, childRowId);
 
     byte[] results = requestData(req, urlToApp, params);
     if (null == results) results = new byte[0];
@@ -112,7 +112,7 @@ public class PSFieldRetriever {
       PSRequest req, PSLocator itemId, String fieldName, int childRowId)
       throws PSCmsException, PSInvalidContentTypeException {
     String urlToApp = getRequestUrl(req, itemId, fieldName, childRowId);
-    Map params = prepareParams(itemId, fieldName, childRowId);
+    Map<String, Object> params = prepareParams(itemId, fieldName, childRowId);
 
     PSMimeContentResult mimeContent = requestMimeContent(req, urlToApp, params);
     if (mimeContent != null) return mimeContent.getFileResource();
@@ -159,7 +159,9 @@ public class PSFieldRetriever {
   }
 
   /**
-   * Add the necessary parameters.
+   * Add the necessary parameters for a binary field retrieval request.
+   *
+   * <p>Package-private for unit tests (issue #2624).
    *
    * @param itemId assumed not <code>null</code> and valid. See {@link #getFieldContent(PSRequest,
    *     PSLocator, String, int) getFieldContent} for more info.
@@ -167,15 +169,18 @@ public class PSFieldRetriever {
    *     PSLocator, String, int) getFieldContent} for more info.
    * @param childRowId the childRowId for retrieving the correct child row data. If < 0 then we are
    *     not trying to retrieve a child row.
+   * @return never {@code null}; keys are HTML parameter names, values are request parameter objects
    */
-  private Map prepareParams(PSLocator itemId, String fieldName, int childRowId) {
+  Map<String, Object> prepareParams(PSLocator itemId, String fieldName, int childRowId) {
     Map<String, Object> params = new HashMap<>();
     params.put(IPSHtmlParameters.SYS_COMMAND, IPSMimeContentTypes.MIME_ENC_BINARY);
     params.put(IPSHtmlParameters.SYS_CONTENTID, Integer.valueOf(itemId.getId()));
     params.put(IPSHtmlParameters.SYS_REVISION, Integer.valueOf(itemId.getRevision()));
     params.put(IPSConstants.SUBMITNAME_PARAM_NAME, fieldName);
 
-    if (childRowId >= 0) params.put("sys_childrowid", Integer.toString(childRowId));
+    if (childRowId >= 0) {
+      params.put("sys_childrowid", Integer.toString(childRowId));
+    }
 
     return params;
   }
@@ -259,7 +264,7 @@ public class PSFieldRetriever {
    * @return the data, may be <code>null</code> if there is no data.
    * @throws PSCmsException if there is a problem acquiring the data.
    */
-  private byte[] requestData(PSRequest request, String requestUrl, Map params)
+  private byte[] requestData(PSRequest request, String requestUrl, Map<String, Object> params)
       throws PSCmsException {
     InputStream inStream = null;
     byte[] data = null;
@@ -296,8 +301,8 @@ public class PSFieldRetriever {
    * @return the mime content result, may be <code>null</code> if there is no data.
    * @throws PSCmsException if there is a problem acquiring the result.
    */
-  private PSMimeContentResult requestMimeContent(PSRequest request, String requestUrl, Map params)
-      throws PSCmsException {
+  private PSMimeContentResult requestMimeContent(
+      PSRequest request, String requestUrl, Map<String, Object> params) throws PSCmsException {
     PSExecutionData execData = null;
     try {
       PSInternalRequest ir = PSServer.getInternalRequest(requestUrl, request, params, false);

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSLoadChildDataExit.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSLoadChildDataExit.java
@@ -25,7 +25,6 @@ import com.percussion.server.IPSInternalRequest;
 import com.percussion.server.IPSRequestContext;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -98,17 +97,11 @@ public class PSLoadChildDataExit extends PSDefaultExtension implements IPSResult
     NodeList elements = root.getElementsByTagName(baseElementName);
     if (elements == null) return resultDoc;
 
-    // need to collect elements into list since modifying the doc as we go
-    // will slow down the performance of traversing the NodeList
-    int len = elements.getLength();
-    List nodeList = new ArrayList(len);
-    for (int i = 0; i < len; i++) {
-      nodeList.add(elements.item(i));
-    }
+    // Snapshot elements before mutation: live NodeList traversal while
+    // replacing children would skip/duplicate nodes under W3C DOM.
+    List<Element> baseElements = snapshotElements(elements);
 
-    Iterator nodes = nodeList.iterator();
-    while (nodes.hasNext()) {
-      Element baseEl = (Element) nodes.next();
+    for (Element baseEl : baseElements) {
       PSXmlTreeWalker tree = new PSXmlTreeWalker(baseEl);
       Element childEl =
           tree.getNextElement(childElementName, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
@@ -124,6 +117,29 @@ public class PSLoadChildDataExit extends PSDefaultExtension implements IPSResult
     }
 
     return resultDoc;
+  }
+
+  /**
+   * Copy a {@link NodeList} of elements into an independent list so callers can mutate the document
+   * without live-list side effects.
+   *
+   * <p>Package-private for unit tests (issue #2624).
+   *
+   * @param elements may be {@code null}; treated as empty
+   * @return never {@code null}; may be empty; only {@link Element} nodes are included
+   */
+  static List<Element> snapshotElements(NodeList elements) {
+    if (elements == null) {
+      return List.of();
+    }
+    int len = elements.getLength();
+    List<Element> nodeList = new ArrayList<>(len);
+    for (int i = 0; i < len; i++) {
+      if (elements.item(i) instanceof Element el) {
+        nodeList.add(el);
+      }
+    }
+    return nodeList;
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSServerItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSServerItem.java
@@ -865,9 +865,11 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
    *     returned by the above mentioned method).
    * @throws PSCmsException If {@link PSInternalRequest#getResultDoc()} throws and exception.
    */
-  private Document makeRequest(String path, PSRequest request, Map params, boolean inherit)
+  private Document makeRequest(
+      String path, PSRequest request, Map<String, ?> params, boolean inherit)
       throws PSCmsException {
     try {
+      // PSServer still exposes a raw Map API; Map<String, ?> is the call-site contract here.
       PSInternalRequest iReq = PSServer.getInternalRequest(path, request, params, inherit);
 
       return iReq.getResultDoc();
@@ -954,9 +956,9 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
   private void validateRelatedItems(PSRequest request) throws PSCmsException {
     PSRelationshipProcessor processor = PSRelationshipProcessor.getInstance();
 
-    Iterator relatedItems = getAllRelatedItems();
+    Iterator<PSItemRelatedItem> relatedItems = getAllRelatedItems();
     while (relatedItems.hasNext()) {
-      PSItemRelatedItem relatedItem = (PSItemRelatedItem) relatedItems.next();
+      PSItemRelatedItem relatedItem = relatedItems.next();
 
       PSRelationshipConfig config = processor.getConfig(relatedItem.getRelatedType());
       if (config == null)
@@ -986,7 +988,7 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
     fieldParams.put(PSContentEditorHandler.PAGE_ID_PARAM_NAME, "0");
     fieldParams.put(DB_ACTION_TYPE, (getContentId() == -1) ? DB_ACTION_INSERT : DB_ACTION_UPDATE);
 
-    Iterator fieldIter = getAllFields();
+    Iterator<PSItemField> fieldIter = getAllFields();
     populateFieldParams(fieldParams, fieldIter);
 
     processUpdateAction(path, request, fieldParams);
@@ -996,16 +998,20 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
    * Iterates over the supplied fields and adds entries to the params in preparation for calling
    * {@link #processUpdateAction(String, PSRequest, Map)}.
    *
+   * <p>Package-private for unit tests (issue #2624). Values may be {@link String}, {@link List} of
+   * strings (multi-value fields), or binary file objects.
+   *
    * @param fieldParams Map of html params to which field values are added, assumed not <code>null
-   *     </code>, key are <code>String</code> objects and values are objects.
+   *     </code>, keys are parameter names and values are request parameter objects.
    * @param fieldIter An iterator over zero or more {@link PSItemField} objects, assumed not <code>
    *     null</code>.
    * @throws PSCmsException If there is an error converting a field value to it's string
    *     representation
    */
-  private void populateFieldParams(Map fieldParams, Iterator fieldIter) throws PSCmsException {
+  void populateFieldParams(Map<String, Object> fieldParams, Iterator<PSItemField> fieldIter)
+      throws PSCmsException {
     while (fieldIter.hasNext()) {
-      PSItemField field = (PSItemField) fieldIter.next();
+      PSItemField field = fieldIter.next();
 
       // ignore the binary field if it has no value and never loaded.
       if (field.getItemFieldMeta().isBinary()
@@ -1025,9 +1031,9 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
         fieldParams.put(field.getName(), val.getValueFile());
       } else if (field.getItemFieldMeta().isMultiValueField()) {
         List<String> newVals = new ArrayList<>();
-        Iterator values = field.getAllValues();
+        Iterator<IPSFieldValue> values = field.getAllValues();
         while (values.hasNext()) {
-          IPSFieldValue val = (IPSFieldValue) values.next();
+          IPSFieldValue val = values.next();
           newVals.add(val.getValueAsString());
         }
         fieldParams.put(field.getName(), newVals);
@@ -1049,18 +1055,18 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
    */
   private void saveAllChilds(PSRequest request, String path) throws PSCmsException {
     // update the children
-    Iterator childIter = getAllChildren();
+    Iterator<PSItemChild> childIter = getAllChildren();
     while (childIter.hasNext()) {
-      Map<String, String> baseParams = new HashMap<>();
+      Map<String, Object> baseParams = new HashMap<>();
 
-      PSItemChild child = (PSItemChild) childIter.next();
+      PSItemChild child = childIter.next();
       baseParams.put(
           PSContentEditorHandler.CHILD_ID_PARAM_NAME, String.valueOf(child.getChildId()));
 
-      Iterator childEntryIter = child.getAllEntries();
+      Iterator<PSItemChildEntry> childEntryIter = child.getAllEntries();
       while (childEntryIter.hasNext()) {
-        Map<String, String> childParams = new HashMap<>(baseParams);
-        PSItemChildEntry childEntry = (PSItemChildEntry) childEntryIter.next();
+        Map<String, Object> childParams = new HashMap<>(baseParams);
+        PSItemChildEntry childEntry = childEntryIter.next();
 
         String action = childEntry.getAction();
         if (action != null && !action.equals("") && !action.equalsIgnoreCase("ignore")) {
@@ -1071,7 +1077,7 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
                 PSContentEditorHandler.CHILD_ROW_ID_PARAM_NAME, Integer.toString(childRowId));
           }
 
-          Iterator childFieldIter = childEntry.getAllFields();
+          Iterator<PSItemField> childFieldIter = childEntry.getAllFields();
           populateFieldParams(childParams, childFieldIter);
           processUpdateAction(path, request, childParams);
 
@@ -1097,9 +1103,9 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
       // if so then collect the rowIds and sortRanks and then update
       if (child.isSequenced()) {
         StringBuilder childIdRows = new StringBuilder();
-        Iterator seqIter = child.getAllEntries();
+        Iterator<PSItemChildEntry> seqIter = child.getAllEntries();
         while (seqIter.hasNext()) {
-          PSItemChildEntry childEntry = (PSItemChildEntry) seqIter.next();
+          PSItemChildEntry childEntry = seqIter.next();
 
           if (!childEntry.getAction().equalsIgnoreCase(PSItemChildEntry.CHILD_ACTION_DELETE)) {
             childIdRows.append(childEntry.getChildRowId());
@@ -1108,7 +1114,7 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
           }
         }
         if (childIdRows.length() > 0) {
-          Map<String, String> seqParams = new HashMap<>(baseParams);
+          Map<String, Object> seqParams = new HashMap<>(baseParams);
           seqParams.put(PSContentEditorHandler.CHILD_ROW_ID_PARAM_NAME, childIdRows.toString());
           seqParams.put(DB_ACTION_TYPE, PSContentEditorHandler.DB_ACTION_RESEQUENCE);
 
@@ -1134,11 +1140,11 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
    */
   private void saveAllRelated(PSRequest request, String path) throws PSCmsException {
     // update the related items
-    Iterator relIter = getAllRelatedItems();
+    Iterator<PSItemRelatedItem> relIter = getAllRelatedItems();
 
     // insert any new content first
     while (relIter.hasNext()) {
-      PSItemRelatedItem related = (PSItemRelatedItem) relIter.next();
+      PSItemRelatedItem related = relIter.next();
       if (related
           .getAction()
           .equalsIgnoreCase(PSItemRelatedItem.PSRelatedItemAction.INSERT.toString())) {
@@ -1190,9 +1196,9 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
     // now do the proper relationship actions (insert, update, delete)
     relIter = getAllRelatedItems();
     while (relIter.hasNext()) {
-      Map<String, String> relatedParams = new HashMap<>();
+      Map<String, Object> relatedParams = new HashMap<>();
 
-      PSItemRelatedItem related = (PSItemRelatedItem) relIter.next();
+      PSItemRelatedItem related = relIter.next();
       String action = related.getAction();
       if (action.equalsIgnoreCase(PSItemRelatedItem.PSRelatedItemAction.INSERT.toString())) {
         relatedParams.put(
@@ -1287,7 +1293,7 @@ public class PSServerItem extends PSCoreItem implements IPSPersister {
    * @param request the original request being worked on, assumed not <code>null</code>
    * @param params a set of extra parameters to pass with the request, may be <code>null</code>
    */
-  private void processUpdateAction(String path, PSRequest request, Map params)
+  private void processUpdateAction(String path, PSRequest request, Map<String, Object> params)
       throws PSCmsException {
     try {
       PSInternalRequest iReq = PSServer.getInternalRequest(path, request, params, true);

--- a/system/src/test/java/com/percussion/cms/objectstore/server/PSObjectStoreServerHandlersRawtypesTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/server/PSObjectStoreServerHandlersRawtypesTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.IPSConstants;
+import com.percussion.content.IPSMimeContentTypes;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.extension.PSParameterMismatchException;
+import com.percussion.system.utils.IPSHtmlParameters;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Behavioral unit tests for typed residual server-handler helpers (issue #2624 / parent #2022 slice
+ * 2h). Full CMS stack paths remain integration-tested; these cover pure parameterization contracts.
+ */
+@Tag("UnitTest")
+public class PSObjectStoreServerHandlersRawtypesTest {
+
+  @Test
+  void fieldRetrieverPrepareParamsIncludesBinaryCommandAndIds() {
+    PSFieldRetriever retriever = new PSFieldRetriever(42L);
+    PSLocator item = new PSLocator(10, 2);
+
+    Map<String, Object> params = retriever.prepareParams(item, "body", -1);
+
+    assertEquals(IPSMimeContentTypes.MIME_ENC_BINARY, params.get(IPSHtmlParameters.SYS_COMMAND));
+    assertEquals(Integer.valueOf(10), params.get(IPSHtmlParameters.SYS_CONTENTID));
+    assertEquals(Integer.valueOf(2), params.get(IPSHtmlParameters.SYS_REVISION));
+    assertEquals("body", params.get(IPSConstants.SUBMITNAME_PARAM_NAME));
+    assertFalse(params.containsKey("sys_childrowid"));
+  }
+
+  @Test
+  void fieldRetrieverPrepareParamsAddsChildRowIdWhenNonNegative() {
+    PSFieldRetriever retriever = new PSFieldRetriever(1L);
+    PSLocator item = new PSLocator(5, 1);
+
+    Map<String, Object> params = retriever.prepareParams(item, "image", 7);
+
+    assertEquals("7", params.get("sys_childrowid"));
+  }
+
+  @Test
+  void fieldRetrieverRejectsInvalidLocator() {
+    PSFieldRetriever retriever = new PSFieldRetriever(1L);
+    assertFalse(retriever.isLocatorValid(new PSLocator(0, 1)));
+    assertFalse(retriever.isLocatorValid(new PSLocator(1, 0)));
+    assertTrue(retriever.isLocatorValid(new PSLocator(1, 1)));
+  }
+
+  @Test
+  void authTypesParseSkipsEmptyValuesAndShortKeys() {
+    Properties props = new Properties();
+    props.setProperty("authtype.1", "sys_aa/RelatedContent");
+    props.setProperty("authtype.2", "");
+    props.setProperty("short", "ignored-because-name-not-longer-than-prefix");
+    props.setProperty("authtype.99", "app/resource");
+
+    Map<String, String> map = PSAuthTypePropertiesParser.parse(props);
+
+    assertEquals(2, map.size());
+    assertEquals("sys_aa/RelatedContent", map.get("1"));
+    assertEquals("app/resource", map.get("99"));
+    assertFalse(map.containsKey("2"));
+  }
+
+  @Test
+  void authTypesParseRejectsNullProperties() {
+    assertThrows(IllegalArgumentException.class, () -> PSAuthTypePropertiesParser.parse(null));
+  }
+
+  @Test
+  void catalogHandlerCollectFieldNamesFromListAndScalar() {
+    Set<String> fromList =
+        PSCatalogServerObjectHandler.collectFieldNames(Arrays.asList("a", null, "b", "a"));
+    assertEquals(Set.of("a", "b"), fromList);
+
+    Set<String> fromScalar = PSCatalogServerObjectHandler.collectFieldNames("solo");
+    assertEquals(Set.of("solo"), fromScalar);
+
+    assertTrue(PSCatalogServerObjectHandler.collectFieldNames(null).isEmpty());
+  }
+
+  @Test
+  void loadChildDataExitSnapshotElementsIsIndependentOfLiveNodeList() throws Exception {
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    Element root = doc.createElement("root");
+    doc.appendChild(root);
+    Element c1 = doc.createElement("child");
+    Element c2 = doc.createElement("child");
+    root.appendChild(c1);
+    root.appendChild(c2);
+
+    NodeList live = root.getElementsByTagName("child");
+    List<Element> snapshot = PSLoadChildDataExit.snapshotElements(live);
+    assertEquals(2, snapshot.size());
+
+    root.removeChild(c1);
+    assertEquals(1, live.getLength());
+    assertEquals(2, snapshot.size());
+    assertTrue(snapshot.contains(c1));
+    assertTrue(snapshot.contains(c2));
+
+    assertTrue(PSLoadChildDataExit.snapshotElements(null).isEmpty());
+  }
+
+  @Test
+  void loadChildDataExitRejectsMissingParams() throws Exception {
+    PSLoadChildDataExit exit = new PSLoadChildDataExit();
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    doc.appendChild(doc.createElement("root"));
+
+    assertThrows(
+        PSParameterMismatchException.class, () -> exit.processResultDocument(null, null, doc));
+    assertThrows(
+        PSParameterMismatchException.class,
+        () -> exit.processResultDocument(new Object[] {}, null, doc));
+    assertThrows(
+        PSParameterMismatchException.class,
+        () -> exit.processResultDocument(new Object[] {"base"}, null, doc));
+    assertThrows(
+        PSParameterMismatchException.class,
+        () -> exit.processResultDocument(new Object[] {"base", "child"}, null, doc));
+  }
+
+  @Test
+  void loadChildDataExitReturnsDocWhenNoRoot() throws Exception {
+    PSLoadChildDataExit exit = new PSLoadChildDataExit();
+    Document empty = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    Document result =
+        exit.processResultDocument(new Object[] {"base", "child", "query"}, null, empty);
+    assertEquals(empty, result);
+  }
+}


### PR DESCRIPTION
## Summary
Parent epic: #2022 / grandparent #2200. Slice **2h** residual cms.objectstore **server handlers** rawtypes after #2453 (PR #2623).

Parameterizes the hottest remaining server-handler rawtypes/unchecked batch:

- `PSServerItem` — typed field/child/related iterators; `Map<String, Object>` HTML param maps on update paths; `Map<String, ?>` for `makeRequest`
- `PSLoadChildDataExit` — `List<Element>` snapshot of base nodes; `snapshotElements` helper
- `PSFieldRetriever` — `Map<String, Object>` `prepareParams` / request helpers
- `PSAuthTypes` — `stringPropertyNames()`; pure `PSAuthTypePropertiesParser` (avoids singleton static init in unit tests); try-with-resources
- `PSCatalogServerObjectHandler` — `Collection<String>` init, `Iterator<String>` roots, `collectFieldNames` for multi-value field-name params

Prefer real generics; no new rawtypes suppressions in this batch.

## Out of scope
- design.objectstore `IPSComponent` parentComponents (#2455)
- data/data.jdbc
- this-escape/serial
- typing `PSServer.getInternalRequest(..., Map, ...)` API boundary

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1441**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] New tests: `PSObjectStoreServerHandlersRawtypesTest` (9)
- [x] Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2624-objectstore-server-handlers-rawtypes-erlang.md`

## Residual
Named hottest list for this slice is zeroed. No residual child filed for incomplete batch scope.

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2624.

Parent tracker: #2022.

> Co-Authored by Grok Build using grok-4.5 with agent main.
