### PR TITLE
fix(webui): Display Format detail GUID unwrap for Object ACL (#2689)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
@@ -79,10 +79,37 @@ export async function listDisplayFormats(
   return asArray<DisplayFormat>(payload);
 }
 
+/**
+ * Unwrap Jackson root wrap for a single display format
+ * ({@code {"DisplayFormat":{…}}}) so {@code guid.stringValue} is reachable
+ * (issue #2689). Flat payloads pass through.
+ */
+export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
+  if (payload == null) {
+    return {};
+  }
+  if (typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const root = payload as Record<string, unknown>;
+  const nested = root.DisplayFormat ?? root.displayFormat;
+  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as DisplayFormat;
+  }
+  if (Array.isArray(nested) && nested.length > 0) {
+    const first = nested[0];
+    if (first != null && typeof first === "object") {
+      return first as DisplayFormat;
+    }
+  }
+  return root as DisplayFormat;
+}
+
 /** GET /services/displayformats/{idOrName} */
 export async function getDisplayFormatDetail(
   idOrName: string,
 ): Promise<DisplayFormat> {
   const key = encodeURIComponent(idOrName);
-  return get<DisplayFormat>(`${PATHS.DISPLAY_FORMATS}/${key}`);
+  const payload = await get<unknown>(`${PATHS.DISPLAY_FORMATS}/${key}`);
+  return unwrapDisplayFormat(payload);
 }

--- a/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
@@ -35,6 +35,37 @@ function asArray<T>(payload: unknown): T[] {
   return [];
 }
 
+/**
+ * Unwrap Jackson {@code WRAP_ROOT_VALUE} envelopes for a single display format.
+ *
+ * <p>REST {@code JacksonContextResolver} wraps DTOs as
+ * {@code {"DisplayFormat":{…}}}. Without unwrapping, detail panels read
+ * {@code detail.guid} as undefined and Object ACL shows
+ * "Object GUID not available" even though the server supplied a GUID
+ * (issue #2689). Flat payloads (no wrap) pass through unchanged.
+ */
+export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
+  if (payload == null) {
+    return {};
+  }
+  if (typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const root = payload as Record<string, unknown>;
+  const nested = root.DisplayFormat ?? root.displayFormat;
+  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as DisplayFormat;
+  }
+  if (Array.isArray(nested) && nested.length > 0) {
+    const first = nested[0];
+    if (first != null && typeof first === "object") {
+      return first as DisplayFormat;
+    }
+  }
+  // Flat body (WRAP_ROOT_VALUE off or already unwrapped)
+  return root as DisplayFormat;
+}
+
 export function normalizeColumns(
   columns: DisplayFormat["columns"],
 ): DisplayFormatColumn[] {
@@ -54,5 +85,6 @@ export async function listDisplayFormats(): Promise<DisplayFormat[]> {
 /** GET /services/displayformats/{idOrName} */
 export async function getDisplayFormatDetail(idOrName: string): Promise<DisplayFormat> {
   const key = encodeURIComponent(idOrName);
-  return get<DisplayFormat>(`${PATHS.DISPLAY_FORMATS}/${key}`);
+  const payload = await get<unknown>(`${PATHS.DISPLAY_FORMATS}/${key}`);
+  return unwrapDisplayFormat(payload);
 }

--- a/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getDisplayFormatDetail,
+  unwrapDisplayFormat,
+} from "../../../../main/ts/api/developer/displayFormatsApi";
+
+describe("unwrapDisplayFormat", () => {
+  it("unwraps Jackson DisplayFormat root envelope so guid is reachable (#2689)", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: {
+        name: "By_Author",
+        label: "By Author",
+        guid: { stringValue: "0-11-5", type: 11, uuid: 5 },
+        columns: [{ source: "sys_title" }],
+      },
+    });
+    expect(unwrapped.name).toBe("By_Author");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-5");
+    expect(unwrapped.columns).toHaveLength(1);
+  });
+
+  it("unwraps camelCase displayFormat envelope", () => {
+    const unwrapped = unwrapDisplayFormat({
+      displayFormat: {
+        name: "Default",
+        guid: { stringValue: "0-11-1" },
+      },
+    });
+    expect(unwrapped.name).toBe("Default");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-1");
+  });
+
+  it("passes through flat payloads without wrap", () => {
+    const flat = {
+      name: "FolderList",
+      guid: { stringValue: "0-11-2" },
+    };
+    expect(unwrapDisplayFormat(flat)).toEqual(flat);
+  });
+
+  it("takes first element when envelope holds a singleton array", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: [{ name: "only", guid: { stringValue: "0-11-9" } }],
+    });
+    expect(unwrapped.name).toBe("only");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-9");
+  });
+
+  it("returns empty object for null/non-object payloads", () => {
+    expect(unwrapDisplayFormat(null)).toEqual({});
+    expect(unwrapDisplayFormat(undefined)).toEqual({});
+    expect(unwrapDisplayFormat("x")).toEqual({});
+    expect(unwrapDisplayFormat([])).toEqual({});
+  });
+});
+
+describe("getDisplayFormatDetail", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("unwraps wrapped REST body before returning detail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            DisplayFormat: {
+              name: "By_Author",
+              guid: { stringValue: "0-11-5" },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    const detail = await getDisplayFormatDetail("By_Author");
+    expect(detail.name).toBe("By_Author");
+    expect(detail.guid?.stringValue).toBe("0-11-5");
+    expect(fetch).toHaveBeenCalled();
+    const calledUrl = String((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(calledUrl).toContain("/displayformats/");
+    expect(calledUrl).toContain("By_Author");
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
@@ -16,8 +16,10 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  getDisplayFormatDetail,
   listDisplayFormats,
   normalizeDisplayFormatColumns,
+  unwrapDisplayFormat,
 } from "../../../main/ts/api/contentExplorer/displayFormatsApi";
 import { mockFetch } from "./setup";
 
@@ -48,5 +50,35 @@ describe("displayFormatsApi", () => {
       }),
     ).toHaveLength(2);
     expect(normalizeDisplayFormatColumns(undefined)).toEqual([]);
+  });
+
+  it("unwrapDisplayFormat exposes guid under Jackson root wrap (#2689)", () => {
+    const df = unwrapDisplayFormat({
+      DisplayFormat: {
+        name: "By_Author",
+        guid: { stringValue: "0-11-5" },
+      },
+    });
+    expect(df.name).toBe("By_Author");
+    expect(df.guid?.stringValue).toBe("0-11-5");
+  });
+
+  it("getDisplayFormatDetail unwraps wrapped body", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      expect(url).toContain("/displayformats/By_Author");
+      return new Response(
+        JSON.stringify({
+          DisplayFormat: {
+            name: "By_Author",
+            guid: { stringValue: "0-11-5" },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const detail = await getDisplayFormatDetail("By_Author");
+    expect(detail.name).toBe("By_Author");
+    expect(detail.guid?.stringValue).toBe("0-11-5");
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -366,7 +366,12 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
       "developer-df-acl",
       "display-format",
     );
-    expect(["table", "no-guid", "empty"]).toContain(mode);
+    // Issue #2689: detail client must unwrap Jackson DisplayFormat root so
+    // objectGuid is present — no-guid shell is a product defect for DF detail.
+    expect(
+      ["table", "empty"],
+      `display-format Object ACL must load with GUID (got mode=${mode})`,
+    ).toContain(mode);
   });
 
   test("preferences default ACL template shows Design/Runtime column groups", async ({

--- a/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
@@ -18,11 +18,17 @@
 package com.percussion.rest.displayformat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.rest.Guid;
+import com.percussion.rest.JacksonContextResolver;
 import java.io.IOException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+@Tag("UnitTest")
 public class TestDisplayFormat {
 
   @Test
@@ -34,14 +40,31 @@ public class TestDisplayFormat {
 
     var mapper = JsonMapper.builder().build();
     var json = mapper.writeValueAsString(f);
-    System.out.println(json);
 
     var d2 = mapper.readValue(json, DisplayFormat.class);
 
     assertEquals("DescriptionTest", d2.getDescription());
     assertEquals("DisplayNameTest", d2.getDisplayName());
     assertEquals("InternalNameTest", d2.getInternalName());
+  }
 
-    // TODO: Finish me - test all the properties
+  /**
+   * Developer SPA reads {@code detail.guid.stringValue} for Object ACL. REST Jackson mapper must
+   * emit {@code stringValue} under the DisplayFormat root wrap (issue #2689).
+   */
+  @Test
+  public void jacksonContextResolver_serializesGuidStringValueUnderRootWrap() {
+    DisplayFormat f = new DisplayFormat();
+    f.setName("By_Author");
+    f.setLabel("By Author");
+    f.setGuid(new Guid("0-11-5"));
+
+    ObjectMapper mapper = new JacksonContextResolver().getContext(DisplayFormat.class);
+    String json = mapper.writeValueAsString(f);
+
+    assertTrue(json.contains("\"DisplayFormat\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"stringValue\""), json);
+    assertTrue(json.contains("0-11-5"), json);
+    assertTrue(json.contains("By_Author"), json);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #2689: Display Format detail (e.g. By_Author) showed Object ACL with **"Object GUID not available"** even though the server returns a GUID.

**Root cause:** REST `JacksonContextResolver` enables `WRAP_ROOT_VALUE`, so `GET /services/displayformats/{idOrName}` returns `{"DisplayFormat":{ name, guid, columns, … }}`. `getDisplayFormatDetail` returned that envelope as-is, so `detail.guid` was `undefined` and `ObjectAclSection` never received an object GUID.

**Fix:** Unwrap the Jackson root envelope in developer and contentExplorer `displayFormatsApi` (`unwrapDisplayFormat`) before returning detail. Flat payloads still pass through.

**Also:** REST unit test that Jackson emits `stringValue` under the root wrap; Playwright DF ACL product path no longer treats `no-guid` as success.

**Out of scope (per issue):** DTS cookie-consent log noise, preferences 404, path_management 400 ambient errors.

## Test plan
1. `cd rest && ../mvnw clean install` — BUILD SUCCESS (includes `TestDisplayFormat` GUID wrap test)
2. `cd WebUI && ../mvnw clean install` — BUILD SUCCESS (Vitest includes new displayFormatsApi tests)
3. `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS
4. Focused Vitest: `displayFormatsApi` developer + contentExplorer — 10 tests pass
5. Manual/QA: System Definition → Display Formats → By_Author → Object ACL should load (table or empty create path, not "GUID not available")

## Gates
- Erlang-style self-review: no path I/O issues; root-cause at design-object API client unwrap (not UI mask)
- Behavioral unit tests for unwrap + detail fetch
- No new module warnings introduced by this change (baseline unused-deps warnings only)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2689

> Co-Authored by Grok Build using grok-4.5 with agent main.
