### PR TITLE
fix(system): large JSON body temp-file / size hardening (#2666)

### DIFF
--- a/docs/developer-module/classic-xml-app-json-io.md
+++ b/docs/developer-module/classic-xml-app-json-io.md
@@ -79,7 +79,8 @@ Goldens: `system/src/test/resources/com/percussion/data/json-codec/`
 - Same trust boundary as XML input.
 - Embedded file URL attributes (`PSXUrlReferenceAttribute`) are rejected (document cleared), matching `PSXmlContentParser`.
 - No script execution; pure structural transform.
-- Nesting limited by `MAX_DEPTH`.
+- Nesting limited by `MAX_DEPTH` (`PSXmlDocumentJsonCodec.MAX_DEPTH` = 64).
+- **Body intake / size:** `PSJsonContentParser` streams the request body into a purgable temp file in fixed-size chunks (same helper as `PSXmlContentParser`), then decodes with a charset-aware `Reader`. This avoids allocating a single `byte[Content-Length]` for the entire body on the happy path. There is **no additional hard max body size** beyond the Content-Length `int` already used by the classic request parser (same policy as the XML content path). Content-Length mismatches log a server warning and parse what was actually read.
 
 ## Classic apps vs Pipeline IR
 

--- a/system/src/main/java/com/percussion/server/content/PSJsonContentParser.java
+++ b/system/src/main/java/com/percussion/server/content/PSJsonContentParser.java
@@ -28,9 +28,13 @@ import com.percussion.util.PSBaseHttpUtils;
 import com.percussion.util.PSCharSets;
 import com.percussion.util.PSCharSetsConstants;
 import com.percussion.util.PSInputStreamReader;
+import com.percussion.util.PSPurgableTempFile;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Arrays;
 import org.w3c.dom.Document;
 
@@ -38,6 +42,12 @@ import org.w3c.dom.Document;
  * Parses {@code application/json} request bodies into an input XML {@link Document} using {@link
  * PSXmlDocumentJsonCodec}, so classic update pipes and other input-document consumers can accept
  * JSON without changing mapper/exit code.
+ *
+ * <p>Large-body intake matches {@link PSXmlContentParser}: the request stream is copied into a
+ * purgable temp file in fixed-size chunks (no single {@code byte[Content-Length]} allocation), then
+ * decoded via a charset-aware {@link Reader}. There is no additional hard max-size beyond the
+ * Content-Length {@code int} used by the request parser (same as the classic XML path). Nesting is
+ * limited by {@link PSXmlDocumentJsonCodec#MAX_DEPTH}.
  */
 public class PSJsonContentParser extends PSContentParser {
 
@@ -77,42 +87,50 @@ public class PSJsonContentParser extends PSContentParser {
       throw new PSRequestParsingException("Unsupported character set for JSON body: " + charset);
     }
 
-    byte[] buf = new byte[length];
-    int bytesRead = getContentFromReader(content, buf, length);
-    if (bytesRead != length) {
-      Object[] args = {
-        request.getUserSessionId(),
-        mimeType,
-        String.valueOf(length),
-        String.valueOf(bytesRead)
-      };
-      com.percussion.log.PSLogManager.write(
-          new com.percussion.log.PSLogServerWarning(
-              IPSServerErrors.CONTENT_LENGTH_DOES_NOT_MATCH_DATA_READ,
-              args,
-              true,
-              "PSJsonContentParser"));
-    }
-
-    String jsonText = new String(buf, 0, bytesRead, javaCharset);
-
-    Document doc;
+    /*
+     * Stream body to a purgable temp file (same pattern as PSXmlContentParser) so hostile or
+     * large Content-Length values do not force a single heap buffer for the entire body.
+     */
+    PSPurgableTempFile tempFile =
+        readContentIntoPurgableTempFile("psj", ".json", null, content, length);
     try {
-      doc = PSXmlDocumentJsonCodec.fromJson(jsonText);
-    } catch (PSConversionException e) {
-      Object[] args = {e.getLocalizedMessage()};
-      throw new PSRequestParsingException(IPSServerErrors.JSON_PARSER_ERROR, args);
-    }
+      long fileLength = tempFile.length();
+      if (length != fileLength) {
+        Object[] args = {
+          request.getUserSessionId(),
+          mimeType,
+          String.valueOf(length),
+          String.valueOf(fileLength)
+        };
+        com.percussion.log.PSLogManager.write(
+            new com.percussion.log.PSLogServerWarning(
+                IPSServerErrors.CONTENT_LENGTH_DOES_NOT_MATCH_DATA_READ,
+                args,
+                true,
+                "PSJsonContentParser"));
+      }
 
-    /* Reject embedded file URLs (same security rule as XML content parser). */
-    PSXmlTreeWalker walker = new PSXmlTreeWalker(doc);
-    String str =
-        walker.getElementData("@" + PSXmlFieldExtractor.XML_URL_REFERENCE_ATTRIBUTE, true);
-    if (str != null) {
-      doc = null;
-    }
+      Document doc;
+      try (Reader reader =
+          new InputStreamReader(Files.newInputStream(tempFile.toPath()), javaCharset)) {
+        doc = PSXmlDocumentJsonCodec.fromJson(reader);
+      } catch (PSConversionException e) {
+        Object[] args = {e.getLocalizedMessage()};
+        throw new PSRequestParsingException(IPSServerErrors.JSON_PARSER_ERROR, args);
+      }
 
-    request.setInputDocument(doc);
+      /* Reject embedded file URLs (same security rule as XML content parser). */
+      PSXmlTreeWalker walker = new PSXmlTreeWalker(doc);
+      String str =
+          walker.getElementData("@" + PSXmlFieldExtractor.XML_URL_REFERENCE_ATTRIBUTE, true);
+      if (str != null) {
+        doc = null;
+      }
+
+      request.setInputDocument(doc);
+    } finally {
+      tempFile.release();
+    }
   }
 
   @Override

--- a/system/src/test/java/com/percussion/server/content/PSJsonContentParserTest.java
+++ b/system/src/test/java/com/percussion/server/content/PSJsonContentParserTest.java
@@ -151,6 +151,29 @@ class PSJsonContentParserTest {
   }
 
   @Test
+  void parse_contentLengthLongerThanStream_invalidTruncatedJson_throwsJsonParserError() {
+    PSRequest request = new PSRequest(null, null, null, null);
+    // Incomplete JSON body with Content-Length claiming more bytes than available. Temp-file path
+    // must still surface JSON_PARSER_ERROR (not an unexpected exception) after the short read.
+    byte[] bytes = "{\"Item\":{\"Id\":".getBytes(StandardCharsets.UTF_8);
+    PSInputStreamReader reader =
+        new PSInputStreamReader(
+            new ByteArrayInputStream(bytes), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
+
+    PSRequestParsingException ex =
+        assertThrows(
+            PSRequestParsingException.class,
+            () ->
+                parser.parse(
+                    request,
+                    IPSMimeContentTypes.MIME_TYPE_JSON,
+                    "UTF-8",
+                    reader,
+                    bytes.length + 50));
+    assertEquals(IPSServerErrors.JSON_PARSER_ERROR, ex.getErrorCode());
+  }
+
+  @Test
   void parse_moderateBody_viaTempFilePath() throws Exception {
     PSRequest request = new PSRequest(null, null, null, null);
     // Large enough to span multiple 2KB read chunks in readContentIntoPurgableTempFile.

--- a/system/src/test/java/com/percussion/server/content/PSJsonContentParserTest.java
+++ b/system/src/test/java/com/percussion/server/content/PSJsonContentParserTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.content.IPSMimeContentTypes;
+import com.percussion.data.PSXmlFieldExtractor;
 import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSRequestParsingException;
@@ -51,13 +52,7 @@ class PSJsonContentParserTest {
   void parse_setsInputDocument() throws Exception {
     PSRequest request = new PSRequest(null, null, null, null);
     String json = "{\"Properties\":{\"Type\":\"workflow\",\"Name\":\"wf1\"}}";
-    byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
-    PSInputStreamReader reader =
-        new PSInputStreamReader(
-            new ByteArrayInputStream(bytes), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
-
-    parser.parse(
-        request, IPSMimeContentTypes.MIME_TYPE_JSON, "UTF-8", reader, bytes.length);
+    parseJson(request, json);
 
     Document doc = request.getInputDocument();
     assertNotNull(doc);
@@ -94,6 +89,148 @@ class PSJsonContentParserTest {
                 parser.parse(
                     request, IPSMimeContentTypes.MIME_TYPE_JSON, "UTF-8", reader, bytes.length));
     assertEquals(IPSServerErrors.JSON_PARSER_ERROR, ex.getErrorCode());
+  }
+
+  @Test
+  void parse_negativeContentLength_throws() {
+    PSRequest request = new PSRequest(null, null, null, null);
+    PSInputStreamReader reader =
+        new PSInputStreamReader(
+            new ByteArrayInputStream(new byte[0]), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
+
+    PSRequestParsingException ex =
+        assertThrows(
+            PSRequestParsingException.class,
+            () ->
+                parser.parse(
+                    request, IPSMimeContentTypes.MIME_TYPE_JSON, "UTF-8", reader, -1));
+    assertTrue(ex.getMessage().contains("Invalid Content-Length"));
+  }
+
+  @Test
+  void parse_contentLengthShorterThanStream_parsesAvailableBytes() throws Exception {
+    PSRequest request = new PSRequest(null, null, null, null);
+    // Body is well-formed JSON; Content-Length claims fewer bytes than available (peer can send
+    // extra). Parser must only consume the declared length and still parse successfully.
+    String json = "{\"Order\":{\"Sku\":\"A\"}}";
+    byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+    byte[] padded = new byte[bytes.length + 32];
+    System.arraycopy(bytes, 0, padded, 0, bytes.length);
+    PSInputStreamReader reader =
+        new PSInputStreamReader(
+            new ByteArrayInputStream(padded), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
+
+    parser.parse(
+        request, IPSMimeContentTypes.MIME_TYPE_JSON, "UTF-8", reader, bytes.length);
+
+    Document doc = request.getInputDocument();
+    assertNotNull(doc);
+    assertEquals("Order", doc.getDocumentElement().getNodeName());
+    assertEquals("A", textChild(doc.getDocumentElement(), "Sku"));
+  }
+
+  @Test
+  void parse_contentLengthLongerThanStream_warnsAndParsesTruncatedBodyWhenValid()
+      throws Exception {
+    PSRequest request = new PSRequest(null, null, null, null);
+    String json = "{\"Item\":{\"Id\":\"1\"}}";
+    byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+    PSInputStreamReader reader =
+        new PSInputStreamReader(
+            new ByteArrayInputStream(bytes), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
+
+    // Declared length exceeds available data (socket closed early). Temp-file length is shorter;
+    // still parse what was read (same warning path as PSXmlContentParser).
+    parser.parse(
+        request, IPSMimeContentTypes.MIME_TYPE_JSON, "UTF-8", reader, bytes.length + 50);
+
+    Document doc = request.getInputDocument();
+    assertNotNull(doc);
+    assertEquals("Item", doc.getDocumentElement().getNodeName());
+    assertEquals("1", textChild(doc.getDocumentElement(), "Id"));
+  }
+
+  @Test
+  void parse_moderateBody_viaTempFilePath() throws Exception {
+    PSRequest request = new PSRequest(null, null, null, null);
+    // Large enough to span multiple 2KB read chunks in readContentIntoPurgableTempFile.
+    StringBuilder items = new StringBuilder();
+    items.append("{\"Catalog\":{\"Item\":[");
+    for (int i = 0; i < 200; i++) {
+      if (i > 0) {
+        items.append(',');
+      }
+      items
+          .append("{\"Sku\":\"SKU-")
+          .append(String.format("%04d", i))
+          .append("\",\"Desc\":\"item description padding ")
+          .append("x".repeat(40))
+          .append("\"}");
+    }
+    items.append("]}}");
+    String json = items.toString();
+    assertTrue(json.length() > 4096, "body should exceed single 2KB temp-file chunk");
+
+    parseJson(request, json);
+
+    Document doc = request.getInputDocument();
+    assertNotNull(doc);
+    assertEquals("Catalog", doc.getDocumentElement().getNodeName());
+    assertEquals(
+        200, doc.getDocumentElement().getElementsByTagName("Item").getLength());
+  }
+
+  @Test
+  void parse_rejectsEmbeddedFileUrlAttribute() throws Exception {
+    PSRequest request = new PSRequest(null, null, null, null);
+    // JSON attribute form is "@name" → XML attribute (codec ATTR_PREFIX).
+    String attrKey = "@" + PSXmlFieldExtractor.XML_URL_REFERENCE_ATTRIBUTE;
+    String json =
+        "{\"Doc\":{\"" + attrKey + "\":\"file:///etc/passwd\",\"Name\":\"x\"}}";
+    parseJson(request, json);
+
+    // Same security rule as PSXmlContentParser: document cleared when file URL attr present.
+    assertNull(request.getInputDocument());
+  }
+
+  @Test
+  void parse_nullCharset_usesDefaultAndSucceeds() throws Exception {
+    PSRequest request = new PSRequest(null, null, null, null);
+    String json = "{\"Root\":{\"V\":\"ok\"}}";
+    byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+    PSInputStreamReader reader =
+        new PSInputStreamReader(
+            new ByteArrayInputStream(bytes), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
+
+    parser.parse(request, IPSMimeContentTypes.MIME_TYPE_JSON, null, reader, bytes.length);
+
+    assertNotNull(request.getInputDocument());
+    assertEquals("ok", textChild(request.getInputDocument().getDocumentElement(), "V"));
+  }
+
+  @Test
+  void parse_unsupportedContentType_throws() {
+    PSRequest request = new PSRequest(null, null, null, null);
+    PSInputStreamReader reader =
+        new PSInputStreamReader(
+            new ByteArrayInputStream(new byte[0]), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
+
+    PSRequestParsingException ex =
+        assertThrows(
+            PSRequestParsingException.class,
+            () ->
+                parser.parse(
+                    request, "text/plain", "UTF-8", reader, 0));
+    assertEquals(IPSServerErrors.PARSER_UNSUPPORTED_CONTENT_TYPE, ex.getErrorCode());
+  }
+
+  private void parseJson(PSRequest request, String json) throws Exception {
+    byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+    PSInputStreamReader reader =
+        new PSInputStreamReader(
+            new ByteArrayInputStream(bytes), false, PSContentParser.MIN_PUSHBACK_BUF_SIZE);
+    parser.parse(
+        request, IPSMimeContentTypes.MIME_TYPE_JSON, "UTF-8", reader, bytes.length);
   }
 
   private static String textChild(Element parent, String name) {


### PR DESCRIPTION
## Summary

Aligns classic `application/json` request body intake with the XML content parser temp-file path so large or hostile Content-Length values do not force a single `byte[Content-Length]` heap allocation.

- `PSJsonContentParser` streams the body into a purgable temp file (fixed-size chunks via `readContentIntoPurgableTempFile`), then decodes with a charset-aware `Reader` + `PSXmlDocumentJsonCodec.fromJson(Reader)`.
- Preserves charset defaults, file-URL attribute reject (`PSXUrlReferenceAttribute`), and codec `MAX_DEPTH` (64).
- Documents size policy in `docs/developer-module/classic-xml-app-json-io.md` Security: **no additional hard max** beyond classic Content-Length `int` (same as XML).
- Expanded unit tests: small update-pipe JSON, multi-chunk moderate body, Content-Length short/long edges, negative length, file-URL reject, null charset.

Fixes #2666  
Parent tracker: #2662  
Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd system && ../mvnw.cmd -Dtest=PSJsonContentParserTest test` — Tests run: 11, Failures: 0
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS** (module suite Tests run: 1486, Failures: 0, Errors: 0, Skipped: 240)
- [x] No new compiler warnings attributable to this change
- [x] Cross-platform paths: temp file via `PSPurgableTempFile` + `Files.newInputStream(tempFile.toPath())` (NIO; no hardcoded separators)

## Erlang / change-class notes

- Change class: server content-parser body intake hardening (peer: `PSXmlContentParser`).
- Companions: unit tests + security docs update.
- No UI / installer / QA handoff required (pure server tech-debt; agent-proven unit tests).

> Co-Authored by Grok Build using grok-4.5 with agent main.