### PR TITLE
security(docs): redact QA ADMIN_PASSWORD from #2484 Erlang review

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2484-golden-login-surface-smoke-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2484-golden-login-surface-smoke-erlang.md
@@ -108,7 +108,7 @@ report missing HEALTHCHECK. The golden/login surface smoke itself
 
 1. `python docker/scripts/perc-devctl.py qa-up --skip-image-build
    --timeout-seconds 1200`
-   → `RESULT:OK STEP:qa-up QA_CMS_HOST_PORT=9993 TEST_CMS_URL=http://127.0.0.1:9993 ADMIN_PASSWORD=5vx$N0Sz9GhX37H4p*`
+   → `RESULT:OK STEP:qa-up QA_CMS_HOST_PORT=9993 TEST_CMS_URL=http://127.0.0.1:9993 ADMIN_PASSWORD=<from qa-up stdout — never commit>`
 2. `npm run test:surface -- --path tests/golden-unattended-smoke.spec.js`
    → `2 passed (9.9s)` (golden-unattended-smoke + Content Explorer shell).
 3. `python docker/scripts/perc-devctl.py qa-down`


### PR DESCRIPTION
## Summary
- Finding: Durable Erlang report committed a live ADMIN_PASSWORD from perc-devctl qa-up stdout (merged via #2567).
- Mitigation: Replace literal with placeholder ADMIN_PASSWORD=<from qa-up stdout — never commit>.
- Scope: Single docs line; docs-only; no Maven.

## Secret classification
- Ephemeral QA-mode H2 admin password (not product secrets). Still must not live in git tip.
- Rotation: session-scoped; qa-down / new qa-up rotates. History of d9dfece527 still has the value (history rewrite not done).

## Verification
- Repo-wide grep: only this file had the literal; redacted on this branch tip.

## Test plan
- [x] Diff is only the redaction line
- [x] No other literal ADMIN_PASSWORD in docs/