### PR TITLE
feat(sitemanage): CM1 region↔slot mapping + CssPref/UserPref upgrade (#2690)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -54,6 +54,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | [gadget-definition-inventory.md](./gadget-definition-inventory.md) | Gadget XML / SPA survey |
 | [adr/](./adr/) | Architecture decision records |
 | [parity-notes.md](./parity-notes.md) | Region vs slot, pageAssembler vs velocity, etc. |
+| [region-slot-mapping.md](./region-slot-mapping.md) | Phase 2 residual: region↔slot composition + CssPref upgrade (#2690) |
 | [binding-modules.md](./binding-modules.md) | `$sys` / `$rx` / `$perc` + assembler picker guide |
 
 ## Code anchors

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/003-slot-layout-styles.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/003-slot-layout-styles.md
@@ -38,6 +38,6 @@ Schema helper: `PSSlotLayoutStyles` (`SCHEMA_VERSION = 1`). Persistence: `RXSLOT
 ## Consequences
 
 - Schema/persistence changes for slots (`SLOT_LAYOUT` / `SLOT_STYLES` columns).
-- Upgrade maps widget `CssPref` / layout-ish `UserPref` → slot defaults + instance overrides (residual after first slice).
+- Upgrade maps widget `CssPref` / layout-ish `UserPref` → slot defaults + instance overrides — implemented as offline mappers in #2690 (`PSWidgetPrefToSlotMapper`, `PSRegionToSlotCompositionMapper`; see [region-slot-mapping.md](../region-slot-mapping.md)).
 - Visual Design editor edits these properties on slots (later phases).
 - Do not invent an open-ended CSS-in-DB product in v1 — start with CM1-parity property set and version the schema.

--- a/docs/ai-generated/tasks/template-assembler-normalization/parity-notes.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/parity-notes.md
@@ -24,6 +24,8 @@ Living document for Phase 0–3 implementers. Not a customer-facing guide.
 
 **Target:** one **Slot** abstraction. Regions rename/map to slots. Layout chrome moves to **`slot_layout` / `slot_styles`**.
 
+**Implementation sketch (#2690):** [region-slot-mapping.md](./region-slot-mapping.md) — `PSRegionToSlotCompositionMapper` (`regionId` → slot name, nested regions → nested composition, widgets → ordered items) and `PSWidgetPrefToSlotMapper` (CssPref/UserPref → layout/styles maps).
+
 ## 3. Widget Code vs template bindings
 
 | | Widget `Code` | Template bindings |

--- a/docs/ai-generated/tasks/template-assembler-normalization/region-slot-mapping.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/region-slot-mapping.md
@@ -1,0 +1,99 @@
+# CM1 region ↔ unified slot composition mapping
+
+| Field | Value |
+|-------|--------|
+| **Status** | Phase 2 residual (#2690) |
+| **Parent** | #2629 · Grandparent epic #2626 |
+| **Code** | `projects/sitemanage/.../mapper/PSRegionToSlotCompositionMapper` |
+| **CssPref upgrade** | `.../mapper/PSWidgetPrefToSlotMapper` |
+| **Schema** | ADR-003 · `PSSlotLayoutStyles` (system) |
+
+## Goals of this residual
+
+1. Document and unit-test **region tree → slot composition** mapping rules.
+2. Sketch **CssPref / layout-ish UserPref → `slot_styles` / `slot_layout`** upgrade (definition defaults + instance overrides).
+3. List **package upgrade residual steps** for Phase 3 (#2630) — inventory only here; no bulk package rewrite.
+
+Out of scope: REST/Workbench fields (#2691), product Widget XML elimination (#2630), Design SPA (#2631).
+
+## Region ↔ slot mapping rules
+
+| CM1 concept | Unified slot composition |
+|-------------|--------------------------|
+| `PSRegion.regionId` | `PSSlotCompositionNode.slotName` (identity in v1 sketch) |
+| Nested `PSRegion` children | Nested `PSSlotCompositionNode` children |
+| `PSRegionCode` (markup) | Not a slot — stays template body between holes |
+| `PSRegion.cssClass` | Seeds `slot_styles.rootclass` on the composition node |
+| `PSRegionWidgets` / widget items | Ordered `PSSlotCompositionItem` list on that slot |
+| Widget instance `cssProperties` | Instance `styleOverrides` |
+| Layout-ish widget `properties` | Instance `layoutOverrides` |
+
+### Runtime sketch
+
+```text
+PSRegionTree
+  rootRegion ──► PSSlotCompositionNode (slotName = regionId)
+       │              ├── slot_styles (region cssClass → rootclass)
+       │              ├── items[]  (widgets on this region)
+       │              └── children[] (child regions only)
+```
+
+Call entry points (offline / upgrade tools):
+
+- `PSRegionToSlotCompositionMapper.map(PSRegionTree)`
+- `PSRegionToSlotCompositionMapper.map(PSRegionTree, Map<String,PSWidgetDefinition>)`
+- `PSRegionToSlotCompositionMapper.regionIdToSlotNameMap(root)` — flat id map for tooling
+
+## CssPref / UserPref → slot_layout / slot_styles
+
+| Source | Target map | Canonical keys |
+|--------|------------|----------------|
+| `CssPref` (any name) | `slot_styles` | `rootclass`, `itemclass`, plus custom names preserved |
+| UserPref `rootclass` / `itemclass` (legacy) | `slot_styles` | same |
+| UserPref `layout` / `orientation` | `slot_layout` | `orientation` (`ui-perc-list-horizontal` → `horizontal`) |
+| UserPref `maxlength` / `max_results` / `maxItems` | `slot_layout` | `maxItems` |
+| UserPref `columns`, `emptyState`, `wrapperClassPolicy` | `slot_layout` | matching ADR-003 keys |
+| Other UserPrefs (e.g. `target`, content filters) | **not** mapped | remain content-type / snippet properties |
+
+### Definition vs instance
+
+| Layer | Method | Role |
+|-------|--------|------|
+| Slot **definition** defaults | `definitionStyleDefaults` / `definitionLayoutDefaults` | From widget XML prefs → future component slot catalog |
+| Slot **instance** overrides | `instanceStyleOverrides` / `instanceLayoutOverrides` | From placed `PSWidgetItem` maps |
+| Merge | `merge(base, overrides, layout?)` | Instance wins; schema version stamped |
+
+Persistence of maps on classic slots is already in `RXSLOTTYPE.SLOT_LAYOUT` / `SLOT_STYLES` (#2692). Composition-level instance storage / REST is #2691.
+
+## Residual package upgrade steps (Phase 3 inventory)
+
+These steps are **not** automated in #2690. Product packages under `modules/perc-packages/.../Widgets/`:
+
+1. **Inventory** — use `widget-xml-inventory.md` / `.csv`; filter widgets with `CssPref` or layout-ish `UserPref` (`layout`, `maxlength`, `rootclass`, …).
+2. **Slot catalog defaults** — for each converted component, write definition defaults via `PSWidgetPrefToSlotMapper.definition*Defaults` into the new package slot metadata (or `PSTemplateSlot` when classic slots are generated).
+3. **Page/template composition** — for each CM1 template/page region tree, run `PSRegionToSlotCompositionMapper.map` to produce slot composition + per-item overrides; persist when Phase 3 storage exists.
+4. **Velocity/JEXL consumers** — migrate `$perc.widget.item.cssProperties.get('rootclass')` reads toward `$sys.slot.styles.rootclass` (binding names locked in ADR-003 / #2692).
+5. **Leave content UserPrefs** on the snippet/content type until content model migration defines their home.
+6. **Do not delete** Widget XML in this residual; elimination is #2630 after upgrade tooling exists.
+
+### Example (product pattern)
+
+`percRichText` / `percSimpleText`: single `CssPref name="rootclass"` → slot definition styles `{ schemaVersion: 1, rootclass: <default if any> }`; page instance values from Design CSS dialog → item `styleOverrides.rootclass`.
+
+`percArchiveList`: `UserPref layout` + `CssPref rootclass` / `summaryclass` → layout `orientation` + styles map including custom `summaryclass`.
+
+## Tests
+
+Offline (no Spring / no DB):
+
+- `PSWidgetPrefToSlotMapperTest`
+- `PSRegionToSlotCompositionMapperTest`
+
+Module: `cd projects/sitemanage && ../../mvnw clean install`
+
+## Related
+
+- [ADR-003](./adr/003-slot-layout-styles.md)
+- [parity-notes.md](./parity-notes.md) § Region vs slot
+- [plan.md](./plan.md) §3.3
+- Residual REST/Workbench: #2691

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSRegionToSlotCompositionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSRegionToSlotCompositionMapper.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.mapper;
+
+import com.percussion.pagemanagement.data.PSRegion;
+import com.percussion.pagemanagement.data.PSRegionNode;
+import com.percussion.pagemanagement.data.PSRegionTree;
+import com.percussion.pagemanagement.data.PSRegionWidgetAssociations;
+import com.percussion.pagemanagement.data.PSWidgetDefinition;
+import com.percussion.pagemanagement.data.PSWidgetItem;
+import com.percussion.services.assembly.data.PSSlotLayoutStyles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Maps a CM1 {@link PSRegionTree} (structure + region↔widget associations) onto a unified slot
+ * composition tree ({@link PSSlotCompositionNode}) for Phase 2 residual #2690.
+ *
+ * <h2>Mapping rules (documented + unit-tested)</h2>
+ *
+ * <ol>
+ *   <li>Each {@link PSRegion} becomes one slot composition node; {@code regionId} → {@code
+ *       slotName}.
+ *   <li>Nested region children become nested slot composition children (code nodes are ignored for
+ *       structure).
+ *   <li>Region {@code cssClass} seeds {@code slot_styles.rootclass} when non-blank.
+ *   <li>Widget items on a region (from associations) become ordered {@link PSSlotCompositionItem}s
+ *       with instance layout/style overrides from {@link PSWidgetPrefToSlotMapper}.
+ *   <li>Optional widget definitions supply slot definition defaults merged under region styles
+ *       (definition defaults first, then region cssClass, then first-item merges are not applied at
+ *       the slot level — items keep their own overrides).
+ * </ol>
+ *
+ * <p>This is a pure offline sketch: no Hibernate, REST, or package I/O.
+ *
+ * @see PSWidgetPrefToSlotMapper
+ */
+public final class PSRegionToSlotCompositionMapper {
+
+  private PSRegionToSlotCompositionMapper() {}
+
+  /**
+   * Map a region tree and its widget associations to a unified slot composition root.
+   *
+   * @param tree never {@code null}; must have a root region
+   * @return composition root for {@link PSRegionTree#getRootRegion()}, never {@code null}
+   * @throws IllegalArgumentException if tree or root is missing
+   */
+  public static PSSlotCompositionNode map(PSRegionTree tree) {
+    return map(tree, Collections.emptyMap());
+  }
+
+  /**
+   * Map a region tree with optional widget definitions for definition-level layout/style defaults
+   * (used when attaching items; not required for structure).
+   *
+   * @param tree never {@code null}
+   * @param definitionsById map of widget definition id → definition; may be empty, never {@code
+   *     null}
+   * @return composition root, never {@code null}
+   */
+  public static PSSlotCompositionNode map(
+      PSRegionTree tree, Map<String, PSWidgetDefinition> definitionsById) {
+    Objects.requireNonNull(tree, "tree");
+    Objects.requireNonNull(definitionsById, "definitionsById");
+    PSRegion root = tree.getRootRegion();
+    if (root == null) {
+      throw new IllegalArgumentException("region tree root is required");
+    }
+    Map<String, List<PSWidgetItem>> widgetsByRegion = tree.getRegionWidgetsMap();
+    return mapRegion(root, widgetsByRegion, definitionsById);
+  }
+
+  /**
+   * Map a single region subtree with associations supplied separately (for tests or non-tree
+   * callers).
+   *
+   * @param region never {@code null}
+   * @param associations may be {@code null} (no widgets)
+   * @param definitionsById may be {@code null} (treated empty)
+   * @return composition node for {@code region}, never {@code null}
+   */
+  public static PSSlotCompositionNode mapRegion(
+      PSRegion region,
+      PSRegionWidgetAssociations associations,
+      Map<String, PSWidgetDefinition> definitionsById) {
+    Objects.requireNonNull(region, "region");
+    Map<String, List<PSWidgetItem>> widgetsByRegion =
+        associations == null
+            ? Collections.emptyMap()
+            : associations.getRegionWidgetsMap();
+    Map<String, PSWidgetDefinition> defs =
+        definitionsById == null ? Collections.emptyMap() : definitionsById;
+    return mapRegion(region, widgetsByRegion, defs);
+  }
+
+  private static PSSlotCompositionNode mapRegion(
+      PSRegion region,
+      Map<String, List<PSWidgetItem>> widgetsByRegion,
+      Map<String, PSWidgetDefinition> definitionsById) {
+    String regionId = region.getRegionId();
+    if (StringUtils.isBlank(regionId)) {
+      throw new IllegalArgumentException("regionId is required on every region");
+    }
+
+    Map<String, Object> layout = PSSlotLayoutStyles.defaultLayout();
+    Map<String, Object> styles = PSSlotLayoutStyles.defaultStyles();
+    if (StringUtils.isNotBlank(region.getCssClass())) {
+      styles.put(PSSlotLayoutStyles.KEY_ROOTCLASS, region.getCssClass().trim());
+    }
+
+    List<PSWidgetItem> widgets =
+        widgetsByRegion.getOrDefault(regionId, Collections.emptyList());
+    List<PSSlotCompositionItem> items = new ArrayList<>();
+    for (PSWidgetItem widget : widgets) {
+      if (widget == null) {
+        continue;
+      }
+      Map<String, Object> itemLayout = PSWidgetPrefToSlotMapper.instanceLayoutOverrides(widget);
+      Map<String, Object> itemStyles = PSWidgetPrefToSlotMapper.instanceStyleOverrides(widget);
+      String defId = widget.getDefinitionId();
+      if (StringUtils.isNotBlank(defId) && definitionsById.containsKey(defId)) {
+        PSWidgetDefinition def = definitionsById.get(defId);
+        itemLayout =
+            PSWidgetPrefToSlotMapper.merge(
+                PSWidgetPrefToSlotMapper.definitionLayoutDefaults(def), itemLayout, true);
+        itemStyles =
+            PSWidgetPrefToSlotMapper.merge(
+                PSWidgetPrefToSlotMapper.definitionStyleDefaults(def), itemStyles, false);
+      }
+      items.add(
+          new PSSlotCompositionItem(widget.getId(), defId, itemLayout, itemStyles));
+    }
+
+    List<PSSlotCompositionNode> children = new ArrayList<>();
+    List<PSRegionNode> childNodes = region.getChildren();
+    if (childNodes != null) {
+      for (PSRegionNode node : childNodes) {
+        if (node instanceof PSRegion childRegion) {
+          children.add(mapRegion(childRegion, widgetsByRegion, definitionsById));
+        }
+        // PSRegionCode nodes are template markup between regions — not slots.
+      }
+    }
+
+    return new PSSlotCompositionNode(
+        regionId, regionId, region.getCssClass(), layout, styles, items, children);
+  }
+
+  /**
+   * Collect a flat regionId → slotName map for upgrade tooling (identity mapping under the Phase 2
+   * sketch).
+   *
+   * @param root never {@code null}
+   * @return linked map in preorder; never {@code null}
+   */
+  public static Map<String, String> regionIdToSlotNameMap(PSSlotCompositionNode root) {
+    Objects.requireNonNull(root, "root");
+    Map<String, String> map = new LinkedHashMap<>();
+    for (PSSlotCompositionNode node : root.flattenPreorder()) {
+      map.put(node.getSourceRegionId(), node.getSlotName());
+    }
+    return map;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSSlotCompositionItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSSlotCompositionItem.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.mapper;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Ordered content item inside a {@link PSSlotCompositionNode}, typically a CM1 widget instance
+ * upgraded onto a unified slot composition (instance layout/style overrides).
+ */
+public final class PSSlotCompositionItem {
+
+  private final String widgetInstanceId;
+  private final String definitionId;
+  private final Map<String, Object> layoutOverrides;
+  private final Map<String, Object> styleOverrides;
+
+  /**
+   * @param widgetInstanceId may be {@code null} when not yet assigned
+   * @param definitionId may be {@code null} when unknown
+   * @param layoutOverrides never {@code null} (copied)
+   * @param styleOverrides never {@code null} (copied)
+   */
+  public PSSlotCompositionItem(
+      String widgetInstanceId,
+      String definitionId,
+      Map<String, Object> layoutOverrides,
+      Map<String, Object> styleOverrides) {
+    this.widgetInstanceId = widgetInstanceId;
+    this.definitionId = definitionId;
+    this.layoutOverrides =
+        Collections.unmodifiableMap(
+            new LinkedHashMap<>(Objects.requireNonNull(layoutOverrides, "layoutOverrides")));
+    this.styleOverrides =
+        Collections.unmodifiableMap(
+            new LinkedHashMap<>(Objects.requireNonNull(styleOverrides, "styleOverrides")));
+  }
+
+  public String getWidgetInstanceId() {
+    return widgetInstanceId;
+  }
+
+  public String getDefinitionId() {
+    return definitionId;
+  }
+
+  public Map<String, Object> getLayoutOverrides() {
+    return layoutOverrides;
+  }
+
+  public Map<String, Object> getStyleOverrides() {
+    return styleOverrides;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSSlotCompositionNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSSlotCompositionNode.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.mapper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Unified slot composition node produced from a CM1 region (tree sketch for Phase 2 residual
+ * #2690). Not a persisted entity — upgrade/runtime mappers and offline tests use this DTO.
+ *
+ * <p>Mapping rule: {@code regionId} → {@link #getSlotName()}; nested regions → nested slot
+ * composition; widgets on the region → ordered {@link #getItems()}.
+ */
+public final class PSSlotCompositionNode {
+
+  private final String slotName;
+  private final String sourceRegionId;
+  private final String regionCssClass;
+  private final Map<String, Object> slotLayout;
+  private final Map<String, Object> slotStyles;
+  private final List<PSSlotCompositionItem> items;
+  private final List<PSSlotCompositionNode> children;
+
+  /**
+   * @param slotName never blank
+   * @param sourceRegionId never blank
+   * @param regionCssClass may be {@code null}
+   * @param slotLayout never {@code null} (copied)
+   * @param slotStyles never {@code null} (copied)
+   * @param items never {@code null} (copied)
+   * @param children never {@code null} (copied)
+   */
+  public PSSlotCompositionNode(
+      String slotName,
+      String sourceRegionId,
+      String regionCssClass,
+      Map<String, Object> slotLayout,
+      Map<String, Object> slotStyles,
+      List<PSSlotCompositionItem> items,
+      List<PSSlotCompositionNode> children) {
+    this.slotName = Objects.requireNonNull(slotName, "slotName");
+    this.sourceRegionId = Objects.requireNonNull(sourceRegionId, "sourceRegionId");
+    this.regionCssClass = regionCssClass;
+    this.slotLayout =
+        Collections.unmodifiableMap(new LinkedHashMap<>(Objects.requireNonNull(slotLayout)));
+    this.slotStyles =
+        Collections.unmodifiableMap(new LinkedHashMap<>(Objects.requireNonNull(slotStyles)));
+    this.items = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(items)));
+    this.children =
+        Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(children)));
+  }
+
+  public String getSlotName() {
+    return slotName;
+  }
+
+  public String getSourceRegionId() {
+    return sourceRegionId;
+  }
+
+  public String getRegionCssClass() {
+    return regionCssClass;
+  }
+
+  public Map<String, Object> getSlotLayout() {
+    return slotLayout;
+  }
+
+  public Map<String, Object> getSlotStyles() {
+    return slotStyles;
+  }
+
+  public List<PSSlotCompositionItem> getItems() {
+    return items;
+  }
+
+  public List<PSSlotCompositionNode> getChildren() {
+    return children;
+  }
+
+  /** Flatten this node and all descendants in preorder. */
+  public List<PSSlotCompositionNode> flattenPreorder() {
+    List<PSSlotCompositionNode> out = new ArrayList<>();
+    flattenPreorder(this, out);
+    return out;
+  }
+
+  private static void flattenPreorder(PSSlotCompositionNode node, List<PSSlotCompositionNode> out) {
+    out.add(node);
+    for (PSSlotCompositionNode child : node.children) {
+      flattenPreorder(child, out);
+    }
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSWidgetPrefToSlotMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/mapper/PSWidgetPrefToSlotMapper.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.mapper;
+
+import com.percussion.pagemanagement.data.PSWidgetDefinition;
+import com.percussion.pagemanagement.data.PSWidgetDefinition.AbstractUserPref;
+import com.percussion.pagemanagement.data.PSWidgetDefinition.CssPref;
+import com.percussion.pagemanagement.data.PSWidgetDefinition.UserPref;
+import com.percussion.pagemanagement.data.PSWidgetItem;
+import com.percussion.services.assembly.data.PSSlotLayoutStyles;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Offline-friendly upgrade/runtime sketch that maps CM1 widget {@code CssPref} / layout-ish {@code
+ * UserPref} definitions and instance values onto unified {@code slot_layout} / {@code slot_styles}
+ * maps (ADR-003 / Phase 2 residual #2690).
+ *
+ * <p>Does not touch the database or packages; callers apply the maps to slot definitions or
+ * composition instances. REST/Workbench exposure is out of scope (#2691).
+ *
+ * @see PSRegionToSlotCompositionMapper
+ * @see PSSlotLayoutStyles
+ */
+public final class PSWidgetPrefToSlotMapper {
+
+  /**
+   * UserPref names treated as structural layout (→ {@code slot_layout}). Case-insensitive match on
+   * the pref name.
+   */
+  public static final Set<String> LAYOUT_USER_PREF_NAMES =
+      Set.of(
+          "layout",
+          "orientation",
+          "columns",
+          "maxitems",
+          "maxlength",
+          "max_results",
+          "maxresults",
+          "emptystate",
+          "wrapperclasspolicy");
+
+  /**
+   * UserPref names that are presentational style tokens even when declared as UserPref (legacy
+   * widgets sometimes put {@code rootclass} here instead of CssPref).
+   */
+  public static final Set<String> STYLE_USER_PREF_NAMES = Set.of("rootclass", "itemclass");
+
+  private PSWidgetPrefToSlotMapper() {}
+
+  /**
+   * Build slot definition {@code slot_styles} defaults from widget definition CssPref entries (and
+   * style-ish UserPrefs with default values).
+   *
+   * @param definition may be {@code null} → empty defaults
+   * @return mutable map including schema version; never {@code null}
+   */
+  public static Map<String, Object> definitionStyleDefaults(PSWidgetDefinition definition) {
+    Map<String, Object> styles = PSSlotLayoutStyles.defaultStyles();
+    if (definition == null) {
+      return styles;
+    }
+    for (CssPref pref : definition.getCssPref()) {
+      putPrefDefault(styles, normalizeStyleKey(pref.getName()), pref);
+    }
+    for (UserPref pref : definition.getUserPref()) {
+      if (pref == null || pref.getName() == null) {
+        continue;
+      }
+      if (isStyleUserPref(pref.getName())) {
+        putPrefDefault(styles, normalizeStyleKey(pref.getName()), pref);
+      }
+    }
+    return styles;
+  }
+
+  /**
+   * Build slot definition {@code slot_layout} defaults from layout-ish UserPref default values.
+   *
+   * @param definition may be {@code null} → empty defaults
+   * @return mutable map including schema version; never {@code null}
+   */
+  public static Map<String, Object> definitionLayoutDefaults(PSWidgetDefinition definition) {
+    Map<String, Object> layout = PSSlotLayoutStyles.defaultLayout();
+    if (definition == null) {
+      return layout;
+    }
+    for (UserPref pref : definition.getUserPref()) {
+      if (pref == null || pref.getName() == null) {
+        continue;
+      }
+      if (!isLayoutUserPref(pref.getName())) {
+        continue;
+      }
+      putPrefDefault(layout, mapLayoutKey(pref.getName()), pref);
+    }
+    return layout;
+  }
+
+  /**
+   * Instance style overrides from a placed widget item ({@link PSWidgetItem#getCssProperties()}
+   * plus style-ish keys in {@link PSWidgetItem#getProperties()}).
+   *
+   * @param item may be {@code null} → empty defaults (schema only)
+   * @return mutable map including schema version; never {@code null}
+   */
+  public static Map<String, Object> instanceStyleOverrides(PSWidgetItem item) {
+    Map<String, Object> styles = PSSlotLayoutStyles.defaultStyles();
+    if (item == null) {
+      return styles;
+    }
+    copyMappedValues(styles, item.getCssProperties(), true);
+    copyMappedValues(styles, item.getProperties(), true);
+    return styles;
+  }
+
+  /**
+   * Instance layout overrides from a placed widget item's properties.
+   *
+   * @param item may be {@code null} → empty defaults (schema only)
+   * @return mutable map including schema version; never {@code null}
+   */
+  public static Map<String, Object> instanceLayoutOverrides(PSWidgetItem item) {
+    Map<String, Object> layout = PSSlotLayoutStyles.defaultLayout();
+    if (item == null) {
+      return layout;
+    }
+    copyMappedValues(layout, item.getProperties(), false);
+    return layout;
+  }
+
+  /**
+   * Merge base definition map with instance overrides. Instance keys win. Schema version is
+   * stamped from {@link PSSlotLayoutStyles#SCHEMA_VERSION}.
+   *
+   * @param base may be {@code null}
+   * @param overrides may be {@code null}
+   * @param layout {@code true} for layout maps, {@code false} for styles
+   * @return new mutable map; never {@code null}
+   */
+  public static Map<String, Object> merge(
+      Map<String, Object> base, Map<String, Object> overrides, boolean layout) {
+    Map<String, Object> out = layout ? PSSlotLayoutStyles.defaultLayout() : PSSlotLayoutStyles.defaultStyles();
+    putNonSchema(out, base);
+    putNonSchema(out, overrides);
+    out.put(PSSlotLayoutStyles.KEY_SCHEMA_VERSION, PSSlotLayoutStyles.SCHEMA_VERSION);
+    return out;
+  }
+
+  /**
+   * Whether a UserPref / property name is considered layout-ish for upgrade mapping.
+   *
+   * @param name may be {@code null}
+   * @return {@code true} if layout-mapped
+   */
+  public static boolean isLayoutUserPref(String name) {
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
+    return LAYOUT_USER_PREF_NAMES.contains(name.trim().toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Whether a UserPref name is treated as a style token (legacy rootclass-as-UserPref).
+   *
+   * @param name may be {@code null}
+   * @return {@code true} if style-mapped from UserPref
+   */
+  public static boolean isStyleUserPref(String name) {
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
+    return STYLE_USER_PREF_NAMES.contains(name.trim().toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Map a CM1 layout UserPref name onto a {@link PSSlotLayoutStyles} layout key.
+   *
+   * @param prefName never {@code null} when used after {@link #isLayoutUserPref(String)}
+   * @return canonical layout key
+   */
+  public static String mapLayoutKey(String prefName) {
+    Objects.requireNonNull(prefName, "prefName");
+    String n = prefName.trim().toLowerCase(Locale.ROOT);
+    return switch (n) {
+      case "layout", "orientation" -> PSSlotLayoutStyles.KEY_ORIENTATION;
+      case "columns" -> PSSlotLayoutStyles.KEY_COLUMNS;
+      case "maxitems", "maxlength", "max_results", "maxresults" -> PSSlotLayoutStyles.KEY_MAX_ITEMS;
+      case "emptystate" -> PSSlotLayoutStyles.KEY_EMPTY_STATE;
+      case "wrapperclasspolicy" -> PSSlotLayoutStyles.KEY_WRAPPER_CLASS_POLICY;
+      default -> prefName.trim();
+    };
+  }
+
+  /**
+   * Normalize a style key. Known CM1 names are lowercased to match {@link
+   * PSSlotLayoutStyles#KEY_ROOTCLASS} / {@link PSSlotLayoutStyles#KEY_ITEMCLASS}; other CssPref
+   * names are preserved with trimmed original casing after lowercasing for rootclass/itemclass
+   * only.
+   *
+   * @param name may be blank
+   * @return normalized key or {@code null} if blank
+   */
+  public static String normalizeStyleKey(String name) {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    String trimmed = name.trim();
+    String lower = trimmed.toLowerCase(Locale.ROOT);
+    if (PSSlotLayoutStyles.KEY_ROOTCLASS.equals(lower)
+        || PSSlotLayoutStyles.KEY_ITEMCLASS.equals(lower)) {
+      return lower;
+    }
+    return trimmed;
+  }
+
+  /**
+   * Known layout-ish property names that upgrade tools should scan in package widget XML (for
+   * residual package upgrade documentation / inventory).
+   *
+   * @return unmodifiable set of lower-case names
+   */
+  public static Set<String> knownLayoutPrefNamesLower() {
+    return Collections.unmodifiableSet(new LinkedHashSet<>(LAYOUT_USER_PREF_NAMES));
+  }
+
+  private static void putPrefDefault(
+      Map<String, Object> target, String key, AbstractUserPref pref) {
+    if (key == null || pref == null) {
+      return;
+    }
+    String def = pref.getDefaultValue();
+    if (StringUtils.isBlank(def)) {
+      // Presence of the pref still documents the allowed key for tools; skip empty defaults so
+      // encode() can store null for schema-only maps.
+      return;
+    }
+    target.put(key, coerceLayoutValue(key, def.trim()));
+  }
+
+  private static void copyMappedValues(
+      Map<String, Object> target, Map<String, Object> source, boolean styles) {
+    if (source == null || source.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<String, Object> e : source.entrySet()) {
+      if (e.getKey() == null || e.getValue() == null) {
+        continue;
+      }
+      String rawName = e.getKey().trim();
+      if (rawName.isEmpty()) {
+        continue;
+      }
+      if (styles) {
+        // Css properties map is style-primary; also accept style-ish property keys.
+        if (isLayoutUserPref(rawName) && !isStyleUserPref(rawName)) {
+          continue;
+        }
+        String key = normalizeStyleKey(rawName);
+        if (key != null) {
+          target.put(key, stringValue(e.getValue()));
+        }
+      } else {
+        if (!isLayoutUserPref(rawName)) {
+          continue;
+        }
+        String key = mapLayoutKey(rawName);
+        target.put(key, coerceLayoutValue(key, stringValue(e.getValue())));
+      }
+    }
+  }
+
+  private static void putNonSchema(Map<String, Object> out, Map<String, Object> source) {
+    if (source == null) {
+      return;
+    }
+    for (Map.Entry<String, Object> e : source.entrySet()) {
+      if (e.getKey() == null
+          || PSSlotLayoutStyles.KEY_SCHEMA_VERSION.equals(e.getKey())
+          || e.getValue() == null) {
+        continue;
+      }
+      out.put(e.getKey(), e.getValue());
+    }
+  }
+
+  /**
+   * Map CM1 list "layout" enum values (e.g. {@code ui-perc-list-horizontal}) onto orientation
+   * tokens when the target key is orientation; otherwise keep the string.
+   */
+  private static Object coerceLayoutValue(String key, String value) {
+    if (value == null) {
+      return null;
+    }
+    if (PSSlotLayoutStyles.KEY_ORIENTATION.equals(key)) {
+      String lower = value.toLowerCase(Locale.ROOT);
+      if (lower.contains("horizontal")) {
+        return "horizontal";
+      }
+      if (lower.contains("vertical")) {
+        return "vertical";
+      }
+    }
+    return value;
+  }
+
+  private static String stringValue(Object value) {
+    return value == null ? null : value.toString();
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/mapper/PSRegionToSlotCompositionMapperTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/mapper/PSRegionToSlotCompositionMapperTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.pagemanagement.data.PSRegion;
+import com.percussion.pagemanagement.data.PSRegionCode;
+import com.percussion.pagemanagement.data.PSRegionTree;
+import com.percussion.pagemanagement.data.PSWidgetDefinition;
+import com.percussion.pagemanagement.data.PSWidgetDefinition.CssPref;
+import com.percussion.pagemanagement.data.PSWidgetItem;
+import com.percussion.services.assembly.data.PSSlotLayoutStyles;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Offline unit tests for CM1 region tree → unified slot composition mapping. */
+@DisplayName("PSRegionToSlotCompositionMapper")
+class PSRegionToSlotCompositionMapperTest {
+
+  @Test
+  void mapsRegionHierarchyToSlotNames() {
+    PSRegion root = region("container", "perc-container");
+    PSRegion header = region("header", null);
+    PSRegion content = region("content", "main-content");
+    root.getChildren().add(header);
+    root.getChildren().add(newCode("<!-- sep -->"));
+    root.getChildren().add(content);
+
+    PSRegionTree tree = new PSRegionTree();
+    tree.setRootRegion(root);
+
+    PSSlotCompositionNode composition = PSRegionToSlotCompositionMapper.map(tree);
+    assertEquals("container", composition.getSlotName());
+    assertEquals("container", composition.getSourceRegionId());
+    assertEquals(
+        "perc-container", composition.getSlotStyles().get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals(2, composition.getChildren().size());
+    assertEquals("header", composition.getChildren().get(0).getSlotName());
+    assertEquals("content", composition.getChildren().get(1).getSlotName());
+    assertEquals(
+        "main-content",
+        composition.getChildren().get(1).getSlotStyles().get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+
+    Map<String, String> idMap = PSRegionToSlotCompositionMapper.regionIdToSlotNameMap(composition);
+    assertEquals(3, idMap.size());
+    assertEquals("header", idMap.get("header"));
+    assertTrue(composition.flattenPreorder().stream().noneMatch(n -> n.getSlotName().isBlank()));
+  }
+
+  @Test
+  void mapsWidgetItemsWithInstanceOverrides() {
+    PSRegion root = region("container", null);
+    PSRegion content = region("content", null);
+    root.getChildren().add(content);
+
+    PSWidgetItem item = new PSWidgetItem();
+    item.setId("-42");
+    item.setDefinitionId("percRichText");
+    Map<String, Object> css = new HashMap<>();
+    css.put("rootclass", "page-widget-root");
+    item.setCssProperties(css);
+    Map<String, Object> props = new HashMap<>();
+    props.put("layout", "ui-perc-list-horizontal");
+    item.setProperties(props);
+
+    PSRegionTree tree = new PSRegionTree();
+    tree.setRootRegion(root);
+    tree.setRegionWidgets("content", List.of(item));
+
+    PSSlotCompositionNode composition = PSRegionToSlotCompositionMapper.map(tree);
+    PSSlotCompositionNode contentNode = composition.getChildren().get(0);
+    assertEquals(1, contentNode.getItems().size());
+    PSSlotCompositionItem mapped = contentNode.getItems().get(0);
+    assertEquals("-42", mapped.getWidgetInstanceId());
+    assertEquals("percRichText", mapped.getDefinitionId());
+    assertEquals(
+        "page-widget-root", mapped.getStyleOverrides().get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals(
+        "horizontal", mapped.getLayoutOverrides().get(PSSlotLayoutStyles.KEY_ORIENTATION));
+  }
+
+  @Test
+  void mergesWidgetDefinitionDefaultsUnderInstance() {
+    PSRegion root = region("container", null);
+    PSWidgetItem item = new PSWidgetItem();
+    item.setId("-1");
+    item.setDefinitionId("w1");
+    Map<String, Object> css = new HashMap<>();
+    css.put("rootclass", "instance");
+    item.setCssProperties(css);
+
+    PSRegionTree tree = new PSRegionTree();
+    tree.setRootRegion(root);
+    tree.setRegionWidgets("container", List.of(item));
+
+    PSWidgetDefinition def = new PSWidgetDefinition();
+    def.setId("w1");
+    CssPref rootPref = new CssPref();
+    rootPref.setName("rootclass");
+    rootPref.setDefaultValue("definition-default");
+    def.getCssPref().add(rootPref);
+    CssPref sum = new CssPref();
+    sum.setName("summaryclass");
+    sum.setDefaultValue("def-summary");
+    def.getCssPref().add(sum);
+
+    Map<String, PSWidgetDefinition> defs = Map.of("w1", def);
+    PSSlotCompositionNode composition = PSRegionToSlotCompositionMapper.map(tree, defs);
+    PSSlotCompositionItem mapped = composition.getItems().get(0);
+    assertEquals("instance", mapped.getStyleOverrides().get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals("def-summary", mapped.getStyleOverrides().get("summaryclass"));
+  }
+
+  @Test
+  void requiresRootRegion() {
+    PSRegionTree tree = new PSRegionTree();
+    assertThrows(IllegalArgumentException.class, () -> PSRegionToSlotCompositionMapper.map(tree));
+  }
+
+  private static PSRegion region(String id, String cssClass) {
+    PSRegion r = new PSRegion();
+    r.setRegionId(id);
+    r.setCssClass(cssClass);
+    return r;
+  }
+
+  private static PSRegionCode newCode(String templateCode) {
+    PSRegionCode code = new PSRegionCode();
+    code.setTemplateCode(templateCode);
+    return code;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/mapper/PSWidgetPrefToSlotMapperTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/mapper/PSWidgetPrefToSlotMapperTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.pagemanagement.data.PSWidgetDefinition;
+import com.percussion.pagemanagement.data.PSWidgetDefinition.CssPref;
+import com.percussion.pagemanagement.data.PSWidgetDefinition.UserPref;
+import com.percussion.pagemanagement.data.PSWidgetItem;
+import com.percussion.services.assembly.data.PSSlotLayoutStyles;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Offline unit tests for CssPref / UserPref → slot_layout / slot_styles mapping rules. */
+@DisplayName("PSWidgetPrefToSlotMapper")
+class PSWidgetPrefToSlotMapperTest {
+
+  @Test
+  void definitionStyleDefaultsFromCssPref() {
+    PSWidgetDefinition def = new PSWidgetDefinition();
+    CssPref root = new CssPref();
+    root.setName("rootclass");
+    root.setDefaultValue("perc-widget-root");
+    def.getCssPref().add(root);
+    CssPref item = new CssPref();
+    item.setName("itemclass");
+    item.setDefaultValue("perc-item");
+    def.getCssPref().add(item);
+    CssPref custom = new CssPref();
+    custom.setName("summaryclass");
+    custom.setDefaultValue("perc-summary");
+    def.getCssPref().add(custom);
+
+    Map<String, Object> styles = PSWidgetPrefToSlotMapper.definitionStyleDefaults(def);
+    assertEquals(PSSlotLayoutStyles.SCHEMA_VERSION, styles.get(PSSlotLayoutStyles.KEY_SCHEMA_VERSION));
+    assertEquals("perc-widget-root", styles.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals("perc-item", styles.get(PSSlotLayoutStyles.KEY_ITEMCLASS));
+    assertEquals("perc-summary", styles.get("summaryclass"));
+  }
+
+  @Test
+  void definitionStyleDefaultsIncludeLegacyRootclassUserPref() {
+    PSWidgetDefinition def = new PSWidgetDefinition();
+    UserPref root = new UserPref();
+    root.setName("rootclass");
+    root.setDefaultValue("legacy-root");
+    def.getUserPref().add(root);
+
+    Map<String, Object> styles = PSWidgetPrefToSlotMapper.definitionStyleDefaults(def);
+    assertEquals("legacy-root", styles.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+  }
+
+  @Test
+  void definitionLayoutDefaultsMapLayoutAndMaxlength() {
+    PSWidgetDefinition def = new PSWidgetDefinition();
+    UserPref layout = new UserPref();
+    layout.setName("layout");
+    layout.setDefaultValue("ui-perc-list-horizontal");
+    def.getUserPref().add(layout);
+    UserPref max = new UserPref();
+    max.setName("maxlength");
+    max.setDefaultValue("10");
+    def.getUserPref().add(max);
+    UserPref nonLayout = new UserPref();
+    nonLayout.setName("target");
+    nonLayout.setDefaultValue("_blank");
+    def.getUserPref().add(nonLayout);
+
+    Map<String, Object> layoutMap = PSWidgetPrefToSlotMapper.definitionLayoutDefaults(def);
+    assertEquals("horizontal", layoutMap.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("10", layoutMap.get(PSSlotLayoutStyles.KEY_MAX_ITEMS));
+    assertFalse(layoutMap.containsKey("target"));
+  }
+
+  @Test
+  void instanceOverridesFromWidgetItem() {
+    PSWidgetItem item = new PSWidgetItem();
+    item.setId("-1");
+    item.setDefinitionId("percRichText");
+    Map<String, Object> css = new HashMap<>();
+    css.put("rootclass", "instance-root");
+    css.put("my_css", "extra");
+    item.setCssProperties(css);
+    Map<String, Object> props = new HashMap<>();
+    props.put("layout", "ui-perc-list-vertical");
+    props.put("maxlength", "3");
+    props.put("target", "_self");
+    item.setProperties(props);
+
+    Map<String, Object> styles = PSWidgetPrefToSlotMapper.instanceStyleOverrides(item);
+    assertEquals("instance-root", styles.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals("extra", styles.get("my_css"));
+    assertFalse(styles.containsKey(PSSlotLayoutStyles.KEY_ORIENTATION));
+
+    Map<String, Object> layout = PSWidgetPrefToSlotMapper.instanceLayoutOverrides(item);
+    assertEquals("vertical", layout.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("3", layout.get(PSSlotLayoutStyles.KEY_MAX_ITEMS));
+    assertFalse(layout.containsKey("target"));
+  }
+
+  @Test
+  void mergeInstanceWinsOverDefinition() {
+    Map<String, Object> base = PSSlotLayoutStyles.defaultStyles();
+    base.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "def-root");
+    base.put("summaryclass", "def-sum");
+    Map<String, Object> over = PSSlotLayoutStyles.defaultStyles();
+    over.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "inst-root");
+
+    Map<String, Object> merged = PSWidgetPrefToSlotMapper.merge(base, over, false);
+    assertEquals("inst-root", merged.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals("def-sum", merged.get("summaryclass"));
+    assertEquals(PSSlotLayoutStyles.SCHEMA_VERSION, merged.get(PSSlotLayoutStyles.KEY_SCHEMA_VERSION));
+  }
+
+  @Test
+  void nullDefinitionAndItemYieldSchemaOnlyDefaults() {
+    Map<String, Object> styles = PSWidgetPrefToSlotMapper.definitionStyleDefaults(null);
+    Map<String, Object> layout = PSWidgetPrefToSlotMapper.definitionLayoutDefaults(null);
+    assertEquals(1, styles.size());
+    assertEquals(1, layout.size());
+    assertTrue(styles.containsKey(PSSlotLayoutStyles.KEY_SCHEMA_VERSION));
+
+    Map<String, Object> instStyles = PSWidgetPrefToSlotMapper.instanceStyleOverrides(null);
+    Map<String, Object> instLayout = PSWidgetPrefToSlotMapper.instanceLayoutOverrides(null);
+    assertEquals(1, instStyles.size());
+    assertEquals(1, instLayout.size());
+  }
+
+  @Test
+  void classifyPrefNames() {
+    assertTrue(PSWidgetPrefToSlotMapper.isLayoutUserPref("Layout"));
+    assertTrue(PSWidgetPrefToSlotMapper.isLayoutUserPref("max_results"));
+    assertFalse(PSWidgetPrefToSlotMapper.isLayoutUserPref("sectionPath"));
+    assertTrue(PSWidgetPrefToSlotMapper.isStyleUserPref("RootClass"));
+    assertEquals(
+        PSSlotLayoutStyles.KEY_ORIENTATION, PSWidgetPrefToSlotMapper.mapLayoutKey("layout"));
+    assertEquals("rootclass", PSWidgetPrefToSlotMapper.normalizeStyleKey("RootClass"));
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 residual of **#2629** (grandparent epic **#2626**): CM1 region tree ↔ unified slot composition mapping sketch and CssPref / layout-ish UserPref → `slot_styles` / `slot_layout` upgrade helpers.

### Implementation (`projects/sitemanage`)

| Class | Role |
|-------|------|
| `PSRegionToSlotCompositionMapper` | `PSRegionTree` → `PSSlotCompositionNode` tree (`regionId` → slot name; nested regions; widgets → ordered items) |
| `PSWidgetPrefToSlotMapper` | CssPref + layout-ish UserPref → definition defaults + instance overrides; merge with instance wins |
| `PSSlotCompositionNode` / `PSSlotCompositionItem` | Offline composition DTOs |

### Docs

- `docs/ai-generated/tasks/template-assembler-normalization/region-slot-mapping.md` — mapping rules + residual package upgrade steps for Phase 3
- ADR-003 / parity-notes / README cross-links

### Out of scope

- REST/Workbench exposure — **#2691**
- Product Widget XML elimination — **#2630**
- Design SPA — **#2631**

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
2. Mapper unit tests (Failures: 0):
   - `PSWidgetPrefToSlotMapperTest` — Tests run: 7
   - `PSRegionToSlotCompositionMapperTest` — Tests run: 4
3. Module suite green as part of clean install

## Gates evidence

- Erlang-style self-review: pure offline mappers, no path I/O, Intersoft 2026 headers on new files, companions (tests + docs)
- Standalone clean install of **sitemanage** only (system SNAPSHOT reinstalled locally for `PSSlotLayoutStyles` from merged #2692; no system source change in this PR)
- No product UI / installer surface → no human QA issue

## Issue linkage

Fixes #2690  
Partial progress on #2629  
Refs #2626  

> Co-Authored by Grok Build using grok-4.5 with agent main.
