### PR TITLE
feat(WebUI): workflow transitions in Explorer menus (#2732)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/itemWorkflowApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/itemWorkflowApi.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Thin client for sitemanage itemmanagement workflow endpoints used by
+ * Explorer menus (#2732 / parent #2400).
+ *
+ * <p>Provider: {@code PSItemWorkflowService} under
+ * {@code /services/itemmanagement/workflow/*}. Mirrors the same surface
+ * {@code WorkflowActionsPanel} already uses — no new REST contract.</p>
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+
+/**
+ * Wire shape for {@code GET .../workflow/getTransitions/{id}}
+ * ({@code PSItemStateTransition}).
+ */
+export interface ItemStateTransition {
+  itemId?: string;
+  stateId?: string;
+  stateName?: string;
+  workflowId?: string;
+  transitionTriggers?: string[];
+}
+
+/**
+ * Wire shape for transition results
+ * ({@code PSItemTransitionResults}) — fields optional; success is HTTP 200.
+ */
+export interface ItemTransitionResults {
+  itemId?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * List allowed workflow transition trigger names for a content item.
+ *
+ * @param itemId content / component id as returned by pathmanagement
+ */
+export async function getItemWorkflowTransitions(
+  itemId: string,
+): Promise<ItemStateTransition> {
+  const id = String(itemId ?? "").trim();
+  if (!id) {
+    return { transitionTriggers: [] };
+  }
+  return get<ItemStateTransition>(
+    `${PATHS.ITEM_WORKFLOW_TRANSITIONS}${encodeURIComponent(id)}`,
+  );
+}
+
+/**
+ * Execute a named workflow transition for the item (optional comment).
+ *
+ * <p>Uses {@code transitionWithComments} so comments can be supplied later
+ * without a second client path; empty comment is allowed by the service.</p>
+ */
+export async function transitionItem(
+  itemId: string,
+  trigger: string,
+  comment?: string,
+): Promise<ItemTransitionResults> {
+  const id = String(itemId ?? "").trim();
+  const trig = String(trigger ?? "").trim();
+  if (!id || !trig) {
+    throw new Error("transitionItem requires itemId and trigger");
+  }
+  let url = `${PATHS.ITEM_WORKFLOW_TRANSITION_WITH_COMMENTS}${encodeURIComponent(id)}/${encodeURIComponent(trig)}`;
+  if (comment != null && String(comment).length > 0) {
+    url += `?comment=${encodeURIComponent(String(comment))}`;
+  }
+  return get<ItemTransitionResults>(url);
+}

--- a/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ActionToolbar.tsx
@@ -19,15 +19,15 @@
  *
  * <p>Renders the configured action set returned by {@code /actions/find*}
  * as a horizontal action bar that the user can activate by mouse click
- * or keyboard. Server-provided URLs navigate; otherwise the action is
- * delegated to the {@link ActionToolbarProps.onInvoke} callback, so the
- * host (typically the explorer shell) can run client-side logic such as
- * ReducedActions-bar-style commands.</p>
+ * or keyboard. Cascading groups (e.g. Workflow transitions, #2732) render
+ * as labeled button groups so each child is one-click invokable.
+ * Server-provided URLs navigate; otherwise the action is delegated to
+ * {@link ActionToolbarProps.onInvoke}.</p>
  *
  * <p>Toolbar refreshes when the {@link ActionToolbarProps.actions} prop
  * changes (e.g. on selection change the parent fetches the allowed
- * actions via {@code findAllowedContentTypeMenus} and re-renders this
- * component).</p>
+ * actions via {@code findAllowedContentTypeMenus} + workflow transitions
+ * and re-renders this component).</p>
  */
 
 import React from "react";
@@ -44,6 +44,52 @@ export interface ActionToolbarProps {
   className?: string;
 }
 
+function activate(
+  action: MenuAction,
+  baseHref: string,
+  onInvoke?: (name: string, a: MenuAction) => void,
+): void {
+  if (action.url) {
+    const result = safeNavigate(action.url, baseHref);
+    if (!result.ok) {
+      // eslint-disable-next-line no-console -- surface rejection for ops
+      console.warn(
+        `[ActionToolbar] rejected action "${action.name}" url "${result.href}" reason="${result.reason}"`,
+      );
+      onInvoke?.(action.name, action);
+      return;
+    }
+    return;
+  }
+  onInvoke?.(action.name, action);
+}
+
+const buttonStyle: React.CSSProperties = {
+  padding: "4px 10px",
+  border: "1px solid #ccc",
+  background: "#fafafa",
+  cursor: "pointer",
+};
+
+const groupStyle: React.CSSProperties = {
+  display: "inline-flex",
+  flexWrap: "wrap",
+  gap: 4,
+  alignItems: "center",
+  border: "1px solid #e2e8f0",
+  borderRadius: 4,
+  padding: "2px 4px",
+  background: "#f8fafc",
+};
+
+const groupLabelStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "#64748b",
+  marginRight: 4,
+  textTransform: "uppercase",
+  letterSpacing: "0.02em",
+};
+
 export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
   const { actions, onInvoke, ariaLabel, emptyMessage, className } = props;
   const baseHref =
@@ -54,45 +100,57 @@ export function ActionToolbar(props: ActionToolbarProps): React.JSX.Element {
       aria-label={ariaLabel ?? "Action toolbar"}
       data-testid="action-toolbar"
       className={className}
-      style={{ display: "flex", gap: 4, flexWrap: "wrap" }}
+      style={{ display: "flex", gap: 4, flexWrap: "wrap", alignItems: "center" }}
     >
       {actions.length === 0 ? (
         <span data-testid="action-toolbar-empty" style={{ color: "#888" }}>
           {message(emptyMessage ?? "perc.ui.explorer@No actions")}
         </span>
       ) : (
-        actions.map((a) => (
-          <button
-            type="button"
-            key={a.name}
-            data-testid={`action-toolbar-item-${a.name}`}
-            aria-label={a.label}
-            title={a.description ?? a.label}
-            onClick={() => {
-              if (a.url) {
-                const result = safeNavigate(a.url, baseHref);
-                if (!result.ok) {
-                  // eslint-disable-next-line no-console -- surface rejection for ops
-                  console.warn(
-                    `[ActionToolbar] rejected action "${a.name}" url "${result.href}" reason="${result.reason}"`,
-                  );
-                  onInvoke?.(a.name, a);
-                  return;
-                }
-                return;
-              }
-              onInvoke?.(a.name, a);
-            }}
-            style={{
-              padding: "4px 10px",
-              border: "1px solid #ccc",
-              background: "#fafafa",
-              cursor: "pointer",
-            }}
-          >
-            {a.label}
-          </button>
-        ))
+        actions.map((a) => {
+          const children = a.children ?? [];
+          if (children.length > 0) {
+            return (
+              <span
+                key={a.name}
+                role="group"
+                aria-label={a.label}
+                data-testid={`action-toolbar-group-${a.name}`}
+                style={groupStyle}
+              >
+                <span style={groupLabelStyle} aria-hidden="true">
+                  {a.label}
+                </span>
+                {children.map((c) => (
+                  <button
+                    type="button"
+                    key={c.name}
+                    data-testid={`action-toolbar-item-${c.name}`}
+                    aria-label={c.label}
+                    title={c.description ?? c.label}
+                    onClick={() => activate(c, baseHref, onInvoke)}
+                    style={buttonStyle}
+                  >
+                    {c.label}
+                  </button>
+                ))}
+              </span>
+            );
+          }
+          return (
+            <button
+              type="button"
+              key={a.name}
+              data-testid={`action-toolbar-item-${a.name}`}
+              aria-label={a.label}
+              title={a.description ?? a.label}
+              onClick={() => activate(a, baseHref, onInvoke)}
+              style={buttonStyle}
+            >
+              {a.label}
+            </button>
+          );
+        })
       )}
     </div>
   );

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -22,7 +22,13 @@
  * SPA route approaches Desktop Content Explorer parity.</p>
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   findActions,
   findAllowedContentTypeMenus,
@@ -297,6 +303,12 @@ export function ContentExplorerShell({
   const [selectedFormatKey, setSelectedFormatKey] = useState<string>("");
   const [menuActions, setMenuActions] = useState<MenuAction[]>([]);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+  /**
+   * Monotonic generation for context-menu loads. Rapid right-clicks on
+   * different rows race two async IIFEs; only the latest generation may
+   * call setContextMenu (avoids stale workflow menus at the first item's XY).
+   */
+  const contextMenuRequestIdRef = useRef(0);
   const [listEpoch, setListEpoch] = useState(0);
   const [multiSelectedIds, setMultiSelectedIds] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
@@ -468,21 +480,25 @@ export function ContentExplorerShell({
   const handleItemContextMenu = useCallback(
     (item: PSPathItem, clientX: number, clientY: number) => {
       setSelection((prev) => ({ ...prev, item }));
+      const requestId = ++contextMenuRequestIdRef.current;
       void (async () => {
         try {
           const base = await loadMenuActions(item);
+          if (requestId !== contextMenuRequestIdRef.current) return;
           let workflow: MenuAction | null = null;
           try {
             workflow = await loadWorkflowMenuActions(item);
           } catch {
             workflow = null;
           }
+          if (requestId !== contextMenuRequestIdRef.current) return;
           setContextMenu({
             actions: mergeWorkflowMenuActions(base ?? [], workflow),
             x: clientX,
             y: clientY,
           });
         } catch {
+          if (requestId !== contextMenuRequestIdRef.current) return;
           setContextMenu({
             actions: [],
             x: clientX,

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -33,6 +33,10 @@ import {
   normalizeDisplayFormatColumns,
   type DisplayFormat,
 } from "../api/contentExplorer/displayFormatsApi";
+import {
+  getItemWorkflowTransitions,
+  transitionItem,
+} from "../api/contentExplorer/itemWorkflowApi";
 import { findItemByPath } from "../api/contentExplorer/pathApi";
 import type {
   Clipboard,
@@ -71,6 +75,11 @@ import {
   shellStyle,
 } from "./styles";
 import { TranslationsPanel } from "./TranslationsPanel";
+import {
+  buildWorkflowTransitionMenu,
+  mergeWorkflowMenuActions,
+  parseWorkflowTransitionTrigger,
+} from "./workflowMenuActions";
 
 export interface ContentExplorerShellProps {
   /** Folder path to display on mount; defaults to product root. */
@@ -89,6 +98,14 @@ export interface ContentExplorerShellProps {
   /** Test seam: override action menu load. */
   loadMenuActions?: (item: PSPathItem | null) => Promise<MenuAction[]>;
   /**
+   * Test seam: override workflow-transition menu enrichment for a selected
+   * content item (#2732). Default loads triggers via itemmanagement.
+   * Return {@code null} to skip workflow group (folders / no triggers).
+   */
+  loadWorkflowMenuActions?: (
+    item: PSPathItem | null,
+  ) => Promise<MenuAction | null>;
+  /**
    * Identities for folder ACL self-lockout (USER name + ROLE names).
    * When omitted, derived from SPA bootstrap ({@code userName}, admin/designer
    * flags). Tests inject an explicit list so lockout gates stay deterministic.
@@ -99,6 +116,14 @@ export interface ContentExplorerShellProps {
    * Default uses pathmanagement {@link findItemByPath}.
    */
   resolveFolderId?: (path: string) => Promise<string | undefined>;
+  /**
+   * Test seam: execute a workflow transition. Default uses itemmanagement
+   * {@code transitionWithComments}.
+   */
+  runWorkflowTransition?: (
+    itemId: string,
+    trigger: string,
+  ) => Promise<void>;
 }
 
 type ContextMenuState = {
@@ -158,6 +183,14 @@ function parseContentId(id: string | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/** True when the selection can receive workflow transitions (not a folder). */
+function isWorkflowEligibleItem(item: PSPathItem | null | undefined): boolean {
+  if (!item) return false;
+  if (item.type === "folder") return false;
+  const id = item.id != null ? String(item.id).trim() : "";
+  return id.length > 0;
+}
+
 async function defaultLoadMenuActions(
   item: PSPathItem | null,
 ): Promise<MenuAction[]> {
@@ -170,6 +203,35 @@ async function defaultLoadMenuActions(
   }
   const menus = await findActions({ item: true });
   return mapActionMenusToMenuActions(menus);
+}
+
+/**
+ * Load Workflow cascade from itemmanagement allowed transitions.
+ * Returns {@code null} when the item is ineligible or has no triggers.
+ */
+async function defaultLoadWorkflowMenuActions(
+  item: PSPathItem | null,
+): Promise<MenuAction | null> {
+  if (!isWorkflowEligibleItem(item)) {
+    return null;
+  }
+  try {
+    const state = await getItemWorkflowTransitions(String(item!.id));
+    return buildWorkflowTransitionMenu(state?.transitionTriggers ?? [], {
+      groupLabel: message(EXPLORER_MSG.WORKFLOW_MENU_LABEL),
+      stateName: state?.stateName,
+    });
+  } catch {
+    // Non-fatal: keep server action menus without workflow group.
+    return null;
+  }
+}
+
+async function defaultRunWorkflowTransition(
+  itemId: string,
+  trigger: string,
+): Promise<void> {
+  await transitionItem(itemId, trigger);
 }
 
 /** Stable default — module scope so useEffect deps do not refetch every render. */
@@ -197,8 +259,10 @@ export function ContentExplorerShell({
   onFolderActivated,
   loadDisplayFormats = defaultLoadDisplayFormats,
   loadMenuActions = defaultLoadMenuActions,
+  loadWorkflowMenuActions = defaultLoadWorkflowMenuActions,
   currentUserIdentities: currentUserIdentitiesProp,
   resolveFolderId = defaultResolveFolderId,
+  runWorkflowTransition = defaultRunWorkflowTransition,
 }: ContentExplorerShellProps): React.ReactElement {
   const bootstrap = useSpaBootstrap();
   const currentUserIdentities = useMemo(() => {
@@ -283,17 +347,27 @@ export function ContentExplorerShell({
 
   useEffect(() => {
     let cancelled = false;
-    loadMenuActions(selection.item)
-      .then((actions) => {
-        if (!cancelled) setMenuActions(actions ?? []);
-      })
-      .catch(() => {
+    async function loadMenus(): Promise<void> {
+      try {
+        const base = await loadMenuActions(selection.item);
+        if (cancelled) return;
+        let workflow: MenuAction | null = null;
+        try {
+          workflow = await loadWorkflowMenuActions(selection.item);
+        } catch {
+          workflow = null;
+        }
+        if (cancelled) return;
+        setMenuActions(mergeWorkflowMenuActions(base ?? [], workflow));
+      } catch {
         if (!cancelled) setMenuActions([]);
-      });
+      }
+    }
+    void loadMenus();
     return () => {
       cancelled = true;
     };
-  }, [selection.item, loadMenuActions, listEpoch]);
+  }, [selection.item, loadMenuActions, loadWorkflowMenuActions, listEpoch]);
 
   const selectedFormat = useMemo(() => {
     if (!selectedFormatKey) return null;
@@ -394,15 +468,68 @@ export function ContentExplorerShell({
   const handleItemContextMenu = useCallback(
     (item: PSPathItem, clientX: number, clientY: number) => {
       setSelection((prev) => ({ ...prev, item }));
-      void loadMenuActions(item).then((actions) => {
-        setContextMenu({
-          actions: actions ?? [],
-          x: clientX,
-          y: clientY,
-        });
-      });
+      void (async () => {
+        try {
+          const base = await loadMenuActions(item);
+          let workflow: MenuAction | null = null;
+          try {
+            workflow = await loadWorkflowMenuActions(item);
+          } catch {
+            workflow = null;
+          }
+          setContextMenu({
+            actions: mergeWorkflowMenuActions(base ?? [], workflow),
+            x: clientX,
+            y: clientY,
+          });
+        } catch {
+          setContextMenu({
+            actions: [],
+            x: clientX,
+            y: clientY,
+          });
+        }
+      })();
     },
-    [loadMenuActions],
+    [loadMenuActions, loadWorkflowMenuActions],
+  );
+
+  /**
+   * Route toolbar / context-menu activations. Workflow transition names are
+   * client-tagged ({@code workflow-transition:Trigger}); other actions fall
+   * through to list refresh (URL actions already navigated in the child).
+   */
+  const handleMenuInvoke = useCallback(
+    (actionName: string, _action: MenuAction) => {
+      const trigger = parseWorkflowTransitionTrigger(actionName);
+      if (trigger != null) {
+        const item = selection.item;
+        const itemId =
+          item?.id != null && isWorkflowEligibleItem(item)
+            ? String(item.id)
+            : "";
+        if (!itemId) {
+          setError(message(EXPLORER_MSG.WORKFLOW_TRANSITION_FAILED));
+          return;
+        }
+        void (async () => {
+          try {
+            await runWorkflowTransition(itemId, trigger);
+            setError(null);
+            setListEpoch((n) => n + 1);
+          } catch (err: unknown) {
+            const detail =
+              err instanceof Error && err.message
+                ? err.message
+                : message(EXPLORER_MSG.WORKFLOW_TRANSITION_FAILED);
+            setError(detail);
+          }
+        })();
+        return;
+      }
+      setListEpoch((n) => n + 1);
+    },
+    [selection.item, runWorkflowTransition],
   );
 
   const handleSearchOpen = useCallback((result: PSItemProperties) => {
@@ -495,10 +622,7 @@ export function ContentExplorerShell({
             <ActionToolbar
               actions={menuActions}
               ariaLabel={message(EXPLORER_MSG.SERVER_ACTIONS_ARIA)}
-              onInvoke={() => {
-                // Server URL actions navigate; client-only refresh list.
-                setListEpoch((n) => n + 1);
-              }}
+              onInvoke={handleMenuInvoke}
             />
           </div>
           <div
@@ -766,9 +890,9 @@ export function ContentExplorerShell({
           <ContextMenu
             actions={contextMenu.actions}
             onClose={() => setContextMenu(null)}
-            onInvoke={() => {
+            onInvoke={(actionName, action) => {
               setContextMenu(null);
-              setListEpoch((n) => n + 1);
+              handleMenuInvoke(actionName, action);
             }}
           />
         </div>

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -220,6 +220,5 @@ export const EXPLORER_MSG = {
   WORKFLOW_MENU_LABEL: "perc.ui.explorer@Workflow",
   WORKFLOW_TRANSITION_FAILED:
     "perc.ui.explorer@Workflow transition failed",
-  WORKFLOW_TRANSITION_SUCCESS:
-    "perc.ui.explorer@Workflow transition completed",
+  // Success path refreshes the list silently (error banner is fail-only).
 } as const;

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -216,4 +216,10 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Created {count} translation variants",
   TRANSLATIONS_INFLIGHT_OUT:
     "perc.ui.explorer@In-flight translation queue status is not available (product disposition).",
+  // Workflow transitions in Explorer menus (#2732 / parent #2400)
+  WORKFLOW_MENU_LABEL: "perc.ui.explorer@Workflow",
+  WORKFLOW_TRANSITION_FAILED:
+    "perc.ui.explorer@Workflow transition failed",
+  WORKFLOW_TRANSITION_SUCCESS:
+    "perc.ui.explorer@Workflow transition completed",
 } as const;

--- a/WebUI/src/main/ts/contentExplorer/workflowMenuActions.ts
+++ b/WebUI/src/main/ts/contentExplorer/workflowMenuActions.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure mapping helpers that project itemmanagement workflow transitions into
+ * Explorer {@link MenuAction} trees (#2732 / parent #2400).
+ *
+ * <p>DCE exposes workflow transitions as menu entries under the Workflow
+ * action group. The modern Explorer uses the same trigger names from
+ * {@code GET .../itemmanagement/workflow/getTransitions/{id}} and tags each
+ * action name with a stable client prefix so invoke handlers can route to
+ * {@code transitionWithComments} without inventing server menu fields.</p>
+ */
+
+import type { MenuAction } from "../api/contentExplorer/types";
+
+/** Stable prefix for client-routed workflow transition menu actions. */
+export const WORKFLOW_TRANSITION_PREFIX = "workflow-transition:";
+
+/** Canonical parent menu name for the Workflow group (DCE-aligned). */
+export const WORKFLOW_MENU_NAME = "workflow";
+
+/** Default sort rank so the Workflow group trails ordinary server menus. */
+export const WORKFLOW_MENU_SORT_RANK = 9000;
+
+export interface BuildWorkflowMenuOptions {
+  /** Display label for the parent group (i18n-resolved by caller). */
+  groupLabel?: string;
+  /** Optional state name for description / accessibility. */
+  stateName?: string;
+  /** Parent sort rank; defaults to {@link WORKFLOW_MENU_SORT_RANK}. */
+  sortRank?: number;
+}
+
+/**
+ * True when {@code name} is a client-tagged workflow transition action.
+ */
+export function isWorkflowTransitionActionName(name: string | undefined): boolean {
+  return typeof name === "string" && name.startsWith(WORKFLOW_TRANSITION_PREFIX);
+}
+
+/**
+ * Extract the server trigger from a tagged action name, or {@code null}.
+ */
+export function parseWorkflowTransitionTrigger(
+  actionName: string | undefined,
+): string | null {
+  if (!isWorkflowTransitionActionName(actionName)) {
+    return null;
+  }
+  const trigger = actionName!.slice(WORKFLOW_TRANSITION_PREFIX.length).trim();
+  return trigger.length > 0 ? trigger : null;
+}
+
+/**
+ * Build a single MenuAction for one transition trigger.
+ */
+export function buildWorkflowTransitionChild(
+  trigger: string,
+  sortRank: number,
+): MenuAction {
+  const label = String(trigger ?? "").trim() || "transition";
+  return {
+    name: `${WORKFLOW_TRANSITION_PREFIX}${label}`,
+    label,
+    description: label,
+    sortRank,
+    menuType: "MENUITEM",
+    handler: "client",
+  };
+}
+
+/**
+ * Map allowed transition trigger names into a cascading Workflow menu group.
+ *
+ * <p>Returns {@code null} when there are no usable triggers so the host can
+ * omit the group entirely (server is authoritative — FR-011).</p>
+ */
+export function buildWorkflowTransitionMenu(
+  triggers: readonly string[] | null | undefined,
+  options: BuildWorkflowMenuOptions = {},
+): MenuAction | null {
+  const cleaned = (triggers ?? [])
+    .map((t) => String(t ?? "").trim())
+    .filter((t) => t.length > 0);
+  // De-dupe while preserving first-seen order (default trigger is first).
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const t of cleaned) {
+    if (seen.has(t)) continue;
+    seen.add(t);
+    unique.push(t);
+  }
+  if (unique.length === 0) {
+    return null;
+  }
+  const children = unique.map((t, i) => buildWorkflowTransitionChild(t, i + 1));
+  const groupLabel = options.groupLabel?.trim() || "Workflow";
+  const stateName = options.stateName?.trim();
+  return {
+    name: WORKFLOW_MENU_NAME,
+    label: groupLabel,
+    description: stateName
+      ? `${groupLabel} (${stateName})`
+      : groupLabel,
+    sortRank: options.sortRank ?? WORKFLOW_MENU_SORT_RANK,
+    menuType: "MENU",
+    handler: "client",
+    children,
+  };
+}
+
+/**
+ * Merge a Workflow group into an existing action list.
+ *
+ * <p>Replaces any prior client Workflow group (same {@link WORKFLOW_MENU_NAME})
+ * then sorts by {@code sortRank}. Pure — does not mutate inputs.</p>
+ */
+export function mergeWorkflowMenuActions(
+  baseActions: readonly MenuAction[] | null | undefined,
+  workflowMenu: MenuAction | null | undefined,
+): MenuAction[] {
+  const base = (baseActions ?? []).filter(
+    (a) => a != null && a.name !== WORKFLOW_MENU_NAME,
+  );
+  if (!workflowMenu || !(workflowMenu.children?.length)) {
+    return base.slice().sort((a, b) => a.sortRank - b.sortRank);
+  }
+  return [...base, workflowMenu].sort((a, b) => a.sortRank - b.sortRank);
+}
+
+/**
+ * Flatten cascading Workflow children for one-click toolbar buttons while
+ * keeping non-workflow menus intact (parents without children stay as-is).
+ *
+ * <p>Context menus keep the cascading tree; the toolbar prefers a flat
+ * strip of invokable transition buttons under the Workflow label via
+ * ActionToolbar group rendering — callers may pass either shape.</p>
+ */
+export function flattenMenuActionsForToolbar(
+  actions: readonly MenuAction[] | null | undefined,
+): MenuAction[] {
+  const out: MenuAction[] = [];
+  for (const a of actions ?? []) {
+    if (a == null) continue;
+    if (a.name === WORKFLOW_MENU_NAME && (a.children?.length ?? 0) > 0) {
+      // Keep the parent so ActionToolbar can render a labeled group.
+      out.push(a);
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+}

--- a/WebUI/src/main/ts/contentExplorer/workflowMenuActions.ts
+++ b/WebUI/src/main/ts/contentExplorer/workflowMenuActions.ts
@@ -141,27 +141,3 @@ export function mergeWorkflowMenuActions(
   }
   return [...base, workflowMenu].sort((a, b) => a.sortRank - b.sortRank);
 }
-
-/**
- * Flatten cascading Workflow children for one-click toolbar buttons while
- * keeping non-workflow menus intact (parents without children stay as-is).
- *
- * <p>Context menus keep the cascading tree; the toolbar prefers a flat
- * strip of invokable transition buttons under the Workflow label via
- * ActionToolbar group rendering — callers may pass either shape.</p>
- */
-export function flattenMenuActionsForToolbar(
-  actions: readonly MenuAction[] | null | undefined,
-): MenuAction[] {
-  const out: MenuAction[] = [];
-  for (const a of actions ?? []) {
-    if (a == null) continue;
-    if (a.name === WORKFLOW_MENU_NAME && (a.children?.length ?? 0) > 0) {
-      // Keep the parent so ActionToolbar can render a labeled group.
-      out.push(a);
-      continue;
-    }
-    out.push(a);
-  }
-  return out;
-}

--- a/WebUI/src/test/ts/contentExplorer/ActionToolbar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ActionToolbar.test.tsx
@@ -63,4 +63,31 @@ describe("ActionToolbar", () => {
     const { container } = render(<ActionToolbar actions={[]} ariaLabel="Item actions" />);
     await renderA11yGate(container);
   });
+
+  it("renders cascading Workflow children as a labeled group (#2732)", () => {
+    const onInvoke = vi.fn();
+    const actions: MenuAction[] = [
+      {
+        name: "workflow",
+        label: "Workflow",
+        sortRank: 9000,
+        menuType: "MENU",
+        children: [
+          {
+            name: "workflow-transition:Submit",
+            label: "Submit",
+            sortRank: 1,
+            menuType: "MENUITEM",
+          },
+        ],
+      },
+    ];
+    render(<ActionToolbar actions={actions} onInvoke={onInvoke} />);
+    expect(screen.getByTestId("action-toolbar-group-workflow")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("action-toolbar-item-workflow-transition:Submit"));
+    expect(onInvoke).toHaveBeenCalledWith(
+      "workflow-transition:Submit",
+      expect.objectContaining({ label: "Submit" }),
+    );
+  });
 });

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -146,6 +146,109 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
   });
 
+  it("discards stale context-menu loads when right-clicking rows rapidly (#2732 race)", async () => {
+    let releaseSlow: (() => void) | undefined;
+    const slowGate = new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+    const loadMenuActions = vi.fn(async (item: { id?: string | number } | null) => {
+      if (String(item?.id) === "101") {
+        await slowGate;
+        return [
+          {
+            name: "open-slow",
+            label: "Open slow",
+            sortRank: 1,
+            menuType: "MENUITEM" as const,
+          },
+        ];
+      }
+      return [
+        {
+          name: "open-fast",
+          label: "Open fast",
+          sortRank: 1,
+          menuType: "MENUITEM" as const,
+        },
+      ];
+    });
+    const loadWorkflowMenuActions = vi.fn(async () => null);
+
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "101",
+                  name: "item-a",
+                  path: "/Sites/item-a",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+                {
+                  id: "202",
+                  name: "item-b",
+                  path: "/Sites/item-b",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 2,
+              startIndex: 1,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={loadMenuActions}
+        loadWorkflowMenuActions={loadWorkflowMenuActions}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-101")).toBeInTheDocument();
+      expect(screen.getByTestId("detail-row-202")).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId("detail-row-101"), {
+      clientX: 10,
+      clientY: 20,
+    });
+    fireEvent.contextMenu(screen.getByTestId("detail-row-202"), {
+      clientX: 40,
+      clientY: 50,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("context-menu")).toBeInTheDocument();
+      expect(screen.getByTestId("context-menu-item-open-fast")).toBeInTheDocument();
+    });
+
+    releaseSlow?.();
+    // Allow the slow first request to resolve; generation guard must ignore it.
+    await waitFor(() => {
+      expect(loadMenuActions.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(screen.getByTestId("context-menu-item-open-fast")).toBeInTheDocument();
+    expect(screen.queryByTestId("context-menu-item-open-slow")).toBeNull();
+  });
+
   it("merges workflow transition group into toolbar and invokes transition (#2732)", async () => {
     const runWorkflowTransition = vi.fn(async () => undefined);
     const loadWorkflowMenuActions = vi.fn(async (item) => {
@@ -266,7 +369,6 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       EXPLORER_MSG.FOLDER_PROPS_LOCALE,
       EXPLORER_MSG.WORKFLOW_MENU_LABEL,
       EXPLORER_MSG.WORKFLOW_TRANSITION_FAILED,
-      EXPLORER_MSG.WORKFLOW_TRANSITION_SUCCESS,
     ];
     for (const key of chromeKeys) {
       expect(key.startsWith("perc.ui.explorer@")).toBe(true);

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -128,18 +128,117 @@ describe("ContentExplorerShell product composition (#2400)", () => {
   it("uses injected loaders only (no real network for menus/formats)", async () => {
     const loadDisplayFormats = vi.fn(async () => []);
     const loadMenuActions = vi.fn(async () => []);
+    const loadWorkflowMenuActions = vi.fn(async () => null);
     stubPathFetch();
 
     renderShell(
       <ContentExplorerShell
         loadDisplayFormats={loadDisplayFormats}
         loadMenuActions={loadMenuActions}
+        loadWorkflowMenuActions={loadWorkflowMenuActions}
       />,
     );
 
     await waitFor(() => {
       expect(loadDisplayFormats).toHaveBeenCalled();
       expect(loadMenuActions).toHaveBeenCalled();
+      expect(loadWorkflowMenuActions).toHaveBeenCalled();
+    });
+  });
+
+  it("merges workflow transition group into toolbar and invokes transition (#2732)", async () => {
+    const runWorkflowTransition = vi.fn(async () => undefined);
+    const loadWorkflowMenuActions = vi.fn(async (item) => {
+      if (!item?.id) return null;
+      return {
+        name: "workflow",
+        label: "Workflow",
+        sortRank: 9000,
+        menuType: "MENU" as const,
+        children: [
+          {
+            name: "workflow-transition:Submit",
+            label: "Submit",
+            sortRank: 1,
+            menuType: "MENUITEM" as const,
+          },
+        ],
+      };
+    });
+
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "33554432-101-1",
+                  name: "page-one",
+                  path: "/Sites/page-one",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 1,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => [
+          {
+            name: "open",
+            label: "Open",
+            sortRank: 1,
+            menuType: "MENUITEM",
+          },
+        ]}
+        loadWorkflowMenuActions={loadWorkflowMenuActions}
+        runWorkflowTransition={runWorkflowTransition}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("detail-row-33554432-101-1") ||
+          screen.getByText("page-one"),
+      ).toBeTruthy();
+    });
+
+    const row =
+      screen.queryByTestId("detail-row-33554432-101-1") ??
+      screen.getByText("page-one");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("action-toolbar-group-workflow"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByTestId("action-toolbar-item-workflow-transition:Submit"),
+    );
+
+    await waitFor(() => {
+      expect(runWorkflowTransition).toHaveBeenCalledWith(
+        "33554432-101-1",
+        "Submit",
+      );
     });
   });
 
@@ -165,6 +264,9 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       EXPLORER_MSG.FOLDER_PROPS_TITLE,
       EXPLORER_MSG.FOLDER_PROPS_COMMUNITY,
       EXPLORER_MSG.FOLDER_PROPS_LOCALE,
+      EXPLORER_MSG.WORKFLOW_MENU_LABEL,
+      EXPLORER_MSG.WORKFLOW_TRANSITION_FAILED,
+      EXPLORER_MSG.WORKFLOW_TRANSITION_SUCCESS,
     ];
     for (const key of chromeKeys) {
       expect(key.startsWith("perc.ui.explorer@")).toBe(true);

--- a/WebUI/src/test/ts/contentExplorer/itemWorkflowApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/itemWorkflowApi.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getItemWorkflowTransitions,
+  transitionItem,
+} from "../../../main/ts/api/contentExplorer/itemWorkflowApi";
+import * as client from "../../../main/ts/api/client";
+import { PATHS } from "../../../main/ts/api/paths";
+
+vi.mock("../../../main/ts/api/client", () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+describe("itemWorkflowApi (#2732)", () => {
+  beforeEach(() => {
+    vi.mocked(client.get).mockReset();
+  });
+
+  it("getItemWorkflowTransitions calls getTransitions path with encoded id", async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      itemId: "101-1",
+      stateName: "Draft",
+      transitionTriggers: ["Submit"],
+    });
+    const result = await getItemWorkflowTransitions("101-1");
+    expect(client.get).toHaveBeenCalledWith(
+      `${PATHS.ITEM_WORKFLOW_TRANSITIONS}${encodeURIComponent("101-1")}`,
+    );
+    expect(result.transitionTriggers).toEqual(["Submit"]);
+  });
+
+  it("getItemWorkflowTransitions returns empty triggers for blank id without fetch", async () => {
+    const result = await getItemWorkflowTransitions("  ");
+    expect(client.get).not.toHaveBeenCalled();
+    expect(result.transitionTriggers).toEqual([]);
+  });
+
+  it("transitionItem posts trigger via transitionWithComments path", async () => {
+    vi.mocked(client.get).mockResolvedValue({ itemId: "55" });
+    await transitionItem("55", "Submit");
+    expect(client.get).toHaveBeenCalledWith(
+      `${PATHS.ITEM_WORKFLOW_TRANSITION_WITH_COMMENTS}${encodeURIComponent("55")}/${encodeURIComponent("Submit")}`,
+    );
+  });
+
+  it("transitionItem appends comment query when provided", async () => {
+    vi.mocked(client.get).mockResolvedValue({ itemId: "55" });
+    await transitionItem("55", "Approve", "looks good");
+    const url = vi.mocked(client.get).mock.calls[0]?.[0] as string;
+    expect(url).toContain("comment=");
+    expect(url).toContain(encodeURIComponent("looks good"));
+  });
+
+  it("transitionItem rejects missing id or trigger", async () => {
+    await expect(transitionItem("", "Submit")).rejects.toThrow(/requires/);
+    await expect(transitionItem("1", "")).rejects.toThrow(/requires/);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/itemWorkflowApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/itemWorkflowApi.test.ts
@@ -53,7 +53,7 @@ describe("itemWorkflowApi (#2732)", () => {
     expect(result.transitionTriggers).toEqual([]);
   });
 
-  it("transitionItem posts trigger via transitionWithComments path", async () => {
+  it("transitionItem fetches trigger via transitionWithComments path", async () => {
     vi.mocked(client.get).mockResolvedValue({ itemId: "55" });
     await transitionItem("55", "Submit");
     expect(client.get).toHaveBeenCalledWith(

--- a/WebUI/src/test/ts/contentExplorer/workflowMenuActions.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/workflowMenuActions.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
+import {
+  WORKFLOW_MENU_NAME,
+  WORKFLOW_TRANSITION_PREFIX,
+  buildWorkflowTransitionMenu,
+  isWorkflowTransitionActionName,
+  mergeWorkflowMenuActions,
+  parseWorkflowTransitionTrigger,
+} from "../../../main/ts/contentExplorer/workflowMenuActions";
+
+describe("workflowMenuActions mapping (#2732)", () => {
+  it("returns null when triggers are empty or blank", () => {
+    expect(buildWorkflowTransitionMenu([])).toBeNull();
+    expect(buildWorkflowTransitionMenu(null)).toBeNull();
+    expect(buildWorkflowTransitionMenu(["", "  "])).toBeNull();
+  });
+
+  it("builds a Workflow MENU group with tagged children", () => {
+    const menu = buildWorkflowTransitionMenu(["Submit", "Approve"], {
+      groupLabel: "Workflow",
+      stateName: "Draft",
+    });
+    expect(menu).not.toBeNull();
+    expect(menu!.name).toBe(WORKFLOW_MENU_NAME);
+    expect(menu!.menuType).toBe("MENU");
+    expect(menu!.label).toBe("Workflow");
+    expect(menu!.description).toContain("Draft");
+    expect(menu!.children?.map((c) => c.name)).toEqual([
+      `${WORKFLOW_TRANSITION_PREFIX}Submit`,
+      `${WORKFLOW_TRANSITION_PREFIX}Approve`,
+    ]);
+    expect(menu!.children?.map((c) => c.label)).toEqual([
+      "Submit",
+      "Approve",
+    ]);
+  });
+
+  it("de-duplicates triggers preserving first-seen order", () => {
+    const menu = buildWorkflowTransitionMenu([
+      "Submit",
+      "Approve",
+      "Submit",
+      "  Approve  ",
+    ]);
+    expect(menu!.children?.map((c) => c.label)).toEqual(["Submit", "Approve"]);
+  });
+
+  it("merges workflow group after base actions and replaces prior workflow group", () => {
+    const base: MenuAction[] = [
+      { name: "open", label: "Open", sortRank: 10, menuType: "MENUITEM" },
+      {
+        name: WORKFLOW_MENU_NAME,
+        label: "Stale",
+        sortRank: 1,
+        menuType: "MENU",
+        children: [
+          {
+            name: `${WORKFLOW_TRANSITION_PREFIX}Old`,
+            label: "Old",
+            sortRank: 1,
+            menuType: "MENUITEM",
+          },
+        ],
+      },
+    ];
+    const wf = buildWorkflowTransitionMenu(["Submit"], {
+      groupLabel: "Workflow",
+      sortRank: 9000,
+    });
+    const merged = mergeWorkflowMenuActions(base, wf);
+    expect(merged.map((a) => a.name)).toEqual(["open", WORKFLOW_MENU_NAME]);
+    expect(merged[1]?.children?.[0]?.label).toBe("Submit");
+  });
+
+  it("omits workflow group when null", () => {
+    const base: MenuAction[] = [
+      { name: "open", label: "Open", sortRank: 1, menuType: "MENUITEM" },
+    ];
+    expect(mergeWorkflowMenuActions(base, null).map((a) => a.name)).toEqual([
+      "open",
+    ]);
+  });
+
+  it("parses and detects workflow transition action names", () => {
+    expect(isWorkflowTransitionActionName(`${WORKFLOW_TRANSITION_PREFIX}Submit`)).toBe(
+      true,
+    );
+    expect(isWorkflowTransitionActionName("open")).toBe(false);
+    expect(parseWorkflowTransitionTrigger(`${WORKFLOW_TRANSITION_PREFIX}Approve`)).toBe(
+      "Approve",
+    );
+    expect(parseWorkflowTransitionTrigger("open")).toBeNull();
+    expect(parseWorkflowTransitionTrigger(WORKFLOW_TRANSITION_PREFIX)).toBeNull();
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
@@ -31,6 +31,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
 
 async function listWaitReady(page) {
   await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
@@ -66,6 +67,10 @@ test.describe("modern React Content Explorer - workflow transitions (#2732)", ()
       await expect(
         page.locator('[data-testid="explorer-server-actions"]'),
       ).toBeVisible();
+      // T082b / WebUI AGENTS.md — a11y gate on product Explorer shell surface.
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
     },
   );
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-workflow-transitions.spec.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Playwright surface: #2732 / parent #2400 — Workflow transitions in Explorer menus.
+ *
+ * <p>Verifies the modern React Content Explorer toolbar can surface workflow
+ * transitions for a selected content item (itemmanagement getTransitions) and
+ * that a transition control is invokable. When the H2 QA fixture has no
+ * transition-eligible content, soft-skips with a documented reason (not suite red).</p>
+ *
+ * <p>Tags: {@code @explorer-workflow} {@code @workflow} {@code @smoke}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-workflow-transitions.spec.js}
+ * from {@code modules/perc-qa-automation/frontend}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+async function listWaitReady(page) {
+  await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
+}
+
+/**
+ * Soft-skip reason when the stack has no transition-capable content selection.
+ * Issue #2732 acceptance allows documented soft-skip when fixture is thin.
+ */
+const FIXTURE_SKIP =
+  "H2 QA fixture has no selectable content item with workflow transitions " +
+  "(issue #2732 soft-skip; chrome/mapping covered by Vitest)";
+
+test.describe("modern React Content Explorer - workflow transitions (#2732)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(45_000);
+    await loginAsAdmin(page);
+    await page.goto(
+      `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`,
+    );
+    await page.waitForLoadState("networkidle");
+  });
+
+  test(
+    "shell mounts server action toolbar (workflow surface host)",
+    { tag: ["@explorer-workflow", "@workflow", "@smoke"] },
+    async ({ page }) => {
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(
+        page.locator('[data-testid="explorer-server-actions"]'),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    "selecting a content item shows Workflow transition controls when available",
+    { tag: ["@explorer-workflow", "@workflow"] },
+    async ({ page }) => {
+      test.setTimeout(90_000);
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      await expect(tree).toBeVisible({ timeout: 15_000 });
+      const sitesNode = page
+        .locator(
+          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+        )
+        .first();
+      if ((await sitesNode.count()) > 0) {
+        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        await listWaitReady(page);
+        await page.waitForLoadState("networkidle").catch(() => {});
+      }
+
+      const list = page.locator('[data-testid="detail-list"]');
+      await expect(list).toBeVisible({ timeout: 15_000 });
+
+      const enabledRows = list.locator(
+        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      );
+      const anyRows = list.locator('tbody tr[data-testid^="detail-row-"]');
+      const enabledCount = await enabledRows.count();
+      const anyCount = await anyRows.count();
+      if (enabledCount === 0 && anyCount === 0) {
+        test.skip(true, FIXTURE_SKIP);
+        return;
+      }
+
+      // Probe a few rows for a Workflow group (folder rows won't get transitions).
+      const probeLimit = Math.min(
+        Math.max(enabledCount, anyCount),
+        8,
+      );
+      let foundWorkflow = false;
+      for (let i = 0; i < probeLimit; i++) {
+        const target =
+          enabledCount > 0
+            ? enabledRows.nth(i)
+            : anyRows.nth(i);
+        if ((await target.count()) === 0) break;
+        await target.click({ force: true, timeout: 10_000 }).catch(() => {});
+        await page.waitForTimeout(400);
+        const group = page.locator(
+          '[data-testid="action-toolbar-group-workflow"]',
+        );
+        if ((await group.count()) > 0 && (await group.isVisible())) {
+          foundWorkflow = true;
+          // Prefer first transition child button.
+          const transitionBtn = page
+            .locator('[data-testid^="action-toolbar-item-workflow-transition:"]')
+            .first();
+          if ((await transitionBtn.count()) === 0) {
+            test.skip(true, FIXTURE_SKIP);
+            return;
+          }
+          await expect(transitionBtn).toBeVisible();
+          // Happy path: click once; do not assert state change hard (may need checkout).
+          // If the CMS rejects, still prove the control was invokable (no throw on click).
+          await transitionBtn.click({ force: true, timeout: 10_000 });
+          // Toolbar host remains mounted after invoke.
+          await expect(
+            page.locator('[data-testid="action-toolbar"]'),
+          ).toBeVisible();
+          break;
+        }
+      }
+
+      if (!foundWorkflow) {
+        test.skip(true, FIXTURE_SKIP);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Implements **#2732** (slice of parent **#2400**): workflow transitions are discoverable and invokable from modern Content Explorer toolbar / context menus.

### Approach
- Inventory: DCE uses workflow menu actions via the action manager; modern Explorer already loads `/actions/find*` but **`getAllowedTransitions` remains a stub** and sitemanage `findAllowedTransitions` returns empty.
- **No new REST contract** this PR — reuse proven **itemmanagement** endpoints already used by `WorkflowActionsPanel`:
  - `GET .../workflow/getTransitions/{id}`
  - `GET .../workflow/transitionWithComments/{id}/{trigger}`
- Client maps triggers into a **Workflow** cascading menu group (`workflow-transition:Trigger` names) and merges into server action menus on content selection.
- `ActionToolbar` renders cascading children as a labeled group for one-click transitions; `ContextMenu` already supports submenus.

### Files
- `itemWorkflowApi.ts`, `workflowMenuActions.ts` (pure mapping)
- `ContentExplorerShell.tsx` load/merge/invoke
- `ActionToolbar.tsx` group rendering
- Vitest + Playwright soft-skip surface

## Test plan
1. Vitest (WebUI): mapping, API, toolbar group, shell invoke path
2. `cd WebUI && ../mvnw clean install` — BUILD SUCCESS
3. `modules/perc-qa-automation` unit suite green
4. Playwright: `tests/explorer-workflow-transitions.spec.js` (QA mode); soft-skips when H2 has no transition-eligible content

### Manual QA
1. Open `/cm/app/spa.jsp?entry=explorer` as Admin
2. Select a content item with allowed transitions
3. Confirm **Workflow** group on server action toolbar
4. Click a transition (e.g. Submit); list refreshes / no crash

## Gates evidence
- **Erlang-style self-review:** no bugs found; portable paths (NIO not involved; URL paths use `/`); companions delivered (Vitest + Playwright); no new REST modules
- **Pre-PR Maven:** `cd WebUI; ..\mvnw.cmd clean install` → BUILD SUCCESS; WAR present
- **Vitest:** workflowMenuActions, itemWorkflowApi, ActionToolbar, ContentExplorerShell — 28 tests passed
- **perc-qa-automation unit:** 199 passed
- **Spotless:** not required by AGENTS.md

## Fixes
Fixes #2732  
Parent: #2400

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
