### PR TITLE
feat(auditlog): audit-of-audit viewer access events (#2716)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -86,6 +86,22 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 6, ctx, "5", "jdoe"); // WF access
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 
+### Audit-of-audit (Phase 5 / #2716)
+
+Viewer and export access to the system security audit log is itself auditable:
+
+| Code | Event | When |
+|------|-------|------|
+| `AUDIT-1` `VIEWER_ACCESS` | `AUDIT_VIEW` SUCCESS | List or detail query allowed |
+| `AUDIT-3` `VIEWER_ACCESS_DENIED` | `AUDIT_VIEW` FAILURE | Explicit AuthZ deny on list/detail |
+| `AUDIT-4` `EXPORT_ACCESS` | `AUDIT_EXPORT` SUCCESS | Export allowed (call from export path) |
+| `AUDIT-5` `EXPORT_ACCESS_DENIED` | `AUDIT_EXPORT` FAILURE | Explicit AuthZ deny on export |
+
+Facade: `PSSystemAuditLogger.auditViewerAccess` / `auditViewerAccessDenied` /
+`auditExportAccess` / `auditExportAccessDenied`. Wired for list/detail in
+`com.percussion.apibridge.AuditLogAdaptor`. Nested dual-write during a sink write is
+skipped by `DefaultAuditLogService` reentrancy guard (no recursive storms).
+
 `PSErrorHandler.appendError` calls `PSSystemAuditLogger.logLegacyIfAuditable` for every
 `PSException` so only cataloged auditable codes dual-write on the central error path.
 

--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -97,6 +97,11 @@ Viewer and export access to the system security audit log is itself auditable:
 | `AUDIT-4` `EXPORT_ACCESS` | `AUDIT_EXPORT` SUCCESS | Export allowed (call from export path) |
 | `AUDIT-5` `EXPORT_ACCESS_DENIED` | `AUDIT_EXPORT` FAILURE | Explicit AuthZ deny on export |
 
+**Log message shape (`VIEWER_ACCESS`):** free-text template is
+`Audit log viewed actor={} action={} detail={}` (action = `list` / `detail`). This **replaces**
+the earlier main-line two-arg `actor={} filters={}` template for AUDIT-1. Update SIEM/parser
+rules accordingly; structured audit attributes still carry `action` and `detail`.
+
 Facade: `PSSystemAuditLogger.auditViewerAccess` / `auditViewerAccessDenied` /
 `auditExportAccess` / `auditExportAccessDenied`. Wired for list/detail in
 `com.percussion.apibridge.AuditLogAdaptor`. Nested dual-write during a sink write is

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/DefaultAuditLogService.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/DefaultAuditLogService.java
@@ -44,6 +44,13 @@ public final class DefaultAuditLogService implements AuditLogService {
 
   private static final AuditLogId SKIPPED = AuditLogId.of("00000000-0000-0000-0000-000000000000");
 
+  /**
+   * Nested {@link #log} calls (e.g. audit-of-audit re-entering via a sink or access path) are
+   * skipped so dual-write cannot recurse endlessly. One event per outer emit is enough.
+   */
+  private static final ThreadLocal<Boolean> REENTRANT =
+      ThreadLocal.withInitial(() -> Boolean.FALSE);
+
   private final AuditRedactor redactor;
   private final Clock clock;
   private final Supplier<AuditLogId> idSupplier;
@@ -114,6 +121,21 @@ public final class DefaultAuditLogService implements AuditLogService {
       return SKIPPED;
     }
 
+    // Prevent recursive dual-write storms (audit-of-audit / nested sink side-effects).
+    if (Boolean.TRUE.equals(REENTRANT.get())) {
+      return SKIPPED;
+    }
+
+    REENTRANT.set(Boolean.TRUE);
+    try {
+      return writeRecord(code, context, outcome, params);
+    } finally {
+      REENTRANT.set(Boolean.FALSE);
+    }
+  }
+
+  private AuditLogId writeRecord(
+      SystemErrorCode code, AuditContext context, AuditOutcome outcome, Object... params) {
     Object[] safeParams = redactor.redactParams(params == null ? new Object[0] : params);
     String userBody =
         redactor.redact(

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
@@ -30,7 +30,16 @@ import com.intsof.percussioncms.auditlog.SystemErrorCode;
  * guard so access events cannot storm.
  */
 public enum AuditSubsystemErrorCodes implements SystemErrorCode {
-  /** Successful list or detail view of the system security audit log. */
+  /**
+   * Successful list or detail view of the system security audit log.
+   *
+   * <p><strong>Log template note (Phase 5 / #2716):</strong> the durable log message shape is
+   * {@code actor={} action={} detail={}} (action = {@code list}/{@code detail}, detail = filter
+   * summary or audit id). Pre-#2716 main only had a two-arg {@code actor={} filters={}} form with
+   * no list/detail split. SIEM / log parsers for AUDITview success must match the three-arg
+   * template; structured attributes on the audit row still carry {@code action} and {@code detail}
+   * independently of free-text log format.
+   */
   VIEWER_ACCESS(
       1,
       true,

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
@@ -36,9 +36,9 @@ public enum AuditSubsystemErrorCodes implements SystemErrorCode {
    * <p><strong>Log template note (Phase 5 / #2716):</strong> the durable log message shape is
    * {@code actor={} action={} detail={}} (action = {@code list}/{@code detail}, detail = filter
    * summary or audit id). Pre-#2716 main only had a two-arg {@code actor={} filters={}} form with
-   * no list/detail split. SIEM / log parsers for AUDITview success must match the three-arg
-   * template; structured attributes on the audit row still carry {@code action} and {@code detail}
-   * independently of free-text log format.
+   * no list/detail split. SIEM / log parsers for {@link AuditEventType#AUDIT_VIEW} success must
+   * match the three-arg template; structured attributes on the audit row still carry {@code
+   * action} and {@code detail} independently of free-text log format.
    */
   VIEWER_ACCESS(
       1,

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AuditSubsystemErrorCodes.java
@@ -21,15 +21,23 @@ import com.intsof.percussioncms.auditlog.AuditModule;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
 
-/** Self-codes for the audit subsystem (viewer access, retention, sink failures). */
+/**
+ * Self-codes for the audit subsystem (viewer/export access, retention, sink failures).
+ *
+ * <p>Phase 5 / #2716: {@link #VIEWER_ACCESS}, {@link #VIEWER_ACCESS_DENIED}, {@link #EXPORT_ACCESS},
+ * and {@link #EXPORT_ACCESS_DENIED} make audit-log viewer and export access itself auditable
+ * (audit-of-audit). Nested dual-write is suppressed by {@code DefaultAuditLogService} reentrancy
+ * guard so access events cannot storm.
+ */
 public enum AuditSubsystemErrorCodes implements SystemErrorCode {
+  /** Successful list or detail view of the system security audit log. */
   VIEWER_ACCESS(
       1,
       true,
       AuditEventType.AUDIT_VIEW,
       AuditOutcome.SUCCESS,
       "Audit log viewed by {}",
-      "Audit log viewed actor={} filters={}"),
+      "Audit log viewed actor={} action={} detail={}"),
 
   SINK_FAILURE(
       2,
@@ -37,7 +45,34 @@ public enum AuditSubsystemErrorCodes implements SystemErrorCode {
       AuditEventType.AUDIT_SINK_FAILURE,
       AuditOutcome.ERROR,
       "Audit sink failure",
-      "Audit sink failure sink={} logId={} detail={}");
+      "Audit sink failure sink={} logId={} detail={}"),
+
+  /** Explicit deny when a principal lacks Admin / sys_securityAuditLogViewer. */
+  VIEWER_ACCESS_DENIED(
+      3,
+      true,
+      AuditEventType.AUDIT_VIEW,
+      AuditOutcome.FAILURE,
+      "Audit log view denied for {}",
+      "Audit log view denied actor={} action={} reason={}"),
+
+  /** Successful CSV/JSON export of the system security audit log. */
+  EXPORT_ACCESS(
+      4,
+      true,
+      AuditEventType.AUDIT_EXPORT,
+      AuditOutcome.SUCCESS,
+      "Audit log exported by {}",
+      "Audit log export actor={} format={} detail={}"),
+
+  /** Explicit deny on export when the principal is not authorized. */
+  EXPORT_ACCESS_DENIED(
+      5,
+      true,
+      AuditEventType.AUDIT_EXPORT,
+      AuditOutcome.FAILURE,
+      "Audit log export denied for {}",
+      "Audit log export denied actor={} reason={}");
 
   private final int numericCode;
   private final boolean auditable;

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/DefaultAuditLogServiceTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/DefaultAuditLogServiceTest.java
@@ -19,11 +19,14 @@ package com.intsof.percussioncms.auditlog;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.intsof.percussioncms.auditlog.codes.AuditSubsystemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
+import com.intsof.percussioncms.auditlog.sink.AuditLogSink;
 import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class DefaultAuditLogServiceTest {
@@ -111,5 +114,69 @@ class DefaultAuditLogServiceTest {
 
     String logMsg = sink.records().get(0).logMessage();
     assertTrue(logMsg.contains("[REDACTED]") || !logMsg.contains("hunter2"));
+  }
+
+  @Test
+  void nestedLogDuringSinkWriteIsSkippedToPreventRecursion() {
+    CapturingAuditLogSink cap = new CapturingAuditLogSink("cap");
+    AtomicInteger nestedAttempts = new AtomicInteger();
+    DefaultAuditLogService[] holder = new DefaultAuditLogService[1];
+    AuditLogSink recursive =
+        new AuditLogSink() {
+          @Override
+          public String name() {
+            return "recursive";
+          }
+
+          @Override
+          public void write(AuditRecord record) {
+            nestedAttempts.incrementAndGet();
+            // Nested dual-write (audit-of-audit storm path) must not write again.
+            AuditLogId nested =
+                holder[0].log(
+                    AuditSubsystemErrorCodes.VIEWER_ACCESS,
+                    AuditContext.builder().actor("nested").build(),
+                    AuditOutcome.SUCCESS,
+                    "nested",
+                    "list",
+                    "filters");
+            assertEquals("00000000-0000-0000-0000-000000000000", nested.value());
+          }
+        };
+    holder[0] =
+        DefaultAuditLogService.builder().addSink(recursive).addSink(cap).build();
+
+    AuditLogId outer =
+        holder[0].log(
+            AuditSubsystemErrorCodes.VIEWER_ACCESS,
+            AuditContext.builder().actor("admin").build(),
+            AuditOutcome.SUCCESS,
+            "admin",
+            "list",
+            "module=AUTH");
+
+    assertEquals(1, nestedAttempts.get());
+    assertEquals(1, cap.records().size());
+    assertEquals(outer, cap.records().get(0).logId());
+    assertEquals(1, cap.records().get(0).code().numericCode());
+  }
+
+  @Test
+  void auditSubsystemViewerAccessIsAuditable() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    svc.log(
+        AuditSubsystemErrorCodes.VIEWER_ACCESS_DENIED,
+        AuditContext.builder().actor("author").build(),
+        AuditOutcome.FAILURE,
+        "author",
+        "list",
+        "forbidden");
+
+    assertEquals(1, sink.records().size());
+    assertEquals(AuditSubsystemErrorCodes.VIEWER_ACCESS_DENIED, sink.records().get(0).code());
+    assertEquals(AuditOutcome.FAILURE, sink.records().get(0).outcome());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[AUDIT-3]-"));
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.apibridge;
 
+import static com.percussion.webservices.PSWebserviceUtils.getUserName;
 import static com.percussion.webservices.PSWebserviceUtils.getUserRoles;
 
 import com.percussion.rest.auditlog.IAuditLogAdaptor;
@@ -24,6 +25,7 @@ import com.percussion.rest.auditlog.SystemAuditLogExport;
 import com.percussion.rest.auditlog.SystemAuditLogPage;
 import com.percussion.security.IPSPrincipalAttribute;
 import com.percussion.services.audit.PSSystemAuditLogPermission;
+import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.services.audit.data.PSSystemAuditLogEntry;
 import com.percussion.services.audit.impl.PSSystemAuditLogRepository;
 import com.percussion.services.security.IPSRoleMgr;
@@ -49,6 +51,10 @@ import org.springframework.context.annotation.Lazy;
  *
  * <p>AuthZ: {@link PSSystemAuditLogPermission} — Admin always allowed, otherwise role property
  * {@code sys_securityAuditLogViewer}.
+ *
+ * <p>Phase 5 / #2716: list/detail success and explicit deny emit audit-of-audit events via {@link
+ * PSSystemAuditLogger} (dual-write). Nested dual-write is suppressed by the audit service
+ * reentrancy guard.
  */
 @PSSiteManageBean
 @Lazy
@@ -56,16 +62,23 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
 
   private static final Logger log = LogManager.getLogger(AuditLogAdaptor.class);
 
+  private static final String ACTION_LIST = "list";
+  private static final String ACTION_DETAIL = "detail";
+  private static final String ACTION_EXPORT = "export";
+  private static final String DENY_REASON = "forbidden";
+
   private final PSSystemAuditLogRepository repository;
   private final Supplier<List<String>> userRolesSupplier;
   private final Function<String, Boolean> roleHasViewerProperty;
+  private final Supplier<String> currentUserSupplier;
 
   @Autowired
   public AuditLogAdaptor(PSSystemAuditLogRepository repository) {
     this(
         repository,
         () -> getUserRoles(),
-        AuditLogAdaptor::roleHasViewerPropertyFromRoleMgr);
+        AuditLogAdaptor::roleHasViewerPropertyFromRoleMgr,
+        () -> getUserName());
   }
 
   /** Package-visible test constructor. */
@@ -73,10 +86,21 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
       PSSystemAuditLogRepository repository,
       Supplier<List<String>> userRolesSupplier,
       Function<String, Boolean> roleHasViewerProperty) {
+    this(repository, userRolesSupplier, roleHasViewerProperty, () -> "test-user");
+  }
+
+  /** Package-visible test constructor with explicit actor. */
+  AuditLogAdaptor(
+      PSSystemAuditLogRepository repository,
+      Supplier<List<String>> userRolesSupplier,
+      Function<String, Boolean> roleHasViewerProperty,
+      Supplier<String> currentUserSupplier) {
     this.repository = Objects.requireNonNull(repository, "repository");
     this.userRolesSupplier = Objects.requireNonNull(userRolesSupplier, "userRolesSupplier");
     this.roleHasViewerProperty =
         Objects.requireNonNull(roleHasViewerProperty, "roleHasViewerProperty");
+    this.currentUserSupplier =
+        Objects.requireNonNull(currentUserSupplier, "currentUserSupplier");
   }
 
   @Override
@@ -89,7 +113,7 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
       String actor,
       int offset,
       int limit) {
-    requireViewer();
+    requireViewer(ACTION_LIST, summarizeFilters(fromIso, toIso, moduleCode, eventType, outcome, actor));
     Instant from = parseInstant(fromIso, "from");
     Instant to = parseInstant(toIso, "to");
     int safeOffset = Math.max(0, offset);
@@ -104,16 +128,25 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
     for (PSSystemAuditLogEntry row : rows) {
       entries.add(toDto(row));
     }
+    emitViewerSuccess(
+        ACTION_LIST,
+        summarizeFilters(fromIso, toIso, moduleCode, eventType, outcome, actor)
+            + ",offset="
+            + safeOffset
+            + ",limit="
+            + safeLimit);
     return new SystemAuditLogPage(entries, total, safeOffset, safeLimit);
   }
 
   @Override
   public SystemAuditLogEntry findById(String auditId) {
-    requireViewer();
+    requireViewer(ACTION_DETAIL, StringUtils.defaultString(auditId));
     if (StringUtils.isBlank(auditId)) {
       throw new IllegalArgumentException("auditId is required");
     }
-    Optional<PSSystemAuditLogEntry> found = repository.findById(auditId.trim());
+    String id = auditId.trim();
+    Optional<PSSystemAuditLogEntry> found = repository.findById(id);
+    emitViewerSuccess(ACTION_DETAIL, "auditId=" + id);
     return found.map(AuditLogAdaptor::toDto).orElse(null);
   }
 
@@ -126,7 +159,9 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
       String outcome,
       String actor,
       int maxRows) {
-    requireViewer();
+    requireViewer(
+        ACTION_EXPORT,
+        summarizeFilters(fromIso, toIso, moduleCode, eventType, outcome, actor));
     Instant from = parseInstant(fromIso, "from");
     Instant to = parseInstant(toIso, "to");
     int cap = SystemAuditLogExport.clampMaxRows(maxRows);
@@ -151,26 +186,90 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
         break;
       }
     }
+    emitViewerSuccess(
+        ACTION_EXPORT,
+        summarizeFilters(fromIso, toIso, moduleCode, eventType, outcome, actor)
+            + ",maxRows="
+            + cap
+            + ",count="
+            + all.size());
     return all;
   }
 
-  private void requireViewer() {
+  private void requireViewer(String action, String detail) {
     List<String> roles;
     try {
       roles = userRolesSupplier.get();
     } catch (Exception e) {
       log.debug("Could not resolve user roles for audit log access", e);
+      emitViewerDenied(action, "role-resolution-failed");
       throw new SecurityException("Unable to resolve user roles for audit log access");
     }
     boolean allowed =
         PSSystemAuditLogPermission.allows(
             roles, role -> Boolean.TRUE.equals(roleHasViewerProperty.apply(role)));
     if (!allowed) {
+      emitViewerDenied(action, DENY_REASON);
       throw new SecurityException(
           "Not authorized to view the system security audit log (Admin role or "
               + PSSystemAuditLogPermission.ROLE_PROPERTY
               + " required)");
     }
+  }
+
+  private void emitViewerSuccess(String action, String detail) {
+    try {
+      PSSystemAuditLogger.auditViewerAccess(resolveActor(), action, detail);
+    } catch (RuntimeException e) {
+      log.debug("Audit-of-audit viewer success emit failed", e);
+    }
+  }
+
+  private void emitViewerDenied(String action, String reason) {
+    try {
+      PSSystemAuditLogger.auditViewerAccessDenied(resolveActor(), action, reason);
+    } catch (RuntimeException e) {
+      log.debug("Audit-of-audit viewer deny emit failed", e);
+    }
+  }
+
+  private String resolveActor() {
+    try {
+      String user = currentUserSupplier.get();
+      if (user != null && !user.isBlank()) {
+        return user.trim();
+      }
+    } catch (Exception e) {
+      log.debug("Could not resolve current user for audit-of-audit", e);
+    }
+    return "unknown";
+  }
+
+  static String summarizeFilters(
+      String fromIso,
+      String toIso,
+      String moduleCode,
+      String eventType,
+      String outcome,
+      String actor) {
+    StringBuilder sb = new StringBuilder();
+    appendFilter(sb, "from", fromIso);
+    appendFilter(sb, "to", toIso);
+    appendFilter(sb, "module", moduleCode);
+    appendFilter(sb, "eventType", eventType);
+    appendFilter(sb, "outcome", outcome);
+    appendFilter(sb, "actor", actor);
+    return sb.length() == 0 ? "none" : sb.toString();
+  }
+
+  private static void appendFilter(StringBuilder sb, String name, String value) {
+    if (StringUtils.isBlank(value)) {
+      return;
+    }
+    if (sb.length() > 0) {
+      sb.append(',');
+    }
+    sb.append(name).append('=').append(value.trim());
   }
 
   static Instant parseInstant(String raw, String fieldName) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AuditLogAdaptor.java
@@ -269,8 +269,20 @@ public class AuditLogAdaptor implements IAuditLogAdaptor {
     if (sb.length() > 0) {
       sb.append(',');
     }
-    sb.append(name).append('=').append(value.trim());
+    sb.append(name).append('=').append(escapeFilterValue(value.trim()));
   }
+
+  /**
+   * Quote filter values that contain commas, equals, or quotes so the comma-delimited
+   * {@link #summarizeFilters} summary stays unambiguous for operators and parsers.
+   */
+  static String escapeFilterValue(String value) {
+    if (value.indexOf(',') < 0 && value.indexOf('=') < 0 && value.indexOf('"') < 0) {
+      return value;
+    }
+    return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+  }
+
 
   static Instant parseInstant(String raw, String fieldName) {
     if (StringUtils.isBlank(raw)) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
@@ -279,6 +279,33 @@ class AuditLogAdaptorTest {
         ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
   }
 
+  @Test
+  void summarizeFiltersOmitsBlanksAndJoinsWithComma() {
+    assertEquals("none", AuditLogAdaptor.summarizeFilters(null, null, null, null, null, null));
+    assertEquals(
+        "from=2026-01-01T00:00:00Z,module=AUTH,actor=admin",
+        AuditLogAdaptor.summarizeFilters(
+            "2026-01-01T00:00:00Z", null, "AUTH", null, null, "admin"));
+  }
+
+  @Test
+  void summarizeFiltersQuotesValuesWithCommasOrQuotes() {
+    // append order is from,to,module,eventType,outcome,actor
+    assertEquals(
+        "module=AUTH,actor=\"Doe, John\"",
+        AuditLogAdaptor.summarizeFilters(null, null, "AUTH", null, null, "Doe, John"));
+    assertEquals(
+        "actor=\"a\\\"b\"", AuditLogAdaptor.summarizeFilters(null, null, null, null, null, "a\"b"));
+    assertEquals(
+        "module=\"x=y\"", AuditLogAdaptor.summarizeFilters(null, null, "x=y", null, null, null));
+  }
+
+  @Test
+  void escapeFilterValueLeavesPlainTokensUnquoted() {
+    assertEquals("admin", AuditLogAdaptor.escapeFilterValue("admin"));
+    assertEquals("\"a,b\"", AuditLogAdaptor.escapeFilterValue("a,b"));
+  }
+
   private static PSSystemAuditLogEntry sampleRow() {
     PSSystemAuditLogEntry e = new PSSystemAuditLogEntry();
     e.setAuditId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/AuditLogAdaptorTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -30,6 +31,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.codes.AuditSubsystemErrorCodes;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
 import com.percussion.rest.auditlog.SystemAuditLogEntry;
 import com.percussion.rest.auditlog.SystemAuditLogPage;
 import com.percussion.services.audit.data.PSSystemAuditLogEntry;
@@ -38,11 +43,25 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("UnitTest")
 class AuditLogAdaptorTest {
+
+  @BeforeEach
+  void setUpAuditSink() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @AfterEach
+  void tearDownAuditSink() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
 
   @Test
   void adminCanQuery() {
@@ -55,7 +74,7 @@ class AuditLogAdaptorTest {
         .thenReturn(1L);
 
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false, () -> "admin");
 
     SystemAuditLogPage page =
         adaptor.query(null, null, null, null, null, null, 0, 50);
@@ -74,7 +93,8 @@ class AuditLogAdaptorTest {
     when(repo.countEntries(any(), any(), any(), any(), any(), any())).thenReturn(0L);
 
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Editor"), role -> "Editor".equals(role));
+        new AuditLogAdaptor(
+            repo, () -> List.of("Editor"), role -> "Editor".equals(role), () -> "editor");
 
     SystemAuditLogPage page =
         adaptor.query(null, null, null, null, null, null, 0, 10);
@@ -86,7 +106,7 @@ class AuditLogAdaptorTest {
   void unauthorizedThrowsSecurityExceptionWithoutTouchingRepo() {
     PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false, () -> "author");
 
     assertThrows(
         SecurityException.class,
@@ -99,7 +119,7 @@ class AuditLogAdaptorTest {
   void invalidFromIsIllegalArgument() {
     PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false, () -> "admin");
     assertThrows(
         IllegalArgumentException.class,
         () -> adaptor.query("not-an-instant", null, null, null, null, null, 0, 50));
@@ -112,7 +132,7 @@ class AuditLogAdaptorTest {
     when(repo.findById(eq("id-1"))).thenReturn(Optional.of(sampleRow()));
 
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false, () -> "admin");
 
     assertNull(adaptor.findById("missing"));
     SystemAuditLogEntry found = adaptor.findById("id-1");
@@ -125,7 +145,7 @@ class AuditLogAdaptorTest {
   void findByIdUnauthorized() {
     PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false, () -> "author");
     assertThrows(SecurityException.class, () -> adaptor.findById("id-1"));
     verify(repo, never()).findById(anyString());
   }
@@ -138,7 +158,7 @@ class AuditLogAdaptorTest {
         .thenReturn(List.of(sampleRow()));
 
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false, () -> "admin");
 
     List<SystemAuditLogEntry> out =
         adaptor.export(null, null, "AUTH", null, null, null, 50);
@@ -154,7 +174,7 @@ class AuditLogAdaptorTest {
   void exportUnauthorizedDoesNotTouchRepo() {
     PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false, () -> "author");
 
     assertThrows(
         SecurityException.class,
@@ -170,7 +190,8 @@ class AuditLogAdaptorTest {
         .thenReturn(List.of());
 
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Editor"), role -> "Editor".equals(role));
+        new AuditLogAdaptor(
+            repo, () -> List.of("Editor"), role -> "Editor".equals(role), () -> "editor");
 
     List<SystemAuditLogEntry> out =
         adaptor.export(null, null, null, null, null, null, 10);
@@ -182,10 +203,80 @@ class AuditLogAdaptorTest {
   void exportInvalidFromIsIllegalArgument() {
     PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
     AuditLogAdaptor adaptor =
-        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false);
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false, () -> "admin");
     assertThrows(
         IllegalArgumentException.class,
         () -> adaptor.export("not-an-instant", null, null, null, null, null, 10));
+  }
+
+  @Test
+  void querySuccessEmitsViewerAccessAuditEvent() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    when(repo.findEntries(any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(List.of());
+    when(repo.countEntries(any(), any(), any(), any(), any(), any())).thenReturn(0L);
+
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false, () -> "admin");
+
+    adaptor.query(null, null, "AUTH", null, null, null, 0, 50);
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(AuditSubsystemErrorCodes.VIEWER_ACCESS, rec.code());
+    assertEquals(AuditOutcome.SUCCESS, rec.outcome());
+    assertEquals("admin", rec.actor().orElse(""));
+    assertTrue(rec.logMessage().contains("list"));
+    assertTrue(rec.logMessage().contains("module=AUTH"));
+  }
+
+  @Test
+  void findByIdSuccessEmitsDetailViewerAccess() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    when(repo.findById(eq("id-1"))).thenReturn(Optional.of(sampleRow()));
+
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Admin"), role -> false, () -> "viewer1");
+
+    adaptor.findById("id-1");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(AuditSubsystemErrorCodes.VIEWER_ACCESS, rec.code());
+    assertTrue(rec.logMessage().contains("detail"));
+    assertTrue(rec.logMessage().contains("auditId=id-1"));
+    assertEquals("viewer1", rec.actor().orElse(""));
+  }
+
+  @Test
+  void queryDeniedEmitsViewerAccessDenied() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false, () -> "author");
+
+    assertThrows(
+        SecurityException.class,
+        () -> adaptor.query(null, null, null, null, null, null, 0, 50));
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(AuditSubsystemErrorCodes.VIEWER_ACCESS_DENIED, rec.code());
+    assertEquals(AuditOutcome.FAILURE, rec.outcome());
+    assertEquals("author", rec.actor().orElse(""));
+  }
+
+  @Test
+  void findByIdDeniedEmitsViewerAccessDenied() {
+    PSSystemAuditLogRepository repo = mock(PSSystemAuditLogRepository.class);
+    AuditLogAdaptor adaptor =
+        new AuditLogAdaptor(repo, () -> List.of("Author"), role -> false, () -> "author");
+
+    assertThrows(SecurityException.class, () -> adaptor.findById("id-1"));
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertEquals(
+        AuditSubsystemErrorCodes.VIEWER_ACCESS_DENIED,
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
   }
 
   private static PSSystemAuditLogEntry sampleRow() {

--- a/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
+++ b/system/services/src/com/percussion/services/audit/PSSystemAuditLogger.java
@@ -23,6 +23,7 @@ import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.AuditSubsystemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.AuthenticationErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
@@ -347,6 +348,85 @@ public final class PSSystemAuditLogger {
   /** Design object delete (DESN-2903). */
   public static void designDelete(String actor, String type, String name, String guid) {
     design(DesignErrorCodes.DELETE, actor, type, name, guid);
+  }
+
+  /**
+   * Audit-of-audit: successful list or detail view of the system security audit log (Phase 5 /
+   * #2716). Nested dual-write is suppressed by {@link DefaultAuditLogService} reentrancy guard.
+   *
+   * @param actor principal who viewed the log (blank → {@code "unknown"})
+   * @param action short action label such as {@code list} or {@code detail}
+   * @param detail free-form filter summary or audit id (may be blank)
+   */
+  public static void auditViewerAccess(String actor, String action, String detail) {
+    String a = blankToUnknown(actor);
+    String act = nullToEmpty(action);
+    String d = nullToEmpty(detail);
+    AuditContext ctx =
+        AuditContext.builder()
+            .actor(a)
+            .target(act)
+            .attribute("action", act)
+            .attribute("detail", d)
+            .build();
+    log(AuditSubsystemErrorCodes.VIEWER_ACCESS, ctx, AuditOutcome.SUCCESS, a, act, d);
+  }
+
+  /**
+   * Audit-of-audit: explicit deny when a principal lacks Admin / {@code
+   * sys_securityAuditLogViewer} for list/detail access.
+   */
+  public static void auditViewerAccessDenied(String actor, String action, String reason) {
+    String a = blankToUnknown(actor);
+    String act = nullToEmpty(action);
+    String r = nullToEmpty(reason);
+    AuditContext ctx =
+        AuditContext.builder()
+            .actor(a)
+            .target(act)
+            .attribute("action", act)
+            .attribute("reason", r)
+            .build();
+    log(AuditSubsystemErrorCodes.VIEWER_ACCESS_DENIED, ctx, AuditOutcome.FAILURE, a, act, r);
+  }
+
+  /**
+   * Audit-of-audit: successful CSV/JSON export of the system security audit log. Ready for the
+   * export API (#2715) to call; does not implement export itself.
+   *
+   * @param format normalized format ({@code csv} / {@code json}); may be blank
+   * @param detail free-form filter summary (may be blank)
+   */
+  public static void auditExportAccess(String actor, String format, String detail) {
+    String a = blankToUnknown(actor);
+    String f = nullToEmpty(format);
+    String d = nullToEmpty(detail);
+    AuditContext ctx =
+        AuditContext.builder()
+            .actor(a)
+            .target(f)
+            .attribute("format", f)
+            .attribute("detail", d)
+            .build();
+    log(AuditSubsystemErrorCodes.EXPORT_ACCESS, ctx, AuditOutcome.SUCCESS, a, f, d);
+  }
+
+  /**
+   * Audit-of-audit: explicit deny on export when the principal is not authorized.
+   */
+  public static void auditExportAccessDenied(String actor, String reason) {
+    String a = blankToUnknown(actor);
+    String r = nullToEmpty(reason);
+    AuditContext ctx =
+        AuditContext.builder().actor(a).attribute("reason", r).build();
+    log(AuditSubsystemErrorCodes.EXPORT_ACCESS_DENIED, ctx, AuditOutcome.FAILURE, a, r);
+  }
+
+  private static String blankToUnknown(String actor) {
+    if (actor == null || actor.isBlank()) {
+      return "unknown";
+    }
+    return actor.trim();
   }
 
   private static AuditContext contentContext(HttpServletRequest request, String guid) {

--- a/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
+++ b/system/src/test/java/com/percussion/services/audit/PSSystemAuditLoggerTest.java
@@ -25,6 +25,7 @@ import com.intsof.percussioncms.auditlog.AuditContext;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.AuditSubsystemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
@@ -263,6 +264,58 @@ class PSSystemAuditLoggerTest {
   void designNullCodeIsNoOp() {
     PSSystemAuditLogger.design(null, "u", "t", "n", "g");
     assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void auditViewerAccessWritesAuditViewEvent() {
+    PSSystemAuditLogger.auditViewerAccess("admin", "list", "module=AUTH,limit=50");
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(AuditSubsystemErrorCodes.VIEWER_ACCESS, rec.code());
+    assertEquals("AUDIT", rec.code().module().code());
+    assertEquals(1, rec.code().numericCode());
+    assertEquals(AuditOutcome.SUCCESS, rec.outcome());
+    assertEquals("admin", rec.actor().orElse(""));
+    assertTrue(rec.formattedLine().startsWith("[AUDIT-1]-"));
+    assertTrue(rec.logMessage().contains("list"));
+  }
+
+  @Test
+  void auditViewerAccessDeniedWritesFailure() {
+    PSSystemAuditLogger.auditViewerAccessDenied("author", "detail", "forbidden");
+
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(AuditSubsystemErrorCodes.VIEWER_ACCESS_DENIED, rec.code());
+    assertEquals(AuditOutcome.FAILURE, rec.outcome());
+    assertEquals(3, rec.code().numericCode());
+  }
+
+  @Test
+  void auditExportAccessAndDeniedWriteExportEvents() {
+    PSSystemAuditLogger.auditExportAccess("admin", "csv", "module=AUTH,maxRows=100");
+    PSSystemAuditLogger.auditExportAccessDenied("guest", "forbidden");
+
+    assertEquals(2, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var codes =
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().stream()
+            .map(r -> r.code().numericCode())
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(codes.contains(4));
+    assertTrue(codes.contains(5));
+    assertEquals(
+        AuditSubsystemErrorCodes.EXPORT_ACCESS,
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
+    assertEquals(
+        AuditOutcome.FAILURE,
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(1).outcome());
+  }
+
+  @Test
+  void auditViewerBlankActorBecomesUnknown() {
+    PSSystemAuditLogger.auditViewerAccess("  ", "list", "");
+    assertEquals(
+        "unknown", ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).actor().orElse(""));
   }
 
   private static HttpServletRequest mockRequest(String user, String ip) {


### PR DESCRIPTION
## Summary
Phase 5 / parent **#2620** slice 2 (**#2716**): make system audit log **viewer access itself auditable** (audit-of-audit).

- Expand `AuditSubsystemErrorCodes`: `VIEWER_ACCESS` (AUDIT-1), `VIEWER_ACCESS_DENIED` (AUDIT-3), `EXPORT_ACCESS` (AUDIT-4), `EXPORT_ACCESS_DENIED` (AUDIT-5)
- `PSSystemAuditLogger.auditViewerAccess*` / `auditExportAccess*` dual-write helpers
- `AuditLogAdaptor` emits success/deny events for list and detail (Admin or `sys_securityAuditLogViewer`)
- `DefaultAuditLogService` ThreadLocal reentrancy guard prevents nested dual-write storms
- Unit tests: sink calls + adaptor wiring (success + deny)

**Out of scope (siblings):** export API body (#2715 / PR #2720), federal runbook (#2717). Export helpers are ready for #2715 to call on success/deny.

## Parent
#2620 — System audit log Phase 5: Hardening / compliance pack

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw clean install` — BUILD SUCCESS (DefaultAuditLogServiceTest 6/0/0 incl. reentrancy + AUDIT-3)
- [x] `cd system && ../mvnw clean install -Dmaven.javadoc.skip=true` — BUILD SUCCESS; `PSSystemAuditLoggerTest` 30/0/0 (javadoc skip is baseline legacy errors, unrelated)
- [x] `cd projects/sitemanage && ../../mvnw clean install -Dmaven.javadoc.skip=true` — BUILD SUCCESS; `AuditLogAdaptorTest` 10/0/0
- [x] rest reinstalled from this tree only to clear a stale SNAPSHOT that already had #2715 export (not part of this PR)

## Gates
- Erlang-style self-review: no path I/O; reentrancy guard; deny still throws SecurityException; emit failures swallowed so audit sink issues cannot break viewer
- No new warnings attributable to this change

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2716

## Operator / SIEM note (review follow-up)
`VIEWER_ACCESS` (AUDIT-1) free-text log template is now `actor={} action={} detail={}` (list/detail + filter summary), replacing the pre-#2716 two-arg `actor={} filters={}` shape on main. Update parsers/SIEM rules. Filter summaries quote values that contain commas/equals/quotes.

