### PR TITLE
fix(perc-system): type HTTPClient package rawtypes/unchecked (#2460)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2460-httpclient-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2460-httpclient-rawtypes-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue #2460 HTTPClient rawtypes
+
+**Scope:** `system/.../com/percussion/HTTPClient/**` rawtypes/unchecked cleanup  
+**Reviewer persona:** Erlang (pre-commit gate)  
+**Date:** 2026-08-09
+
+## Verdict
+
+**PASS** — safe to commit / open PR.
+
+## Findings
+
+### Bugs
+None. Generics match existing map/list element types; cast removals preserve runtime behavior. Cookie jar load retains a single justified `@SuppressWarnings("unchecked")` on `ObjectInputStream.readObject()`.
+
+### Tests
+Added behavioral unit tests:
+- `UtilGenericsTest` — parseHeader / getElement / assembleHeader / getList
+- `CIHashtableGenericsTest` — case-insensitive keys + key enumeration
+- `URIDefaultPortsGenericsTest` — typed scheme maps
+
+`cd system && ../mvnw clean install`: **BUILD SUCCESS**, Tests run: 1439, Failures: 0 (new HTTPClient suites green).
+
+### Cross-platform paths
+No path I/O changes.
+
+### Change-class companions
+Package-scoped rawtypes cleanup; consumers of `Util.parseHeader` / `getList` updated in-package. Public API `Class[]` module methods widened to `Class<?>` (binary-compatible for callers). No Spring/DI surface.
+
+### Residual
+Package rawtypes/unchecked for in-scope collections zeroed in this PR; no residual child filed.
+
+## Notes
+- `HTTPConnection` module lists typed as `Vector<Class<?>>`; instantiation uses `getDeclaredConstructor().newInstance()`.
+- Avoided overlap with open serial/this-escape work (#2650/#2653).

--- a/system/src/main/java/com/percussion/HTTPClient/AuthorizationInfo.java
+++ b/system/src/main/java/com/percussion/HTTPClient/AuthorizationInfo.java
@@ -69,13 +69,14 @@ public class AuthorizationInfo implements Cloneable {
   // class fields
 
   /** Holds the list of lists of authorization info structures */
-  private static ConcurrentHashMap CntxtList = new ConcurrentHashMap();
+  private static final ConcurrentHashMap<Object, ConcurrentHashMap<AuthorizationInfo, AuthorizationInfo>>
+      CntxtList = new ConcurrentHashMap<>();
 
   /** A pointer to the handler to be called when we need authorization info */
   private static AuthorizationHandler AuthHandler = new DefaultAuthHandler();
 
   static {
-    CntxtList.put(HTTPConnection.getDefaultContext(), new ConcurrentHashMap());
+    CntxtList.put(HTTPConnection.getDefaultContext(), new ConcurrentHashMap<>());
   }
 
   // the instance oriented stuff
@@ -246,12 +247,13 @@ public class AuthorizationInfo implements Cloneable {
    */
   public static synchronized AuthorizationInfo getAuthorization(
       String host, int port, String scheme, String realm, Object context) {
-    ConcurrentHashMap AuthList = Util.getList(CntxtList, context);
+    ConcurrentHashMap<AuthorizationInfo, AuthorizationInfo> AuthList =
+        Util.getList(CntxtList, context);
 
     AuthorizationInfo auth_info =
         new AuthorizationInfo(host, port, scheme, realm, (NVPair[]) null, null);
 
-    return (AuthorizationInfo) AuthList.get(auth_info);
+    return AuthList.get(auth_info);
   }
 
   /**
@@ -295,11 +297,11 @@ public class AuthorizationInfo implements Cloneable {
   static synchronized AuthorizationInfo getAuthorization(
       AuthorizationInfo auth_info, RoRequest req, RoResponse resp, boolean query_auth_h)
       throws AuthSchemeNotImplException, IOException {
-    ConcurrentHashMap AuthList;
+    ConcurrentHashMap<AuthorizationInfo, AuthorizationInfo> AuthList;
     if (req != null) AuthList = Util.getList(CntxtList, req.getConnection().getContext());
     else AuthList = Util.getList(CntxtList, HTTPConnection.getDefaultContext());
 
-    AuthorizationInfo new_info = (AuthorizationInfo) AuthList.get(auth_info);
+    AuthorizationInfo new_info = AuthList.get(auth_info);
 
     if (new_info == null && query_auth_h) new_info = queryAuthHandler(auth_info, req, resp);
 
@@ -355,10 +357,11 @@ public class AuthorizationInfo implements Cloneable {
    * @param context the context to associate this info with
    */
   public static synchronized void addAuthorization(AuthorizationInfo auth_info, Object context) {
-    ConcurrentHashMap AuthList = Util.getList(CntxtList, context);
+    ConcurrentHashMap<AuthorizationInfo, AuthorizationInfo> AuthList =
+        Util.getList(CntxtList, context);
 
     // merge path list
-    AuthorizationInfo old_info = (AuthorizationInfo) AuthList.get(auth_info);
+    AuthorizationInfo old_info = AuthList.get(auth_info);
     if (old_info != null) {
       int ol = old_info.paths.length, al = auth_info.paths.length;
 
@@ -545,7 +548,8 @@ public class AuthorizationInfo implements Cloneable {
    * @param context the context this info is associated with
    */
   public static synchronized void removeAuthorization(AuthorizationInfo auth_info, Object context) {
-    ConcurrentHashMap AuthList = Util.getList(CntxtList, context);
+    ConcurrentHashMap<AuthorizationInfo, AuthorizationInfo> AuthList =
+        Util.getList(CntxtList, context);
     AuthList.remove(auth_info);
   }
 
@@ -593,10 +597,11 @@ public class AuthorizationInfo implements Cloneable {
 
     // First search for an exact match
 
-    ConcurrentHashMap AuthList = Util.getList(CntxtList, req.getConnection().getContext());
-    Enumeration list = AuthList.elements();
+    ConcurrentHashMap<AuthorizationInfo, AuthorizationInfo> AuthList =
+        Util.getList(CntxtList, req.getConnection().getContext());
+    Enumeration<AuthorizationInfo> list = AuthList.elements();
     while (list.hasMoreElements()) {
-      AuthorizationInfo info = (AuthorizationInfo) list.nextElement();
+      AuthorizationInfo info = list.nextElement();
 
       if (!info.host.equals(host) || info.port != port) continue;
 
@@ -614,7 +619,7 @@ public class AuthorizationInfo implements Cloneable {
 
     list = AuthList.elements();
     while (list.hasMoreElements()) {
-      AuthorizationInfo info = (AuthorizationInfo) list.nextElement();
+      AuthorizationInfo info = list.nextElement();
 
       if (!info.host.equals(host) || info.port != port) continue;
 
@@ -721,7 +726,7 @@ public class AuthorizationInfo implements Cloneable {
 
         pos_ref[0] = beg;
         pos_ref[1] = end;
-        Vector params = parseParams(challenge, buf, pos_ref, len, curr);
+        Vector<NVPair> params = parseParams(challenge, buf, pos_ref, len, curr);
         beg = pos_ref[0];
         end = pos_ref[1];
 
@@ -747,7 +752,7 @@ public class AuthorizationInfo implements Cloneable {
     return auth_arr;
   }
 
-  private static final Vector parseParams(
+  private static final Vector<NVPair> parseParams(
       String challenge, char[] buf, int[] pos_ref, int len, AuthorizationInfo curr)
       throws ProtocolException {
     int beg = pos_ref[0];
@@ -755,7 +760,7 @@ public class AuthorizationInfo implements Cloneable {
 
     // get auth-parameters
     boolean first = true;
-    Vector params = new Vector();
+    Vector<NVPair> params = new Vector<>();
     while (true) {
       beg = Util.skipSpace(buf, end);
       if (beg == len) break;

--- a/system/src/main/java/com/percussion/HTTPClient/AuthorizationModule.java
+++ b/system/src/main/java/com/percussion/HTTPClient/AuthorizationModule.java
@@ -32,10 +32,12 @@ import java.util.concurrent.ConcurrentHashMap;
 @Deprecated
 class AuthorizationModule implements HTTPClientModule {
   /** This holds the current Proxy-Authorization-Info for each HTTPConnection */
-  private static ConcurrentHashMap proxy_cntxt_list = new ConcurrentHashMap();
+  private static final ConcurrentHashMap<Object, ConcurrentHashMap<String, AuthorizationInfo>>
+      proxy_cntxt_list = new ConcurrentHashMap<>();
 
   /** a list of deferred authorization retries (used with Response.retryRequest()) */
-  private static ConcurrentHashMap deferred_auth_list = new ConcurrentHashMap();
+  private static final ConcurrentHashMap<HttpOutputStream, AuthorizationModule> deferred_auth_list =
+      new ConcurrentHashMap<>();
 
   /** counters for challenge and auth-info lists */
   private int auth_lst_idx, prxy_lst_idx, auth_scm_idx, prxy_scm_idx;
@@ -93,7 +95,7 @@ class AuthorizationModule implements HTTPClientModule {
 
     HttpOutputStream out = req.getStream();
     if (out != null && deferred_auth_list.get(out) != null) {
-      copyFrom((AuthorizationModule) deferred_auth_list.remove(out));
+      copyFrom(deferred_auth_list.remove(out));
       req.copyFrom(saved_req);
 
       Log.write(Log.AUTH, "AuthM: Handling deferred auth challenge");
@@ -121,9 +123,9 @@ class AuthorizationModule implements HTTPClientModule {
           break;
         }
       }
-      ConcurrentHashMap proxy_auth_list = Util.getList(proxy_cntxt_list, con.getContext());
-      guess =
-          (AuthorizationInfo) proxy_auth_list.get(con.getProxyHost() + ":" + con.getProxyPort());
+      ConcurrentHashMap<String, AuthorizationInfo> proxy_auth_list =
+          Util.getList(proxy_cntxt_list, con.getContext());
+      guess = proxy_auth_list.get(con.getProxyHost() + ":" + con.getProxyPort());
       if (guess == null) break Proxy;
 
       if (auth_handler != null) {

--- a/system/src/main/java/com/percussion/HTTPClient/CIHashtable.java
+++ b/system/src/main/java/com/percussion/HTTPClient/CIHashtable.java
@@ -28,7 +28,7 @@ import java.util.Hashtable;
  * @deprecated
  */
 @Deprecated
-class CIHashtable extends Hashtable {
+class CIHashtable extends Hashtable<Object, Object> {
   // Constructors
 
   /**
@@ -116,7 +116,8 @@ class CIHashtable extends Hashtable {
    * @return the requested Enumerator
    * @see java.util.Hashtable#keys()
    */
-  public Enumeration keys() {
+  @Override
+  public Enumeration<Object> keys() {
     return new CIHashtableEnumeration(super.keys());
   }
 }
@@ -125,10 +126,10 @@ class CIHashtable extends Hashtable {
  * A simple enumerator which delegates everything to the real enumerator. If a CIString element is
  * returned, then the string it represents is returned instead.
  */
-final class CIHashtableEnumeration implements Enumeration {
-  Enumeration HTEnum;
+final class CIHashtableEnumeration implements Enumeration<Object> {
+  private final Enumeration<?> HTEnum;
 
-  public CIHashtableEnumeration(Enumeration e) {
+  public CIHashtableEnumeration(Enumeration<?> e) {
     HTEnum = e;
   }
 

--- a/system/src/main/java/com/percussion/HTTPClient/Codecs.java
+++ b/system/src/main/java/com/percussion/HTTPClient/Codecs.java
@@ -774,7 +774,7 @@ public class Codecs {
         }
 
         if (!hdr.regionMatches(true, 0, "Content-Disposition", 0, 19)) continue;
-        Vector pcd = Util.parseHeader(hdr.substring(hdr.indexOf(':') + 1));
+        Vector<HttpHeaderElement> pcd = Util.parseHeader(hdr.substring(hdr.indexOf(':') + 1));
         HttpHeaderElement elem = Util.getElement(pcd, "form-data");
 
         if (elem == null)

--- a/system/src/main/java/com/percussion/HTTPClient/ContentEncodingModule.java
+++ b/system/src/main/java/com/percussion/HTTPClient/ContentEncodingModule.java
@@ -42,11 +42,11 @@ class ContentEncodingModule implements HTTPClientModule {
     for (idx = 0; idx < hdrs.length; idx++)
       if (hdrs[idx].getName().equalsIgnoreCase("Accept-Encoding")) break;
 
-    Vector pae;
+    Vector<HttpHeaderElement> pae;
     if (idx == hdrs.length) {
       hdrs = Util.resizeArray(hdrs, idx + 1);
       req.setHeaders(hdrs);
-      pae = new Vector();
+      pae = new Vector<>();
     } else {
       try {
         pae = Util.parseHeader(hdrs[idx].getValue());
@@ -108,7 +108,7 @@ class ContentEncodingModule implements HTTPClientModule {
     String ce = resp.getHeader("Content-Encoding");
     if (ce == null || req.getMethod().equals("HEAD") || resp.getStatusCode() == 206) return;
 
-    Vector pce;
+    Vector<HttpHeaderElement> pce;
     try {
       pce = Util.parseHeader(ce);
     } catch (ParseException pe) {
@@ -117,7 +117,7 @@ class ContentEncodingModule implements HTTPClientModule {
 
     if (pce.size() == 0) return;
 
-    String encoding = ((HttpHeaderElement) pce.firstElement()).getName();
+    String encoding = pce.firstElement().getName();
     if (encoding.equalsIgnoreCase("gzip") || encoding.equalsIgnoreCase("x-gzip")) {
       Log.write(Log.MODS, "CEM:   pushing gzip-input-stream");
 

--- a/system/src/main/java/com/percussion/HTTPClient/Cookie2.java
+++ b/system/src/main/java/com/percussion/HTTPClient/Cookie2.java
@@ -136,7 +136,7 @@ public class Cookie2 extends Cookie {
    * @exception ProtocolException if an error occurs during parsing
    */
   protected static Cookie[] parse(String set_cookie, RoRequest req) throws ProtocolException {
-    Vector cookies;
+    Vector<HttpHeaderElement> cookies;
     try {
       cookies = Util.parseHeader(set_cookie);
     } catch (ParseException pe) {
@@ -146,7 +146,7 @@ public class Cookie2 extends Cookie {
     Cookie cookie_arr[] = new Cookie[cookies.size()];
     int cidx = 0;
     for (int idx = 0; idx < cookie_arr.length; idx++) {
-      HttpHeaderElement c_elem = (HttpHeaderElement) cookies.elementAt(idx);
+      HttpHeaderElement c_elem = cookies.elementAt(idx);
 
       // set NAME and VALUE
 

--- a/system/src/main/java/com/percussion/HTTPClient/CookieModule.java
+++ b/system/src/main/java/com/percussion/HTTPClient/CookieModule.java
@@ -66,7 +66,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Deprecated
 public class CookieModule implements HTTPClientModule {
   /** the list of known cookies */
-  private static ConcurrentHashMap cookie_cntxt_list = new ConcurrentHashMap();
+  private static final ConcurrentHashMap<Object, ConcurrentHashMap<Cookie, Cookie>> cookie_cntxt_list =
+      new ConcurrentHashMap<>();
 
   /** the file to use for persistent cookie storage */
   private static File cookie_jar = null;
@@ -113,8 +114,10 @@ public class CookieModule implements HTTPClientModule {
         String filterSpec = SerializationValidation.buildPackageFilterSpec("com.percussion.**");
         ois.setObjectInputFilter(Config.createFilter(filterSpec));
 
-        cookie_cntxt_list.put(
-            HTTPConnection.getDefaultContext(), (ConcurrentHashMap) ois.readObject());
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<Cookie, Cookie> loaded =
+            (ConcurrentHashMap<Cookie, Cookie>) ois.readObject();
+        cookie_cntxt_list.put(HTTPConnection.getDefaultContext(), loaded);
       } catch (IOException | ClassNotFoundException e) {
         cookie_jar = null;
       }
@@ -124,14 +127,14 @@ public class CookieModule implements HTTPClientModule {
   private static void saveCookies() {
     if (cookie_jar != null
         && (!cookie_jar.exists() || cookie_jar.isFile() && cookie_jar.canWrite())) {
-      ConcurrentHashMap cookie_list = new ConcurrentHashMap();
-      Enumeration e =
+      ConcurrentHashMap<Cookie, Cookie> cookie_list = new ConcurrentHashMap<>();
+      Enumeration<Cookie> e =
           Util.getList(cookie_cntxt_list, HTTPConnection.getDefaultContext()).elements();
 
       // discard cookies which are not to be kept across sessions
 
       while (e.hasMoreElements()) {
-        Cookie cookie = (Cookie) e.nextElement();
+        Cookie cookie = e.nextElement();
         if (!cookie.discard()) cookie_list.put(cookie, cookie);
       }
 
@@ -208,23 +211,23 @@ public class CookieModule implements HTTPClientModule {
 
     // Now set any new cookie headers
 
-    Vector names = new Vector();
-    Vector lens = new Vector();
+    Vector<String> names = new Vector<>();
+    Vector<Integer> lens = new Vector<>();
     int version = 0;
 
-    ConcurrentHashMap cookie_list =
+    ConcurrentHashMap<Cookie, Cookie> cookie_list =
         Util.getList(cookie_cntxt_list, req.getConnection().getContext());
     if (cookie_list.size() == 0) return REQ_CONTINUE; // no need to create a lot of objects
 
-    Enumeration list = cookie_list.elements();
-    Vector remove_list = null;
+    Enumeration<Cookie> list = cookie_list.elements();
+    Vector<Cookie> remove_list = null;
 
     while (list.hasMoreElements()) {
-      Cookie cookie = (Cookie) list.nextElement();
+      Cookie cookie = list.nextElement();
 
       if (cookie.hasExpired()) {
         Log.write(Log.COOKI, "CookM: cookie has expired and is " + "being removed: " + cookie);
-        if (remove_list == null) remove_list = new Vector();
+        if (remove_list == null) remove_list = new Vector<>();
         remove_list.addElement(cookie);
         continue;
       }
@@ -236,7 +239,7 @@ public class CookieModule implements HTTPClientModule {
 
         // insert in correct position
         for (idx = 0; idx < lens.size(); idx++)
-          if (((Integer) lens.elementAt(idx)).intValue() < len) break;
+          if (lens.elementAt(idx).intValue() < len) break;
 
         names.insertElementAt(cookie.toExternalForm(), idx);
         lens.insertElementAt(Integer.valueOf(len), idx);
@@ -257,10 +260,10 @@ public class CookieModule implements HTTPClientModule {
 
       if (version > 0) value.append("$Version=\"" + version + "\"; ");
 
-      value.append((String) names.elementAt(0));
+      value.append(names.elementAt(0));
       for (int idx = 1; idx < names.size(); idx++) {
         value.append("; ");
-        value.append((String) names.elementAt(idx));
+        value.append(names.elementAt(idx));
       }
       hdrs = Util.resizeArray(hdrs, hdrs.length + 1);
       hdrs[hdrs.length - 1] = new NVPair("Cookie", value.toString());
@@ -338,11 +341,11 @@ public class CookieModule implements HTTPClientModule {
         Log.write(Log.COOKI, "CookM: Cookie " + idx + ": " + cookies[idx]);
     }
 
-    ConcurrentHashMap cookie_list =
+    ConcurrentHashMap<Cookie, Cookie> cookie_list =
         Util.getList(cookie_cntxt_list, req.getConnection().getContext());
 
     for (int idx = 0; idx < cookies.length; idx++) {
-      Cookie cookie = (Cookie) cookie_list.get(cookies[idx]);
+      Cookie cookie = cookie_list.get(cookies[idx]);
       if (cookie != null && cookies[idx].hasExpired()) {
         Log.write(Log.COOKI, "CookM: cookie has expired and is " + "being removed: " + cookie);
         cookie_list.remove(cookie); // expired, so remove
@@ -384,13 +387,13 @@ public class CookieModule implements HTTPClientModule {
     Cookie[] cookies = new Cookie[0];
     int idx = 0;
 
-    Enumeration cntxt_list = cookie_cntxt_list.elements();
+    Enumeration<ConcurrentHashMap<Cookie, Cookie>> cntxt_list = cookie_cntxt_list.elements();
     while (cntxt_list.hasMoreElements()) {
-      ConcurrentHashMap cntxt = (ConcurrentHashMap) cntxt_list.nextElement();
+      ConcurrentHashMap<Cookie, Cookie> cntxt = cntxt_list.nextElement();
 
       cookies = Util.resizeArray(cookies, idx + cntxt.size());
-      Enumeration cookie_list = cntxt.elements();
-      while (cookie_list.hasMoreElements()) cookies[idx++] = (Cookie) cookie_list.nextElement();
+      Enumeration<Cookie> cookie_list = cntxt.elements();
+      while (cookie_list.hasMoreElements()) cookies[idx++] = cookie_list.nextElement();
     }
 
     return cookies;
@@ -404,13 +407,13 @@ public class CookieModule implements HTTPClientModule {
    * @since V0.3-1
    */
   public static Cookie[] listAllCookies(Object context) {
-    ConcurrentHashMap cookie_list = Util.getList(cookie_cntxt_list, context);
+    ConcurrentHashMap<Cookie, Cookie> cookie_list = Util.getList(cookie_cntxt_list, context);
 
     Cookie[] cookies = new Cookie[cookie_list.size()];
     int idx = 0;
 
-    Enumeration e = cookie_list.elements();
-    while (e.hasMoreElements()) cookies[idx++] = (Cookie) e.nextElement();
+    Enumeration<Cookie> e = cookie_list.elements();
+    while (e.hasMoreElements()) cookies[idx++] = e.nextElement();
 
     return cookies;
   }
@@ -424,7 +427,7 @@ public class CookieModule implements HTTPClientModule {
    * @since V0.3-1
    */
   public static void addCookie(Cookie cookie) {
-    ConcurrentHashMap cookie_list =
+    ConcurrentHashMap<Cookie, Cookie> cookie_list =
         Util.getList(cookie_cntxt_list, HTTPConnection.getDefaultContext());
     cookie_list.put(cookie, cookie);
   }
@@ -439,7 +442,7 @@ public class CookieModule implements HTTPClientModule {
    * @since V0.3-1
    */
   public static void addCookie(Cookie cookie, Object context) {
-    ConcurrentHashMap cookie_list = Util.getList(cookie_cntxt_list, context);
+    ConcurrentHashMap<Cookie, Cookie> cookie_list = Util.getList(cookie_cntxt_list, context);
     cookie_list.put(cookie, cookie);
   }
 
@@ -451,7 +454,7 @@ public class CookieModule implements HTTPClientModule {
    * @since V0.3-1
    */
   public static void removeCookie(Cookie cookie) {
-    ConcurrentHashMap cookie_list =
+    ConcurrentHashMap<Cookie, Cookie> cookie_list =
         Util.getList(cookie_cntxt_list, HTTPConnection.getDefaultContext());
     cookie_list.remove(cookie);
   }
@@ -465,7 +468,7 @@ public class CookieModule implements HTTPClientModule {
    * @since V0.3-1
    */
   public static void removeCookie(Cookie cookie, Object context) {
-    ConcurrentHashMap cookie_list = Util.getList(cookie_cntxt_list, context);
+    ConcurrentHashMap<Cookie, Cookie> cookie_list = Util.getList(cookie_cntxt_list, context);
     cookie_list.remove(cookie);
   }
 

--- a/system/src/main/java/com/percussion/HTTPClient/DefaultAuthHandler.java
+++ b/system/src/main/java/com/percussion/HTTPClient/DefaultAuthHandler.java
@@ -228,7 +228,7 @@ public class DefaultAuthHandler implements AuthorizationHandler, GlobalConstants
       throws ParseException, IOException {
     if (auth_info == null) return;
 
-    Vector pai = Util.parseHeader(auth_info);
+    Vector<HttpHeaderElement> pai = Util.parseHeader(auth_info);
     HttpHeaderElement elem;
 
     if (handle_nextnonce(prev, req, elem = Util.getElement(pai, "nextnonce")))
@@ -690,7 +690,11 @@ public class DefaultAuthHandler implements AuthorizationHandler, GlobalConstants
 
   /** Handle rspauth field of the Authentication-Info response header. */
   private static boolean handle_rspauth(
-      AuthorizationInfo prev, Response resp, RoRequest req, Vector auth_info, String hdr_name)
+      AuthorizationInfo prev,
+      Response resp,
+      RoRequest req,
+      Vector<HttpHeaderElement> auth_info,
+      String hdr_name)
       throws IOException {
     if (prev == null) return false;
 
@@ -1084,7 +1088,7 @@ class VerifyRspAuth implements HashVerifier, GlobalConstants {
     if (auth_info == null) auth_info = resp.getTrailer(hdr);
     if (auth_info == null) return;
 
-    Vector pai;
+    Vector<HttpHeaderElement> pai;
     try {
       pai = Util.parseHeader(auth_info);
     } catch (ParseException pe) {
@@ -1170,7 +1174,7 @@ class VerifyDigest implements HashVerifier, GlobalConstants {
     if (auth_info == null) auth_info = resp.getTrailer(hdr);
     if (auth_info == null) return;
 
-    Vector pai;
+    Vector<HttpHeaderElement> pai;
     try {
       pai = Util.parseHeader(auth_info);
     } catch (ParseException pe) {

--- a/system/src/main/java/com/percussion/HTTPClient/HTTPConnection.java
+++ b/system/src/main/java/com/percussion/HTTPClient/HTTPConnection.java
@@ -1611,7 +1611,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
 
     // check if module implements HTTPClientModule
     try {
-      HTTPClientModule tmp = (HTTPClientModule) module.getDeclaredConstructor().newInstance();
+      HTTPClientModule tmp = newModuleInstance(module);
     } catch (RuntimeException re) {
       throw re;
     } catch (Exception e) {
@@ -2206,7 +2206,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
       for (int idx = 0; idx < ModuleList.size(); idx++) {
         Class<?> mod = ModuleList.elementAt(idx);
         try {
-          mod_insts[idx] = (HTTPClientModule) mod.getDeclaredConstructor().newInstance();
+          mod_insts[idx] = newModuleInstance(mod);
         } catch (Exception e) {
           throw new Error(
               "HTTPClient Internal Error: could not "
@@ -2219,6 +2219,20 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
 
       return mod_insts;
     }
+  }
+
+  /**
+   * Instantiate an {@link HTTPClientModule} via its no-arg constructor.
+   *
+   * <p>Uses {@link Class#getDeclaredConstructor()} (not {@link Class#getConstructor()}) because
+   * several built-in modules are package-private with package-private constructors (e.g. {@code
+   * DefaultModule}, {@code AuthorizationModule}). {@code getConstructor()} only sees public
+   * constructors and would throw {@link NoSuchMethodException} for those classes. Module classes
+   * must declare a no-arg constructor on the concrete class itself (Java default constructors
+   * count; constructors are never inherited from superclasses).
+   */
+  private static HTTPClientModule newModuleInstance(Class<?> module) throws Exception {
+    return (HTTPClientModule) module.getDeclaredConstructor().newInstance();
   }
 
   /**

--- a/system/src/main/java/com/percussion/HTTPClient/HTTPConnection.java
+++ b/system/src/main/java/com/percussion/HTTPClient/HTTPConnection.java
@@ -232,9 +232,9 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
   /** The list of hosts for which no proxy is to be used */
   private static CIHashtable non_proxy_host_list = new CIHashtable();
 
-  private static Vector non_proxy_dom_list = new Vector();
-  private static Vector non_proxy_addr_list = new Vector();
-  private static Vector non_proxy_mask_list = new Vector();
+  private static final Vector<String> non_proxy_dom_list = new Vector<>();
+  private static final Vector<byte[]> non_proxy_addr_list = new Vector<>();
+  private static final Vector<byte[]> non_proxy_mask_list = new Vector<>();
 
   /** The socks server to use */
   private SocksClient Socks_client = null;
@@ -291,10 +291,10 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
   private NVPair[] DefaultHeaders = new NVPair[0];
 
   /** The default list of modules (as a Vector of Class objects) */
-  private static Vector DefaultModuleList;
+  private static Vector<Class<?>> DefaultModuleList;
 
   /** The list of modules (as a Vector of Class objects) */
-  private Vector ModuleList;
+  private Vector<Class<?>> ModuleList;
 
   /** controls whether modules are allowed to interact with user */
   private static boolean defaultAllowUI = true;
@@ -387,7 +387,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
       in_applet = true;
     }
 
-    DefaultModuleList = new Vector();
+    DefaultModuleList = new Vector<>();
     String[] list = Util.splitProperty(modules);
     for (int idx = 0; idx < list.length; idx++) {
       try {
@@ -582,7 +582,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
 
     Socks_client = Default_Socks_client;
     Timeout = DefaultTimeout;
-    ModuleList = (Vector) DefaultModuleList.clone();
+    ModuleList = new Vector<>(DefaultModuleList);
     allowUI = defaultAllowUI;
     if (noKeepAlives) setDefaultHeaders(new NVPair[] {new NVPair("Connection", "close")});
     sslFactory = defaultSSLFactory;
@@ -603,7 +603,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
     // Check domain name list
 
     for (int idx = 0; idx < non_proxy_dom_list.size(); idx++)
-      if (host.endsWith((String) non_proxy_dom_list.elementAt(idx))) return true;
+      if (host.endsWith(non_proxy_dom_list.elementAt(idx))) return true;
 
     // Check IP-address and subnet list
 
@@ -617,8 +617,8 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
     } // maybe the proxy has better luck
 
     for (int idx = 0; idx < non_proxy_addr_list.size(); idx++) {
-      byte[] addr = (byte[]) non_proxy_addr_list.elementAt(idx);
-      byte[] mask = (byte[]) non_proxy_mask_list.elementAt(idx);
+      byte[] addr = non_proxy_addr_list.elementAt(idx);
+      byte[] mask = non_proxy_mask_list.elementAt(idx);
 
       ip_loop:
       for (int idx2 = 0; idx2 < host_addr.length; idx2++) {
@@ -1502,7 +1502,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
    *
    * @return an array of classes
    */
-  public static Class[] getDefaultModules() {
+  public static Class<?>[] getDefaultModules() {
     return getModules(DefaultModuleList);
   }
 
@@ -1542,7 +1542,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
    *     <var>HTTPClientModule</var> interface.
    * @exception RuntimeException if <var>module</var> cannot be instantiated.
    */
-  public static boolean addDefaultModule(Class module, int pos) {
+  public static boolean addDefaultModule(Class<?> module, int pos) {
     return addModule(DefaultModuleList, module, pos);
   }
 
@@ -1554,7 +1554,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
    * @param module the module's Class object
    * @return true if module was successfully removed; false otherwise
    */
-  public static boolean removeDefaultModule(Class module) {
+  public static boolean removeDefaultModule(Class<?> module) {
     return removeModule(DefaultModuleList, module);
   }
 
@@ -1563,7 +1563,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
    *
    * @return an array of classes
    */
-  public Class[] getModules() {
+  public Class<?>[] getModules() {
     return getModules(ModuleList);
   }
 
@@ -1584,7 +1584,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
    *     <var>HTTPClientModule</var> interface.
    * @exception RuntimeException if <var>module</var> cannot be instantiated.
    */
-  public boolean addModule(Class module, int pos) {
+  public boolean addModule(Class<?> module, int pos) {
     return addModule(ModuleList, module, pos);
   }
 
@@ -1594,24 +1594,24 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
    * @param module the module's Class object
    * @return true if module was successfully removed; false otherwise
    */
-  public boolean removeModule(Class module) {
+  public boolean removeModule(Class<?> module) {
     return removeModule(ModuleList, module);
   }
 
-  private static final Class[] getModules(Vector list) {
+  private static final Class<?>[] getModules(Vector<Class<?>> list) {
     synchronized (list) {
-      Class[] modules = new Class[list.size()];
+      Class<?>[] modules = new Class<?>[list.size()];
       list.copyInto(modules);
       return modules;
     }
   }
 
-  private static final boolean addModule(Vector list, Class module, int pos) {
+  private static final boolean addModule(Vector<Class<?>> list, Class<?> module, int pos) {
     if (module == null) return false;
 
     // check if module implements HTTPClientModule
     try {
-      HTTPClientModule tmp = (HTTPClientModule) module.newInstance();
+      HTTPClientModule tmp = (HTTPClientModule) module.getDeclaredConstructor().newInstance();
     } catch (RuntimeException re) {
       throw re;
     } catch (Exception e) {
@@ -1638,7 +1638,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
     return true;
   }
 
-  private static final boolean removeModule(Vector list, Class module) {
+  private static final boolean removeModule(Vector<Class<?>> list, Class<?> module) {
     if (module == null) return false;
 
     boolean removed = list.removeElement(module);
@@ -1896,8 +1896,8 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
 
     ip_loop:
     for (int idx = 0; idx < non_proxy_addr_list.size(); idx++) {
-      byte[] addr = (byte[]) non_proxy_addr_list.elementAt(idx);
-      byte[] mask = (byte[]) non_proxy_mask_list.elementAt(idx);
+      byte[] addr = non_proxy_addr_list.elementAt(idx);
+      byte[] mask = non_proxy_mask_list.elementAt(idx);
       if (addr.length != ip_addr.length) continue;
 
       for (int idx2 = 0; idx2 < addr.length; idx2++) {
@@ -1982,8 +1982,8 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
 
     ip_loop:
     for (int idx = 0; idx < non_proxy_addr_list.size(); idx++) {
-      byte[] addr = (byte[]) non_proxy_addr_list.elementAt(idx);
-      byte[] mask = (byte[]) non_proxy_mask_list.elementAt(idx);
+      byte[] addr = non_proxy_addr_list.elementAt(idx);
+      byte[] mask = non_proxy_mask_list.elementAt(idx);
       if (addr.length != ip_addr.length) continue;
 
       for (int idx2 = 0; idx2 < addr.length; idx2++) {
@@ -2204,9 +2204,9 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
       HTTPClientModule[] mod_insts = new HTTPClientModule[ModuleList.size()];
 
       for (int idx = 0; idx < ModuleList.size(); idx++) {
-        Class mod = (Class) ModuleList.elementAt(idx);
+        Class<?> mod = ModuleList.elementAt(idx);
         try {
-          mod_insts[idx] = (HTTPClientModule) mod.newInstance();
+          mod_insts[idx] = (HTTPClientModule) mod.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
           throw new Error(
               "HTTPClient Internal Error: could not "
@@ -2692,7 +2692,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
       throws IOException, ModuleException {
     // copy User-Agent and Proxy-Auth headers from request
 
-    Vector hdrs = new Vector();
+    Vector<NVPair> hdrs = new Vector<>();
     for (int idx = 0; idx < req.getHeaders().length; idx++) {
       String name = req.getHeaders()[idx].getName();
       if (name.equalsIgnoreCase("User-Agent") || name.equalsIgnoreCase("Proxy-Authorization"))
@@ -2926,7 +2926,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
 
     if (te_idx != -1) {
       dataout.writeBytes("TE: ");
-      Vector pte;
+      Vector<HttpHeaderElement> pte;
       try {
         pte = Util.parseHeader(hdrs[te_idx].getValue());
       } catch (ParseException pe) {
@@ -2977,7 +2977,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
         dataout.writeBytes("Expect: " + con_hdrs[1] + "\r\n");
       }
     } else if (ex_idx != -1) {
-      Vector expect_tokens;
+      Vector<HttpHeaderElement> expect_tokens;
       try {
         expect_tokens = Util.parseHeader(hdrs[ex_idx].getValue());
       } catch (ParseException pe) {

--- a/system/src/main/java/com/percussion/HTTPClient/HTTPResponse.java
+++ b/system/src/main/java/com/percussion/HTTPClient/HTTPResponse.java
@@ -315,7 +315,7 @@ public class HTTPResponse implements HTTPClientModuleConstants {
    * @exception IOException If any exception occurs on the socket.
    * @exception ModuleException if any module encounters an exception.
    */
-  public Enumeration listHeaders() throws IOException, ModuleException {
+  public Enumeration<Object> listHeaders() throws IOException, ModuleException {
     if (!initialized) handleResponse();
     return Headers.keys();
   }
@@ -399,7 +399,7 @@ public class HTTPResponse implements HTTPClientModuleConstants {
    * @exception IOException If any exception occurs on the socket.
    * @exception ModuleException if any module encounters an exception.
    */
-  public Enumeration listTrailers() throws IOException, ModuleException {
+  public Enumeration<Object> listTrailers() throws IOException, ModuleException {
     if (!got_trailers) getTrailers();
     return Trailers.keys();
   }
@@ -582,7 +582,7 @@ public class HTTPResponse implements HTTPClientModuleConstants {
       str.append(nl);
     }
 
-    Enumeration hdr_list = Headers.keys();
+    Enumeration<Object> hdr_list = Headers.keys();
     while (hdr_list.hasMoreElements()) {
       String hdr = (String) hdr_list.nextElement();
       str.append(hdr);

--- a/system/src/main/java/com/percussion/HTTPClient/HttpURLConnection.java
+++ b/system/src/main/java/com/percussion/HTTPClient/HttpURLConnection.java
@@ -392,7 +392,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
 
       // count number of headers
       int num = 1;
-      Enumeration e = resp.listHeaders();
+      Enumeration<Object> e = resp.listHeaders();
       while (e.hasMoreElements()) {
         num++;
         e.nextElement();

--- a/system/src/main/java/com/percussion/HTTPClient/IdempotentSequence.java
+++ b/system/src/main/java/com/percussion/HTTPClient/IdempotentSequence.java
@@ -72,7 +72,7 @@ class IdempotentSequence {
   /** trigger analysis of threads */
   private boolean analysis_done = false;
 
-  private ConcurrentHashMap threads = new ConcurrentHashMap();
+  private final ConcurrentHashMap<String, Object> threads = new ConcurrentHashMap<>();
 
   // Constructors
 
@@ -154,9 +154,9 @@ class IdempotentSequence {
     }
 
     // any thread still indeterminate must be idempotent
-    Enumeration te = threads.keys();
+    Enumeration<String> te = threads.keys();
     while (te.hasMoreElements()) {
-      String res = (String) te.nextElement();
+      String res = te.nextElement();
       if (threads.get(res) == INDET) threads.put(res, Boolean.TRUE);
     }
   }

--- a/system/src/main/java/com/percussion/HTTPClient/RedirectionModule.java
+++ b/system/src/main/java/com/percussion/HTTPClient/RedirectionModule.java
@@ -30,10 +30,12 @@ import java.util.concurrent.ConcurrentHashMap;
 @Deprecated
 public class RedirectionModule implements HTTPClientModule {
   /** a list of permanent redirections (301) */
-  private static ConcurrentHashMap perm_redir_cntxt_list = new ConcurrentHashMap();
+  private static final ConcurrentHashMap<Object, ConcurrentHashMap<URI, URI>> perm_redir_cntxt_list =
+      new ConcurrentHashMap<>();
 
   /** a list of deferred redirections (used with Response.retryRequest()) */
-  private static ConcurrentHashMap deferred_redir_list = new ConcurrentHashMap();
+  private static final ConcurrentHashMap<HttpOutputStream, RedirectionModule> deferred_redir_list =
+      new ConcurrentHashMap<>();
 
   /** the level of redirection */
   private int level;
@@ -67,7 +69,7 @@ public class RedirectionModule implements HTTPClientModule {
 
     HttpOutputStream out = req.getStream();
     if (out != null && deferred_redir_list.get(out) != null) {
-      copyFrom((RedirectionModule) deferred_redir_list.remove(out));
+      copyFrom(deferred_redir_list.remove(out));
       req.copyFrom(saved_req);
 
       if (new_con) return REQ_NEWCON_RST;
@@ -86,9 +88,9 @@ public class RedirectionModule implements HTTPClientModule {
 
     // handle permanent redirections
 
-    ConcurrentHashMap perm_redir_list =
+    ConcurrentHashMap<URI, URI> perm_redir_list =
         Util.getList(perm_redir_cntxt_list, req.getConnection().getContext());
-    if ((new_loc = (URI) perm_redir_list.get(cur_loc)) != null) {
+    if ((new_loc = perm_redir_list.get(cur_loc)) != null) {
       /* copy query if present in old url but not in new url. This
           * isn't strictly conforming, but some scripts fail to properly
           * propagate the query string to the Location header.
@@ -399,7 +401,8 @@ public class RedirectionModule implements HTTPClientModule {
     }
 
     if (!cur_loc.equals(new_loc)) {
-      ConcurrentHashMap perm_redir_list = Util.getList(perm_redir_cntxt_list, con.getContext());
+      ConcurrentHashMap<URI, URI> perm_redir_list =
+          Util.getList(perm_redir_cntxt_list, con.getContext());
       perm_redir_list.put(cur_loc, new_loc);
     }
   }

--- a/system/src/main/java/com/percussion/HTTPClient/Response.java
+++ b/system/src/main/java/com/percussion/HTTPClient/Response.java
@@ -43,7 +43,7 @@ import java.util.Vector;
 @Deprecated
 public final class Response implements RoResponse, GlobalConstants, Cloneable {
   /** This contains a list of headers which may only have a single value */
-  private static final Hashtable singleValueHeaders;
+  private static final Hashtable<String, String> singleValueHeaders;
 
   /** our http connection */
   private HTTPConnection connection;
@@ -149,7 +149,7 @@ public final class Response implements RoResponse, GlobalConstants, Cloneable {
       "retry-after",
     };
 
-    singleValueHeaders = new Hashtable(singleValueHeaderNames.length);
+    singleValueHeaders = new Hashtable<>(singleValueHeaderNames.length);
     for (int idx = 0; idx < singleValueHeaderNames.length; idx++)
       singleValueHeaders.put(singleValueHeaderNames[idx], singleValueHeaderNames[idx]);
   }
@@ -647,15 +647,15 @@ public final class Response implements RoResponse, GlobalConstants, Cloneable {
     // parse the Transfer-Encoding header
 
     boolean te_chunked = false, te_is_identity = true, ct_mpbr = false;
-    Vector te_hdr = null;
+    Vector<HttpHeaderElement> te_hdr = null;
     try {
       te_hdr = Util.parseHeader((String) Headers.get("Transfer-Encoding"));
     } catch (ParseException pe) {
     }
     if (te_hdr != null) {
-      te_chunked = ((HttpHeaderElement) te_hdr.lastElement()).getName().equalsIgnoreCase("chunked");
+      te_chunked = te_hdr.lastElement().getName().equalsIgnoreCase("chunked");
       for (int idx = 0; idx < te_hdr.size(); idx++)
-        if (((HttpHeaderElement) te_hdr.elementAt(idx)).getName().equalsIgnoreCase("identity"))
+        if (te_hdr.elementAt(idx).getName().equalsIgnoreCase("identity"))
           te_hdr.removeElementAt(idx--);
         else te_is_identity = false;
     }
@@ -665,7 +665,7 @@ public final class Response implements RoResponse, GlobalConstants, Cloneable {
     try {
       String hdr;
       if ((hdr = (String) Headers.get("Content-Type")) != null) {
-        Vector phdr = Util.parseHeader(hdr);
+        Vector<HttpHeaderElement> phdr = Util.parseHeader(hdr);
         ct_mpbr =
             phdr.contains(new HttpHeaderElement("multipart/byteranges"))
                 || phdr.contains(new HttpHeaderElement("multipart/x-byteranges"));
@@ -733,7 +733,7 @@ public final class Response implements RoResponse, GlobalConstants, Cloneable {
       if (connection.getProxyHost() != null) deleteHeader("Connection");
       else deleteHeader("Proxy-Connection");
 
-      Vector pco;
+      Vector<HttpHeaderElement> pco;
       try {
         pco = Util.parseHeader((String) Headers.get("Connection"));
       } catch (ParseException pe) {
@@ -742,7 +742,7 @@ public final class Response implements RoResponse, GlobalConstants, Cloneable {
 
       if (pco != null) {
         for (int idx = 0; idx < pco.size(); idx++) {
-          String name = ((HttpHeaderElement) pco.elementAt(idx)).getName();
+          String name = pco.elementAt(idx).getName();
           if (!name.equalsIgnoreCase("keep-alive")) {
             pco.removeElementAt(idx);
             deleteHeader(name);

--- a/system/src/main/java/com/percussion/HTTPClient/TransferEncodingModule.java
+++ b/system/src/main/java/com/percussion/HTTPClient/TransferEncodingModule.java
@@ -41,11 +41,11 @@ class TransferEncodingModule implements HTTPClientModule {
     NVPair[] hdrs = req.getHeaders();
     for (idx = 0; idx < hdrs.length; idx++) if (hdrs[idx].getName().equalsIgnoreCase("TE")) break;
 
-    Vector pte;
+    Vector<HttpHeaderElement> pte;
     if (idx == hdrs.length) {
       hdrs = Util.resizeArray(hdrs, idx + 1);
       req.setHeaders(hdrs);
-      pte = new Vector();
+      pte = new Vector<>();
     } else {
       try {
         pte = Util.parseHeader(hdrs[idx].getValue());
@@ -103,7 +103,7 @@ class TransferEncodingModule implements HTTPClientModule {
     String te = resp.getHeader("Transfer-Encoding");
     if (te == null || req.getMethod().equals("HEAD")) return;
 
-    Vector pte;
+    Vector<HttpHeaderElement> pte;
     try {
       pte = Util.parseHeader(te);
     } catch (ParseException pe) {
@@ -111,7 +111,7 @@ class TransferEncodingModule implements HTTPClientModule {
     }
 
     while (pte.size() > 0) {
-      String encoding = ((HttpHeaderElement) pte.lastElement()).getName();
+      String encoding = pte.lastElement().getName();
       if (encoding.equalsIgnoreCase("gzip")) {
         Log.write(Log.MODS, "TEM:   pushing gzip-input-stream");
 

--- a/system/src/main/java/com/percussion/HTTPClient/URI.java
+++ b/system/src/main/java/com/percussion/HTTPClient/URI.java
@@ -68,9 +68,11 @@ public class URI {
    */
   public static final boolean ENABLE_BACKWARDS_COMPATIBILITY = true;
 
-  protected static final ConcurrentHashMap defaultPorts = new ConcurrentHashMap();
-  protected static final ConcurrentHashMap usesGenericSyntax = new ConcurrentHashMap();
-  protected static final ConcurrentHashMap usesSemiGenericSyntax = new ConcurrentHashMap();
+  protected static final ConcurrentHashMap<String, Integer> defaultPorts = new ConcurrentHashMap<>();
+  protected static final ConcurrentHashMap<String, Boolean> usesGenericSyntax =
+      new ConcurrentHashMap<>();
+  protected static final ConcurrentHashMap<String, Boolean> usesSemiGenericSyntax =
+      new ConcurrentHashMap<>();
 
   /* various character classes as defined in the draft */
   protected static final BitSet alphanumChar;
@@ -721,7 +723,7 @@ public class URI {
    * @return the port number, or 0 if unknown
    */
   public static final int defaultPort(String protocol) {
-    Integer port = (Integer) defaultPorts.get(protocol.trim().toLowerCase());
+    Integer port = defaultPorts.get(protocol.trim().toLowerCase());
     return (port != null) ? port.intValue() : 0;
   }
 

--- a/system/src/main/java/com/percussion/HTTPClient/Util.java
+++ b/system/src/main/java/com/percussion/HTTPClient/Util.java
@@ -177,13 +177,17 @@ public class Util {
    * Helper method for context lists used by modules. Returns the list associated with the context
    * if it exists; otherwise it creates a new list and adds it to the context list.
    *
+   * @param <K> key type of the inner context map
+   * @param <V> value type of the inner context map
    * @param cntxt_list the list of lists indexed by context
    * @param cntxt the context
+   * @return the inner map for {@code cntxt}, never null
    */
-  static final ConcurrentHashMap getList(ConcurrentHashMap cntxt_list, Object cntxt) {
-    ConcurrentHashMap list = (ConcurrentHashMap) cntxt_list.get(cntxt);
+  static final <K, V> ConcurrentHashMap<K, V> getList(
+      ConcurrentHashMap<Object, ConcurrentHashMap<K, V>> cntxt_list, Object cntxt) {
+    ConcurrentHashMap<K, V> list = cntxt_list.get(cntxt);
     if (list == null) {
-      list = new ConcurrentHashMap();
+      list = new ConcurrentHashMap<>();
       cntxt_list.put(cntxt, list);
     }
 
@@ -354,7 +358,7 @@ public class Util {
    *     <var>HttpHeaderElement</var>.
    * @exception ParseException if the syntax rules are violated.
    */
-  public static final Vector parseHeader(String header) throws ParseException {
+  public static final Vector<HttpHeaderElement> parseHeader(String header) throws ParseException {
     return parseHeader(header, true);
   }
 
@@ -388,10 +392,11 @@ public class Util {
    * @exception ParseException if the above syntax rules are violated.
    * @see com.percussion.HTTPClient.HttpHeaderElement
    */
-  public static final Vector parseHeader(String header, boolean dequote) throws ParseException {
+  public static final Vector<HttpHeaderElement> parseHeader(String header, boolean dequote)
+      throws ParseException {
     if (header == null) return null;
     char[] buf = header.toCharArray();
-    Vector elems = new Vector();
+    Vector<HttpHeaderElement> elems = new Vector<>();
     boolean first = true;
     int beg = -1, end = 0, len = buf.length, abeg[] = new int[1];
     String elem_name, elem_value;
@@ -570,10 +575,10 @@ public class Util {
    * @return the request element, or null if none found.
    * @see #parseHeader(java.lang.String)
    */
-  public static final HttpHeaderElement getElement(Vector header, String name) {
+  public static final HttpHeaderElement getElement(Vector<HttpHeaderElement> header, String name) {
     int idx = header.indexOf(new HttpHeaderElement(name));
     if (idx == -1) return null;
-    else return (HttpHeaderElement) header.elementAt(idx);
+    else return header.elementAt(idx);
   }
 
   /**
@@ -591,7 +596,7 @@ public class Util {
    * @exception ParseException if the above syntax rules are violated.
    */
   public static final String getParameter(String param, String hdr) throws ParseException {
-    NVPair[] params = ((HttpHeaderElement) parseHeader(hdr).firstElement()).getParams();
+    NVPair[] params = parseHeader(hdr).firstElement().getParams();
 
     for (int idx = 0; idx < params.length; idx++) {
       if (params[idx].getName().equalsIgnoreCase(param)) return params[idx].getValue();
@@ -607,12 +612,12 @@ public class Util {
    * @param pheader the parsed header
    * @return a string containing the assembled header
    */
-  public static final String assembleHeader(Vector pheader) {
+  public static final String assembleHeader(Vector<HttpHeaderElement> pheader) {
     StringBuilder hdr = new StringBuilder(200);
     int len = pheader.size();
 
     for (int idx = 0; idx < len; idx++) {
-      ((HttpHeaderElement) pheader.elementAt(idx)).appendTo(hdr);
+      pheader.elementAt(idx).appendTo(hdr);
       hdr.append(", ");
     }
     hdr.setLength(hdr.length() - 2);

--- a/system/src/test/java/com/percussion/HTTPClient/CIHashtableGenericsTest.java
+++ b/system/src/test/java/com/percussion/HTTPClient/CIHashtableGenericsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.HTTPClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Enumeration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for typed CIHashtable after rawtypes cleanup (#2460). */
+@DisplayName("HTTPClient CIHashtable generics")
+class CIHashtableGenericsTest {
+
+  @Test
+  @DisplayName("keys are case-insensitive and original case is preserved in keys()")
+  void caseInsensitiveKeysPreserveOriginalCase() {
+    CIHashtable table = new CIHashtable();
+    table.put("Content-Type", "text/html");
+
+    assertEquals("text/html", table.get("content-type"));
+    assertEquals("text/html", table.get("CONTENT-TYPE"));
+    assertTrue(table.containsKey("CoNtEnT-TyPe"));
+
+    Enumeration<Object> keys = table.keys();
+    assertTrue(keys.hasMoreElements());
+    assertEquals("Content-Type", keys.nextElement());
+    assertFalse(keys.hasMoreElements());
+  }
+}

--- a/system/src/test/java/com/percussion/HTTPClient/HTTPConnectionModuleInstantiationTest.java
+++ b/system/src/test/java/com/percussion/HTTPClient/HTTPConnectionModuleInstantiationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.HTTPClient;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Documents intentional {@code getDeclaredConstructor()} use for HTTPClient modules (#2460 review).
+ *
+ * <p>Built-in modules are often package-private with package-private no-arg constructors; {@code
+ * Class.getConstructor()} (public-only) would fail for them.
+ */
+@DisplayName("HTTPConnection module instantiation")
+class HTTPConnectionModuleInstantiationTest {
+
+  @Test
+  @DisplayName("package-private DefaultModule has no public constructor")
+  void packagePrivateModuleHasNoPublicConstructor() {
+    assertThrows(NoSuchMethodException.class, () -> DefaultModule.class.getConstructor());
+  }
+
+  @Test
+  @DisplayName("getDeclaredConstructor instantiates package-private DefaultModule")
+  void declaredConstructorInstantiatesPackagePrivateModule() throws Exception {
+    HTTPClientModule instance = DefaultModule.class.getDeclaredConstructor().newInstance();
+    assertNotNull(instance);
+  }
+
+  @Test
+  @DisplayName("addModule accepts package-private DefaultModule class")
+  void addModuleAcceptsPackagePrivateDefaultModule() {
+    HTTPConnection conn = new HTTPConnection("localhost", 80);
+    // May already be on the default list; remove first so add can succeed.
+    conn.removeModule(DefaultModule.class);
+    assertTrue(conn.addModule(DefaultModule.class, 0));
+    assertTrue(conn.removeModule(DefaultModule.class));
+  }
+}

--- a/system/src/test/java/com/percussion/HTTPClient/URIDefaultPortsGenericsTest.java
+++ b/system/src/test/java/com/percussion/HTTPClient/URIDefaultPortsGenericsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.HTTPClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for typed URI scheme maps after rawtypes cleanup (#2460). */
+@DisplayName("HTTPClient URI typed scheme maps")
+class URIDefaultPortsGenericsTest {
+
+  @Test
+  @DisplayName("defaultPort reads typed ConcurrentHashMap entries")
+  void defaultPortFromTypedMap() {
+    assertEquals(80, URI.defaultPort("http"));
+    assertEquals(443, URI.defaultPort("HTTPS"));
+    assertEquals(21, URI.defaultPort("ftp"));
+  }
+
+  @Test
+  @DisplayName("generic and semi-generic scheme flags remain true")
+  void schemeSyntaxFlags() {
+    assertTrue(URI.usesGenericSyntax("http"));
+    assertTrue(URI.usesGenericSyntax("HTTPS"));
+    assertTrue(URI.usesSemiGenericSyntax("ldap"));
+  }
+}

--- a/system/src/test/java/com/percussion/HTTPClient/UtilGenericsTest.java
+++ b/system/src/test/java/com/percussion/HTTPClient/UtilGenericsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.HTTPClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed HTTPClient utility APIs after rawtypes cleanup (#2460).
+ */
+@DisplayName("HTTPClient Util generics")
+class UtilGenericsTest {
+
+  @Test
+  @DisplayName("parseHeader returns typed HttpHeaderElement vector")
+  void parseHeaderReturnsTypedElements() throws Exception {
+    Vector<HttpHeaderElement> elems = Util.parseHeader("gzip, deflate;q=0.5");
+    assertNotNull(elems);
+    assertEquals(2, elems.size());
+    assertEquals("gzip", elems.firstElement().getName());
+    assertNull(elems.firstElement().getValue());
+
+    HttpHeaderElement deflate = elems.elementAt(1);
+    assertEquals("deflate", deflate.getName());
+    assertEquals(1, deflate.getParams().length);
+    assertEquals("q", deflate.getParams()[0].getName());
+    assertEquals("0.5", deflate.getParams()[0].getValue());
+  }
+
+  @Test
+  @DisplayName("getElement is case-insensitive on typed vector")
+  void getElementCaseInsensitive() throws Exception {
+    Vector<HttpHeaderElement> elems = Util.parseHeader("Identity, Chunked");
+    assertNotNull(Util.getElement(elems, "identity"));
+    assertNotNull(Util.getElement(elems, "CHUNKED"));
+    assertNull(Util.getElement(elems, "gzip"));
+  }
+
+  @Test
+  @DisplayName("assembleHeader round-trips parsed header elements")
+  void assembleHeaderRoundTrip() throws Exception {
+    Vector<HttpHeaderElement> elems = Util.parseHeader("gzip, deflate");
+    String assembled = Util.assembleHeader(elems);
+    assertTrue(assembled.toLowerCase().contains("gzip"));
+    assertTrue(assembled.toLowerCase().contains("deflate"));
+
+    Vector<HttpHeaderElement> again = Util.parseHeader(assembled);
+    assertEquals(elems.size(), again.size());
+  }
+
+  @Test
+  @DisplayName("getList creates and reuses typed context maps")
+  void getListCreatesAndReuses() {
+    ConcurrentHashMap<Object, ConcurrentHashMap<String, Integer>> outer = new ConcurrentHashMap<>();
+    Object ctx = new Object();
+
+    ConcurrentHashMap<String, Integer> first = Util.getList(outer, ctx);
+    assertNotNull(first);
+    first.put("a", 1);
+
+    ConcurrentHashMap<String, Integer> second = Util.getList(outer, ctx);
+    assertSame(first, second);
+    assertEquals(1, second.get("a"));
+  }
+}


### PR DESCRIPTION
## Summary
PR-sized `-Xlint` rawtypes/unchecked cleanup for the legacy **`com.percussion.HTTPClient`** package (parent epic **#2022**, residual of **#2386** / PR #2458 which took security catalogers).

Real generics preferred over blanket suppress:
- `Util.getList` / `parseHeader` / `getElement` / `assembleHeader`
- Auth / cookie / redirection / idempotent context `ConcurrentHashMap`s
- `URI` scheme maps, `CIHashtable`, `Response` header helpers
- `HTTPConnection` module lists (`Vector<Class<?>>`) and non-proxy lists
- Consumers: encoding modules, `DefaultAuthHandler`, `Cookie2`, `Codecs`, `HttpURLConnection`

No residual filed — package collection rawtypes/unchecked zeroed for this scope. Stayed out of open serial/this-escape PRs (#2650/#2653).

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] Unit tests: `UtilGenericsTest` (4), `CIHashtableGenericsTest` (1), `URIDefaultPortsGenericsTest` (2)
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1439**, Failures: **0**, Errors: **0** (Skipped: 240 baseline)
- [x] Erlang pre-commit review PASS — `docs/ai-generated/code-reviews/issue-2460-httpclient-rawtypes-erlang.md`

## Gates
- Pre-PR Maven verification (standalone system clean install)
- Erlang review
- No new path I/O; no human QA (pure tech-debt generics)

Fixes #2460  
Parent tracker: #2022

> Co-Authored by Grok Build using grok-4.5 with agent main.
