### PR TITLE
feat(WebUI): top nav restructure — Explorer after Home, single Admin (#2702)

### DIFF
--- a/WebUI/src/main/ts/admin/AdminChrome.module.css
+++ b/WebUI/src/main/ts/admin/AdminChrome.module.css
@@ -18,12 +18,33 @@
   margin-bottom: 20px;
 }
 
+.headerRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+}
+
 .header h1 {
   margin: 0;
   font-size: 1.5rem;
   line-height: 1.25;
   word-wrap: break-word;
   overflow-wrap: anywhere;
+}
+
+/* Sibling admin surface deep link after top-nav Admin consolidation (#2702) */
+.siblingLink {
+  font-size: 0.95rem;
+  color: #007ea8;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.siblingLink:hover,
+.siblingLink:focus {
+  text-decoration: underline;
 }
 
 .tabNav {

--- a/WebUI/src/main/ts/admin/AdminShell.tsx
+++ b/WebUI/src/main/ts/admin/AdminShell.tsx
@@ -15,7 +15,8 @@
  */
 
 import React, { useState } from "react";
-import { message } from "../i18n/message";
+import { Link } from "react-router";
+import { message, MSG } from "../i18n/message";
 import { ADMIN_MSG } from "./messages";
 import { TasksSection } from "./TasksSection";
 import { TaskLogsSection } from "./TaskLogsSection";
@@ -70,7 +71,17 @@ export const AdminShell: React.FC<AdminShellProps> = ({
       data-testid="perc-admin-shell"
     >
       <header className={styles.header}>
-        <h1>{message(ADMIN_MSG.ADMIN_TITLE)}</h1>
+        <div className={styles.headerRow}>
+          <h1>{message(ADMIN_MSG.ADMIN_TITLE)}</h1>
+          {/* Top nav consolidates Admin (#2702); keep Workflow admin reachable here. */}
+          <Link
+            to="/workflow"
+            className={styles.siblingLink}
+            data-testid="admin-sibling-workflow-link"
+          >
+            {message(MSG.NAV_ADMINISTRATION)}
+          </Link>
+        </div>
       </header>
 
       <nav

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -16,24 +16,34 @@
  */
 
 import React from "react";
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import { i18nKeyAttr } from "../../i18n/i18nDom";
 import { message, MSG } from "../../i18n/message";
 import { UserMenu } from "./UserMenu";
 import styles from "./AppLayout.module.css";
+import { isAdminNavPath, topNavItemIds } from "./topNavConfig";
 
 /**
  * Product top navigation for the SPA shell.
  * SPA routes use client NavLink; unmigrated surfaces are full-page legacy exits.
+ *
+ * Order / labels: Home → Explorer → … → single Admin (issue #2702).
+ * Dashboard is not a top-nav item (gadgets remain under Home / deep link).
  */
 export function TopNav(): React.ReactElement {
   const { isAdmin, isDesigner, isWidgetBuilderActive } = useSpaBootstrap();
-  const canPublish = isAdmin || isDesigner;
-  const canWb = isWidgetBuilderActive && (isAdmin || isDesigner);
+  const location = useLocation();
+  const itemIds = topNavItemIds({
+    isAdmin,
+    isDesigner,
+    isWidgetBuilderActive,
+  });
 
   const linkClass = ({ isActive }: { isActive: boolean }): string =>
     isActive ? `${styles.navLink} ${styles.navLinkActive}` : styles.navLink;
+
+  const adminActive = isAdminNavPath(location.pathname);
 
   return (
     <nav
@@ -42,124 +52,127 @@ export function TopNav(): React.ReactElement {
       data-testid="perc-spa-topnav"
     >
       <ul className={styles.navGroup}>
-        <li>
-          {/* Product default landing after login (not a separate "dashboard" SPA) */}
-          <NavLink
-            to="/home"
-            className={linkClass}
-            end
-            data-testid="nav-home"
-            {...i18nKeyAttr(MSG.NAV_HOME)}
-          >
-            {message(MSG.NAV_HOME)}
-          </NavLink>
-        </li>
-        <li>
-          {/*
-            PR-7 product lock: gadgets live on Home (not a peer SPA /dashboard).
-            Label kept as Dashboard for familiarity; deep link is /home/gadgets.
-          */}
-          <NavLink
-            to="/home/gadgets"
-            className={linkClass}
-            data-testid="nav-dashboard"
-            title={message(MSG.NAV_DASHBOARD_TITLE)}
-            {...i18nKeyAttr(MSG.NAV_DASHBOARD)}
-          >
-            {message(MSG.NAV_DASHBOARD)}
-          </NavLink>
-        </li>
-        <li>
-          <a
-            className={styles.navLink}
-            href="/cm/app/?view=editor"
-            data-testid="nav-editor"
-            {...i18nKeyAttr(MSG.NAV_EDITOR)}
-          >
-            {message(MSG.NAV_EDITOR)}
-          </a>
-        </li>
-        {canPublish ? (
-          <>
-            <li>
-              <a
-                className={styles.navLink}
-                href="/cm/app/?view=arch"
-                data-testid="nav-architecture"
-                {...i18nKeyAttr(MSG.NAV_ARCHITECTURE)}
-              >
-                {message(MSG.NAV_ARCHITECTURE)}
-              </a>
-            </li>
-            <li>
-              <NavLink
-                to="/developer"
-                className={linkClass}
-                data-testid="nav-developer"
-                title={message(MSG.NAV_DEVELOPER_TITLE)}
-                {...i18nKeyAttr(MSG.NAV_DEVELOPER)}
-              >
-                {message(MSG.NAV_DEVELOPER)}
-              </NavLink>
-            </li>
-            <li>
-              <NavLink
-                to="/publish"
-                className={linkClass}
-                data-testid="nav-publish"
-                {...i18nKeyAttr(MSG.NAV_PUBLISH)}
-              >
-                {message(MSG.NAV_PUBLISH)}
-              </NavLink>
-            </li>
-          </>
-        ) : null}
-        {isAdmin ? (
-          <li>
-            <NavLink
-              to="/workflow"
-              className={linkClass}
-              data-testid="nav-workflow"
-              {...i18nKeyAttr(MSG.NAV_ADMINISTRATION)}
-            >
-              {message(MSG.NAV_ADMINISTRATION)}
-            </NavLink>
-          </li>
-        ) : null}
-        {isAdmin ? (
-          <li>
-            <NavLink
-              to="/admin"
-              className={linkClass}
-              data-testid="nav-admin"
-              {...i18nKeyAttr(MSG.NAV_ADMIN_TOOLS)}
-            >
-              {message(MSG.NAV_ADMIN_TOOLS)}
-            </NavLink>
-          </li>
-        ) : null}
-        {canWb ? (
-          <li>
-            <NavLink
-              to="/widget-builder"
-              className={linkClass}
-              data-testid="nav-widget-builder"
-              {...i18nKeyAttr(MSG.NAV_WIDGET_BUILDER)}
-            >
-              {message(MSG.NAV_WIDGET_BUILDER)}
-            </NavLink>
-          </li>
-        ) : null}
-        <li>
-          <NavLink
-            to="/explorer"
-            className={linkClass}
-            data-testid="nav-explorer"
-            {...i18nKeyAttr(MSG.NAV_EXPLORER)}
-          >
-            {message(MSG.NAV_EXPLORER)}
-          </NavLink>
-        </li>
+        {itemIds.map((id) => {
+          switch (id) {
+            case "home":
+              return (
+                <li key={id}>
+                  <NavLink
+                    to="/home"
+                    className={linkClass}
+                    end
+                    data-testid="nav-home"
+                    {...i18nKeyAttr(MSG.NAV_HOME)}
+                  >
+                    {message(MSG.NAV_HOME)}
+                  </NavLink>
+                </li>
+              );
+            case "explorer":
+              return (
+                <li key={id}>
+                  <NavLink
+                    to="/explorer"
+                    className={linkClass}
+                    data-testid="nav-explorer"
+                    {...i18nKeyAttr(MSG.NAV_EXPLORER)}
+                  >
+                    {message(MSG.NAV_EXPLORER)}
+                  </NavLink>
+                </li>
+              );
+            case "editor":
+              return (
+                <li key={id}>
+                  <a
+                    className={styles.navLink}
+                    href="/cm/app/?view=editor"
+                    data-testid="nav-editor"
+                    {...i18nKeyAttr(MSG.NAV_EDITOR)}
+                  >
+                    {message(MSG.NAV_EDITOR)}
+                  </a>
+                </li>
+              );
+            case "architecture":
+              return (
+                <li key={id}>
+                  <a
+                    className={styles.navLink}
+                    href="/cm/app/?view=arch"
+                    data-testid="nav-architecture"
+                    {...i18nKeyAttr(MSG.NAV_ARCHITECTURE)}
+                  >
+                    {message(MSG.NAV_ARCHITECTURE)}
+                  </a>
+                </li>
+              );
+            case "developer":
+              return (
+                <li key={id}>
+                  <NavLink
+                    to="/developer"
+                    className={linkClass}
+                    data-testid="nav-developer"
+                    title={message(MSG.NAV_DEVELOPER_TITLE)}
+                    {...i18nKeyAttr(MSG.NAV_DEVELOPER)}
+                  >
+                    {message(MSG.NAV_DEVELOPER)}
+                  </NavLink>
+                </li>
+              );
+            case "publish":
+              return (
+                <li key={id}>
+                  <NavLink
+                    to="/publish"
+                    className={linkClass}
+                    data-testid="nav-publish"
+                    {...i18nKeyAttr(MSG.NAV_PUBLISH)}
+                  >
+                    {message(MSG.NAV_PUBLISH)}
+                  </NavLink>
+                </li>
+              );
+            case "admin":
+              // Consolidated Administration + Admin tools entry (#2702).
+              // Landing: workflow admin hub; /admin remains deep-linked.
+              return (
+                <li key={id}>
+                  <NavLink
+                    to="/workflow"
+                    className={() =>
+                      adminActive
+                        ? `${styles.navLink} ${styles.navLinkActive}`
+                        : styles.navLink
+                    }
+                    data-testid="nav-admin"
+                    // NavLink only marks active for /workflow*; force for /admin* too
+                    data-nav-active={adminActive ? "true" : "false"}
+                    aria-current={adminActive ? "page" : undefined}
+                    {...i18nKeyAttr(MSG.NAV_ADMIN)}
+                  >
+                    {message(MSG.NAV_ADMIN)}
+                  </NavLink>
+                </li>
+              );
+            case "widget-builder":
+              return (
+                <li key={id}>
+                  <NavLink
+                    to="/widget-builder"
+                    className={linkClass}
+                    data-testid="nav-widget-builder"
+                    {...i18nKeyAttr(MSG.NAV_WIDGET_BUILDER)}
+                  >
+                    {message(MSG.NAV_WIDGET_BUILDER)}
+                  </NavLink>
+                </li>
+              );
+            default:
+              return null;
+          }
+        })}
       </ul>
       <div className={styles.spacer} />
       <UserMenu />

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Primary product top-nav order and role gates (issue #2702).
+ *
+ * Dashboard is intentionally omitted from top chrome (gadgets remain on Home
+ * via deep link {@code /home/gadgets}). Administration + Admin tools collapse
+ * to a single {@code admin} item whose landing is the workflow admin hub;
+ * {@code /admin} remains a deep-linked route for Admin tools.
+ */
+
+export type TopNavItemId =
+  | "home"
+  | "explorer"
+  | "editor"
+  | "architecture"
+  | "developer"
+  | "publish"
+  | "admin"
+  | "widget-builder";
+
+export interface TopNavGates {
+  isAdmin?: boolean;
+  isDesigner?: boolean;
+  isWidgetBuilderActive?: boolean;
+}
+
+/**
+ * Ordered top-nav item ids for the given role / feature gates.
+ * Explorer is always immediately after Home.
+ */
+export function topNavItemIds(gates: TopNavGates = {}): TopNavItemId[] {
+  const isAdmin = !!gates.isAdmin;
+  const isDesigner = !!gates.isDesigner || isAdmin;
+  const canPublish = isAdmin || isDesigner;
+  const canWb =
+    !!gates.isWidgetBuilderActive && (isAdmin || isDesigner);
+
+  const items: TopNavItemId[] = ["home", "explorer", "editor"];
+  if (canPublish) {
+    items.push("architecture", "developer", "publish");
+  }
+  if (isAdmin) {
+    items.push("admin");
+  }
+  if (canWb) {
+    items.push("widget-builder");
+  }
+  return items;
+}
+
+/**
+ * Whether a client pathname should mark the consolidated Admin top-nav active.
+ * Covers both workflow administration and admin-tools SPA routes.
+ */
+export function isAdminNavPath(pathname: string): boolean {
+  const p = pathname || "";
+  return (
+    p === "/admin" ||
+    p.startsWith("/admin/") ||
+    p === "/workflow" ||
+    p.startsWith("/workflow/")
+  );
+}

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -209,11 +209,19 @@ export const MSG = {
   NAV_ARCHITECTURE: "perc.ui.navMenu.architecture@Architecture",
   NAV_DEVELOPER: "perc.ui.dashboard.modern@Developer",
   NAV_PUBLISH: "perc.ui.navMenu.publish@Publish",
+  /**
+   * Consolidated top-nav Admin label (#2702). Classic key en-us is already "Admin".
+   * Prefer this for top chrome over separate Administration / Admin tools entries.
+   */
+  NAV_ADMIN: "perc.ui.navMenu.admin@Administration",
+  /** @deprecated Prefer NAV_ADMIN for top chrome; retained for residual page titles. */
   NAV_ADMINISTRATION: "perc.ui.dashboard.modern@Administration",
+  /** @deprecated Prefer NAV_ADMIN for top chrome; Admin tools remain at /admin deep link. */
   NAV_ADMIN_TOOLS: "perc.ui.dashboard.modern@Admin tools",
   NAV_WIDGET_BUILDER: "perc.ui.navMenu.admin@Widget Builder",
   NAV_EXPLORER: "perc.ui.dashboard.modern@Explorer",
   NAV_ARIA_MAIN: "perc.ui.dashboard.modern@Main",
+  /** Page/title for dashboard gadgets (not top-nav; deep link /home/gadgets). */
   NAV_DASHBOARD_TITLE: "perc.ui.dashboard.modern@Dashboard gadgets on Home",
   NAV_DEVELOPER_TITLE: "perc.ui.dashboard.modern@CMS design tools (content types, templates, ...)",
   USER_SIGNED_IN_AS: "perc.ui.dashboard.modern@Signed in as",

--- a/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
@@ -15,7 +15,8 @@
  */
 
 import React, { useState } from "react";
-import { message } from "../i18n/message";
+import { Link } from "react-router";
+import { message, MSG } from "../i18n/message";
 import styles from "../admin/AdminChrome.module.css";
 import { WF_ADMIN_MSG } from "./messages";
 import { WorkflowSection } from "./workflow/WorkflowSection";
@@ -70,7 +71,17 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
       data-testid="perc-workflow-admin-shell"
     >
       <header className={styles.header}>
-        <h1>{message(WF_ADMIN_MSG.TITLE)}</h1>
+        <div className={styles.headerRow}>
+          <h1>{message(WF_ADMIN_MSG.TITLE)}</h1>
+          {/* Top nav consolidates Admin (#2702); keep Admin tools reachable here. */}
+          <Link
+            to="/admin"
+            className={styles.siblingLink}
+            data-testid="admin-sibling-tools-link"
+          >
+            {message(MSG.NAV_ADMIN_TOOLS)}
+          </Link>
+        </div>
       </header>
 
       <nav

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -60,7 +60,7 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,
-    // Product "Admin" → Administration / Workflow SPA entry
+    // Product consolidated "Admin" top-nav (#2702) → Workflow SPA entry
     labelKey: "perc.ui.navMenu.admin@Administration",
   },
 ] as const;

--- a/WebUI/src/main/webapp/cm/app/includes/mainnav.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/mainnav.jsp
@@ -61,13 +61,15 @@
         var currentView = '<%=mainNavTab%>';
         var views = {
             home: 'VIEW_HOME',
+            // Dashboard removed from top chrome (#2702); deep link still supported
             dashboard: 'VIEW_DASHBOARD',
             pageeditor: 'VIEW_EDITOR',
             architecture: 'VIEW_SITE_ARCH',
             siteadmin: 'VIEW_DESIGN',
             publish: 'VIEW_PUBLISH',
             workflow: 'VIEW_WORKFLOW',
-            widgetbuilder: 'VIEW_WIDGET_BUILDER'
+            widgetbuilder: 'VIEW_WIDGET_BUILDER',
+            explorer: 'VIEW_EXPLORER'
         };
         function clear (evt) {
             clearTimeout(timerid);
@@ -94,6 +96,13 @@
             $(this).find('.perc-actions-menu').show();
         }).on('click', '.perc-topnav li', function onTopNavOptionClick (event) {
             event.stopPropagation();
+            // SPA surface exit (e.g. Explorer) — not a classic PercNavigationManager view
+            var spaHref = $(this).data('spa-href');
+            if (spaHref) {
+                window.location.href = spaHref;
+                $(this).parents('.perc-actions-menu').hide();
+                return;
+            }
             var view = $(this).data('navmgr');
             var navMgrArguments = [navMgr[view], navMgr.getSiteName(), navMgr.getMode(), null, navMgr.getName(), navMgr.getPath(), navMgr.getPathType(), null];
             navMgr.goToLocation.apply(navMgr, navMgrArguments);
@@ -115,13 +124,15 @@
     <label></label><span class="icon-chevron-down fas fa-chevron-down" role="presentation"></span>
     <ul id="perc-top-menu-bar" class="perc-actions-menu box_shadow_with_padding" role="menubar" aria-label="<i18n:message key="perc.ui.navMenu.topNav@Top Navigation"/>">
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_HOME"><i18n:message key="perc.ui.navMenu.home@Home"/></li>
-        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DASHBOARD"><i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/></li>
+        <%-- #2702: Explorer immediately after Home (SPA deep link); Dashboard removed from top chrome --%>
+        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_EXPLORER" data-spa-href="/cm/app/spa.jsp?entry=explorer"><i18n:message key="perc.ui.dashboard.modern@Explorer"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_EDITOR"><i18n:message key="perc.ui.navMenu.webmgt@Editor"/></li>
         <% if (isAdmin || isDesigner) { %>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_SITE_ARCH"><i18n:message key="perc.ui.navMenu.architecture@Architecture"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DESIGN"><i18n:message key="perc.ui.navMenu.design@Design"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_PUBLISH"><i18n:message key="perc.ui.navMenu.publish@Publish"/></li>
         <% } %><% if (isAdmin) { %>
+        <%-- Single Admin entry (en-us label already "Admin"); classic Administration surfaces --%>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WORKFLOW"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
         <% } %>
         <% if (isWdgActive && (isAdmin || isDesigner)) { %>

--- a/WebUI/src/main/webapp/cm/app/includes/minuetCommonTemplates/navigationTemplates.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/minuetCommonTemplates/navigationTemplates.jsp
@@ -24,10 +24,11 @@
                     <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.home@Home"/></span>
                 </div>
             </div>
+            <%-- #2702: Explorer after Home; Dashboard removed from top chrome --%>
             <div class="col-6 col-md-4 col-lg-3">
-                <div role="button" title='<i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/>' tabindex="0" data-navmgr="VIEW_DASHBOARD" class="perc-nav-item perc-actions-menu-item text-center">
-                    <i aria-hidden class="perc-nav-icon fas fa-tachometer-alt fa-5x fa-fw"></i>
-                    <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/></span>
+                <div role="button" title='<i18n:message key="perc.ui.dashboard.modern@Explorer"/>' tabindex="0" data-navmgr="VIEW_EXPLORER" data-spa-href="/cm/app/spa.jsp?entry=explorer" class="perc-nav-item perc-actions-menu-item text-center">
+                    <i aria-hidden class="perc-nav-icon fas fa-folder-open fa-5x fa-fw"></i>
+                    <span class="perc-nav-description"><i18n:message key="perc.ui.dashboard.modern@Explorer"/></span>
                 </div>
             </div>
             <div class="col-6 col-md-4 col-lg-3">

--- a/WebUI/src/main/webapp/cm/app/js/legacy/views/PercNavigationMinuetView.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/views/PercNavigationMinuetView.js
@@ -71,6 +71,12 @@ function updateNavLocation(newSiteName, newPath) {
 }
 
 function processNavigationRequest(eventObj) {
+  // SPA surface exit (e.g. Explorer after #2702 top-nav restructure)
+  var spaHref = $(eventObj).data("spa-href");
+  if (spaHref) {
+    window.location.href = spaHref;
+    return;
+  }
   var view = $(eventObj).data("navmgr");
   var navMgrArguments = [
     navMgr[view],

--- a/WebUI/src/main/webapp/cm/pages/app/includes/mainnav.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/mainnav.jsp
@@ -52,13 +52,15 @@
         var currentView = '<%=mainNavTab%>';
         var views = {
             home: 'VIEW_HOME',
+            // Dashboard removed from top chrome (#2702); deep link still supported
             dashboard: 'VIEW_DASHBOARD',
             pageeditor: 'VIEW_EDITOR',
             architecture: 'VIEW_SITE_ARCH',
             siteadmin: 'VIEW_DESIGN',
             publish: 'VIEW_PUBLISH',
             workflow: 'VIEW_WORKFLOW',
-            widgetbuilder: 'VIEW_WIDGET_BUILDER'
+            widgetbuilder: 'VIEW_WIDGET_BUILDER',
+            explorer: 'VIEW_EXPLORER'
         };
         function clear (evt) {
             clearTimeout(timerid);
@@ -85,6 +87,13 @@
             $(this).find('.perc-actions-menu').show();
         }).on('click', '.perc-topnav li', function onTopNavOptionClick (event) {
             event.stopPropagation();
+            // SPA surface exit (e.g. Explorer) — not a classic PercNavigationManager view
+            var spaHref = $(this).data('spa-href');
+            if (spaHref) {
+                window.location.href = spaHref;
+                $(this).parents('.perc-actions-menu').hide();
+                return;
+            }
             var view = $(this).data('navmgr');
             var navMgrArguments = [navMgr[view], navMgr.getSiteName(), navMgr.getMode(), null, navMgr.getName(), navMgr.getPath(), navMgr.getPathType(), null];
             navMgr.goToLocation.apply(navMgr, navMgrArguments);
@@ -106,13 +115,15 @@
     <label></label><span class="icon-chevron-down fas fa-chevron-down" role="presentation"></span>
     <ul id="perc-top-menu-bar" class="perc-actions-menu box_shadow_with_padding" role="menubar" aria-label="<i18n:message key="perc.ui.navMenu.topNav@Top Navigation"/>">
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_HOME"><i18n:message key="perc.ui.navMenu.home@Home"/></li>
-        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DASHBOARD"><i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/></li>
+        <%-- #2702: Explorer immediately after Home (SPA deep link); Dashboard removed from top chrome --%>
+        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_EXPLORER" data-spa-href="/cm/app/spa.jsp?entry=explorer"><i18n:message key="perc.ui.dashboard.modern@Explorer"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_EDITOR"><i18n:message key="perc.ui.navMenu.webmgt@Editor"/></li>
         <% if (isAdmin || isDesigner) { %>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_SITE_ARCH"><i18n:message key="perc.ui.navMenu.architecture@Architecture"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DESIGN"><i18n:message key="perc.ui.navMenu.design@Design"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_PUBLISH"><i18n:message key="perc.ui.navMenu.publish@Publish"/></li>
         <% } %><% if (isAdmin) { %>
+        <%-- Single Admin entry (en-us label already "Admin"); classic Administration surfaces --%>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WORKFLOW"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
         <% } %>
         <% if (isWdgActive && (isAdmin || isDesigner)) { %>

--- a/WebUI/src/main/webapp/cm/pages/app/includes/minuetCommonTemplates/navigationTemplates.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/minuetCommonTemplates/navigationTemplates.jsp
@@ -24,10 +24,11 @@
                     <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.home@Home"/></span>
                 </div>
             </div>
+            <%-- #2702: Explorer after Home; Dashboard removed from top chrome --%>
             <div class="col-6 col-md-4 col-lg-3">
-                <div role="button" title='<i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/>' tabindex="0" data-navmgr="VIEW_DASHBOARD" class="perc-nav-item perc-actions-menu-item text-center">
-                    <i aria-hidden class="perc-nav-icon fas fa-tachometer-alt fa-5x fa-fw"></i>
-                    <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/></span>
+                <div role="button" title='<i18n:message key="perc.ui.dashboard.modern@Explorer"/>' tabindex="0" data-navmgr="VIEW_EXPLORER" data-spa-href="/cm/app/spa.jsp?entry=explorer" class="perc-nav-item perc-actions-menu-item text-center">
+                    <i aria-hidden class="perc-nav-icon fas fa-folder-open fa-5x fa-fw"></i>
+                    <span class="perc-nav-description"><i18n:message key="perc.ui.dashboard.modern@Explorer"/></span>
                 </div>
             </div>
             <div class="col-6 col-md-4 col-lg-3">

--- a/WebUI/src/main/webapp/cm/views/PercNavigationMinuetView.js
+++ b/WebUI/src/main/webapp/cm/views/PercNavigationMinuetView.js
@@ -71,6 +71,12 @@ function updateNavLocation(newSiteName, newPath) {
 }
 
 function processNavigationRequest(eventObj) {
+  // SPA surface exit (e.g. Explorer after #2702 top-nav restructure)
+  var spaHref = $(eventObj).data("spa-href");
+  if (spaHref) {
+    window.location.href = spaHref;
+    return;
+  }
   var view = $(eventObj).data("navmgr");
   var navMgrArguments = [
     navMgr[view],

--- a/WebUI/src/test/ts/admin/AdminShell.test.tsx
+++ b/WebUI/src/test/ts/admin/AdminShell.test.tsx
@@ -16,6 +16,7 @@
 
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import { AdminShell } from "../../../main/ts/admin/AdminShell";
 
@@ -36,15 +37,24 @@ vi.mock("../../../main/ts/admin/tools/ToolsSection", () => ({
   ToolsSection: () => <div data-testid="mock-tools-section">Tools Content</div>,
 }));
 
+function renderShell(ui: React.ReactElement) {
+  return render(
+    <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/admin"]}>
+      {ui}
+    </MemoryRouter>,
+  );
+}
+
 describe("AdminShell", () => {
   it("renders administration shell title and default active tab", () => {
-    render(<AdminShell />);
+    renderShell(<AdminShell />);
     expect(screen.getByTestId("perc-admin-shell")).toBeDefined();
     expect(screen.getByTestId("mock-tasks-section")).toBeDefined();
+    expect(screen.getByTestId("admin-sibling-workflow-link")).toBeDefined();
   });
 
   it("exposes responsive tablist chrome for narrow / portrait layouts", () => {
-    render(<AdminShell />);
+    renderShell(<AdminShell />);
     const shell = screen.getByTestId("perc-admin-shell");
     const tablist = screen.getByTestId("perc-admin-tablist");
     expect(tablist.getAttribute("role")).toBe("tablist");
@@ -58,7 +68,7 @@ describe("AdminShell", () => {
   });
 
   it("switches tabs when nav buttons are clicked", () => {
-    render(<AdminShell />);
+    renderShell(<AdminShell />);
 
     const logsTab = screen.getByTestId("tab-logs");
     fireEvent.click(logsTab);

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -200,6 +200,29 @@ describe("App shell", () => {
     await screen.findByTestId("home-shell", {}, { timeout: SHELL_TIMEOUT });
   });
 
+  it("top nav order is Home then Explorer with single Admin (#2702)", async () => {
+    window.history.replaceState({}, "", "/cm/app/home");
+    render(
+      <App bootstrap={bootstrap} entrySearch="?entry=home" basename="/cm/app" />,
+    );
+    const nav = screen.getByTestId("perc-spa-topnav");
+    const home = screen.getByTestId("nav-home");
+    const explorer = screen.getByTestId("nav-explorer");
+    expect(screen.queryByTestId("nav-dashboard")).toBeNull();
+    expect(screen.queryByTestId("nav-workflow")).toBeNull();
+    expect(screen.getByTestId("nav-admin")).toBeTruthy();
+    // Document order: Home immediately before Explorer
+    expect(
+      home.compareDocumentPosition(explorer) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // No other top-nav link between them
+    let sibling = home.parentElement?.nextElementSibling;
+    expect(sibling?.querySelector("[data-testid='nav-explorer']")).toBeTruthy();
+    await screen.findByTestId("home-shell", {}, { timeout: SHELL_TIMEOUT });
+    expect(nav).toBeTruthy();
+  });
+
   it("loads WorkflowAdminShell for admin entry", async () => {
     window.history.replaceState({}, "", "/cm/app/workflow/roles");
     render(

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TopNav } from "../../../../main/ts/app/layout/TopNav";
+
+const bootstrapState = {
+  isAdmin: true,
+  isDesigner: true,
+  isWidgetBuilderActive: true,
+};
+
+vi.mock("../../../../main/ts/app/bootstrap/BootstrapContext", () => ({
+  useSpaBootstrap: () => bootstrapState,
+}));
+
+vi.mock("../../../../main/ts/app/layout/UserMenu", () => ({
+  UserMenu: () => <div data-testid="user-menu-stub" />,
+}));
+
+describe("TopNav (#2702)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      // Return the English fallback after @ for readable assertions
+      message: (key: string) => {
+        const at = key.indexOf("@");
+        return at >= 0 ? key.slice(at + 1) : key;
+      },
+    };
+    bootstrapState.isAdmin = true;
+    bootstrapState.isDesigner = true;
+    bootstrapState.isWidgetBuilderActive = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderNav(path = "/cm/app/home") {
+    return render(
+      <MemoryRouter initialEntries={[path]} basename="/cm/app">
+        <TopNav />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders Home then Explorer, no Dashboard, single Admin", () => {
+    renderNav();
+    const nav = screen.getByTestId("perc-spa-topnav");
+    const links = within(nav).getAllByRole("link");
+    const testIds = links
+      .map((el) => el.getAttribute("data-testid"))
+      .filter(Boolean);
+
+    expect(testIds[0]).toBe("nav-home");
+    expect(testIds[1]).toBe("nav-explorer");
+    expect(testIds).not.toContain("nav-dashboard");
+    expect(testIds).not.toContain("nav-workflow");
+    expect(testIds.filter((id) => id === "nav-admin")).toEqual(["nav-admin"]);
+    expect(screen.getByTestId("nav-admin").textContent).toMatch(/Admin/i);
+  });
+
+  it("hides Admin for non-admin", () => {
+    bootstrapState.isAdmin = false;
+    bootstrapState.isDesigner = false;
+    renderNav();
+    expect(screen.queryByTestId("nav-admin")).toBeNull();
+    expect(screen.getByTestId("nav-home")).toBeTruthy();
+    expect(screen.getByTestId("nav-explorer")).toBeTruthy();
+  });
+
+  it("marks Admin active on workflow and admin-tools routes", () => {
+    const { unmount } = renderNav("/cm/app/workflow/roles");
+    expect(screen.getByTestId("nav-admin").getAttribute("data-nav-active")).toBe(
+      "true",
+    );
+    unmount();
+    renderNav("/cm/app/admin/tools");
+    expect(screen.getByTestId("nav-admin").getAttribute("data-nav-active")).toBe(
+      "true",
+    );
+  });
+});
+
+

--- a/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
+++ b/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  isAdminNavPath,
+  topNavItemIds,
+} from "../../../../main/ts/app/layout/topNavConfig";
+
+describe("topNavItemIds (#2702)", () => {
+  it("places Explorer immediately after Home for all roles", () => {
+    for (const gates of [
+      {},
+      { isAdmin: true, isDesigner: true, isWidgetBuilderActive: true },
+      { isAdmin: false, isDesigner: true },
+      { isAdmin: false, isDesigner: false },
+    ]) {
+      const ids = topNavItemIds(gates);
+      expect(ids[0]).toBe("home");
+      expect(ids[1]).toBe("explorer");
+      expect(ids).not.toContain("dashboard" as never);
+    }
+  });
+
+  it("does not expose Admin for non-admin users", () => {
+    expect(topNavItemIds({ isAdmin: false, isDesigner: true })).not.toContain(
+      "admin",
+    );
+    expect(topNavItemIds({ isAdmin: false, isDesigner: false })).not.toContain(
+      "admin",
+    );
+  });
+
+  it("exposes a single consolidated Admin item for admins", () => {
+    const ids = topNavItemIds({
+      isAdmin: true,
+      isDesigner: true,
+      isWidgetBuilderActive: true,
+    });
+    expect(ids.filter((id) => id === "admin")).toEqual(["admin"]);
+    expect(ids).toEqual([
+      "home",
+      "explorer",
+      "editor",
+      "architecture",
+      "developer",
+      "publish",
+      "admin",
+      "widget-builder",
+    ]);
+  });
+
+  it("includes designer publish surfaces without Admin", () => {
+    expect(
+      topNavItemIds({ isAdmin: false, isDesigner: true }),
+    ).toEqual([
+      "home",
+      "explorer",
+      "editor",
+      "architecture",
+      "developer",
+      "publish",
+    ]);
+  });
+});
+
+describe("isAdminNavPath", () => {
+  it("marks workflow and admin-tools SPA paths as Admin-active", () => {
+    expect(isAdminNavPath("/workflow")).toBe(true);
+    expect(isAdminNavPath("/workflow/roles")).toBe(true);
+    expect(isAdminNavPath("/admin")).toBe(true);
+    expect(isAdminNavPath("/admin/tools")).toBe(true);
+    expect(isAdminNavPath("/home")).toBe(false);
+    expect(isAdminNavPath("/explorer")).toBe(false);
+  });
+});

--- a/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
@@ -16,6 +16,7 @@
 
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import { WorkflowAdminShell } from "../../../main/ts/workflowAdmin/WorkflowAdminShell";
 
@@ -36,15 +37,24 @@ vi.mock("../../../main/ts/workflowAdmin/category/CategoriesSection", () => ({
   CategoriesSection: () => <div data-testid="perc-categories-section">Categories Content</div>,
 }));
 
+function renderShell(ui: React.ReactElement) {
+  return render(
+    <MemoryRouter basename="/cm/app" initialEntries={["/cm/app/workflow"]}>
+      {ui}
+    </MemoryRouter>,
+  );
+}
+
 describe("WorkflowAdminShell", () => {
   it("renders shell title and default active tab", () => {
-    render(<WorkflowAdminShell />);
+    renderShell(<WorkflowAdminShell />);
     expect(screen.getByTestId("perc-workflow-admin-shell")).toBeTruthy();
     expect(screen.getByTestId("mock-workflow-section")).toBeTruthy();
+    expect(screen.getByTestId("admin-sibling-tools-link")).toBeTruthy();
   });
 
   it("exposes responsive tablist chrome for narrow / portrait layouts", () => {
-    render(<WorkflowAdminShell />);
+    renderShell(<WorkflowAdminShell />);
     const shell = screen.getByTestId("perc-workflow-admin-shell");
     const tablist = screen.getByTestId("perc-workflow-admin-tablist");
     expect(tablist.getAttribute("role")).toBe("tablist");
@@ -53,8 +63,8 @@ describe("WorkflowAdminShell", () => {
   });
 
   it("switches tabs when nav buttons are clicked", () => {
-    render(<WorkflowAdminShell />);
-    
+    renderShell(<WorkflowAdminShell />);
+
     const rolesTab = screen.getByTestId("tab-roles");
     fireEvent.click(rolesTab);
     expect(screen.getByTestId("perc-roles-section")).toBeTruthy();
@@ -69,3 +79,4 @@ describe("WorkflowAdminShell", () => {
     expect(screen.getByTestId("perc-categories-section")).toBeTruthy();
   });
 });
+

--- a/WebUI/war/app/includes/mainnav.jsp
+++ b/WebUI/war/app/includes/mainnav.jsp
@@ -52,13 +52,15 @@
         var currentView = '<%=mainNavTab%>';
         var views = {
             home: 'VIEW_HOME',
+            // Dashboard removed from top chrome (#2702); deep link still supported
             dashboard: 'VIEW_DASHBOARD',
             pageeditor: 'VIEW_EDITOR',
             architecture: 'VIEW_SITE_ARCH',
             siteadmin: 'VIEW_DESIGN',
             publish: 'VIEW_PUBLISH',
             workflow: 'VIEW_WORKFLOW',
-            widgetbuilder: 'VIEW_WIDGET_BUILDER'
+            widgetbuilder: 'VIEW_WIDGET_BUILDER',
+            explorer: 'VIEW_EXPLORER'
         };
         function clear (evt) {
             clearTimeout(timerid);
@@ -85,6 +87,13 @@
             $(this).find('.perc-actions-menu').show();
         }).on('click', '.perc-topnav li', function onTopNavOptionClick (event) {
             event.stopPropagation();
+            // SPA surface exit (e.g. Explorer) — not a classic PercNavigationManager view
+            var spaHref = $(this).data('spa-href');
+            if (spaHref) {
+                window.location.href = spaHref;
+                $(this).parents('.perc-actions-menu').hide();
+                return;
+            }
             var view = $(this).data('navmgr');
             var navMgrArguments = [navMgr[view], navMgr.getSiteName(), navMgr.getMode(), null, navMgr.getName(), navMgr.getPath(), navMgr.getPathType(), null];
             navMgr.goToLocation.apply(navMgr, navMgrArguments);
@@ -106,13 +115,15 @@
     <label></label><span class="icon-chevron-down fas fa-chevron-down" role="presentation"></span>
     <ul id="perc-top-menu-bar" class="perc-actions-menu box_shadow_with_padding" role="menubar" aria-label="<i18n:message key="perc.ui.navMenu.topNav@Top Navigation"/>">
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_HOME"><i18n:message key="perc.ui.navMenu.home@Home"/></li>
-        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DASHBOARD"><i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/></li>
+        <%-- #2702: Explorer immediately after Home (SPA deep link); Dashboard removed from top chrome --%>
+        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_EXPLORER" data-spa-href="/cm/app/spa.jsp?entry=explorer"><i18n:message key="perc.ui.dashboard.modern@Explorer"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_EDITOR"><i18n:message key="perc.ui.navMenu.webmgt@Editor"/></li>
         <% if (isAdmin || isDesigner) { %>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_SITE_ARCH"><i18n:message key="perc.ui.navMenu.architecture@Architecture"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DESIGN"><i18n:message key="perc.ui.navMenu.design@Design"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_PUBLISH"><i18n:message key="perc.ui.navMenu.publish@Publish"/></li>
         <% } %><% if (isAdmin) { %>
+        <%-- Single Admin entry (en-us label already "Admin"); classic Administration surfaces --%>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WORKFLOW"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
         <% } %>
         <% if (isWdgActive && (isAdmin || isDesigner)) { %>

--- a/WebUI/war/app/includes/minuetCommonTemplates/navigationTemplates.jsp
+++ b/WebUI/war/app/includes/minuetCommonTemplates/navigationTemplates.jsp
@@ -24,10 +24,11 @@
                     <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.home@Home"/></span>
                 </div>
             </div>
+            <%-- #2702: Explorer after Home; Dashboard removed from top chrome --%>
             <div class="col-6 col-md-4 col-lg-3">
-                <div role="button" title='<i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/>' tabindex="0" data-navmgr="VIEW_DASHBOARD" class="perc-nav-item perc-actions-menu-item text-center">
-                    <i aria-hidden class="perc-nav-icon fas fa-tachometer-alt fa-5x fa-fw"></i>
-                    <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.dashboard@Dashboard"/></span>
+                <div role="button" title='<i18n:message key="perc.ui.dashboard.modern@Explorer"/>' tabindex="0" data-navmgr="VIEW_EXPLORER" data-spa-href="/cm/app/spa.jsp?entry=explorer" class="perc-nav-item perc-actions-menu-item text-center">
+                    <i aria-hidden class="perc-nav-icon fas fa-folder-open fa-5x fa-fw"></i>
+                    <span class="perc-nav-description"><i18n:message key="perc.ui.dashboard.modern@Explorer"/></span>
                 </div>
             </div>
             <div class="col-6 col-md-4 col-lg-3">

--- a/WebUI/war/views/PercNavigationMinuetView.js
+++ b/WebUI/war/views/PercNavigationMinuetView.js
@@ -73,6 +73,12 @@ function updateNavLocation(newSiteName, newPath) {
 }
 
 function processNavigationRequest(eventObj) {
+    // SPA surface exit (e.g. Explorer after #2702 top-nav restructure)
+    var spaHref = $(eventObj).data('spa-href');
+    if (spaHref) {
+        window.location.href = spaHref;
+        return;
+    }
     var view = $(eventObj).data('navmgr');
     var navMgrArguments = [navMgr[view], navMgr.getSiteName(), navMgr.getMode(), null, navMgr.getName(), navMgr.getPath(), navMgr.getPathType(), null];
     navMgr.goToLocation.apply(navMgr, navMgrArguments);

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Top navigation restructure (#2702):
+ * - Dashboard removed from SPA top chrome
+ * - Explorer immediately after Home
+ * - Single consolidated Admin (no separate Administration + Admin tools)
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/top-nav-restructure.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function homeDeepLink() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function expectSpaTopNav(page) {
+  await expect(page.getByTestId("perc-spa-app")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("perc-spa-topnav")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+test.describe("Top nav restructure (#2702)", () => {
+  test("Home then Explorer; no Dashboard; single Admin @smoke @ui", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+    await page.goto(homeDeepLink(), { waitUntil: "domcontentloaded" });
+    await expectSpaTopNav(page);
+
+    const nav = page.getByTestId("perc-spa-topnav");
+    const home = nav.getByTestId("nav-home");
+    const explorer = nav.getByTestId("nav-explorer");
+    const admin = nav.getByTestId("nav-admin");
+
+    await expect(home).toBeVisible();
+    await expect(explorer).toBeVisible();
+    await expect(admin).toBeVisible();
+    await expect(nav.getByTestId("nav-dashboard")).toHaveCount(0);
+    await expect(nav.getByTestId("nav-workflow")).toHaveCount(0);
+
+    // DOM adjacency: Explorer is the next top-level nav item after Home
+    const adjacency = await page.evaluate(() => {
+      const homeLi = document
+        .querySelector('[data-testid="nav-home"]')
+        ?.closest("li");
+      const next = homeLi?.nextElementSibling;
+      return !!next?.querySelector('[data-testid="nav-explorer"]');
+    });
+    expect(adjacency).toBe(true);
+
+    // Consolidated Admin lands on workflow hub
+    await admin.click();
+    await expect(page.getByTestId("perc-workflow-admin-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+    // Admin tools still reachable from workflow hub sibling link
+    const toolsLink = page.getByTestId("admin-sibling-tools-link");
+    await expect(toolsLink).toBeVisible();
+    await toolsLink.click();
+    await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Restructures application top navigation per #2702:

1. **Remove Dashboard** from SPA and classic top chrome (gadgets remain via deep link `/home/gadgets` and Home sections).
2. **Explorer immediately after Home** in SPA shell and classic Minuet top nav / nav grid.
3. **Consolidate Administration + Admin tools** into a single top-level **Admin** item (label key `perc.ui.navMenu.admin@Administration`, en-us already "Admin"). Landing is `/workflow`; `/admin` remains deep-linked with sibling cross-links between shells.

## Dual-ship
- SPA: `WebUI/src/main/ts/app/layout/TopNav.tsx` + `topNavConfig.ts`
- Classic: `mainnav.jsp`, `navigationTemplates.jsp` under `src/main/webapp` (app + pages) and `WebUI/war`
- Minuet click handlers honor `data-spa-href` for Explorer SPA exit

## Test plan
- [x] Vitest: `topNavConfig`, `TopNav`, `App` shell order, Admin/Workflow shell Router wrappers
- [x] `cd WebUI && ../mvnw clean install` — **BUILD SUCCESS**
- [x] `cd modules/perc-qa-automation && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] `npm run test:unit` + `test:surface:list` for new Playwright path
- [ ] Live Playwright surface (blocked this run — `perc-devctl qa-up` failed matrix install/context; human QA to run):
  ```
  perc-devctl qa-up
  TEST_CMS_URL=... npm run test:surface -- --path tests/top-nav-restructure.spec.js
  ```
- [ ] Manual: Admin sees Home → Explorer, no Dashboard, single Admin; tools still reachable; non-admin has no Admin

## Gates
- Erlang-style self-review: no bugs found in scope; portable paths; change-class companions (Vitest + Playwright + dual-ship)
- No new rule-file commits
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2702

> Co-Authored by Grok Build using grok-4.5 with agent main.
