### PR TITLE
feat(ci): path-filtered product-docs build smoke (#2704)

### DIFF
--- a/.github/workflows/product-docs-build.yml
+++ b/.github/workflows/product-docs-build.yml
@@ -1,0 +1,83 @@
+# Path-filtered product-docs Virtual Site build smoke (issue #2704 / epic #2678).
+#
+# Runs only when product-docs content, docs build scripts, Virtual Site Java
+# sources, or this workflow change — avoids full monorepo CI cost on unrelated PRs.
+#
+# On ubuntu: scripts/build-cms-docs.sh (via scripts/ci-smoke-product-docs.sh).
+# Windows operators: use scripts\build-cms-docs.bat / scripts\ci-smoke-product-docs.bat
+# (documented in product-docs/README.md); this job stays on ubuntu for runner cost.
+
+name: product-docs-build
+
+on:
+  pull_request:
+    paths:
+      - "product-docs/**"
+      - "scripts/build-cms-docs.sh"
+      - "scripts/build-cms-docs.bat"
+      - "scripts/ci-smoke-product-docs.sh"
+      - "scripts/ci-smoke-product-docs.bat"
+      - "system/services/src/com/percussion/services/virtualsite/**"
+      - "system/src/test/java/com/percussion/services/virtualsite/**"
+      - "system/src/test/resources/virtualsite/**"
+      - ".github/workflows/product-docs-build.yml"
+  push:
+    branches: [main]
+    paths:
+      - "product-docs/**"
+      - "scripts/build-cms-docs.sh"
+      - "scripts/build-cms-docs.bat"
+      - "scripts/ci-smoke-product-docs.sh"
+      - "scripts/ci-smoke-product-docs.bat"
+      - "system/services/src/com/percussion/services/virtualsite/**"
+      - "system/src/test/java/com/percussion/services/virtualsite/**"
+      - "system/src/test/resources/virtualsite/**"
+      - ".github/workflows/product-docs-build.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  product-docs-smoke:
+    name: product-docs build smoke
+    runs-on: ubuntu-latest
+    # system + upstream reactor compile is heavier than pure script smoke
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Install system + upstream reactor deps (skip tests)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Sibling SNAPSHOTs are not published; install also-make chain so
+          # scripts/build-cms-docs.sh can compile/exec PSVirtualSiteBuildMain.
+          # Scoped to system (+ deps), not full monorepo reactor.
+          ./mvnw -B -pl system -am -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            install
+
+      - name: Build product-docs and assert index HTML
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x scripts/build-cms-docs.sh scripts/ci-smoke-product-docs.sh
+          bash scripts/ci-smoke-product-docs.sh
+
+      - name: Upload built site (debug artifact)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: product-docs-site-failed
+          path: tmp/product-docs-site/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/product-docs/README.md
+++ b/product-docs/README.md
@@ -34,8 +34,40 @@ scripts\build-cms-docs.bat
 scripts/build-cms-docs.sh
 ```
 
-Output defaults to `tmp/product-docs-site/`. The build fails if internal `id:` or relative Markdown
-links cannot be resolved.
+Output defaults to `tmp/product-docs-site/` (versioned pages under `8.2/`, e.g. `8.2/index.html`).
+The build fails if internal `id:` or relative Markdown links cannot be resolved.
+
+### CI smoke (path-filtered)
+
+GitHub Actions workflow **`product-docs-build`** (`.github/workflows/product-docs-build.yml`)
+runs on PRs/pushes that touch:
+
+- `product-docs/**`
+- `scripts/build-cms-docs*` / `scripts/ci-smoke-product-docs*`
+- `system/**/virtualsite/**` (Virtual Site build sources/tests)
+- the workflow file itself
+
+**CI runner (ubuntu):** installs `system` + upstream reactor SNAPSHOTs (`./mvnw -pl system -am -DskipTests install`), then runs:
+
+```bash
+scripts/ci-smoke-product-docs.sh
+```
+
+That wrapper builds the site and **fails** if the build exits non-zero or no `index.html` is emitted (expects `tmp/product-docs-site/8.2/index.html`). Broken Markdown, frontmatter, or `_config.yaml` that break the Virtual Site build will red the job.
+
+**Local Windows parity** (same assertions; not used by the ubuntu CI job):
+
+```bat
+scripts\ci-smoke-product-docs.bat
+```
+
+**Local Unix parity:**
+
+```bash
+scripts/ci-smoke-product-docs.sh
+```
+
+Operators: prefer the smoke wrappers before opening a docs-only PR so CI does not become the first signal of a broken tree.
 
 ## Working model (8.2)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -58,6 +58,10 @@ Path-filtered CI / local **smoke** around `build-cms-docs` (issue #2704).
 
 - **Failure path**: non-zero build exit (broken md/config/link ids) **or** missing
   index HTML → exit 1. See `product-docs/README.md` → **CI smoke**.
+- **Failure artifacts**: after wipe, the smoke scripts **recreate** the output root and
+  write `.ci-smoke-meta.txt` so the workflow `if: failure()` upload of
+  `tmp/product-docs-site/` always has a path and at least one file (partial build
+  output is preserved when the builder emits anything before failing).
 
 ### Third-party license inventory (Maven + npm merge)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,6 +34,31 @@ Build the **product documentation Virtual Site** (`product-docs/`) to static HTM
 - **Prereqs**: JDK 21, repo-root `mvnw`/`mvnw.cmd`, network once for Maven deps.
 - **Design docs**: `docs/ai-generated/tasks/virtual-sites-git-docs/`.
 
+### `ci-smoke-product-docs.bat` / `ci-smoke-product-docs.sh`
+
+Path-filtered CI / local **smoke** around `build-cms-docs` (issue #2704).
+
+- **Purpose**: Clean the output dir, run the docs build, and **fail** if no versioned
+  `index.html` is emitted (default check: `tmp/product-docs-site/8.2/index.html`).
+- **CI**: `.github/workflows/product-docs-build.yml` (ubuntu) installs `system` +
+  upstream reactor SNAPSHOTs, then runs the `.sh` smoke script.
+- **Windows operators**: use the `.bat` entrypoint for the same assertions; CI itself
+  stays on ubuntu to control runner cost.
+- **Usage**:
+
+  ```bat
+  scripts\ci-smoke-product-docs.bat
+  scripts\ci-smoke-product-docs.bat C:\path\to\product-docs C:\path\to\out
+  ```
+
+  ```bash
+  scripts/ci-smoke-product-docs.sh
+  scripts/ci-smoke-product-docs.sh /path/to/product-docs /path/to/out
+  ```
+
+- **Failure path**: non-zero build exit (broken md/config/link ids) **or** missing
+  index HTML → exit 1. See `product-docs/README.md` → **CI smoke**.
+
 ### Third-party license inventory (Maven + npm merge)
 
 **Not a Python script.** Merged inventory generation for issue #1689 lives in

--- a/scripts/ci-smoke-product-docs.bat
+++ b/scripts/ci-smoke-product-docs.bat
@@ -3,6 +3,10 @@ REM CI / local smoke for product-docs Virtual Site build (issue #2704).
 REM Runs scripts\build-cms-docs.bat then fails if default versioned index HTML is missing.
 REM Usage: scripts\ci-smoke-product-docs.bat [siteRoot] [outputRoot]
 REM Unix parity: scripts/ci-smoke-product-docs.sh
+REM
+REM Failure artifacts: output root is recreated empty (not left deleted) and a
+REM .ci-smoke-meta.txt marker is always written so CI upload-artifact on
+REM failure has a path + file even when the docs build emits nothing.
 setlocal EnableExtensions
 set "REPO_ROOT=%~dp0.."
 set "SITE_ROOT=%~1"
@@ -11,17 +15,29 @@ set "OUT_ROOT=%~2"
 if "%OUT_ROOT%"=="" set "OUT_ROOT=%REPO_ROOT%\tmp\product-docs-site"
 
 REM Fresh output so stale HTML cannot mask a failed emit.
+REM Recreate dir immediately so failure artifacts always have a path.
 if exist "%OUT_ROOT%" rmdir /s /q "%OUT_ROOT%"
+mkdir "%OUT_ROOT%" 2>nul
+(
+  echo status=running
+  echo siteRoot=%SITE_ROOT%
+  echo outRoot=%OUT_ROOT%
+) > "%OUT_ROOT%\.ci-smoke-meta.txt"
 
 echo ci-smoke-product-docs: building siteRoot=%SITE_ROOT% -^> outRoot=%OUT_ROOT%
 call "%~dp0build-cms-docs.bat" "%SITE_ROOT%" "%OUT_ROOT%"
 if errorlevel 1 (
+  (
+    echo status=build_failed
+    echo buildExit=non-zero
+  ) >> "%OUT_ROOT%\.ci-smoke-meta.txt"
   echo ci-smoke-product-docs: FAIL — build-cms-docs.bat exited non-zero 1>&2
   exit /b 1
 )
 
 set "DEFAULT_INDEX=%OUT_ROOT%\8.2\index.html"
 if exist "%DEFAULT_INDEX%" (
+  echo status=ok>> "%OUT_ROOT%\.ci-smoke-meta.txt"
   echo ci-smoke-product-docs: OK — found %DEFAULT_INDEX%
   exit /b 0
 )
@@ -34,10 +50,15 @@ for /f "delims=" %%F in ('dir /s /b "%OUT_ROOT%\index.html" 2^>nul') do (
 )
 :found
 if defined FOUND (
+  echo status=ok>> "%OUT_ROOT%\.ci-smoke-meta.txt"
   echo ci-smoke-product-docs: OK — found index HTML at %FOUND%
   exit /b 0
 )
 
+(
+  echo status=missing_index
+  echo expectedDefault=%DEFAULT_INDEX%
+) >> "%OUT_ROOT%\.ci-smoke-meta.txt"
 echo ci-smoke-product-docs: FAIL — no index.html under %OUT_ROOT% 1>&2
 echo   Expected at least %DEFAULT_INDEX% (or any **\index.html^). 1>&2
 echo   Broken Markdown/frontmatter/_config.yaml or Virtual Site build bugs 1>&2

--- a/scripts/ci-smoke-product-docs.bat
+++ b/scripts/ci-smoke-product-docs.bat
@@ -1,0 +1,45 @@
+@echo off
+REM CI / local smoke for product-docs Virtual Site build (issue #2704).
+REM Runs scripts\build-cms-docs.bat then fails if default versioned index HTML is missing.
+REM Usage: scripts\ci-smoke-product-docs.bat [siteRoot] [outputRoot]
+REM Unix parity: scripts/ci-smoke-product-docs.sh
+setlocal EnableExtensions
+set "REPO_ROOT=%~dp0.."
+set "SITE_ROOT=%~1"
+if "%SITE_ROOT%"=="" set "SITE_ROOT=%REPO_ROOT%\product-docs"
+set "OUT_ROOT=%~2"
+if "%OUT_ROOT%"=="" set "OUT_ROOT=%REPO_ROOT%\tmp\product-docs-site"
+
+REM Fresh output so stale HTML cannot mask a failed emit.
+if exist "%OUT_ROOT%" rmdir /s /q "%OUT_ROOT%"
+
+echo ci-smoke-product-docs: building siteRoot=%SITE_ROOT% -^> outRoot=%OUT_ROOT%
+call "%~dp0build-cms-docs.bat" "%SITE_ROOT%" "%OUT_ROOT%"
+if errorlevel 1 (
+  echo ci-smoke-product-docs: FAIL — build-cms-docs.bat exited non-zero 1>&2
+  exit /b 1
+)
+
+set "DEFAULT_INDEX=%OUT_ROOT%\8.2\index.html"
+if exist "%DEFAULT_INDEX%" (
+  echo ci-smoke-product-docs: OK — found %DEFAULT_INDEX%
+  exit /b 0
+)
+
+REM Fallback: any index.html under the output tree (dir /s is recursive).
+set "FOUND="
+for /f "delims=" %%F in ('dir /s /b "%OUT_ROOT%\index.html" 2^>nul') do (
+  set "FOUND=%%F"
+  goto :found
+)
+:found
+if defined FOUND (
+  echo ci-smoke-product-docs: OK — found index HTML at %FOUND%
+  exit /b 0
+)
+
+echo ci-smoke-product-docs: FAIL — no index.html under %OUT_ROOT% 1>&2
+echo   Expected at least %DEFAULT_INDEX% (or any **\index.html^). 1>&2
+echo   Broken Markdown/frontmatter/_config.yaml or Virtual Site build bugs 1>&2
+echo   cause this failure; fix content or system virtualsite package and re-run. 1>&2
+exit /b 1

--- a/scripts/ci-smoke-product-docs.sh
+++ b/scripts/ci-smoke-product-docs.sh
@@ -12,6 +12,10 @@
 # Exit codes:
 #   0 — build succeeded and at least one index.html was emitted
 #   1 — build failed (non-zero from build-cms-docs) or index HTML missing
+#
+# Failure artifacts: output root is recreated empty (not left deleted) and a
+# .ci-smoke-meta.txt marker is always written so CI upload-artifact on
+# failure() has a path + file even when the docs build emits nothing.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,14 +24,36 @@ SITE_ROOT="${1:-${REPO_ROOT}/product-docs}"
 OUT_ROOT="${2:-${REPO_ROOT}/tmp/product-docs-site}"
 
 # Fresh output so stale HTML from prior runs cannot mask a failed emit.
+# Recreate the directory immediately so workflow failure artifacts always have
+# a path (rm -rf alone leaves nothing for actions/upload-artifact).
 rm -rf "${OUT_ROOT}"
+mkdir -p "${OUT_ROOT}"
+{
+  echo "status=running"
+  echo "siteRoot=${SITE_ROOT}"
+  echo "outRoot=${OUT_ROOT}"
+} > "${OUT_ROOT}/.ci-smoke-meta.txt"
 
 echo "ci-smoke-product-docs: building siteRoot=${SITE_ROOT} → outRoot=${OUT_ROOT}"
+
+set +e
 bash "${SCRIPT_DIR}/build-cms-docs.sh" "${SITE_ROOT}" "${OUT_ROOT}"
+BUILD_RC=$?
+set -e
+
+if [[ "${BUILD_RC}" -ne 0 ]]; then
+  {
+    echo "status=build_failed"
+    echo "buildExit=${BUILD_RC}"
+  } >> "${OUT_ROOT}/.ci-smoke-meta.txt"
+  echo "ci-smoke-product-docs: FAIL — build-cms-docs.sh exited ${BUILD_RC}" >&2
+  exit 1
+fi
 
 # Prefer default product version path (product-docs/_config.yaml → 8.2).
 DEFAULT_INDEX="${OUT_ROOT}/8.2/index.html"
 if [[ -f "${DEFAULT_INDEX}" ]]; then
+  echo "status=ok" >> "${OUT_ROOT}/.ci-smoke-meta.txt"
   echo "ci-smoke-product-docs: OK — found ${DEFAULT_INDEX}"
   exit 0
 fi
@@ -36,10 +62,15 @@ fi
 # Portable: find (no hardcoded OS separators beyond URL-style path join above).
 FOUND="$(find "${OUT_ROOT}" -type f -name 'index.html' 2>/dev/null | head -n 1 || true)"
 if [[ -n "${FOUND}" ]]; then
+  echo "status=ok" >> "${OUT_ROOT}/.ci-smoke-meta.txt"
   echo "ci-smoke-product-docs: OK — found index HTML at ${FOUND}"
   exit 0
 fi
 
+{
+  echo "status=missing_index"
+  echo "expectedDefault=${DEFAULT_INDEX}"
+} >> "${OUT_ROOT}/.ci-smoke-meta.txt"
 echo "ci-smoke-product-docs: FAIL — no index.html under ${OUT_ROOT}" >&2
 echo "  Expected at least ${DEFAULT_INDEX} (or any **/index.html)." >&2
 echo "  Broken Markdown/frontmatter/_config.yaml or Virtual Site build bugs" >&2

--- a/scripts/ci-smoke-product-docs.sh
+++ b/scripts/ci-smoke-product-docs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# CI / local smoke for product-docs Virtual Site build (issue #2704).
+#
+# Runs scripts/build-cms-docs.sh then fails if the default versioned index
+# HTML is missing (or no index.html under the output root).
+#
+# Usage (from repo root, after system classpath is available):
+#   scripts/ci-smoke-product-docs.sh [siteRoot] [outputRoot]
+#
+# Windows parity: scripts\ci-smoke-product-docs.bat
+#
+# Exit codes:
+#   0 — build succeeded and at least one index.html was emitted
+#   1 — build failed (non-zero from build-cms-docs) or index HTML missing
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SITE_ROOT="${1:-${REPO_ROOT}/product-docs}"
+OUT_ROOT="${2:-${REPO_ROOT}/tmp/product-docs-site}"
+
+# Fresh output so stale HTML from prior runs cannot mask a failed emit.
+rm -rf "${OUT_ROOT}"
+
+echo "ci-smoke-product-docs: building siteRoot=${SITE_ROOT} → outRoot=${OUT_ROOT}"
+bash "${SCRIPT_DIR}/build-cms-docs.sh" "${SITE_ROOT}" "${OUT_ROOT}"
+
+# Prefer default product version path (product-docs/_config.yaml → 8.2).
+DEFAULT_INDEX="${OUT_ROOT}/8.2/index.html"
+if [[ -f "${DEFAULT_INDEX}" ]]; then
+  echo "ci-smoke-product-docs: OK — found ${DEFAULT_INDEX}"
+  exit 0
+fi
+
+# Fallback: any index.html under the output tree (future multi-version layouts).
+# Portable: find (no hardcoded OS separators beyond URL-style path join above).
+FOUND="$(find "${OUT_ROOT}" -type f -name 'index.html' 2>/dev/null | head -n 1 || true)"
+if [[ -n "${FOUND}" ]]; then
+  echo "ci-smoke-product-docs: OK — found index HTML at ${FOUND}"
+  exit 0
+fi
+
+echo "ci-smoke-product-docs: FAIL — no index.html under ${OUT_ROOT}" >&2
+echo "  Expected at least ${DEFAULT_INDEX} (or any **/index.html)." >&2
+echo "  Broken Markdown/frontmatter/_config.yaml or Virtual Site build bugs" >&2
+echo "  cause this failure; fix content or system virtualsite package and re-run." >&2
+exit 1


### PR DESCRIPTION
## Summary

Path-filtered **product-docs Virtual Site build smoke** for Phase 2 residual slice 2 of epic #2678 (issue #2704).

- New workflow `.github/workflows/product-docs-build.yml` runs on PRs/pushes that touch:
  - `product-docs/**`
  - `scripts/build-cms-docs*` / `scripts/ci-smoke-product-docs*`
  - `system/**/virtualsite/**` (sources, tests, fixtures)
  - the workflow file itself
- Job (ubuntu): JDK 21 → `./mvnw -pl system -am -DskipTests install` (scoped SNAPSHOT chain, not full monorepo) → `scripts/ci-smoke-product-docs.sh`
- Smoke wrapper cleans output, runs `build-cms-docs`, **fails** on non-zero exit or missing `tmp/product-docs-site/8.2/index.html`
- Windows parity: `scripts\ci-smoke-product-docs.bat` (documented; CI stays on ubuntu for cost)
- Operator notes in `product-docs/README.md` and `scripts/README.md`

Out of scope (siblings): content rewrite #2703, SPI polish #2705.

**Parent tracker:** #2678  
**Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #2704

## Test plan

1. Local Windows: `scripts\ci-smoke-product-docs.bat` → exit 0, finds `tmp\product-docs-site\8.2\index.html` (verified this session).
2. Failure path: smoke against a site root without `_config.yaml` → exit 1 (verified).
3. CI: this PR touches the workflow + smoke scripts → `product-docs-build` job should run and pass on ubuntu.
4. Unrelated path-only PRs should **not** trigger this workflow (path filters).

## Gates evidence

- **Change class:** CI workflow + portable smoke scripts + README operator notes (no Maven production modules).
- **Erlang-style self-review:** no new production Java; smoke asserts index HTML after clean output; path filters avoid monorepo-wide runs; `.sh` + `.bat` parity documented.
- **Maven clean install:** N/A — no Maven module sources/tests/POMs changed.
- **Local smoke:** `scripts\ci-smoke-product-docs.bat` BUILD/OK; broken-site path fails non-zero.

## Residual

None planned for this slice. Remaining epic work is #2705 (operator polish + tests).