### PR TITLE
feat(auditlog): permission-gated CSV/JSON export (#2715)

### DIFF
--- a/docs/ai-generated/tasks/system-audit-log/design.md
+++ b/docs/ai-generated/tasks/system-audit-log/design.md
@@ -72,10 +72,13 @@ SystemErrorCode (*ErrorCodes) → AuditLogService
 |--------|------|-------|
 | `GET` | `/Rhythmyx/rest/auditlog/entries` | Admin or property |
 | `GET` | `/Rhythmyx/rest/auditlog/entries/{auditId}` | Admin or property |
+| `GET` | `/Rhythmyx/rest/auditlog/export?format=csv\|json` | Admin or property (Phase 5 / #2715) |
 
 Query parameters on list: `from`, `to` (ISO-8601 instants), `module`, `eventType`, `outcome`, `actor`, `offset`, `limit` (default 50, max 200).
 
-Responses: `200` page/entry, `403` without permission, `404` missing id, `400` bad dates.
+Export uses the same filters plus `format` (`csv`/`json`) and `maxRows` (default 5000, max 10000). See [export.md](export.md).
+
+Responses: `200` page/entry/export body, `403` without permission, `404` missing id, `400` bad dates/format.
 
 **Not in Phase 3:** Admin WebUI viewer / Playwright (#2619).
 

--- a/docs/ai-generated/tasks/system-audit-log/export.md
+++ b/docs/ai-generated/tasks/system-audit-log/export.md
@@ -1,0 +1,56 @@
+# System audit log export (CSV / JSON)
+
+**Issue:** [#2715](https://github.com/intersoftdatalabs-in/percussioncms/issues/2715) (Parent [#2620](https://github.com/intersoftdatalabs-in/percussioncms/issues/2620) Phase 5 slice 1)  
+**Status:** Implemented (REST)
+
+## Endpoint
+
+| Method | Path | AuthZ |
+|--------|------|-------|
+| `GET` | `/Rhythmyx/rest/auditlog/export` | Admin role **or** role property `sys_securityAuditLogViewer` (truthy) |
+
+Same permission model as Phase 3 query API (`GET /auditlog/entries`). Unauthorized → **HTTP 403**.
+
+### Query parameters
+
+| Param | Description |
+|-------|-------------|
+| `format` | `csv` or `json` (default `json`) |
+| `from` / `to` | ISO-8601 instants (same as query API) |
+| `module` | Module code filter (e.g. `AUTH`) |
+| `eventType` | Event type filter |
+| `outcome` | Outcome filter (`SUCCESS`, `FAILURE`, …) |
+| `actor` | Actor (user name), case-insensitive |
+| `maxRows` | Max rows to export (default **5000**, hard cap **10000**) |
+
+### Response
+
+| Format | Content-Type | Content-Disposition |
+|--------|--------------|---------------------|
+| `json` | `application/json` | `attachment; filename="system-audit-log.json"` |
+| `csv` | `text/csv` | `attachment; filename="system-audit-log.csv"` |
+
+- **JSON:** root array of entry objects (ISO-8601 `eventTime`, no root wrapper).
+- **CSV:** RFC 4180-style header + data rows; columns match wire DTO field names (`auditId`, `eventTime`, `moduleCode`, …).
+
+### Examples
+
+```http
+GET /Rhythmyx/rest/auditlog/export?format=csv&module=AUTH&from=2026-01-01T00:00:00Z
+GET /Rhythmyx/rest/auditlog/export?format=json&actor=admin&maxRows=1000
+```
+
+## Layers
+
+| Layer | Location |
+|-------|----------|
+| Resource | `rest` `com.percussion.rest.auditlog.AuditLogResource` |
+| Formatter | `rest` `SystemAuditLogExport` |
+| Adaptor | `rest` `IAuditLogAdaptor#export` → `sitemanage` `AuditLogAdaptor` |
+| Store | `PSSystemAuditLogRepository#findEntries` (paged under the export cap) |
+
+## Out of scope (siblings)
+
+- Audit-of-audit (viewer access events) — separate slice
+- Federal/ops runbook + integrity hash — separate slice
+- Admin SPA export button — optional follow-up (REST-only is enough for this slice)

--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -113,10 +113,11 @@ Phase 2a migrated production call sites to `PSSystemAuditLogger` helpers + packa
 
 **REST** (public adaptor pattern):
 
-* Resource: `com.percussion.rest.auditlog.AuditLogResource` → `/auditlog/entries`
-* Interface: `IAuditLogAdaptor`
+* Resource: `com.percussion.rest.auditlog.AuditLogResource` → `/auditlog/entries`, `/auditlog/entries/{auditId}`, `/auditlog/export`
+* Interface: `IAuditLogAdaptor` (query + export)
 * Impl: `com.percussion.apibridge.AuditLogAdaptor` (sitemanage) → `PSSystemAuditLogRepository` query helpers
 * Seed: installer `cmsTableData.xml` registers the property and seeds Admin=`true`
+* Export (#2715): `GET /auditlog/export?format=csv|json` with the same AuthZ and filters; see `docs/ai-generated/tasks/system-audit-log/export.md`
 
 Unauthorized callers receive HTTP **403**. Admin UI for browsing is Phase 4 (#2619).
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
@@ -20,6 +20,7 @@ import static com.percussion.webservices.PSWebserviceUtils.getUserRoles;
 
 import com.percussion.rest.auditlog.IAuditLogAdaptor;
 import com.percussion.rest.auditlog.SystemAuditLogEntry;
+import com.percussion.rest.auditlog.SystemAuditLogExport;
 import com.percussion.rest.auditlog.SystemAuditLogPage;
 import com.percussion.security.IPSPrincipalAttribute;
 import com.percussion.services.audit.PSSystemAuditLogPermission;
@@ -44,7 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
 /**
- * sitemanage apibridge for system audit log query API (#2618).
+ * sitemanage apibridge for system audit log query (#2618) and export (#2715).
  *
  * <p>AuthZ: {@link PSSystemAuditLogPermission} — Admin always allowed, otherwise role property
  * {@code sys_securityAuditLogViewer}.
@@ -114,6 +115,43 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
     }
     Optional<PSSystemAuditLogEntry> found = repository.findById(auditId.trim());
     return found.map(AuditLogAdaptor::toDto).orElse(null);
+  }
+
+  @Override
+  public List<SystemAuditLogEntry> export(
+      String fromIso,
+      String toIso,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor,
+      int maxRows) {
+    requireViewer();
+    Instant from = parseInstant(fromIso, "from");
+    Instant to = parseInstant(toIso, "to");
+    int cap = SystemAuditLogExport.clampMaxRows(maxRows);
+
+    // Page through repository (query hard-cap 200) until export cap or end of result set.
+    List<SystemAuditLogEntry> all = new ArrayList<>(Math.min(cap, 256));
+    int offset = 0;
+    while (all.size() < cap) {
+      int pageSize =
+          Math.min(PSSystemAuditLogRepository.MAX_PAGE_SIZE, cap - all.size());
+      List<PSSystemAuditLogEntry> rows =
+          repository.findEntries(
+              from, to, moduleCode, eventType, outcome, actor, offset, pageSize);
+      if (rows == null || rows.isEmpty()) {
+        break;
+      }
+      for (PSSystemAuditLogEntry row : rows) {
+        all.add(toDto(row));
+      }
+      offset += rows.size();
+      if (rows.size() < pageSize) {
+        break;
+      }
+    }
+    return all;
   }
 
   private void requireViewer() {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
@@ -130,6 +130,64 @@ class AuditLogAdaptorTest {
     verify(repo, never()).findById(anyString());
   }
 
+  @Test
+  void exportAdminPagesThroughRepositoryAndMaps() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    when(repo.findEntries(
+            isNull(), isNull(), eq("AUTH"), isNull(), isNull(), isNull(), eq(0), eq(50)))
+        .thenReturn(List.of(sampleRow()));
+
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+
+    List<SystemAuditLogEntry> out =
+        adaptor.export(null, null, "AUTH", null, null, null, 50);
+    assertEquals(1, out.size());
+    assertEquals("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", out.get(0).getAuditId());
+    assertEquals("AUTH", out.get(0).getModuleCode());
+    verify(repo)
+        .findEntries(
+            isNull(), isNull(), eq("AUTH"), isNull(), isNull(), isNull(), eq(0), eq(50));
+  }
+
+  @Test
+  void exportUnauthorizedDoesNotTouchRepo() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false);
+
+    assertThrows(
+        SecurityException.class,
+        () -> adaptor.export(null, null, null, null, null, null, 100));
+    verify(repo, never())
+        .findEntries(any(), any(), any(), any(), any(), any(), anyInt(), anyInt());
+  }
+
+  @Test
+  void exportPropertyHolderAllowed() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    when(repo.findEntries(any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(List.of());
+
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Editor"), role -> "Editor".equals(role));
+
+    List<SystemAuditLogEntry> out =
+        adaptor.export(null, null, null, null, null, null, 10);
+    assertNotNull(out);
+    assertEquals(0, out.size());
+  }
+
+  @Test
+  void exportInvalidFromIsIllegalArgument() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.export("not-an-instant", null, null, null, null, null, 10));
+  }
+
   private static PSSystemAuditLogEntry sampleRow() {
     PSSystemAuditLogEntry e = new PSSystemAuditLogEntry();
     e.setAuditId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");

--- a/rest/src/main/java/com/percussion/rest/auditlog/AuditLogResource.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/AuditLogResource.java
@@ -32,16 +32,19 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Public REST surface for querying {@code PSX_SYSTEM_AUDIT_LOG} (Phase 3 / #2618).
+ * Public REST surface for querying and exporting {@code PSX_SYSTEM_AUDIT_LOG} (Phase 3 / #2618,
+ * Phase 5 export / #2715).
  *
  * <pre>
  *   GET /Rhythmyx/rest/auditlog/entries
  *   GET /Rhythmyx/rest/auditlog/entries/{auditId}
+ *   GET /Rhythmyx/rest/auditlog/export?format=csv|json
  * </pre>
  *
  * <p>AuthZ is enforced in the sitemanage apibridge: Admin role or role property {@code
@@ -52,10 +55,12 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 @PSSiteManageBean(value = "restAuditLogResource")
 @Path("/auditlog")
-@Tag(name = "Audit Log", description = "System security audit log query API")
+@Tag(name = "Audit Log", description = "System security audit log query and export API")
 public class AuditLogResource {
 
   private static final Logger log = LogManager.getLogger(AuditLogResource.class);
+
+  private static final String MEDIA_TEXT_CSV = "text/csv";
 
   private final IAuditLogAdaptor adaptor;
 
@@ -154,6 +159,78 @@ public class AuditLogResource {
     } catch (Exception e) {
       log.error("Audit log get failed for id={}", auditId, e);
       throw new WebApplicationException("Failed to load audit log entry", e, 500);
+    }
+  }
+
+  /**
+   * Export filtered system audit log rows as CSV or JSON download (Phase 5 / #2715).
+   *
+   * <p>Uses the same filters and AuthZ as {@link #queryEntries}. Default format is {@code json};
+   * max rows default {@link SystemAuditLogExport#DEFAULT_MAX_ROWS}, hard cap {@link
+   * SystemAuditLogExport#MAX_ROWS}.
+   */
+  @GET
+  @Path("/export")
+  @Operation(
+      summary = "Export system audit log entries (CSV or JSON)",
+      description =
+          "Downloads durable system audit log rows matching the same filters as the query API."
+              + " Requires Admin role or role property sys_securityAuditLogViewer=true. format=csv"
+              + " or format=json (default json).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Export body (CSV or JSON)",
+            content = {
+              @Content(mediaType = MediaType.APPLICATION_JSON),
+              @Content(mediaType = MEDIA_TEXT_CSV)
+            }),
+        @ApiResponse(responseCode = "400", description = "Invalid query parameters"),
+        @ApiResponse(responseCode = "403", description = "Caller not allowed to view audit log"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Server error")
+      })
+  public Response exportEntries(
+      @Parameter(description = "Export format: csv or json (default json)") @QueryParam("format")
+          String format,
+      @Parameter(description = "Inclusive lower bound (ISO-8601 instant)") @QueryParam("from")
+          String from,
+      @Parameter(description = "Exclusive upper bound (ISO-8601 instant)") @QueryParam("to")
+          String to,
+      @Parameter(description = "Module code filter (e.g. AUTH)") @QueryParam("module")
+          String module,
+      @Parameter(description = "Event type filter") @QueryParam("eventType") String eventType,
+      @Parameter(description = "Outcome filter (SUCCESS, FAILURE, …)") @QueryParam("outcome")
+          String outcome,
+      @Parameter(description = "Actor (user name) filter, case-insensitive") @QueryParam("actor")
+          String actor,
+      @Parameter(description = "Max rows (server clamps; default 5000, max 10000)")
+          @QueryParam("maxRows")
+          @DefaultValue("0")
+          int maxRows) {
+    try {
+      String normalized = SystemAuditLogExport.normalizeFormat(format);
+      List<SystemAuditLogEntry> entries =
+          requireAdaptor().export(from, to, module, eventType, outcome, actor, maxRows);
+      if ("csv".equals(normalized)) {
+        String body = SystemAuditLogExport.toCsv(entries);
+        return Response.ok(body, MEDIA_TEXT_CSV)
+            .header("Content-Disposition", "attachment; filename=\"system-audit-log.csv\"")
+            .build();
+      }
+      String body = SystemAuditLogExport.toJson(entries);
+      return Response.ok(body, MediaType.APPLICATION_JSON)
+          .header("Content-Disposition", "attachment; filename=\"system-audit-log.json\"")
+          .build();
+    } catch (SecurityException e) {
+      throw new WebApplicationException(e.getMessage(), e, Response.Status.FORBIDDEN);
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), e, Response.Status.BAD_REQUEST);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Audit log export failed", e);
+      throw new WebApplicationException("Failed to export audit log", e, 500);
     }
   }
 

--- a/rest/src/main/java/com/percussion/rest/auditlog/IAuditLogAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/IAuditLogAdaptor.java
@@ -16,8 +16,11 @@
  */
 package com.percussion.rest.auditlog;
 
+import java.util.List;
+
 /**
- * Adaptor contract for the system security audit log query API (Phase 3 / #2618).
+ * Adaptor contract for the system security audit log query and export API (Phase 3 / #2618, Phase 5
+ * export / #2715).
  *
  * <p>Implementations enforce AuthZ (Admin role or role property {@code
  * sys_securityAuditLogViewer}) and map domain rows to wire DTOs. Unauthorized callers must surface
@@ -56,4 +59,28 @@ public interface IAuditLogAdaptor {
    *     return null so the resource can map 404
    */
   SystemAuditLogEntry findById(String auditId);
+
+  /**
+   * Export durable audit rows matching the same filters as {@link #query}, up to a server-clamped
+   * max row count (newest first). Same AuthZ as query.
+   *
+   * @param fromIso optional inclusive lower bound (ISO-8601 instant); null/blank ignored
+   * @param toIso optional exclusive upper bound (ISO-8601 instant); null/blank ignored
+   * @param moduleCode optional module filter (e.g. AUTH)
+   * @param eventType optional event type filter
+   * @param outcome optional outcome filter (SUCCESS / FAILURE / …)
+   * @param actor optional actor (user name) filter; case-insensitive
+   * @param maxRows requested max rows (clamped server-side; non-positive → default)
+   * @return entries newest first (never null; may be empty)
+   * @throws SecurityException when the caller is not allowed
+   * @throws IllegalArgumentException when date filters are invalid
+   */
+  List<SystemAuditLogEntry> export(
+      String fromIso,
+      String toIso,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor,
+      int maxRows);
 }

--- a/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogExport.java
+++ b/rest/src/main/java/com/percussion/rest/auditlog/SystemAuditLogExport.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Formats {@link SystemAuditLogEntry} lists for downloadable CSV/JSON export (#2715 / Phase 5).
+ *
+ * <p>CSV is RFC 4180-style (comma-separated, double-quote escaping, CRLF record separators). JSON is
+ * a root array of entry objects with ISO-8601 instants (no root wrapper).
+ */
+public final class SystemAuditLogExport {
+
+  /** Default max rows when the client omits or passes a non-positive limit. */
+  public static final int DEFAULT_MAX_ROWS = 5_000;
+
+  /** Hard cap on export size (resource/adaptor clamp). */
+  public static final int MAX_ROWS = 10_000;
+
+  /** CSV column header order (stable for consumers). */
+  public static final String[] CSV_HEADERS = {
+    "auditId",
+    "eventTime",
+    "moduleCode",
+    "messageCode",
+    "eventType",
+    "outcome",
+    "actor",
+    "target",
+    "sourceIp",
+    "sourceHost",
+    "userMessage",
+    "logMessage",
+    "correlationId",
+    "attributesJson",
+    "serverNode"
+  };
+
+  private static final JsonMapper JSON =
+      JsonMapper.builder()
+          .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .disable(SerializationFeature.WRAP_ROOT_VALUE)
+          .build();
+
+  private SystemAuditLogExport() {}
+
+  /**
+   * Clamp requested export size to {@code 1..MAX_ROWS}; non-positive → {@link #DEFAULT_MAX_ROWS}.
+   */
+  public static int clampMaxRows(int maxRows) {
+    if (maxRows <= 0) {
+      return DEFAULT_MAX_ROWS;
+    }
+    return Math.min(maxRows, MAX_ROWS);
+  }
+
+  /** Serialize entries as a JSON array string. */
+  public static String toJson(List<SystemAuditLogEntry> entries) {
+    Objects.requireNonNull(entries, "entries");
+    try {
+      return JSON.writeValueAsString(entries);
+    } catch (JacksonException e) {
+      throw new IllegalStateException("Failed to serialize audit log export as JSON", e);
+    }
+  }
+
+  /** Serialize entries as RFC 4180 CSV with a header row. */
+  public static String toCsv(List<SystemAuditLogEntry> entries) {
+    Objects.requireNonNull(entries, "entries");
+    StringBuilder sb = new StringBuilder(Math.max(256, entries.size() * 128));
+    appendCsvRow(sb, CSV_HEADERS);
+    for (SystemAuditLogEntry e : entries) {
+      if (e == null) {
+        continue;
+      }
+      appendCsvRow(
+          sb,
+          new String[] {
+            nullToEmpty(e.getAuditId()),
+            instantToEmpty(e.getEventTime()),
+            nullToEmpty(e.getModuleCode()),
+            e.getMessageCode() == null ? "" : Integer.toString(e.getMessageCode()),
+            nullToEmpty(e.getEventType()),
+            nullToEmpty(e.getOutcome()),
+            nullToEmpty(e.getActor()),
+            nullToEmpty(e.getTarget()),
+            nullToEmpty(e.getSourceIp()),
+            nullToEmpty(e.getSourceHost()),
+            nullToEmpty(e.getUserMessage()),
+            nullToEmpty(e.getLogMessage()),
+            nullToEmpty(e.getCorrelationId()),
+            nullToEmpty(e.getAttributesJson()),
+            nullToEmpty(e.getServerNode())
+          });
+    }
+    return sb.toString();
+  }
+
+  static String escapeCsvField(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    boolean needsQuotes =
+        value.indexOf(',') >= 0
+            || value.indexOf('"') >= 0
+            || value.indexOf('\n') >= 0
+            || value.indexOf('\r') >= 0;
+    if (!needsQuotes) {
+      return value;
+    }
+    return "\"" + value.replace("\"", "\"\"") + "\"";
+  }
+
+  private static void appendCsvRow(StringBuilder sb, String[] fields) {
+    for (int i = 0; i < fields.length; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(escapeCsvField(fields[i]));
+    }
+    sb.append("\r\n");
+  }
+
+  private static String nullToEmpty(String s) {
+    return s == null ? "" : s;
+  }
+
+  private static String instantToEmpty(Instant instant) {
+    return instant == null ? "" : instant.toString();
+  }
+
+  /** Normalize format query value to {@code csv} or {@code json}; null/blank defaults to json. */
+  public static String normalizeFormat(String format) {
+    if (format == null || format.isBlank()) {
+      return "json";
+    }
+    String f = format.trim().toLowerCase(Locale.ROOT);
+    if ("csv".equals(f) || "json".equals(f)) {
+      return f;
+    }
+    throw new IllegalArgumentException("format must be csv or json, got: " + format);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/auditlog/AuditLogResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/auditlog/AuditLogResourceTest.java
@@ -19,6 +19,7 @@ package com.percussion.rest.auditlog;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -26,6 +27,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -115,5 +119,70 @@ public class AuditLogResourceTest {
             WebApplicationException.class,
             () -> bare.queryEntries(null, null, null, null, null, null, 0, 50));
     assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void exportJsonAuthorizedShape() {
+    SystemAuditLogEntry entry = new SystemAuditLogEntry();
+    entry.setAuditId("id-export-1");
+    entry.setEventTime(Instant.parse("2026-08-09T12:00:00Z"));
+    entry.setModuleCode("AUTH");
+    entry.setOutcome("SUCCESS");
+    when(adaptor.export(
+            isNull(), isNull(), eq("AUTH"), isNull(), isNull(), isNull(), eq(100)))
+        .thenReturn(List.of(entry));
+
+    Response response =
+        resource.exportEntries("json", null, null, "AUTH", null, null, null, 100);
+    assertEquals(200, response.getStatus());
+    assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
+    String body = String.valueOf(response.getEntity());
+    assertTrue(body.contains("id-export-1"));
+    assertTrue(body.contains("AUTH"));
+    assertTrue(String.valueOf(response.getHeaderString("Content-Disposition")).contains(".json"));
+    verify(adaptor)
+        .export(isNull(), isNull(), eq("AUTH"), isNull(), isNull(), isNull(), eq(100));
+  }
+
+  @Test
+  public void exportCsvAuthorizedShape() {
+    SystemAuditLogEntry entry = new SystemAuditLogEntry();
+    entry.setAuditId("id-csv-1");
+    entry.setModuleCode("AUTH");
+    entry.setUserMessage("ok");
+    when(adaptor.export(
+            isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(0)))
+        .thenReturn(List.of(entry));
+
+    Response response =
+        resource.exportEntries("csv", null, null, null, null, null, null, 0);
+    assertEquals(200, response.getStatus());
+    assertEquals("text/csv", response.getMediaType().toString());
+    String body = String.valueOf(response.getEntity());
+    assertTrue(body.startsWith("auditId,") || body.replace("\r\n", "\n").startsWith("auditId,"));
+    assertTrue(body.contains("id-csv-1"));
+    assertTrue(String.valueOf(response.getHeaderString("Content-Disposition")).contains(".csv"));
+  }
+
+  @Test
+  public void exportMapsSecurityExceptionTo403() {
+    when(adaptor.export(
+            isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(0)))
+        .thenThrow(new SecurityException("not allowed"));
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.exportEntries("json", null, null, null, null, null, null, 0));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void exportInvalidFormatIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.exportEntries("xml", null, null, null, null, null, null, 0));
+    assertEquals(400, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/auditlog/SystemAuditLogExportTest.java
+++ b/rest/src/test/java/com/percussion/rest/auditlog/SystemAuditLogExportTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class SystemAuditLogExportTest {
+
+  @Test
+  public void clampMaxRowsDefaultsAndCaps() {
+    assertEquals(SystemAuditLogExport.DEFAULT_MAX_ROWS, SystemAuditLogExport.clampMaxRows(0));
+    assertEquals(SystemAuditLogExport.DEFAULT_MAX_ROWS, SystemAuditLogExport.clampMaxRows(-1));
+    assertEquals(100, SystemAuditLogExport.clampMaxRows(100));
+    assertEquals(
+        SystemAuditLogExport.MAX_ROWS,
+        SystemAuditLogExport.clampMaxRows(SystemAuditLogExport.MAX_ROWS + 500));
+  }
+
+  @Test
+  public void normalizeFormatAcceptsCsvJsonDefault() {
+    assertEquals("json", SystemAuditLogExport.normalizeFormat(null));
+    assertEquals("json", SystemAuditLogExport.normalizeFormat(""));
+    assertEquals("json", SystemAuditLogExport.normalizeFormat(" JSON "));
+    assertEquals("csv", SystemAuditLogExport.normalizeFormat("csv"));
+    assertThrows(IllegalArgumentException.class, () -> SystemAuditLogExport.normalizeFormat("xml"));
+  }
+
+  @Test
+  public void toCsvIncludesHeaderAndEscapesCommasQuotes() {
+    SystemAuditLogEntry e = sample();
+    e.setUserMessage("hello, \"world\"");
+    String csv = SystemAuditLogExport.toCsv(List.of(e));
+    // Portable: normalize CRLF to LF for line assertions
+    String[] lines = csv.replace("\r\n", "\n").split("\n", -1);
+    assertTrue(lines[0].startsWith("auditId,eventTime,moduleCode"));
+    assertTrue(lines[1].contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+    assertTrue(lines[1].contains("\"hello, \"\"world\"\"\""));
+    assertTrue(lines[1].contains("AUTH"));
+  }
+
+  @Test
+  public void toJsonIsArrayWithFields() {
+    String json = SystemAuditLogExport.toJson(List.of(sample()));
+    assertTrue(json.startsWith("["));
+    assertTrue(json.contains("\"auditId\""));
+    assertTrue(json.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+    assertTrue(json.contains("AUTH"));
+    assertFalse(json.contains("SystemAuditLogEntry"));
+  }
+
+  @Test
+  public void emptyExportShapes() {
+    assertTrue(SystemAuditLogExport.toJson(List.of()).equals("[]") || SystemAuditLogExport.toJson(List.of()).contains("[]"));
+    String csv = SystemAuditLogExport.toCsv(List.of());
+    assertTrue(csv.replace("\r\n", "\n").startsWith("auditId,eventTime"));
+  }
+
+  private static SystemAuditLogEntry sample() {
+    SystemAuditLogEntry e = new SystemAuditLogEntry();
+    e.setAuditId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    e.setEventTime(Instant.parse("2026-08-09T12:00:00Z"));
+    e.setModuleCode("AUTH");
+    e.setMessageCode(1001);
+    e.setEventType("LOGIN");
+    e.setOutcome("SUCCESS");
+    e.setActor("admin");
+    e.setUserMessage("login ok");
+    e.setLogMessage("login ok");
+    return e;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/auditlog/SystemAuditLogExportTest.java
+++ b/rest/src/test/java/com/percussion/rest/auditlog/SystemAuditLogExportTest.java
@@ -73,7 +73,7 @@ public class SystemAuditLogExportTest {
 
   @Test
   public void emptyExportShapes() {
-    assertTrue(SystemAuditLogExport.toJson(List.of()).equals("[]") || SystemAuditLogExport.toJson(List.of()).contains("[]"));
+    assertEquals("[]", SystemAuditLogExport.toJson(List.of()));
     String csv = SystemAuditLogExport.toCsv(List.of());
     assertTrue(csv.replace("\r\n", "\n").startsWith("auditId,eventTime"));
   }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestAuditLogAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestAuditLogAdaptor.java
@@ -43,4 +43,16 @@ public class TestAuditLogAdaptor implements IAuditLogAdaptor {
   public SystemAuditLogEntry findById(String auditId) {
     return null;
   }
+
+  @Override
+  public List<SystemAuditLogEntry> export(
+      String fromIso,
+      String toIso,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor,
+      int maxRows) {
+    return List.of();
+  }
 }


### PR DESCRIPTION
## Summary

Permission-gated **CSV + JSON export** for `PSX_SYSTEM_AUDIT_LOG` (Phase 5 slice 1 / #2715).

- `GET /Rhythmyx/rest/auditlog/export?format=csv|json` with the same filters as the Phase 3 query API
- AuthZ: **Admin** or role property `sys_securityAuditLogViewer` (403 when denied)
- `maxRows` default 5000, hard cap 10000 (pages through repository max page size)
- Formatter: `SystemAuditLogExport` (RFC 4180 CSV, JSON array)
- Docs: `docs/ai-generated/tasks/system-audit-log/export.md`

**Parent:** #2620  
**Out of scope (siblings):** audit-of-audit (#2716), runbook/hash (#2717)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Unit tests: authorized CSV/JSON shape, 403 deny, invalid format 400
- [x] Adaptor: Admin/property allow, unauthorized does not touch repo, filter passthrough
- [x] `TestAuditLogAdaptor` Spring stub implements `export`
- [x] Standalone module clean install

### Pre-PR Maven (standalone)

```bat
cd rest
..\mvnw.cmd clean install
:: BUILD SUCCESS — AuditLogResourceTest Tests run: 11, Failures: 0
:: SystemAuditLogExportTest Tests run: 5, Failures: 0

cd projects\sitemanage
..\..\mvnw.cmd clean install
:: BUILD SUCCESS — AuditLogAdaptorTest Tests run: 10, Failures: 0
```

No new warnings attributed to this change. No system module code change (export pages existing `findEntries`).

## Fixes

Fixes #2715  
Partial for #2620 (export slice only)

> Co-Authored by Grok Build using grok-4.5 with agent main.
