### PR TITLE
feat(system): Virtual Sites Phase 1 filesystem docs build (#2679)

### DIFF
--- a/docs/ai-generated/code-reviews/virtual-sites-git-docs-2679-erlang.md
+++ b/docs/ai-generated/code-reviews/virtual-sites-git-docs-2679-erlang.md
@@ -1,0 +1,64 @@
+# Erlang review — Virtual Sites Phase 1 (#2679)
+
+| Field | Value |
+|-------|--------|
+| **Branch** | `feat/virtual-sites-git-docs` |
+| **Scope** | Uncommitted Phase 1 Virtual Site package + product-docs + build scripts |
+| **Date** | 2026-08-09 |
+| **Reviewer** | Erlang (pre-commit, implementer session) |
+| **Recommendation** | **approve** |
+| **May commit/push** | **yes** |
+
+## Summary
+
+Phase 1 delivers a filesystem Virtual Site SPI, Markdown+frontmatter discovery, static HTML build (Markdown assembler helpers + layout theme), in-memory virtual participants with JSONL flush, link checking, site property helper, `product-docs/` skeleton, and cross-platform build scripts.
+
+Focused tests: **17** (parser, nav, helper, build, link rewriter) green. Module `system` **`mvnw clean install`** **BUILD SUCCESS**. Offline `scripts/build-cms-docs` emits 7 pages with clean link-report.
+
+## Gate checklist
+
+| Gate | Result |
+|------|--------|
+| Behavioral unit tests for non-trivial logic | Pass — parser, nav, build, helper, link rewrite |
+| Cross-platform path/file I/O | Pass — `Path`/`Files`, `resolveHref` segment join, CRLF frontmatter, `.bat`+`.sh` scripts; URL/href paths correctly use `/` |
+| Change-class closure | Pass for Phase 1 offline package — no Spring bean scan of new types into shared test contexts; no WebUI/REST surface |
+| Secrets / empty catch | Pass |
+| New copyright headers | Pass — Intersoft 2026 |
+
+## Issues
+
+None blocking.
+
+### Suggestions (non-blocking)
+
+1. **Site-root absolute hrefs** (`/8.2/...`) require the static site to be served at host root (or a reverse-proxy strip). Fine for help.intsof.com; file:// dogfood of nested pages still depends on absolute CSS. Document in product-docs README if operators host under a subpath later.
+2. **Path containment** in `PSGitFilesystemVirtualSiteSource.load` uses `Path.startsWith` after normalize — correct for NIO; keep this pattern if Git/clone adapters add remote fetch later.
+3. **JSONL hand-escape** is minimal (quote/backslash only). Adequate for controlled ids/paths; if free-text titles are added to flush later, switch to a real JSON writer.
+
+## Memory patterns hit
+
+- Behavioral tests for new logic (not string presence alone)
+- Portable `Path`/`Files` over hardcoded separators
+- Both Windows and Unix scripts for required automation
+- Module standalone clean install before PR
+
+## Cross-platform path checklist
+
+- [x] No new filesystem path construction with hardcoded `/` or `\\` joins (hrefs intentionally use `/`)
+- [x] Path resolve / Files APIs for discovery, write, asset copy
+- [x] Tests assert portable Path equality / forward-slash normalized published paths
+- [x] Line endings normalized in frontmatter parser
+- [x] build-cms-docs has `.bat` and `.sh`
+
+## Verification evidence
+
+```text
+cd system && ../mvnw.cmd -Dtest=VirtualFrontmatterParserTest,VirtualNavBuilderTest,PSVirtualSiteHelperTest,PSVirtualSiteBuildServiceTest,VirtualMarkdownLinkRewriterTest test
+# Tests run: 17, Failures: 0
+
+cd system && ../mvnw.cmd clean install
+# BUILD SUCCESS
+
+scripts\build-cms-docs.bat
+# Built 7 page(s); link-report: OK
+```

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/README.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/README.md
@@ -1,0 +1,35 @@
+# Virtual Sites & Git-Backed Documentation (8.2)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Active — Phase 1 implementation |
+| **Created** | 2026-08-09 |
+| **Type** | Product architecture |
+| **GitHub epic** | [#2678](https://github.com/intersoftdatalabs-in/percussioncms/issues/2678) |
+| **Phase 1 issue** | [#2679](https://github.com/intersoftdatalabs-in/percussioncms/issues/2679) |
+| **Related** | Assembler epic [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626), Markdown assemblers [#2628](https://github.com/intersoftdatalabs-in/percussioncms/issues/2628) |
+
+## North star
+
+**Virtual Sites** are Sites whose content originates outside the Percussion content repository. Phase 1 delivers a **Git/Filesystem** adapter for product documentation under repo-root **`product-docs/`**, using Percussion assemblers as the site generator while Git remains system of record.
+
+## Documents
+
+| Doc | Purpose |
+|-----|---------|
+| [spec.md](./spec.md) | Product specification |
+| [adr/](./adr/) | Architecture decision records |
+| [contracts/](./contracts/) | Frontmatter and site config contracts |
+
+## Code anchors
+
+| Area | Path |
+|------|------|
+| Virtual site package | `system/services/.../virtualsite/` |
+| Markdown render helpers | `system/services/.../assembly/impl/plugin/PSTextAssemblerSupport.java` |
+| Product docs tree | `product-docs/` |
+| Build script | `scripts/build-cms-docs.bat` / `scripts/build-cms-docs.sh` |
+
+## Working model (8.2)
+
+When landing a product feature, add or update corresponding Markdown under `product-docs/` in the same (or immediate follow-up) change set. Run the docs build locally or in CI to produce static HTML.

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/adr/001-site-not-channel.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/adr/001-site-not-channel.md
@@ -1,0 +1,20 @@
+# ADR-001: Site retains name; Virtual Site = source kind
+
+## Status
+
+Accepted
+
+## Context
+
+Product channels (different websites, audiences, delivery targets) are already modeled as Sites. Renaming Site to Channel would churn domain language, UI, schema, and APIs without improving the external-content problem.
+
+## Decision
+
+- Keep the primary product term **Site**.
+- External-origin content is a **Virtual Site**: a Site with a non-repository **source kind / adapter**.
+- Do not introduce “Channel” as a replacement for Site.
+
+## Consequences
+
+- Site Properties / site manager remain the configuration surface.
+- Docs and UI say: “A Site may be backed by the content repository or by an external source (Virtual Site).”

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/adr/002-no-ingest.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/adr/002-no-ingest.md
@@ -1,0 +1,21 @@
+# ADR-002: No repository ingest for Virtual Site items
+
+## Status
+
+Accepted
+
+## Context
+
+Ingesting Git documentation into the CMS as editable content items would create dual systems of record, workflow/permission conflicts, and drift from developer PR review.
+
+## Decision
+
+- Virtual Site content remains owned by the external source (Git/filesystem in Phase 1).
+- Percussion discovers, projects, assembles, and optionally registers lightweight identities.
+- Items are **not** created as normal editable CMS content items in the repository.
+
+## Consequences
+
+- Finder folder trees are not the authoring surface for Virtual pages.
+- Identity uses source-defined stable ids (frontmatter `id`), not content IDs.
+- Optional future visual editing layers must respect Git as source of truth if added.

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/adr/003-virtual-publish-path.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/adr/003-virtual-publish-path.md
@@ -1,0 +1,27 @@
+# ADR-003: Virtual publish path (not fake content lists) in Phase 1
+
+## Status
+
+Accepted
+
+## Context
+
+Classic publishing uses `IPSContentListGenerator` → content IDs → JCR nodes → assembly → delivery. Virtual Markdown pages are not repository items. Faking content IDs and content types would be fragile and couple docs to repository schema.
+
+## Decision
+
+Phase 1 implements a **Virtual Site build/assemble path** that:
+
+1. Discovers items via `IPSVirtualSiteSource`.
+2. Loads Markdown + frontmatter.
+3. Renders body with Markdown assembler helpers (`PSTextAssemblerSupport` / `markdownAssembler`).
+4. Wraps layout theme HTML.
+5. Writes static output and registers virtual participants.
+
+Classic content-list / Edition UI parity for Virtual Sites is deferred.
+
+## Consequences
+
+- Assembler machinery is dogfooded without abusing content lists.
+- Later phases may bridge Editions if product requires it.
+- Offline/CI builds can run without a full CMS repository.

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/adr/004-docs-tree-location.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/adr/004-docs-tree-location.md
@@ -1,0 +1,23 @@
+# ADR-004: Product documentation tree at `product-docs/`
+
+## Status
+
+Accepted
+
+## Context
+
+Monorepo `docs/` already holds internal material (AI task notes, developer-module guides, policies). Putting product help under `docs/` would mix audiences and tooling.
+
+Isolating product documentation early keeps Virtual Site content discoverable and separable from agent/dev trees.
+
+## Decision
+
+- Product documentation Virtual Site root is **`product-docs/`** at the repository root.
+- Theme lives at `product-docs/_theme/`.
+- Internal `docs/` remains for engineering/AI/policy material.
+
+## Consequences
+
+- Agents and developers update `product-docs/**` in lockstep with features.
+- Build scripts and CI path-filter on `product-docs/**`.
+- Earlier draft idea of `docs/cms/` is superseded.

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/adr/README.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/adr/README.md
@@ -1,0 +1,8 @@
+# ADRs — Virtual Sites
+
+| ADR | Decision | Status |
+|-----|----------|--------|
+| [001](./001-site-not-channel.md) | Keep term Site; Virtual Site = source kind | Accepted |
+| [002](./002-no-ingest.md) | Do not ingest Virtual items as editable CMS content | Accepted |
+| [003](./003-virtual-publish-path.md) | Phase 1 uses virtual assemble path, not fake content lists | Accepted |
+| [004](./004-docs-tree-location.md) | Product docs root = `product-docs/` | Accepted |

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/frontmatter.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/frontmatter.md
@@ -1,0 +1,34 @@
+# Frontmatter contract
+
+Every Markdown page under a version folder should start with a YAML frontmatter block:
+
+```yaml
+---
+id: install-overview
+title: Installation Overview
+description: How to install Percussion CMS 8.2
+version: "8.2"
+sidebar: true
+order: 10
+tags: [install, admin]
+deprecated: false
+---
+```
+
+## Fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | **Yes** | Stable identity for virtual participants / links. Unique within a version. |
+| `title` | **Yes** | Page title. |
+| `description` | No | Short summary. |
+| `version` | No | Inherited from version folder name when omitted. |
+| `sidebar` | No | Default `true`. |
+| `order` | No | Sort key among siblings (default `0`). |
+| `tags` | No | List of strings. |
+| `deprecated` | No | Default `false`. |
+
+## Validation
+
+- Missing `id` or `title` fails the page (build error).
+- Duplicate `id` within the same version fails the build.

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-config.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-config.md
@@ -1,0 +1,44 @@
+# Site configuration contract (`_config.yaml`)
+
+Located at the Virtual Site root (`product-docs/_config.yaml`).
+
+```yaml
+site:
+  title: Percussion CMS Documentation
+  url: https://percussioncmshelp.intsof.com
+
+versions:
+  - id: "8.2"
+    label: "8.2 (current)"
+    path: 8.2
+    default: true
+
+nav:
+  - title: Getting Started
+    id: getting-started
+  - title: Administration
+    id: admin
+  - title: Developer
+    id: developer
+
+theme:
+  layout: page.html
+```
+
+## Rules
+
+- `versions[].path` is a directory under the site root.
+- If `nav` is omitted, navigation is derived from folders + frontmatter `order`.
+- `theme.layout` is relative to `_theme/` (default `page.html`).
+
+## Site properties (CMS Site object)
+
+When a Percussion Site is configured as virtual (Phase 1 property contract):
+
+| Property name | Example | Meaning |
+|---------------|---------|---------|
+| `virtual.sourceKind` | `git-filesystem` | Non-blank ⇒ Virtual Site |
+| `virtual.rootPath` | absolute or install-relative path to tree | Source root |
+| `virtual.configFile` | `_config.yaml` | Optional; default `_config.yaml` |
+
+Empty / missing `virtual.sourceKind` means traditional **repository** site.

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-properties.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-properties.md
@@ -1,0 +1,12 @@
+# Virtual Site property keys
+
+Used on `IPSSite` / `PSSiteProperty` without requiring new `RXSITES` columns in Phase 1.
+
+| Key | Required for Virtual | Values |
+|-----|----------------------|--------|
+| `virtual.sourceKind` | Yes | `git-filesystem` (Phase 1). Other kinds later. |
+| `virtual.rootPath` | Yes | Filesystem path to Virtual Site root (`product-docs` checkout). |
+| `virtual.configFile` | No | Default `_config.yaml`. |
+| `virtual.siteKey` | No | Key for participant registry; default site name. |
+
+Helper: `com.percussion.services.virtualsite.PSVirtualSiteHelper`.

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/spec.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/spec.md
@@ -1,0 +1,186 @@
+# Specification: Virtual Sites & Git-Backed Documentation (8.2)
+
+## 1. Purpose
+
+Introduce **Virtual Sites** — Sites whose content originates outside the traditional Percussion content repository — and deliver the first concrete implementation for Git/Filesystem-backed documentation.
+
+### Goals
+
+- Keep Git as the source of truth for documentation (developer lockstep, PR review, continuous updates).
+- Use Percussion’s assembler and publishing machinery as the site generator (dogfooding).
+- Enable lightweight relationship/link integrity for documentation pages.
+- Establish a general external-content-source pattern for later adapters (databases, APIs, other CMSes).
+- Avoid ingesting documentation into the normal content repository as editable CMS items.
+
+This work builds on assembler modernization [#2628](https://github.com/intersoftdatalabs-in/percussioncms/issues/2628) (HTML-first + Markdown assemblers).
+
+## 2. Historical context: what a “Site” is
+
+Historically in Percussion (Rhythmyx → CM1 → current):
+
+- A **Site** defines a location where content is published (filesystem, FTP, database, etc.).
+- It is also the organizational unit: the Site Folder tree in the Finder drives structure, navigation, and publishing.
+- Site Properties include hostname, permissions, publishing configuration, etc.
+- Managed Navigation and publishing are Site-centric.
+
+**Decision:** Retain the term **Site**. Do not rename the core concept to “Channel.” External content becomes a **source type** on a Site.
+
+## 3. Core concept: Virtual Site
+
+A Virtual Site is a Site whose content does not live in the traditional Percussion content repository. The CMS reads content from an external source at discovery/assembly time (or via controlled sync).
+
+### 3.1 Source types (extensible)
+
+| Source type | Priority | Notes |
+|-------------|----------|-------|
+| Git / Filesystem | Phase 1 | Primary target (documentation) |
+| SQL / Database | Future | Structured reference data, catalogs |
+| API / Headless CMS | Future | Syndication |
+| CSV / Flat files | Future | Simple structured lists |
+| Object storage | Future | Large binary sets |
+
+### 3.2 Responsibilities
+
+- Declare source type + connection details.
+- Discover items from the external source.
+- Determine stable identity for each item.
+- Project items into a form the assembler can consume (transient or lightly cached).
+- Optionally register items with the relationship / virtual participant engine.
+- Participate in normal Site-level publishing configuration where applicable.
+
+Content remains owned by the external source.
+
+## 4. Traditional Site vs Virtual Site
+
+| Aspect | Traditional Site | Virtual Site |
+|--------|------------------|--------------|
+| Content origin | Percussion content repository | External (Git, DB, API, …) |
+| Editing | CMS UI, workflow, permissions | External tools (Git, SQL client, etc.) |
+| Folder / page tree | First-class CMS folders & pages | Projected from external structure |
+| Identity | Content IDs | Source-defined stable ID (e.g. frontmatter `id`) |
+| Relationship participation | Full | Optional / lightweight |
+| Assembly & publishing | Yes | Yes (virtual publish path in Phase 1) |
+| Site Properties / pub config | Yes | Yes (where applicable) |
+
+Both appear as Sites. A Site has a source kind: **repository** (default) or a **Virtual Site** adapter.
+
+## 5. Phase 1 scope: Git/Filesystem Virtual Site for documentation
+
+### In scope
+
+- Git or filesystem directory of Markdown files as a Virtual Site source.
+- Navigable static documentation site via the assembler helpers.
+- Stable page identities for basic relationship / broken-link support.
+- Continuous documentation during 8.2 development.
+
+### Out of scope
+
+- Full CMS content-type mapping or UI editing of Virtual Site items.
+- Automatic migration of existing help.intsof.com content.
+- Additional source adapters (SQL, API, etc.).
+- Advanced redirect management or full link rewriting.
+- Fake content IDs through classic `IPSContentListGenerator` (see ADR-003).
+
+## 6. Documentation tree contract
+
+Root: **`product-docs/`** (repo root — isolated from internal `docs/`).
+
+```text
+product-docs/
+├── _config.yaml
+├── _redirects.yaml          # optional
+├── _theme/                  # layout templates + CSS
+├── assets/
+│   └── ...
+└── 8.2/
+    ├── index.md
+    ├── getting-started/
+    │   ├── index.md
+    │   ├── install.md
+    │   └── upgrade.md
+    ├── admin/
+    ├── developer/
+    └── reference/
+```
+
+- Folder structure is the primary navigation hierarchy.
+- `index.md` is the landing page for a section.
+- One top-level folder per major documentation version.
+
+## 7. Frontmatter contract
+
+```yaml
+---
+id: install-overview              # stable identity (required for relationships)
+title: Installation Overview
+description: How to install Percussion CMS 8.2
+version: "8.2"                    # may be inherited from folder
+sidebar: true                     # default true
+order: 10                         # sort within parent
+tags: [install, admin]
+deprecated: false
+---
+```
+
+`id` is mandatory for relationship participation. Paths may change; `id` should remain stable.
+
+## 8. Site configuration (`_config.yaml`)
+
+```yaml
+site:
+  title: Percussion CMS Documentation
+  url: https://percussioncmshelp.intsof.com
+
+versions:
+  - id: "8.2"
+    label: "8.2 (current)"
+    path: 8.2
+    default: true
+
+nav:
+  - title: Getting Started
+    id: getting-started
+  - title: Administration
+    id: admin
+  - title: Developer
+    id: developer
+
+theme:
+  layout: page.html
+```
+
+## 9. Assembler responsibilities (Phase 1)
+
+Building on #2628 Markdown / HTML-first assemblers:
+
+- Accept a filesystem or Git checkout of the docs tree as a Virtual Site source.
+- Discover and parse Markdown + frontmatter.
+- Build navigation from folder structure + order + optional nav config.
+- Apply templates (layout, sidebar, version switcher, TOC, etc.).
+- Emit static site output (HTML + assets).
+- Register each page’s stable id and final published path with the virtual participant registry.
+- Publish to the configured filesystem target.
+
+## 10. Relationship engine participation
+
+- On assembly, upsert a virtual participant keyed by frontmatter `id`.
+- Record the published path/URL.
+- Support detection of missing targets (broken links) at build or report time.
+- Future: managed links that use stable ids, move/rename resilience, impact analysis.
+
+Virtual Site items are a **thin projection**, not full first-class content items. Phase 1 does **not** use `PSX_MANAGEDLINK` (content-id based).
+
+## 11. Naming & language
+
+- Primary term remains **Site**.
+- External-origin Sites are **Virtual Sites**.
+- UI/docs language: “A Site may be backed by the content repository or by an external source (Virtual Site).”
+- Do **not** introduce “Channel” as a replacement for Site.
+
+## 12. Success criteria (Phase 1)
+
+1. A Git-backed documentation tree can be configured as a Virtual Site source.
+2. The assembler produces a navigable static documentation site from that tree.
+3. Pages carry stable ids visible to the virtual participant registry.
+4. Documentation can be updated via normal Git workflows in lockstep with product changes.
+5. The design leaves a clear extension point for additional Virtual Site source types.

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -1,0 +1,11 @@
+---
+id: admin
+title: Administration
+description: Operating and administering Percussion CMS 8.2
+version: "8.2"
+order: 40
+---
+
+# Administration
+
+Operator and administrator topics for Percussion CMS 8.2.

--- a/product-docs/8.2/developer/index.md
+++ b/product-docs/8.2/developer/index.md
@@ -1,0 +1,15 @@
+---
+id: developer
+title: Developer
+description: Developer guides for Percussion CMS 8.2
+version: "8.2"
+order: 50
+---
+
+# Developer
+
+Extension points, REST, assemblers, and Virtual Sites.
+
+## Related
+
+- Virtual Sites design notes live under `docs/ai-generated/tasks/virtual-sites-git-docs/`.

--- a/product-docs/8.2/getting-started/index.md
+++ b/product-docs/8.2/getting-started/index.md
@@ -1,0 +1,12 @@
+---
+id: getting-started
+title: Getting Started
+description: Install and first steps for Percussion CMS 8.2
+version: "8.2"
+order: 10
+---
+
+# Getting Started
+
+- [Installation Overview](id:install-overview)
+- [Upgrade Overview](id:upgrade-overview)

--- a/product-docs/8.2/getting-started/install.md
+++ b/product-docs/8.2/getting-started/install.md
@@ -1,0 +1,14 @@
+---
+id: install-overview
+title: Installation Overview
+description: How to install Percussion CMS 8.2
+version: "8.2"
+order: 20
+tags: [install, admin]
+---
+
+# Installation Overview
+
+Document install prerequisites, supported platforms, and the recommended install path for 8.2.
+
+> Content grows in lockstep with product changes — expand this page as install tooling lands.

--- a/product-docs/8.2/getting-started/upgrade.md
+++ b/product-docs/8.2/getting-started/upgrade.md
@@ -1,0 +1,14 @@
+---
+id: upgrade-overview
+title: Upgrade Overview
+description: How to upgrade to Percussion CMS 8.2
+version: "8.2"
+order: 30
+tags: [upgrade, admin]
+---
+
+# Upgrade Overview
+
+Document upgrade paths from prior releases into 8.2.
+
+> Stub — fill in as upgrade tooling and release notes stabilize.

--- a/product-docs/8.2/index.md
+++ b/product-docs/8.2/index.md
@@ -1,0 +1,25 @@
+---
+id: home-8.2
+title: Percussion CMS 8.2 Documentation
+description: Product documentation home for Percussion CMS 8.2
+version: "8.2"
+order: 0
+---
+
+# Percussion CMS 8.2 Documentation
+
+Welcome. This tree is a **Git-backed Virtual Site** source. Documentation is authored in Markdown
+in the product repository and assembled into a static site with Percussion’s Markdown assembler.
+
+## Sections
+
+- [Getting Started](id:getting-started)
+- [Administration](id:admin)
+- [Developer](id:developer)
+- [Reference](id:reference)
+
+## Working model
+
+When you land a product feature in 8.2, add or update the corresponding page under `product-docs/`
+in the same change set (or an immediate follow-up). Keep frontmatter `id` values **stable** when
+paths rename.

--- a/product-docs/8.2/reference/index.md
+++ b/product-docs/8.2/reference/index.md
@@ -1,0 +1,11 @@
+---
+id: reference
+title: Reference
+description: Reference material for Percussion CMS 8.2
+version: "8.2"
+order: 60
+---
+
+# Reference
+
+API, configuration, and glossary material.

--- a/product-docs/README.md
+++ b/product-docs/README.md
@@ -1,0 +1,36 @@
+# product-docs
+
+Git-backed **product documentation** for Percussion CMS (Virtual Site source tree).
+
+This directory is intentionally separate from repository `docs/` (engineering / AI / policy notes).
+
+## Layout
+
+```text
+product-docs/
+  _config.yaml       # site title, versions, nav, theme
+  _theme/            # HTML-first layout templates
+  assets/            # static CSS/images
+  8.2/               # versioned Markdown content
+```
+
+Every page uses YAML frontmatter with a stable `id` (see
+`docs/ai-generated/tasks/virtual-sites-git-docs/contracts/frontmatter.md`).
+
+## Build
+
+From the repo root (after `system` is built/installed once so the classpath is available):
+
+```bat
+scripts\build-cms-docs.bat
+```
+
+```bash
+scripts/build-cms-docs.sh
+```
+
+Output defaults to `tmp/product-docs-site/`.
+
+## Working model (8.2)
+
+Add or update Markdown here when features land so documentation stays in lockstep with the product.

--- a/product-docs/_config.yaml
+++ b/product-docs/_config.yaml
@@ -1,0 +1,22 @@
+site:
+  title: Percussion CMS Documentation
+  url: https://percussioncmshelp.intsof.com
+
+versions:
+  - id: "8.2"
+    label: "8.2 (current)"
+    path: 8.2
+    default: true
+
+nav:
+  - title: Getting Started
+    id: getting-started
+  - title: Administration
+    id: admin
+  - title: Developer
+    id: developer
+  - title: Reference
+    id: reference
+
+theme:
+  layout: page.html

--- a/product-docs/_theme/page.html
+++ b/product-docs/_theme/page.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>${pageTitle} — ${siteTitle}</title>
+  <meta name="description" content="${description}"/>
+  <link rel="stylesheet" href="/assets/site.css"/>
+</head>
+<body>
+  <header class="site-header">
+    <div class="brand">${siteTitle}</div>
+    <div class="version-switcher">${versionSwitcher}</div>
+  </header>
+  <div class="layout">
+    <nav class="sidebar" aria-label="Documentation">
+      ${nav}
+    </nav>
+    <main class="content">
+      <p class="version-label">${versionLabel}</p>
+      <article>
+        ${content}
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/product-docs/assets/site.css
+++ b/product-docs/assets/site.css
@@ -1,0 +1,91 @@
+:root {
+  --bg: #f8fafc;
+  --fg: #0f172a;
+  --muted: #64748b;
+  --accent: #0369a1;
+  --border: #e2e8f0;
+  --sidebar-w: 16rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  line-height: 1.55;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: #fff;
+}
+
+.brand {
+  font-weight: 650;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  min-height: calc(100vh - 3.25rem);
+}
+
+.sidebar {
+  padding: 1rem;
+  border-right: 1px solid var(--border);
+  background: #fff;
+}
+
+.sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 0.75rem;
+}
+
+.sidebar > ul {
+  padding-left: 0;
+}
+
+.sidebar a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.sidebar a:hover {
+  text-decoration: underline;
+}
+
+.content {
+  padding: 1.25rem 1.75rem 3rem;
+  max-width: 52rem;
+}
+
+.version-label {
+  color: var(--muted);
+  font-size: 0.875rem;
+  margin: 0 0 0.5rem;
+}
+
+article h1:first-child {
+  margin-top: 0;
+}
+
+@media (max-width: 800px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,28 @@ Out of scope for spec 994 (must NOT be touched):
 
 ## Scripts
 
+### `build-cms-docs.bat` / `build-cms-docs.sh`
+
+Build the **product documentation Virtual Site** (`product-docs/`) to static HTML using the
+`system` module Virtual Site build service (`PSVirtualSiteBuildMain`).
+
+- **Purpose**: Offline/CI dogfood of Git-backed docs assembly (Markdown + frontmatter → HTML).
+- **Defaults**: site root = repo `product-docs/`; output = `tmp/product-docs-site/`.
+- **Usage**:
+
+  ```bat
+  scripts\build-cms-docs.bat
+  scripts\build-cms-docs.bat C:\path\to\product-docs C:\path\to\out
+  ```
+
+  ```bash
+  scripts/build-cms-docs.sh
+  scripts/build-cms-docs.sh /path/to/product-docs /path/to/out
+  ```
+
+- **Prereqs**: JDK 21, repo-root `mvnw`/`mvnw.cmd`, network once for Maven deps.
+- **Design docs**: `docs/ai-generated/tasks/virtual-sites-git-docs/`.
+
 ### Third-party license inventory (Maven + npm merge)
 
 **Not a Python script.** Merged inventory generation for issue #1689 lives in

--- a/scripts/build-cms-docs.bat
+++ b/scripts/build-cms-docs.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Build product-docs Virtual Site to static HTML via Maven exec:java (system module).
+REM Usage: scripts\build-cms-docs.bat [siteRoot] [outputRoot]
+setlocal
+set "REPO_ROOT=%~dp0.."
+set "SITE_ROOT=%~1"
+if "%SITE_ROOT%"=="" set "SITE_ROOT=%REPO_ROOT%\product-docs"
+set "OUT_ROOT=%~2"
+if "%OUT_ROOT%"=="" set "OUT_ROOT=%REPO_ROOT%\tmp\product-docs-site"
+
+pushd "%REPO_ROOT%\system" || exit /b 1
+call "..\mvnw.cmd" -q -DskipTests compile org.codehaus.mojo:exec-maven-plugin:3.5.0:java ^
+  "-Dexec.classpathScope=compile" ^
+  "-Dexec.mainClass=com.percussion.services.virtualsite.PSVirtualSiteBuildMain" ^
+  "-Dexec.args=%SITE_ROOT% %OUT_ROOT% product-docs"
+set "RC=%ERRORLEVEL%"
+popd
+exit /b %RC%

--- a/scripts/build-cms-docs.sh
+++ b/scripts/build-cms-docs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build product-docs Virtual Site to static HTML via Maven exec:java (system module).
+# Usage: scripts/build-cms-docs.sh [siteRoot] [outputRoot]
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SITE_ROOT="${1:-${REPO_ROOT}/product-docs}"
+OUT_ROOT="${2:-${REPO_ROOT}/tmp/product-docs-site}"
+
+cd "${REPO_ROOT}/system"
+exec ../mvnw -q -DskipTests compile org.codehaus.mojo:exec-maven-plugin:3.5.0:java \
+  -Dexec.classpathScope=compile \
+  -Dexec.mainClass=com.percussion.services.virtualsite.PSVirtualSiteBuildMain \
+  -Dexec.args="${SITE_ROOT} ${OUT_ROOT} product-docs"

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -336,6 +336,13 @@
 			<groupId>org.commonmark</groupId>
 			<artifactId>commonmark</artifactId>
 		</dependency>
+		<!-- SnakeYAML for Virtual Site frontmatter / _config.yaml (Git-backed docs).
+		     Parent dependencyManagement scopes snakeyaml as runtime-only; we need compile. -->
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<scope>compile</scope>
+		</dependency>
 		<dependency>
 			<groupId>javax.jcr</groupId>
 			<artifactId>jcr</artifactId>

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualParticipantService.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualParticipantService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+/** Registry of Virtual Site page identities for link integrity (Phase 1: file/memory). */
+public interface IPSVirtualParticipantService {
+
+  void upsert(VirtualParticipant participant);
+
+  Optional<VirtualParticipant> find(String siteKey, String stableId);
+
+  Collection<VirtualParticipant> list(String siteKey);
+
+  /** Persist all participants for a site (implementation-specific). */
+  void flush(String siteKey) throws IOException;
+}

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * SPI for Virtual Site content sources. Phase 1: {@link PSGitFilesystemVirtualSiteSource}.
+ * Future adapters (SQL, API, …) implement this interface.
+ */
+public interface IPSVirtualSiteSource {
+
+  /** Wire name for this source type (e.g. {@code git-filesystem}). */
+  String sourceType();
+
+  /**
+   * Discover all page references under the configured root.
+   *
+   * @param config site config with root and versions
+   * @return ordered discovery list (not necessarily final nav order)
+   * @throws IOException on filesystem errors
+   * @throws VirtualSiteException on contract validation failures
+   */
+  List<VirtualItemRef> discover(VirtualSiteConfig config) throws IOException, VirtualSiteException;
+
+  /**
+   * Load full content for a previously discovered ref.
+   *
+   * @param config site config
+   * @param ref item reference
+   * @return loaded item
+   * @throws IOException on filesystem errors
+   * @throws VirtualSiteException on parse/validation failures
+   */
+  VirtualItem load(VirtualSiteConfig config, VirtualItemRef ref)
+      throws IOException, VirtualSiteException;
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSGitFilesystemVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSGitFilesystemVirtualSiteSource.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.virtualsite.VirtualFrontmatterParser.Parsed;
+import com.percussion.services.virtualsite.VirtualSiteConfig.VersionSpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Phase 1 Virtual Site source: local filesystem tree (Git checkout). Discovers {@code *.md} under
+ * each configured version path.
+ */
+public class PSGitFilesystemVirtualSiteSource implements IPSVirtualSiteSource {
+
+  @Override
+  public String sourceType() {
+    return VirtualSiteSourceType.GIT_FILESYSTEM.wireName();
+  }
+
+  @Override
+  public List<VirtualItemRef> discover(VirtualSiteConfig config)
+      throws IOException, VirtualSiteException {
+    List<VirtualItemRef> refs = new ArrayList<>();
+    Map<String, Path> seenIds = new HashMap<>();
+
+    for (VersionSpec version : config.versions()) {
+      Path versionRoot = config.root().resolve(version.path());
+      if (!Files.isDirectory(versionRoot)) {
+        throw new VirtualSiteException("Version path not found: " + versionRoot);
+      }
+      try (Stream<Path> walk = Files.walk(versionRoot)) {
+        List<Path> mdFiles =
+            walk.filter(Files::isRegularFile)
+                .filter(p -> p.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".md"))
+                .sorted(Comparator.comparing(p -> p.toString().replace('\\', '/')))
+                .toList();
+        for (Path abs : mdFiles) {
+          Path rel = config.root().relativize(abs);
+          Parsed parsed = parseFile(abs, version.id(), rel.toString());
+          String idKey = version.id() + "\0" + parsed.frontmatter().id();
+          Path previous = seenIds.put(idKey, rel);
+          if (previous != null) {
+            throw new VirtualSiteException(
+                "Duplicate frontmatter id '"
+                    + parsed.frontmatter().id()
+                    + "' in version "
+                    + version.id()
+                    + ": "
+                    + previous
+                    + " and "
+                    + rel);
+          }
+          refs.add(
+              new VirtualItemRef(
+                  parsed.frontmatter().id(),
+                  version.id(),
+                  rel,
+                  parsed.frontmatter().order(),
+                  parsed.frontmatter().title()));
+        }
+      }
+    }
+    refs.sort(
+        Comparator.comparing(VirtualItemRef::versionId)
+            .thenComparingInt(VirtualItemRef::order)
+            .thenComparing(r -> r.relativePath().toString().replace('\\', '/')));
+    return refs;
+  }
+
+  @Override
+  public VirtualItem load(VirtualSiteConfig config, VirtualItemRef ref)
+      throws IOException, VirtualSiteException {
+    Path abs = config.root().resolve(ref.relativePath()).normalize();
+    if (!abs.startsWith(config.root().normalize())) {
+      throw new VirtualSiteException("Ref escapes site root: " + ref.relativePath());
+    }
+    Parsed parsed = parseFile(abs, ref.versionId(), ref.relativePath().toString());
+    return new VirtualItem(ref, parsed.frontmatter(), parsed.body(), abs);
+  }
+
+  private static Parsed parseFile(Path abs, String versionId, String label)
+      throws IOException, VirtualSiteException {
+    String text = Files.readString(abs, StandardCharsets.UTF_8);
+    return VirtualFrontmatterParser.parse(text, versionId, label);
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSInMemoryVirtualParticipantService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSInMemoryVirtualParticipantService.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory virtual participant registry with optional JSON-lines flush for offline builds.
+ *
+ * <p>Not a Hibernate entity — Phase 1 avoids CMS content IDs and {@code PSX_MANAGEDLINK}.
+ */
+public class PSInMemoryVirtualParticipantService implements IPSVirtualParticipantService {
+
+  private final Map<String, Map<String, VirtualParticipant>> bySite = new ConcurrentHashMap<>();
+  private final Path flushDirectory;
+
+  public PSInMemoryVirtualParticipantService() {
+    this(null);
+  }
+
+  /**
+   * @param flushDirectory if non-null, {@link #flush(String)} writes {@code participants-<site>.jsonl}
+   */
+  public PSInMemoryVirtualParticipantService(Path flushDirectory) {
+    this.flushDirectory = flushDirectory;
+  }
+
+  @Override
+  public void upsert(VirtualParticipant participant) {
+    bySite
+        .computeIfAbsent(participant.siteKey(), k -> new ConcurrentHashMap<>())
+        .put(participant.stableId(), participant);
+  }
+
+  @Override
+  public Optional<VirtualParticipant> find(String siteKey, String stableId) {
+    Map<String, VirtualParticipant> map = bySite.get(siteKey);
+    if (map == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(map.get(stableId));
+  }
+
+  @Override
+  public Collection<VirtualParticipant> list(String siteKey) {
+    Map<String, VirtualParticipant> map = bySite.get(siteKey);
+    if (map == null) {
+      return List.of();
+    }
+    return List.copyOf(map.values());
+  }
+
+  @Override
+  public void flush(String siteKey) throws IOException {
+    if (flushDirectory == null) {
+      return;
+    }
+    Files.createDirectories(flushDirectory);
+    Path out = flushDirectory.resolve("participants-" + sanitize(siteKey) + ".jsonl");
+    Collection<VirtualParticipant> all = list(siteKey);
+    List<String> lines = new ArrayList<>();
+    for (VirtualParticipant p : all) {
+      lines.add(toJsonLine(p));
+    }
+    Files.write(out, lines, StandardCharsets.UTF_8);
+  }
+
+  private static String sanitize(String siteKey) {
+    return siteKey.replaceAll("[^a-zA-Z0-9._-]", "_");
+  }
+
+  private static String toJsonLine(VirtualParticipant p) {
+    // Minimal JSON without pulling a full object mapper dependency into this path.
+    return "{"
+        + "\"siteKey\":\""
+        + esc(p.siteKey())
+        + "\","
+        + "\"stableId\":\""
+        + esc(p.stableId())
+        + "\","
+        + "\"versionId\":\""
+        + esc(p.versionId())
+        + "\","
+        + "\"publishedPath\":\""
+        + esc(p.publishedPath())
+        + "\","
+        + "\"sourcePath\":\""
+        + esc(p.sourcePath())
+        + "\""
+        + "}";
+  }
+
+  private static String esc(String s) {
+    if (s == null) {
+      return "";
+    }
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  /** Snapshot of all sites (testing). */
+  public Map<String, Map<String, VirtualParticipant>> snapshot() {
+    Map<String, Map<String, VirtualParticipant>> copy = new LinkedHashMap<>();
+    for (Map.Entry<String, Map<String, VirtualParticipant>> e : bySite.entrySet()) {
+      copy.put(e.getKey(), Map.copyOf(e.getValue()));
+    }
+    return copy;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildMain.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildMain.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+
+/**
+ * CLI entry for offline Virtual Site builds.
+ *
+ * <p>Usage: {@code PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey]}
+ */
+public final class PSVirtualSiteBuildMain {
+
+  private PSVirtualSiteBuildMain() {}
+
+  public static void main(String[] args) throws Exception {
+    if (args.length < 2) {
+      System.err.println(
+          "Usage: PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey]");
+      System.exit(2);
+    }
+    Path siteRoot = Path.of(args[0]);
+    Path outputRoot = Path.of(args[1]);
+    String siteKey = args.length >= 3 ? args[2] : "product-docs";
+
+    Path participantDir = outputRoot.resolve("_meta");
+    IPSVirtualParticipantService participants =
+        new PSInMemoryVirtualParticipantService(participantDir);
+    PSVirtualSiteBuildService service =
+        new PSVirtualSiteBuildService(new PSGitFilesystemVirtualSiteSource(), participants);
+
+    PSVirtualSiteBuildResult result = service.build(siteRoot, outputRoot, siteKey);
+    System.out.println(
+        "Built "
+            + result.pageCount()
+            + " page(s) → "
+            + result.outputRoot().toAbsolutePath());
+    if (result.hasLinkProblems()) {
+      System.err.println("Link problems (" + result.linkProblems().size() + "):");
+      for (String p : result.linkProblems()) {
+        System.err.println("  " + p);
+      }
+      System.exit(1);
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildResult.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Outcome of a Virtual Site static build. */
+public final class PSVirtualSiteBuildResult {
+
+  private final Path outputRoot;
+  private final int pageCount;
+  private final List<String> linkProblems;
+  private final List<String> writtenFiles;
+
+  public PSVirtualSiteBuildResult(
+      Path outputRoot, int pageCount, List<String> linkProblems, List<String> writtenFiles) {
+    this.outputRoot = outputRoot;
+    this.pageCount = pageCount;
+    this.linkProblems =
+        linkProblems == null
+            ? List.of()
+            : Collections.unmodifiableList(new ArrayList<>(linkProblems));
+    this.writtenFiles =
+        writtenFiles == null
+            ? List.of()
+            : Collections.unmodifiableList(new ArrayList<>(writtenFiles));
+  }
+
+  public Path outputRoot() {
+    return outputRoot;
+  }
+
+  public int pageCount() {
+    return pageCount;
+  }
+
+  public List<String> linkProblems() {
+    return linkProblems;
+  }
+
+  public List<String> writtenFiles() {
+    return writtenFiles;
+  }
+
+  public boolean hasLinkProblems() {
+    return !linkProblems.isEmpty();
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.assembly.impl.plugin.PSTextAssemblerSupport;
+import com.percussion.services.virtualsite.VirtualSiteConfig.VersionSpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * End-to-end Virtual Site build: discover → assemble Markdown → layout → static emit → register
+ * participants → link check.
+ *
+ * <p>Does not require Spring or a CMS repository. Safe for offline / CI dogfood.
+ */
+public class PSVirtualSiteBuildService {
+
+  private final IPSVirtualSiteSource source;
+  private final IPSVirtualParticipantService participants;
+
+  public PSVirtualSiteBuildService() {
+    this(new PSGitFilesystemVirtualSiteSource(), new PSInMemoryVirtualParticipantService());
+  }
+
+  public PSVirtualSiteBuildService(
+      IPSVirtualSiteSource source, IPSVirtualParticipantService participants) {
+    this.source = source != null ? source : new PSGitFilesystemVirtualSiteSource();
+    this.participants =
+        participants != null ? participants : new PSInMemoryVirtualParticipantService();
+  }
+
+  /**
+   * Build a Virtual Site from a filesystem root into {@code outputRoot}.
+   *
+   * @param siteRoot source tree (contains {@code _config.yaml})
+   * @param outputRoot destination for HTML + assets
+   * @param siteKey participant key
+   * @return build result
+   */
+  public PSVirtualSiteBuildResult build(Path siteRoot, Path outputRoot, String siteKey)
+      throws IOException, VirtualSiteException {
+    VirtualSiteConfig config =
+        VirtualSiteConfigLoader.load(siteRoot, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, siteKey);
+    return build(config, outputRoot);
+  }
+
+  public PSVirtualSiteBuildResult build(VirtualSiteConfig config, Path outputRoot)
+      throws IOException, VirtualSiteException {
+    Files.createDirectories(outputRoot);
+
+    List<VirtualItemRef> refs = source.discover(config);
+    List<VirtualItem> items = new ArrayList<>();
+    for (VirtualItemRef ref : refs) {
+      items.add(source.load(config, ref));
+    }
+
+    // ids / paths per version for link checks and participants
+    Map<String, Map<String, String>> idsByVersion = new HashMap<>();
+    Map<String, Set<String>> pathsByVersion = new HashMap<>();
+    for (VirtualItem item : items) {
+      String ver = item.ref().versionId();
+      String href = VirtualNavBuilder.toHref(item.ref().relativePath());
+      idsByVersion
+          .computeIfAbsent(ver, k -> new HashMap<>())
+          .put(item.frontmatter().id(), href);
+      pathsByVersion.computeIfAbsent(ver, k -> new LinkedHashSet<>()).add(href);
+    }
+
+    Map<String, List<VirtualNavNode>> navByVersion = new HashMap<>();
+    for (VersionSpec v : config.versions()) {
+      List<VirtualItemRef> versionRefs =
+          refs.stream().filter(r -> r.versionId().equals(v.id())).toList();
+      navByVersion.put(v.id(), VirtualNavBuilder.build(v.path(), versionRefs, config));
+    }
+
+    List<String> written = new ArrayList<>();
+    List<String> linkProblems = new ArrayList<>();
+
+    for (VirtualItem item : items) {
+      String sourcePath = item.ref().relativePath().toString().replace('\\', '/');
+      Map<String, String> ids =
+          idsByVersion.getOrDefault(item.ref().versionId(), Map.of());
+      String rewrittenBody =
+          VirtualMarkdownLinkRewriter.rewrite(item.markdownBody(), sourcePath, ids);
+      String contentHtml = PSTextAssemblerSupport.renderMarkdown(rewrittenBody, Map.of());
+      VersionSpec version = findVersion(config, item.ref().versionId());
+      String navHtml =
+          PSVirtualSiteLayoutRenderer.renderNavHtml(
+              navByVersion.getOrDefault(item.ref().versionId(), List.of()));
+      String versionSwitcher =
+          PSVirtualSiteLayoutRenderer.renderVersionSwitcher(config, item.ref().versionId());
+      String html =
+          PSVirtualSiteLayoutRenderer.render(
+              config.themeDir(),
+              config.layoutFile(),
+              config.siteTitle(),
+              item.frontmatter().title(),
+              item.frontmatter().description(),
+              contentHtml,
+              navHtml,
+              version != null ? version.label() : item.ref().versionId(),
+              versionSwitcher);
+
+      String href = VirtualNavBuilder.toHref(item.ref().relativePath());
+      Path outFile = resolveHref(outputRoot, href);
+      Files.createDirectories(outFile.getParent());
+      Files.writeString(outFile, html, StandardCharsets.UTF_8);
+      written.add(href);
+
+      participants.upsert(
+          new VirtualParticipant(
+              config.siteKey(),
+              item.frontmatter().id(),
+              item.ref().versionId(),
+              href,
+              sourcePath));
+
+      linkProblems.addAll(
+          VirtualLinkChecker.checkPage(
+              config.siteKey(),
+              item.ref().versionId(),
+              sourcePath,
+              item.markdownBody(),
+              ids,
+              pathsByVersion.getOrDefault(item.ref().versionId(), Set.of())));
+    }
+
+    copyAssets(config.assetsDir(), outputRoot.resolve("assets"));
+    if (Files.isDirectory(config.themeDir().resolve("assets"))) {
+      copyAssets(config.themeDir().resolve("assets"), outputRoot.resolve("assets"));
+    }
+
+    participants.flush(config.siteKey());
+
+    // Write link report
+    Path report = outputRoot.resolve("link-report.txt");
+    if (linkProblems.isEmpty()) {
+      Files.writeString(report, "OK: no link problems\n", StandardCharsets.UTF_8);
+    } else {
+      Files.writeString(
+          report, String.join("\n", linkProblems) + "\n", StandardCharsets.UTF_8);
+    }
+    written.add("link-report.txt");
+
+    return new PSVirtualSiteBuildResult(outputRoot, items.size(), linkProblems, written);
+  }
+
+  private static VersionSpec findVersion(VirtualSiteConfig config, String id) {
+    for (VersionSpec v : config.versions()) {
+      if (v.id().equals(id)) {
+        return v;
+      }
+    }
+    return null;
+  }
+
+  static Path resolveHref(Path outputRoot, String href) {
+    Path p = outputRoot;
+    for (String seg : href.split("/")) {
+      if (!seg.isEmpty()) {
+        p = p.resolve(seg);
+      }
+    }
+    return p;
+  }
+
+  private static void copyAssets(Path from, Path to) throws IOException {
+    if (!Files.isDirectory(from)) {
+      return;
+    }
+    Files.createDirectories(to);
+    Files.walkFileTree(
+        from,
+        new SimpleFileVisitor<>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+              throws IOException {
+            Path rel = from.relativize(dir);
+            Path dest = to.resolve(rel.toString());
+            Files.createDirectories(dest);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Path rel = from.relativize(file);
+            Path dest = to.resolve(rel.toString());
+            Files.createDirectories(dest.getParent());
+            Files.copy(file, dest, StandardCopyOption.REPLACE_EXISTING);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.sitemgr.IPSSite;
+import com.percussion.services.sitemgr.data.PSSite;
+import com.percussion.services.sitemgr.data.PSSiteProperty;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Site property contract for Virtual Sites (Phase 1 — no new {@code RXSITES} columns).
+ *
+ * <p>Property keys:
+ *
+ * <ul>
+ *   <li>{@code virtual.sourceKind} — e.g. {@code git-filesystem}; blank ⇒ repository
+ *   <li>{@code virtual.rootPath} — filesystem path to Virtual Site root
+ *   <li>{@code virtual.configFile} — optional; default {@code _config.yaml}
+ *   <li>{@code virtual.siteKey} — optional participant key; default site name
+ * </ul>
+ */
+public final class PSVirtualSiteHelper {
+
+  public static final String PROP_SOURCE_KIND = "virtual.sourceKind";
+  public static final String PROP_ROOT_PATH = "virtual.rootPath";
+  public static final String PROP_CONFIG_FILE = "virtual.configFile";
+  public static final String PROP_SITE_KEY = "virtual.siteKey";
+
+  private PSVirtualSiteHelper() {}
+
+  public static SourceKind sourceKind(IPSSite site) {
+    String kind = findProperty(site, PROP_SOURCE_KIND).orElse("");
+    if (StringUtils.isBlank(kind) || "repository".equalsIgnoreCase(kind.trim())) {
+      return SourceKind.REPOSITORY;
+    }
+    return SourceKind.VIRTUAL;
+  }
+
+  public static boolean isVirtual(IPSSite site) {
+    return sourceKind(site) == SourceKind.VIRTUAL;
+  }
+
+  public static Optional<VirtualSiteSourceType> virtualSourceType(IPSSite site) {
+    return findProperty(site, PROP_SOURCE_KIND).map(VirtualSiteSourceType::fromWireName);
+  }
+
+  public static Optional<Path> rootPath(IPSSite site) {
+    return findProperty(site, PROP_ROOT_PATH).filter(StringUtils::isNotBlank).map(Path::of);
+  }
+
+  public static String configFile(IPSSite site) {
+    return findProperty(site, PROP_CONFIG_FILE)
+        .filter(StringUtils::isNotBlank)
+        .orElse(VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE);
+  }
+
+  public static String siteKey(IPSSite site) {
+    Optional<String> key = findProperty(site, PROP_SITE_KEY).filter(StringUtils::isNotBlank);
+    if (key.isPresent()) {
+      return key.get();
+    }
+    if (site != null && StringUtils.isNotBlank(site.getName())) {
+      return site.getName();
+    }
+    return "default";
+  }
+
+  /**
+   * Find first property value by name across all contexts.
+   *
+   * <p>{@link IPSSite} does not expose properties; the concrete {@link PSSite} entity does.
+   *
+   * @param site may be null
+   * @param name property name
+   * @return value if present
+   */
+  public static Optional<String> findProperty(IPSSite site, String name) {
+    Objects.requireNonNull(name, "name");
+    if (site == null) {
+      return Optional.empty();
+    }
+    Set<PSSiteProperty> props = propertiesOf(site);
+    if (props.isEmpty()) {
+      return Optional.empty();
+    }
+    for (PSSiteProperty p : props) {
+      if (p != null && name.equals(p.getName()) && StringUtils.isNotBlank(p.getValue())) {
+        return Optional.of(p.getValue().trim());
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Set<PSSiteProperty> propertiesOf(IPSSite site) {
+    if (site instanceof PSSite ps) {
+      Set<PSSiteProperty> props = ps.getProperties();
+      return props != null ? props : Collections.emptySet();
+    }
+    return Collections.emptySet();
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteLayoutRenderer.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteLayoutRenderer.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.assembly.impl.plugin.PSBindingPlaceholderRenderer;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Applies HTML-first layout templates from {@code _theme/} using {@code ${path}} placeholders
+ * (ADR-002 / assembler Phase 1).
+ */
+public final class PSVirtualSiteLayoutRenderer {
+
+  private PSVirtualSiteLayoutRenderer() {}
+
+  public static String render(
+      Path themeDir,
+      String layoutFile,
+      String siteTitle,
+      String pageTitle,
+      String description,
+      String contentHtml,
+      String navHtml,
+      String versionLabel,
+      String versionSwitcherHtml)
+      throws IOException, VirtualSiteException {
+    Path layout = themeDir.resolve(layoutFile);
+    if (!Files.isRegularFile(layout)) {
+      // Built-in minimal layout when theme missing
+      return defaultLayout(
+          siteTitle, pageTitle, description, contentHtml, navHtml, versionLabel, versionSwitcherHtml);
+    }
+    String template = Files.readString(layout, StandardCharsets.UTF_8);
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("siteTitle", siteTitle);
+    bindings.put("pageTitle", pageTitle);
+    bindings.put("description", description != null ? description : "");
+    bindings.put("content", contentHtml);
+    bindings.put("nav", navHtml);
+    bindings.put("versionLabel", versionLabel != null ? versionLabel : "");
+    bindings.put("versionSwitcher", versionSwitcherHtml != null ? versionSwitcherHtml : "");
+    return PSBindingPlaceholderRenderer.render(template, bindings);
+  }
+
+  public static String renderNavHtml(List<VirtualNavNode> nodes) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("<ul class=\"vs-nav\">\n");
+    for (VirtualNavNode n : nodes) {
+      appendNode(sb, n, 1);
+    }
+    sb.append("</ul>\n");
+    return sb.toString();
+  }
+
+  private static void appendNode(StringBuilder sb, VirtualNavNode n, int depth) {
+    sb.append("  ".repeat(depth));
+    sb.append("<li>");
+    if (n.href() != null && !n.href().isBlank()) {
+      sb.append("<a href=\"")
+          .append(htmlEscape(VirtualMarkdownLinkRewriter.toSiteRootHref(n.href())))
+          .append("\">")
+          .append(htmlEscape(n.title()))
+          .append("</a>");
+    } else {
+      sb.append(htmlEscape(n.title()));
+    }
+    if (!n.children().isEmpty()) {
+      sb.append("\n").append("  ".repeat(depth)).append("<ul>\n");
+      for (VirtualNavNode c : n.children()) {
+        appendNode(sb, c, depth + 1);
+      }
+      sb.append("  ".repeat(depth)).append("</ul>\n").append("  ".repeat(depth));
+    }
+    sb.append("</li>\n");
+  }
+
+  public static String renderVersionSwitcher(VirtualSiteConfig config, String currentVersionId) {
+    if (config.versions().size() <= 1) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append("<select class=\"vs-version\" onchange=\"if(this.value)location.href=this.value\">");
+    for (VirtualSiteConfig.VersionSpec v : config.versions()) {
+      String href = VirtualMarkdownLinkRewriter.toSiteRootHref(v.path() + "/index.html");
+      sb.append("<option value=\"")
+          .append(htmlEscape(href))
+          .append("\"");
+      if (v.id().equals(currentVersionId)) {
+        sb.append(" selected");
+      }
+      sb.append(">").append(htmlEscape(v.label())).append("</option>");
+    }
+    sb.append("</select>");
+    return sb.toString();
+  }
+
+  private static String defaultLayout(
+      String siteTitle,
+      String pageTitle,
+      String description,
+      String contentHtml,
+      String navHtml,
+      String versionLabel,
+      String versionSwitcherHtml) {
+    return "<!DOCTYPE html>\n"
+        + "<html lang=\"en\">\n"
+        + "<head>\n"
+        + "<meta charset=\"utf-8\"/>\n"
+        + "<title>"
+        + htmlEscape(pageTitle)
+        + " — "
+        + htmlEscape(siteTitle)
+        + "</title>\n"
+        + "<meta name=\"description\" content=\""
+        + htmlEscape(description)
+        + "\"/>\n"
+        + "<link rel=\"stylesheet\" href=\"/assets/site.css\"/>\n"
+        + "</head>\n"
+        + "<body>\n"
+        + "<header><h1>"
+        + htmlEscape(siteTitle)
+        + "</h1>"
+        + versionSwitcherHtml
+        + "</header>\n"
+        + "<div class=\"layout\">\n"
+        + "<nav>"
+        + navHtml
+        + "</nav>\n"
+        + "<main>\n"
+        + "<p class=\"version\">"
+        + htmlEscape(versionLabel)
+        + "</p>\n"
+        + "<h1>"
+        + htmlEscape(pageTitle)
+        + "</h1>\n"
+        + contentHtml
+        + "\n</main>\n"
+        + "</div>\n"
+        + "</body>\n"
+        + "</html>\n";
+  }
+
+  static String htmlEscape(String s) {
+    if (s == null) {
+      return "";
+    }
+    return s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;");
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/SourceKind.java
+++ b/system/services/src/com/percussion/services/virtualsite/SourceKind.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+/**
+ * Whether a Site is backed by the content repository or an external Virtual Site source.
+ */
+public enum SourceKind {
+  /** Traditional Site: content lives in the Percussion repository. */
+  REPOSITORY,
+  /** Virtual Site: content discovered from an external adapter. */
+  VIRTUAL
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualFrontmatter.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualFrontmatter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Parsed page frontmatter for a Virtual Site Markdown page. */
+public final class VirtualFrontmatter {
+
+  private final String id;
+  private final String title;
+  private final String description;
+  private final String version;
+  private final boolean sidebar;
+  private final int order;
+  private final List<String> tags;
+  private final boolean deprecated;
+
+  public VirtualFrontmatter(
+      String id,
+      String title,
+      String description,
+      String version,
+      boolean sidebar,
+      int order,
+      List<String> tags,
+      boolean deprecated) {
+    this.id = Objects.requireNonNull(id, "id");
+    this.title = Objects.requireNonNull(title, "title");
+    this.description = description != null ? description : "";
+    this.version = version;
+    this.sidebar = sidebar;
+    this.order = order;
+    this.tags =
+        tags == null
+            ? List.of()
+            : Collections.unmodifiableList(new ArrayList<>(tags));
+    this.deprecated = deprecated;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public String title() {
+    return title;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public String version() {
+    return version;
+  }
+
+  public boolean sidebar() {
+    return sidebar;
+  }
+
+  public int order() {
+    return order;
+  }
+
+  public List<String> tags() {
+    return tags;
+  }
+
+  public boolean deprecated() {
+    return deprecated;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualFrontmatterParser.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualFrontmatterParser.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/**
+ * Parses Markdown files with optional YAML frontmatter between {@code ---} fences.
+ *
+ * <p>Pure helper — no Spring.
+ */
+public final class VirtualFrontmatterParser {
+
+  private VirtualFrontmatterParser() {}
+
+  /**
+   * Parse raw file text into frontmatter + body.
+   *
+   * @param text full file content, never null
+   * @param defaultVersion version inherited from folder when frontmatter omits {@code version}
+   * @param sourceLabel path label for error messages
+   * @return parse result
+   * @throws VirtualSiteException if required fields missing or YAML invalid
+   */
+  public static Parsed parse(String text, String defaultVersion, String sourceLabel)
+      throws VirtualSiteException {
+    if (text == null) {
+      throw new VirtualSiteException("Page text is null: " + sourceLabel);
+    }
+    String normalized = text.replace("\r\n", "\n").replace('\r', '\n');
+    if (!normalized.startsWith("---\n") && !normalized.equals("---")) {
+      throw new VirtualSiteException(
+          "Missing YAML frontmatter (expected leading ---) in " + sourceLabel);
+    }
+    int end = normalized.indexOf("\n---\n", 4);
+    String yamlBlock;
+    String body;
+    if (end < 0) {
+      // frontmatter only or closing --- at EOF
+      int endEof = normalized.indexOf("\n---", 4);
+      if (endEof < 0) {
+        throw new VirtualSiteException("Unclosed frontmatter in " + sourceLabel);
+      }
+      yamlBlock = normalized.substring(4, endEof);
+      body = normalized.substring(endEof + 4).replaceFirst("^\n", "");
+    } else {
+      yamlBlock = normalized.substring(4, end);
+      body = normalized.substring(end + 5);
+    }
+
+    Map<String, Object> map = loadYamlMap(yamlBlock, sourceLabel);
+    String id = stringVal(map.get("id"));
+    String title = stringVal(map.get("title"));
+    if (id == null || id.isBlank()) {
+      throw new VirtualSiteException("Frontmatter 'id' is required in " + sourceLabel);
+    }
+    if (title == null || title.isBlank()) {
+      throw new VirtualSiteException("Frontmatter 'title' is required in " + sourceLabel);
+    }
+    String description = stringVal(map.get("description"));
+    String version = stringVal(map.get("version"));
+    if (version == null || version.isBlank()) {
+      version = defaultVersion;
+    }
+    boolean sidebar = booleanVal(map.get("sidebar"), true);
+    int order = intVal(map.get("order"), 0);
+    List<String> tags = stringList(map.get("tags"));
+    boolean deprecated = booleanVal(map.get("deprecated"), false);
+
+    VirtualFrontmatter fm =
+        new VirtualFrontmatter(
+            id.trim(), title.trim(), description, version, sidebar, order, tags, deprecated);
+    return new Parsed(fm, body != null ? body : "");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> loadYamlMap(String yamlBlock, String sourceLabel)
+      throws VirtualSiteException {
+    try {
+      Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+      Object loaded = yaml.load(yamlBlock);
+      if (loaded == null) {
+        return new LinkedHashMap<>();
+      }
+      if (!(loaded instanceof Map)) {
+        throw new VirtualSiteException("Frontmatter must be a YAML mapping in " + sourceLabel);
+      }
+      return (Map<String, Object>) loaded;
+    } catch (VirtualSiteException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new VirtualSiteException("Invalid frontmatter YAML in " + sourceLabel, e);
+    }
+  }
+
+  private static String stringVal(Object o) {
+    return o == null ? null : String.valueOf(o).trim();
+  }
+
+  private static boolean booleanVal(Object o, boolean defaultValue) {
+    if (o == null) {
+      return defaultValue;
+    }
+    if (o instanceof Boolean b) {
+      return b;
+    }
+    return Boolean.parseBoolean(String.valueOf(o));
+  }
+
+  private static int intVal(Object o, int defaultValue) {
+    if (o == null) {
+      return defaultValue;
+    }
+    if (o instanceof Number n) {
+      return n.intValue();
+    }
+    try {
+      return Integer.parseInt(String.valueOf(o).trim());
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
+  }
+
+  private static List<String> stringList(Object o) {
+    if (o == null) {
+      return List.of();
+    }
+    if (o instanceof List<?> list) {
+      List<String> out = new ArrayList<>();
+      for (Object item : list) {
+        if (item != null) {
+          out.add(String.valueOf(item));
+        }
+      }
+      return out;
+    }
+    return List.of(String.valueOf(o));
+  }
+
+  /** Frontmatter + Markdown body after fences. */
+  public static final class Parsed {
+    private final VirtualFrontmatter frontmatter;
+    private final String body;
+
+    public Parsed(VirtualFrontmatter frontmatter, String body) {
+      this.frontmatter = frontmatter;
+      this.body = body;
+    }
+
+    public VirtualFrontmatter frontmatter() {
+      return frontmatter;
+    }
+
+    public String body() {
+      return body;
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualItem.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualItem.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/** Fully loaded Virtual Site page (frontmatter + Markdown body). */
+public final class VirtualItem {
+
+  private final VirtualItemRef ref;
+  private final VirtualFrontmatter frontmatter;
+  private final String markdownBody;
+  private final Path absolutePath;
+
+  public VirtualItem(
+      VirtualItemRef ref,
+      VirtualFrontmatter frontmatter,
+      String markdownBody,
+      Path absolutePath) {
+    this.ref = Objects.requireNonNull(ref, "ref");
+    this.frontmatter = Objects.requireNonNull(frontmatter, "frontmatter");
+    this.markdownBody = markdownBody != null ? markdownBody : "";
+    this.absolutePath = Objects.requireNonNull(absolutePath, "absolutePath");
+  }
+
+  public VirtualItemRef ref() {
+    return ref;
+  }
+
+  public VirtualFrontmatter frontmatter() {
+    return frontmatter;
+  }
+
+  public String markdownBody() {
+    return markdownBody;
+  }
+
+  public Path absolutePath() {
+    return absolutePath;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualItemRef.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualItemRef.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/** Lightweight discovery handle for a Virtual Site page. */
+public final class VirtualItemRef {
+
+  private final String id;
+  private final String versionId;
+  private final Path relativePath;
+  private final int order;
+  private final String title;
+
+  public VirtualItemRef(
+      String id, String versionId, Path relativePath, int order, String title) {
+    this.id = Objects.requireNonNull(id, "id");
+    this.versionId = Objects.requireNonNull(versionId, "versionId");
+    this.relativePath = Objects.requireNonNull(relativePath, "relativePath");
+    this.order = order;
+    this.title = title != null ? title : id;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public String versionId() {
+    return versionId;
+  }
+
+  public Path relativePath() {
+    return relativePath;
+  }
+
+  public int order() {
+    return order;
+  }
+
+  public String title() {
+    return title;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualLinkChecker.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualLinkChecker.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight broken-link detection for Virtual Site Markdown bodies.
+ *
+ * <p>Recognizes:
+ *
+ * <ul>
+ *   <li>Markdown links {@code [text](target)} where target is a relative {@code .md}/{@code .html}
+ *       path or {@code id:stable-id}
+ *   <li>Skips {@code http(s):}, {@code mailto:}, anchors-only {@code #frag}
+ * </ul>
+ */
+public final class VirtualLinkChecker {
+
+  private static final Pattern MD_LINK =
+      Pattern.compile("\\[[^\\]]*\\]\\(([^)]+)\\)");
+
+  private VirtualLinkChecker() {}
+
+  /**
+   * @param siteKey site key
+   * @param versionId version of the source page
+   * @param sourcePath relative source path of the page
+   * @param markdownBody body after frontmatter
+   * @param idsInVersion map of stableId → published path for this version
+   * @param publishedPaths set of published paths (forward-slash) for this version
+   * @return list of problem descriptions
+   */
+  public static List<String> checkPage(
+      String siteKey,
+      String versionId,
+      String sourcePath,
+      String markdownBody,
+      Map<String, String> idsInVersion,
+      Set<String> publishedPaths) {
+    List<String> problems = new ArrayList<>();
+    if (markdownBody == null || markdownBody.isEmpty()) {
+      return problems;
+    }
+    Matcher m = MD_LINK.matcher(markdownBody);
+    while (m.find()) {
+      String raw = m.group(1).trim();
+      // strip optional title in quotes
+      int space = indexOfUnquotedSpace(raw);
+      if (space > 0) {
+        raw = raw.substring(0, space).trim();
+      }
+      if (raw.startsWith("<") && raw.endsWith(">")) {
+        raw = raw.substring(1, raw.length() - 1);
+      }
+      String target = stripFragment(raw);
+      if (target.isEmpty() || isExternal(target)) {
+        continue;
+      }
+      if (target.toLowerCase(Locale.ROOT).startsWith("id:")) {
+        String id = target.substring(3).trim();
+        if (!idsInVersion.containsKey(id)) {
+          problems.add(
+              sourcePath
+                  + ": missing id target '"
+                  + id
+                  + "' (version "
+                  + versionId
+                  + ", site "
+                  + siteKey
+                  + ")");
+        }
+        continue;
+      }
+      // relative path — resolve against source directory using simple join (not OS Path — URL-ish)
+      String resolved = resolveRelative(sourcePath, target);
+      if (resolved.toLowerCase(Locale.ROOT).endsWith(".md")) {
+        resolved = resolved.substring(0, resolved.length() - 3) + ".html";
+      }
+      if (!publishedPaths.contains(resolved)) {
+        problems.add(sourcePath + ": missing path target '" + target + "' → " + resolved);
+      }
+    }
+    return problems;
+  }
+
+  private static int indexOfUnquotedSpace(String raw) {
+    boolean inQuote = false;
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (c == '"' || c == '\'') {
+        inQuote = !inQuote;
+      } else if (!inQuote && Character.isWhitespace(c)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static String stripFragment(String target) {
+    int hash = target.indexOf('#');
+    return hash >= 0 ? target.substring(0, hash) : target;
+  }
+
+  private static boolean isExternal(String target) {
+    String lower = target.toLowerCase(Locale.ROOT);
+    return lower.startsWith("http://")
+        || lower.startsWith("https://")
+        || lower.startsWith("mailto:")
+        || lower.startsWith("//");
+  }
+
+  static String resolveRelative(String sourcePath, String target) {
+    String src = sourcePath.replace('\\', '/');
+    String tgt = target.replace('\\', '/');
+    if (tgt.startsWith("/")) {
+      return tgt.substring(1);
+    }
+    int slash = src.lastIndexOf('/');
+    String dir = slash >= 0 ? src.substring(0, slash + 1) : "";
+    String combined = dir + tgt;
+    return normalizePosix(combined);
+  }
+
+  static String normalizePosix(String path) {
+    String[] parts = path.split("/");
+    List<String> stack = new ArrayList<>();
+    for (String p : parts) {
+      if (p.isEmpty() || ".".equals(p)) {
+        continue;
+      }
+      if ("..".equals(p)) {
+        if (!stack.isEmpty()) {
+          stack.remove(stack.size() - 1);
+        }
+        continue;
+      }
+      stack.add(p);
+    }
+    return String.join("/", stack);
+  }
+
+  /** Convenience for unique path set. */
+  public static Set<String> pathSet(Iterable<String> paths) {
+    Set<String> set = new LinkedHashSet<>();
+    for (String p : paths) {
+      set.add(p.replace('\\', '/'));
+    }
+    return set;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualMarkdownLinkRewriter.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualMarkdownLinkRewriter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rewrites Markdown link targets for static site emit.
+ *
+ * <ul>
+ *   <li>{@code id:stable-id} → site-root published path ({@code /8.2/...html})
+ *   <li>Relative {@code *.md} paths → resolved + {@code .html}
+ *   <li>Leaves {@code http(s):}, {@code mailto:}, and bare anchors alone
+ * </ul>
+ */
+public final class VirtualMarkdownLinkRewriter {
+
+  private static final Pattern MD_LINK = Pattern.compile("\\[([^\\]]*)\\]\\(([^)]+)\\)");
+
+  private VirtualMarkdownLinkRewriter() {}
+
+  /**
+   * @param markdownBody body after frontmatter
+   * @param sourcePath source relative path (e.g. {@code 8.2/index.md})
+   * @param idsInVersion stableId → published path (no leading slash)
+   * @return body with rewritten link targets
+   */
+  public static String rewrite(
+      String markdownBody, String sourcePath, Map<String, String> idsInVersion) {
+    if (markdownBody == null || markdownBody.isEmpty()) {
+      return markdownBody == null ? "" : markdownBody;
+    }
+    Matcher m = MD_LINK.matcher(markdownBody);
+    StringBuilder out = new StringBuilder();
+    while (m.find()) {
+      String text = m.group(1);
+      String rawDest = m.group(2).trim();
+      String titleSuffix = "";
+      int space = indexOfUnquotedSpace(rawDest);
+      if (space > 0) {
+        titleSuffix = rawDest.substring(space);
+        rawDest = rawDest.substring(0, space).trim();
+      }
+      if (rawDest.startsWith("<") && rawDest.endsWith(">")) {
+        rawDest = rawDest.substring(1, rawDest.length() - 1);
+      }
+      String fragment = "";
+      String target = rawDest;
+      int hash = rawDest.indexOf('#');
+      if (hash >= 0) {
+        fragment = rawDest.substring(hash);
+        target = rawDest.substring(0, hash);
+      }
+      String rewritten = rewriteTarget(target, sourcePath, idsInVersion);
+      String replacement = "[" + text + "](" + rewritten + fragment + titleSuffix + ")";
+      m.appendReplacement(out, Matcher.quoteReplacement(replacement));
+    }
+    m.appendTail(out);
+    return out.toString();
+  }
+
+  static String rewriteTarget(
+      String target, String sourcePath, Map<String, String> idsInVersion) {
+    if (target == null || target.isEmpty()) {
+      return target == null ? "" : target;
+    }
+    String lower = target.toLowerCase(Locale.ROOT);
+    if (lower.startsWith("http://")
+        || lower.startsWith("https://")
+        || lower.startsWith("mailto:")
+        || lower.startsWith("//")
+        || target.startsWith("#")) {
+      return target;
+    }
+    if (lower.startsWith("id:")) {
+      String id = target.substring(3).trim();
+      String published = idsInVersion != null ? idsInVersion.get(id) : null;
+      if (published == null || published.isBlank()) {
+        // leave unresolved; link checker reports separately
+        return target;
+      }
+      return toSiteRootHref(published);
+    }
+    String resolved = VirtualLinkChecker.resolveRelative(sourcePath, target);
+    if (resolved.toLowerCase(Locale.ROOT).endsWith(".md")) {
+      resolved = resolved.substring(0, resolved.length() - 3) + ".html";
+    }
+    return toSiteRootHref(resolved);
+  }
+
+  /** Published path without leading slash → site-root absolute href. */
+  public static String toSiteRootHref(String publishedPath) {
+    if (publishedPath == null || publishedPath.isBlank()) {
+      return "/";
+    }
+    String p = publishedPath.replace('\\', '/');
+    if (p.startsWith("/")) {
+      return p;
+    }
+    return "/" + p;
+  }
+
+  private static int indexOfUnquotedSpace(String raw) {
+    boolean inQuote = false;
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (c == '"' || c == '\'') {
+        inQuote = !inQuote;
+      } else if (!inQuote && Character.isWhitespace(c)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualNavBuilder.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualNavBuilder.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Builds a simple hierarchical nav tree from discovered page refs under a version folder. Uses
+ * folder segments + frontmatter order; optional config {@code nav} only affects top-level titles.
+ */
+public final class VirtualNavBuilder {
+
+  private VirtualNavBuilder() {}
+
+  /**
+   * Build nav for one version.
+   *
+   * @param versionPath version directory name as in config (e.g. {@code 8.2})
+   * @param refs all refs for this version
+   * @param config site config (nav overrides)
+   * @return top-level nav nodes
+   */
+  public static List<VirtualNavNode> build(
+      String versionPath, List<VirtualItemRef> refs, VirtualSiteConfig config) {
+    // sectionKey (first folder under version, or "" for root pages) -> pages
+    Map<String, List<VirtualItemRef>> bySection = new LinkedHashMap<>();
+    for (VirtualItemRef ref : refs) {
+      Path rel = ref.relativePath();
+      // rel is like 8.2/getting-started/install.md
+      Path underVersion = stripVersionPrefix(rel, versionPath);
+      String section = sectionKey(underVersion);
+      bySection.computeIfAbsent(section, k -> new ArrayList<>()).add(ref);
+    }
+
+    Map<String, String> navTitles = new LinkedHashMap<>();
+    for (VirtualSiteConfig.NavSpec n : config.nav()) {
+      navTitles.put(n.id(), n.title());
+    }
+
+    List<VirtualNavNode> roots = new ArrayList<>();
+    for (Map.Entry<String, List<VirtualItemRef>> e : bySection.entrySet()) {
+      String section = e.getKey();
+      List<VirtualItemRef> pages = new ArrayList<>(e.getValue());
+      pages.sort(
+          Comparator.comparingInt(VirtualItemRef::order)
+              .thenComparing(VirtualItemRef::title, String.CASE_INSENSITIVE_ORDER));
+
+      if (section.isEmpty()) {
+        for (VirtualItemRef p : pages) {
+          roots.add(
+              new VirtualNavNode(
+                  p.title(), p.id(), toHref(p.relativePath()), p.order(), List.of()));
+        }
+        continue;
+      }
+
+      String title =
+          navTitles.getOrDefault(section, humanize(section));
+      VirtualItemRef index = findIndex(pages, section);
+      String href = index != null ? toHref(index.relativePath()) : toHref(pages.get(0).relativePath());
+      int order = index != null ? index.order() : pages.get(0).order();
+      String sectionId = index != null ? index.id() : section;
+
+      List<VirtualNavNode> children = new ArrayList<>();
+      for (VirtualItemRef p : pages) {
+        if (index != null && p.id().equals(index.id())) {
+          continue;
+        }
+        children.add(
+            new VirtualNavNode(p.title(), p.id(), toHref(p.relativePath()), p.order(), List.of()));
+      }
+      roots.add(new VirtualNavNode(title, sectionId, href, order, children));
+    }
+
+    roots.sort(
+        Comparator.comparingInt(VirtualNavNode::order)
+            .thenComparing(VirtualNavNode::title, String.CASE_INSENSITIVE_ORDER));
+    return roots;
+  }
+
+  private static Path stripVersionPrefix(Path rel, String versionPath) {
+    String first = rel.getNameCount() > 0 ? rel.getName(0).toString() : "";
+    if (first.equals(versionPath) && rel.getNameCount() > 1) {
+      return rel.subpath(1, rel.getNameCount());
+    }
+    if (first.equals(versionPath)) {
+      return Path.of("");
+    }
+    return rel;
+  }
+
+  private static String sectionKey(Path underVersion) {
+    if (underVersion == null || underVersion.getNameCount() == 0) {
+      return "";
+    }
+    String name = underVersion.getName(0).toString();
+    if (underVersion.getNameCount() == 1 && isMarkdown(name)) {
+      return ""; // page at version root
+    }
+    return name;
+  }
+
+  private static boolean isMarkdown(String name) {
+    return name.toLowerCase(Locale.ROOT).endsWith(".md");
+  }
+
+  private static VirtualItemRef findIndex(List<VirtualItemRef> pages, String section) {
+    for (VirtualItemRef p : pages) {
+      String file = p.relativePath().getFileName().toString().toLowerCase(Locale.ROOT);
+      if ("index.md".equals(file)) {
+        Path parent = p.relativePath().getParent();
+        if (parent != null && parent.getFileName() != null
+            && section.equals(parent.getFileName().toString())) {
+          return p;
+        }
+        // version/index.md handled as root
+        if (parent != null && parent.getNameCount() >= 1) {
+          return p;
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Convert source relative path to output HTML path using forward slashes. */
+  public static String toHref(Path relativeMarkdown) {
+    String s = relativeMarkdown.toString().replace('\\', '/');
+    if (s.toLowerCase(Locale.ROOT).endsWith(".md")) {
+      s = s.substring(0, s.length() - 3) + ".html";
+    }
+    if (s.toLowerCase(Locale.ROOT).endsWith("/index.html")) {
+      // keep index.html for clarity in Phase 1
+    }
+    return s;
+  }
+
+  private static String humanize(String section) {
+    String[] parts = section.split("[-_]");
+    StringBuilder sb = new StringBuilder();
+    for (String p : parts) {
+      if (p.isEmpty()) {
+        continue;
+      }
+      if (sb.length() > 0) {
+        sb.append(' ');
+      }
+      sb.append(Character.toUpperCase(p.charAt(0)));
+      if (p.length() > 1) {
+        sb.append(p.substring(1));
+      }
+    }
+    return sb.length() == 0 ? section : sb.toString();
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualNavNode.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualNavNode.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Navigation node for a Virtual Site version tree. */
+public final class VirtualNavNode {
+
+  private final String title;
+  private final String id;
+  private final String href;
+  private final int order;
+  private final List<VirtualNavNode> children;
+
+  public VirtualNavNode(
+      String title, String id, String href, int order, List<VirtualNavNode> children) {
+    this.title = Objects.requireNonNull(title, "title");
+    this.id = id;
+    this.href = href;
+    this.order = order;
+    this.children =
+        children == null
+            ? List.of()
+            : Collections.unmodifiableList(new ArrayList<>(children));
+  }
+
+  public String title() {
+    return title;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public String href() {
+    return href;
+  }
+
+  public int order() {
+    return order;
+  }
+
+  public List<VirtualNavNode> children() {
+    return children;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualParticipant.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualParticipant.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.util.Objects;
+
+/** Lightweight identity projection for a Virtual Site page (not a CMS content item). */
+public final class VirtualParticipant {
+
+  private final String siteKey;
+  private final String stableId;
+  private final String versionId;
+  private final String publishedPath;
+  private final String sourcePath;
+
+  public VirtualParticipant(
+      String siteKey,
+      String stableId,
+      String versionId,
+      String publishedPath,
+      String sourcePath) {
+    this.siteKey = Objects.requireNonNull(siteKey, "siteKey");
+    this.stableId = Objects.requireNonNull(stableId, "stableId");
+    this.versionId = versionId != null ? versionId : "";
+    this.publishedPath = Objects.requireNonNull(publishedPath, "publishedPath");
+    this.sourcePath = sourcePath != null ? sourcePath : "";
+  }
+
+  public String siteKey() {
+    return siteKey;
+  }
+
+  public String stableId() {
+    return stableId;
+  }
+
+  public String versionId() {
+    return versionId;
+  }
+
+  public String publishedPath() {
+    return publishedPath;
+  }
+
+  public String sourcePath() {
+    return sourcePath;
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfig.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfig.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Runtime configuration for a Virtual Site build: filesystem root plus parsed {@code _config.yaml}.
+ */
+public final class VirtualSiteConfig {
+
+  private final Path root;
+  private final String siteTitle;
+  private final String siteUrl;
+  private final String layoutFile;
+  private final List<VersionSpec> versions;
+  private final List<NavSpec> nav;
+  private final String siteKey;
+
+  public VirtualSiteConfig(
+      Path root,
+      String siteTitle,
+      String siteUrl,
+      String layoutFile,
+      List<VersionSpec> versions,
+      List<NavSpec> nav,
+      String siteKey) {
+    this.root = Objects.requireNonNull(root, "root");
+    this.siteTitle = siteTitle != null ? siteTitle : "Documentation";
+    this.siteUrl = siteUrl != null ? siteUrl : "";
+    this.layoutFile = layoutFile != null && !layoutFile.isBlank() ? layoutFile : "page.html";
+    this.versions =
+        versions == null
+            ? List.of()
+            : Collections.unmodifiableList(new ArrayList<>(versions));
+    this.nav =
+        nav == null ? List.of() : Collections.unmodifiableList(new ArrayList<>(nav));
+    this.siteKey = siteKey != null && !siteKey.isBlank() ? siteKey : "default";
+  }
+
+  public Path root() {
+    return root;
+  }
+
+  public String siteTitle() {
+    return siteTitle;
+  }
+
+  public String siteUrl() {
+    return siteUrl;
+  }
+
+  public String layoutFile() {
+    return layoutFile;
+  }
+
+  public List<VersionSpec> versions() {
+    return versions;
+  }
+
+  public List<NavSpec> nav() {
+    return nav;
+  }
+
+  public String siteKey() {
+    return siteKey;
+  }
+
+  public Path themeDir() {
+    return root.resolve("_theme");
+  }
+
+  public Path assetsDir() {
+    return root.resolve("assets");
+  }
+
+  /** Version entry from {@code _config.yaml}. */
+  public static final class VersionSpec {
+    private final String id;
+    private final String label;
+    private final String path;
+    private final boolean defaultVersion;
+
+    public VersionSpec(String id, String label, String path, boolean defaultVersion) {
+      this.id = Objects.requireNonNull(id, "id");
+      this.label = label != null ? label : id;
+      this.path = path != null ? path : id;
+      this.defaultVersion = defaultVersion;
+    }
+
+    public String id() {
+      return id;
+    }
+
+    public String label() {
+      return label;
+    }
+
+    public String path() {
+      return path;
+    }
+
+    public boolean defaultVersion() {
+      return defaultVersion;
+    }
+  }
+
+  /** Optional top-level nav override. */
+  public static final class NavSpec {
+    private final String title;
+    private final String id;
+
+    public NavSpec(String title, String id) {
+      this.title = title != null ? title : id;
+      this.id = Objects.requireNonNull(id, "id");
+    }
+
+    public String title() {
+      return title;
+    }
+
+    public String id() {
+      return id;
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import com.percussion.services.virtualsite.VirtualSiteConfig.NavSpec;
+import com.percussion.services.virtualsite.VirtualSiteConfig.VersionSpec;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/** Loads {@code _config.yaml} from a Virtual Site root. */
+public final class VirtualSiteConfigLoader {
+
+  public static final String DEFAULT_CONFIG_FILE = "_config.yaml";
+
+  private VirtualSiteConfigLoader() {}
+
+  /**
+   * Load config from {@code root/_config.yaml} (or custom name).
+   *
+   * @param root Virtual Site root directory
+   * @param configFileName config file name, may be null for default
+   * @param siteKey participant/site key
+   * @return config
+   * @throws IOException if file missing/unreadable
+   * @throws VirtualSiteException if YAML invalid
+   */
+  public static VirtualSiteConfig load(Path root, String configFileName, String siteKey)
+      throws IOException, VirtualSiteException {
+    if (root == null) {
+      throw new VirtualSiteException("Virtual Site root is null");
+    }
+    String name =
+        configFileName == null || configFileName.isBlank() ? DEFAULT_CONFIG_FILE : configFileName;
+    Path configPath = root.resolve(name);
+    if (!Files.isRegularFile(configPath)) {
+      throw new VirtualSiteException("Config file not found: " + configPath);
+    }
+    try (InputStream in = Files.newInputStream(configPath)) {
+      return parse(root, in, siteKey, configPath.toString());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static VirtualSiteConfig parse(Path root, InputStream in, String siteKey, String sourceLabel)
+      throws VirtualSiteException {
+    try {
+      Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+      Object loaded = yaml.load(in);
+      if (!(loaded instanceof Map)) {
+        throw new VirtualSiteException("Config root must be a YAML mapping: " + sourceLabel);
+      }
+      Map<String, Object> map = (Map<String, Object>) loaded;
+
+      Map<String, Object> site = asMap(map.get("site"));
+      String title = stringVal(site.get("title"));
+      String url = stringVal(site.get("url"));
+
+      Map<String, Object> theme = asMap(map.get("theme"));
+      String layout = stringVal(theme.get("layout"));
+
+      List<VersionSpec> versions = new ArrayList<>();
+      Object versionsObj = map.get("versions");
+      if (versionsObj instanceof List<?> list) {
+        for (Object item : list) {
+          if (item instanceof Map<?, ?> m) {
+            Map<String, Object> vm = (Map<String, Object>) m;
+            String id = stringVal(vm.get("id"));
+            if (id == null || id.isBlank()) {
+              continue;
+            }
+            String label = stringVal(vm.get("label"));
+            String path = stringVal(vm.get("path"));
+            boolean def = booleanVal(vm.get("default"), false);
+            versions.add(new VersionSpec(id, label, path, def));
+          }
+        }
+      }
+      if (versions.isEmpty()) {
+        throw new VirtualSiteException("Config must declare at least one version: " + sourceLabel);
+      }
+
+      List<NavSpec> nav = new ArrayList<>();
+      Object navObj = map.get("nav");
+      if (navObj instanceof List<?> list) {
+        for (Object item : list) {
+          if (item instanceof Map<?, ?> m) {
+            Map<String, Object> nm = (Map<String, Object>) m;
+            String id = stringVal(nm.get("id"));
+            if (id == null || id.isBlank()) {
+              continue;
+            }
+            String ntitle = stringVal(nm.get("title"));
+            nav.add(new NavSpec(ntitle, id));
+          }
+        }
+      }
+
+      return new VirtualSiteConfig(root, title, url, layout, versions, nav, siteKey);
+    } catch (VirtualSiteException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new VirtualSiteException("Failed to parse config: " + sourceLabel, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asMap(Object o) {
+    if (o instanceof Map) {
+      return (Map<String, Object>) o;
+    }
+    return Map.of();
+  }
+
+  private static String stringVal(Object o) {
+    return o == null ? null : String.valueOf(o).trim();
+  }
+
+  private static boolean booleanVal(Object o, boolean defaultValue) {
+    if (o == null) {
+      return defaultValue;
+    }
+    if (o instanceof Boolean b) {
+      return b;
+    }
+    return Boolean.parseBoolean(String.valueOf(o));
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteException.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+/** Contract or build failure for Virtual Sites. */
+public class VirtualSiteException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public VirtualSiteException(String message) {
+    super(message);
+  }
+
+  public VirtualSiteException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteSourceType.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteSourceType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+/**
+ * Registered Virtual Site adapter kinds. Phase 1 implements {@link #GIT_FILESYSTEM} only.
+ */
+public enum VirtualSiteSourceType {
+  GIT_FILESYSTEM("git-filesystem");
+
+  private final String wireName;
+
+  VirtualSiteSourceType(String wireName) {
+    this.wireName = wireName;
+  }
+
+  public String wireName() {
+    return wireName;
+  }
+
+  /**
+   * Parse a property / config wire name.
+   *
+   * @param value may be null
+   * @return matching type or null if unknown/blank
+   */
+  public static VirtualSiteSourceType fromWireName(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String v = value.trim();
+    for (VirtualSiteSourceType t : values()) {
+      if (t.wireName.equalsIgnoreCase(v)) {
+        return t;
+      }
+    }
+    return null;
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PSVirtualSiteBuildServiceTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void buildsSampleTreeAndRegistersParticipants() throws Exception {
+    Path sample = resolveSampleDocs();
+    Path out = tempDir.resolve("site-out");
+    Path meta = tempDir.resolve("meta");
+
+    PSInMemoryVirtualParticipantService participants =
+        new PSInMemoryVirtualParticipantService(meta);
+    PSVirtualSiteBuildService service =
+        new PSVirtualSiteBuildService(new PSGitFilesystemVirtualSiteSource(), participants);
+
+    PSVirtualSiteBuildResult result = service.build(sample, out, "sample");
+
+    assertEquals(3, result.pageCount());
+    assertFalse(result.hasLinkProblems(), () -> result.linkProblems().toString());
+
+    Path home = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(home), "missing " + home);
+    String html = Files.readString(home, StandardCharsets.UTF_8);
+    assertTrue(html.contains("Sample Docs"), html);
+    assertTrue(html.contains("Welcome") || html.contains("welcome"), html);
+    // Body + nav links must be site-root HTML (not source .md)
+    assertTrue(html.contains("/8.2/getting-started/index.html"), html);
+    assertFalse(html.contains("getting-started/index.md"), html);
+    assertTrue(html.contains("href=\"/8.2/getting-started/install.html\""), html);
+
+    Path install = out.resolve("8.2").resolve("getting-started").resolve("install.html");
+    assertTrue(Files.isRegularFile(install));
+
+    Optional<VirtualParticipant> p = participants.find("sample", "install-overview");
+    assertTrue(p.isPresent());
+    assertEquals("8.2/getting-started/install.html", p.get().publishedPath().replace('\\', '/'));
+
+    participants.flush("sample");
+    assertTrue(Files.isRegularFile(meta.resolve("participants-sample.jsonl")));
+  }
+
+  @Test
+  void linkCheckerReportsMissingId() {
+    var problems =
+        VirtualLinkChecker.checkPage(
+            "s",
+            "8.2",
+            "8.2/index.md",
+            "See [x](id:missing-page)",
+            java.util.Map.of("home", "8.2/index.html"),
+            java.util.Set.of("8.2/index.html"));
+    assertEquals(1, problems.size());
+    assertTrue(problems.get(0).contains("missing-page"));
+  }
+
+  @Test
+  void resolveHrefIsPortable() {
+    Path base = tempDir.resolve("out");
+    Path resolved = PSVirtualSiteBuildService.resolveHref(base, "8.2/getting-started/install.html");
+    assertEquals(
+        base.resolve("8.2").resolve("getting-started").resolve("install.html"), resolved);
+  }
+
+  private static Path resolveSampleDocs() throws Exception {
+    URL url =
+        PSVirtualSiteBuildServiceTest.class
+            .getClassLoader()
+            .getResource("virtualsite/sample-docs/_config.yaml");
+    if (url == null) {
+      throw new IllegalStateException("sample-docs fixture missing from test classpath");
+    }
+    Path config = Path.of(url.toURI());
+    return config.getParent();
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.sitemgr.data.PSSite;
+import com.percussion.services.sitemgr.data.PSSiteProperty;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PSVirtualSiteHelperTest {
+
+  @Test
+  void repositoryWhenNoSourceKind() {
+    PSSite site = mock(PSSite.class);
+    when(site.getProperties()).thenReturn(Set.of());
+    assertEquals(SourceKind.REPOSITORY, PSVirtualSiteHelper.sourceKind(site));
+    assertFalse(PSVirtualSiteHelper.isVirtual(site));
+  }
+
+  @Test
+  void virtualWhenGitFilesystem() {
+    PSSite site = mock(PSSite.class);
+    PSSiteProperty kind = new PSSiteProperty();
+    kind.setName(PSVirtualSiteHelper.PROP_SOURCE_KIND);
+    kind.setValue("git-filesystem");
+    PSSiteProperty root = new PSSiteProperty();
+    root.setName(PSVirtualSiteHelper.PROP_ROOT_PATH);
+    root.setValue("C:/docs/product-docs");
+    Set<PSSiteProperty> props = new HashSet<>();
+    props.add(kind);
+    props.add(root);
+    when(site.getProperties()).thenReturn(props);
+    when(site.getName()).thenReturn("Help");
+
+    assertTrue(PSVirtualSiteHelper.isVirtual(site));
+    assertEquals(
+        VirtualSiteSourceType.GIT_FILESYSTEM,
+        PSVirtualSiteHelper.virtualSourceType(site).orElseThrow());
+    assertEquals("Help", PSVirtualSiteHelper.siteKey(site));
+    assertTrue(PSVirtualSiteHelper.rootPath(site).isPresent());
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualFrontmatterParserTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualFrontmatterParserTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.virtualsite.VirtualFrontmatterParser.Parsed;
+import org.junit.jupiter.api.Test;
+
+class VirtualFrontmatterParserTest {
+
+  @Test
+  void parsesRequiredFieldsAndBody() throws Exception {
+    String text =
+        "---\n"
+            + "id: install-overview\n"
+            + "title: Installation Overview\n"
+            + "order: 20\n"
+            + "tags: [install, admin]\n"
+            + "---\n"
+            + "\n"
+            + "# Hello\n";
+    Parsed p = VirtualFrontmatterParser.parse(text, "8.2", "install.md");
+    assertEquals("install-overview", p.frontmatter().id());
+    assertEquals("Installation Overview", p.frontmatter().title());
+    assertEquals("8.2", p.frontmatter().version());
+    assertEquals(20, p.frontmatter().order());
+    assertEquals(2, p.frontmatter().tags().size());
+    assertTrue(p.body().contains("# Hello"));
+  }
+
+  @Test
+  void acceptsCrlfLineEndings() throws Exception {
+    String text =
+        "---\r\n"
+            + "id: a\r\n"
+            + "title: A\r\n"
+            + "---\r\n"
+            + "Body\r\n";
+    Parsed p = VirtualFrontmatterParser.parse(text, "8.2", "a.md");
+    assertEquals("a", p.frontmatter().id());
+    assertTrue(p.body().contains("Body"));
+  }
+
+  @Test
+  void missingIdFails() {
+    String text = "---\ntitle: Only title\n---\n";
+    assertThrows(
+        VirtualSiteException.class,
+        () -> VirtualFrontmatterParser.parse(text, "8.2", "x.md"));
+  }
+
+  @Test
+  void missingFrontmatterFails() {
+    assertThrows(
+        VirtualSiteException.class,
+        () -> VirtualFrontmatterParser.parse("# no fm\n", "8.2", "x.md"));
+  }
+
+  @Test
+  void sidebarDefaultsTrue() throws Exception {
+    String text = "---\nid: x\ntitle: X\n---\n";
+    Parsed p = VirtualFrontmatterParser.parse(text, "8.2", "x.md");
+    assertTrue(p.frontmatter().sidebar());
+    assertFalse(p.frontmatter().deprecated());
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualMarkdownLinkRewriterTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualMarkdownLinkRewriterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class VirtualMarkdownLinkRewriterTest {
+
+  @Test
+  void rewritesRelativeMarkdownToSiteRootHtml() {
+    String body = "See [Getting Started](getting-started/index.md).";
+    String out =
+        VirtualMarkdownLinkRewriter.rewrite(body, "8.2/index.md", Map.of());
+    assertTrue(out.contains("(/8.2/getting-started/index.html)"), out);
+  }
+
+  @Test
+  void rewritesStableIdLinks() {
+    String body = "Jump [Install](id:install-overview).";
+    String out =
+        VirtualMarkdownLinkRewriter.rewrite(
+            body,
+            "8.2/index.md",
+            Map.of("install-overview", "8.2/getting-started/install.html"));
+    assertTrue(out.contains("(/8.2/getting-started/install.html)"), out);
+  }
+
+  @Test
+  void leavesExternalAndAnchorsAlone() {
+    String body = "[a](https://example.com) [b](#frag) [c](mailto:x@y.z)";
+    String out = VirtualMarkdownLinkRewriter.rewrite(body, "8.2/index.md", Map.of());
+    assertEquals(body, out);
+  }
+
+  @Test
+  void preservesTitleAndFragment() {
+    String body = "[x](install.md#section \"title\")";
+    String out =
+        VirtualMarkdownLinkRewriter.rewrite(
+            body, "8.2/getting-started/index.md", Map.of());
+    assertEquals("[x](/8.2/getting-started/install.html#section \"title\")", out);
+  }
+
+  @Test
+  void toSiteRootHrefPrefixesSlash() {
+    assertEquals("/8.2/index.html", VirtualMarkdownLinkRewriter.toSiteRootHref("8.2/index.html"));
+    assertEquals("/a.html", VirtualMarkdownLinkRewriter.toSiteRootHref("/a.html"));
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualNavBuilderTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualNavBuilderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VirtualNavBuilderTest {
+
+  @Test
+  void toHrefReplacesMarkdownExtension() {
+    assertEquals(
+        "8.2/getting-started/install.html",
+        VirtualNavBuilder.toHref(Path.of("8.2", "getting-started", "install.md")));
+  }
+
+  @Test
+  void buildsSectionWithChildren() {
+    VirtualSiteConfig config =
+        new VirtualSiteConfig(
+            Path.of("root"),
+            "T",
+            "",
+            "page.html",
+            List.of(new VirtualSiteConfig.VersionSpec("8.2", "8.2", "8.2", true)),
+            List.of(new VirtualSiteConfig.NavSpec("Getting Started", "getting-started")),
+            "k");
+
+    List<VirtualItemRef> refs =
+        List.of(
+            new VirtualItemRef(
+                "getting-started",
+                "8.2",
+                Path.of("8.2", "getting-started", "index.md"),
+                10,
+                "Getting Started"),
+            new VirtualItemRef(
+                "install-overview",
+                "8.2",
+                Path.of("8.2", "getting-started", "install.md"),
+                20,
+                "Install"));
+
+    List<VirtualNavNode> nav = VirtualNavBuilder.build("8.2", refs, config);
+    assertEquals(1, nav.size());
+    assertEquals("Getting Started", nav.get(0).title());
+    assertTrue(nav.get(0).children().stream().anyMatch(c -> "install-overview".equals(c.id())));
+  }
+}

--- a/system/src/test/resources/virtualsite/sample-docs/8.2/getting-started/index.md
+++ b/system/src/test/resources/virtualsite/sample-docs/8.2/getting-started/index.md
@@ -1,0 +1,11 @@
+---
+id: getting-started
+title: Getting Started
+description: Start here
+version: "8.2"
+order: 10
+---
+
+# Getting Started
+
+- [Installation](install.md)

--- a/system/src/test/resources/virtualsite/sample-docs/8.2/getting-started/install.md
+++ b/system/src/test/resources/virtualsite/sample-docs/8.2/getting-started/install.md
@@ -1,0 +1,14 @@
+---
+id: install-overview
+title: Installation Overview
+description: How to install Percussion CMS 8.2
+version: "8.2"
+order: 20
+tags: [install, admin]
+---
+
+# Installation Overview
+
+Install steps go here.
+
+Back to [Getting Started](index.md).

--- a/system/src/test/resources/virtualsite/sample-docs/8.2/index.md
+++ b/system/src/test/resources/virtualsite/sample-docs/8.2/index.md
@@ -1,0 +1,13 @@
+---
+id: home-8.2
+title: Percussion CMS 8.2 Documentation
+description: Home for the 8.2 documentation set
+version: "8.2"
+order: 0
+---
+
+# Welcome
+
+This is the sample documentation home page for Virtual Site builds.
+
+See [Getting Started](getting-started/index.md) or jump by id: [Install](id:install-overview).

--- a/system/src/test/resources/virtualsite/sample-docs/_config.yaml
+++ b/system/src/test/resources/virtualsite/sample-docs/_config.yaml
@@ -1,0 +1,16 @@
+site:
+  title: Sample Docs
+  url: https://example.test/docs
+
+versions:
+  - id: "8.2"
+    label: "8.2 (current)"
+    path: 8.2
+    default: true
+
+nav:
+  - title: Getting Started
+    id: getting-started
+
+theme:
+  layout: page.html

--- a/system/src/test/resources/virtualsite/sample-docs/_theme/page.html
+++ b/system/src/test/resources/virtualsite/sample-docs/_theme/page.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>${pageTitle} — ${siteTitle}</title>
+<meta name="description" content="${description}"/>
+</head>
+<body>
+<header><h1>${siteTitle}</h1>${versionSwitcher}</header>
+<div class="layout">
+<nav>${nav}</nav>
+<main>
+<p class="version">${versionLabel}</p>
+<article>
+${content}
+</article>
+</main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Phase 1 of **Virtual Sites** (#2678 / #2679): Sites whose content originates outside the Percussion repository. First adapter is **Git/Filesystem** for product documentation under repo-root `product-docs/`.

- Discover Markdown + YAML frontmatter from a filesystem tree
- Assemble via Markdown helpers (#2628) + `_theme` layout
- Register lightweight virtual participants (stable frontmatter `id`)
- Rewrite relative `.md` / `id:` links to site-root HTML hrefs
- Emit static HTML + assets + link report (offline/CI dogfood)
- Site property helper keys (`virtual.sourceKind`, `virtual.rootPath`, …)
- Spec + ADRs under `docs/ai-generated/tasks/virtual-sites-git-docs/`

## Build / test evidence

```text
cd system
../mvnw.cmd "-Dtest=VirtualFrontmatterParserTest,VirtualNavBuilderTest,PSVirtualSiteHelperTest,PSVirtualSiteBuildServiceTest,VirtualMarkdownLinkRewriterTest" test
# Tests run: 17, Failures: 0

../mvnw.cmd clean install
# BUILD SUCCESS

scripts\build-cms-docs.bat
# Built 7 page(s); link-report: OK: no link problems
```

No new compiler warnings attributable to this change (module baseline warnings unchanged).

## Erlang

Pre-commit review: `docs/ai-generated/code-reviews/virtual-sites-git-docs-2679-erlang.md` — **approve**.

## Related

- Closes #2679
- Refs #2678 (epic), #2628 (Markdown assemblers)

## How to try

```bat
scripts\build-cms-docs.bat
# output: tmp\product-docs-site\
```

> Co-Authored by Grok Build using grok-4.5 with agent main.