### PR TITLE
fix(perc-system): PSRole DB-component serial-field hierarchy (#2677)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
@@ -39,6 +39,9 @@ import org.w3c.dom.Element;
  */
 @SuppressWarnings(value = {"unchecked"})
 public class PSAttribute extends PSDatabaseComponentCollection {
+
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
@@ -28,8 +28,14 @@ import org.w3c.dom.Element;
  * This class defines a set of attributes stored as a database component. Each attribute will be
  * defined as a mapping from a name (type <code>String</code>) and a collection of values (The
  * collection will contain <code>String</code> objects.
+ *
+ * <p>Serializable via {@link PSDatabaseComponentCollection} for holders such as {@link PSRole}
+ * attribute lists. Wire/XML behavior is unchanged.
  */
 public class PSAttributeList extends PSDatabaseComponentCollection implements IPSComponent {
+
+  private static final long serialVersionUID = 1L;
+
   /** Constructor for serialization, fromXml, etc. */
   public PSAttributeList() {
     super((new PSAttribute()).getClass(), (new PSAttribute()).getDatabaseAppQueryDatasetName());

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttributeValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttributeValue.java
@@ -31,6 +31,9 @@ import org.w3c.dom.Element;
  * @see PSAttribute
  */
 public class PSAttributeValue extends PSDatabaseComponent {
+
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponent.java
@@ -21,16 +21,25 @@ import com.percussion.design.objectstore.server.PSDatabaseComponentLoader;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.error.PSSqlException;
 import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.Serializable;
 import java.sql.SQLException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /**
- * This interface is used by Object store components whose state is saved in a database rather than
- * an XML file. The objects are still XML based. The object uses this interface to serialize itself
- * to and from a back end database via a different XML format and a Rx application.
+ * Base for object-store components whose state is saved in a database rather than an XML file. The
+ * objects are still XML based. The object uses this interface to serialize itself to and from a
+ * back end database via a different XML format and a Rx application.
+ *
+ * <p>Also implements {@link Serializable} so holders such as {@link PSRole} (Serializable via {@code
+ * IPSCatalogSummary}) can declare database-component collection fields without {@code
+ * -Xlint:serial} serial-field diagnostics. Java serialization is product-safe for in-process /
+ * session use; wire and XML behavior is unchanged.
  */
-public abstract class PSDatabaseComponent implements IPSDatabaseComponent {
+public abstract class PSDatabaseComponent implements IPSDatabaseComponent, Serializable {
+
+  private static final long serialVersionUID = 1L;
+
   // see interface for description
   public Object clone() {
     PSDatabaseComponent copy = null;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponentCollection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponentCollection.java
@@ -21,6 +21,7 @@ import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.collections.PSIteratorUtils;
 import com.percussion.xml.PSXmlTreeWalker;
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -33,8 +34,14 @@ import org.w3c.dom.Element;
  * PSDatabaseComponents and maintaining state information on additions, deletions, or modifications
  * to the collection so that the back end database can be updated appropriately. Note: The interface
  * to this "collection" most closely resembles a subset of "List".
+ *
+ * <p>Serializable via {@link PSDatabaseComponent} so {@link PSRole} subject/attribute collection
+ * fields clear {@code -Xlint:serial} serial-field. Contained components are also {@link
+ * Serializable}. Wire/XML behavior is unchanged.
  */
-public class PSDatabaseComponentCollection extends PSDatabaseComponent {
+public class PSDatabaseComponentCollection extends PSDatabaseComponent implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   /**
    * Construct a collection of database components.

--- a/system/src/main/java/com/percussion/design/objectstore/PSGlobalSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSGlobalSubject.java
@@ -32,6 +32,8 @@ import org.w3c.dom.Element;
  */
 public class PSGlobalSubject extends PSSubject {
 
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelation.java
@@ -30,6 +30,9 @@ import org.w3c.dom.Element;
  * identifies a row in a relationship table in the database.
  */
 public class PSRelation extends PSDatabaseComponent implements Cloneable {
+
+  private static final long serialVersionUID = 1L;
+
   /** Construct a new, empty relation object. */
   public PSRelation() {}
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelativeSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelativeSubject.java
@@ -33,6 +33,9 @@ import org.w3c.dom.Element;
  * @see PSGlobalSubject
  */
 public class PSRelativeSubject extends PSSubject {
+
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSRole.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRole.java
@@ -43,6 +43,9 @@ import org.w3c.dom.Element;
  * @see PSCollectionComponent
  */
 public class PSRole extends PSDatabaseComponent implements Comparable, IPSCatalogSummary {
+
+  private static final long serialVersionUID = 1L;
+
   /**
    * Searches for a matching subject in this role.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
@@ -35,6 +35,9 @@ import org.w3c.dom.Element;
  * @since 4.0
  */
 public abstract class PSSubject extends PSDatabaseComponent {
+
+  private static final long serialVersionUID = 1L;
+
   /* The SUBJECT_TYPE_xxx values must be flags so they can be OR'd together
   by users of this class. */
 

--- a/system/src/test/java/com/percussion/design/objectstore/PSRoleDatabaseComponentSerialFieldTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSRoleDatabaseComponentSerialFieldTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Java serialization surface for PSRole database-component fields after #2451 residual (#2677 /
+ * parent #2022). Hierarchy under {@link PSDatabaseComponent} is product-safe {@link Serializable}
+ * so {@code m_subjects} / {@code m_attributes} clear {@code -Xlint:serial} serial-field. Wire/XML
+ * behavior is unchanged.
+ */
+public class PSRoleDatabaseComponentSerialFieldTest {
+
+  @Test
+  public void testDatabaseComponentHierarchyIsSerializable() {
+    assertTrue(Serializable.class.isAssignableFrom(PSDatabaseComponent.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSDatabaseComponentCollection.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSAttributeList.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSAttribute.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSAttributeValue.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSSubject.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSRelativeSubject.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSGlobalSubject.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSRelation.class));
+    assertTrue(Serializable.class.isAssignableFrom(PSRole.class));
+  }
+
+  @Test
+  public void testPsRoleSubjectAndAttributeFieldsAreSerializableTypes() throws Exception {
+    Class<?> subjectsType = PSRole.class.getDeclaredField("m_subjects").getType();
+    Class<?> attributesType = PSRole.class.getDeclaredField("m_attributes").getType();
+
+    assertEquals(PSDatabaseComponentCollection.class, subjectsType);
+    assertEquals(PSAttributeList.class, attributesType);
+    assertTrue(Serializable.class.isAssignableFrom(subjectsType));
+    assertTrue(Serializable.class.isAssignableFrom(attributesType));
+  }
+
+  @Test
+  public void testEmptyRoleJavaSerializationRoundTrip() throws Exception {
+    PSRole role = new PSRole("Editors");
+    PSRole ser = roundTrip(role);
+
+    assertEquals(role.getName(), ser.getName());
+    assertEquals(0, ser.getSubjects().size());
+    assertEquals(0, ser.getAttributes().size());
+    assertTrue(PSRoleTest.testRoleEquals(role, ser));
+  }
+
+  @Test
+  public void testRoleWithSubjectsAndAttributesRoundTrip() throws Exception {
+    PSRole role = new PSRole("Authors");
+    role.getSubjects()
+        .add(new PSRelativeSubject("alice", PSSubject.SUBJECT_TYPE_USER, new PSAttributeList()));
+    role.getAttributes().setAttribute("dept", Arrays.asList("editorial"));
+
+    PSRole ser = roundTrip(role);
+
+    assertEquals("Authors", ser.getName());
+    assertEquals(1, ser.getSubjects().size());
+    assertTrue(
+        role.containsCorrespondingSubject((PSSubject) ser.getSubjects().get(0))
+            || ser.containsCorrespondingSubject(
+                (PSSubject) role.getSubjects().get(0)));
+    assertEquals(1, ser.getAttributes().size());
+    PSAttribute attr = ser.getAttributes().getAttribute("dept");
+    assertNotNull(attr);
+    assertEquals(Arrays.asList("editorial"), attr.getValues());
+    assertTrue(PSRoleTest.testRoleEquals(role, ser));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    byte[] bytes;
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(value);
+      bytes = bos.toByteArray();
+    }
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      return (T) ois.readObject();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Clears the **#2451 residual** serial-field diagnostics on `PSRole` (`m_subjects` / `m_attributes`) by making the `PSDatabaseComponent` hierarchy product-safe `Serializable`.

**Parent:** #2022 / grandparent #2200  
**Prior:** #2451 / PR #2676  
**Operator:** Grok: night-issue-prs (model grok-4.5)

### Approach
Prefer Serializable hierarchy (shared by subjects, attributes, relations) over product-safe `transient`. No wire/XML behavior change — Java serialization surface only.

| Type | Change |
| --- | --- |
| `PSDatabaseComponent` | `implements Serializable` + `serialVersionUID` |
| `PSDatabaseComponentCollection` | inherits + UID; fields already use serializable `PSCollection` |
| `PSAttributeList` / `PSAttribute` / `PSAttributeValue` | companion UIDs |
| `PSSubject` / `PSRelativeSubject` / `PSGlobalSubject` / `PSRelation` / `PSRole` | companion UIDs |

### Metrics
| Kind | Before (#2451 residual) | After |
| --- | ---: | ---: |
| design.objectstore serial-field on PSRole | 2 | **0** |

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Module suite: Tests run: **1488**, Failures: **0**, Errors: **0**, Skipped: **237**
- [x] New `PSRoleDatabaseComponentSerialFieldTest` — Tests run: **4**, Failures: **0**
  - hierarchy is Serializable
  - `m_subjects` / `m_attributes` field types are Serializable
  - empty role round-trip
  - role with subjects + attributes round-trip

## Gates
- Erlang-style self-review: no bugs, portable paths N/A, companions delivered
- Pre-PR Maven: standalone system clean install
- No residuals filed (acceptance fully covered)

Fixes #2677

> Co-Authored by Grok Build using grok-4.5 with agent main.