### PR TITLE
docs(product-docs): expand 8.2 content (issue #2703)

### DIFF
--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -4,8 +4,32 @@ title: Administration
 description: Operating and administering Percussion CMS 8.2
 version: "8.2"
 order: 40
+tags: [admin]
 ---
 
 # Administration
 
-Operator and administrator topics for Percussion CMS 8.2.
+Operator and administrator topics for Percussion CMS 8.2 — Sites, security, publishing, and
+day-two server operations.
+
+## Topics
+
+- [Sites & content structure](id:admin-sites)
+- [Users, roles & security](id:admin-users-roles)
+- [Publishing](id:admin-publishing)
+- [Server operations](id:admin-server-ops)
+
+## Day-two checklist
+
+| Task | Frequency | Notes |
+|------|-----------|--------|
+| Review server logs | Daily | Jetty/base logs under the install tree |
+| Backup DB + config | Per policy | Before upgrades and major package changes |
+| User/role audit | Quarterly | Remove stale accounts; least privilege |
+| Publish health | After deploy | Verify last successful pub jobs and delivery targets |
+| Certificate expiry | Before TLS renewals | Edge proxy and any embedded keystores |
+
+## Related
+
+- [Getting Started](id:getting-started)
+- [Reference](id:reference)

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -1,0 +1,51 @@
+---
+id: admin-publishing
+title: Publishing
+description: Publishing content and delivery targets in Percussion CMS 8.2
+version: "8.2"
+order: 43
+tags: [admin, publishing]
+---
+
+# Publishing
+
+Publishing is how Percussion turns assembled content into deliverables for websites and other
+channels (static files, FTP, database, custom locations).
+
+## Concepts
+
+| Term | Meaning |
+|------|---------|
+| **Publish** | Run assembly for selected content and write results to configured destinations |
+| **Edition / pub job** | Configured unit of work (what, where, when) |
+| **Delivery location** | Filesystem path, FTP, or other target for assembled output |
+| **Delivery Tier Service (DTS)** | Optional dynamic services (forms, comments, membership, metadata, polls, …) used by published sites |
+
+## Operator workflow
+
+1. Ensure content is in an **approved** (or otherwise publishable) workflow state.
+2. Select the Site and publish scope (incremental vs full, as configured).
+3. Run the publish job from the admin UI or scheduled task.
+4. Verify logs for assembly errors and missing resources.
+5. Spot-check delivered files or the live site.
+
+## Virtual Sites and docs builds
+
+For Git/filesystem Virtual Sites such as product documentation:
+
+- Offline / CI builds use `scripts/build-cms-docs` to emit static HTML without a full CMS UI session.
+- Runtime virtual assemble paths (when configured on a Site) participate in normal Site-level publishing configuration where applicable.
+
+See [Virtual Sites](id:developer-virtual-sites) and [Build product docs](id:developer-build-source#product-docs-build).
+
+## Failure modes to watch
+
+- Missing template/variant or broken relationship links
+- File permission errors on delivery paths
+- Partial publish after mid-job failure (re-run after fixing root cause)
+- DTS connectivity issues that surface as broken dynamic widgets on an otherwise static site
+
+## Related
+
+- [Sites & content structure](id:admin-sites)
+- [Server operations](id:admin-server-ops)

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -33,7 +33,7 @@ channels (static files, FTP, database, custom locations).
 
 For Git/filesystem Virtual Sites such as product documentation:
 
-- Offline / CI builds use `scripts/build-cms-docs` to emit static HTML without a full CMS UI session.
+- Offline / CI builds use `scripts/build-cms-docs.bat` / `scripts/build-cms-docs.sh` to emit static HTML without a full CMS UI session.
 - Runtime virtual assemble paths (when configured on a Site) participate in normal Site-level publishing configuration where applicable.
 
 See [Virtual Sites](id:developer-virtual-sites) and [Build product docs](id:developer-build-source#product-docs-build).

--- a/product-docs/8.2/admin/server-ops.md
+++ b/product-docs/8.2/admin/server-ops.md
@@ -1,0 +1,63 @@
+---
+id: admin-server-ops
+title: Server operations
+description: Start, stop, logs, and operational basics for Percussion CMS 8.2
+version: "8.2"
+order: 44
+tags: [admin, operations]
+---
+
+# Server operations
+
+Day-to-day control of the CMS process, logs, and configuration surfaces.
+
+## Process control
+
+Installations typically register a platform service:
+
+| Platform | Common control |
+|----------|----------------|
+| Windows | Windows Service for the CMS (and DTS if installed) |
+| Linux | systemd unit and/or classic init scripts shipped under installer `Linux` trees |
+| Developer hosts | Foreground Jetty start scripts under the install tree |
+
+Always stop services cleanly before upgrades or invasive config edits.
+
+## Logs
+
+Primary server logs live under the install’s Jetty base, commonly:
+
+- `jetty/base/logs/` (server and application logs)
+
+When filing bugs, attach relevant log excerpts (not secrets) and note CMS version from
+`Version.properties` or the About dialog.
+
+## Configuration surfaces
+
+| Area | Examples |
+|------|----------|
+| Server properties | Feature flags, runtime toggles under server config |
+| Jetty | Connectors, TLS, thread pools |
+| Database | JDBC settings established at install / reconfig |
+| Packages | Deployed `.ppkg` components and their configs |
+| Custom extensions | JARs and registrations under extension paths |
+
+Prefer change control: edit → restart if required → smoke test → document.
+
+## Health checks
+
+- Login page responds.
+- Authenticated navigation works.
+- Representative content open/save succeeds.
+- Publish job completes to a staging location.
+- Disk space for repository, temp, and publish targets remains healthy.
+
+## Ports & paths
+
+See [Ports & paths reference](id:reference-ports-paths) for common locations. Exact ports are
+**install-time choices** — do not assume a single fixed port across all environments.
+
+## Related
+
+- [Installation Overview](id:install-overview)
+- [Upgrade Overview](id:upgrade-overview)

--- a/product-docs/8.2/admin/server-ops.md
+++ b/product-docs/8.2/admin/server-ops.md
@@ -1,13 +1,13 @@
 ---
 id: admin-server-ops
-title: Server operations
+title: Server Operations
 description: Start, stop, logs, and operational basics for Percussion CMS 8.2
 version: "8.2"
 order: 44
 tags: [admin, operations]
 ---
 
-# Server operations
+# Server Operations
 
 Day-to-day control of the CMS process, logs, and configuration surfaces.
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -1,0 +1,55 @@
+---
+id: admin-sites
+title: Sites & content structure
+description: Sites, folders, and content organization in Percussion CMS 8.2
+version: "8.2"
+order: 41
+tags: [admin, sites]
+---
+
+# Sites & content structure
+
+A **Site** is the primary organizational unit for published output and editorial structure in
+Percussion CMS. Site properties include hostnames, permissions, publishing configuration, and
+(optionally) Virtual Site source settings.
+
+## Traditional Sites
+
+Traditional Sites store pages and assets in the Percussion **content repository**:
+
+- Editors work in the Web UI / Finder against Site folders and pages.
+- Workflow, ACL permissions, and revisions apply to repository items.
+- Publishing assembles templates/variants and delivers to filesystem, FTP, or other pub locations.
+
+## Virtual Sites (8.2)
+
+A **Virtual Site** is a Site whose content originates **outside** the traditional repository
+(for example Git/filesystem Markdown under `product-docs/`). Virtual items are discovered and
+assembled without ingesting them as ordinary CMS content items.
+
+Operators configure Virtual Sites through Site properties (source kind, root path, config file).
+Authors of Virtual content use Git and Markdown tooling, not the classic page editor.
+
+See [Virtual Sites (developer)](id:developer-virtual-sites) and
+[Site configuration reference](id:reference-site-config).
+
+## Folders, pages, and assets
+
+| Concept | Role |
+|---------|------|
+| **Site root / folders** | Hierarchy in Finder; drives navigation and pub structure |
+| **Pages** | Assembled HTML (or other) destinations for site visitors |
+| **Assets** | Shared content fragments (images, rich text, shared widgets) referenced by pages |
+| **Templates / variants** | Presentation used during assembly and publishing |
+
+## Operational tips
+
+- Prefer clear folder naming that matches the public URL tree when possible.
+- Limit deep nesting that confuses editors and slows Finder browsing.
+- Document which Sites are production vs staging vs documentation Virtual Sites.
+- After property changes that affect Virtual roots, re-run the offline docs build or CMS pub path to verify links.
+
+## Related
+
+- [Publishing](id:admin-publishing)
+- [Users, roles & security](id:admin-users-roles)

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -1,0 +1,61 @@
+---
+id: admin-users-roles
+title: Users, roles & security
+description: Accounts, roles, and access control for Percussion CMS 8.2
+version: "8.2"
+order: 42
+tags: [admin, security]
+---
+
+# Users, roles & security
+
+Percussion CMS enforces editorial and administrative access through users, roles, communities, and
+ACL-style permissions on content and design objects.
+
+## Accounts
+
+- Create administrative and editorial accounts through the product security / user management UI
+  (or directory integration when configured).
+- Use **unique accounts** for operators; avoid shared passwords for auditability.
+- Disable or remove accounts that leave the organization.
+
+## Roles and least privilege
+
+Assign the minimum role set needed for each job function:
+
+| Audience | Typical needs |
+|----------|----------------|
+| Content authors | Edit assigned folders/pages; workflow submit |
+| Approvers | Transition workflow; limited publish rights |
+| Site admins | Site properties, folder ACL, publish jobs |
+| System admins | Server config, extensions, security admin |
+
+Revisit role membership when Sites or departments reorganize.
+
+## Workflow
+
+Workflow states gate who can edit and publish. Common patterns:
+
+1. Draft → Review → Approved → Live (names vary by package/configuration).
+2. Reject paths return content to authors with comments.
+3. Scheduled or manual publish after approval depending on Site configuration.
+
+## Authentication notes
+
+- Local authentication is available out of the box for many installs.
+- Enterprise deployments often integrate external identity providers; follow the security module
+  documentation for your configured authenticator.
+- Protect the login endpoint behind TLS at the reverse proxy or edge.
+
+## Hardening checklist
+
+- [ ] Change default/install admin passwords immediately.
+- [ ] Restrict admin UI exposure (VPN, IP allow lists, SSO).
+- [ ] Keep the 8.2 / 8.1.x line patched for security fixes.
+- [ ] Review extension JARs and third-party libraries periodically.
+- [ ] Ensure backups of security configuration and role maps.
+
+## Related
+
+- [Server operations](id:admin-server-ops)
+- [Sites & content structure](id:admin-sites)

--- a/product-docs/8.2/developer/build-source.md
+++ b/product-docs/8.2/developer/build-source.md
@@ -1,0 +1,80 @@
+---
+id: developer-build-source
+title: Build from source
+description: Build Percussion CMS 8.2 and product-docs from the monorepo
+version: "8.2"
+order: 54
+tags: [developer, build]
+---
+
+# Build from source
+
+Instructions for developers building Percussion CMS 8.2 from this monorepo.
+
+## Prerequisites
+
+| Tool | Notes |
+|------|--------|
+| **JDK 21** | `JAVA_HOME` must point at JDK 21 |
+| **Maven wrapper** | Use repo-root `mvnw` / `mvnw.cmd` (do not require a global Maven version fight) |
+| **Git** | Clone `intersoftdatalabs-in/percussioncms` |
+| **Node.js** | Required for WebUI / TinyMCE-related modules when those modules are built |
+| **Windows long paths** | Enable long path support when building Node-heavy modules on Windows |
+
+## Full reactor build
+
+```bash
+# Linux / macOS
+./mvnw clean install
+
+# Windows
+mvnw.cmd clean install
+```
+
+Full monorepo builds are large. For feature work, prefer **standalone module builds**:
+
+```bash
+cd rest
+../mvnw clean install
+```
+
+```bat
+cd projects\sitemanage
+..\..\mvnw.cmd clean install
+```
+
+Build producers before consumers when both change (install the upstream SNAPSHOT first).
+
+## Product docs build
+
+<a id="product-docs-build"></a>
+
+After `system` compiles successfully:
+
+```bat
+scripts\build-cms-docs.bat
+```
+
+```bash
+scripts/build-cms-docs.sh
+```
+
+Optional arguments: `[siteRoot] [outputRoot]`. Defaults:
+
+- site root: `product-docs/`
+- output: `tmp/product-docs-site/`
+
+The CLI exits non-zero if link checks fail (missing `id:` targets or broken relative `.md` links).
+
+## Contribution basics
+
+- Follow root `AGENTS.md` / `CONTRIBUTING.md` for process gates.
+- Add or update unit tests with code changes.
+- Keep documentation under `product-docs/` in lockstep with product features when operators need it.
+- Open PRs against **`main`** for the active 8.2 line.
+
+## Related
+
+- [Installation Overview](id:install-overview)
+- [Virtual Sites](id:developer-virtual-sites)
+- [REST API](id:developer-rest)

--- a/product-docs/8.2/developer/extensions.md
+++ b/product-docs/8.2/developer/extensions.md
@@ -1,0 +1,52 @@
+---
+id: developer-extensions
+title: Extensions & packages
+description: Java extensions, packages, and deployment units for Percussion CMS 8.2
+version: "8.2"
+order: 53
+tags: [developer, extensions]
+---
+
+# Extensions & packages
+
+Percussion CMS is extended through **Java extensions**, **packages** (`.ppkg`), templates/variants,
+and related design objects.
+
+## Extensions
+
+Built-in and custom extensions live in modules such as:
+
+- `modules/extensions-main`
+- `modules/extensions-workflow`
+- `modules/extensions-nav`
+- `modules/extensions-sfp`
+- Additional specialized extension modules
+
+Extensions implement product extension points (assembly exits, workflow actions, content converters,
+and more). New extension code should:
+
+1. Target **JDK 21** APIs used by the 8.2 line.
+2. Include unit tests for non-trivial logic.
+3. Avoid non-portable path construction (use `java.nio.file.Path` / `Files`).
+4. Ship with package/resources as required so installs receive them.
+
+## Packages
+
+A **package** is a deployable unit of CMS components (content types, templates, apps, configs)
+distributed as a `.ppkg` (zip). Installers and startup packaging deploy packages into the CMS.
+
+When changing packaging:
+
+- Keep platform entry points (`.bat` / `.cmd` / `.sh`) in lockstep where operators need them.
+- Document install/upgrade impact for operators.
+
+## REST vs extensions
+
+Prefer **public REST + adaptors** for new integration surfaces that clients will call over HTTP.
+Prefer **extensions** when you must participate in assembly, workflow, or other in-process CMS
+extension points.
+
+## Related
+
+- [REST API](id:developer-rest)
+- [Publishing](id:admin-publishing)

--- a/product-docs/8.2/developer/index.md
+++ b/product-docs/8.2/developer/index.md
@@ -4,12 +4,47 @@ title: Developer
 description: Developer guides for Percussion CMS 8.2
 version: "8.2"
 order: 50
+tags: [developer]
 ---
 
 # Developer
 
-Extension points, REST, assemblers, and Virtual Sites.
+Extension points, REST, assemblers, Virtual Sites, and building Percussion CMS 8.2 from source.
 
-## Related
+## Topics
 
-- Virtual Sites design notes live under `docs/ai-generated/tasks/virtual-sites-git-docs/`.
+- [REST API](id:developer-rest)
+- [Virtual Sites](id:developer-virtual-sites)
+- [Extensions & packages](id:developer-extensions)
+- [Build from source](id:developer-build-source)
+
+## Architecture snapshot
+
+```text
+WebUI (SPA / editors)
+        │
+        ▼
+Public REST (rest module: resources, DTOs, IXxxAdaptor)
+        │
+        ▼
+sitemanage apibridge (implements adaptors)
+        │
+        ▼
+system / design webservices / objectstore
+```
+
+Key rules for modern APIs:
+
+- New public HTTP surfaces belong in the **`rest`** module.
+- **`rest` must not depend on `sitemanage`** (reactor cycle).
+- Adaptor implementations live in **sitemanage** and stay thin.
+
+## Assemblers
+
+8.2 continues assembler modernization (HTML-first and Markdown helpers). Product documentation
+dogfoods Markdown assembly through Virtual Sites.
+
+## Related engineering notes
+
+Internal task docs for Virtual Sites live under repository
+`docs/ai-generated/tasks/virtual-sites-git-docs/` (not part of this product site tree).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1,0 +1,55 @@
+---
+id: developer-rest
+title: REST API
+description: Public REST API orientation for Percussion CMS 8.2
+version: "8.2"
+order: 51
+tags: [developer, rest]
+---
+
+# REST API
+
+Percussion CMS exposes a public **REST** surface for product integrations and modern UI clients.
+
+## Module layout
+
+| Module | Responsibility |
+|--------|----------------|
+| **`rest`** | JAX-RS resources, wire DTOs, `IXxxAdaptor` interfaces, OpenAPI generation inputs |
+| **`projects/sitemanage`** | Thin `com.percussion.apibridge` implementations of those interfaces |
+| **`system`** | Core services, objectstore, assembly, design backends |
+
+Do **not** reverse the dependency: `rest` never depends on `sitemanage`.
+
+## OpenAPI / exploration
+
+- OpenAPI artifacts are generated from JAX-RS annotations (see `modules/perc-openapi-generator-plugin`).
+- A Swagger UI webapp module packages interactive exploration for supported deployments.
+
+Prefer the generated contract as the integration source of truth rather than reverse-engineering
+UI traffic alone.
+
+## Auth and clients
+
+- REST calls require the authentication mode configured for the server (session/cookie or token
+  patterns depending on surface and deployment).
+- Treat credentials and tokens as secrets; never commit them to Git or product-docs examples.
+
+## Workbench-replacement APIs
+
+Developer-module (Workbench replacement) endpoints should map design operations through clean REST
++ adaptors to the same design/system capabilities classic tools used — not ad-hoc sitemanage
+endpoints chosen only because they “look REST.” See repository
+`docs/developer-module/workbench-rest-and-qa-modes.md` for the engineering contract.
+
+## Testing tips
+
+- Unit-test resources with Mockito and provide Spring test stubs for new adaptor interfaces on the
+  rest test classpath.
+- Exercise adaptor implementations in sitemanage tests.
+- Run **standalone** `mvnw clean install` in each changed module before PR (see root `AGENTS.md`).
+
+## Related
+
+- [Extensions & packages](id:developer-extensions)
+- [Build from source](id:developer-build-source)

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -1,0 +1,91 @@
+---
+id: developer-virtual-sites
+title: Virtual Sites
+description: Git/filesystem Virtual Sites for documentation and external content
+version: "8.2"
+order: 52
+tags: [developer, virtual-sites]
+---
+
+# Virtual Sites
+
+**Virtual Sites** are Sites whose content originates outside the traditional Percussion content
+repository. Phase 1 delivers a **Git / filesystem** adapter aimed at product documentation.
+
+## Goals
+
+- Keep Git as the system of record for documentation (PR review, lockstep with product changes).
+- Use Percussion assemblers as the site generator (Markdown → HTML).
+- Provide stable page identities (`frontmatter.id`) for lightweight link checks / participants.
+- Leave the door open for future adapters (SQL, API, object storage) without renaming Site → Channel.
+
+## Source tree contract
+
+Repository root:
+
+```text
+product-docs/
+  _config.yaml
+  _theme/
+  assets/
+  8.2/
+    index.md
+    getting-started/
+    admin/
+    developer/
+    reference/
+```
+
+- Folder structure drives navigation hierarchy.
+- `index.md` is the landing page for a section.
+- One top-level folder per documentation version (for example `8.2/`).
+
+## Stable identity
+
+Every Markdown page requires YAML frontmatter with a unique **`id`** within the version.
+Paths may change; `id` should not. Cross-page links use stable id links:
+
+```markdown
+See [Installation](id:install-overview).
+```
+
+Details: [Frontmatter reference](id:reference-frontmatter).
+
+## Site properties (CMS)
+
+When a Percussion Site is configured as virtual:
+
+| Property | Example | Meaning |
+|----------|---------|---------|
+| `virtual.sourceKind` | `git-filesystem` | Non-blank ⇒ Virtual Site |
+| `virtual.rootPath` | path to tree | Source root |
+| `virtual.configFile` | `_config.yaml` | Optional; default `_config.yaml` |
+
+Empty / missing `virtual.sourceKind` means a traditional repository Site.
+
+## Offline build
+
+From the repository root (after the `system` module can compile):
+
+```bat
+scripts\build-cms-docs.bat
+```
+
+```bash
+scripts/build-cms-docs.sh
+```
+
+Default output: `tmp/product-docs-site/`. The build fails non-zero when internal `id:` or relative
+Markdown links cannot be resolved.
+
+## What is not in Phase 1
+
+- CMS UI editing of Virtual items as normal content types
+- Automatic migration of the full legacy help site
+- SQL/API adapters
+- Fake classic content-list generators for virtual items
+
+## Related
+
+- [Site configuration reference](id:reference-site-config)
+- [Build from source](id:developer-build-source)

--- a/product-docs/8.2/getting-started/index.md
+++ b/product-docs/8.2/getting-started/index.md
@@ -4,9 +4,34 @@ title: Getting Started
 description: Install and first steps for Percussion CMS 8.2
 version: "8.2"
 order: 10
+tags: [getting-started]
 ---
 
 # Getting Started
 
-- [Installation Overview](id:install-overview)
-- [Upgrade Overview](id:upgrade-overview)
+This section covers how to obtain, install, upgrade, and take first steps with Percussion CMS 8.2.
+
+## Topics
+
+- [Installation Overview](id:install-overview) — prerequisites, packages, first start
+- [Upgrade Overview](id:upgrade-overview) — paths from prior releases into 8.2
+
+## Who should read this
+
+| Role | Recommended path |
+|------|------------------|
+| New operator | Install binaries from GitHub Releases → verify login → configure first Site |
+| Upgrading customer | Read upgrade notes → back up → run installer upgrade path |
+| Developer | [Build from source](id:developer-build-source) after a quick install overview |
+
+## After install
+
+1. Confirm the server process starts and logs under the install `jetty/base/logs` (or platform service logs) are clean.
+2. Sign in with the administrative account created at install time.
+3. Create or open a **Site**, confirm Finder navigation, and open the Web UI editor.
+4. Review [Server operations](id:admin-server-ops) for ports, service control, and logs.
+
+## Related
+
+- [Administration](id:admin) — day-two operations
+- [Developer](id:developer) — REST, extensions, Virtual Sites

--- a/product-docs/8.2/getting-started/install.md
+++ b/product-docs/8.2/getting-started/install.md
@@ -53,7 +53,7 @@ Exact wizard screens differ by platform, but the flow is consistent:
 
 ### Docker / evaluation
 
-Repository `docker/` and compose files support evaluation and QA-style environments (including H2
+Repository `docker/` scripts and the root `docker-compose.yml` support evaluation and QA-style environments (including H2
 QA mode for automated testing). Prefer documented `perc-devctl` / compose flows for agent and
 developer QA rather than one-off container recipes.
 

--- a/product-docs/8.2/getting-started/install.md
+++ b/product-docs/8.2/getting-started/install.md
@@ -9,6 +9,69 @@ tags: [install, admin]
 
 # Installation Overview
 
-Document install prerequisites, supported platforms, and the recommended install path for 8.2.
+This page summarizes installing Percussion CMS 8.2 on supported platforms. Prefer official
+installers from the project **Releases** page when operating a production or QA host.
 
-> Content grows in lockstep with product changes — expand this page as install tooling lands.
+## Supported platforms
+
+Percussion CMS is a **cross-platform** product. Install, run, and administer on:
+
+- **Windows** (server and developer workstations)
+- **Linux**
+- **macOS** (typically developer and evaluation hosts)
+
+File paths, scripts, and services differ by OS; use the installer packages and service wrappers
+shipped for your platform rather than hard-coding Unix-only paths.
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|--------|
+| **JDK 21** | Runtime and toolchain for the 8.2 line. Set `JAVA_HOME` to a JDK 21 installation. |
+| **Supported RDBMS** (production) | Use the database drivers and schemas documented for your release; evaluation/dev often uses H2. |
+| **Disk & ports** | Enough space for install tree, content repository, and publish targets; free HTTP(S) ports (defaults vary by install; common developer CMS UI ports include the install-time configured Jetty ports). |
+| **Permissions** | Installer/service account needs write access under the install directory and configured data/publish paths. |
+
+## Obtain packages
+
+1. Open the [GitHub Releases](https://github.com/intersoftdatalabs-in/percussioncms/releases) page for this repository.
+2. Download the CMS distribution/installer for your platform and the matching **Delivery Tier Service (DTS)** packages if you use dynamic widgets (comments, forms, membership, metadata, polls, and related services).
+3. Verify checksums when provided on the release.
+
+Commercial support customers may also receive packages through Intersoft Data Labs channels.
+
+## Install steps (high level)
+
+Exact wizard screens differ by platform, but the flow is consistent:
+
+1. **Stop** any previous CMS instance that would bind the same ports or install path.
+2. Run the **CMS installer** (GUI or silent, as documented for that package).
+3. Choose install directory, database connection, ports, and admin credentials.
+4. Complete installation and start the CMS service (Windows service, Linux systemd/init scripts, or the platform service wrapper shipped with the product).
+5. Optionally install and configure the **DTS** against the same or related environment.
+6. Open the Web UI URL printed by the installer and sign in.
+
+### Docker / evaluation
+
+Repository `docker/` and compose files support evaluation and QA-style environments (including H2
+QA mode for automated testing). Prefer documented `perc-devctl` / compose flows for agent and
+developer QA rather than one-off container recipes.
+
+## First verification checklist
+
+- [ ] Process is running; no fatal errors in server logs under the install tree.
+- [ ] Login page loads over the configured host/port.
+- [ ] Admin user can authenticate.
+- [ ] At least one Site is visible (sample or newly created).
+- [ ] Version information matches 8.2 (About box or `Version.properties` under the install root).
+
+## Build from source (developers)
+
+To compile the monorepo instead of installing binaries, see
+[Build from source](id:developer-build-source). Building is not required for ordinary operator installs.
+
+## Related
+
+- [Upgrade Overview](id:upgrade-overview)
+- [Server operations](id:admin-server-ops)
+- [Ports & paths](id:reference-ports-paths)

--- a/product-docs/8.2/getting-started/upgrade.md
+++ b/product-docs/8.2/getting-started/upgrade.md
@@ -9,6 +9,60 @@ tags: [upgrade, admin]
 
 # Upgrade Overview
 
-Document upgrade paths from prior releases into 8.2.
+This page describes upgrade planning into Percussion CMS **8.2**. Always follow the release notes
+and installer guidance for the exact build you are deploying.
 
-> Stub — fill in as upgrade tooling and release notes stabilize.
+## Before you upgrade
+
+1. **Inventory** current CMS and DTS versions, OS, JDK, and database platform.
+2. **Read** the target release notes for breaking changes, property renames, and required JDK level (**JDK 21** for 8.2).
+3. **Back up**:
+   - Install tree configuration (Jetty base, `rxconfig`, server properties, custom extensions)
+   - Database(s)
+   - Published output if you need a rollback snapshot of delivery files
+4. **Schedule** maintenance: upgrades typically require a CMS (and often DTS) outage window.
+5. **Validate** on a lower environment that mirrors production data shape before production.
+
+## Recommended paths
+
+| From | Guidance |
+|------|----------|
+| **8.1.x** | Preferred path into 8.2. Apply latest 8.1.x security patches first when possible, then run the 8.2 installer upgrade mode against a clone of production. |
+| **Older 8.x / CM1 lineage** | Plan multi-hop upgrades (stable intermediate releases) rather than jumping multiple major lines at once. Engage Intersoft support for complex multi-version leaps. |
+| **Customized installs** | Catalog custom Java extensions, XSL/variants, WebUI overlays, and third-party JARs; recompile against the 8.2 toolchain (JDK 21) and retest. |
+
+## Upgrade steps (high level)
+
+1. Put the system in maintenance (stop traffic, freeze content freezes if required by policy).
+2. Stop CMS and DTS services cleanly.
+3. Take final backups.
+4. Run the **8.2 installer** in upgrade/update mode for the existing install root (or follow the package-specific silent upgrade flags).
+5. Allow schema / tablefactory and package install steps to complete; capture logs.
+6. Re-apply environment-specific configuration only when the installer does not preserve it (custom ports, reverse proxy headers, TLS keystores, external auth).
+7. Start services; run smoke tests (login, open Site, edit page, publish sample, DTS widgets if used).
+8. Monitor logs for extension load failures and missing resources.
+
+## Post-upgrade smoke tests
+
+- [ ] Login and role-based navigation work.
+- [ ] Finder shows Sites and folders; open a representative page and asset.
+- [ ] Workflow transitions complete without server errors.
+- [ ] Publish to a non-production location succeeds.
+- [ ] REST health / authenticated sample call succeeds if you integrate headlessly.
+- [ ] DTS endpoints used by the site respond as before.
+
+## Rollback notes
+
+True in-place rollback depends on how far schema and package updates progressed. Prefer:
+
+1. Restore database from pre-upgrade backup.
+2. Restore install tree (or reinstall previous version into a clean path and restore config).
+3. Restore publish targets if delivery files were partially overwritten.
+
+Document your environment-specific rollback runbook before production cutover.
+
+## Related
+
+- [Installation Overview](id:install-overview)
+- [Server operations](id:admin-server-ops)
+- [Publishing](id:admin-publishing)

--- a/product-docs/8.2/index.md
+++ b/product-docs/8.2/index.md
@@ -8,18 +8,38 @@ order: 0
 
 # Percussion CMS 8.2 Documentation
 
-Welcome. This tree is a **Git-backed Virtual Site** source. Documentation is authored in Markdown
-in the product repository and assembled into a static site with Percussion’s Markdown assembler.
+Welcome to the product documentation for **Percussion CMS 8.2**.
+
+Percussion CMS is an enterprise content management system for authoring, assembling, and
+publishing websites and multi-channel content. The 8.2 line continues platform modernization
+(Java 21, assemblers, REST, UI, Virtual Sites) while preserving the production strengths of
+CM1 / Rhythmyx.
+
+This tree is a **Git-backed Virtual Site** source. Documentation is authored as Markdown in the
+product repository and assembled into a static site with Percussion’s Markdown assembler.
 
 ## Sections
 
-- [Getting Started](id:getting-started)
-- [Administration](id:admin)
-- [Developer](id:developer)
-- [Reference](id:reference)
+| Section | Audience | Start here |
+|---------|----------|------------|
+| [Getting Started](id:getting-started) | Operators installing or upgrading | [Installation](id:install-overview), [Upgrade](id:upgrade-overview) |
+| [Administration](id:admin) | Site admins and operators | [Sites](id:admin-sites), [Users & roles](id:admin-users-roles), [Publishing](id:admin-publishing) |
+| [Developer](id:developer) | Integrators and extension authors | [REST](id:developer-rest), [Virtual Sites](id:developer-virtual-sites), [Build from source](id:developer-build-source) |
+| [Reference](id:reference) | All readers | [Frontmatter](id:reference-frontmatter), [Site config](id:reference-site-config), [Glossary](id:reference-glossary) |
+
+## Product lines at a glance
+
+| Version | Role |
+|---------|------|
+| **8.1.x** | Current stable production line (security, accessibility, REST fixes) |
+| **8.2** | Active development / modernization (this documentation set) |
+
+Commercial support and services: [Intersoft Data Labs](https://www.intsof.com) ·
+[Support portal](https://percussionsupport.intsof.com) ·
+Legacy help site: [percussioncmshelp.intsof.com](https://percussioncmshelp.intsof.com)
 
 ## Working model
 
-When you land a product feature in 8.2, add or update the corresponding page under `product-docs/`
-in the same change set (or an immediate follow-up). Keep frontmatter `id` values **stable** when
-paths rename.
+When you land a product feature in 8.2, add or update the corresponding page under
+`product-docs/` in the same change set (or an immediate follow-up). Keep frontmatter `id`
+values **stable** when paths rename. See [Frontmatter reference](id:reference-frontmatter).

--- a/product-docs/8.2/reference/frontmatter.md
+++ b/product-docs/8.2/reference/frontmatter.md
@@ -1,0 +1,61 @@
+---
+id: reference-frontmatter
+title: Frontmatter contract
+description: Required YAML frontmatter fields for product-docs Markdown pages
+version: "8.2"
+order: 61
+tags: [reference, docs]
+---
+
+# Frontmatter contract
+
+Every Markdown page under a version folder must start with a YAML frontmatter block.
+
+## Example
+
+```yaml
+---
+id: install-overview
+title: Installation Overview
+description: How to install Percussion CMS 8.2
+version: "8.2"
+sidebar: true
+order: 10
+tags: [install, admin]
+deprecated: false
+---
+```
+
+## Fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `id` | **Yes** | Stable identity for virtual participants / links. Unique within a version. |
+| `title` | **Yes** | Page title. |
+| `description` | No | Short summary. |
+| `version` | No | Inherited from version folder name when omitted. |
+| `sidebar` | No | Default `true`. |
+| `order` | No | Sort key among siblings (default `0`). |
+| `tags` | No | List of strings. |
+| `deprecated` | No | Default `false`. |
+
+## Validation
+
+- Missing `id` or `title` fails the page (build error).
+- Duplicate `id` within the same version fails the build.
+- Prefer stable `id` values even when files move.
+
+## Linking
+
+Use stable id links in Markdown bodies:
+
+```markdown
+[Installation Overview](id:install-overview)
+```
+
+Relative `.md` links also work and are rewritten to site-root HTML paths during build.
+
+## Related
+
+- [Site configuration](id:reference-site-config)
+- [Virtual Sites](id:developer-virtual-sites)

--- a/product-docs/8.2/reference/glossary.md
+++ b/product-docs/8.2/reference/glossary.md
@@ -1,0 +1,37 @@
+---
+id: reference-glossary
+title: Glossary
+description: Glossary of Percussion CMS 8.2 terms
+version: "8.2"
+order: 64
+tags: [reference]
+---
+
+# Glossary
+
+| Term | Definition |
+|------|------------|
+| **Assembly** | Process of merging content with templates/variants to produce deliverable output |
+| **Asset** | Shared content fragment referenced by pages |
+| **CM1** | Marketing name historically used for the modern Percussion CMS product line |
+| **CMS** | Content Management System — this product |
+| **Content repository** | Traditional storage of CMS items (pages, assets, design objects) |
+| **DTS** | Delivery Tier Service — dynamic microservices for published sites |
+| **Edition / publish job** | Configured publishing unit of work |
+| **Extension** | In-process plugin implementing a CMS extension point |
+| **Finder** | UI navigation over Sites, folders, and items |
+| **Frontmatter** | YAML metadata block at the top of a Markdown docs page |
+| **Package (`.ppkg`)** | Deployable zip of CMS components |
+| **Page** | Primary assembled document for a Site URL |
+| **Rhythmyx** | Historic product name for the core platform lineage |
+| **REST adaptor** | Interface in `rest` implemented by sitemanage apibridge |
+| **Site** | Organizational and publishing unit (traditional or Virtual) |
+| **Template / variant** | Presentation definition used during assembly |
+| **Virtual Site** | Site whose content comes from an external source (e.g. Git filesystem) |
+| **Workflow** | State machine governing edit/approve/publish rights |
+| **WebUI** | Primary browser UI for editors and admins |
+
+## Related
+
+- [Sites & content structure](id:admin-sites)
+- [Virtual Sites](id:developer-virtual-sites)

--- a/product-docs/8.2/reference/index.md
+++ b/product-docs/8.2/reference/index.md
@@ -4,8 +4,28 @@ title: Reference
 description: Reference material for Percussion CMS 8.2
 version: "8.2"
 order: 60
+tags: [reference]
 ---
 
 # Reference
 
-API, configuration, and glossary material.
+Contracts, configuration, ports/paths, and glossary material for Percussion CMS 8.2.
+
+## Topics
+
+- [Frontmatter contract](id:reference-frontmatter)
+- [Site configuration (`_config.yaml`)](id:reference-site-config)
+- [Ports & paths](id:reference-ports-paths)
+- [Glossary](id:reference-glossary)
+
+## Product vs engineering docs
+
+| Tree | Purpose |
+|------|---------|
+| **`product-docs/`** | Operator/developer product documentation (this site) |
+| **`docs/`** | Engineering, AI task notes, policies — not this Virtual Site |
+
+## Related
+
+- [Developer](id:developer)
+- [Administration](id:admin)

--- a/product-docs/8.2/reference/ports-paths.md
+++ b/product-docs/8.2/reference/ports-paths.md
@@ -1,0 +1,54 @@
+---
+id: reference-ports-paths
+title: Ports & paths
+description: Common ports and filesystem paths for Percussion CMS 8.2
+version: "8.2"
+order: 63
+tags: [reference, admin]
+---
+
+# Ports & paths
+
+Exact ports and paths are **environment-specific**. This page lists common conventions; always
+confirm against your install wizard choices and `Version.properties` / Jetty config.
+
+## Ports
+
+| Service | Notes |
+|---------|--------|
+| CMS HTTP / HTTPS | Chosen at install; developer machines often use non-80 ports |
+| DTS HTTP | Separate connectors when DTS is installed |
+| Database | External to CMS; firewall as appropriate |
+| Reverse proxy | TLS usually terminates at the proxy in production |
+
+Do not hard-code ports in documentation examples as universal truths.
+
+## Install tree highlights
+
+Paths below are relative to the CMS install root unless noted. Separators differ by OS; use the
+platform path form.
+
+| Location | Purpose |
+|----------|---------|
+| `Version.properties` | Installed product version metadata |
+| `jetty/` | Embedded Jetty runtime |
+| `jetty/base/logs/` | Server and application logs |
+| `rxconfig/` (when present) | Classic configuration trees |
+| Publish locations | Configured per Site / delivery type — not a single fixed folder |
+
+## Repository (source) paths of interest
+
+| Path | Purpose |
+|------|---------|
+| `product-docs/` | Git-backed product documentation Virtual Site source |
+| `tmp/product-docs-site/` | Default offline docs build output |
+| `scripts/build-cms-docs.bat` / `.sh` | Docs build entry points |
+| `rest/` | Public REST module |
+| `projects/sitemanage/` | UI middleware + REST adaptors |
+| `system/` | Core CMS module |
+| `modules/perc-qa-automation/` | Playwright E2E |
+
+## Related
+
+- [Server operations](id:admin-server-ops)
+- [Installation Overview](id:install-overview)

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -1,0 +1,63 @@
+---
+id: reference-site-config
+title: Site configuration
+description: product-docs _config.yaml and Virtual Site properties
+version: "8.2"
+order: 62
+tags: [reference, docs, virtual-sites]
+---
+
+# Site configuration
+
+## `_config.yaml` (Virtual Site root)
+
+Located at `product-docs/_config.yaml`.
+
+```yaml
+site:
+  title: Percussion CMS Documentation
+  url: https://percussioncmshelp.intsof.com
+
+versions:
+  - id: "8.2"
+    label: "8.2 (current)"
+    path: 8.2
+    default: true
+
+nav:
+  - title: Getting Started
+    id: getting-started
+  - title: Administration
+    id: admin
+  - title: Developer
+    id: developer
+  - title: Reference
+    id: reference
+
+theme:
+  layout: page.html
+```
+
+### Rules
+
+- `versions[].path` is a directory under the site root.
+- If `nav` is omitted, navigation is derived from folders + frontmatter `order`.
+- `theme.layout` is relative to `_theme/` (default `page.html`).
+- `nav[].id` values should match section landing page frontmatter `id`s.
+
+## CMS Site properties (Virtual)
+
+When a Percussion Site is configured as virtual:
+
+| Property name | Example | Meaning |
+|---------------|---------|---------|
+| `virtual.sourceKind` | `git-filesystem` | Non-blank ⇒ Virtual Site |
+| `virtual.rootPath` | absolute or install-relative path to tree | Source root |
+| `virtual.configFile` | `_config.yaml` | Optional; default `_config.yaml` |
+
+Empty / missing `virtual.sourceKind` means traditional **repository** site.
+
+## Related
+
+- [Frontmatter contract](id:reference-frontmatter)
+- [Virtual Sites](id:developer-virtual-sites)

--- a/product-docs/README.md
+++ b/product-docs/README.md
@@ -12,10 +12,15 @@ product-docs/
   _theme/            # HTML-first layout templates
   assets/            # static CSS/images
   8.2/               # versioned Markdown content
+    getting-started/
+    admin/
+    developer/
+    reference/
 ```
 
 Every page uses YAML frontmatter with a stable `id` (see
-`docs/ai-generated/tasks/virtual-sites-git-docs/contracts/frontmatter.md`).
+`docs/ai-generated/tasks/virtual-sites-git-docs/contracts/frontmatter.md` and the product
+page `8.2/reference/frontmatter.md`).
 
 ## Build
 
@@ -29,8 +34,10 @@ scripts\build-cms-docs.bat
 scripts/build-cms-docs.sh
 ```
 
-Output defaults to `tmp/product-docs-site/`.
+Output defaults to `tmp/product-docs-site/`. The build fails if internal `id:` or relative Markdown
+links cannot be resolved.
 
 ## Working model (8.2)
 
 Add or update Markdown here when features land so documentation stays in lockstep with the product.
+Keep frontmatter `id` values stable when paths rename.


### PR DESCRIPTION
## Summary

Expand skeleton `product-docs/8.2` into usable operator/developer documentation for Percussion CMS 8.2 (Virtual Site Git-backed docs, Phase 2 residual slice 1 of epic #2678).

- **Getting Started**: install prerequisites/platforms, upgrade planning, post-install checks
- **Administration**: sites (traditional + Virtual), users/roles, publishing, server ops
- **Developer**: REST module layout, Virtual Sites, extensions/packages, build from source + docs build
- **Reference**: frontmatter contract, `_config.yaml` / Site properties, ports & paths, glossary
- Stable frontmatter `id` / `title` / `order` retained; cross-links use `id:…` form

**Parent:** #2678  
**Fixes:** #2703  
**Refs:** #2679

Out of scope (siblings): CI docs smoke (#2704), SPI/tests polish (#2705), new adapters.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. From repo root (JDK 21, `system` compile available): `scripts\build-cms-docs.bat` (or `.sh`)
2. Confirm output under `tmp/product-docs-site/`
3. Confirm CLI reports **19 page(s)** and **exit 0** (no link problems)
4. Spot-check HTML: home links to section landings; install/upgrade/admin/developer/reference pages render

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang self-review | Docs-only; portable path guidance; no code logic bugs |
| Pre-PR Maven clean install | **N/A** — no Maven module sources/tests/resources changed (product-docs + README only) |
| `scripts/build-cms-docs` | **BUILD SUCCESS** — 19 pages, 0 link problems |
| Unit tests | N/A for pure Markdown content (no inventory assertion change) |

## Acceptance mapping

- [x] `product-docs/8.2/**` non-stub main nav sections
- [x] build produces navigable HTML without broken internal links from this slice
- [x] Frontmatter contracts honored
- [x] Parent #2678 Agent progress updated after PR

> Co-Authored by Grok Build using grok-4.5 with agent main.