### PR TITLE
feat(system): design-object auditor dual-write via DesignErrorCodes (#2673)

### DIFF
--- a/docs/ai-generated/code-reviews/2673-design-object-auditor-dual-write-erlang.md
+++ b/docs/ai-generated/code-reviews/2673-design-object-auditor-dual-write-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review — #2673 Design-object auditor dual-write (DESN)
+
+**Date:** 2026-08-10  
+**Branch:** `fix/issue-2673-design-object-auditor-dual-write`  
+**Scope:** uncommitted `system` changes vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Slice 1 of parent #2617 wires `PSDesignObjectAuditor` so design save/delete AOP audits dual-write through `PSSystemAuditLogger` / `DesignErrorCodes` (DESN-2902 update, DESN-2903 delete) into the system audit dual-write path, while retaining legacy `PSX_DESIGN_AUDIT_LOG` rows. When design auditing is disabled, neither path is written. CADF/jcadf untouched.
+
+## Memory patterns hit
+
+- Dual-write must not break primary business path (audit sink failures swallowed)
+- Static/locator test hooks must restore state in `@AfterEach`
+- Blank/missing actor → `"unknown"` for audit trails
+- No mega-PR with jcadf removal in design-auditor slice
+
+## Cross-platform path checklist
+
+N/A — no new file I/O or path construction. Result: clean.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+### Nits (non-blocking)
+
+1. **SAVE always maps to `DesignErrorCodes.UPDATE` (not `CREATE`)** — legacy AOP only distinguishes save vs delete via method name; version-based create detection is out of scope for this slice. `designCreate` helper exists for future call sites.
+2. **`m_auditEnabled` cache remains sticky for the AOP bean lifetime** — pre-existing behavior; tests force fresh auditor instances / mock config.
+
+## Tests / verification
+
+- `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
+- Surefire total: **Tests run: 1500, Failures: 0, Errors: 0**
+- Focused: `PSDesignObjectAuditorTest` 12/0/0; `PSSystemAuditLoggerTest` 26/0/0
+- Coverage: enabled save/delete dual-write, multi-object collection, disabled no-op, blank user → unknown, createAuditData extract logic, design helpers blank actor / null code
+
+## Gate
+
+**approve** — no bugs, behavioral tests present, no CADF removal, module clean install green.

--- a/system/business/src/com/percussion/rx/audit/PSDesignObjectAuditor.java
+++ b/system/business/src/com/percussion/rx/audit/PSDesignObjectAuditor.java
@@ -122,11 +122,11 @@ public class PSDesignObjectAuditor {
       String name = guidStr;
       PSSystemAuditLogger.design(code, userName, typeName, name, guidStr);
     } catch (RuntimeException ex) {
+      // Pass throwable so stack is retained when debug logging is off (prod).
       log.error(
-          "Failed to dual-write design system audit for action={}: {}",
+          "Failed to dual-write design system audit for action={}",
           data.mi_auditAction,
-          ex.toString());
-      log.debug("Design system audit dual-write failure details", ex);
+          ex);
     }
   }
 

--- a/system/business/src/com/percussion/rx/audit/PSDesignObjectAuditor.java
+++ b/system/business/src/com/percussion/rx/audit/PSDesignObjectAuditor.java
@@ -1,201 +1,261 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.rx.audit;
 
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.percussion.server.PSRequest;
-// Removed unused imports per lint warning
 import com.percussion.services.audit.PSDesignObjectAuditServiceLocator;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.services.audit.data.PSAuditLogEntry;
 import com.percussion.services.audit.data.PSAuditLogEntry.AuditTypes;
 import com.percussion.services.catalog.IPSCatalogIdentifier;
+import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.aspectj.lang.JoinPoint;
 
 /**
- * Java 11 refactored: This class is intended to be configured with Spring AOP to write
- * {@link PSAuditLogEntry} object whenever a design object is inserted, updated,
- * or removed from the repository.
+ * Configured with Spring AOP to write design-object audit events whenever a design object is
+ * inserted, updated, or removed from the repository.
+ *
+ * <p>Writes the legacy {@link PSAuditLogEntry} table ({@code PSX_DESIGN_AUDIT_LOG}) and dual-writes
+ * the same save/delete events through {@link PSSystemAuditLogger} / {@link DesignErrorCodes} into
+ * the system audit path ({@code PSX_SYSTEM_AUDIT_LOG} + Log4j). When design auditing is disabled,
+ * neither path is written.
  */
 public class PSDesignObjectAuditor {
-   /**
-    * Perform the audit of the method call specified in the supplied joinpoint.
-    * If auditing is notenabled, simply returns, otherwise performs the audit
-    * as follows:
-    * <p>
-    * Only audits method signatures that start with "save" or "delete".
-    * <p>
-    * Only considers the first parameter of the method signature.  This argument
-    * must be an instance of {@link IPSCatalogIdentifier} or a collection of
-    * such instances.
-    * <p>
-    * For each object audited, a {@link PSAuditData} object is inserted in the
-    * repository.
-    *
-    * @param joinPoint The joinpoint, never <code>null</code>.
-    *
-    * @throws Throwable If there are any errors.
-    */
-    public void audit(JoinPoint joinPoint) throws Throwable {
-        if (joinPoint == null) {
-            throw new IllegalArgumentException("joinPoint may not be null");
-        }
-        var auditDate = new Date();
-        var args = joinPoint.getArgs();
-        if (args == null || args.length == 0) {
-            return;
-        }
-        if (!isAuditingEnabled()) {
-            return;
-        }
-        var userName = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
-        if (StringUtils.isBlank(userName)) {
-            var req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
-            if (req != null) {
-                userName = req.getUserSession().getRealAuthenticatedUserEntry();
-            }
-        }
-        if (StringUtils.isBlank(userName)) {
-            userName = "unknown";
-        }
-        var svc = PSDesignObjectAuditServiceLocator.getAuditService();
-        var entries = new ArrayList<PSAuditLogEntry>();
-        var name = joinPoint.getSignature().getName();
-        var auditData = createAuditData(name, args[0]);
-        for (var data : auditData) {
-            var entry = svc.createAuditLogEntry();
-            entry.setAction(data.mi_auditAction);
-            // setDate(Date) is deprecated, but required for backward compatibility (see migration notes)
-            entry.setDate(auditDate);
-            entry.setObjectGUID(data.mi_objectGuid);
-            entry.setUserName(userName);
-            entries.add(entry);
-        }
-        svc.saveAuditLogEntries(entries);
+
+  private static final Logger log = LogManager.getLogger(PSDesignObjectAuditor.class);
+
+  /**
+   * Perform the audit of the method call specified in the supplied joinpoint. If auditing is not
+   * enabled, simply returns, otherwise performs the audit as follows:
+   *
+   * <p>Only audits method signatures that start with "save" or "delete".
+   *
+   * <p>Only considers the first parameter of the method signature. This argument must be an
+   * instance of {@link IPSCatalogIdentifier} or a collection of such instances.
+   *
+   * <p>For each object audited, a {@link PSAuditLogEntry} is inserted in the legacy repository and
+   * a DESN system-audit dual-write is emitted.
+   *
+   * @param joinPoint The joinpoint, never <code>null</code>.
+   * @throws Throwable If there are any errors.
+   */
+  public void audit(JoinPoint joinPoint) throws Throwable {
+    if (joinPoint == null) {
+      throw new IllegalArgumentException("joinPoint may not be null");
     }
-
-   /**
-    * Worker method of {@link #audit(JoinPoint)}, see that method for
-    * a description of the auditing logic. This method determines the resulting
-    * action(s) and guid(s) from the supplied argument and method name. This
-    * method is not intended to be called directly, and is public to allow for
-    * unit testing.
-    *
-    * @param methodName The name of the method being audited, used to determine
-    * the audited action, may be <code>null</code> in which case an empty
-    * collection is returned.
-    * @param arg The argument from which to extract one or more guids for the
-    * audited action, may be <code>null</code> in which case an empty
-    * collection is returned.
-    *
-    * @return The resulting list of audit data, never <code>null</code>, may be
-    * empty.
-    */
-
-    public Collection<PSAuditData> createAuditData(String methodName, Object arg) {
-        var dataList = new ArrayList<PSAuditData>();
-        if (methodName == null) {
-            return dataList;
-        }
-        AuditTypes type;
-        if (methodName.startsWith("delete")) {
-            type = AuditTypes.DELETE;
-        } else if (methodName.startsWith("save")) {
-            type = AuditTypes.SAVE;
-        } else {
-            return dataList;
-        }
-        Collection<?> argCollection = null;
-        if (arg instanceof IPSCatalogIdentifier || arg instanceof IPSGuid) {
-            argCollection = new ArrayList<>();
-            ((ArrayList<Object>) argCollection).add(arg);
-        }
-        if (arg instanceof Collection) {
-            argCollection = (Collection<?>) arg;
-        }
-        if (argCollection == null) {
-            return dataList;
-        }
-        for (var object : argCollection) {
-            IPSGuid guid;
-            if (object instanceof IPSGuid) {
-                guid = (IPSGuid) object;
-            } else if (object instanceof IPSCatalogIdentifier) {
-                var id = (IPSCatalogIdentifier) object;
-                guid = id.getGUID();
-            } else {
-                continue;
-            }
-            var data = new PSAuditData();
-            data.mi_objectGuid = guid;
-            data.mi_auditAction = type;
-            dataList.add(data);
-        }
-        return dataList;
+    var args = joinPoint.getArgs();
+    if (args == null || args.length == 0) {
+      return;
     }
-
-   /**
-    * Check the audit service to determine if auditing is enabled, caching the
-    * result for use by future invocations of this method.
-    *
-    * @return <code>true</code> if it is enabled, <code>false</code>
-    * otherwise.
-    */
-    private boolean isAuditingEnabled() {
-        if (m_auditEnabled == null) {
-            var svc = PSDesignObjectAuditServiceLocator.getAuditService();
-            var config = svc.getConfig();
-            m_auditEnabled = config.isEnabled();
-        }
-        return m_auditEnabled;
+    if (!isAuditingEnabled()) {
+      return;
     }
+    var name = joinPoint.getSignature().getName();
+    var auditData = createAuditData(name, args[0]);
+    if (auditData.isEmpty()) {
+      return;
+    }
+    var userName = resolveUserName();
+    var auditDate = new Date();
+    var svc = PSDesignObjectAuditServiceLocator.getAuditService();
+    var entries = new ArrayList<PSAuditLogEntry>();
+    for (var data : auditData) {
+      var entry = svc.createAuditLogEntry();
+      entry.setAction(data.mi_auditAction);
+      // setDate(Date) is deprecated, but required for backward compatibility (see migration notes)
+      entry.setDate(auditDate);
+      entry.setObjectGUID(data.mi_objectGuid);
+      entry.setUserName(userName);
+      entries.add(entry);
+      dualWriteSystemAudit(userName, data);
+    }
+    svc.saveAuditLogEntries(entries);
+  }
 
-   /**
-    * Saves the enabled setting from the audit config, <code>null</code> until
-    * the config is checked for the first time, immutable after that.
-    */
-    Boolean m_auditEnabled = null;
-
-   /**
-    * Simple data structure to hold the guid and audit action, package access
-    * for unit testing.
-    */
-   class PSAuditData
-   {
-      /**
-       * The guid of the object modified by the method being audited, may be
-       * <code>null</code>.
-       */
-      private IPSGuid mi_objectGuid;
-
-      /**
-       * The action being performed by the method being audited, may be
-       * <code>null</code>.
-       */
-      private AuditTypes mi_auditAction;
-
-      /**
-       * Get the guid
-       *
-       * @return The guid, may be <code>null</code>.
-       */
-      IPSGuid getGuid()
-      {
-         return mi_objectGuid;
+  /**
+   * Resolve the actor for the audit event. Blank / missing request context maps to {@code
+   * "unknown"}.
+   *
+   * <p>Package-visible for unit tests.
+   */
+  String resolveUserName() {
+    var userName = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+    if (StringUtils.isBlank(userName)) {
+      var req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
+      if (req != null && req.getUserSession() != null) {
+        userName = req.getUserSession().getRealAuthenticatedUserEntry();
       }
+    }
+    if (StringUtils.isBlank(userName)) {
+      return "unknown";
+    }
+    return userName;
+  }
 
-      /**
-       * Get the action.
-       *
-       * @return The action, may be <code>null</code>.
-       */
-      AuditTypes getAction()
-      {
-         return mi_auditAction;
+  /**
+   * Dual-write one design audit event through {@link PSSystemAuditLogger}. Failures are logged and
+   * swallowed so design operations are never blocked by the system audit sink.
+   *
+   * <p>Package-visible for unit tests.
+   */
+  void dualWriteSystemAudit(String userName, PSAuditData data) {
+    if (data == null || data.mi_auditAction == null) {
+      return;
+    }
+    try {
+      DesignErrorCodes code =
+          data.mi_auditAction == AuditTypes.DELETE
+              ? DesignErrorCodes.DELETE
+              : DesignErrorCodes.UPDATE;
+      IPSGuid guid = data.mi_objectGuid;
+      String guidStr = guid == null ? "" : String.valueOf(guid);
+      String typeName = resolveTypeName(guid);
+      // No separate design-object display name is available on the AOP path; reuse GUID.
+      String name = guidStr;
+      PSSystemAuditLogger.design(code, userName, typeName, name, guidStr);
+    } catch (RuntimeException ex) {
+      log.error(
+          "Failed to dual-write design system audit for action={}: {}",
+          data.mi_auditAction,
+          ex.toString());
+      log.debug("Design system audit dual-write failure details", ex);
+    }
+  }
+
+  /**
+   * Map a design object GUID type ordinal to a stable label for audit messages.
+   *
+   * <p>Package-visible for unit tests.
+   */
+  static String resolveTypeName(IPSGuid guid) {
+    if (guid == null) {
+      return "";
+    }
+    try {
+      PSTypeEnum typeEnum = PSTypeEnum.valueOf(guid.getType());
+      if (typeEnum != null) {
+        return typeEnum.name();
       }
-   }
+    } catch (RuntimeException ignored) {
+      // fall through
+    }
+    return String.valueOf(guid.getType());
+  }
+
+  /**
+   * Worker method of {@link #audit(JoinPoint)}, see that method for a description of the auditing
+   * logic. This method determines the resulting action(s) and guid(s) from the supplied argument and
+   * method name. This method is not intended to be called directly, and is public to allow for unit
+   * testing.
+   *
+   * @param methodName The name of the method being audited, used to determine the audited action,
+   *     may be <code>null</code> in which case an empty collection is returned.
+   * @param arg The argument from which to extract one or more guids for the audited action, may be
+   *     <code>null</code> in which case an empty collection is returned.
+   * @return The resulting list of audit data, never <code>null</code>, may be empty.
+   */
+  public Collection<PSAuditData> createAuditData(String methodName, Object arg) {
+    var dataList = new ArrayList<PSAuditData>();
+    if (methodName == null) {
+      return dataList;
+    }
+    AuditTypes type;
+    if (methodName.startsWith("delete")) {
+      type = AuditTypes.DELETE;
+    } else if (methodName.startsWith("save")) {
+      type = AuditTypes.SAVE;
+    } else {
+      return dataList;
+    }
+    Collection<?> argCollection = null;
+    if (arg instanceof IPSCatalogIdentifier || arg instanceof IPSGuid) {
+      argCollection = new ArrayList<>();
+      ((ArrayList<Object>) argCollection).add(arg);
+    }
+    if (arg instanceof Collection) {
+      argCollection = (Collection<?>) arg;
+    }
+    if (argCollection == null) {
+      return dataList;
+    }
+    for (var object : argCollection) {
+      IPSGuid guid;
+      if (object instanceof IPSGuid) {
+        guid = (IPSGuid) object;
+      } else if (object instanceof IPSCatalogIdentifier) {
+        var id = (IPSCatalogIdentifier) object;
+        guid = id.getGUID();
+      } else {
+        continue;
+      }
+      var data = new PSAuditData();
+      data.mi_objectGuid = guid;
+      data.mi_auditAction = type;
+      dataList.add(data);
+    }
+    return dataList;
+  }
+
+  /**
+   * Check the audit service to determine if auditing is enabled, caching the result for use by
+   * future invocations of this method.
+   *
+   * @return <code>true</code> if it is enabled, <code>false</code> otherwise.
+   */
+  private boolean isAuditingEnabled() {
+    if (m_auditEnabled == null) {
+      var svc = PSDesignObjectAuditServiceLocator.getAuditService();
+      var config = svc.getConfig();
+      m_auditEnabled = config.isEnabled();
+    }
+    return m_auditEnabled;
+  }
+
+  /**
+   * Saves the enabled setting from the audit config, <code>null</code> until the config is checked
+   * for the first time, immutable after that. Package-visible for unit tests so the cache can be
+   * reset or forced.
+   */
+  Boolean m_auditEnabled = null;
+
+  /**
+   * Simple data structure to hold the guid and audit action, package access for unit testing.
+   */
+  class PSAuditData {
+    /**
+     * The guid of the object modified by the method being audited, may be <code>null</code>.
+     */
+    private IPSGuid mi_objectGuid;
+
+    /**
+     * The action being performed by the method being audited, may be <code>null</code>.
+     */
+    private AuditTypes mi_auditAction;
+
+    /**
+     * Get the guid
+     *
+     * @return The guid, may be <code>null</code>.
+     */
+    IPSGuid getGuid() {
+      return mi_objectGuid;
+    }
+
+    /**
+     * Get the action.
+     *
+     * @return The action, may be <code>null</code>.
+     */
+    AuditTypes getAction() {
+      return mi_auditAction;
+    }
+  }
 }
-

--- a/system/services/src/com/percussion/services/audit/PSDesignObjectAuditServiceLocator.java
+++ b/system/services/src/com/percussion/services/audit/PSDesignObjectAuditServiceLocator.java
@@ -56,6 +56,16 @@ public class PSDesignObjectAuditServiceLocator {
    }
 
    /**
+    * Override the cached service — primarily for unit tests. Pass {@code null} to clear (same as
+    * {@link #clearCache()}).
+    *
+    * @param service replacement instance, or {@code null} to force reinitialization
+    */
+   public static void setAuditService(IPSDesignObjectAuditService service) {
+      AUDIT_SERVICE_REF.set(service);
+   }
+
+   /**
     * Clear the cached service instance - primarily for testing purposes.
     * This method is thread-safe and will force reinitialization on next access.
     */

--- a/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
+++ b/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
@@ -25,6 +25,7 @@ import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.UserManagementErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import jakarta.servlet.http.HttpServletRequest;
@@ -297,6 +298,56 @@ public final class PSSystemAuditLogger {
             .attribute("toState", to)
             .build();
     log(WorkflowErrorCodes.TRANSITION, ctx, o, cid, g, from, to);
+  }
+
+  /**
+   * Design-object lifecycle dual-write (DESN-2901..2903). Used by {@code PSDesignObjectAuditor} so
+   * design save/delete events land in {@code PSX_SYSTEM_AUDIT_LOG} (and Log4j) alongside the legacy
+   * design audit table.
+   *
+   * <p>Message params match {@link DesignErrorCodes} templates: {@code type}, {@code name}, {@code
+   * guid}.
+   *
+   * @param code one of {@link DesignErrorCodes#CREATE}, {@link DesignErrorCodes#UPDATE}, or {@link
+   *     DesignErrorCodes#DELETE}
+   * @param actor authenticated operator; blank becomes {@code "unknown"}
+   * @param type design object type label (e.g. {@code CONTENT_LIST})
+   * @param name design object name when known; may be blank
+   * @param guid string form of the design object GUID
+   */
+  public static void design(
+      DesignErrorCodes code, String actor, String type, String name, String guid) {
+    if (code == null) {
+      return;
+    }
+    String a = (actor == null || actor.isBlank()) ? "unknown" : actor.trim();
+    String t = nullToEmpty(type);
+    String n = nullToEmpty(name);
+    String g = nullToEmpty(guid);
+    AuditOutcome o = code.defaultOutcome() != null ? code.defaultOutcome() : AuditOutcome.SUCCESS;
+    AuditContext ctx =
+        AuditContext.builder()
+            .actor(a)
+            .target(g.isEmpty() ? t : g)
+            .attribute("type", t)
+            .attribute("name", n)
+            .build();
+    log(code, ctx, o, t, n, g);
+  }
+
+  /** Design object create (DESN-2901). */
+  public static void designCreate(String actor, String type, String name, String guid) {
+    design(DesignErrorCodes.CREATE, actor, type, name, guid);
+  }
+
+  /** Design object update/save (DESN-2902). */
+  public static void designUpdate(String actor, String type, String name, String guid) {
+    design(DesignErrorCodes.UPDATE, actor, type, name, guid);
+  }
+
+  /** Design object delete (DESN-2903). */
+  public static void designDelete(String actor, String type, String name, String guid) {
+    design(DesignErrorCodes.DELETE, actor, type, name, guid);
   }
 
   private static AuditContext contentContext(HttpServletRequest request, String guid) {

--- a/system/src/test/java/com/percussion/rx/audit/PSDesignObjectAuditorTest.java
+++ b/system/src/test/java/com/percussion/rx/audit/PSDesignObjectAuditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,92 @@
  */
 package com.percussion.rx.audit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
 import com.percussion.rx.audit.PSDesignObjectAuditor.PSAuditData;
+import com.percussion.services.audit.IPSDesignObjectAuditConfig;
+import com.percussion.services.audit.IPSDesignObjectAuditService;
+import com.percussion.services.audit.PSDesignObjectAuditServiceLocator;
+import com.percussion.services.audit.data.PSAuditLogEntry;
 import com.percussion.services.audit.data.PSAuditLogEntry.AuditTypes;
 import com.percussion.services.catalog.IPSCatalogIdentifier;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.Signature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-/** Unit test for the {@link PSDesignObjectAuditor} class. */
-public class PSDesignObjectAuditorTest {
-  /**
-   * Test the logic of the {@link PSDesignObjectAuditor} for a method name and argument. Does not
-   * test actual AOP joinpoint processing or persisting of audit data.
-   */
-  public void testExtractAuditData() {
+/**
+ * Unit tests for {@link PSDesignObjectAuditor}: extract audit data and dual-write through {@link
+ * DesignErrorCodes} / system audit log when design auditing is enabled.
+ */
+class PSDesignObjectAuditorTest {
+
+  private IPSDesignObjectAuditService auditService;
+  private IPSDesignObjectAuditConfig auditConfig;
+  private List<Collection<PSAuditLogEntry>> savedBatches;
+
+  @BeforeEach
+  void setUp() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+    if (PSRequestInfo.isInited()) {
+      PSRequestInfo.resetRequestInfo();
+    }
+
+    auditService = mock(IPSDesignObjectAuditService.class);
+    auditConfig = mock(IPSDesignObjectAuditConfig.class);
+    when(auditService.getConfig()).thenReturn(auditConfig);
+    when(auditConfig.isEnabled()).thenReturn(true);
+    when(auditService.createAuditLogEntry()).thenAnswer(inv -> new PSAuditLogEntry());
+    savedBatches = new ArrayList<>();
+    org.mockito.Mockito.doAnswer(
+            inv -> {
+              @SuppressWarnings("unchecked")
+              Collection<PSAuditLogEntry> batch = inv.getArgument(0);
+              savedBatches.add(new ArrayList<>(batch));
+              return null;
+            })
+        .when(auditService)
+        .saveAuditLogEntries(any());
+
+    PSDesignObjectAuditServiceLocator.setAuditService(auditService);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSDesignObjectAuditServiceLocator.clearCache();
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+    if (PSRequestInfo.isInited()) {
+      PSRequestInfo.resetRequestInfo();
+    }
+  }
+
+  @Test
+  void createAuditDataExtractsSaveAndDeleteGuids() {
     PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
 
-    // test non-audited inputs
     assertTrue(auditor.createAuditData(null, null).isEmpty());
     assertTrue(auditor.createAuditData("", null).isEmpty());
     assertTrue(auditor.createAuditData("findSomething", null).isEmpty());
@@ -48,10 +110,8 @@ public class PSDesignObjectAuditorTest {
     assertTrue(auditor.createAuditData("saveSomething", "Test").isEmpty());
 
     IPSGuid guid = new PSGuid(PSTypeEnum.CONTENT_LIST, 301);
-
     assertTrue(auditor.createAuditData("findSomething", guid).isEmpty());
 
-    // test delete with guid and identifier
     Collection<PSAuditData> auditData = auditor.createAuditData("deleteSomething", guid);
     assertFalse(auditData.isEmpty());
     PSAuditData data = auditData.iterator().next();
@@ -65,20 +125,20 @@ public class PSDesignObjectAuditorTest {
     auditData = auditor.createAuditData("deleteSomething", id);
     assertFalse(auditData.isEmpty());
     data = auditData.iterator().next();
-    assertNotNull(data);
     assertEquals(guid, data.getGuid());
     assertEquals(AuditTypes.DELETE, data.getAction());
 
-    // test update
     id.mi_version = Integer.valueOf(2);
     auditData = auditor.createAuditData("saveSomething", id);
     assertFalse(auditData.isEmpty());
     data = auditData.iterator().next();
-    assertNotNull(data);
     assertEquals(AuditTypes.SAVE, data.getAction());
+  }
 
-    // test collections
-    List<Object> coll = new ArrayList<Object>();
+  @Test
+  void createAuditDataHandlesCollections() {
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    List<Object> coll = new ArrayList<>();
 
     PSMockCatalogIdentifier id1 = new PSMockCatalogIdentifier();
     PSMockCatalogIdentifier id2 = new PSMockCatalogIdentifier();
@@ -95,7 +155,7 @@ public class PSDesignObjectAuditorTest {
     coll.add(id2);
     coll.add(id3);
 
-    auditData = auditor.createAuditData("saveSomething", coll);
+    Collection<PSAuditData> auditData = auditor.createAuditData("saveSomething", coll);
     assertEquals(coll.size(), auditData.size());
     validateAuditedCollection(coll, auditData);
 
@@ -104,7 +164,6 @@ public class PSDesignObjectAuditorTest {
     assertEquals(coll.size() - 1, auditData.size());
     validateAuditedCollection(coll, auditData);
 
-    // test mix for delete
     coll.clear();
     coll.add(id1.mi_guid);
     coll.add(id2.mi_guid);
@@ -115,29 +174,193 @@ public class PSDesignObjectAuditorTest {
     validateAuditedCollection(coll, auditData);
   }
 
-  /**
-   * Validates that each object in the collection that should be audited has a corresponding and
-   * correct result in the audit data. Assumes the method call was a "save".
-   *
-   * @param coll The collection of objects that may or may not be instances of {@link
-   *     PSMockCatalogIdentifier} or {@link IPSGuid}, assumed not <code>null</code>.
-   * @param auditData The resulting audit data to validate, assumed not <code>null</code>.
-   */
+  @Test
+  void enabledSaveDualWritesUpdateAndLegacyEntry() throws Throwable {
+    Map<String, Object> initial = new HashMap<>();
+    initial.put(PSRequestInfo.KEY_USER, "designer");
+    PSRequestInfo.initRequestInfo(initial);
+
+    PSMockCatalogIdentifier id = new PSMockCatalogIdentifier();
+    id.mi_guid = new PSGuid(PSTypeEnum.CONTENT_LIST, 401);
+    id.mi_version = 1;
+
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    auditor.audit(joinPoint("saveContentList", id));
+
+    assertEquals(1, savedBatches.size());
+    assertEquals(1, savedBatches.get(0).size());
+    PSAuditLogEntry legacy = savedBatches.get(0).iterator().next();
+    assertEquals(AuditTypes.SAVE, legacy.getAction());
+    assertEquals("designer", legacy.getUserName());
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(DesignErrorCodes.UPDATE, rec.code());
+    assertEquals("DESN", rec.code().module().code());
+    assertEquals(2902, rec.code().numericCode());
+    assertEquals("designer", rec.actor().orElse(""));
+    assertTrue(rec.formattedLine().startsWith("[DESN-2902]-"));
+  }
+
+  @Test
+  void enabledDeleteDualWritesDeleteCode() throws Throwable {
+    Map<String, Object> initial = new HashMap<>();
+    initial.put(PSRequestInfo.KEY_USER, "admin");
+    PSRequestInfo.initRequestInfo(initial);
+
+    IPSGuid guid = new PSGuid(PSTypeEnum.TEMPLATE, 55);
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    auditor.audit(joinPoint("deleteTemplate", guid));
+
+    assertEquals(1, savedBatches.size());
+    assertEquals(AuditTypes.DELETE, savedBatches.get(0).iterator().next().getAction());
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(DesignErrorCodes.DELETE, rec.code());
+    assertEquals(2903, rec.code().numericCode());
+    assertEquals("admin", rec.actor().orElse(""));
+  }
+
+  @Test
+  void multiObjectCollectionDualWritesEach() throws Throwable {
+    Map<String, Object> initial = new HashMap<>();
+    initial.put(PSRequestInfo.KEY_USER, "bulkuser");
+    PSRequestInfo.initRequestInfo(initial);
+
+    List<Object> coll = new ArrayList<>();
+    coll.add(new PSGuid(PSTypeEnum.CONTENT_LIST, 501));
+    coll.add(new PSGuid(PSTypeEnum.CONTENT_LIST, 502));
+    coll.add(new PSGuid(PSTypeEnum.CONTENT_LIST, 503));
+
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    auditor.audit(joinPoint("deleteMany", coll));
+
+    assertEquals(1, savedBatches.size());
+    assertEquals(3, savedBatches.get(0).size());
+    assertEquals(3, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertTrue(
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().stream()
+            .allMatch(r -> r.code() == DesignErrorCodes.DELETE));
+  }
+
+  @Test
+  void disabledAuditingWritesNothing() throws Throwable {
+    when(auditConfig.isEnabled()).thenReturn(false);
+
+    Map<String, Object> initial = new HashMap<>();
+    initial.put(PSRequestInfo.KEY_USER, "designer");
+    PSRequestInfo.initRequestInfo(initial);
+
+    PSMockCatalogIdentifier id = new PSMockCatalogIdentifier();
+    id.mi_guid = new PSGuid(PSTypeEnum.CONTENT_LIST, 601);
+    id.mi_version = 1;
+
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    auditor.audit(joinPoint("saveContentList", id));
+
+    verify(auditService, never()).saveAuditLogEntries(any());
+    verify(auditService, never()).createAuditLogEntry();
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertTrue(savedBatches.isEmpty());
+  }
+
+  @Test
+  void blankUserMapsToUnknownOnBothPaths() throws Throwable {
+    // No KEY_USER and no KEY_PSREQUEST → unknown
+    Map<String, Object> initial = new HashMap<>();
+    PSRequestInfo.initRequestInfo(initial);
+
+    IPSGuid guid = new PSGuid(PSTypeEnum.SITE, 9);
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    auditor.audit(joinPoint("saveSite", guid));
+
+    assertEquals(1, savedBatches.size());
+    assertEquals("unknown", savedBatches.get(0).iterator().next().getUserName());
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals("unknown", rec.actor().orElse(""));
+    assertEquals(DesignErrorCodes.UPDATE, rec.code());
+  }
+
+  @Test
+  void resolveUserNameBlankWithoutRequestInfoIsUnknown() {
+    // PSRequestInfo not inited — getRequestInfo returns null
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    assertEquals("unknown", auditor.resolveUserName());
+  }
+
+  @Test
+  void dualWriteSystemAuditUsesUpdateForSaveAction() {
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    Collection<PSAuditData> data =
+        auditor.createAuditData("saveX", new PSGuid(PSTypeEnum.CONTENT_LIST, 1));
+    auditor.dualWriteSystemAudit("u1", data.iterator().next());
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertEquals(
+        DesignErrorCodes.UPDATE, ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
+  }
+
+  @Test
+  void dualWriteSystemAuditUsesDeleteForDeleteAction() {
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    Collection<PSAuditData> data =
+        auditor.createAuditData("deleteX", new PSGuid(PSTypeEnum.CONTENT_LIST, 2));
+    auditor.dualWriteSystemAudit("u2", data.iterator().next());
+
+    assertEquals(
+        DesignErrorCodes.DELETE, ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
+  }
+
+  @Test
+  void nonAuditedMethodDoesNotWrite() throws Throwable {
+    Map<String, Object> initial = new HashMap<>();
+    initial.put(PSRequestInfo.KEY_USER, "designer");
+    PSRequestInfo.initRequestInfo(initial);
+
+    IPSGuid guid = new PSGuid(PSTypeEnum.CONTENT_LIST, 701);
+    PSDesignObjectAuditor auditor = new PSDesignObjectAuditor();
+    auditor.audit(joinPoint("findContentList", guid));
+
+    verify(auditService, never()).saveAuditLogEntries(any());
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void resolveTypeNameUsesTypeEnum() {
+    IPSGuid guid = new PSGuid(PSTypeEnum.CONTENT_LIST, 1);
+    assertEquals("CONTENT_LIST", PSDesignObjectAuditor.resolveTypeName(guid));
+    assertEquals("", PSDesignObjectAuditor.resolveTypeName(null));
+  }
+
+  private static JoinPoint joinPoint(String methodName, Object firstArg) {
+    JoinPoint jp = mock(JoinPoint.class);
+    Signature sig = mock(Signature.class);
+    when(jp.getSignature()).thenReturn(sig);
+    when(sig.getName()).thenReturn(methodName);
+    when(jp.getArgs()).thenReturn(new Object[] {firstArg});
+    return jp;
+  }
+
   private void validateAuditedCollection(List<Object> coll, Collection<PSAuditData> auditData) {
-    PSMockCatalogIdentifier id;
-    Map<IPSGuid, PSAuditData> resultMap = new HashMap<IPSGuid, PSAuditData>();
+    Map<IPSGuid, PSAuditData> resultMap = new HashMap<>();
     for (PSAuditData result : auditData) {
       resultMap.put(result.getGuid(), result);
     }
 
     for (Object object : coll) {
       if (object instanceof PSMockCatalogIdentifier) {
-        id = (PSMockCatalogIdentifier) object;
+        PSMockCatalogIdentifier id = (PSMockCatalogIdentifier) object;
         PSAuditData result = resultMap.get(id.getGUID());
         assertNotNull(result);
         Integer version = id.getVersion();
-        if (version == null) assertEquals(AuditTypes.DELETE, result.getAction());
-        else assertEquals(AuditTypes.SAVE, result.getAction());
+        if (version == null) {
+          assertEquals(AuditTypes.DELETE, result.getAction());
+        } else {
+          assertEquals(AuditTypes.SAVE, result.getAction());
+        }
       } else if (object instanceof IPSGuid) {
         PSAuditData result = resultMap.get(object);
         assertNotNull(result);
@@ -146,34 +369,16 @@ public class PSDesignObjectAuditorTest {
     }
   }
 
-  /**
-   * Mock implementation of the {@link IPSCatalogIdentifier} interface that also provides a <code>
-   * getVersion()</code> method.
-   */
-  public class PSMockCatalogIdentifier implements IPSCatalogIdentifier {
-    /** The guid of the identifier, may be <code>null</code>. */
+  /** Mock implementation of {@link IPSCatalogIdentifier} with optional Hibernate version. */
+  static class PSMockCatalogIdentifier implements IPSCatalogIdentifier {
     private IPSGuid mi_guid;
-
-    /**
-     * The version of the identifier, may be <code>null</code>, used to provide a value for the
-     * {@link #getVersion()} method. A <code>null</code> is used by the test to expect a delete.
-     */
     private Integer mi_version;
 
-    /**
-     * Get the guid of this object
-     *
-     * @return The guid, may be <code>null</code>.
-     */
+    @Override
     public IPSGuid getGUID() {
       return mi_guid;
     }
 
-    /**
-     * Get the Hibernate version of this object.
-     *
-     * @return The version, may be <code>null</code>.
-     */
     public Integer getVersion() {
       return mi_version;
     }

--- a/system/src/test/java/com/percussion/rx/audit/PSDesignObjectAuditorTest.java
+++ b/system/src/test/java/com/percussion/rx/audit/PSDesignObjectAuditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ * Copyright 1999-2025 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
@@ -223,6 +223,48 @@ class PSSystemAuditLoggerTest {
     assertEquals(3, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
   }
 
+  @Test
+  void designUpdateWritesDesnUpdateCode() {
+    PSSystemAuditLogger.designUpdate("designer", "CONTENT_LIST", "list-1", "guid-d1");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(DesignErrorCodes.UPDATE, rec.code());
+    assertEquals("DESN", rec.code().module().code());
+    assertEquals(2902, rec.code().numericCode());
+    assertEquals("designer", rec.actor().orElse(""));
+    assertEquals("guid-d1", rec.target().orElse(""));
+    assertTrue(rec.formattedLine().startsWith("[DESN-2902]-"));
+  }
+
+  @Test
+  void designDeleteAndCreateWriteLifecycleCodes() {
+    PSSystemAuditLogger.designCreate("u1", "TEMPLATE", "t1", "g-c");
+    PSSystemAuditLogger.designDelete("u2", "TEMPLATE", "t1", "g-d");
+
+    assertEquals(2, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var codes =
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().stream()
+            .map(r -> r.code().numericCode())
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(codes.contains(2901));
+    assertTrue(codes.contains(2903));
+  }
+
+  @Test
+  void designBlankActorBecomesUnknown() {
+    PSSystemAuditLogger.design(DesignErrorCodes.UPDATE, "  ", "SITE", "", "g-x");
+
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals("unknown", rec.actor().orElse(""));
+  }
+
+  @Test
+  void designNullCodeIsNoOp() {
+    PSSystemAuditLogger.design(null, "u", "t", "n", "g");
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
   private static HttpServletRequest mockRequest(String user, String ip) {
     HttpServletRequest request = mock(HttpServletRequest.class);
     when(request.getRemoteUser()).thenReturn(user);


### PR DESCRIPTION
## Summary
Parent **#2617** slice 1: wire `PSDesignObjectAuditor` so design save/delete AOP audits dual-write through `PSSystemAuditLogger` + `DesignErrorCodes` (DESN-2902 update / DESN-2903 delete) into the system audit path (`PSX_SYSTEM_AUDIT_LOG` + Log4j), while retaining legacy `PSX_DESIGN_AUDIT_LOG` rows.

- When design auditing is **enabled**: legacy design audit entries + DESN system audit dual-write
- When design auditing is **disabled**: no legacy rows and **no** new system audit rows
- Blank / missing actor → `"unknown"`
- Dual-write sink failures are logged and swallowed (never block design save/delete)
- **Out of scope:** CADF/jcadf removal (#2675), retention scheduler (#2674), Admin UI

## Changes
- `PSDesignObjectAuditor` — dual-write after building legacy entries
- `PSSystemAuditLogger` — `design` / `designCreate` / `designUpdate` / `designDelete` helpers
- `PSDesignObjectAuditServiceLocator.setAuditService` — unit-test override
- Unit tests: enabled/disabled, save vs delete, multi-object, blank user, extract-audit-data

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Surefire: **Tests run: 1500, Failures: 0, Errors: 0**
- [x] `PSDesignObjectAuditorTest` — 12 tests
- [x] `PSSystemAuditLoggerTest` — 26 tests (includes design helpers)
- [x] Erlang pre-commit review: **approve** (`docs/ai-generated/code-reviews/2673-design-object-auditor-dual-write-erlang.md`)

## Gates evidence
| Gate | Result |
|------|--------|
| Behavioral unit tests | yes |
| Erlang review | approve |
| Module clean install (`system`) | BUILD SUCCESS |
| No CADF removal | confirmed |
| Cross-platform path I/O | N/A (no new path I/O) |

## Links
- Fixes #2673
- Parent epic: #2617
- Related remaining slices: #2674 (retention), #2675 (CADF purge)

**Operator:** Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
