### PR TITLE
fix(perc-content-explorer): clear PSFolderPropertiesPanel last rawtypes (#2380)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2380-psfolder-properties-rawtypes-residual-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2380-psfolder-properties-rawtypes-residual-erlang.md
@@ -1,0 +1,28 @@
+# Erlang self-review — issue #2380 residual (PSFolderPropertiesPanel rawtypes)
+
+**Date:** 2026-08-10  
+**Branch:** fix/issue-2380-psfolder-panels-rawtypes  
+**Module:** modules/DesktopContentExplorer  
+**Verdict:** PASS
+
+## Scope
+Clear last residual rawtypes/unchecked in `PSFolderPropertiesPanel` after merged PR #2438 left Security/General at 0 Xlint diags and Properties with one `Vector` rawtypes from `DefaultTableModel#getDataVector()`.
+
+**Out of scope:** `PSFolderAclEditorDialog` (owned by open #2439).
+
+## Findings
+| Severity | Finding | Disposition |
+|----------|---------|-------------|
+| — | none | — |
+
+## Checklist
+- [x] No product behavior change (same name/value/desc read path via TableModel#getValueAt)
+- [x] No non-portable path/file I/O
+- [x] Unit test for `stringValue` helper + existing `stringCell`
+- [x] Module standalone `mvnw clean install` BUILD SUCCESS — Tests run: 101, Failures: 0
+- [x] Direct javac `-Xlint:rawtypes,unchecked` on Properties panel: 0 warnings
+- [x] Security/General panels already 0 diags (verified); not re-churned
+
+## Companions
+- Change class: Swing rawtypes residual polish (typed table row access + helper)
+- Peers: prior #2438 helpers on Security/General panels

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderPropertiesPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderPropertiesPanel.java
@@ -146,12 +146,14 @@ public class PSFolderPropertiesPanel extends UTPropertiesTablePanel {
 
     for (int i = 0; i < rowCount; i++) {
       String name = stringValue(model.getValueAt(i, 0));
+      // value/desc may be null (e.g. unset DefaultTableModel cells). PSFolderProperty converts
+      // null value/desc to "" — same as the pre-getValueAt raw Vector path. Do not skip null
+      // values: that would delete the property via m_mapLoadedProperties cleanup instead of
+      // saving an empty string.
       String value = stringValue(model.getValueAt(i, 1));
       String desc = stringValue(model.getValueAt(i, 2));
 
       if (name == null || name.trim().length() <= 0) continue;
-
-      if (value == null) continue;
 
       PSFolderProperty prop = new PSFolderProperty(name, value, desc);
 

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderPropertiesPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSFolderPropertiesPanel.java
@@ -32,6 +32,7 @@ import javax.swing.JTable;
 import javax.swing.UIManager;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableModel;
 
 /**
  * Properties Panel on the Cx Folder Properties Dialog. Allows users to change custom folder
@@ -39,12 +40,6 @@ import javax.swing.table.TableColumnModel;
  */
 @SuppressWarnings("serial")
 public class PSFolderPropertiesPanel extends UTPropertiesTablePanel {
-  /**
-   * The only constructor.
-   *
-   * @param folder shared instance of the PSFolder, never <code>null</code>.
-   * @param editable <code>true</code> if any data can be entered, <code>false</code> otherwise.
-   */
   /**
    * The only constructor.
    *
@@ -104,18 +99,14 @@ public class PSFolderPropertiesPanel extends UTPropertiesTablePanel {
 
   /** loads folder properties into the table. */
   private void loadTableData() {
-    Iterator<?> iter = m_folder.getProperties();
+    Iterator<PSFolderProperty> iter = m_folder.getProperties();
 
     DefaultTableModel model = (DefaultTableModel) getTableModel();
 
     clearAllRows();
 
     while (iter.hasNext()) {
-      Object next = iter.next();
-      if (!(next instanceof PSFolderProperty)) {
-        continue;
-      }
-      PSFolderProperty property = (PSFolderProperty) next;
+      PSFolderProperty property = iter.next();
 
       // skip properties which are handled in other tab's
       if (PSFolder.isDisplayFormatProperty(property)
@@ -148,17 +139,15 @@ public class PSFolderPropertiesPanel extends UTPropertiesTablePanel {
 
     if (!validateData()) return false;
 
-    DefaultTableModel model = (DefaultTableModel) getTableModel();
+    // Prefer TableModel getValueAt over DefaultTableModel#getDataVector() so we avoid the
+    // Swing raw Vector return and keep row iteration fully typed (no rawtypes/unchecked).
+    TableModel model = getTableModel();
+    int rowCount = model.getRowCount();
 
-    @SuppressWarnings("unchecked")
-    Vector<Vector> vRows = model.getDataVector();
-
-    for (int i = 0; i < vRows.size(); i++) {
-      Vector<?> vColumns = vRows.elementAt(i);
-
-      String name = stringCell(vColumns, 0);
-      String value = stringCell(vColumns, 1);
-      String desc = stringCell(vColumns, 2);
+    for (int i = 0; i < rowCount; i++) {
+      String name = stringValue(model.getValueAt(i, 0));
+      String value = stringValue(model.getValueAt(i, 1));
+      String desc = stringValue(model.getValueAt(i, 2));
 
       if (name == null || name.trim().length() <= 0) continue;
 
@@ -199,7 +188,16 @@ public class PSFolderPropertiesPanel extends UTPropertiesTablePanel {
     if (row == null || index < 0 || index >= row.size()) {
       return null;
     }
-    Object cell = row.elementAt(index);
+    return stringValue(row.elementAt(index));
+  }
+
+  /**
+   * Converts a table-model cell to a string (null-safe). Package-visible for unit tests.
+   *
+   * @param cell cell value from {@link TableModel#getValueAt(int, int)}, may be <code>null</code>
+   * @return string value or <code>null</code>
+   */
+  static String stringValue(Object cell) {
     return cell == null ? null : cell.toString();
   }
 

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSFolderPropertiesPanelTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSFolderPropertiesPanelTest.java
@@ -38,4 +38,11 @@ public class PSFolderPropertiesPanelTest {
     assertNull(PSFolderPropertiesPanel.stringCell(row, 99));
     assertNull(PSFolderPropertiesPanel.stringCell(null, 0));
   }
+
+  @Test
+  public void stringValueNullSafeAndToString() {
+    assertNull(PSFolderPropertiesPanel.stringValue(null));
+    assertEquals("name", PSFolderPropertiesPanel.stringValue("name"));
+    assertEquals("42", PSFolderPropertiesPanel.stringValue(Integer.valueOf(42)));
+  }
 }

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSFolderPropertiesPanelTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSFolderPropertiesPanelTest.java
@@ -45,4 +45,22 @@ public class PSFolderPropertiesPanelTest {
     assertEquals("name", PSFolderPropertiesPanel.stringValue("name"));
     assertEquals("42", PSFolderPropertiesPanel.stringValue(Integer.valueOf(42)));
   }
+
+  /**
+   * Documents the onOk contract for null value cells: stringValue leaves null; {@code
+   * PSFolderProperty} then stores empty string. Rows with a non-blank name and null value must not
+   * be skipped (that would delete the property).
+   */
+  @Test
+  public void nullValueCellFlowsAsNullForFolderPropertyEmptyString() {
+    // Mirror onOk cell reads for a named row with unset value/desc cells.
+    String name = PSFolderPropertiesPanel.stringValue("myProp");
+    String value = PSFolderPropertiesPanel.stringValue(null);
+    String desc = PSFolderPropertiesPanel.stringValue(null);
+    assertEquals("myProp", name);
+    assertNull(value);
+    assertNull(desc);
+    // Production path: new PSFolderProperty(name, value, desc) → value becomes "".
+    // Skip-if-null would incorrectly treat this as a removed property.
+  }
 }


### PR DESCRIPTION
## Summary
Residual polish for **#2380** (parent module tracker **#2045**, monorepo **#2200**, residual of **#2369**).

Prior merged PR #2438 already parameterized Security/General/Properties panels. This PR clears the **last** rawtypes residual in `PSFolderPropertiesPanel`:

- Replace `DefaultTableModel#getDataVector()` (raw `Vector`) with typed `TableModel#getValueAt` row walk
- Type `getProperties()` iterator as `Iterator<PSFolderProperty>`
- Add package-visible `stringValue` helper + unit test

**Verified 0** `-Xlint:rawtypes,unchecked` on:
- `PSFolderSecurityPanel` (already clean)
- `PSFolderGeneralPanel` (already clean)
- `PSFolderPropertiesPanel` (this PR)

**Not touched:** `PSFolderAclEditorDialog` — owned by open **#2439** (~77 rawtypes/unchecked).

No product behavior change.

## Residual
- **#2439** `PSFolderAclEditorDialog` rawtypes (In Progress elsewhere) — only remaining work under this slice family

## Test plan
- [x] Erlang self-review PASS — `docs/ai-generated/code-reviews/issue-2380-psfolder-properties-rawtypes-residual-erlang.md`
- [x] Module standalone clean install:
  ```
  cd modules/DesktopContentExplorer
  ../../mvnw.cmd clean install
  ```
  **BUILD SUCCESS** — Tests run: 101, Failures: 0
- [x] Direct javac `-Xlint:rawtypes,unchecked` on Properties panel: 0 warnings
- [x] No new warnings attributable to this change (baseline shade/dependency-analyze only)

## Gates
- Pre-PR Maven verification: standalone module clean install green
- Unit tests for pure helpers (`stringCell`, `stringValue`)
- Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2380. Refs #2045 #2200 #2369 #2439.

> Co-Authored by Grok Build using grok-4.5 with agent main.
