### PR TITLE
fix(WebUI,rest): Gravatar preference save UserPreference wire root (#2708)

### DIFF
--- a/WebUI/src/main/ts/api/preferences/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/preferences/preferencesApi.ts
@@ -97,12 +97,28 @@ function isUserPreferenceShape(value: unknown): value is UserPreference {
   return typeof o.name === "string";
 }
 
+/** Options for {@link unwrapUserPreference}. */
+export type UnwrapUserPreferenceOptions = {
+  /**
+   * When true (default), accept a flat {@code { name, value }} object if the
+   * Jackson root is missing. Production GET/PUT response parsing uses
+   * {@code false} so a dropped root wrap surfaces as null rather than silently
+   * treating a mis-shaped body as success (#2708 review).
+   */
+  acceptFlat?: boolean;
+};
+
 /**
  * Normalize a PreferenceResource single-pref response or request body to a flat
- * {@link UserPreference}. Accepts Jackson-wrapped
- * {@code { UserPreference: { ... } }} or a flat object (tests / legacy).
+ * {@link UserPreference}. Prefers Jackson-wrapped
+ * {@code { UserPreference: { ... } }}. Flat objects are only accepted when
+ * {@code acceptFlat} is true (tests / explicit callers).
  */
-export function unwrapUserPreference(data: unknown): UserPreference | null {
+export function unwrapUserPreference(
+  data: unknown,
+  options?: UnwrapUserPreferenceOptions,
+): UserPreference | null {
+  const acceptFlat = options?.acceptFlat !== false;
   const root = asRecord(data);
   if (!root) {
     return null;
@@ -110,6 +126,10 @@ export function unwrapUserPreference(data: unknown): UserPreference | null {
   const nested = asRecord(root[USER_PREFERENCE_ROOT]);
   if (nested && isUserPreferenceShape(nested)) {
     return nested;
+  }
+  // Production: do not mask a missing UserPreference root with a flat fallback.
+  if (!acceptFlat) {
+    return null;
   }
   if (isUserPreferenceShape(root)) {
     return root;
@@ -168,7 +188,8 @@ export async function loadUserPreference(
   const key = encodeURIComponent(preferenceName);
   try {
     const data = await get<unknown>(`${PATHS.PREFERENCES}/${key}`);
-    return unwrapUserPreference(data);
+    // Prefer wrapped wire; do not accept flat as a successful production parse.
+    return unwrapUserPreference(data, { acceptFlat: false });
   } catch (err: unknown) {
     if (isNotFound(err)) {
       return null;
@@ -191,11 +212,13 @@ export async function saveUserPreference(
     PATHS.PREFERENCES,
     wrapUserPreferenceForWire(pref),
   );
-  const unwrapped = unwrapUserPreference(data);
+  // Response must be wrapped; flat/mis-shaped bodies fall through to sent fields.
+  const unwrapped = unwrapUserPreference(data, { acceptFlat: false });
   if (unwrapped) {
     return unwrapped;
   }
-  // Defensive: if server returned unexpected shape, surface the fields we sent.
+  // Defensive: if server returned unexpected shape, surface the fields we sent
+  // so UI state stays consistent after a successful HTTP PUT (#2708).
   return {
     name: pref.name,
     value: pref.value ?? "",

--- a/WebUI/src/main/ts/api/preferences/preferencesApi.ts
+++ b/WebUI/src/main/ts/api/preferences/preferencesApi.ts
@@ -39,6 +39,17 @@ export type UserPreference = {
   extraParam?: string;
 };
 
+/**
+ * Jackson root name for {@code UserPreference} ({@code @XmlRootElement} /
+ * {@code @JsonRootName}). REST {@code JacksonContextResolver} enables
+ * {@code WRAP_ROOT_VALUE} / {@code UNWRAP_ROOT_VALUE}, so PUT/DELETE bodies and
+ * single-pref responses use {@code { "UserPreference": { ... } }}.
+ *
+ * <p>A bare flat body starting with {@code name} is rejected as unexpected root
+ * (JAXB/Jackson: expected {@code UserPreference}) — see #2708.</p>
+ */
+export const USER_PREFERENCE_ROOT = "UserPreference";
+
 /** Default category PreferenceResource applies when omitted on save. */
 export const PREF_CATEGORY_SYS = "sys_preferences";
 
@@ -48,6 +59,13 @@ export const PREF_CONTEXT_PRIVATE = "private";
 function isNotFound(err: unknown): boolean {
   const api = err as ApiError;
   return !!api && typeof api.status === "number" && api.status === 404;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
 }
 
 function asPreferenceArray(data: unknown): UserPreference[] {
@@ -80,6 +98,49 @@ function isUserPreferenceShape(value: unknown): value is UserPreference {
 }
 
 /**
+ * Normalize a PreferenceResource single-pref response or request body to a flat
+ * {@link UserPreference}. Accepts Jackson-wrapped
+ * {@code { UserPreference: { ... } }} or a flat object (tests / legacy).
+ */
+export function unwrapUserPreference(data: unknown): UserPreference | null {
+  const root = asRecord(data);
+  if (!root) {
+    return null;
+  }
+  const nested = asRecord(root[USER_PREFERENCE_ROOT]);
+  if (nested && isUserPreferenceShape(nested)) {
+    return nested;
+  }
+  if (isUserPreferenceShape(root)) {
+    return root;
+  }
+  return null;
+}
+
+/**
+ * Build the wire JSON body for PreferenceResource PUT/DELETE.
+ *
+ * <p>Must nest fields under {@link USER_PREFERENCE_ROOT} — a flat
+ * {@code { name, value, ... }} body fails server unwrap with unexpected root
+ * {@code name} (#2708).</p>
+ */
+export function wrapUserPreferenceForWire(
+  pref: UserPreference,
+): Record<string, UserPreference> {
+  const dto: UserPreference = {
+    name: pref.name,
+    value: pref.value ?? "",
+    category: pref.category || PREF_CATEGORY_SYS,
+    context: pref.context || PREF_CONTEXT_PRIVATE,
+    userName: pref.userName ?? "",
+  };
+  if (pref.extraParam !== undefined) {
+    dto.extraParam = pref.extraParam;
+  }
+  return { [USER_PREFERENCE_ROOT]: dto };
+}
+
+/**
  * GET /services/preferences/ — all stored prefs for the current user.
  *
  * @returns empty array when none stored (404) or body is empty
@@ -106,7 +167,8 @@ export async function loadUserPreference(
 ): Promise<UserPreference | null> {
   const key = encodeURIComponent(preferenceName);
   try {
-    return await get<UserPreference>(`${PATHS.PREFERENCES}/${key}`);
+    const data = await get<unknown>(`${PATHS.PREFERENCES}/${key}`);
+    return unwrapUserPreference(data);
   } catch (err: unknown) {
     if (isNotFound(err)) {
       return null;
@@ -119,16 +181,27 @@ export async function loadUserPreference(
  * PUT /services/preferences/ — save a single preference for the current user.
  *
  * <p>{@code userName} should be set (server DTO requires it).</p>
+ * <p>Body is Jackson root-wrapped as {@code { UserPreference: { ... } }}
+ * (#2708).</p>
  */
 export async function saveUserPreference(
   pref: UserPreference,
 ): Promise<UserPreference> {
-  return put<UserPreference>(PATHS.PREFERENCES, {
+  const data = await put<unknown>(
+    PATHS.PREFERENCES,
+    wrapUserPreferenceForWire(pref),
+  );
+  const unwrapped = unwrapUserPreference(data);
+  if (unwrapped) {
+    return unwrapped;
+  }
+  // Defensive: if server returned unexpected shape, surface the fields we sent.
+  return {
     name: pref.name,
     value: pref.value ?? "",
     category: pref.category || PREF_CATEGORY_SYS,
     context: pref.context || PREF_CONTEXT_PRIVATE,
     userName: pref.userName ?? "",
     extraParam: pref.extraParam,
-  });
+  };
 }

--- a/WebUI/src/test/ts/api/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/preferencesApi.test.ts
@@ -110,7 +110,7 @@ describe("preferencesApi (PreferenceResource)", () => {
     expect(wire.UserPreference.name).toBe("perc_profile_gravatar_email");
   });
 
-  it("unwrapUserPreference accepts flat and wrapped shapes", () => {
+  it("unwrapUserPreference accepts flat only when acceptFlat is true", () => {
     expect(
       unwrapUserPreference({
         name: "k",
@@ -118,10 +118,60 @@ describe("preferencesApi (PreferenceResource)", () => {
       })?.value,
     ).toBe("v");
     expect(
+      unwrapUserPreference(
+        {
+          name: "k",
+          value: "v",
+        },
+        { acceptFlat: false },
+      ),
+    ).toBeNull();
+    expect(
       unwrapUserPreference({
         UserPreference: { name: "k", value: "wrapped" },
       })?.value,
     ).toBe("wrapped");
+    expect(
+      unwrapUserPreference(
+        {
+          UserPreference: { name: "k", value: "wrapped" },
+        },
+        { acceptFlat: false },
+      )?.value,
+    ).toBe("wrapped");
     expect(unwrapUserPreference(null)).toBeNull();
+  });
+
+  it("saveUserPreference falls back to sent fields when response is unparseable", async () => {
+    vi.spyOn(client, "put").mockResolvedValueOnce({ unexpected: true });
+    const saved = await saveUserPreference({
+      name: "perc_profile_gravatar_email",
+      value: "avatar@example.com",
+      userName: "Admin",
+      category: "sys_preferences",
+      context: "private",
+    });
+    expect(saved.name).toBe("perc_profile_gravatar_email");
+    expect(saved.value).toBe("avatar@example.com");
+    expect(saved.userName).toBe("Admin");
+    expect(saved.category).toBe("sys_preferences");
+    expect(saved.context).toBe("private");
+  });
+
+  it("saveUserPreference does not treat flat response as success unwrap", async () => {
+    // Flat body is not the production wire; use sent-fields fallback instead.
+    vi.spyOn(client, "put").mockResolvedValueOnce({
+      name: "other",
+      value: "from-flat",
+      userName: "X",
+    });
+    const saved = await saveUserPreference({
+      name: "k",
+      value: "sent",
+      userName: "Admin",
+    });
+    expect(saved.name).toBe("k");
+    expect(saved.value).toBe("sent");
+    expect(saved.userName).toBe("Admin");
   });
 });

--- a/WebUI/src/test/ts/api/preferencesApi.test.ts
+++ b/WebUI/src/test/ts/api/preferencesApi.test.ts
@@ -20,6 +20,9 @@ import {
   getAllUserPreferences,
   loadUserPreference,
   saveUserPreference,
+  unwrapUserPreference,
+  wrapUserPreferenceForWire,
+  USER_PREFERENCE_ROOT,
 } from "../../../main/ts/api/preferences/preferencesApi";
 import * as client from "../../../main/ts/api/client";
 
@@ -52,19 +55,73 @@ describe("preferencesApi (PreferenceResource)", () => {
     await expect(loadUserPreference("missing")).resolves.toBeNull();
   });
 
-  it("saveUserPreference puts DTO with defaults", async () => {
+  it("loadUserPreference unwraps Jackson UserPreference root", async () => {
+    vi.spyOn(client, "get").mockResolvedValueOnce({
+      UserPreference: {
+        name: "perc_profile_gravatar_email",
+        value: "avatar@example.com",
+        category: "sys_preferences",
+        context: "private",
+        userName: "Admin",
+      },
+    });
+    const pref = await loadUserPreference("perc_profile_gravatar_email");
+    expect(pref?.name).toBe("perc_profile_gravatar_email");
+    expect(pref?.value).toBe("avatar@example.com");
+  });
+
+  it("saveUserPreference wraps body under UserPreference root (#2708)", async () => {
     const putSpy = vi.spyOn(client, "put").mockResolvedValueOnce({
+      UserPreference: {
+        name: "k",
+        value: "v",
+        category: "sys_preferences",
+        context: "private",
+        userName: "Admin",
+      },
+    });
+    const saved = await saveUserPreference({
       name: "k",
       value: "v",
-      category: "sys_preferences",
-      context: "private",
       userName: "Admin",
     });
-    await saveUserPreference({ name: "k", value: "v", userName: "Admin" });
     expect(putSpy).toHaveBeenCalled();
-    const body = putSpy.mock.calls[0][1] as Record<string, string>;
-    expect(body.category).toBe("sys_preferences");
-    expect(body.context).toBe("private");
-    expect(body.userName).toBe("Admin");
+    const body = putSpy.mock.calls[0][1] as Record<string, Record<string, string>>;
+    // Must not send flat { name, ... } — server UNWRAP_ROOT_VALUE expects UserPreference
+    expect(body).not.toHaveProperty("name");
+    expect(body[USER_PREFERENCE_ROOT]).toBeDefined();
+    expect(body[USER_PREFERENCE_ROOT].name).toBe("k");
+    expect(body[USER_PREFERENCE_ROOT].value).toBe("v");
+    expect(body[USER_PREFERENCE_ROOT].category).toBe("sys_preferences");
+    expect(body[USER_PREFERENCE_ROOT].context).toBe("private");
+    expect(body[USER_PREFERENCE_ROOT].userName).toBe("Admin");
+    expect(saved.name).toBe("k");
+    expect(saved.value).toBe("v");
+  });
+
+  it("wrapUserPreferenceForWire nests Gravatar override fields under root", () => {
+    const wire = wrapUserPreferenceForWire({
+      name: "perc_profile_gravatar_email",
+      value: "avatar@example.com",
+      userName: "Admin",
+    });
+    expect(Object.keys(wire)).toEqual([USER_PREFERENCE_ROOT]);
+    expect(wire.UserPreference.value).toBe("avatar@example.com");
+    expect(wire.UserPreference.name).toBe("perc_profile_gravatar_email");
+  });
+
+  it("unwrapUserPreference accepts flat and wrapped shapes", () => {
+    expect(
+      unwrapUserPreference({
+        name: "k",
+        value: "v",
+      })?.value,
+    ).toBe("v");
+    expect(
+      unwrapUserPreference({
+        UserPreference: { name: "k", value: "wrapped" },
+      })?.value,
+    ).toBe("wrapped");
+    expect(unwrapUserPreference(null)).toBeNull();
   });
 });

--- a/rest/src/main/java/com/percussion/rest/preferences/UserPreference.java
+++ b/rest/src/main/java/com/percussion/rest/preferences/UserPreference.java
@@ -19,11 +19,19 @@
 
 package com.percussion.rest.preferences;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
-/** Represents a user preference. Sunny Sal: "User preference ka hero, customization ka zero!" */
+/**
+ * Represents a user preference. Sunny Sal: "User preference ka hero, customization ka zero!"
+ *
+ * <p>{@link JsonRootName} matches {@link XmlRootElement} so Jackson
+ * {@code WRAP_ROOT_VALUE}/{@code UNWRAP_ROOT_VALUE} expects wire shape
+ * {@code { "UserPreference": { ... } }} (WebUI #2708).
+ */
 @XmlRootElement(name = "UserPreference")
+@JsonRootName("UserPreference")
 @Schema(description = "UserPreference")
 public class UserPreference {
 

--- a/rest/src/test/java/com/percussion/rest/preferences/UserPreferenceSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/preferences/UserPreferenceSerialDeserialTest.java
@@ -70,8 +70,15 @@ public class UserPreferenceSerialDeserialTest {
     // Flat body that WebUI previously sent — root key is "name", not "UserPreference"
     var flat = "{\"name\":\"perc_profile_gravatar_email\",\"value\":\"x\",\"userName\":\"Admin\"}";
     try {
-      mapper.readValue(flat, UserPreference.class);
-      // Some Jackson versions may throw; if not, still not a successful preference shape
+      UserPreference result = mapper.readValue(flat, UserPreference.class);
+      // Must not vacuous-pass: if Jackson did not throw, the result must not look like a
+      // successfully unwrapped preference (name populated from unexpected root).
+      assertTrue(
+          result == null
+              || result.getName() == null
+              || result.getName().isBlank(),
+          "flat body must not deserialize as named UserPreference under UNWRAP_ROOT_VALUE; got name="
+              + (result == null ? "null" : result.getName()));
     } catch (Exception expected) {
       // Expected for UNWRAP_ROOT_VALUE mismatch (#2708 class of failure)
       assertTrue(

--- a/rest/src/test/java/com/percussion/rest/preferences/UserPreferenceSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/preferences/UserPreferenceSerialDeserialTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Wire shape for PreferenceResource single-pref PUT/GET must use Jackson root wrap {@code
+ * UserPreference} (matches WebUI #2708 and {@code JacksonContextResolver}).
+ */
+public class UserPreferenceSerialDeserialTest {
+
+  @Test
+  public void serializeAndDeserializeWrapsRootNameUserPreference() throws JacksonException {
+    var mapper =
+        JsonMapper.builder()
+            .enable(SerializationFeature.WRAP_ROOT_VALUE)
+            .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+            .build();
+
+    var pref = new UserPreference();
+    pref.setName("perc_profile_gravatar_email");
+    pref.setValue("avatar@example.com");
+    pref.setCategory("sys_preferences");
+    pref.setContext("private");
+    pref.setUserName("Admin");
+
+    var json = mapper.writeValueAsString(pref);
+    assertTrue(
+        json.contains("\"UserPreference\""),
+        "expected UserPreference root wrap, got: " + json);
+    assertTrue(json.contains("perc_profile_gravatar_email"));
+
+    var roundTrip = mapper.readValue(json, UserPreference.class);
+    assertEquals(pref.getName(), roundTrip.getName());
+    assertEquals(pref.getValue(), roundTrip.getValue());
+    assertEquals(pref.getUserName(), roundTrip.getUserName());
+  }
+
+  @Test
+  public void deserializeRejectsFlatNameRootWhenUnwrapping() {
+    var mapper =
+        JsonMapper.builder()
+            .enable(SerializationFeature.WRAP_ROOT_VALUE)
+            .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+            .build();
+
+    // Flat body that WebUI previously sent — root key is "name", not "UserPreference"
+    var flat = "{\"name\":\"perc_profile_gravatar_email\",\"value\":\"x\",\"userName\":\"Admin\"}";
+    try {
+      mapper.readValue(flat, UserPreference.class);
+      // Some Jackson versions may throw; if not, still not a successful preference shape
+    } catch (Exception expected) {
+      // Expected for UNWRAP_ROOT_VALUE mismatch (#2708 class of failure)
+      assertTrue(
+          expected.getMessage() != null
+              && (expected.getMessage().contains("UserPreference")
+                  || expected.getMessage().contains("Root name")
+                  || expected.getMessage().contains("name")),
+          "unexpected failure: " + expected);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes Gravatar settings save when **Use primary account email for Gravatar** is unchecked and a manual email is saved.

`PreferenceResource` PUT uses Jackson `WRAP_ROOT_VALUE` / `UNWRAP_ROOT_VALUE`. The WebUI client was POSTing a **flat** preference body:

```json
{ "name": "perc_profile_gravatar_email", "value": "...", ... }
```

Server expected root name `UserPreference`:

```json
{ "UserPreference": { "name": "...", "value": "...", ... } }
```

Flat `name` was treated as the root element → `JAXBException: unexpected element local:"name". Expected elements are <{}UserPreference>` (#2708). Same family as #2701 / PR #2710 root-name wire mismatches.

### Fix

- **WebUI** `preferencesApi.saveUserPreference`: wrap body under `UserPreference`; unwrap load/save responses
- **rest** `UserPreference`: add `@JsonRootName("UserPreference")` aligned with `@XmlRootElement`
- Vitest: wrap/unwrap + Gravatar override field coverage
- Java: Jackson serial/deserial root-name unit test

No sitemanage change (adaptor already fine). UI screen path unchanged (API wire only); Playwright optional per triage.

Fixes #2708

## Test plan

- [x] Vitest `preferencesApi.test.ts` — 6 tests including `#2708` root wrap
- [x] `cd WebUI` → `..\mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `cd rest` → `..\mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `UserPreferenceSerialDeserialTest` — Tests run: 2, Failures: 0
- [ ] Human QA: Profile → Avatar → uncheck primary email → enter Gravatar email → Save (no JAXB error; settings persist)

## Gates evidence

| Gate | Result |
|------|--------|
| Change class | REST wire payload for UserPreference (client root wrap + DTO JsonRootName) |
| Companions | Vitest + rest serial test; peer wrap pattern (RolesSection psstring / PR #2710 family) |
| Erlang self-review | No bugs found; no path I/O; war dual-ship N/A (TS under src/main/ts) |
| Pre-PR Maven | `cd WebUI` + `cd rest` standalone clean install **BUILD SUCCESS** |
| Cross-platform | No path/file I/O changes |

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
