### PR TITLE
fix(perc-system): clear cms.objectstore this-escape CoreItem/processors (#2652)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2652-objectstore-this-escape-coreitem-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2652-objectstore-this-escape-coreitem-erlang.md
@@ -1,0 +1,40 @@
+# Erlang review - #2652 cms.objectstore CoreItem/processors this-escape residual
+
+**Status:** pass (self-review before commit)  
+**Date:** 2026-08-10  
+**Module:** `system` / perc-system
+
+## Change class
+
+Real `-Xlint:this-escape` reduction in residual `cms.objectstore` after #2613: CoreItem definition extract without passing `this`, final leaf types, private construction helpers for processors/values. **No** suppress-only.
+
+## Findings
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| none | CoreItem extractDef behavioral change | Covered by `PSObjectStoreThisEscapeCoreItemTest` (definition extract + fields) |
+| none | ProcessorProxy NPE contract for invalid type | Restored flushCache-without-null-check; `PSActiveAssemblyProcessorProxyTest` green |
+| none | Non-portable paths | BinaryFileValue uses `File` / NIO-style streams only; path string for mime uses existing `/` normalize for URL-ish metadata |
+| note | Many leaf types marked `final` | No in-repo subclasses (verified before marking) |
+| note | cms.objectstore this-escape fully cleared this batch | Residual 0 under package-scoped measure |
+
+## Metrics (cms.objectstore `this-escape`, `-Xmaxwarns 10000`)
+
+| | Count |
+| --- | ---: |
+| Before | 61 |
+| After | 0 |
+| Δ | **−61** |
+
+## Tests
+
+- `cd system && ../mvnw.cmd clean install` - BUILD SUCCESS  
+- Tests run: 1573, Failures: 0, Errors: 0 (Skipped: 240)  
+- Focused: `PSObjectStoreThisEscapeCoreItemTest` 6/6, residual + DbComponent suites green  
+
+## Hard gates
+
+- [x] Behavioral unit tests for touched ctor/extract paths  
+- [x] No suppress-only this-escape  
+- [x] Cross-platform path handling OK  
+- [x] Module clean install green  

--- a/system/src/main/java/com/percussion/cms/objectstore/PSActiveAssemblerHandlerRequest.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSActiveAssemblerHandlerRequest.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** This class encapsulates a request to the Active Assembler Request handler. */
-public class PSActiveAssemblerHandlerRequest extends PSCmsComponent {
+public final class PSActiveAssemblerHandlerRequest extends PSCmsComponent {
   /**
    * Constructs a new active asembler request for the supplied parameters.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSBinaryValue.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSBinaryValue.java
@@ -39,7 +39,8 @@ public class PSBinaryValue extends PSFieldValue {
    *     null</code>, a new empty array will be created.
    */
   public PSBinaryValue(byte[] content) {
-    setData(content);
+    // Private base-load — avoid overridable setData during construction (this-escape).
+    applyDataBytes(content);
   }
 
   /**
@@ -50,7 +51,8 @@ public class PSBinaryValue extends PSFieldValue {
    * @throws IOException if there is a problem with the stream.
    */
   public PSBinaryValue(InputStream content) throws IOException {
-    setData(content);
+    // Private base-load — avoid overridable setData during construction (this-escape).
+    applyDataStream(content);
   }
 
   /**
@@ -123,9 +125,17 @@ public class PSBinaryValue extends PSFieldValue {
    *     empty array.
    */
   public void setData(byte[] content) {
-    if (content == null) m_data = new byte[0];
+    applyDataBytes(content);
+  }
 
-    m_data = content;
+  /**
+   * Construction-safe byte assign used by constructors and {@link #setData(byte[])}.
+   *
+   * @param content may be {@code null} (stored as empty array)
+   */
+  private void applyDataBytes(byte[] content) {
+    if (content == null) m_data = new byte[0];
+    else m_data = content;
     m_isDataLoaded = true;
   }
 
@@ -137,6 +147,15 @@ public class PSBinaryValue extends PSFieldValue {
    *     method assumes ownership of the stream and is responsible for closing it.
    */
   public void setData(InputStream content) throws IOException {
+    applyDataStream(content);
+  }
+
+  /**
+   * Construction-safe stream load used by constructors and {@link #setData(InputStream)}.
+   *
+   * @param content never {@code null}
+   */
+  private void applyDataStream(InputStream content) throws IOException {
     if (content == null) throw new IllegalArgumentException("content must not be null");
 
     try {
@@ -144,7 +163,7 @@ public class PSBinaryValue extends PSFieldValue {
       IOTools.copyStream(content, out);
 
       byte[] data = out.toByteArray();
-      setData(data);
+      applyDataBytes(data);
     } finally {
       content.close();
     }
@@ -265,6 +284,16 @@ public class PSBinaryValue extends PSFieldValue {
     }
 
     return m_data;
+  }
+
+  /**
+   * Construction-safe access to already-applied bytes for subclasses (e.g. {@code
+   * PSBinaryFileValue}) without overridable {@link #getValue()} / {@link #getData()}.
+   *
+   * @return never {@code null} (empty array if unset)
+   */
+  protected final byte[] dataBytesForConstruction() {
+    return m_data != null ? m_data : new byte[0];
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCloneSiteFolderRequest.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCloneSiteFolderRequest.java
@@ -33,7 +33,7 @@ import org.w3c.dom.Node;
  * Object store implementation for the <code>CloneSiteFolderRequest</code> object as defined in
  * schema sys_FolderParameters.xsd.
  */
-public class PSCloneSiteFolderRequest extends PSComponent {
+public final class PSCloneSiteFolderRequest extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
@@ -32,7 +32,7 @@ import org.w3c.dom.Element;
  * Object store implementation to the <code>PSXCloningOptions</code> object as defined in schema
  * sys_FolderParameters.xsd.
  */
-public class PSCloningOptions extends PSComponent {
+public final class PSCloningOptions extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCmsObject.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCmsObject.java
@@ -34,7 +34,7 @@ import org.w3c.dom.Element;
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSCmsObject")
 @Table(name = "PSX_OBJECTS")
-public class PSCmsObject implements IPSCmsComponent {
+public final class PSCmsObject implements IPSCmsComponent {
 
   /** Default constructor, which is needed for Hibernate. */
   public PSCmsObject() {}

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummaries.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummaries.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Element;
 /**
  * The PSComponentSummaries is a container class which contains a set of PSComponentSummary objects
  */
-public class PSComponentSummaries extends PSDbComponentSet<PSComponentSummary> {
+public final class PSComponentSummaries extends PSDbComponentSet<PSComponentSummary> {
   /** Default constructor. */
   public PSComponentSummaries() {
     super(PSComponentSummary.class);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
@@ -75,7 +75,7 @@ import org.w3c.dom.Element;
 })
 @DynamicInsert
 @DynamicUpdate
-public class PSComponentSummary extends PSDbComponent implements Serializable {
+public final class PSComponentSummary extends PSDbComponent implements Serializable {
   /** Serial id identifies versions of serialized data */
   private static final long serialVersionUID = 1L;
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeVariantSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSContentTypeVariantSet.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Element;
  * @deprecated Use the assembly service to load and manipulate variant information
  */
 @Deprecated
-public class PSContentTypeVariantSet extends PSDbComponentSet<PSContentTypeTemplate> {
+public final class PSContentTypeVariantSet extends PSDbComponentSet<PSContentTypeTemplate> {
   /** Default constructor. See {@link PSDbComponentSet#PSDbComponentSet(Class)} for more details. */
   @SuppressWarnings("unused")
   public PSContentTypeVariantSet() throws PSCmsException {

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCoreItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCoreItem.java
@@ -55,6 +55,7 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
 
     m_itemDefinition = itemDefinition;
     init();
+    // Private base-load: extract def without passing this to external visitor (this-escape).
     extractDef();
   }
 
@@ -68,20 +69,38 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
   }
 
   /**
-   * Populates this item with meta data.
+   * Populates this item with meta data from the item definition without passing {@code this} to
+   * external types during construction ({@code -Xlint:this-escape} / subclass safety).
    *
    * @throws PSCmsException if there is an error populating this item.
    */
   private void extractDef() throws PSCmsException {
-    PSItemDefExtractor.populateItemDefinition(this);
+    applyExtractedDefinition(PSItemDefExtractor.extractDefinition(m_itemDefinition));
   }
 
   /**
-   * Called by the extractor. Accepts an <code>IPSVisitor</code>.
+   * Applies extracted definition parts. Package-visible for {@link
+   * PSItemDefExtractor#populateItemDefinition(PSCoreItem)} after full construction.
+   *
+   * @param parts never {@code null}
+   */
+  final void applyExtractedDefinition(PSItemDefExtractor.DefinitionParts parts) {
+    if (parts == null) throw new IllegalArgumentException("parts must not be null");
+    for (PSItemField field : parts.getFields()) {
+      addField(field);
+    }
+    for (PSItemChild child : parts.getChildren()) {
+      addChild(child);
+    }
+  }
+
+  /**
+   * Called by the extractor / visitors after construction. Final so definition registration cannot
+   * be overridden during subclass init (this-escape).
    *
    * @param visitor must not be <code>null</code>
    */
-  public void accept(IPSVisitor visitor) {
+  public final void accept(IPSVisitor visitor) {
     if (visitor == null) throw new IllegalArgumentException("visitor must not be null");
 
     // if getObject returns null, then no field/child will be added.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDFMultiProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDFMultiProperty.java
@@ -23,7 +23,8 @@ import org.w3c.dom.Element;
  * See base class for description. Represents a property of a given {@link
  * com.percussion.cms.objectstore.PSDisplayFormat}
  */
-public class PSDFMultiProperty extends PSMultiValuedProperty {
+// Final leaf — Element/named ctors use MultiValuedProperty private load (this-escape free).
+public final class PSDFMultiProperty extends PSMultiValuedProperty {
   /**
    * Required ctor to be contained within a {@link
    * com.percussion.cms.objectstore.PSDbComponentCollection}

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDFProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDFProperty.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Element;
  * See base class for description. Represents a property of a given {@link
  * com.percussion.cms.objectstore.PSDisplayFormat}
  */
-public class PSDFProperty extends PSCmsProperty {
+public final class PSDFProperty extends PSCmsProperty {
   /** Empty constructor */
   public PSDFProperty() {}
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDateValue.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDateValue.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import org.apache.commons.lang3.time.FastDateFormat;
 
 /** The value of an <code>PSItemField</code> that is treated as a date value. */
-public class PSDateValue extends PSFieldValue {
+public final class PSDateValue extends PSFieldValue {
   /**
    * Constructs a new object with the date as the value. Using the default format ("yyyy-MM-dd") and
    * default <code>Locale</code> "en-us". This is a convenience method that is equivalent to calling

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDependent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDependent.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** This object encapsulates a locator together with properties. */
-public class PSDependent extends PSCmsComponent {
+public final class PSDependent extends PSCmsComponent {
   /**
    * Create a new dependent for the supplied relationship id and locator.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDependentSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDependentSet.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Element;
  * This class encapsulates a collection of <code>PSDependent</code> objects as a <code>
  * PSCollectionComponent</code>.
  */
-public class PSDependentSet extends PSCollectionComponent {
+public final class PSDependentSet extends PSCollectionComponent {
   /** Constucts an empty dependent set. */
   public PSDependentSet() {
     super(PSDependent.class);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDisplayColumn.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDisplayColumn.java
@@ -24,7 +24,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Represents a single column used be a given display format. */
-public class PSDisplayColumn extends PSDbComponent implements IPSSequencedComponent {
+public final class PSDisplayColumn extends PSDbComponent implements IPSSequencedComponent {
   /**
    * ctor, see base for description, sets up this objects key definition, and initializes any class
    * attributes.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolderPermissions.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolderPermissions.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
  * This class computes the user's permission on a folder object. This should only be used in the
  * context of a folder object.
  */
-public class PSFolderPermissions extends PSObjectPermissions {
+public final class PSFolderPermissions extends PSObjectPermissions {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemChildLocator.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemChildLocator.java
@@ -25,7 +25,7 @@ package com.percussion.cms.objectstore;
  *
  * @author paulhoward
  */
-public class PSItemChildLocator extends PSKey {
+public final class PSItemChildLocator extends PSKey {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefExtractor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefExtractor.java
@@ -25,32 +25,38 @@ import com.percussion.design.objectstore.PSDisplayMapping;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSUIDefinition;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * This class extracts definition data for <code>PSCoreItem</code> object population. It parses a
  * <code>PSContentEditor</code> object and populates a <code>PSCoreItem</code> object from that
- * definition. This cannot be instantiated explicitely by callers. This also uses a Visitor like
- * pattern, passing itself to acceptable object methods, and those objects understand to call <code>
- * getObject()</code> on this class.
+ * definition. This cannot be instantiated explicitly by callers.
+ *
+ * <p>Definition extraction for construction uses {@link #extractDefinition(PSItemDefinition)} so
+ * {@link PSCoreItem} does not pass {@code this} to an external type while subclasses are still
+ * initializing ({@code -Xlint:this-escape}). The visitor path remains for populating fully
+ * constructed {@link PSItemChildEntry} templates.
  */
 public class PSItemDefExtractor implements IPSVisitor {
   /**
-   * Cannot be instantiated by outsiders. Does any initialization then calls processFieldSet();
+   * Cannot be instantiated by outsiders. Builds field/child lists from the item definition without
+   * holding a {@link PSCoreItem} reference.
    *
-   * @param coreItem - assumed not <code>null</code>
-   * @throws PSCmsException if an error occurs populating the <code>coreItem</code>
+   * @param itemDefinition assumed not <code>null</code>
+   * @throws PSCmsException if an error occurs extracting the definition
    */
-  private PSItemDefExtractor(PSCoreItem coreItem) throws PSCmsException {
-    m_coreItem = coreItem;
-    processFieldSet(getFieldSet(), m_coreItem, false);
+  private PSItemDefExtractor(PSItemDefinition itemDefinition) throws PSCmsException {
+    m_itemDefinition = itemDefinition;
+    m_fields = new ArrayList<>();
+    m_children = new ArrayList<>();
+    processFieldSet(getFieldSet(), null, false);
   }
 
   /**
-   * Populates the <code>PSCoreItem</code> with it's definition. This a utility method that removes
-   * this responsibility from the <code>PSCoreItem</code>. This allows high-cohesion in the <code>
-   * PSCoreItem</code> and lowers the coupling between the <code>PSCoreItem</code> and the <code>
-   * com.percussion.objectstore</code> package.
+   * Populates the <code>PSCoreItem</code> with its definition. Prefer construction via {@link
+   * PSCoreItem}'s private extract path which uses {@link #extractDefinition(PSItemDefinition)}.
    *
    * @param coreItem must not be <code>null</code>.
    * @throws PSCmsException if an error occurs populating the <code>coreItem</code>
@@ -58,7 +64,46 @@ public class PSItemDefExtractor implements IPSVisitor {
   public static void populateItemDefinition(PSCoreItem coreItem) throws PSCmsException {
     if (coreItem == null) throw new IllegalArgumentException("coreItem must not be null");
 
-    PSItemDefExtractor xtr = new PSItemDefExtractor(coreItem);
+    DefinitionParts parts = extractDefinition(coreItem.getItemDefinition());
+    coreItem.applyExtractedDefinition(parts);
+  }
+
+  /**
+   * Extracts field and child definitions from an item definition without a live {@link PSCoreItem}.
+   * Used by {@link PSCoreItem} construction to avoid this-escape.
+   *
+   * @param itemDefinition must not be <code>null</code>
+   * @return extracted parts, never <code>null</code>
+   * @throws PSCmsException if an error occurs extracting the definition
+   */
+  public static DefinitionParts extractDefinition(PSItemDefinition itemDefinition)
+      throws PSCmsException {
+    if (itemDefinition == null) throw new IllegalArgumentException("itemDefinition must not be null");
+
+    PSItemDefExtractor xtr = new PSItemDefExtractor(itemDefinition);
+    return new DefinitionParts(xtr.m_fields, xtr.m_children);
+  }
+
+  /**
+   * Result of definition extraction: parent-level fields and complex children (with template entry
+   * fields already populated).
+   */
+  public static final class DefinitionParts {
+    private final List<PSItemField> fields;
+    private final List<PSItemChild> children;
+
+    DefinitionParts(List<PSItemField> fields, List<PSItemChild> children) {
+      this.fields = fields;
+      this.children = children;
+    }
+
+    public List<PSItemField> getFields() {
+      return fields;
+    }
+
+    public List<PSItemChild> getChildren() {
+      return children;
+    }
   }
 
   /**
@@ -68,13 +113,14 @@ public class PSItemDefExtractor implements IPSVisitor {
    * PSItemChildEntry</code> and then recursively calls itself to add the <code>PSItemFields</code>
    * to the <code>PSItemChildEntry</code>.
    *
-   * <p>The PSCoreItem and the <code>PSItemChildEntry</code> are <code>IPSItemAccessor</code>
-   * objects and this object is a <code>IPSVisitor</code>. This passes itself to the <code>
-   * IPSItemAccessors</code> <code>accept()</code> method. The <code>IPSItemAccessor</code> then
-   * acts upon this object by calling <code>getObject()</code>.
+   * <p>When {@code itemAccessor} is {@code null}, parent-level fields and children are accumulated
+   * into {@link #m_fields} / {@link #m_children} (construction-safe path). When non-null (child
+   * entry population), the visitor {@link IPSItemAccessor#accept} path is used — the accessor is a
+   * fully constructed {@link PSItemChildEntry}.
    *
    * @param fieldSet the fieldset to parse - assumed not <code>null</code>
-   * @param itemAccessor the item on which to add the elements - assumed not <code>null</code>
+   * @param itemAccessor the item on which to add the elements, or {@code null} for parent-level
+   *     accumulation
    * @param isMultiValue <code>true</code> if it is, otherwise <code>false</code>.
    */
   private void processFieldSet(
@@ -89,13 +135,13 @@ public class PSItemDefExtractor implements IPSVisitor {
 
         // Is it multiPropertySimpleChild
         if (childSet.getType() == PSFieldSet.TYPE_MULTI_PROPERTY_SIMPLE_CHILD)
-          // just add the fields to the parent core item
-          processFieldSet(childSet, m_coreItem, false);
+          // just add the fields to the parent level
+          processFieldSet(childSet, itemAccessor, false);
 
         // Is it  simpleChild
         else if (childSet.getType() == PSFieldSet.TYPE_SIMPLE_CHILD)
           // this is a multivalue field, add to parent:
-          processFieldSet(childSet, m_coreItem, true);
+          processFieldSet(childSet, itemAccessor, true);
         else if (childSet.getType() == PSFieldSet.TYPE_COMPLEX_CHILD) {
           mapping = getDisplayMapping(childSet.getName());
           if (mapping == null) continue; // ignore non-mapped fields
@@ -103,19 +149,19 @@ public class PSItemDefExtractor implements IPSVisitor {
           // create child
           PSItemChild child = new PSItemChild(childSet, mapping);
 
-          // create entry (which is item accessor) and add entry to child
+          // create entry (which is item accessor) and populate template fields
           PSItemChildEntry entry = child.createChildEntry();
 
-          // add child to item:
-          m_object = child;
-
           // TODO: SUPPORT CHILDREN OF CHILDREN???
-          itemAccessor.accept(this);
+          if (itemAccessor == null) {
+            m_children.add(child);
+          } else {
+            m_object = child;
+            itemAccessor.accept(this);
+            m_object = null;
+          }
 
-          // null the object:
-          m_object = null;
-
-          // now let's recurse and add the fields to the entry:
+          // populate template entry fields (entry is fully constructed)
           processFieldSet(childSet, entry, false);
         }
       } else if (o instanceof PSField) {
@@ -125,12 +171,14 @@ public class PSItemDefExtractor implements IPSVisitor {
         mapping = getDisplayMapping(field.getSubmitName());
         if (mapping == null) continue; // ignore non-mapped fields
 
-        // create field and set to member
-        m_object = new PSItemField(field, mapping.getUISet(), isMultiValue);
-        // send this object to accessor for extraction
-        itemAccessor.accept(this);
-        // null the value for the next element.
-        m_object = null;
+        PSItemField itemField = new PSItemField(field, mapping.getUISet(), isMultiValue);
+        if (itemAccessor == null) {
+          m_fields.add(itemField);
+        } else {
+          m_object = itemField;
+          itemAccessor.accept(this);
+          m_object = null;
+        }
       }
     }
   }
@@ -174,7 +222,7 @@ public class PSItemDefExtractor implements IPSVisitor {
   private PSFieldSet getFieldSet() throws PSCmsException {
     // get pipe:
     PSContentEditorPipe cePipe =
-        (PSContentEditorPipe) m_coreItem.getItemDefinition().getContentEditor().getPipe();
+        (PSContentEditorPipe) m_itemDefinition.getContentEditor().getPipe();
 
     if (cePipe == null) throw new PSCmsException(IPSCmsErrors.DATA_EXTRACTION_ERROR_NULL_DATAPIPE);
 
@@ -190,18 +238,19 @@ public class PSItemDefExtractor implements IPSVisitor {
   }
 
   /**
-   * The definition to be used to create the <code>PSCoreItem</code>, set by <code>getFieldSet()
-   * </code> and should not change and should not be <code>null</code>.
-   */
-
-  /**
    * The Parent Mapper. The top most mapper of the <code>PSContentEditor</code>, set by <code>
    * getFieldSet()</code>, never <code>null</code>.
    */
   private PSContentEditorMapper m_parentMapper;
 
-  /** The PSCoreItem being populated, set by the ctor, never <code>null</code>. */
-  private PSCoreItem m_coreItem;
+  /** Item definition being extracted, set by the ctor, never <code>null</code>. */
+  private final PSItemDefinition m_itemDefinition;
+
+  /** Parent-level fields accumulated during extraction. */
+  private final List<PSItemField> m_fields;
+
+  /** Complex children accumulated during extraction. */
+  private final List<PSItemChild> m_children;
 
   /** Temporary field. Mostly <code>null</code>. Used in creation of objects. */
   private Object m_object;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
@@ -58,7 +58,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, IPSCloneTuner {
+public final class PSItemDefinition extends PSItemDefSummary implements IPSComponent, IPSCloneTuner {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemRelatedItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemRelatedItem.java
@@ -32,7 +32,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 
 /** An object representation of the StandardItem RelatedItem element. */
-public class PSItemRelatedItem extends PSItemComponent {
+public final class PSItemRelatedItem extends PSItemComponent {
   public PSItemRelatedItem() {}
 
   /** Construct using xml nodes */

--- a/system/src/main/java/com/percussion/cms/objectstore/PSMenuChild.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSMenuChild.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Element;
  * @see PSMenuContext
  * @see PSAction
  */
-public class PSMenuChild extends PSDbComponent {
+public final class PSMenuChild extends PSDbComponent {
   /**
    * Create a new relation between a menu and its 'item'. It is only useful once it has been added
    * to an action.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSMenuContext.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSMenuContext.java
@@ -33,7 +33,7 @@ import org.w3c.dom.Element;
  * @author Paul Howard
  * @version 1.0
  */
-public class PSMenuContext extends PSName {
+public final class PSMenuContext extends PSName {
   /**
    * Since this object is read-only, it can only be instantiated from an existing object, obtained
    * from the processor load method.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSMenuMode.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSMenuMode.java
@@ -32,7 +32,7 @@ import org.w3c.dom.Element;
  * @author Paul Howard
  * @version 1.0
  */
-public class PSMenuMode extends PSName {
+public final class PSMenuMode extends PSName {
   /**
    * Since this object is read-only, it can only be instantiated from an existing object, obtained
    * from the processor load method.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSMenuModeContextMapping.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSMenuModeContextMapping.java
@@ -34,7 +34,7 @@ import org.w3c.dom.Element;
  * @see PSMenuContext
  * @see PSAction
  */
-public class PSMenuModeContextMapping extends PSDbComponent {
+public final class PSMenuModeContextMapping extends PSDbComponent {
   /** no-args constructor */
   public PSMenuModeContextMapping() {}
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSMultiValuedProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSMultiValuedProperty.java
@@ -64,7 +64,8 @@ public abstract class PSMultiValuedProperty extends PSCmsProperty {
    */
   protected PSMultiValuedProperty(Element src) throws PSUnknownNodeTypeException {
     super(getKeyDef(), src.getAttribute(XML_ATTR_PROPNAME));
-    fromXml(src);
+    // Private base-load — avoid overridable fromXml during construction (this-escape).
+    loadFieldsFromXml(src);
   }
 
   /**
@@ -92,13 +93,25 @@ public abstract class PSMultiValuedProperty extends PSCmsProperty {
 
   // see base class for description
   public void fromXml(Element src) throws PSUnknownNodeTypeException {
+    loadFieldsFromXml(src);
+  }
+
+  /**
+   * Loads multi-value property collection from XML. Construction path uses the source element's
+   * node name (no virtual {@link #getNodeName()}) for this-escape safety.
+   *
+   * @param src never {@code null}
+   */
+  private void loadFieldsFromXml(Element src) throws PSUnknownNodeTypeException {
     if (null == src) throw new IllegalArgumentException("Source cannot be null.");
 
+    // Always use source node name — never virtual getNodeName during load (this-escape).
+    String nodeName = src.getNodeName();
     if (null == m_props) {
-      m_props = new PSDbComponentCollection(src, getNodeName());
+      m_props = new PSDbComponentCollection(src, nodeName);
     } else {
       m_props = new PSDbComponentCollection(m_props.getMemberClass());
-      m_props.fromXml(src, getNodeName());
+      m_props.fromXml(src, nodeName);
     }
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSObjectAclEntry.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSObjectAclEntry.java
@@ -47,7 +47,7 @@ import org.w3c.dom.Element;
  * should be in one of the DBSTATE_xxx states. This state decides whether it will be inserted,
  * updated or deleted from the database on serialization.
  */
-public class PSObjectAclEntry extends PSDbComponent {
+public final class PSObjectAclEntry extends PSDbComponent {
   /**
    * Use this for creating a new (non-persisted) ACL entry. This constructor should generally be
    * used for specifying ACL entries for users.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSProcessingStatistics.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSProcessingStatistics.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Element;
  * @author Paul Howard
  * @version 1.0
  */
-public class PSProcessingStatistics implements IPSCmsComponent {
+public final class PSProcessingStatistics implements IPSCmsComponent {
   /**
    * Creates a new instance with the supplied values.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSProcessorProxy.java
@@ -158,7 +158,8 @@ public abstract class PSProcessorProxy {
         if (null != pc) m_processorConfig = pc;
       } while (null != pc);
 
-      if (ctx != null) setProcessorContext(ctx);
+      // Private base-load — avoid overridable setProcessorContext during construction (this-escape).
+      if (ctx != null) applyProcessorContext(ctx);
     } catch (PSUnknownNodeTypeException unte) {
       throw new PSCmsException(unte.getErrorCode(), unte.getErrorArguments());
     } catch (SAXException se) {
@@ -290,6 +291,17 @@ public abstract class PSProcessorProxy {
    *     processor does not require one.
    */
   public void setProcessorContext(Object ctx) {
+    applyProcessorContext(ctx);
+  }
+
+  /**
+   * Construction-safe context assign used by ctor and {@link #setProcessorContext(Object)}.
+   *
+   * @param ctx may be {@code null}
+   */
+  private void applyProcessorContext(Object ctx) {
+    // Same as historic setProcessorContext: flushCache first. Invalid processor type leaves
+    // m_processorConfig null and yields NPE (covered by PSActiveAssemblyProcessorProxyTest).
     m_processorConfig.flushCache();
     m_context = ctx;
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipFilter.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipFilter.java
@@ -65,7 +65,7 @@ import org.w3c.dom.NodeList;
  *
  * @author RammohanVangapalli
  */
-public class PSRelationshipFilter {
+public final class PSRelationshipFilter {
 
   /** Default constructor */
   public PSRelationshipFilter() {}

--- a/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipInfo.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipInfo.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Element;
  * This is a read only class, it contains partial information of a specific relationship
  * configuration.
  */
-public class PSRelationshipInfo implements IPSCmsComponent {
+public final class PSRelationshipInfo implements IPSCmsComponent {
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipInfoSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipInfoSet.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** The PSRelationshipInfoSet contains a list of PSRelationshipInfo objects */
-public class PSRelationshipInfoSet implements IPSCmsComponent {
+public final class PSRelationshipInfoSet implements IPSCmsComponent {
   /** Default constructor. */
   public PSRelationshipInfoSet() {}
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSProperty.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Element;
  * See base class for description. Represents a property of a given {@link
  * com.percussion.cms.objectstore.PSDisplayFormat}.
  */
-public class PSSProperty extends PSCmsProperty {
+public final class PSSProperty extends PSCmsProperty {
   /** Required ctor taking a element */
   public PSSProperty(Element e) throws PSUnknownNodeTypeException {
     super(PSSProperty.createKey(new String[] {}), "dummy");

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSaveResults.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSaveResults.java
@@ -36,7 +36,7 @@ import org.w3c.dom.Element;
  * @author Paul Howard
  * @version 1.0
  */
-public class PSSaveResults implements IPSCmsComponent {
+public final class PSSaveResults implements IPSCmsComponent {
   /**
    * Create a new instance.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearchMultiProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearchMultiProperty.java
@@ -25,7 +25,8 @@ import org.w3c.dom.Element;
  * See base class for description. Represents a property of a given {@link
  * com.percussion.cms.objectstore.PSSearch}.
  */
-public class PSSearchMultiProperty extends PSMultiValuedProperty {
+// Final leaf — Element/named ctors use MultiValuedProperty private load (this-escape free).
+public final class PSSearchMultiProperty extends PSMultiValuedProperty {
   /**
    * Required ctor to be contained within a {@link
    * com.percussion.cms.objectstore.PSDbComponentCollection}

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSecurityProviderCataloger.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSecurityProviderCataloger.java
@@ -33,7 +33,7 @@ import org.w3c.dom.NodeList;
  * Catalogs all server security providers by querying the ../sys_components/getSecurityProviders.xml
  * app.
  */
-public class PSSecurityProviderCataloger {
+public final class PSSecurityProviderCataloger {
   /**
    * Constructor meant to be used in the context of an applet. This may not work in other contexts
    * since there is no way of supplying credentials for logging in.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSecurityProviderInstanceSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSecurityProviderInstanceSummary.java
@@ -30,7 +30,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
 /** Security provider instance summary returned by the SecurityProvider cataloger. */
-public class PSSecurityProviderInstanceSummary implements IPSCmsComponent {
+public final class PSSecurityProviderInstanceSummary implements IPSCmsComponent {
 
   private static final Logger log = LogManager.getLogger(PSSecurityProviderInstanceSummary.class);
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
@@ -36,7 +36,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 /** This object represents a site definition. See {@link #toXml(Document)} for the expected DTD. */
-public class PSSite extends PSComponent {
+public final class PSSite extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSlot.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSlot.java
@@ -36,7 +36,7 @@ import org.w3c.dom.Element;
  * <p>This class doesn't override the clone method because the clone provided by the Object base
  * class is satisfactory.
  */
-public class PSSlot extends PSCmsComponent {
+public final class PSSlot extends PSCmsComponent {
   /**
    * Creates an instance. Related content can be added after creation using the <code>addRelatedItem
    * </code> method.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSTextValue.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSTextValue.java
@@ -17,7 +17,7 @@
 package com.percussion.cms.objectstore;
 
 /** The value of an <code>PSItemField</code> that is treated as a <code>String</code> value. */
-public class PSTextValue extends PSFieldValue {
+public final class PSTextValue extends PSFieldValue {
   /**
    * Creates a new instance with the <code>textValue</code> as its value. The text, may be <code>
    * null</code> or empty.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSUserInfo.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSUserInfo.java
@@ -58,7 +58,7 @@ import org.w3c.dom.Element;
  *       state information this object can provide.
  * </ol>
  */
-public class PSUserInfo implements IPSCmsComponent {
+public final class PSUserInfo implements IPSCmsComponent {
 
   private static final Logger log = LogManager.getLogger(PSUserInfo.class);
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSVariantSlotTypeSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSVariantSlotTypeSet.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Element;
  *
  * @deprecated use the assembly service instead
  */
-public class PSVariantSlotTypeSet extends PSDbComponentSet<PSVariantSlotType> {
+public final class PSVariantSlotTypeSet extends PSDbComponentSet<PSVariantSlotType> {
   /** Default constructor. See {@link PSDbComponentList#PSDbComponentList()} for more details. */
   public PSVariantSlotTypeSet() {
     super(PSVariantSlotType.class);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSVisibilityContextEntry.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSVisibilityContextEntry.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Element;
  * @author Paul Howard
  * @version 1.0
  */
-public class PSVisibilityContextEntry extends PSCmsProperty {
+public final class PSVisibilityContextEntry extends PSCmsProperty {
   /** no-args constructor */
   public PSVisibilityContextEntry() {}
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSXmlValue.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSXmlValue.java
@@ -21,7 +21,7 @@ import com.percussion.util.PSXMLDomUtil;
 import org.w3c.dom.Element;
 
 /** The value of an <code>PSItemField</code> that is treated as an XML element. */
-public class PSXmlValue extends PSFieldValue {
+public final class PSXmlValue extends PSFieldValue {
   /**
    * Creates a new instance with the element as the value.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/client/PSContentEditorFieldCataloger.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/client/PSContentEditorFieldCataloger.java
@@ -38,7 +38,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /** Client side object containing the cataloged content editor fields. */
-public class PSContentEditorFieldCataloger {
+public final class PSContentEditorFieldCataloger {
   /**
    * Construct this cataloger without an initial set of fields. See {@link
    * #PSContentEditorFieldCataloger(IPSFieldCataloger, Set, int)} for more info.

--- a/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteAgent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteAgent.java
@@ -61,7 +61,7 @@ import org.xml.sax.SAXException;
 /**
  * This class provides convenient methods to communicate with the remote server for various tasks.
  */
-public class PSRemoteAgent {
+public final class PSRemoteAgent {
 
   private static final Logger log = LogManager.getLogger(PSRemoteAgent.class);
 
@@ -78,7 +78,8 @@ public class PSRemoteAgent {
    *     requests. Cannot be <code>null</code>.
    */
   public PSRemoteAgent(IPSRemoteRequester requester) {
-    setRequester(requester);
+    // Private base-load — avoid overridable setRequester during construction (this-escape).
+    applyRequester(requester);
   }
 
   /**
@@ -88,6 +89,15 @@ public class PSRemoteAgent {
    *     requests. Cannot be <code>null</code>.
    */
   protected void setRequester(IPSRemoteRequester requester) {
+    applyRequester(requester);
+  }
+
+  /**
+   * Construction-safe requester assign used by ctor and {@link #setRequester}.
+   *
+   * @param requester never {@code null}
+   */
+  private void applyRequester(IPSRemoteRequester requester) {
     if (requester == null) throw new IllegalArgumentException("Requester cannot be null.");
 
     m_requester = new PSRemoteWsRequester(requester);

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSBinaryFileValue.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSBinaryFileValue.java
@@ -20,7 +20,7 @@ import com.percussion.cms.objectstore.PSBinaryValue;
 import com.percussion.content.PSContentFactory;
 import com.percussion.util.IOTools;
 import com.percussion.util.PSPurgableTempFile;
-import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -51,9 +51,18 @@ public class PSBinaryFileValue extends PSBinaryValue {
    * @throws IOException If there is an error reading from or writing to a file.
    */
   public PSBinaryFileValue(File file) throws FileNotFoundException, IOException {
-    super(new FileInputStream(file));
+    // Two-phase via static helper: load bytes without this, then super + temp write from local
+    // array (no overridable getValue — this-escape free for open subclass hierarchy).
+    this(readAllBytes(file), file);
+  }
 
-    // create temp file including source path with normalized separator
+  /**
+   * Construction helper: bytes already loaded off-heap from {@code file}; assigns super data and
+   * creates purgable temp with original path/mime metadata.
+   */
+  private PSBinaryFileValue(byte[] data, File file) throws IOException {
+    super(data);
+
     m_tempFile =
         new PSPurgableTempFile(
             "psx",
@@ -63,18 +72,17 @@ public class PSBinaryFileValue extends PSBinaryValue {
             PSContentFactory.guessMimeType(file),
             null);
 
-    OutputStream out = null;
-    try {
-      out = new FileOutputStream(m_tempFile);
-      IOTools.copyStream(new ByteArrayInputStream((byte[]) getValue()), out);
-    } finally {
-      if (out != null) {
-        try {
-          out.close();
-        } catch (IOException e) {
-          // ignore
-        }
-      }
+    try (OutputStream out = new FileOutputStream(m_tempFile)) {
+      out.write(data != null ? data : new byte[0]);
+    }
+  }
+
+  /** Static file→byte[] load for construction (no {@code this}). */
+  private static byte[] readAllBytes(File file) throws FileNotFoundException, IOException {
+    try (FileInputStream in = new FileInputStream(file);
+        ByteArrayOutputStream buf = new ByteArrayOutputStream(Math.max(32, in.available()))) {
+      IOTools.copyStream(in, buf);
+      return buf.toByteArray();
     }
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSCorruptDatabaseException.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSCorruptDatabaseException.java
@@ -25,7 +25,7 @@ import com.percussion.error.PSRuntimeException;
  * The parameters should provide sufficient information so that support staff can track the problem
  * down and fix it.
  */
-public class PSCorruptDatabaseException extends PSRuntimeException {
+public final class PSCorruptDatabaseException extends PSRuntimeException {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSLocalExecutableSearch.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSLocalExecutableSearch.java
@@ -35,7 +35,7 @@ import org.xml.sax.SAXException;
  * A utility class to hold search criteria, build search request and execute it locally to the
  * Rhythmyx server.
  */
-public class PSLocalExecutableSearch extends PSBaseExecutableSearch {
+public final class PSLocalExecutableSearch extends PSBaseExecutableSearch {
   /**
    * Construct an executable search with a search object and a list of result column names.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSRelationshipDbProcessor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSRelationshipDbProcessor.java
@@ -80,7 +80,7 @@ import org.apache.logging.log4j.Logger;
  * This class encapsulates all backend operations to create, modify, delete and catalog
  * relationships.
  */
-public class PSRelationshipDbProcessor {
+public final class PSRelationshipDbProcessor {
 
   public PSRelationshipDbProcessor(boolean thread_context) {
     this.thread_context = thread_context;
@@ -95,7 +95,8 @@ public class PSRelationshipDbProcessor {
    *     yet.
    */
   public PSRelationshipDbProcessor(PSRequest request) throws PSCmsException {
-    setRequest(request);
+    // Private base-load — avoid overridable setRequest during construction (this-escape).
+    applyRequest(request);
   }
 
   /**
@@ -107,7 +108,8 @@ public class PSRelationshipDbProcessor {
    *     yet.
    */
   public PSRelationshipDbProcessor(IPSRequestContext context) throws PSCmsException {
-    setRequestContext(context);
+    // Private base-load — avoid overridable setRequestContext during construction (this-escape).
+    applyRequestContext(context);
   }
 
   /**
@@ -1080,6 +1082,15 @@ public class PSRelationshipDbProcessor {
    *     will be used to perform the requests.
    */
   public void setRequest(PSRequest request) {
+    applyRequest(request);
+  }
+
+  /**
+   * Construction-safe request assign used by ctor and {@link #setRequest}.
+   *
+   * @param request may be {@code null}
+   */
+  private void applyRequest(PSRequest request) {
     if (request != null) m_context = new PSRequestContext(request);
     else m_context = null;
   }
@@ -1091,6 +1102,15 @@ public class PSRelationshipDbProcessor {
    *     rhythmyx user will be used to perform the requests.
    */
   public void setRequestContext(IPSRequestContext context) {
+    applyRequestContext(context);
+  }
+
+  /**
+   * Construction-safe context assign used by ctor and {@link #setRequestContext}.
+   *
+   * @param context may be {@code null}
+   */
+  private void applyRequestContext(IPSRequestContext context) {
     m_context = context;
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSServerBinaryLocator.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSServerBinaryLocator.java
@@ -27,7 +27,7 @@ import com.percussion.util.PSPurgableTempFile;
  * This class facilitates the locating of binary content through the use of internal Rhythmyx
  * objects and returning the data of that binary content.
  */
-public class PSServerBinaryLocator extends PSFieldRetriever implements IPSBinaryLocator {
+public final class PSServerBinaryLocator extends PSFieldRetriever implements IPSBinaryLocator {
   /**
    * Convenience ctor that calls {@link #PSServerBinaryLocator(PSRequest, PSLocator, String, long,
    * int) this(request, locator, fieldName, contentTypeId, -1)}.

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSServerItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSServerItem.java
@@ -86,7 +86,7 @@ import org.xml.sax.SAXException;
 
 /** A PSCoreItem that is Rhythmyx server aware. Meaning it can persist itself to the system. */
 @Transactional
-public class PSServerItem extends PSCoreItem implements IPSPersister {
+public final class PSServerItem extends PSCoreItem implements IPSPersister {
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj);

--- a/system/src/test/java/com/percussion/cms/objectstore/PSObjectStoreThisEscapeCoreItemTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSObjectStoreThisEscapeCoreItemTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.server.PSRelationshipDbProcessor;
+import com.percussion.cms.objectstore.server.util.PSFieldFinderUtilTest;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for residual cms.objectstore this-escape real fixes (#2652 / parent #2022):
+ * CoreItem definition extract without this-escape, leaf value/processor construction, multi-value
+ * Element restore. Complements {@link PSObjectStoreThisEscapeResidualTest} (#2613).
+ */
+public class PSObjectStoreThisEscapeCoreItemTest {
+
+  @Test
+  public void coreItemExtractsFieldsAndChildrenFromDefinition() throws Exception {
+    PSItemDefinition def = PSFieldFinderUtilTest.loadItemDefinition("PSFieldFinderUtilTest1.xml");
+    assertNotNull(def);
+    assertEquals("Press Release", def.getName());
+
+    PSCoreItem item = new PSCoreItem(def);
+    assertNotNull(item.getItemDefinition());
+    assertEquals(def, item.getItemDefinition());
+
+    // Private base-load extract must populate parent fields from the content editor definition.
+    Iterator<String> fieldNames = item.getAllFieldNames();
+    assertTrue(fieldNames.hasNext(), "expected at least one extracted field");
+
+    int fieldCount = 0;
+    while (fieldNames.hasNext()) {
+      String name = fieldNames.next();
+      assertNotNull(item.getFieldByName(name));
+      fieldCount++;
+    }
+    assertTrue(fieldCount > 0);
+
+    // Re-apply via public populate path after construction still works.
+    PSItemDefExtractor.populateItemDefinition(item);
+    assertTrue(item.getAllFieldNames().hasNext());
+  }
+
+  @Test
+  public void itemDefinitionElementRoundTrip() throws Exception {
+    PSItemDefinition original =
+        PSFieldFinderUtilTest.loadItemDefinition("PSFieldFinderUtilTest1.xml");
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+
+    PSItemDefinition restored = new PSItemDefinition(xml);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getTypeId(), restored.getTypeId());
+    assertEquals(original.getAppName(), restored.getAppName());
+  }
+
+  @Test
+  public void textDateXmlBinaryValueCtors() throws Exception {
+    PSTextValue text = new PSTextValue("hello");
+    assertEquals("hello", text.getValueAsString());
+    PSTextValue empty = new PSTextValue(null);
+    assertEquals("", empty.getValueAsString());
+
+    Date now = new Date(1_700_000_000_000L);
+    PSDateValue dateVal = new PSDateValue(now);
+    assertNotNull(dateVal.getValue());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = doc.createElement("payload");
+    el.appendChild(doc.createTextNode("x"));
+    PSXmlValue xmlVal = new PSXmlValue(el);
+    assertEquals("payload", ((Element) xmlVal.getValue()).getNodeName());
+
+    byte[] bytes = "abc".getBytes(StandardCharsets.UTF_8);
+    PSBinaryValue bin = new PSBinaryValue(bytes);
+    assertArrayEquals(bytes, (byte[]) bin.getValue());
+    assertTrue(bin.isDataLoaded());
+
+    PSBinaryValue fromStream =
+        new PSBinaryValue(new ByteArrayInputStream("xyz".getBytes(StandardCharsets.UTF_8)));
+    assertArrayEquals("xyz".getBytes(StandardCharsets.UTF_8), (byte[]) fromStream.getValue());
+  }
+
+  @Test
+  public void searchMultiPropertyElementRoundTrip() throws Exception {
+    PSSearchMultiProperty original = new PSSearchMultiProperty("sys_community");
+    original.add("10");
+    original.add("20");
+    assertTrue(original.contains("10"));
+    assertTrue(original.contains("20"));
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+    PSSearchMultiProperty restored = new PSSearchMultiProperty(xml);
+    assertEquals("sys_community", restored.getName());
+    assertTrue(restored.contains("10"));
+    assertTrue(restored.contains("20"));
+
+    // Public fromXml after construction still works
+    restored.fromXml(xml);
+    assertTrue(restored.contains("10"));
+  }
+
+  @Test
+  public void relationshipDbProcessorCtorsAcceptNullAndThreadContext() throws Exception {
+    PSRelationshipDbProcessor threadProc = new PSRelationshipDbProcessor(true);
+    assertNotNull(threadProc);
+
+    // null request → internal rhythmyx user path; must not throw
+    PSRelationshipDbProcessor nullReq = new PSRelationshipDbProcessor((com.percussion.server.PSRequest) null);
+    assertNotNull(nullReq);
+    nullReq.setRequest(null);
+  }
+
+  @Test
+  public void processingStatisticsNamedCtor() {
+    PSProcessingStatistics stats = new PSProcessingStatistics(1, 2, 3, 4, 5);
+    assertEquals(1, stats.getInsertedCount());
+    assertEquals(2, stats.getUpdatedCount());
+    assertEquals(3, stats.getDeletedCount());
+    assertEquals(4, stats.getSkippedCount());
+    assertEquals(5, stats.getErroredCount());
+    assertFalse(stats.getInsertedCount() < 0);
+  }
+}


### PR DESCRIPTION
## Summary

PR-sized residual for **#2652** (parent **#2022** / grandparent **#2200**): clear residual `-Xlint:this-escape` in **cms.objectstore** after **#2613** with **real** constructor patterns — **not** suppress-only.

### Real this-escape fixes
- **PSCoreItem** / **PSItemDefExtractor**: private base-load via `extractDefinition(PSItemDefinition)` + `DefinitionParts` so construction does not pass `this` to an external visitor; `accept` is `final`
- **PSServerItem** / processors: final leaf types (`PSServerItem`, `PSRemoteAgent`, `PSRelationshipDbProcessor`, `PSLocalExecutableSearch`, …)
- **PSRemoteAgent** / **PSRelationshipDbProcessor** / **PSProcessorProxy** / **PSBinaryValue** / **PSMultiValuedProperty**: private apply/load helpers for construction paths
- **PSBinaryFileValue**: static file→bytes then super(byte[]) (no overridable getValue during open-class construction)
- **~45 leaf value/info types**: marked `final` (no in-repo subclasses)

### Tests
- New `PSObjectStoreThisEscapeCoreItemTest` — 6 cases (CoreItem extract, ItemDefinition Element, value ctors, multi-property Element, RelationshipDbProcessor ctors, ProcessingStatistics)
- Existing residual + DbComponent this-escape suites still green

### Metrics (cms.objectstore `this' escape`, `-Xmaxwarns 10000`)
| | Count |
| --- | ---: |
| Before | 61 |
| After | 0 |
| Δ | **−61** |

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1573**, Failures: **0**, Errors: **0** (Skipped: 240)
- [x] `PSObjectStoreThisEscapeCoreItemTest` — 6/6
- [x] `PSObjectStoreThisEscapeResidualTest` + `PSDbComponentThisEscapeTest` green

## Gates evidence
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2652-objectstore-this-escape-coreitem-erlang.md`
- Per-module standalone clean install: pass
- No monorepo-wide reformat; no suppress-only this-escape

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2652  
Refs #2022 #2200 #2613

> Co-Authored by Grok Build using grok-4.5 with agent main.
