### PR TITLE
feat(rest,assembly): slot_layout/styles REST + instance overrides (#2691)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/003-slot-layout-styles.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/003-slot-layout-styles.md
@@ -29,6 +29,10 @@ Exposed to assembly context for JEXL/templates. **Binding names (locked for Phas
 
 Schema helper: `PSSlotLayoutStyles` (`SCHEMA_VERSION = 1`). Persistence: `RXSLOTTYPE.SLOT_LAYOUT` / `SLOT_STYLES` CLOB JSON on `PSTemplateSlot`.
 
+**REST (Developer module / #2691):** slot definition maps are exposed as `slotLayout` / `slotStyles` on `SlotDetail` (`GET/PUT /slots/{idOrName}`). Non-null maps on PUT replace definition values (empty / schema-only clears to defaults).
+
+**Instance overrides:** composition-level sparse maps merge over definition defaults via `PSSlotLayoutStyles.merge(base, overrides, layout)` (instance keys win). `clearOverride` removes a key from the override map so the definition value applies again. `toAssemblyContext(slot, layoutOverrides, stylesOverrides)` builds the effective `$sys.slot` binding. Sparse override JSON: `encodeOverrides` / `parseOverrides`.
+
 ## Rationale
 
 - Layout chrome applies to any content in a hole, not only “widgets.”

--- a/docs/ai-generated/tasks/template-assembler-normalization/binding-modules.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/binding-modules.md
@@ -41,6 +41,8 @@ so templates can read `$sys.slot.layout` and `$sys.slot.styles`. JEXL helpers on
 
 Schema constant: `PSSlotLayoutStyles.SCHEMA_VERSION` (v1). Known layout keys: `orientation`, `columns`, `maxItems`, `emptyState`, `wrapperClassPolicy`. Styles (CM1 parity first): `rootclass`, `itemclass`.
 
+**Instance overrides (#2691):** `PSSlotLayoutStyles.merge(definition, overrides, layout|styles)` — override keys win; `clearOverride(overrides, key)` restores definition for that key; `toAssemblyContext(slot, layoutOv, stylesOv)` for effective assembly binding. REST definition maps: `SlotDetail.slotLayout` / `slotStyles`.
+
 ## `$rx` (JEXL tool namespaces)
 
 Java classes annotated with `@IPSJexlMethod` registered under namespaces such as:

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
@@ -145,6 +145,13 @@ public class SlotsAdaptor implements ISlotsAdaptor {
       if (body.getDescription() != null) {
         slot.setDescription(body.getDescription());
       }
+      // Non-null layout/styles replace definition maps (empty/schema-only clears to defaults).
+      if (body.getSlotLayout() != null) {
+        slot.setSlotLayout(body.getSlotLayout());
+      }
+      if (body.getSlotStyles() != null) {
+        slot.setSlotStyles(body.getSlotStyles());
+      }
       if (body.getAssociations() != null) {
         slot.setSlotAssociations(toAssociationPairs(body.getAssociations()));
       }
@@ -311,6 +318,16 @@ public class SlotsAdaptor implements ISlotsAdaptor {
       d.setFinderArguments(new HashMap<>(args));
     } else {
       d.setFinderArguments(null);
+    }
+
+    // ADR-003 / #2691: expose definition slot_layout / slot_styles on REST wire DTO.
+    Map<String, Object> layout = slot.getSlotLayout();
+    if (layout != null && !layout.isEmpty()) {
+      d.setSlotLayout(new HashMap<>(layout));
+    }
+    Map<String, Object> styles = slot.getSlotStyles();
+    if (styles != null && !styles.isEmpty()) {
+      d.setSlotStyles(new HashMap<>(styles));
     }
 
     List<SlotAssociationSummary> associations = new ArrayList<>();

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorDesignWsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorDesignWsTest.java
@@ -1,10 +1,24 @@
 /*
  * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.percussion.apibridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -14,19 +28,41 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.percussion.rest.slots.SlotDetail;
 import com.percussion.rest.slots.SlotSummary;
 import com.percussion.services.assembly.IPSTemplateSlot;
+import com.percussion.services.assembly.data.PSSlotLayoutStyles;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.assembly.IPSAssemblyDesignWs;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 @Tag("UnitTest")
 class SlotsAdaptorDesignWsTest {
+
+  @BeforeEach
+  void setRequestInfo() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "test-user");
+  }
+
+  @AfterEach
+  void clearRequestInfo() {
+    PSRequestInfo.resetRequestInfo();
+  }
 
   @Test
   void listSlots_usesFindAndLoadOnDesignWs() throws Exception {
@@ -58,5 +94,86 @@ class SlotsAdaptorDesignWsTest {
     IPSAssemblyDesignWs designWs = mock(IPSAssemblyDesignWs.class);
     when(designWs.findSlots(isNull(), isNull())).thenReturn(List.of());
     assertTrue(new SlotsAdaptor(designWs).listSlots(null).isEmpty());
+  }
+
+  @Test
+  void getSlot_exposesLayoutAndStyles() throws Exception {
+    IPSAssemblyDesignWs designWs = mock(IPSAssemblyDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.SLOT, 11L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn("rffList");
+    when(sum.getLabel()).thenReturn("List");
+
+    Map<String, Object> layout = new LinkedHashMap<>();
+    layout.put(PSSlotLayoutStyles.KEY_SCHEMA_VERSION, PSSlotLayoutStyles.SCHEMA_VERSION);
+    layout.put(PSSlotLayoutStyles.KEY_ORIENTATION, "horizontal");
+    Map<String, Object> styles = new LinkedHashMap<>();
+    styles.put(PSSlotLayoutStyles.KEY_SCHEMA_VERSION, PSSlotLayoutStyles.SCHEMA_VERSION);
+    styles.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "slot-root");
+
+    IPSTemplateSlot slot = mock(IPSTemplateSlot.class);
+    when(slot.getName()).thenReturn("rffList");
+    when(slot.getLabel()).thenReturn("List");
+    when(slot.getGUID()).thenReturn(guid);
+    when(slot.getSlotLayout()).thenReturn(layout);
+    when(slot.getSlotStyles()).thenReturn(styles);
+    when(slot.isSystemSlot()).thenReturn(false);
+
+    when(designWs.findSlots(eq("rffList"), isNull())).thenReturn(List.of(sum));
+    when(designWs.loadSlots(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+
+    SlotDetail detail = new SlotsAdaptor(designWs).getSlot(null, "rffList");
+    assertNotNull(detail);
+    assertEquals("horizontal", detail.getSlotLayout().get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("slot-root", detail.getSlotStyles().get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+  }
+
+  @Test
+  void updateSlot_writesLayoutAndStyles() throws Exception {
+    IPSAssemblyDesignWs designWs = mock(IPSAssemblyDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.SLOT, 12L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn("rffList");
+    when(sum.getLabel()).thenReturn("List");
+
+    IPSTemplateSlot slot = mock(IPSTemplateSlot.class);
+    when(slot.getName()).thenReturn("rffList");
+    when(slot.getLabel()).thenReturn("List");
+    when(slot.getGUID()).thenReturn(guid);
+    when(slot.getSlotLayout()).thenReturn(new HashMap<>(PSSlotLayoutStyles.defaultLayout()));
+    when(slot.getSlotStyles()).thenReturn(new HashMap<>(PSSlotLayoutStyles.defaultStyles()));
+    when(slot.isSystemSlot()).thenReturn(false);
+
+    when(designWs.findSlots(eq("rffList"), isNull())).thenReturn(List.of(sum));
+    // forEdit=true then reload forEdit=false
+    when(designWs.loadSlots(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+    when(designWs.loadSlots(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+
+    SlotDetail body = new SlotDetail();
+    Map<String, Object> layout = new LinkedHashMap<>();
+    layout.put(PSSlotLayoutStyles.KEY_ORIENTATION, "vertical");
+    layout.put(PSSlotLayoutStyles.KEY_COLUMNS, "3");
+    Map<String, Object> styles = new LinkedHashMap<>();
+    styles.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "updated-root");
+    body.setSlotLayout(layout);
+    body.setSlotStyles(styles);
+
+    new SlotsAdaptor(designWs).updateSlot(null, "rffList", body);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> layoutCap = ArgumentCaptor.forClass(Map.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> stylesCap = ArgumentCaptor.forClass(Map.class);
+    verify(slot).setSlotLayout(layoutCap.capture());
+    verify(slot).setSlotStyles(stylesCap.capture());
+    assertEquals("vertical", layoutCap.getValue().get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("3", layoutCap.getValue().get(PSSlotLayoutStyles.KEY_COLUMNS));
+    assertEquals("updated-root", stylesCap.getValue().get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    verify(designWs).saveSlots(anyList(), eq(true), eq("test-session"), eq("test-user"));
   }
 }

--- a/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
@@ -34,10 +34,12 @@ public interface ISlotsAdaptor {
   SlotDetail getSlot(URI baseUri, String idOrName);
 
   /**
-   * Update mutable slot design fields (label, description) and optionally replace content-type /
-   * template associations. When {@code body.associations} is {@code null}, associations are left
-   * unchanged; a non-null list (including empty) replaces the full association set. Name/id is not
-   * changed via this path.
+   * Update mutable slot design fields (label, description, {@code slotLayout}, {@code slotStyles})
+   * and optionally replace content-type / template associations. When {@code body.associations} is
+   * {@code null}, associations are left unchanged; a non-null list (including empty) replaces the
+   * full association set. When {@code body.slotLayout} / {@code body.slotStyles} is non-null, that
+   * map replaces the definition layout/styles (empty or schema-only clears to defaults); null
+   * leaves the field unchanged. Name/id is not changed via this path.
    *
    * @return updated detail, or {@code null} if not found
    */

--- a/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
@@ -42,6 +42,31 @@ public class SlotDetail {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private Map<String, String> finderArguments;
 
+  /**
+   * Structural {@code slot_layout} map (ADR-003). Keys include {@code schemaVersion} plus layout
+   * properties (e.g. {@code orientation}, {@code columns}, {@code maxItems}). On update, a non-null
+   * map replaces the definition layout; omit or leave null to leave unchanged. Empty / schema-only
+   * maps clear stored layout to defaults.
+   */
+  @Schema(
+      description =
+          "slot_layout map (schemaVersion + structural keys). Non-null on PUT replaces definition"
+              + " layout; null leaves unchanged.")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private Map<String, Object> slotLayout;
+
+  /**
+   * Presentational {@code slot_styles} map (ADR-003). Keys include {@code schemaVersion} plus style
+   * tokens (e.g. {@code rootclass}, {@code itemclass}). Same update semantics as {@link
+   * #slotLayout}.
+   */
+  @Schema(
+      description =
+          "slot_styles map (schemaVersion + style tokens). Non-null on PUT replaces definition"
+              + " styles; null leaves unchanged.")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private Map<String, Object> slotStyles;
+
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private List<SlotAssociationSummary> associations;
 
@@ -120,6 +145,22 @@ public class SlotDetail {
 
   public void setFinderArguments(Map<String, String> finderArguments) {
     this.finderArguments = finderArguments;
+  }
+
+  public Map<String, Object> getSlotLayout() {
+    return slotLayout;
+  }
+
+  public void setSlotLayout(Map<String, Object> slotLayout) {
+    this.slotLayout = slotLayout;
+  }
+
+  public Map<String, Object> getSlotStyles() {
+    return slotStyles;
+  }
+
+  public void setSlotStyles(Map<String, Object> slotStyles) {
+    this.slotStyles = slotStyles;
   }
 
   public List<SlotAssociationSummary> getAssociations() {

--- a/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
@@ -102,8 +102,9 @@ public class SlotsResource {
   @Operation(
       summary = "Get slot design detail",
       description =
-          "Read-only slot detail including finder metadata and content-type/template"
-              + " associations. Create/update/delete not supported (see designGaps).",
+          "Slot detail including finder metadata, content-type/template associations, and"
+              + " ADR-003 slot_layout / slot_styles maps. Create/delete not supported (see"
+              + " designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -138,9 +139,10 @@ public class SlotsResource {
   @Operation(
       summary = "Update slot design fields",
       description =
-          "Updates mutable slot fields: label and/or description. When associations is present"
-              + " (including empty), replaces the full content-type/template association set."
-              + " Omit associations to leave them unchanged. Name/id is immutable."
+          "Updates mutable slot fields: label, description, slotLayout, and/or slotStyles. When"
+              + " associations is present (including empty), replaces the full content-type/template"
+              + " association set. Non-null slotLayout/slotStyles replace definition maps (empty or"
+              + " schema-only clears to defaults); omit to leave unchanged. Name/id is immutable."
               + " Create/delete/lock remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(

--- a/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
@@ -214,4 +214,31 @@ public class SlotsResourceDetailTest {
         "0-2-301",
         result.getAssociations().get(0).getContentTypeGuid().getStringValue().orElse(null));
   }
+
+  @Test
+  public void getSlotReturnsLayoutAndStyles() {
+    SlotDetail d = new SlotDetail();
+    d.setName("styled");
+    d.setSlotLayout(java.util.Map.of("schemaVersion", 1, "orientation", "horizontal"));
+    d.setSlotStyles(java.util.Map.of("schemaVersion", 1, "rootclass", "my-root"));
+    when(adaptor.getSlot(any(), eq("styled"))).thenReturn(d);
+    SlotDetail out = resource.getSlot("styled");
+    assertEquals("horizontal", out.getSlotLayout().get("orientation"));
+    assertEquals("my-root", out.getSlotStyles().get("rootclass"));
+  }
+
+  @Test
+  public void updateSlotWithLayoutAndStyles() {
+    SlotDetail body = new SlotDetail();
+    body.setSlotLayout(java.util.Map.of("orientation", "vertical", "columns", "3"));
+    body.setSlotStyles(java.util.Map.of("rootclass", "updated-root"));
+    SlotDetail updated = new SlotDetail();
+    updated.setName("target");
+    updated.setSlotLayout(body.getSlotLayout());
+    updated.setSlotStyles(body.getSlotStyles());
+    when(adaptor.updateSlot(any(), eq("target"), any())).thenReturn(updated);
+    SlotDetail result = resource.updateSlot("target", body);
+    assertEquals("vertical", result.getSlotLayout().get("orientation"));
+    assertEquals("updated-root", result.getSlotStyles().get("rootclass"));
+  }
 }

--- a/system/services/src/com/percussion/services/assembly/data/PSSlotLayoutStyles.java
+++ b/system/services/src/com/percussion/services/assembly/data/PSSlotLayoutStyles.java
@@ -200,14 +200,129 @@ public final class PSSlotLayoutStyles {
    */
   public static Map<String, Object> toAssemblyContext(IPSTemplateSlot slot) {
     Objects.requireNonNull(slot, "slot");
+    return toAssemblyContext(slot, null, null);
+  }
+
+  /**
+   * Build assembly context merging composition-level instance overrides over slot definition
+   * defaults. Override map keys win; absent override keys keep definition values. Pass {@code
+   * null}/empty override maps to use definition only.
+   *
+   * @param slot never {@code null}
+   * @param layoutOverrides sparse layout overrides (may be {@code null})
+   * @param stylesOverrides sparse styles overrides (may be {@code null})
+   * @return unmodifiable context map; never {@code null}
+   */
+  public static Map<String, Object> toAssemblyContext(
+      IPSTemplateSlot slot,
+      Map<String, Object> layoutOverrides,
+      Map<String, Object> stylesOverrides) {
+    Objects.requireNonNull(slot, "slot");
+    Map<String, Object> layout = merge(slot.getSlotLayout(), layoutOverrides, true);
+    Map<String, Object> styles = merge(slot.getSlotStyles(), stylesOverrides, false);
     Map<String, Object> ctx = new LinkedHashMap<>();
-    Map<String, Object> layout = slot.getSlotLayout();
-    Map<String, Object> styles = slot.getSlotStyles();
-    ctx.put(CTX_LAYOUT, Collections.unmodifiableMap(new LinkedHashMap<>(layout)));
-    ctx.put(CTX_STYLES, Collections.unmodifiableMap(new LinkedHashMap<>(styles)));
+    ctx.put(CTX_LAYOUT, Collections.unmodifiableMap(layout));
+    ctx.put(CTX_STYLES, Collections.unmodifiableMap(styles));
     ctx.put(CTX_SCHEMA_VERSION, SCHEMA_VERSION);
     ctx.put(CTX_NAME, slot.getName());
     return Collections.unmodifiableMap(ctx);
+  }
+
+  /**
+   * Merge definition (base) maps with composition-level instance overrides. Instance keys win.
+   * {@link #KEY_SCHEMA_VERSION} is always set to the max of base/override versions (or {@link
+   * #SCHEMA_VERSION}). Null or empty overrides return a normalized copy of base.
+   *
+   * <p>To <em>clear</em> an override for a key, remove that key from the override map (do not put
+   * {@code null} — null values are ignored). After clear, the definition value shows through.
+   *
+   * @param base definition defaults (may be {@code null} → empty defaults)
+   * @param overrides sparse instance overrides (may be {@code null})
+   * @param layout {@code true} for layout maps, {@code false} for styles
+   * @return new mutable effective map, never {@code null}
+   */
+  public static Map<String, Object> merge(
+      Map<String, Object> base, Map<String, Object> overrides, boolean layout) {
+    Map<String, Object> out = layout ? defaultLayout() : defaultStyles();
+    putNonSchema(out, base);
+    putNonSchema(out, overrides);
+    int ver = Math.max(schemaVersionOf(base), schemaVersionOf(overrides));
+    out.put(KEY_SCHEMA_VERSION, ver >= 1 ? ver : SCHEMA_VERSION);
+    return out;
+  }
+
+  /**
+   * Remove a property from a sparse instance-override map so the definition default applies again
+   * on the next {@link #merge}. Does not modify definition maps. No-op if map or key is null, or
+   * key is absent.
+   *
+   * @param overrides mutable override map (may be {@code null})
+   * @param key property to clear (may be {@code null})
+   * @return the same map instance, or {@code null} if overrides was {@code null}
+   */
+  public static Map<String, Object> clearOverride(Map<String, Object> overrides, String key) {
+    if (overrides == null || key == null) {
+      return overrides;
+    }
+    overrides.remove(key);
+    return overrides;
+  }
+
+  /**
+   * Encode a sparse instance-override map for composition storage. Empty / null / schema-only →
+   * {@code null} (no override stored).
+   *
+   * @param overrides may be {@code null}
+   * @param layout {@code true} for layout, {@code false} for styles
+   * @return JSON text or {@code null}
+   */
+  public static String encodeOverrides(Map<String, Object> overrides, boolean layout) {
+    if (overrides == null || overrides.isEmpty()) {
+      return null;
+    }
+    // Reuse encode path: schema-only collapses to null.
+    return layout ? encodeLayout(overrides) : encodeStyles(overrides);
+  }
+
+  /**
+   * Parse a sparse instance-override JSON blob. Blank/invalid → empty mutable map (no overrides).
+   * Unlike {@link #parseLayout}, does not inject defaults other than schema version when the blob
+   * is non-blank — for blank input returns an empty map (caller merges onto definition).
+   *
+   * @param json may be {@code null} or blank
+   * @return mutable map, never {@code null} (empty when no overrides)
+   */
+  public static Map<String, Object> parseOverrides(String json) {
+    Map<String, Object> raw = parseJson(json);
+    if (raw == null || raw.isEmpty()) {
+      return new LinkedHashMap<>();
+    }
+    Map<String, Object> out = new LinkedHashMap<>();
+    for (Map.Entry<String, Object> e : raw.entrySet()) {
+      if (e.getKey() == null || e.getValue() == null) {
+        continue;
+      }
+      if (KEY_SCHEMA_VERSION.equals(e.getKey())) {
+        out.put(KEY_SCHEMA_VERSION, schemaVersionOf(raw));
+      } else {
+        out.put(e.getKey(), e.getValue());
+      }
+    }
+    return out;
+  }
+
+  private static void putNonSchema(Map<String, Object> out, Map<String, Object> src) {
+    if (src == null || src.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<String, Object> e : src.entrySet()) {
+      if (e.getKey() == null || KEY_SCHEMA_VERSION.equals(e.getKey())) {
+        continue;
+      }
+      if (e.getValue() != null) {
+        out.put(e.getKey(), e.getValue());
+      }
+    }
   }
 
   /**

--- a/system/src/test/java/com/percussion/services/assembly/data/PSSlotLayoutStylesTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/data/PSSlotLayoutStylesTest.java
@@ -133,4 +133,107 @@ class PSSlotLayoutStylesTest {
     // Jackson rejects direct self-references; encode must not silently return null.
     assertThrows(IllegalStateException.class, () -> PSSlotLayoutStyles.encodeLayout(layout));
   }
+
+  @Test
+  void mergeInstanceOverrideWinsOverDefinition() {
+    Map<String, Object> definition = new LinkedHashMap<>();
+    definition.put(PSSlotLayoutStyles.KEY_ORIENTATION, "vertical");
+    definition.put(PSSlotLayoutStyles.KEY_COLUMNS, "2");
+    definition.put(PSSlotLayoutStyles.KEY_MAX_ITEMS, "5");
+
+    Map<String, Object> instance = new LinkedHashMap<>();
+    instance.put(PSSlotLayoutStyles.KEY_ORIENTATION, "horizontal");
+    instance.put(PSSlotLayoutStyles.KEY_MAX_ITEMS, "10");
+
+    Map<String, Object> effective = PSSlotLayoutStyles.merge(definition, instance, true);
+    assertEquals("horizontal", effective.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("2", effective.get(PSSlotLayoutStyles.KEY_COLUMNS));
+    assertEquals("10", effective.get(PSSlotLayoutStyles.KEY_MAX_ITEMS));
+    assertEquals(
+        PSSlotLayoutStyles.SCHEMA_VERSION, effective.get(PSSlotLayoutStyles.KEY_SCHEMA_VERSION));
+  }
+
+  @Test
+  void mergeClearOverrideRestoresDefinitionDefault() {
+    Map<String, Object> definition = new LinkedHashMap<>();
+    definition.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "def-root");
+    definition.put(PSSlotLayoutStyles.KEY_ITEMCLASS, "def-item");
+
+    Map<String, Object> instance = new LinkedHashMap<>();
+    instance.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "inst-root");
+
+    Map<String, Object> withOverride = PSSlotLayoutStyles.merge(definition, instance, false);
+    assertEquals("inst-root", withOverride.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals("def-item", withOverride.get(PSSlotLayoutStyles.KEY_ITEMCLASS));
+
+    PSSlotLayoutStyles.clearOverride(instance, PSSlotLayoutStyles.KEY_ROOTCLASS);
+    Map<String, Object> afterClear = PSSlotLayoutStyles.merge(definition, instance, false);
+    assertEquals("def-root", afterClear.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals("def-item", afterClear.get(PSSlotLayoutStyles.KEY_ITEMCLASS));
+  }
+
+  @Test
+  void mergeNullOrEmptyOverridesReturnsDefinition() {
+    Map<String, Object> definition = new LinkedHashMap<>();
+    definition.put(PSSlotLayoutStyles.KEY_ORIENTATION, "vertical");
+    Map<String, Object> fromNull = PSSlotLayoutStyles.merge(definition, null, true);
+    Map<String, Object> fromEmpty = PSSlotLayoutStyles.merge(definition, Map.of(), true);
+    assertEquals("vertical", fromNull.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("vertical", fromEmpty.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+  }
+
+  @Test
+  void instanceOverrideRoundTripEncodeParse() {
+    Map<String, Object> overrides = new LinkedHashMap<>();
+    overrides.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "page-root");
+    overrides.put(PSSlotLayoutStyles.KEY_ORIENTATION, "horizontal");
+
+    String layoutJson = PSSlotLayoutStyles.encodeOverrides(overrides, true);
+    String stylesJson = PSSlotLayoutStyles.encodeOverrides(overrides, false);
+    assertNotNull(layoutJson);
+    assertNotNull(stylesJson);
+
+    Map<String, Object> parsedLayout = PSSlotLayoutStyles.parseOverrides(layoutJson);
+    Map<String, Object> parsedStyles = PSSlotLayoutStyles.parseOverrides(stylesJson);
+    assertEquals("horizontal", parsedLayout.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("page-root", parsedStyles.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+
+    Map<String, Object> defLayout = new LinkedHashMap<>();
+    defLayout.put(PSSlotLayoutStyles.KEY_ORIENTATION, "vertical");
+    defLayout.put(PSSlotLayoutStyles.KEY_COLUMNS, "3");
+    Map<String, Object> effective = PSSlotLayoutStyles.merge(defLayout, parsedLayout, true);
+    assertEquals("horizontal", effective.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("3", effective.get(PSSlotLayoutStyles.KEY_COLUMNS));
+
+    assertNull(PSSlotLayoutStyles.encodeOverrides(null, true));
+    assertNull(PSSlotLayoutStyles.encodeOverrides(Map.of(), false));
+    assertTrue(PSSlotLayoutStyles.parseOverrides(null).isEmpty());
+    assertTrue(PSSlotLayoutStyles.parseOverrides("  ").isEmpty());
+  }
+
+  @Test
+  void toAssemblyContextAppliesInstanceOverrides() {
+    PSTemplateSlot slot = new PSTemplateSlot();
+    slot.setName("testSlot");
+    Map<String, Object> layout = new LinkedHashMap<>();
+    layout.put(PSSlotLayoutStyles.KEY_ORIENTATION, "vertical");
+    slot.setSlotLayout(layout);
+    Map<String, Object> styles = new LinkedHashMap<>();
+    styles.put(PSSlotLayoutStyles.KEY_ROOTCLASS, "def-root");
+    slot.setSlotStyles(styles);
+
+    Map<String, Object> layoutOv = Map.of(PSSlotLayoutStyles.KEY_ORIENTATION, "horizontal");
+    Map<String, Object> stylesOv = Map.of(PSSlotLayoutStyles.KEY_ROOTCLASS, "inst-root");
+    Map<String, Object> ctx = PSSlotLayoutStyles.toAssemblyContext(slot, layoutOv, stylesOv);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> ctxLayout =
+        (Map<String, Object>) ctx.get(PSSlotLayoutStyles.CTX_LAYOUT);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> ctxStyles =
+        (Map<String, Object>) ctx.get(PSSlotLayoutStyles.CTX_STYLES);
+    assertEquals("horizontal", ctxLayout.get(PSSlotLayoutStyles.KEY_ORIENTATION));
+    assertEquals("inst-root", ctxStyles.get(PSSlotLayoutStyles.KEY_ROOTCLASS));
+    assertEquals("testSlot", ctx.get(PSSlotLayoutStyles.CTX_NAME));
+  }
 }


### PR DESCRIPTION
## Summary

Phase 2 residual of **#2629** (grandparent epic **#2626**): REST/Workbench exposure of `slot_layout` / `slot_styles` on slot design detail, plus composition-level **instance override** merge over definition defaults.

### REST (`rest` + `sitemanage`)

| Piece | Change |
|-------|--------|
| `SlotDetail` | Wire fields `slotLayout` / `slotStyles` (`Map<String,Object>`) |
| `ISlotsAdaptor` / `SlotsResource` | Document read/write semantics |
| `SlotsAdaptor` | Map definition maps on GET; non-null maps on PUT replace (empty/schema-only → defaults) |
| Spring test stub | Existing `TestSlotsAdaptor` still implements interface (no signature change) |

### Instance overrides (`system`)

| API | Role |
|-----|------|
| `PSSlotLayoutStyles.merge(base, overrides, layout)` | Instance keys win over definition |
| `clearOverride(overrides, key)` | Remove sparse override so definition applies again |
| `encodeOverrides` / `parseOverrides` | Sparse composition JSON round-trip |
| `toAssemblyContext(slot, layoutOv, stylesOv)` | Effective `$sys.slot` binding |

### Out of scope

- CM1 region mapping / CssPref upgrade — **#2690**
- Product Widget XML elimination — **#2630**
- Design SPA — **#2631**

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd system && ../mvnw.cmd clean install -Dmaven.javadoc.skip=true` — **BUILD SUCCESS** (JDK 21)
2. `cd rest && ../mvnw.cmd clean install -Dmaven.javadoc.skip=true` — **BUILD SUCCESS**
3. `cd projects/sitemanage && ../../mvnw.cmd clean install -Dmaven.javadoc.skip=true` — **BUILD SUCCESS**
4. Unit tests (Failures: 0):
   - `PSSlotLayoutStylesTest` — Tests run: **15** (includes override wins, clear override, round-trip, assembly context)
   - `SlotsResourceDetailTest` — Tests run: **18**
   - `SlotsAdaptorDesignWsTest` — Tests run: **4**

## Gates evidence

- Erlang-style self-review: rest+sitemanage change-class companions (DTO + adaptor interface + apibridge + Spring test stub + resource/adaptor tests); no non-portable paths
- Standalone clean install per changed module
- No product UI / installer surface → no human QA issue

## Issue linkage

Fixes #2691  
Partial progress on #2629  
Refs #2626  

> Co-Authored by Grok Build using grok-4.5 with agent main.
