### PR TITLE
fix(WebUI): Administration PSStringWrapper / roles load (#2701)

### DIFF
--- a/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowSection.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowSection.tsx
@@ -33,12 +33,16 @@ export const WorkflowSection: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const [wfList, roleList] = await Promise.all([
+      // Role names for the workflow editor come from user/roles (GET), not
+      // role/find. POST role/find expects PSStringWrapper root "psstring"
+      // ({ psstring: { value } }); a bare { name: "" } body fails Jackson with
+      // "Root name ('name') does not match expected ('psstring')" (#2701).
+      const [wfList, rolesRes] = await Promise.all([
         get<WorkflowDefinition[]>(PATHS.WORKFLOW_METADATA),
-        post<{ name: string }[]>(PATHS.ROLES_FIND, { name: "" }).catch(() => []),
+        get<{ RoleList: { roles: string[] } }>(PATHS.USER_ROLES).catch(() => null),
       ]);
       setWorkflows(wfList || []);
-      setAvailableRoles((roleList || []).map((r) => r.name));
+      setAvailableRoles(rolesRes?.RoleList?.roles || []);
     } catch (err) {
       setError(message(WF_ADMIN_MSG.ERROR_GENERIC));
     } finally {

--- a/WebUI/src/test/ts/workflowAdmin/WorkflowSection.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/WorkflowSection.test.tsx
@@ -37,8 +37,12 @@ describe("WorkflowSection", () => {
       { name: "Default Workflow", isDefault: true, stagingRoleId: "Editor", steps: [] },
       { name: "Blog Workflow", isDefault: false, stagingRoleId: "Publisher", steps: [] },
     ];
-    vi.mocked(client.get).mockResolvedValue(mockWorkflows);
-    vi.mocked(client.post).mockResolvedValue([{ name: "Editor" }, { name: "Publisher" }]);
+    vi.mocked(client.get).mockImplementation(async (url: string) => {
+      if (url.includes("user/roles") || url.includes("/roles")) {
+        return { RoleList: { roles: ["Editor", "Publisher"] } };
+      }
+      return mockWorkflows;
+    });
 
     render(<WorkflowSection />);
     expect(screen.getByText(/loading/i)).toBeTruthy();
@@ -47,11 +51,20 @@ describe("WorkflowSection", () => {
       expect(screen.getByTestId("workflow-row-Default Workflow")).toBeTruthy();
       expect(screen.getByTestId("workflow-row-Blog Workflow")).toBeTruthy();
     });
+
+    // #2701: must load role names via GET user/roles — never POST role/find with { name: "" }
+    expect(client.post).not.toHaveBeenCalled();
+    const getUrls = vi.mocked(client.get).mock.calls.map((c) => String(c[0]));
+    expect(getUrls.some((u) => u.includes("user/roles") || u.endsWith("/roles"))).toBe(true);
   });
 
   it("opens create editor when Create Workflow button is clicked", async () => {
-    vi.mocked(client.get).mockResolvedValue([]);
-    vi.mocked(client.post).mockResolvedValue([]);
+    vi.mocked(client.get).mockImplementation(async (url: string) => {
+      if (url.includes("user/roles") || url.includes("/roles")) {
+        return { RoleList: { roles: [] } };
+      }
+      return [];
+    });
 
     render(<WorkflowSection />);
     await waitFor(() => {
@@ -60,5 +73,36 @@ describe("WorkflowSection", () => {
 
     fireEvent.click(screen.getByTestId("create-workflow-button"));
     expect(screen.getByTestId("perc-workflow-editor")).toBeTruthy();
+  });
+
+  it("loads available roles from USER_ROLES and does not post PSStringWrapper shape { name }", async () => {
+    vi.mocked(client.get).mockImplementation(async (url: string) => {
+      if (String(url).includes("user/roles")) {
+        return { RoleList: { roles: ["Admin", "Editor"] } };
+      }
+      return [{ name: "Default Workflow", isDefault: true, stagingRoleId: "Admin", steps: [] }];
+    });
+
+    render(<WorkflowSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId("create-workflow-button")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("create-workflow-button"));
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-workflow-editor")).toBeTruthy();
+    });
+
+    // No role/find POST (legacy bug posted { name: "" } which Jackson rejects for PSStringWrapper)
+    const postCalls = vi.mocked(client.post).mock.calls;
+    for (const call of postCalls) {
+      const url = String(call[0] ?? "");
+      const body = call[1] as Record<string, unknown> | undefined;
+      expect(url.includes("role/find")).toBe(false);
+      if (body && typeof body === "object" && "name" in body && !("psstring" in body)) {
+        // bare { name: ... } is never a valid PSStringWrapper body
+        expect(url.includes("role/")).toBe(false);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes **Administration** (Workflow Admin SPA) load failures caused by a bad JSON body on role lookup.

WorkflowSection was POSTing `rolemanagement/role/find` with `{ name: "" }`. Server-side `PSStringWrapper` is annotated `@JsonRootName("psstring")` and expects:

`json
{ "psstring": { "value": "<roleName>" } }
`

Jackson failed with: `Root name ('name') does not match expected ('psstring')`.

### Fix

- Load available workflow-editor role names via **GET** `PATHS.USER_ROLES` (`/user/user/roles`), matching `RolesSection` / product list semantics.
- Do **not** call `ROLES_FIND` for a role-name list (that endpoint finds one role by `PSStringWrapper`).
- Vitest asserts no `role/find` POST on section load and that `USER_ROLES` is requested.

`RolesSection` already posts `{ psstring: { value } }` for find/delete; unchanged. No war dual-ship (TS-only under `WebUI/src/main/ts`).

Fixes #2701

## Test plan

- [x] Vitest `WorkflowSection.test.tsx` (3 tests) — including payload regression for #2701
- [x] Standalone module build: `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **1625 passed** (Vitest suite in module install)
- [x] No new compiler/surefire warnings from this change (pre-existing javadoc/dependency-analyze noise only)
- [ ] Human QA: open **Administration** after login as Admin; confirm shell loads, Workflow tab lists workflows, create editor shows roles, no `PSStringWrapper` / root-name errors in `server.log`

## Gates evidence

| Gate | Result |
|------|--------|
| Change class | WebUI SPA workflow admin API payload fix (list roles) |
| Companions | Vitest payload shape; RolesSection peer pattern |
| Erlang self-review | No bugs found; portable N/A (no path I/O); no dual-ship war needed |
| Pre-PR Maven | `cd WebUI` → `..\mvnw.cmd clean install` **BUILD SUCCESS** |
| Cross-platform | No path/file I/O changes |

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
