### PR TITLE
fix(virtualsite): operator polish + residual tests (#2705)

### DIFF
--- a/docs/ai-generated/tasks/virtual-sites-git-docs/README.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/README.md
@@ -18,6 +18,7 @@
 | Doc | Purpose |
 |-----|---------|
 | [spec.md](./spec.md) | Product specification |
+| [operator-build-and-link-report.md](./operator-build-and-link-report.md) | Operator: filesystem/Git source, offline build, link report |
 | [adr/](./adr/) | Architecture decision records |
 | [contracts/](./contracts/) | Frontmatter and site config contracts |
 

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-properties.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-properties.md
@@ -4,9 +4,11 @@ Used on `IPSSite` / `PSSiteProperty` without requiring new `RXSITES` columns in 
 
 | Key | Required for Virtual | Values |
 |-----|----------------------|--------|
-| `virtual.sourceKind` | Yes | `git-filesystem` (Phase 1). Other kinds later. |
-| `virtual.rootPath` | Yes | Filesystem path to Virtual Site root (`product-docs` checkout). |
+| `virtual.sourceKind` | Yes | `git-filesystem` (Phase 1). Other kinds later. Blank or `repository` ⇒ traditional repository Site. |
+| `virtual.rootPath` | Yes | Filesystem path to Virtual Site root (`product-docs` checkout). Prefer absolute; blank is treated as unset. |
 | `virtual.configFile` | No | Default `_config.yaml`. |
-| `virtual.siteKey` | No | Key for participant registry; default site name. |
+| `virtual.siteKey` | No | Key for participant registry; default site name, else `default`. |
 
 Helper: `com.percussion.services.virtualsite.PSVirtualSiteHelper`.
+
+Operator workflow (build + link report): [../operator-build-and-link-report.md](../operator-build-and-link-report.md).

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/operator-build-and-link-report.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/operator-build-and-link-report.md
@@ -186,7 +186,7 @@ To keep a review snapshot, copy `outputRoot` to a durable location outside `tmp/
 | Link check | `VirtualLinkChecker` |
 | Site properties | `PSVirtualSiteHelper` |
 | Scripts | `scripts/build-cms-docs.bat`, `scripts/build-cms-docs.sh` |
-| CI smoke (Phase 2 residual 2) | `.github/workflows/product-docs-build.yml` (path-filtered) |
+| CI smoke (Phase 2 residual 2) | Path-filtered workflow lands via #2704 / PR #2707 (`.github/workflows/product-docs-build.yml` + `scripts/ci-smoke-product-docs.*`); until merge, local build is `scripts/build-cms-docs.bat` / `.sh` |
 
 ---
 

--- a/docs/ai-generated/tasks/virtual-sites-git-docs/operator-build-and-link-report.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/operator-build-and-link-report.md
@@ -1,0 +1,206 @@
+# Operator guide: Virtual Site filesystem/Git source, build, and link report
+
+| Field | Value |
+|-------|--------|
+| **Audience** | Operators, release engineers, docs authors |
+| **Epic** | [#2678](https://github.com/intersoftdatalabs-in/percussioncms/issues/2678) |
+| **Slice** | [#2705](https://github.com/intersoftdatalabs-in/percussioncms/issues/2705) (Phase 2 residual 3) |
+| **Related contracts** | [site-config.md](./contracts/site-config.md), [site-properties.md](./contracts/site-properties.md), [frontmatter.md](./contracts/frontmatter.md) |
+
+This note is **operator-facing**: how to point a Virtual Site at a Git/filesystem tree, run the offline docs build, and interpret `link-report.txt`. It does not replace product Site Manager UI (out of scope for Phase 1/2 residuals).
+
+---
+
+## 1. Filesystem / Git source tree
+
+Phase 1 Virtual Sites use the **git-filesystem** adapter: content is discovered from a local directory tree (typically a Git checkout). Git remains system of record; the CMS does **not** ingest Markdown into the content repository.
+
+### Default product tree
+
+| Item | Path |
+|------|------|
+| Site root | `product-docs/` (repo root) |
+| Config | `product-docs/_config.yaml` |
+| Theme | `product-docs/_theme/` |
+| Static assets | `product-docs/assets/` |
+| Versioned pages | `product-docs/8.2/**/*.md` |
+
+### Layout rules
+
+1. Site root must contain `_config.yaml` (or the file named by `virtual.configFile`).
+2. Each `versions[].path` is a directory under the site root (e.g. `8.2`).
+3. Every page is Markdown with YAML frontmatter and a stable `id` (see [frontmatter.md](./contracts/frontmatter.md)).
+4. Theme layout HTML lives under `_theme/` (default `page.html`).
+
+### Pointing a CMS Site object at the tree (property contract)
+
+When a Percussion **Site** is configured as virtual (no new `RXSITES` columns in Phase 1), set site properties:
+
+| Property | Required | Example | Meaning |
+|----------|----------|---------|---------|
+| `virtual.sourceKind` | Yes | `git-filesystem` | Non-blank and not `repository` ⇒ Virtual |
+| `virtual.rootPath` | Yes | absolute path to `product-docs` (or install-relative) | Filesystem root |
+| `virtual.configFile` | No | `_config.yaml` | Config file name under root |
+| `virtual.siteKey` | No | `product-docs` | Participant registry key; default = site name |
+
+Helper class: `com.percussion.services.virtualsite.PSVirtualSiteHelper`.
+
+Empty / missing `virtual.sourceKind` (or value `repository`) means a traditional repository-backed Site.
+
+### Cross-platform paths
+
+- Prefer absolute paths on Windows (`C:\…`) and Unix (`/opt/…`).
+- Build and link-check code uses `java.nio.file.Path` for filesystem I/O and forward-slash logical hrefs for published paths.
+- Do not hardcode OS separators when scripting; use the repo wrappers below.
+
+---
+
+## 2. Running the offline build
+
+The build does **not** require a running CMS or Spring. It compiles the `system` module classpath and invokes:
+
+`com.percussion.services.virtualsite.PSVirtualSiteBuildMain`
+
+### Scripts (preferred)
+
+From the **repository root**:
+
+**Windows**
+
+```bat
+scripts\build-cms-docs.bat
+scripts\build-cms-docs.bat C:\path\to\product-docs C:\path\to\out
+```
+
+**Linux / macOS**
+
+```bash
+scripts/build-cms-docs.sh
+scripts/build-cms-docs.sh /path/to/product-docs /path/to/out
+```
+
+| Argument | Default |
+|----------|---------|
+| `siteRoot` | `<repo>/product-docs` |
+| `outputRoot` | `<repo>/tmp/product-docs-site` |
+| site key (fixed in scripts) | `product-docs` |
+
+### Prerequisites
+
+- **JDK 21** via `JAVA_HOME`
+- Repo Maven wrapper (`mvnw` / `mvnw.cmd`)
+- First run may download dependencies; subsequent runs are incremental
+
+### CLI equivalent
+
+```text
+PSVirtualSiteBuildMain <siteRoot> <outputRoot> [siteKey]
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Build succeeded and **no** link problems |
+| `1` | Build wrote HTML but **link problems** were found (stderr lists them) |
+| `2` | Usage error (missing args) |
+
+### Build pipeline (what happens)
+
+1. Load `_config.yaml` → `VirtualSiteConfig`
+2. Discover `*.md` under each version path (`PSGitFilesystemVirtualSiteSource`)
+3. Parse frontmatter; assemble Markdown → HTML
+4. Render layout + nav + version switcher
+5. Write static HTML under `outputRoot`
+6. Copy `assets/` and theme assets
+7. Upsert virtual participants (JSONL under `outputRoot/_meta/` when using the CLI)
+8. Run link check; write **`link-report.txt`** at `outputRoot/link-report.txt`
+
+---
+
+## 3. Interpreting `link-report.txt`
+
+Always present after a successful page write pass.
+
+### Clean build
+
+```text
+OK: no link problems
+```
+
+CLI exits `0`.
+
+### Problems found
+
+One problem per line, for example:
+
+```text
+8.2/index.md: missing path target 'nope.md' → 8.2/nope.html
+8.2/admin/index.md: missing id target 'legacy-page' (version 8.2, site product-docs)
+```
+
+| Pattern | Meaning |
+|---------|---------|
+| `missing path target '…' → …` | Relative Markdown/HTML link does not resolve to a published page in that version |
+| `missing id target '…'` | `id:stable-id` link has no matching frontmatter `id` in that version |
+
+### What is checked
+
+- Markdown links `[text](target)`
+- Relative `.md` / `.html` paths (resolved against the source page directory; `.md` mapped to `.html`)
+- Stable id links `id:some-id`
+
+### What is skipped
+
+- `http://`, `https://`, `mailto:`, protocol-relative `//…`
+- Fragment-only anchors (`#section`)
+
+### Operator response
+
+1. Open the source `.md` path from the report line.
+2. Fix the href or add the missing page / frontmatter `id`.
+3. Rebuild; confirm `link-report.txt` returns to `OK`.
+4. Offline review: open HTML under `outputRoot` in a browser (file:// or any static file server). There is **no** production CDN packaging in Phase 1.
+
+---
+
+## 4. Offline HTML artifact (optional)
+
+| Item | Location |
+|------|----------|
+| Default HTML output | `tmp/product-docs-site/` (gitignored via repo `tmp/`) |
+| Link report | `tmp/product-docs-site/link-report.txt` |
+| Participant meta (CLI) | `tmp/product-docs-site/_meta/participants-product-docs.jsonl` |
+
+To keep a review snapshot, copy `outputRoot` to a durable location outside `tmp/`. Do not commit generated HTML into `product-docs/` (source is Markdown only).
+
+---
+
+## 5. Code anchors
+
+| Area | Path |
+|------|------|
+| Package | `system/services/src/com/percussion/services/virtualsite/` |
+| CLI | `PSVirtualSiteBuildMain` |
+| Build service | `PSVirtualSiteBuildService` |
+| Link check | `VirtualLinkChecker` |
+| Site properties | `PSVirtualSiteHelper` |
+| Scripts | `scripts/build-cms-docs.bat`, `scripts/build-cms-docs.sh` |
+| CI smoke (Phase 2 residual 2) | `.github/workflows/product-docs-build.yml` (path-filtered) |
+
+---
+
+## 6. Unit test coverage (residual)
+
+Public helpers with dedicated residual tests (issue #2705):
+
+- `VirtualLinkChecker` — path/id problems, externals, path normalization
+- `VirtualSiteConfigLoader` — load/parse validation
+- `PSVirtualSiteHelper` — source kind, config file, site key, root path
+- `PSVirtualSiteBuildService` — sample tree build + link report OK/problem files
+
+Run from `system/`:
+
+```bat
+..\mvnw.cmd -Dtest=VirtualLinkCheckerTest,VirtualSiteConfigLoaderTest,PSVirtualSiteHelperTest,PSVirtualSiteBuildServiceTest,VirtualFrontmatterParserTest,VirtualMarkdownLinkRewriterTest,VirtualNavBuilderTest test
+```

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -67,6 +67,61 @@ class PSVirtualSiteBuildServiceTest {
 
     participants.flush("sample");
     assertTrue(Files.isRegularFile(meta.resolve("participants-sample.jsonl")));
+
+    // Link report is always written next to static HTML for operator review
+    Path linkReport = out.resolve("link-report.txt");
+    assertTrue(Files.isRegularFile(linkReport), "missing link-report.txt");
+    String report = Files.readString(linkReport, StandardCharsets.UTF_8);
+    assertTrue(report.contains("OK"), report);
+    assertTrue(result.writtenFiles().contains("link-report.txt"), result.writtenFiles()::toString);
+  }
+
+  @Test
+  void linkReportListsProblemsWhenBrokenLinksPresent() throws Exception {
+    Path siteRoot = tempDir.resolve("broken-site");
+    Path versionDir = siteRoot.resolve("8.2");
+    Files.createDirectories(versionDir);
+    Files.createDirectories(siteRoot.resolve("_theme"));
+    Files.writeString(
+        siteRoot.resolve("_config.yaml"),
+        """
+        site:
+          title: Broken
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("_theme").resolve("page.html"),
+        "<html><body>{{content}}</body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        versionDir.resolve("index.md"),
+        """
+        ---
+        id: broken-home
+        title: Broken Home
+        ---
+
+        See [missing](nope.md).
+        """,
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("broken-out");
+    PSVirtualSiteBuildResult result =
+        new PSVirtualSiteBuildService().build(siteRoot, out, "broken");
+
+    assertTrue(result.hasLinkProblems(), "expected link problems");
+    Path linkReport = out.resolve("link-report.txt");
+    assertTrue(Files.isRegularFile(linkReport));
+    String report = Files.readString(linkReport, StandardCharsets.UTF_8);
+    assertTrue(report.contains("nope.md") || report.contains("nope.html"), report);
+    assertFalse(report.contains("OK: no link problems"), report);
   }
 
   @Test

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
@@ -60,4 +60,57 @@ class PSVirtualSiteHelperTest {
     assertEquals("Help", PSVirtualSiteHelper.siteKey(site));
     assertTrue(PSVirtualSiteHelper.rootPath(site).isPresent());
   }
+
+  @Test
+  void repositoryWhenSourceKindExplicitlyRepository() {
+    PSSite site = mock(PSSite.class);
+    PSSiteProperty kind = new PSSiteProperty();
+    kind.setName(PSVirtualSiteHelper.PROP_SOURCE_KIND);
+    kind.setValue("repository");
+    when(site.getProperties()).thenReturn(Set.of(kind));
+    assertEquals(SourceKind.REPOSITORY, PSVirtualSiteHelper.sourceKind(site));
+    assertFalse(PSVirtualSiteHelper.isVirtual(site));
+  }
+
+  @Test
+  void configFileDefaultsAndOverride() {
+    PSSite bare = mock(PSSite.class);
+    when(bare.getProperties()).thenReturn(Set.of());
+    assertEquals(VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, PSVirtualSiteHelper.configFile(bare));
+
+    PSSite site = mock(PSSite.class);
+    PSSiteProperty cfg = new PSSiteProperty();
+    cfg.setName(PSVirtualSiteHelper.PROP_CONFIG_FILE);
+    cfg.setValue("custom-site.yaml");
+    when(site.getProperties()).thenReturn(Set.of(cfg));
+    assertEquals("custom-site.yaml", PSVirtualSiteHelper.configFile(site));
+  }
+
+  @Test
+  void siteKeyPrefersPropertyThenNameThenDefault() {
+    PSSite withKey = mock(PSSite.class);
+    PSSiteProperty key = new PSSiteProperty();
+    key.setName(PSVirtualSiteHelper.PROP_SITE_KEY);
+    key.setValue("product-docs");
+    when(withKey.getProperties()).thenReturn(Set.of(key));
+    when(withKey.getName()).thenReturn("Help");
+    assertEquals("product-docs", PSVirtualSiteHelper.siteKey(withKey));
+
+    PSSite named = mock(PSSite.class);
+    when(named.getProperties()).thenReturn(Set.of());
+    when(named.getName()).thenReturn("HelpSite");
+    assertEquals("HelpSite", PSVirtualSiteHelper.siteKey(named));
+
+    assertEquals("default", PSVirtualSiteHelper.siteKey(null));
+  }
+
+  @Test
+  void blankRootPathIsAbsent() {
+    PSSite site = mock(PSSite.class);
+    PSSiteProperty root = new PSSiteProperty();
+    root.setName(PSVirtualSiteHelper.PROP_ROOT_PATH);
+    root.setValue("   ");
+    when(site.getProperties()).thenReturn(Set.of(root));
+    assertTrue(PSVirtualSiteHelper.rootPath(site).isEmpty());
+  }
 }

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualLinkCheckerTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualLinkCheckerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Residual unit coverage for {@link VirtualLinkChecker} public helpers and path resolution.
+ */
+class VirtualLinkCheckerTest {
+
+  private static final Map<String, String> IDS =
+      Map.of(
+          "home", "8.2/index.html",
+          "install-overview", "8.2/getting-started/install.html");
+
+  private static final Set<String> PATHS =
+      Set.of("8.2/index.html", "8.2/getting-started/index.html", "8.2/getting-started/install.html");
+
+  @Test
+  void emptyOrNullBodyYieldsNoProblems() {
+    assertTrue(VirtualLinkChecker.checkPage("s", "8.2", "8.2/index.md", null, IDS, PATHS).isEmpty());
+    assertTrue(VirtualLinkChecker.checkPage("s", "8.2", "8.2/index.md", "", IDS, PATHS).isEmpty());
+  }
+
+  @Test
+  void skipsExternalMailtoAndProtocolRelative() {
+    String body =
+        "See [web](https://example.com/docs) [http](http://example.com) "
+            + "[mail](mailto:docs@example.com) [proto](//cdn.example.com/x) [frag](#section)";
+    List<String> problems =
+        VirtualLinkChecker.checkPage("s", "8.2", "8.2/index.md", body, IDS, PATHS);
+    assertTrue(problems.isEmpty(), problems::toString);
+  }
+
+  @Test
+  void reportsMissingRelativeMarkdownPath() {
+    List<String> problems =
+        VirtualLinkChecker.checkPage(
+            "s",
+            "8.2",
+            "8.2/index.md",
+            "See [missing](no-such-page.md)",
+            IDS,
+            PATHS);
+    assertEquals(1, problems.size());
+    assertTrue(problems.get(0).contains("no-such-page.md"), problems.get(0));
+    assertTrue(problems.get(0).contains("8.2/no-such-page.html"), problems.get(0));
+  }
+
+  @Test
+  void acceptsRelativePathThatResolvesToPublishedHtml() {
+    List<String> problems =
+        VirtualLinkChecker.checkPage(
+            "s",
+            "8.2",
+            "8.2/index.md",
+            "See [Install](getting-started/install.md#setup \"Install\")",
+            IDS,
+            PATHS);
+    assertTrue(problems.isEmpty(), problems::toString);
+  }
+
+  @Test
+  void reportsMissingStableId() {
+    List<String> problems =
+        VirtualLinkChecker.checkPage(
+            "help",
+            "8.2",
+            "8.2/index.md",
+            "Jump [x](id:does-not-exist)",
+            IDS,
+            PATHS);
+    assertEquals(1, problems.size());
+    assertTrue(problems.get(0).contains("does-not-exist"), problems.get(0));
+    assertTrue(problems.get(0).contains("help"), problems.get(0));
+  }
+
+  @Test
+  void acceptsKnownStableId() {
+    List<String> problems =
+        VirtualLinkChecker.checkPage(
+            "s",
+            "8.2",
+            "8.2/index.md",
+            "Jump [Install](id:install-overview)",
+            IDS,
+            PATHS);
+    assertTrue(problems.isEmpty(), problems::toString);
+  }
+
+  @Test
+  void stripsAngleBracketTargetsAndQuotedTitles() {
+    List<String> problems =
+        VirtualLinkChecker.checkPage(
+            "s",
+            "8.2",
+            "8.2/index.md",
+            "See [a](<getting-started/install.md> \"t\")",
+            IDS,
+            PATHS);
+    assertTrue(problems.isEmpty(), problems::toString);
+  }
+
+  @Test
+  void resolveRelativeHandlesDotDotAndRootSlash() {
+    assertEquals(
+        "8.2/getting-started/install.html",
+        VirtualLinkChecker.resolveRelative(
+            "8.2/getting-started/index.md", "../getting-started/install.html"));
+    assertEquals(
+        "admin/index.html",
+        VirtualLinkChecker.resolveRelative("8.2/index.md", "/admin/index.html"));
+    assertEquals(
+        "a/b",
+        VirtualLinkChecker.normalizePosix("a/./b/../b"));
+  }
+
+  @Test
+  void pathSetNormalizesBackslashes() {
+    Set<String> set = VirtualLinkChecker.pathSet(List.of("8.2\\index.html", "a/b.html"));
+    assertTrue(set.contains("8.2/index.html"));
+    assertTrue(set.contains("a/b.html"));
+    assertEquals(2, set.size());
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Residual unit coverage for {@link VirtualSiteConfigLoader}. */
+class VirtualSiteConfigLoaderTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void loadsSampleFixtureConfig() throws Exception {
+    Path sampleRoot = resolveSampleDocs();
+    VirtualSiteConfig config =
+        VirtualSiteConfigLoader.load(sampleRoot, null, "sample");
+
+    assertEquals("Sample Docs", config.siteTitle());
+    assertEquals("sample", config.siteKey());
+    assertEquals("page.html", config.layoutFile());
+    assertEquals(1, config.versions().size());
+    assertEquals("8.2", config.versions().get(0).id());
+    assertTrue(config.versions().get(0).defaultVersion());
+    assertEquals(1, config.nav().size());
+    assertEquals("getting-started", config.nav().get(0).id());
+    assertEquals(sampleRoot, config.root());
+  }
+
+  @Test
+  void blankConfigFileNameUsesDefault() throws Exception {
+    Path sampleRoot = resolveSampleDocs();
+    VirtualSiteConfig config =
+        VirtualSiteConfigLoader.load(sampleRoot, "  ", "k");
+    assertEquals("Sample Docs", config.siteTitle());
+  }
+
+  @Test
+  void missingConfigFileFails() {
+    assertThrows(
+        VirtualSiteException.class,
+        () -> VirtualSiteConfigLoader.load(tempDir, "_config.yaml", "k"));
+  }
+
+  @Test
+  void nullRootFails() {
+    assertThrows(
+        VirtualSiteException.class,
+        () -> VirtualSiteConfigLoader.load(null, "_config.yaml", "k"));
+  }
+
+  @Test
+  void requiresAtLeastOneVersion() throws Exception {
+    Path root = tempDir.resolve("empty-versions");
+    Files.createDirectories(root);
+    Files.writeString(
+        root.resolve("_config.yaml"),
+        "site:\n  title: T\nversions: []\n",
+        StandardCharsets.UTF_8);
+    VirtualSiteException ex =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> VirtualSiteConfigLoader.load(root, "_config.yaml", "k"));
+    assertTrue(ex.getMessage().toLowerCase().contains("version"), ex.getMessage());
+  }
+
+  @Test
+  void rejectsNonMappingRoot() throws Exception {
+    Path root = tempDir.resolve("list-root");
+    Files.createDirectories(root);
+    Files.writeString(root.resolve("_config.yaml"), "- just\n- a\n- list\n", StandardCharsets.UTF_8);
+    assertThrows(
+        VirtualSiteException.class,
+        () -> VirtualSiteConfigLoader.load(root, "_config.yaml", "k"));
+  }
+
+  private static Path resolveSampleDocs() throws Exception {
+    URL url =
+        VirtualSiteConfigLoaderTest.class
+            .getClassLoader()
+            .getResource("virtualsite/sample-docs/_config.yaml");
+    if (url == null) {
+      throw new IllegalStateException("sample-docs fixture missing from test classpath");
+    }
+    return Path.of(url.toURI()).getParent();
+  }
+}


### PR DESCRIPTION
## Summary
Phase 2 residual **slice 3** of Virtual Sites epic **#2678**: close residual unit-test gaps for `com.percussion.services.virtualsite` and ship operator-facing notes for filesystem/Git source, offline build, and `link-report.txt`.

**Parent:** #2678  
**Phase 1:** #2679  
**This issue:** #2705

### Tests (no production SPI expansion)
- New `VirtualLinkCheckerTest` — empty body, externals skip, missing path/id, resolveRelative/normalizePosix, pathSet
- New `VirtualSiteConfigLoaderTest` — sample fixture load, missing file, empty versions, non-mapping root
- Extended `PSVirtualSiteHelperTest` — repository kind, configFile default/override, siteKey precedence, blank rootPath
- Extended `PSVirtualSiteBuildServiceTest` — asserts `link-report.txt` OK on clean build; problem report when broken links present

### Docs
- `docs/ai-generated/tasks/virtual-sites-git-docs/operator-build-and-link-report.md`
- Linked from task README + `contracts/site-properties.md`

### Out of scope (unchanged)
- New source adapters
- Site Manager UI
- Content fill / CI job (slices 1–2 done)

## Test plan
1. `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
2. Focused: `..\mvnw.cmd "-Dtest=VirtualLinkCheckerTest,VirtualSiteConfigLoaderTest,PSVirtualSiteHelperTest,PSVirtualSiteBuildServiceTest,VirtualFrontmatterParserTest,VirtualMarkdownLinkRewriterTest,VirtualNavBuilderTest" test` — **37 tests, 0 failures**
3. Module suite: **Tests run: 1607, Failures: 0, Errors: 0** (baseline skips unchanged)
4. No new compiler warnings attributable to this change (tests/docs only)

## Gates evidence
- Erlang self-review: residual unit tests + portable `Path`/`TempDir`; Intersoft 2026 headers on new files
- Pre-PR Maven: standalone `system` `clean install` green
- No residuals filed (acceptance closed for this slice)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2705  
Refs #2678 #2679

> Co-Authored by Grok Build using grok-4.5 with agent main.
