### PR TITLE
fix(system): restore Explorer Search View_All load (GH-2712)

### DIFF
--- a/system/src/main/java/com/percussion/cms/objectstore/PSSFields.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSFields.java
@@ -37,9 +37,13 @@ public class PSSFields extends PSDbComponentList {
   /*
    * Ctor for reserializing. See {@link com.percussion.cms.objectstore.PSDbComponentList(Element)}
    * base ctor for more details.
+   *
+   * <p>Passes {@link #XML_NODE_NAME} explicitly: the base Element path uses a class-derived default
+   * ({@code PSXSFields}) to avoid virtual {@link #getNodeName()} during construction (this-escape).
+   * Wire XML and {@link #toXml} use {@code PSX_FIELDS}, so the expected root must be supplied here.
    */
   public PSSFields(Element src) throws PSUnknownNodeTypeException {
-    super(src);
+    super(src, XML_NODE_NAME);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSProperties.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSProperties.java
@@ -28,9 +28,16 @@ public class PSSProperties extends PSDbComponentCollection {
     super(PSSearchMultiProperty.class);
   }
 
-  /** See base class {@link com.percussion.cms.objectstore.PSDbComponentList} for description. */
+  /**
+   * See base class {@link com.percussion.cms.objectstore.PSDbComponentCollection} for description.
+   *
+   * <p>Passes {@link #XML_NODE_NAME} explicitly: the base Element path uses a class-derived default
+   * ({@code PSXSProperties}) to avoid virtual {@link #getNodeName()} during construction
+   * (this-escape). Wire XML and {@link #toXml} use {@code PSX_PROPERTIES}, so the expected root
+   * must be supplied here.
+   */
   public PSSProperties(Element source) throws PSUnknownNodeTypeException {
-    super(source);
+    super(source, XML_NODE_NAME);
   }
 
   /**

--- a/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentThisEscapeTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSDbComponentThisEscapeTest.java
@@ -184,6 +184,65 @@ public class PSDbComponentThisEscapeTest {
   }
 
   /**
+   * GH-2712: subclasses whose wire root differs from {@code PS + simpleName} (underscore names)
+   * must pass {@code XML_NODE_NAME} into the base Element ctor so construction-safe load does not
+   * expect {@code PSXSFields}/{@code PSXSProperties}.
+   */
+  @Test
+  public void pssFieldsAndPropertiesElementCtorHonorCustomWireNodeNames() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+
+    Element fieldsRoot = doc.createElement(PSSFields.XML_NODE_NAME);
+    fieldsRoot.setAttribute("className", PSSearchField.class.getName());
+    fieldsRoot.setAttribute("ordered", "yes");
+    fieldsRoot.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    PSKey fieldKey =
+        new PSKey(
+            new String[] {"FIELDNAME", "SEARCHID"}, new String[] {"sys_title", "1"}, true);
+    Element fieldEl = doc.createElement("PSXSearchField");
+    fieldEl.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    fieldEl.appendChild(fieldKey.toXml(doc));
+    PSXmlDocumentBuilder.addElement(doc, fieldEl, "FIELDTYPE", PSSearchField.TYPE_TEXT);
+    PSXmlDocumentBuilder.addElement(doc, fieldEl, "FIELDVALUE", "");
+    PSXmlDocumentBuilder.addElement(doc, fieldEl, "FIELDDESCRIPTION", "");
+    PSXmlDocumentBuilder.addElement(doc, fieldEl, "FIELDLABEL", "Title");
+    PSXmlDocumentBuilder.addElement(doc, fieldEl, "OPERATOR", "like");
+    PSXmlDocumentBuilder.addElement(doc, fieldEl, "EXTOPERATOR", "");
+    fieldsRoot.appendChild(fieldEl);
+
+    PSSFields fields = new PSSFields(fieldsRoot);
+    assertEquals(1, fields.size());
+    assertEquals("sys_title", ((PSSearchField) fields.get(0)).getFieldName());
+
+    Element propsRoot = doc.createElement(PSSProperties.XML_NODE_NAME);
+    propsRoot.setAttribute("className", PSSearchMultiProperty.class.getName());
+    propsRoot.setAttribute("ordered", "no");
+    propsRoot.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    Element multi = doc.createElement(PSSearchMultiProperty.XML_NODE_NAME);
+    multi.setAttribute("className", PSSProperty.class.getName());
+    multi.setAttribute("ordered", "no");
+    multi.setAttribute("propName", "cxNewSearch");
+    multi.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    Element leaf = doc.createElement("PSXSProperty");
+    leaf.setAttribute("propName", "cxNewSearch");
+    leaf.setAttribute("state", IPSDbComponent.STATE_LABELS[IPSDbComponent.DBSTATE_UNMODIFIED]);
+    PSKey propKey =
+        new PSKey(
+            new String[] {"PROPERTYNAME", "PROPERTYVALUE", "SEARCHID"},
+            new String[] {"cxNewSearch", "n", "1"},
+            true,
+            false);
+    leaf.appendChild(propKey.toXml(doc));
+    PSXmlDocumentBuilder.addElement(doc, leaf, "Value", "n");
+    PSXmlDocumentBuilder.addElement(doc, leaf, "Description", "");
+    multi.appendChild(leaf);
+    propsRoot.appendChild(multi);
+
+    PSSProperties props = new PSSProperties(propsRoot);
+    assertEquals(1, props.size());
+  }
+
+  /**
    * Builds a minimal {@code PSXVariantSlotType} document matching {@link
    * PSVariantSlotType#toXml(Document)} / super key serialization.
    */

--- a/system/src/test/java/com/percussion/cms/objectstore/PSSearchXmlRoundTripTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSSearchXmlRoundTripTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.StringReader;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Regression for GH-2712: Explorer Search failed while deserializing default {@code View_All}
+ * because {@link PSSFields}/{@link PSSProperties} Element ctors expected class-derived roots
+ * ({@code PSXSFields}/{@code PSXSProperties}) after the this-escape residual (#2612) instead of the
+ * wire names {@code PSX_FIELDS}/{@code PSX_PROPERTIES}.
+ */
+public class PSSearchXmlRoundTripTest {
+
+  /**
+   * Minimal View_All-shaped document matching server XML from issue #2712 / getSearches result
+   * (SEARCHID=3, INTERNALNAME=View_All, PSX_FIELDS + PSX_PROPERTIES).
+   */
+  private static final String VIEW_ALL_XML =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+          + "<PSXSearch state=\"db_unmodified\">\n"
+          + "   <PSXKey isPersisted=\"yes\">\n"
+          + "      <SEARCHID>3</SEARCHID>\n"
+          + "   </PSXKey>\n"
+          + "   <DISPLAYNAME>All</DISPLAYNAME>\n"
+          + "   <DISPLAYFORMAT>1</DISPLAYFORMAT>\n"
+          + "   <PARENTCATEGORY>3</PARENTCATEGORY>\n"
+          + "   <TYPE>View</TYPE>\n"
+          + "   <MAXIMUMITEMS>-1</MAXIMUMITEMS>\n"
+          + "   <CASESENSITIVE>0</CASESENSITIVE>\n"
+          + "   <INTERNALNAME>View_All</INTERNALNAME>\n"
+          + "   <DESCRIPTION>All content for all communities</DESCRIPTION>\n"
+          + "   <VERSION>0</VERSION>\n"
+          + "   <PSX_FIELDS className=\"com.percussion.cms.objectstore.PSSearchField\""
+          + " ordered=\"yes\" state=\"db_unmodified\">\n"
+          + "      <PSXSearchField state=\"db_unmodified\">\n"
+          + "         <PSXKey isPersisted=\"yes\">\n"
+          + "            <FIELDNAME>sys_contentid</FIELDNAME>\n"
+          + "            <SEARCHID>3</SEARCHID>\n"
+          + "         </PSXKey>\n"
+          + "         <FIELDTYPE>Number</FIELDTYPE>\n"
+          + "         <FIELDVALUE>0</FIELDVALUE>\n"
+          + "         <FIELDDESCRIPTION>All content</FIELDDESCRIPTION>\n"
+          + "         <FIELDLABEL>ContentId</FIELDLABEL>\n"
+          + "         <OPERATOR>greaterthan</OPERATOR>\n"
+          + "         <EXTOPERATOR/>\n"
+          + "      </PSXSearchField>\n"
+          + "   </PSX_FIELDS>\n"
+          + "   <PSX_PROPERTIES className=\"com.percussion.cms.objectstore.PSSearchMultiProperty\""
+          + " ordered=\"no\" state=\"db_unmodified\">\n"
+          + "      <PSXSearchMultiProperty className=\"com.percussion.cms.objectstore.PSSProperty\""
+          + " ordered=\"no\" propName=\"aadNewSearch\" state=\"db_unmodified\">\n"
+          + "         <PSXSProperty propName=\"aadNewSearch\" state=\"db_unmodified\">\n"
+          + "            <PSXKey isPersisted=\"yes\" needGenerateId=\"no\">\n"
+          + "               <PROPERTYNAME>aadNewSearch</PROPERTYNAME>\n"
+          + "               <PROPERTYVALUE>n</PROPERTYVALUE>\n"
+          + "               <SEARCHID>3</SEARCHID>\n"
+          + "            </PSXKey>\n"
+          + "            <Value>n</Value>\n"
+          + "            <Description/>\n"
+          + "         </PSXSProperty>\n"
+          + "      </PSXSearchMultiProperty>\n"
+          + "   </PSX_PROPERTIES>\n"
+          + "   <CUSTOMURL/>\n"
+          + "</PSXSearch>\n";
+
+  @Test
+  public void pssFieldsElementCtorAcceptsWireRootPsxFields() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(new StringReader(VIEW_ALL_XML), false);
+    Element searchRoot = doc.getDocumentElement();
+    Element fieldsEl =
+        (Element) searchRoot.getElementsByTagName(PSSFields.XML_NODE_NAME).item(0);
+    assertNotNull(fieldsEl);
+    assertEquals(PSSFields.XML_NODE_NAME, fieldsEl.getNodeName());
+
+    PSSFields fields = new PSSFields(fieldsEl);
+    assertEquals(1, fields.size());
+    PSSearchField field = (PSSearchField) fields.get(0);
+    assertEquals("sys_contentid", field.getFieldName());
+  }
+
+  @Test
+  public void pssPropertiesElementCtorAcceptsWireRootPsxProperties() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(new StringReader(VIEW_ALL_XML), false);
+    Element searchRoot = doc.getDocumentElement();
+    Element propsEl =
+        (Element) searchRoot.getElementsByTagName(PSSProperties.XML_NODE_NAME).item(0);
+    assertNotNull(propsEl);
+    assertEquals(PSSProperties.XML_NODE_NAME, propsEl.getNodeName());
+
+    PSSProperties props = new PSSProperties(propsEl);
+    assertEquals(1, props.size());
+  }
+
+  @Test
+  public void viewAllXmlDeserializesViaPsSearchElementCtor() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(new StringReader(VIEW_ALL_XML), false);
+    PSSearch search = new PSSearch(doc.getDocumentElement());
+
+    assertEquals("View_All", search.getInternalName());
+    assertEquals("All", search.getDisplayName());
+    assertTrue(search.isView());
+    assertEquals(3, search.getParentCategory());
+
+    Iterator<PSSearchField> fields = search.getFields();
+    assertTrue(fields.hasNext());
+    PSSearchField field = fields.next();
+    assertEquals("sys_contentid", field.getFieldName());
+    assertEquals(PSSearchField.TYPE_NUMBER, field.getFieldType());
+    assertFalse(fields.hasNext());
+  }
+
+  @Test
+  public void searchRoundTripPreservesWireFieldAndPropertyRoots() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(new StringReader(VIEW_ALL_XML), false);
+    PSSearch original = new PSSearch(doc.getDocumentElement());
+
+    Document out = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(out);
+    assertNotNull(xml.getElementsByTagName(PSSFields.XML_NODE_NAME).item(0));
+    assertNotNull(xml.getElementsByTagName(PSSProperties.XML_NODE_NAME).item(0));
+
+    PSSearch restored = new PSSearch(xml);
+    assertEquals(original.getInternalName(), restored.getInternalName());
+    assertEquals(original.getDisplayName(), restored.getDisplayName());
+    assertEquals(original.isView(), restored.isView());
+
+    Iterator<PSSearchField> fields = restored.getFields();
+    assertTrue(fields.hasNext());
+    assertEquals("sys_contentid", fields.next().getFieldName());
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiBaseWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiBaseWs.java
@@ -18,7 +18,6 @@ package com.percussion.webservices.ui.impl;
 
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.objectstore.IPSDbComponent;
-import com.percussion.cms.objectstore.PSAction;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.PSInternalRequest;
@@ -163,8 +162,10 @@ public class PSUiBaseWs
       {
 
          int code = IPSWebserviceErrors.FIND_FAILED;
+         // Report the requested component type (search/view/action/display format), not a hardcoded
+         // PSAction — callers use this for PSSearch and others; wrong type misled GH-2712 triage.
          PSErrorException error = new PSErrorException(code, PSWebserviceErrors
-            .createErrorMessage(code, PSAction.class.getName(), name, label, e
+            .createErrorMessage(code, objClass.getName(), name, label, e
                .getLocalizedMessage()), ExceptionUtils.getFullStackTrace(e));
          throw error;
       }


### PR DESCRIPTION
## Summary

Fixes Explorer **Search** saved-search load failure on Percussion CMS 8.2 (`View_All` / SEARCHID=3).

### Root cause

Regression from #2612 (cms.objectstore Element this-escape residual): `PSDbComponentList` / `PSDbComponentCollection` Element construction now uses a class-derived default root (`PS` → `PSX`), avoiding virtual `getNodeName()` during construction.

For `PSSFields` / `PSSProperties` the wire/XML names are **`PSX_FIELDS`** / **`PSX_PROPERTIES`**, not `PSXSFields` / `PSXSProperties`. Deserializing server `getSearches` XML therefore failed with:

```text
A <PSXSFields> XML element was expected but a <PSX_FIELDS> XML element was found instead.
```

The UI/error text also hardcoded `PSAction` in `findComponentsByNameLabel`, which misled triage toward a missing action catalog entry (`name '%' label '%'` is the normal wildcard find for all searches).

### Fix

- `PSSFields(Element)` → `super(src, XML_NODE_NAME)` (`PSX_FIELDS`)
- `PSSProperties(Element)` → `super(source, XML_NODE_NAME)` (`PSX_PROPERTIES`)
- `PSUiBaseWs.findComponentsByNameLabel` reports `objClass.getName()` instead of hardcoded `PSAction`

### Tests

- New `PSSearchXmlRoundTripTest` — View_All-shaped XML from GH-2712 server log; Element ctors + round-trip
- Extended `PSDbComponentThisEscapeTest` — custom wire root names for fields/properties

## Test plan

- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1621**, Failures: **0**, Errors: **0** (Skipped: 240 baseline)
- [x] Focused: `PSSearchXmlRoundTripTest` (4) + `PSDbComponentThisEscapeTest` (10) green
- [ ] Human QA: Explorer → Search loads saved searches including **All** (`View_All`) without error (see QA issue)

## Gates evidence

| Gate | Result |
|------|--------|
| Module standalone clean install | `cd system` → `../mvnw.cmd clean install` → BUILD SUCCESS |
| Unit tests | 1621 run, 0 failures |
| New behavioral tests | View_All XML deserialize + this-escape custom node names |
| Cross-platform paths | N/A (XML/objectstore only) |
| Erlang-style self-review | No bugs found; companions = unit tests only; no WebUI/sitemanage code change |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2712

> Co-Authored by Grok Build using grok-4.5 with agent main.