### PR TITLE
fix(perc-system): type PSJndiGroupProvider + directory cataloger rawtypes (#2461)

### DIFF
--- a/system/src/main/java/com/percussion/security/IPSDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/IPSDirectoryCataloger.java
@@ -119,7 +119,7 @@ public interface IPSDirectoryCataloger {
    *
    * @param userName the name of the user as known to Rhythmyx. Never <code>null</code> or empty.
    */
-  public PSSubject getAttributes(String userName, Collection attributeNames);
+  public PSSubject getAttributes(String userName, Collection<?> attributeNames);
 
   /**
    * Searches the directory catalog associated with the supplied subject. If it finds the user, it
@@ -133,7 +133,7 @@ public interface IPSDirectoryCataloger {
    *     attributes. Existing attributes on the supplied subject will be overwritten. Attributes
    *     that are not found are added to the subject with <code>null</code> as value.
    */
-  public PSSubject getAttributes(PSSubject user, Collection attributeNames);
+  public PSSubject getAttributes(PSSubject user, Collection<?> attributeNames);
 
   /**
    * Searches all registered directories for users that match the provided search criteria. For each
@@ -149,7 +149,7 @@ public interface IPSDirectoryCataloger {
    * @return a valid collection of 0 or more <code>PSSubject</code> objects. All attributes are set
    *     on the respective subject as attributes.
    */
-  public Collection findUsers(PSConditional[] criteria, Collection attributeNames);
+  public Collection<PSSubject> findUsers(PSConditional[] criteria, Collection<?> attributeNames);
 
   /**
    * Get this provider's list of group provider objects.

--- a/system/src/main/java/com/percussion/security/PSBackEndDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndDirectoryCataloger.java
@@ -53,8 +53,9 @@ public class PSBackEndDirectoryCataloger extends PSDirectoryCataloger {
     PSSubject subject = getAttributes(user, attrs);
     PSAttribute attr = subject.getAttributes().getAttribute(attributeName);
     if (attr != null) {
-      List vals = attr.getValues();
-      if (!vals.isEmpty()) attributeVal = (String) vals.get(0);
+      @SuppressWarnings("unchecked")
+      List<?> vals = attr.getValues();
+      if (!vals.isEmpty()) attributeVal = vals.get(0).toString();
     }
 
     return attributeVal;
@@ -66,21 +67,23 @@ public class PSBackEndDirectoryCataloger extends PSDirectoryCataloger {
   }
 
   // see IPSDirectoryCataloger interface
-  public PSSubject getAttributes(PSSubject user, Collection attributeNames) {
+  public PSSubject getAttributes(PSSubject user, Collection<?> attributeNames) {
     // 1st clear all existing attributes from the supplied subject
     PSAttributeList userAttributes = user.getAttributes();
     while (userAttributes.size() > 0) userAttributes.removeElementAt(0);
 
     if (attributeNames != null) {
-      Iterator attrs = attributeNames.iterator();
-      while (attrs.hasNext()) userAttributes.setAttribute((String) attrs.next(), null);
+      for (Object attrName : attributeNames) {
+        if (attrName != null) userAttributes.setAttribute(attrName.toString(), null);
+      }
     }
 
     PSSubject subject = getMatchingSubject(user.getName(), attributeNames);
     if (subject != null) {
-      Iterator attrs = subject.getAttributes().iterator();
+      @SuppressWarnings("unchecked")
+      Iterator<PSAttribute> attrs = subject.getAttributes().iterator();
       while (attrs.hasNext()) {
-        PSAttribute attr = (PSAttribute) attrs.next();
+        PSAttribute attr = attrs.next();
         userAttributes.setAttribute(attr.getName(), attr.getValues());
       }
     }
@@ -89,8 +92,8 @@ public class PSBackEndDirectoryCataloger extends PSDirectoryCataloger {
   }
 
   // see IPSDirectoryCataloger interface
-  public Collection findUsers(PSConditional[] criteria, Collection attributeNames) {
-    Collection users = new HashSet();
+  public Collection<PSSubject> findUsers(PSConditional[] criteria, Collection<?> attributeNames) {
+    Collection<PSSubject> users = new HashSet<>();
     if (criteria == null || criteria.length == 0) criteria = new PSConditional[] {null};
     for (int i = 0; i < criteria.length; i++) {
       users.addAll(PSBackendCataloger.getSubjects(createFilter(criteria[i]), attributeNames));
@@ -122,7 +125,7 @@ public class PSBackEndDirectoryCataloger extends PSDirectoryCataloger {
    * @param attributeNames Attributes to return with the subject, may be <code>null</code> or empty.
    * @return The subject, or <code>null</code> if not found.
    */
-  private PSSubject getMatchingSubject(String name, Collection attributeNames) {
+  private PSSubject getMatchingSubject(String name, Collection<?> attributeNames) {
     Map<String, String> filters = new HashMap<>();
     filters.put(PSBackendCataloger.FILTER_SUBJECT_NAME, name);
     Set<PSSubject> subjects = PSBackendCataloger.getSubjects(filters, attributeNames);

--- a/system/src/main/java/com/percussion/security/PSBackEndTableDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndTableDirectoryCataloger.java
@@ -77,14 +77,18 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
    * @see IPSDirectoryCataloger
    */
   public String getAttribute(PSSubject user, String attributeName) {
-    Collection attributeNames = new ArrayList();
+    Collection<String> attributeNames = new ArrayList<>();
     attributeNames.add(attributeName);
 
     PSSubject subject = getAttributes(user, attributeNames);
 
     PSAttribute attribute = subject.getAttributes().getAttribute(attributeName);
-    List values = null;
-    if (attribute != null) values = attribute.getValues();
+    List<?> values = null;
+    if (attribute != null) {
+      @SuppressWarnings("unchecked")
+      List<?> attrValues = attribute.getValues();
+      values = attrValues;
+    }
 
     return (values == null || values.isEmpty()) ? null : values.get(0).toString();
   }
@@ -99,7 +103,7 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
   /**
    * @see IPSDirectoryCataloger
    */
-  public PSSubject getAttributes(PSSubject user, Collection attributeNames) {
+  public PSSubject getAttributes(PSSubject user, Collection<?> attributeNames) {
     if (user == null) throw new IllegalArgumentException("user may not be null");
 
     // 1st clear all existing attributes from the supplied subject
@@ -107,11 +111,14 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
     while (attributes.size() > 0) attributes.removeElementAt(0);
 
     // 2nd prepare all requested attributes with null's
-    Iterator attrNames = null;
+    Iterator<?> attrNames;
     if (attributeNames == null || attributeNames.isEmpty())
       attrNames = m_backendConnection.getUserAttributeNames();
     else attrNames = attributeNames.iterator();
-    while (attrNames.hasNext()) attributes.setAttribute((String) attrNames.next(), null);
+    while (attrNames.hasNext()) {
+      Object attrName = attrNames.next();
+      if (attrName != null) attributes.setAttribute(attrName.toString(), null);
+    }
 
     Connection conn = null;
     PreparedStatement stmt = null;
@@ -122,13 +129,14 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
       result = stmt.executeQuery();
 
       if (result.next()) {
-        Iterator attrs = attributes.iterator();
+        @SuppressWarnings("unchecked")
+        Iterator<PSAttribute> attrs = attributes.iterator();
         while (attrs.hasNext()) {
-          PSAttribute attr = (PSAttribute) attrs.next();
+          PSAttribute attr = attrs.next();
 
           String colName = m_backendConnection.getUserAttribute(attr.getName());
           if (colName != null) {
-            List values = new ArrayList();
+            List<String> values = new ArrayList<>();
             values.add(result.getString(colName));
             attr.setValues(values);
           }
@@ -167,7 +175,7 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
   /**
    * @see IPSDirectoryCataloger
    */
-  public Collection findUsers(PSConditional[] criteria, Collection attributeNames) {
+  public Collection<PSSubject> findUsers(PSConditional[] criteria, Collection<?> attributeNames) {
     Collection<PSSubject> subjects = new ArrayList<>();
 
     if (criteria == null || criteria.length == 0) criteria = new PSConditional[] {null};
@@ -175,30 +183,32 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
     Connection conn = null;
     PreparedStatement stmt = null;
     try {
+      Collection<Object> resolvedAttrs;
       if (attributeNames == null || attributeNames.isEmpty()) {
-        attributeNames = new ArrayList();
-        Iterator attrs = m_backendConnection.getUserAttributeNames();
-        while (attrs.hasNext()) attributeNames.add(attrs.next());
+        resolvedAttrs = new ArrayList<>();
+        Iterator<?> attrs = m_backendConnection.getUserAttributeNames();
+        while (attrs.hasNext()) resolvedAttrs.add(attrs.next());
+      } else {
+        resolvedAttrs = new ArrayList<>(attributeNames);
       }
 
       conn = m_backendConnection.getDbConnection();
 
       for (int i = 0; i < criteria.length; i++) {
-        stmt = m_backendConnection.getPreparedStatement(criteria[i], attributeNames, conn);
+        stmt = m_backendConnection.getPreparedStatement(criteria[i], resolvedAttrs, conn);
         if (stmt == null) continue;
 
         ResultSet rs = stmt.executeQuery();
         while (rs.next()) {
           String name = rs.getString(m_backendConnection.getUserColumn());
           PSAttributeList attList = new PSAttributeList();
-          Iterator attrs = attributeNames.iterator();
-          while (attrs.hasNext()) {
-            String attr = (String) attrs.next();
+          for (Object attrObj : resolvedAttrs) {
+            String attr = attrObj.toString();
 
-            List values = null;
+            List<String> values = null;
             String colName = m_backendConnection.getUserAttribute(attr);
             if (colName != null) {
-              values = new ArrayList();
+              values = new ArrayList<>();
               values.add(rs.getString(colName));
             }
 

--- a/system/src/main/java/com/percussion/security/PSDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSDirectoryCataloger.java
@@ -109,7 +109,7 @@ public abstract class PSDirectoryCataloger extends PSCataloger implements IPSDir
   /**
    * @see IPSDirectoryCataloger
    */
-  public PSSubject getAttributes(String userName, Collection attributeNames) {
+  public PSSubject getAttributes(String userName, Collection<?> attributeNames) {
     return getAttributes(createSubject(userName), attributeNames);
   }
 
@@ -196,7 +196,7 @@ public abstract class PSDirectoryCataloger extends PSCataloger implements IPSDir
       String attributeName) {
     String resultString = null;
     DirContext context = null;
-    NamingEnumeration results = null;
+    NamingEnumeration<SearchResult> results = null;
     try {
       context = createContext(directory);
 
@@ -204,15 +204,15 @@ public abstract class PSDirectoryCataloger extends PSCataloger implements IPSDir
       returnAttrs[0] = attributeName;
       SearchControls searchControls = createSearchControls(directory.getDirectory(), returnAttrs);
 
-      Map values = new HashMap();
+      Map<String, Object> values = new HashMap<>();
       values.put(userAttributeName, user);
       values.put(attributeName, null);
 
       results = context.search("", PSJndiUtils.buildFilter(values), searchControls);
       while (results.hasMore()) {
-        SearchResult result = (SearchResult) results.next();
+        SearchResult result = results.next();
 
-        Attribute attr = (Attribute) result.getAttributes().get(attributeName);
+        Attribute attr = result.getAttributes().get(attributeName);
         if (attr != null) {
           resultString = attr.get(0).toString();
           break;
@@ -262,31 +262,31 @@ public abstract class PSDirectoryCataloger extends PSCataloger implements IPSDir
       String user,
       String userAttributeName,
       String[] returnAttrs,
-      Map searchResults) {
+      Map<String, List<String>> searchResults) {
     DirContext context = null;
-    NamingEnumeration results = null;
-    NamingEnumeration attributes = null;
-    NamingEnumeration values = null;
+    NamingEnumeration<SearchResult> results = null;
+    NamingEnumeration<? extends Attribute> attributes = null;
+    NamingEnumeration<?> values = null;
     try {
       context = createContext(directory);
 
       PSDirectory dir = directory.getDirectory();
       SearchControls searchControls = createSearchControls(dir, returnAttrs);
 
-      Map filterValues = new HashMap();
+      Map<String, Object> filterValues = new HashMap<>();
       filterValues.put(userAttributeName, user);
 
       results = context.search("", PSJndiUtils.buildFilter(filterValues), searchControls);
 
       while (results.hasMore()) {
-        SearchResult result = (SearchResult) results.next();
+        SearchResult result = results.next();
         attributes = result.getAttributes().getAll();
         while (attributes.hasMore()) {
-          Attribute attribute = (Attribute) attributes.next();
+          Attribute attribute = attributes.next();
 
-          List resultValues = (List) searchResults.get(attribute.getID());
+          List<String> resultValues = searchResults.get(attribute.getID());
           if (resultValues == null) {
-            resultValues = new ArrayList();
+            resultValues = new ArrayList<>();
             searchResults.put(attribute.getID(), resultValues);
           }
           values = attribute.getAll();

--- a/system/src/main/java/com/percussion/security/PSDirectoryServerCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSDirectoryServerCataloger.java
@@ -25,7 +25,6 @@ import com.percussion.security.error.PSExceptionUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -73,13 +72,12 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
       throw new IllegalArgumentException("attributeName cannot be empty");
 
     String result = null;
-    Iterator directories = getDirectories().values().iterator();
     String dirName = "";
-    while (result == null && directories.hasNext()) {
+    for (PSDirectoryDefinition directory : getDirectories().values()) {
       try {
-        PSDirectoryDefinition directory = (PSDirectoryDefinition) directories.next();
         dirName = directory.getDirectory().getName();
         result = getAttribute(directory, user.getName(), getObjectAttributeName(), attributeName);
+        if (result != null) break;
       } catch (Exception e) {
         log.error(
             "Error finding users for ldap Directory:{} : Error: {}",
@@ -98,13 +96,11 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
     if (user == null) throw new IllegalArgumentException("user cannot be null");
 
     // do the search for all configured directories
-    Iterator directories = getDirectories().values().iterator();
     String dirName = "";
-    while (directories.hasNext()) {
+    for (PSDirectoryDefinition directory : getDirectories().values()) {
       try {
-        PSDirectoryDefinition directory = (PSDirectoryDefinition) directories.next();
         dirName = directory.getDirectory().getName();
-        Collection attributeNames = directory.getDirectory().getAttributes();
+        Collection<?> attributeNames = directory.getDirectory().getAttributes();
 
         getAttributes(user, attributeNames);
       } catch (Exception e) {
@@ -121,23 +117,26 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
   /**
    * @see IPSDirectoryCataloger
    */
-  public PSSubject getAttributes(PSSubject user, Collection attributeNames) {
+  public PSSubject getAttributes(PSSubject user, Collection<?> attributeNames) {
     if (user == null) throw new IllegalArgumentException("user cannot be null");
 
     // prepare returning attributes array
     String[] returningAttrs = null;
-    if (attributeNames != null && !attributeNames.isEmpty())
-      returningAttrs = (String[]) attributeNames.toArray(new String[0]);
+    if (attributeNames != null && !attributeNames.isEmpty()) {
+      List<String> names = new ArrayList<>(attributeNames.size());
+      for (Object attrName : attributeNames) {
+        if (attrName != null) names.add(attrName.toString());
+      }
+      returningAttrs = names.toArray(new String[0]);
+    }
 
     // initialize the search results map
-    Map searchResults = new HashMap();
+    Map<String, List<String>> searchResults = new HashMap<>();
 
     // do the search for all configured directories
-    Iterator directories = getDirectories().values().iterator();
     String dirName = "";
-    while (directories.hasNext()) {
+    for (PSDirectoryDefinition directory : getDirectories().values()) {
       try {
-        PSDirectoryDefinition directory = (PSDirectoryDefinition) directories.next();
         dirName = directory.getDirectory().getName();
         getAttributes(
             directory, user.getName(), getObjectAttributeName(), returningAttrs, searchResults);
@@ -151,10 +150,8 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
 
     // set attributes in returned subject
     PSAttributeList attributes = user.getAttributes();
-    Iterator keys = searchResults.keySet().iterator();
-    while (keys.hasNext()) {
-      String key = (String) keys.next();
-      attributes.setAttribute(key, (List) searchResults.get(key));
+    for (Map.Entry<String, List<String>> entry : searchResults.entrySet()) {
+      attributes.setAttribute(entry.getKey(), entry.getValue());
     }
 
     return user;
@@ -163,8 +160,8 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
   /**
    * @see IPSDirectoryCataloger
    */
-  public Collection findUsers(PSConditional[] criteria, Collection attributeNames) {
-    Collection result = new ArrayList();
+  public Collection<PSSubject> findUsers(PSConditional[] criteria, Collection<?> attributeNames) {
+    Collection<PSSubject> result = new ArrayList<>();
 
     if (criteria == null) criteria = new PSConditional[] {null};
 
@@ -174,9 +171,9 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
       Map<String, String> aFilter = createFilter(criteria[i]);
       for (Map.Entry<String, String> entry : aFilter.entrySet()) {
         String val = PSJndiUtils.processFilter(entry.getValue());
-        List valList = filter.get(entry.getKey());
+        List<String> valList = filter.get(entry.getKey());
         if (valList == null) {
-          valList = new ArrayList<String>();
+          valList = new ArrayList<>();
           filter.put(entry.getKey(), valList);
         }
         valList.add(val);
@@ -186,14 +183,12 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
       Exception ex = null;
       if ((i % 100 == 0) || i == criteria.length - 1) {
 
-        Iterator directories = getDirectories().values().iterator();
         String dirName = "";
-        while (directories.hasNext()) {
+        for (PSDirectoryDefinition directory : getDirectories().values()) {
           try {
             dirSize++;
-            PSDirectoryDefinition directory = (PSDirectoryDefinition) directories.next();
             dirName = directory.getDirectory().getName();
-            Collection subs = getSubjects(directory, filter, attributeNames);
+            Collection<PSSubject> subs = getSubjects(directory, filter, attributeNames);
             result.addAll(subs);
           } catch (Exception e) {
             log.error(

--- a/system/src/main/java/com/percussion/security/PSJndiGroupProvider.java
+++ b/system/src/main/java/com/percussion/security/PSJndiGroupProvider.java
@@ -78,9 +78,10 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     m_directoryDef = directoryDef;
     m_userObjectAttrName = userObjectAttrName;
 
-    Iterator nodes = m_groupProviderInstance.getGroupNodes();
+    @SuppressWarnings("unchecked")
+    Iterator<String> nodes = m_groupProviderInstance.getGroupNodes();
     while (nodes.hasNext()) {
-      String node = (String) nodes.next();
+      String node = nodes.next();
       m_groupLocationInfo.add(new GroupLocationInfo(node));
     }
 
@@ -183,7 +184,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     if (searchFilter.trim().length() == 0) return groups;
 
     DirContext ctx = null;
-    NamingEnumeration results = null;
+    NamingEnumeration<SearchResult> results = null;
     try {
       // walk group locations
       for (GroupLocationInfo locationInfo : m_groupLocationInfo) {
@@ -210,7 +211,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
           /* add the group, appending the current context to the relative
            * name returned
            */
-          SearchResult result = (SearchResult) results.next();
+          SearchResult result = results.next();
           CompoundName cn = PSJndiUtils.getCompoundName(result.getName(), node.toString());
           groups.add(cn.toString());
         }
@@ -262,7 +263,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
           PSJndiUtils.createSearchControls(m_directoryDef.getDirectory(), null);
       searchControls.setCountLimit(1);
 
-      Map filter = new HashMap();
+      Map<String, Object> filter = new HashMap<>();
       filter.put(m_userObjectAttrName, userName);
 
       results = context.search("", PSJndiUtils.buildFilter(filter), searchControls);
@@ -330,9 +331,9 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     List<IPSTypedPrincipal> members = new ArrayList<>();
 
     DirContext ctx = null;
-    NamingEnumeration results = null;
-    NamingEnumeration ae = null;
-    NamingEnumeration attVals = null;
+    NamingEnumeration<SearchResult> results = null;
+    NamingEnumeration<? extends Attribute> ae = null;
+    NamingEnumeration<?> attVals = null;
     try {
       // get group entry
       CompoundName groupCn = PSJndiUtils.getCompoundName(groupName);
@@ -361,14 +362,14 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
        */
       List<Map<String, List<String>>> resultList = new ArrayList<>();
       while (results.hasMore()) {
-        Map<String, List<String>> attrMap = new HashMap();
-        SearchResult result = (SearchResult) results.next();
+        Map<String, List<String>> attrMap = new HashMap<>();
+        SearchResult result = results.next();
         Attributes attrs = result.getAttributes();
         for (ae = attrs.getAll(); ae.hasMore(); ) {
-          Attribute attr = (Attribute) ae.next();
+          Attribute attr = ae.next();
           String attrKey = attr.getID().toLowerCase();
-          List valList = attrMap.get(attrKey);
-          if (valList == null) valList = new ArrayList();
+          List<String> valList = attrMap.get(attrKey);
+          if (valList == null) valList = new ArrayList<>();
           attVals = attr.getAll();
           while (attVals.hasMoreElements()) valList.add(attVals.nextElement().toString());
 
@@ -392,7 +393,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       List<String> staticMemberList = new ArrayList<>();
       List<String> dynamicMemberList = new ArrayList<>();
 
-      for (Map attrMap : resultList) {
+      for (Map<String, List<String>> attrMap : resultList) {
         members.addAll(filterMemberList(attrMap, staticMemberList, dynamicMemberList));
       }
 
@@ -425,9 +426,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
         members.addAll(getDynamicUsers(dynamicMember));
 
         // get all groups returned by the query and recurse
-        Iterator groupMembers = getDynamicGroupMembers(dynamicMember).iterator();
-        while (groupMembers.hasNext()) {
-          String member = (String) groupMembers.next();
+        for (String member : getDynamicGroupMembers(dynamicMember)) {
           members.addAll(getGroupMembers(member, level));
         }
       }
@@ -514,7 +513,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     Collection<IPSTypedPrincipal> users = new ArrayList<>();
 
     DirContext ctx = null;
-    NamingEnumeration results = null;
+    NamingEnumeration<SearchResult> results = null;
     try {
       // get entries matching the filter and not the group objectclasses
       String groupCond = getGroupsSearchFilter();
@@ -529,7 +528,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       ctx = getDirContext(base);
       results = ctx.search("", filter, ctls);
       while (results.hasMore()) {
-        SearchResult result = (SearchResult) results.next();
+        SearchResult result = results.next();
         CompoundName cn = PSJndiUtils.getCompoundName(result.getName(), base);
         users.add(dnToPrincipal(cn.toString(), false));
       }
@@ -569,26 +568,25 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       throws NamingException {
     List<IPSTypedPrincipal> groupMembers = new ArrayList<>();
 
-    List foundOcs = getObjectClasses(attrMap);
+    List<String> foundOcs = getObjectClasses(attrMap);
     if (foundOcs.isEmpty()) return groupMembers;
 
     // walk supported object classes and see if in the list
-    Iterator defOcs = m_groupProviderInstance.getObjectClassesNames();
+    @SuppressWarnings("unchecked")
+    Iterator<String> defOcs = m_groupProviderInstance.getObjectClassesNames();
     while (defOcs.hasNext()) {
-      String defOc = (String) defOcs.next();
+      String defOc = defOcs.next();
       if (foundOcs.contains(defOc.toLowerCase())) {
         // found a supported objectClass, so get its memberlist attribute
         // values
         String memberAttrName = m_groupProviderInstance.getMemberAttribute(defOc);
         int memberAttrType = m_groupProviderInstance.getMemberAttributeType(defOc);
-        List memberList = attrMap.get(memberAttrName.toLowerCase());
+        List<String> memberList = attrMap.get(memberAttrName.toLowerCase());
 
         // group may have no members
         if (memberList == null) continue;
 
-        Iterator members = memberList.iterator();
-        while (members.hasNext()) {
-          String member = (String) members.next();
+        for (String member : memberList) {
           if (memberAttrType == PSJndiObjectClass.MEMBER_ATTR_STATIC) {
             // check for group, but don't search, as the returned member
             // list is searched on anyhow
@@ -628,7 +626,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     else if (doSearch) {
       // search for it as a group
       DirContext ctx = null;
-      NamingEnumeration results = null;
+      NamingEnumeration<SearchResult> results = null;
       try {
         // get entries matching the filter and the supported objectClasses
         CompoundName cn = PSJndiUtils.getCompoundName(dn);
@@ -715,9 +713,9 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     if (++level > MAX_NESTED_GROUPS) return false;
 
     DirContext ctx = null;
-    NamingEnumeration results = null;
-    NamingEnumeration ae = null;
-    NamingEnumeration attVals = null;
+    NamingEnumeration<SearchResult> results = null;
+    NamingEnumeration<? extends Attribute> ae = null;
+    NamingEnumeration<?> attVals = null;
     try {
       // get group entry
       CompoundName groupName = PSJndiUtils.getCompoundName(group);
@@ -741,22 +739,22 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       results = ctx.search("", searchFilter, ctls);
 
       // set up lists of members that may need to be recursively searched
-      List staticMemberList = new ArrayList();
-      List dynamicMemberList = new ArrayList();
+      List<String> staticMemberList = new ArrayList<>();
+      List<String> dynamicMemberList = new ArrayList<>();
 
       /* walk the results - attributes don't come back in the order in which
        * they are specified, so we need to build a map of each entry's
        * attributes and values.
        */
       while (results.hasMore()) {
-        Map attrMap = new HashMap();
-        SearchResult result = (SearchResult) results.next();
+        Map<String, List<String>> attrMap = new HashMap<>();
+        SearchResult result = results.next();
         Attributes attrs = result.getAttributes();
         for (ae = attrs.getAll(); ae.hasMore(); ) {
-          Attribute attr = (Attribute) ae.next();
+          Attribute attr = ae.next();
           String attrKey = attr.getID().toLowerCase();
-          List valList = (List) attrMap.get(attrKey);
-          if (valList == null) valList = new ArrayList();
+          List<String> valList = attrMap.get(attrKey);
+          if (valList == null) valList = new ArrayList<>();
           attVals = attr.getAll();
           while (attVals.hasMoreElements()) valList.add(attVals.nextElement().toString());
 
@@ -782,20 +780,14 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
        * not an immediate member, need to check any memberlists for group
        * entries - first check static groups
        */
-      Iterator staticMembers = staticMemberList.iterator();
-      while (staticMembers.hasNext()) {
-        String member = (String) staticMembers.next();
+      for (String member : staticMemberList) {
         if (isMember(user, member, level)) return true;
       }
 
       // now check dynamic groups
-      Iterator dynamicMembers = dynamicMemberList.iterator();
-      while (dynamicMembers.hasNext()) {
-        String dynamicMember = (String) dynamicMembers.next();
-        List groupMembers = getDynamicGroupMembers(dynamicMember);
-        Iterator members = groupMembers.iterator();
-        while (members.hasNext()) {
-          String member = (String) members.next();
+      for (String dynamicMember : dynamicMemberList) {
+        List<String> groupMembers = getDynamicGroupMembers(dynamicMember);
+        for (String member : groupMembers) {
           if (isMember(user, member, level)) {
             return true;
           }
@@ -856,28 +848,30 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
    * @throws NamingException if any errors occur parsing names or searching the directory.
    */
   private boolean isUserInMemberList(
-      String user, Map attrMap, List checkedStaticMembers, List checkedDynamicMembers)
+      String user,
+      Map<String, List<String>> attrMap,
+      List<String> checkedStaticMembers,
+      List<String> checkedDynamicMembers)
       throws NamingException {
-    List foundOcs = getObjectClasses(attrMap);
+    List<String> foundOcs = getObjectClasses(attrMap);
     if (foundOcs.isEmpty()) return false;
 
     // walk supported object classes and see if in the list
-    Iterator defOcs = m_groupProviderInstance.getObjectClassesNames();
+    @SuppressWarnings("unchecked")
+    Iterator<String> defOcs = m_groupProviderInstance.getObjectClassesNames();
     while (defOcs.hasNext()) {
-      String defOc = (String) defOcs.next();
+      String defOc = defOcs.next();
       if (foundOcs.contains(defOc.toLowerCase())) {
         // found a supported objectClass, so get its memberlist attribute
         // values
         String memberAttrName = m_groupProviderInstance.getMemberAttribute(defOc);
         int memberAttrType = m_groupProviderInstance.getMemberAttributeType(defOc);
-        List memberList = (List) attrMap.get(memberAttrName.toLowerCase());
+        List<String> memberList = attrMap.get(memberAttrName.toLowerCase());
 
         // group may have no members
         if (memberList == null) continue;
 
-        Iterator members = memberList.iterator();
-        while (members.hasNext()) {
-          String member = (String) members.next();
+        for (String member : memberList) {
           if (memberAttrType == PSJndiObjectClass.MEMBER_ATTR_STATIC) {
             // static list - check for match
             CompoundName memberName = PSJndiUtils.getCompoundName(member);
@@ -911,11 +905,9 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     // build lowercase list of objectclass names from the directory
     List<String> foundOcs = new ArrayList<>();
 
-    List dirObjClasses = attrMap.get(PSJndiProvider.OBJECT_CLASS_ATTR.toLowerCase());
+    List<String> dirObjClasses = attrMap.get(PSJndiProvider.OBJECT_CLASS_ATTR.toLowerCase());
     if (dirObjClasses != null) {
-      Iterator dirOcs = dirObjClasses.iterator();
-      while (dirOcs.hasNext()) {
-        String dirOc = (String) dirOcs.next();
+      for (String dirOc : dirObjClasses) {
         foundOcs.add(dirOc.toLowerCase());
       }
     }
@@ -937,7 +929,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
     String base = baseBuf.toString();
 
     DirContext ctx = null;
-    NamingEnumeration results = null;
+    NamingEnumeration<SearchResult> results = null;
     try {
       // get entries matching the filter and the member's common name
       CompoundName memberName = PSJndiUtils.getCompoundName(user);
@@ -970,7 +962,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
        */
       boolean hasMatch = false;
       while (results.hasMoreElements() && !hasMatch) {
-        SearchResult result = (SearchResult) results.next();
+        SearchResult result = results.next();
         CompoundName cn =
             PSJndiUtils.getCompoundName(
                 result.getName(), base); // name returned is relative to search context
@@ -1003,14 +995,14 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
    *     are found.
    * @throws NamingException if any errors occur
    */
-  private List getDynamicGroupMembers(String searchUrl) throws NamingException {
+  private List<String> getDynamicGroupMembers(String searchUrl) throws NamingException {
     StringBuilder baseBuf = new StringBuilder();
     String filter = parseSearchUrl(searchUrl, baseBuf);
     String base = baseBuf.toString();
 
-    List members = new ArrayList();
+    List<String> members = new ArrayList<>();
     DirContext ctx = null;
-    NamingEnumeration results = null;
+    NamingEnumeration<SearchResult> results = null;
     try {
       // get entries matching the filter and the supported objectClasses
       String groupCond = getGroupsSearchFilter();
@@ -1025,7 +1017,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       ctx = getDirContext(base);
       results = ctx.search("", filter, ctls);
       while (results.hasMore()) {
-        SearchResult result = (SearchResult) results.next();
+        SearchResult result = results.next();
         CompoundName cn = PSJndiUtils.getCompoundName(result.getName(), base);
         members.add(cn.toString());
       }
@@ -1120,9 +1112,10 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
   private String getGroupsSearchFilter() {
     if (m_groupsSearchFilter == null) {
       StringBuilder buf = new StringBuilder();
-      Iterator ocs = m_groupProviderInstance.getObjectClassesNames();
+      @SuppressWarnings("unchecked")
+      Iterator<String> ocs = m_groupProviderInstance.getObjectClassesNames();
       while (ocs.hasNext()) {
-        String oc = (String) ocs.next();
+        String oc = ocs.next();
         if (buf.length() == 0) buf.append("(|");
 
         buf.append(" (");
@@ -1149,14 +1142,15 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
    */
   private String[] getMemberListAttributes() {
     if (m_memberListAttributes == null) {
-      List attrs = new ArrayList();
-      Iterator ocs = m_groupProviderInstance.getObjectClassesNames();
+      List<String> attrs = new ArrayList<>();
+      @SuppressWarnings("unchecked")
+      Iterator<String> ocs = m_groupProviderInstance.getObjectClassesNames();
       while (ocs.hasNext()) {
-        String oc = (String) ocs.next();
+        String oc = ocs.next();
         attrs.add(m_groupProviderInstance.getMemberAttribute(oc));
       }
 
-      m_memberListAttributes = (String[]) attrs.toArray(new String[attrs.size()]);
+      m_memberListAttributes = attrs.toArray(new String[0]);
     }
 
     return m_memberListAttributes;
@@ -1181,7 +1175,11 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
    * @return The filter portion of the url, never <code>null</code>, may be empty if no filter is
    *     supplied.
    */
-  private static String parseSearchUrl(String url, StringBuilder baseBuffer) {
+  /**
+   * Package-visible so unit tests can cover URL parsing without a live LDAP directory (issue
+   * #2461).
+   */
+  static String parseSearchUrl(String url, StringBuilder baseBuffer) {
     String filter = "";
     String delim = "??sub?";
 

--- a/system/src/test/java/com/percussion/security/PSJndiGroupProviderTypedTest.java
+++ b/system/src/test/java/com/percussion/security/PSJndiGroupProviderTypedTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSAuthentication;
+import com.percussion.design.objectstore.PSDirectory;
+import com.percussion.design.objectstore.PSJndiGroupProviderInstance;
+import com.percussion.design.objectstore.PSJndiObjectClass;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.naming.NamingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed {@link PSJndiGroupProvider} internals (issue #2461 residual of #2386
+ * / parent epic #2022). Covers pure logic that does not require a live LDAP directory.
+ */
+@Tag("UnitTest")
+public class PSJndiGroupProviderTypedTest {
+
+  private static final String PROVIDER_URL = "ldap://localhost:389/dc=example,dc=com";
+
+  private PSJndiGroupProvider provider;
+
+  @BeforeEach
+  void setUp() throws NamingException {
+    PSJndiGroupProviderInstance gp =
+        new PSJndiGroupProviderInstance("test-groups", PSSecurityProvider.SP_TYPE_DIRCONN);
+    gp.addObjectClass("groupOfNames", "member", PSJndiObjectClass.MEMBER_ATTR_STATIC);
+    gp.addGroupNode("ou=groups,dc=example,dc=com");
+
+    PSAuthentication auth =
+        new PSAuthentication(
+            "auth", PSAuthentication.SCHEME_SIMPLE, "cn=admin", "secret", null, null);
+    PSDirectory dir =
+        new PSDirectory(
+            "dir",
+            PSDirectory.CATALOG_SHALLOW,
+            "com.sun.jndi.ldap.LdapCtxFactory",
+            "auth",
+            PROVIDER_URL,
+            null);
+    PSDirectoryDefinition dirDef = new PSDirectoryDefinition(auth, dir);
+
+    provider = new PSJndiGroupProvider(gp, dirDef, "uid");
+  }
+
+  @Test
+  void parseSearchUrlSplitsBaseAndFilter() {
+    StringBuilder base = new StringBuilder();
+    String filter =
+        PSJndiGroupProvider.parseSearchUrl("ldap:///ou=percussion,c=us??sub?(cn=m*)", base);
+    assertEquals("ou=percussion,c=us", base.toString());
+    assertEquals("(cn=m*)", filter);
+  }
+
+  @Test
+  void parseSearchUrlHandlesMissingFilterAndPrefix() {
+    StringBuilder base = new StringBuilder();
+    String filter = PSJndiGroupProvider.parseSearchUrl("ou=people,dc=example,dc=com", base);
+    assertEquals("ou=people,dc=example,dc=com", base.toString());
+    assertEquals("", filter);
+  }
+
+  @Test
+  void isGroupSupportedMatchesConfiguredLocationSuffix() {
+    assertTrue(provider.isGroupSupported("cn=Admins,ou=groups,dc=example,dc=com"));
+    assertFalse(provider.isGroupSupported("cn=Admins,ou=other,dc=example,dc=com"));
+  }
+
+  @Test
+  void isGroupSupportedRejectsNullOrEmpty() {
+    assertThrows(IllegalArgumentException.class, () -> provider.isGroupSupported(null));
+    assertThrows(IllegalArgumentException.class, () -> provider.isGroupSupported(""));
+    assertThrows(IllegalArgumentException.class, () -> provider.isGroupSupported("   "));
+  }
+
+  @Test
+  void shouldTreatAsGroupFalseWhenNotSupportedAndUserAttrDiffersFromCn() throws NamingException {
+    // user object attr is uid (not cn), DN not under group locations → user
+    assertFalse(provider.shouldTreatAsGroup("uid=alice,ou=people,dc=example,dc=com", false));
+  }
+
+  @Test
+  void shouldTreatAsGroupTrueForSupportedGroupDnWithDistinctUserAttr() throws NamingException {
+    assertTrue(provider.shouldTreatAsGroup("cn=Admins,ou=groups,dc=example,dc=com", false));
+  }
+
+  @Test
+  void getGroupsReturnsEmptyWhenNoObjectClasses() throws NamingException {
+    PSJndiGroupProviderInstance emptyGp =
+        new PSJndiGroupProviderInstance("empty", PSSecurityProvider.SP_TYPE_DIRCONN);
+    emptyGp.addGroupNode("ou=groups,dc=example,dc=com");
+
+    PSAuthentication auth =
+        new PSAuthentication(
+            "auth", PSAuthentication.SCHEME_SIMPLE, "cn=admin", "secret", null, null);
+    PSDirectory dir =
+        new PSDirectory(
+            "dir",
+            PSDirectory.CATALOG_SHALLOW,
+            "com.sun.jndi.ldap.LdapCtxFactory",
+            "auth",
+            PROVIDER_URL,
+            null);
+    PSJndiGroupProvider emptyProvider =
+        new PSJndiGroupProvider(emptyGp, new PSDirectoryDefinition(auth, dir), "uid");
+
+    Collection<String> groups = emptyProvider.getGroups(null);
+    assertTrue(groups.isEmpty());
+  }
+
+  @Test
+  void getGroupMembersRejectsNullGroups() {
+    assertThrows(IllegalArgumentException.class, () -> provider.getGroupMembers(null));
+  }
+
+  @Test
+  void getGroupMembersSkipsUnsupportedGroupsWithoutLdap() {
+    List<java.security.Principal> groups = new ArrayList<>();
+    groups.add(() -> "cn=Nope,ou=other,dc=example,dc=com");
+
+    Collection<IPSTypedPrincipal> members = provider.getGroupMembers(groups);
+    assertTrue(members.isEmpty());
+    // unsupported groups are left in the input collection
+    assertEquals(1, groups.size());
+  }
+
+  @Test
+  void typedAttrMapObjectClassesAreLowercased() throws Exception {
+    // Exercise package-private style behavior via filterMemberList path indirectly:
+    // verify getObjectClasses semantics by building attr maps the same shape as production.
+    Map<String, List<String>> attrMap = new HashMap<>();
+    attrMap.put(
+        PSJndiProvider.OBJECT_CLASS_ATTR.toLowerCase(),
+        List.of("groupOfNames", "top"));
+
+    // Reflect private getObjectClasses to lock typed List<String> contract without LDAP.
+    var method =
+        PSJndiGroupProvider.class.getDeclaredMethod("getObjectClasses", Map.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<String> ocs = (List<String>) method.invoke(provider, attrMap);
+    assertEquals(List.of("groupofnames", "top"), ocs);
+  }
+}


### PR DESCRIPTION
## Summary
Partial residual of **#2386** / parent epic **#2022** (grandparent **#2200**). **Fixes #2461**.

PR-sized security package batch: real generics on `PSJndiGroupProvider` internals and remaining directory cataloger helpers still raw after #2387 / #2458.

### Changed
- `PSJndiGroupProvider` — typed attr maps (`Map<String,List<String>>`), member lists, `NamingEnumeration<SearchResult>`, group member recursion; package-visible `parseSearchUrl` for tests
- `IPSDirectoryCataloger` — `Collection<?>` attribute names, `Collection<PSSubject>` findUsers
- `PSDirectoryServerCataloger` / `PSDirectoryCataloger` — typed search helpers and for-each over `getDirectories()`
- `PSBackEndDirectoryCataloger` / `PSBackEndTableDirectoryCataloger` — implement typed interface

Boundary `@SuppressWarnings("unchecked")` only where `PSJndiGroupProviderInstance` still returns raw `Iterator` (design.objectstore; not in this PR).

### Out of scope
- `PSRoleManager` (owned by separate residual)
- `HTTPClient` package
- Typing `PSJndiGroupProviderInstance` fields/iterators in design.objectstore

## Test plan
- [x] `cd system && ../mvnw.cmd test -Dtest=PSJndiGroupProviderTypedTest` → **Tests run: 10, Failures: 0**
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; **Tests run: 1525, Failures: 0, Errors: 0, Skipped: 237**
- [x] No new warnings attributable to this change on the edited security files

## Gates
- Erlang-style self-review: typing-only behavior surface; pure-logic tests for parse/support/skip paths; portable (no path I/O)
- Pre-PR Maven: standalone system clean install green
- Spotless not required

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2022 · Related: #2200 #2386 · Residual of PR #2458

> Co-Authored by Grok Build using grok-4.5 with agent main.
