### PR TITLE
feat(perc-packages): Component Package Manifest model + schema docs (#2750)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -49,6 +49,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Doc | Purpose |
 |-----|---------|
 | [plan.md](./plan.md) | Full strategic plan (canonical) |
+| [component-package-manifest.md](./component-package-manifest.md) | Phase 3 ship-format manifest schema v1.0 + Java model |
 | [widget-xml-inventory.md](./widget-xml-inventory.md) | Product widget matrix (48 defs) |
 | [widget-xml-inventory.csv](./widget-xml-inventory.csv) | Machine-readable inventory |
 | [gadget-definition-inventory.md](./gadget-definition-inventory.md) | Gadget XML / SPA survey |
@@ -71,6 +72,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | CM1 page assembler | `projects/sitemanage/.../assembler/PSPageAssembler.java` |
 | Widget model | `projects/sitemanage/.../data/PSWidgetDefinition.java` |
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
+| Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 
 ## Immediate next work

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -35,3 +35,15 @@ Content types + Templates (assembler + JEXL bindings + source)
 - Compiler/upgrade tooling is mandatory before deleting package XML.
 - Widget Builder / Design tools write modern format only.
 - Package install/export paths must understand the new manifest shape (prefer extending existing package system).
+
+## Component Package Manifest (schema v1.0)
+
+Ship-format model and docs landed as Phase 3 slice 1 (#2750):
+
+| Artifact | Location |
+|----------|----------|
+| Schema / field docs | [../component-package-manifest.md](../component-package-manifest.md) |
+| Java model + IO + validation | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
+| Minimal fixture | `modules/perc-packages/src/test/resources/manifests/minimal-component-package.json` |
+
+**Upgrade-input XML** remains compiler/shim only; **product ship format** is `component-package.json` plus content types, templates, slots, catalog metadata, and resources.

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/README.md
@@ -7,8 +7,11 @@
 | [003](./003-slot-layout-styles.md) | Slot layout and slot styles | Accepted (direction) |
 | [004](./004-no-definition-xml-packaging.md) | No Page/Widget/Gadget XML for product packaging | Accepted |
 
-Open follow-ups before Phase 1 coding freezes:
+Related schema (not a separate ADR):
 
-- HTML-first placeholder syntax choice (ADR-002)
+- [Component Package Manifest v1.0](../component-package-manifest.md) — ship format + Java model (Phase 3 / #2750); grounded in ADR-004
+
+Open follow-ups:
+
 - Exact assembly context keys for slot layout/styles (ADR-003)
-- Component package manifest format (new ADR when drafted)
+- Compiler (#2751) and runtime shim (#2752) consumption of the manifest

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -1,0 +1,191 @@
+# Component Package Manifest (schema v1.0)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Accepted for Phase 3 slice 1 (#2750) |
+| **Schema version** | `1.0` |
+| **Ship file name** | `component-package.json` |
+| **Java model** | `com.percussion.packages.manifest.PSComponentPackageManifest` (`modules/perc-packages`) |
+| **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
+| **Plan** | [plan.md § Phase 3](./plan.md) |
+
+## Purpose
+
+Product **source of truth** for a packaged component (former Widget / Page-definition / Gadget XML role):
+
+```text
+Content types + Templates (assembler + JEXL bindings + source)
+  + Slots (incl. layout/styles) + Catalog metadata + Resources
+```
+
+This document describes the **ship format** (what product packages author and install) versus **upgrade-input XML** (legacy Widget / Page meta / Gadget definition files consumed only by compilers and a time-boxed runtime shim).
+
+## Ship format vs upgrade-input XML
+
+| Concern | Ship format (modern) | Upgrade input (legacy) |
+|---------|----------------------|------------------------|
+| Identity / deps | `component-package.json` fields `id`, `version`, `dependencies`, `publisher`, `cmsVersion` | `psx_archiveInfo.xml` / `PSXDescriptor` |
+| Palette metadata | `catalog` object | Widget `WidgetPrefs` (title, category, thumbnail, …) or gadget registry |
+| Content types | `contentTypes[]` + package-relative CT artifacts | `*.contentType` trees inside `.ppkg` |
+| Templates + JEXL | `templates[]` (`assembler`, `sourceRef`, `bindings[]`) | Widget `Code` (jexl) + `Content` (velocity/html) and/or `*.templateDef` |
+| Slots + layout/styles | `slots[]` with `layout` / `styles` maps (ADR-003) | CM1 region tree + widget instance css/user prefs |
+| Static assets | `resources[]` (`path` → install `target`) | `SupportFile-*` / `sys__UserDependency--*` trees |
+| Instance prefs | `userPreferences[]` / `cssPreferences[]` (transitional) | Widget `UserPref` / `CssPref` |
+| Definition XML | **Not present** in product source | `rxconfig/Widgets/*.xml`, page meta XML, gadget definition XML |
+
+**Rules (ADR-004):**
+
+1. Product packages **ship** without Page / Widget / Gadget definition XML as the authoring format.
+2. Upgrade / compiler tools **read** legacy XML and **emit** this manifest + artifacts (sibling slice #2751).
+3. Runtime may keep a **time-boxed shim** when modern package is absent (sibling slice #2752).
+
+## File placement
+
+```text
+<package-source>/
+  component-package.json          ← this manifest (schemaVersion 1.0)
+  contentTypes/<typeName>/…       ← optional; refs from contentTypes[].ref
+  templates/<templateName>.vm     ← optional; refs from templates[].sourceRef
+  resources/…                     ← optional; refs from resources[].path
+  … legacy .ppkg staging files may coexist during migration …
+```
+
+Paths inside the manifest are **package-relative**, always with `/` separators (URL / zip entry style). Absolute OS paths (`C:\…`, `/tmp/…`, UNC) and `..` segments are invalid.
+
+## Root object
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schemaVersion` | string | yes | Must be `"1.0"` for this model |
+| `id` | string | yes | Stable package id (e.g. `perc.widget.title`) |
+| `name` | string | yes | Display name |
+| `version` | string | yes | Package semver / product version string |
+| `description` | string | no | Human summary |
+| `publisher` | object | no | `{ "name", "url" }` |
+| `cmsVersion` | object | no | `{ "min", "max" }` compatible CMS range |
+| `dependencies` | array | no | `{ "name", "version", "implied" }` |
+| `catalog` | object | no | Palette / UI metadata (see below) |
+| `contentTypes` | array | * | At least one of `contentTypes` or `templates` required |
+| `templates` | array | * | At least one of `contentTypes` or `templates` required |
+| `slots` | array | no | Composition holes with optional layout/styles |
+| `resources` | array | no | CSS/JS/images |
+| `userPreferences` | array | no | Transitional from Widget `UserPref` |
+| `cssPreferences` | array | no | Transitional from Widget `CssPref`; prefer slot styles long-term |
+
+## `catalog`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | string | Default `component`; also `page`, `gadget`, … |
+| `title` | string | Palette title |
+| `category` | string | e.g. `content` |
+| `description` | string | |
+| `thumbnail` / `icon` | string | Package-relative resource path |
+| `author` | string | |
+| `preferredEditorWidth` / `preferredEditorHeight` | number | Editor chrome |
+| `createSharedAsset` | boolean | |
+| `editableOnTemplate` | boolean | |
+| `responsive` | boolean | |
+| `paletteVisible` | boolean | Default `true` |
+
+## `contentTypes[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Content type name |
+| `ref` | string | no | Package-relative path to CT artifact tree |
+
+## `templates[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Template name |
+| `type` | string | no | `snippet` (default), `page`, `global`, `binary`, `resource` |
+| `assembler` | string | no | e.g. `velocityAssembler`, `htmlAssembler`, `markdownAssembler` |
+| `sourceRef` | string | no | Package-relative path to source |
+| `contentType` | string | no | Associated content type name |
+| `bindings` | array | no | Ordered JEXL `{ "variable", "expression" }` (ADR-001 — JEXL only) |
+
+## `slots[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Slot name |
+| `allowedContentTypes` | string[] | no | |
+| `layout` | object | no | Free-form map → Phase 2 `slot_layout` |
+| `styles` | object | no | Free-form map → Phase 2 `slot_styles` |
+
+## `resources[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | yes | Package-relative source path |
+| `target` | string | no | Install-relative target (URL-style `/`) |
+| `type` | string | no | `css`, `js`, `image`, … |
+
+## `userPreferences[]` / `cssPreferences[]`
+
+Transitional mirrors of Widget `UserPref` / `CssPref` so the XML compiler can land without inventing a second preference dialect. New design tools should prefer **slot layout/styles** for presentational concerns (ADR-003).
+
+### User preference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | required |
+| `displayName` | string | |
+| `datatype` | string | e.g. `enum`, `string` |
+| `required` | boolean | |
+| `defaultValue` | string | |
+| `enumValues` | array | `{ "value", "displayValue" }` |
+
+### CSS preference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | required |
+| `displayName` | string | |
+| `datatype` | string | |
+| `defaultValue` | string | |
+
+## Minimal example
+
+See test fixture:
+
+`modules/perc-packages/src/test/resources/manifests/minimal-component-package.json`
+
+(Title widget-shaped minimal package: one content type, one snippet template, one slot, one image resource, one user pref, one css pref.)
+
+## Java API
+
+| Type | Role |
+|------|------|
+| `PSComponentPackageManifest` | Typed model + nested types |
+| `PSComponentPackageManifestIo` | JSON parse / write / Path I/O |
+| `PSComponentPackageManifestValidator` | Structural validation |
+| `PSComponentPackageManifestException` | Parse / validation failure |
+
+```java
+PSComponentPackageManifest m = PSComponentPackageManifestIo.read(path);
+PSComponentPackageManifestValidator.validate(m);
+String json = PSComponentPackageManifestIo.toJson(m);
+```
+
+## Relationship to existing package system
+
+- **Today:** `PSPackageBuilder` zips legacy package source trees into `.ppkg` for the deployer (`psx_archiveInfo.xml` / dependency trees). That path remains for install compatibility.
+- **This manifest:** extends the packaging story with an explicit, tool-friendly **component** model that does not require Widget/Page/Gadget XML. Future slices wire compiler output and install recognition; this slice lands model + schema + tests only.
+
+## Out of scope (sibling slices)
+
+| Slice | Issue | Role |
+|-------|-------|------|
+| Widget XML compiler | #2751 | XML → manifest + artifacts |
+| Runtime legacy shim | #2752 | Load customer XML when modern package absent |
+
+## Validation summary
+
+- `schemaVersion` must be `1.0`
+- `id`, `name`, `version` required non-blank
+- At least one `contentTypes[]` or `templates[]` entry
+- Nested names required when entries present
+- Package-relative paths: `/` only, no `..`, no absolute OS forms

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -357,12 +357,13 @@ This is multi-quarter work even if labeled “8.2.” Split so 8.2 can ship **fo
 
 **Goals:** **ship product out of XML definition files.**
 
-1. Define **Component Package Manifest** (reuse package system where possible) listing content types, templates, slots, catalog metadata, resources.
-2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles).
+1. Define **Component Package Manifest** (reuse package system where possible) listing content types, templates, slots, catalog metadata, resources.  
+   **Done (slice 1 / #2750):** schema docs + Java model + parse/validate/round-trip tests — see [component-package-manifest.md](./component-package-manifest.md) and `com.percussion.packages.manifest` in `modules/perc-packages`.
+2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles). *(#2751)*
 3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.
 4. **Gadget XML** conversion path for remaining XML-defined gadgets.
 5. Convert **baseline / baseWidgets** first; then high-traffic packages (nav, blog, lists, rich text).
-6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format.
+6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format. *(#2752)*
 7. Widget Builder / Design tools write modern package format only.
 
 **Exit criterion for “ship”:** product packages in repo/install are **not** defined by Page/Widget/Gadget XML files; upgrade converts customer XML; shim optional and time-boxed.

--- a/modules/perc-packages/pom.xml
+++ b/modules/perc-packages/pom.xml
@@ -15,6 +15,11 @@
         <skipTests>false</skipTests>
     </properties>
     <dependencies>
+        <!-- Manifest JSON codec for Component Package Manifest (Phase 3 / ADR-004). -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -84,6 +89,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
+            </plugin>
+            <!-- Manifest DTOs are Gson beans; skip -missing doclint noise on accessors. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <doclint>all,-missing</doclint>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
@@ -1,0 +1,978 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Typed model for a <strong>Component Package Manifest</strong> — the modern product packaging
+ * shape for content types, templates, slots, catalog metadata, and resources (ADR-004 / plan Phase
+ * 3).
+ *
+ * <p>Ship format is JSON (default file name {@value #DEFAULT_MANIFEST_FILE_NAME}) living beside
+ * package artifacts. This model does <em>not</em> replace the legacy {@code .ppkg} / {@code
+ * PSXArchiveInfo} deployer format yet; it is the authoring and future install source of truth so
+ * product packages no longer need Page / Widget / Gadget definition XML.
+ *
+ * <p>Upgrade-input Widget XML is out of band: compilers (sibling slice) read XML and emit this
+ * manifest plus CT/template/slot/resource artifacts.
+ *
+ * @see PSComponentPackageManifestIo
+ * @see PSComponentPackageManifestValidator
+ */
+public final class PSComponentPackageManifest {
+
+  /** Default ship-format file name inside a component package source tree. */
+  public static final String DEFAULT_MANIFEST_FILE_NAME = "component-package.json";
+
+  /** Schema version supported by this model (semver major.minor). */
+  public static final String SUPPORTED_SCHEMA_VERSION = "1.0";
+
+  private String schemaVersion = SUPPORTED_SCHEMA_VERSION;
+  private String id;
+  private String name;
+  private String version;
+  private String description;
+  private Publisher publisher;
+  private CmsVersionRange cmsVersion;
+  private List<Dependency> dependencies = new ArrayList<>();
+  private Catalog catalog;
+  private List<ContentTypeRef> contentTypes = new ArrayList<>();
+  private List<TemplateRef> templates = new ArrayList<>();
+  private List<SlotRef> slots = new ArrayList<>();
+  private List<ResourceRef> resources = new ArrayList<>();
+  private List<UserPreference> userPreferences = new ArrayList<>();
+  private List<CssPreference> cssPreferences = new ArrayList<>();
+
+  public String getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  public void setSchemaVersion(String schemaVersion) {
+    this.schemaVersion = schemaVersion;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Publisher getPublisher() {
+    return publisher;
+  }
+
+  public void setPublisher(Publisher publisher) {
+    this.publisher = publisher;
+  }
+
+  public CmsVersionRange getCmsVersion() {
+    return cmsVersion;
+  }
+
+  public void setCmsVersion(CmsVersionRange cmsVersion) {
+    this.cmsVersion = cmsVersion;
+  }
+
+  public List<Dependency> getDependencies() {
+    return dependencies;
+  }
+
+  public void setDependencies(List<Dependency> dependencies) {
+    this.dependencies = dependencies != null ? dependencies : new ArrayList<>();
+  }
+
+  public Catalog getCatalog() {
+    return catalog;
+  }
+
+  public void setCatalog(Catalog catalog) {
+    this.catalog = catalog;
+  }
+
+  public List<ContentTypeRef> getContentTypes() {
+    return contentTypes;
+  }
+
+  public void setContentTypes(List<ContentTypeRef> contentTypes) {
+    this.contentTypes = contentTypes != null ? contentTypes : new ArrayList<>();
+  }
+
+  public List<TemplateRef> getTemplates() {
+    return templates;
+  }
+
+  public void setTemplates(List<TemplateRef> templates) {
+    this.templates = templates != null ? templates : new ArrayList<>();
+  }
+
+  public List<SlotRef> getSlots() {
+    return slots;
+  }
+
+  public void setSlots(List<SlotRef> slots) {
+    this.slots = slots != null ? slots : new ArrayList<>();
+  }
+
+  public List<ResourceRef> getResources() {
+    return resources;
+  }
+
+  public void setResources(List<ResourceRef> resources) {
+    this.resources = resources != null ? resources : new ArrayList<>();
+  }
+
+  public List<UserPreference> getUserPreferences() {
+    return userPreferences;
+  }
+
+  public void setUserPreferences(List<UserPreference> userPreferences) {
+    this.userPreferences = userPreferences != null ? userPreferences : new ArrayList<>();
+  }
+
+  public List<CssPreference> getCssPreferences() {
+    return cssPreferences;
+  }
+
+  public void setCssPreferences(List<CssPreference> cssPreferences) {
+    this.cssPreferences = cssPreferences != null ? cssPreferences : new ArrayList<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSComponentPackageManifest that)) {
+      return false;
+    }
+    return Objects.equals(schemaVersion, that.schemaVersion)
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(version, that.version)
+        && Objects.equals(description, that.description)
+        && Objects.equals(publisher, that.publisher)
+        && Objects.equals(cmsVersion, that.cmsVersion)
+        && Objects.equals(dependencies, that.dependencies)
+        && Objects.equals(catalog, that.catalog)
+        && Objects.equals(contentTypes, that.contentTypes)
+        && Objects.equals(templates, that.templates)
+        && Objects.equals(slots, that.slots)
+        && Objects.equals(resources, that.resources)
+        && Objects.equals(userPreferences, that.userPreferences)
+        && Objects.equals(cssPreferences, that.cssPreferences);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        schemaVersion,
+        id,
+        name,
+        version,
+        description,
+        publisher,
+        cmsVersion,
+        dependencies,
+        catalog,
+        contentTypes,
+        templates,
+        slots,
+        resources,
+        userPreferences,
+        cssPreferences);
+  }
+
+  /** Publisher identity (maps from legacy {@code PSXDescriptor/Publisher}). */
+  public static final class Publisher {
+    private String name;
+    private String url;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Publisher that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name) && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, url);
+    }
+  }
+
+  /** Compatible CMS product version range (maps from {@code CmsVersion min/max}). */
+  public static final class CmsVersionRange {
+    private String min;
+    private String max;
+
+    public String getMin() {
+      return min;
+    }
+
+    public void setMin(String min) {
+      this.min = min;
+    }
+
+    public String getMax() {
+      return max;
+    }
+
+    public void setMax(String max) {
+      this.max = max;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CmsVersionRange that)) {
+        return false;
+      }
+      return Objects.equals(min, that.min) && Objects.equals(max, that.max);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(min, max);
+    }
+  }
+
+  /** Package dependency (maps from {@code PKGDependency}). */
+  public static final class Dependency {
+    private String name;
+    private String version;
+    private boolean implied;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+
+    public boolean isImplied() {
+      return implied;
+    }
+
+    public void setImplied(boolean implied) {
+      this.implied = implied;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Dependency that)) {
+        return false;
+      }
+      return implied == that.implied
+          && Objects.equals(name, that.name)
+          && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, version, implied);
+    }
+  }
+
+  /**
+   * Palette / catalog metadata formerly carried by Widget {@code WidgetPrefs} (and gadget
+   * registry entries).
+   */
+  public static final class Catalog {
+    /** Logical kind: {@code component}, {@code page}, {@code gadget}, etc. */
+    private String kind = "component";
+
+    private String title;
+    private String category;
+    private String description;
+    private String thumbnail;
+    private String icon;
+    private String author;
+    private Integer preferredEditorWidth;
+    private Integer preferredEditorHeight;
+    private Boolean createSharedAsset;
+    private Boolean editableOnTemplate;
+    private Boolean responsive;
+    private Boolean paletteVisible = Boolean.TRUE;
+
+    public String getKind() {
+      return kind;
+    }
+
+    public void setKind(String kind) {
+      this.kind = kind;
+    }
+
+    public String getTitle() {
+      return title;
+    }
+
+    public void setTitle(String title) {
+      this.title = title;
+    }
+
+    public String getCategory() {
+      return category;
+    }
+
+    public void setCategory(String category) {
+      this.category = category;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public String getThumbnail() {
+      return thumbnail;
+    }
+
+    public void setThumbnail(String thumbnail) {
+      this.thumbnail = thumbnail;
+    }
+
+    public String getIcon() {
+      return icon;
+    }
+
+    public void setIcon(String icon) {
+      this.icon = icon;
+    }
+
+    public String getAuthor() {
+      return author;
+    }
+
+    public void setAuthor(String author) {
+      this.author = author;
+    }
+
+    public Integer getPreferredEditorWidth() {
+      return preferredEditorWidth;
+    }
+
+    public void setPreferredEditorWidth(Integer preferredEditorWidth) {
+      this.preferredEditorWidth = preferredEditorWidth;
+    }
+
+    public Integer getPreferredEditorHeight() {
+      return preferredEditorHeight;
+    }
+
+    public void setPreferredEditorHeight(Integer preferredEditorHeight) {
+      this.preferredEditorHeight = preferredEditorHeight;
+    }
+
+    public Boolean getCreateSharedAsset() {
+      return createSharedAsset;
+    }
+
+    public void setCreateSharedAsset(Boolean createSharedAsset) {
+      this.createSharedAsset = createSharedAsset;
+    }
+
+    public Boolean getEditableOnTemplate() {
+      return editableOnTemplate;
+    }
+
+    public void setEditableOnTemplate(Boolean editableOnTemplate) {
+      this.editableOnTemplate = editableOnTemplate;
+    }
+
+    public Boolean getResponsive() {
+      return responsive;
+    }
+
+    public void setResponsive(Boolean responsive) {
+      this.responsive = responsive;
+    }
+
+    public Boolean getPaletteVisible() {
+      return paletteVisible;
+    }
+
+    public void setPaletteVisible(Boolean paletteVisible) {
+      this.paletteVisible = paletteVisible;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Catalog that)) {
+        return false;
+      }
+      return Objects.equals(kind, that.kind)
+          && Objects.equals(title, that.title)
+          && Objects.equals(category, that.category)
+          && Objects.equals(description, that.description)
+          && Objects.equals(thumbnail, that.thumbnail)
+          && Objects.equals(icon, that.icon)
+          && Objects.equals(author, that.author)
+          && Objects.equals(preferredEditorWidth, that.preferredEditorWidth)
+          && Objects.equals(preferredEditorHeight, that.preferredEditorHeight)
+          && Objects.equals(createSharedAsset, that.createSharedAsset)
+          && Objects.equals(editableOnTemplate, that.editableOnTemplate)
+          && Objects.equals(responsive, that.responsive)
+          && Objects.equals(paletteVisible, that.paletteVisible);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          kind,
+          title,
+          category,
+          description,
+          thumbnail,
+          icon,
+          author,
+          preferredEditorWidth,
+          preferredEditorHeight,
+          createSharedAsset,
+          editableOnTemplate,
+          responsive,
+          paletteVisible);
+    }
+  }
+
+  /** Reference to a content type definition packaged with (or required by) this component. */
+  public static final class ContentTypeRef {
+    private String name;
+    /** Package-relative path (URL-style {@code /} separators) to the CT artifact tree. */
+    private String ref;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getRef() {
+      return ref;
+    }
+
+    public void setRef(String ref) {
+      this.ref = ref;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ContentTypeRef that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name) && Objects.equals(ref, that.ref);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, ref);
+    }
+  }
+
+  /** Assembly template packaged with this component (snippet / page / binary / resource). */
+  public static final class TemplateRef {
+    private String name;
+    /** Template kind: {@code snippet}, {@code page}, {@code global}, {@code binary}, {@code resource}. */
+    private String type = "snippet";
+    /** Assembler extension name, e.g. {@code velocityAssembler}, {@code htmlAssembler}. */
+    private String assembler;
+    /** Package-relative path to template source (URL-style separators). */
+    private String sourceRef;
+    private String contentType;
+    private List<Binding> bindings = new ArrayList<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getAssembler() {
+      return assembler;
+    }
+
+    public void setAssembler(String assembler) {
+      this.assembler = assembler;
+    }
+
+    public String getSourceRef() {
+      return sourceRef;
+    }
+
+    public void setSourceRef(String sourceRef) {
+      this.sourceRef = sourceRef;
+    }
+
+    public String getContentType() {
+      return contentType;
+    }
+
+    public void setContentType(String contentType) {
+      this.contentType = contentType;
+    }
+
+    public List<Binding> getBindings() {
+      return bindings;
+    }
+
+    public void setBindings(List<Binding> bindings) {
+      this.bindings = bindings != null ? bindings : new ArrayList<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof TemplateRef that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name)
+          && Objects.equals(type, that.type)
+          && Objects.equals(assembler, that.assembler)
+          && Objects.equals(sourceRef, that.sourceRef)
+          && Objects.equals(contentType, that.contentType)
+          && Objects.equals(bindings, that.bindings);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, type, assembler, sourceRef, contentType, bindings);
+    }
+  }
+
+  /** Ordered JEXL binding (variable + expression). Language is always JEXL (ADR-001). */
+  public static final class Binding {
+    private String variable;
+    private String expression;
+
+    public String getVariable() {
+      return variable;
+    }
+
+    public void setVariable(String variable) {
+      this.variable = variable;
+    }
+
+    public String getExpression() {
+      return expression;
+    }
+
+    public void setExpression(String expression) {
+      this.expression = expression;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Binding that)) {
+        return false;
+      }
+      return Objects.equals(variable, that.variable) && Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(variable, expression);
+    }
+  }
+
+  /**
+   * Slot definition reference. Layout/styles map to Phase 2 {@code slot_layout} / {@code
+   * slot_styles} (ADR-003).
+   */
+  public static final class SlotRef {
+    private String name;
+    private List<String> allowedContentTypes = new ArrayList<>();
+    private Map<String, Object> layout = new LinkedHashMap<>();
+    private Map<String, Object> styles = new LinkedHashMap<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public List<String> getAllowedContentTypes() {
+      return allowedContentTypes;
+    }
+
+    public void setAllowedContentTypes(List<String> allowedContentTypes) {
+      this.allowedContentTypes =
+          allowedContentTypes != null ? allowedContentTypes : new ArrayList<>();
+    }
+
+    public Map<String, Object> getLayout() {
+      return layout;
+    }
+
+    public void setLayout(Map<String, Object> layout) {
+      this.layout = layout != null ? layout : new LinkedHashMap<>();
+    }
+
+    public Map<String, Object> getStyles() {
+      return styles;
+    }
+
+    public void setStyles(Map<String, Object> styles) {
+      this.styles = styles != null ? styles : new LinkedHashMap<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SlotRef that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name)
+          && Objects.equals(allowedContentTypes, that.allowedContentTypes)
+          && Objects.equals(layout, that.layout)
+          && Objects.equals(styles, that.styles);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, allowedContentTypes, layout, styles);
+    }
+  }
+
+  /**
+   * Static resource (CSS/JS/image) packaged with the component. Paths use URL-style {@code /}
+   * separators (not OS filesystem separators).
+   */
+  public static final class ResourceRef {
+    private String path;
+    private String target;
+    private String type;
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(String path) {
+      this.path = path;
+    }
+
+    public String getTarget() {
+      return target;
+    }
+
+    public void setTarget(String target) {
+      this.target = target;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ResourceRef that)) {
+        return false;
+      }
+      return Objects.equals(path, that.path)
+          && Objects.equals(target, that.target)
+          && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, target, type);
+    }
+  }
+
+  /**
+   * Instance preference formerly expressed as Widget {@code UserPref}. Survives in the manifest so
+   * the Widget XML compiler can land without a parallel format.
+   */
+  public static final class UserPreference {
+    private String name;
+    private String displayName;
+    private String datatype;
+    private boolean required;
+    private String defaultValue;
+    private List<EnumValue> enumValues = new ArrayList<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDatatype() {
+      return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+      this.datatype = datatype;
+    }
+
+    public boolean isRequired() {
+      return required;
+    }
+
+    public void setRequired(boolean required) {
+      this.required = required;
+    }
+
+    public String getDefaultValue() {
+      return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    public List<EnumValue> getEnumValues() {
+      return enumValues;
+    }
+
+    public void setEnumValues(List<EnumValue> enumValues) {
+      this.enumValues = enumValues != null ? enumValues : new ArrayList<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof UserPreference that)) {
+        return false;
+      }
+      return required == that.required
+          && Objects.equals(name, that.name)
+          && Objects.equals(displayName, that.displayName)
+          && Objects.equals(datatype, that.datatype)
+          && Objects.equals(defaultValue, that.defaultValue)
+          && Objects.equals(enumValues, that.enumValues);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, displayName, datatype, required, defaultValue, enumValues);
+    }
+  }
+
+  /** Enumerated value for a user preference. */
+  public static final class EnumValue {
+    private String value;
+    private String displayValue;
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public String getDisplayValue() {
+      return displayValue;
+    }
+
+    public void setDisplayValue(String displayValue) {
+      this.displayValue = displayValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof EnumValue that)) {
+        return false;
+      }
+      return Objects.equals(value, that.value) && Objects.equals(displayValue, that.displayValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, displayValue);
+    }
+  }
+
+  /**
+   * Presentational preference formerly Widget {@code CssPref}. Prefer promoting layout/styles to
+   * slots (ADR-003) over growing this list indefinitely.
+   */
+  public static final class CssPreference {
+    private String name;
+    private String displayName;
+    private String datatype;
+    private String defaultValue;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDatatype() {
+      return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+      this.datatype = datatype;
+    }
+
+    public String getDefaultValue() {
+      return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CssPreference that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name)
+          && Objects.equals(displayName, that.displayName)
+          && Objects.equals(datatype, that.datatype)
+          && Objects.equals(defaultValue, that.defaultValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, displayName, datatype, defaultValue);
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+/**
+ * Thrown when a Component Package Manifest cannot be parsed or fails validation.
+ *
+ * @see PSComponentPackageManifest
+ * @see PSComponentPackageManifestValidator
+ */
+public class PSComponentPackageManifestException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSComponentPackageManifestException(String message) {
+    super(message);
+  }
+
+  public PSComponentPackageManifestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestIo.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestIo.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Parse and write {@link PSComponentPackageManifest} as JSON (ship format).
+ *
+ * <p>Uses portable {@link Path} / {@link Files} I/O and UTF-8. Does not validate structural rules —
+ * call {@link PSComponentPackageManifestValidator} after parse when required.
+ */
+public final class PSComponentPackageManifestIo {
+
+  private static final Gson GSON =
+      new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+  private PSComponentPackageManifestIo() {
+    // utility
+  }
+
+  /**
+   * Parse a JSON string into a manifest. Does not validate.
+   *
+   * @param json non-null JSON document
+   * @return parsed model (never null)
+   * @throws PSComponentPackageManifestException if JSON is empty or not a valid document
+   */
+  public static PSComponentPackageManifest parse(String json)
+      throws PSComponentPackageManifestException {
+    Objects.requireNonNull(json, "json");
+    if (json.isBlank()) {
+      throw new PSComponentPackageManifestException("Manifest JSON is empty");
+    }
+    try {
+      PSComponentPackageManifest manifest = GSON.fromJson(json, PSComponentPackageManifest.class);
+      if (manifest == null) {
+        throw new PSComponentPackageManifestException("Manifest JSON parsed to null");
+      }
+      // Gson leaves collection fields null when omitted; normalize for callers.
+      normalizeCollections(manifest);
+      return manifest;
+    } catch (JsonSyntaxException e) {
+      throw new PSComponentPackageManifestException("Invalid manifest JSON: " + e.getMessage(), e);
+    } catch (JsonParseException e) {
+      throw new PSComponentPackageManifestException("Failed to parse manifest JSON", e);
+    }
+  }
+
+  /**
+   * Parse UTF-8 JSON from a reader.
+   *
+   * @param reader non-null reader
+   * @return parsed model
+   * @throws PSComponentPackageManifestException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSComponentPackageManifest parse(Reader reader)
+      throws PSComponentPackageManifestException, IOException {
+    Objects.requireNonNull(reader, "reader");
+    StringBuilder sb = new StringBuilder();
+    char[] buf = new char[4096];
+    int n;
+    while ((n = reader.read(buf)) >= 0) {
+      sb.append(buf, 0, n);
+    }
+    return parse(sb.toString());
+  }
+
+  /**
+   * Read and parse a UTF-8 JSON file.
+   *
+   * @param path non-null path to the manifest file
+   * @return parsed model
+   * @throws PSComponentPackageManifestException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSComponentPackageManifest read(Path path)
+      throws PSComponentPackageManifestException, IOException {
+    Objects.requireNonNull(path, "path");
+    String json = Files.readString(path, StandardCharsets.UTF_8);
+    return parse(json);
+  }
+
+  /**
+   * Serialize a manifest to pretty-printed JSON.
+   *
+   * @param manifest non-null model
+   * @return JSON text (never null)
+   */
+  public static String toJson(PSComponentPackageManifest manifest) {
+    Objects.requireNonNull(manifest, "manifest");
+    normalizeCollections(manifest);
+    return GSON.toJson(manifest);
+  }
+
+  /**
+   * Write a manifest as UTF-8 JSON to a path (creates parent directories if needed).
+   *
+   * @param manifest non-null model
+   * @param path non-null destination path
+   * @throws IOException on I/O failure
+   */
+  public static void write(PSComponentPackageManifest manifest, Path path) throws IOException {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(path, "path");
+    Path parent = path.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.writeString(path, toJson(manifest), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Write a manifest as UTF-8 JSON to a writer.
+   *
+   * @param manifest non-null model
+   * @param writer non-null writer
+   * @throws IOException on I/O failure
+   */
+  public static void write(PSComponentPackageManifest manifest, Writer writer) throws IOException {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(writer, "writer");
+    writer.write(toJson(manifest));
+  }
+
+  private static void normalizeCollections(PSComponentPackageManifest manifest) {
+    if (manifest.getDependencies() == null) {
+      manifest.setDependencies(new java.util.ArrayList<>());
+    }
+    if (manifest.getContentTypes() == null) {
+      manifest.setContentTypes(new java.util.ArrayList<>());
+    }
+    if (manifest.getTemplates() == null) {
+      manifest.setTemplates(new java.util.ArrayList<>());
+    }
+    if (manifest.getSlots() == null) {
+      manifest.setSlots(new java.util.ArrayList<>());
+    }
+    if (manifest.getResources() == null) {
+      manifest.setResources(new java.util.ArrayList<>());
+    }
+    if (manifest.getUserPreferences() == null) {
+      manifest.setUserPreferences(new java.util.ArrayList<>());
+    }
+    if (manifest.getCssPreferences() == null) {
+      manifest.setCssPreferences(new java.util.ArrayList<>());
+    }
+    if (manifest.getTemplates() != null) {
+      for (PSComponentPackageManifest.TemplateRef t : manifest.getTemplates()) {
+        if (t != null && t.getBindings() == null) {
+          t.setBindings(new java.util.ArrayList<>());
+        }
+      }
+    }
+    if (manifest.getSlots() != null) {
+      for (PSComponentPackageManifest.SlotRef s : manifest.getSlots()) {
+        if (s == null) {
+          continue;
+        }
+        if (s.getAllowedContentTypes() == null) {
+          s.setAllowedContentTypes(new java.util.ArrayList<>());
+        }
+        if (s.getLayout() == null) {
+          s.setLayout(new java.util.LinkedHashMap<>());
+        }
+        if (s.getStyles() == null) {
+          s.setStyles(new java.util.LinkedHashMap<>());
+        }
+      }
+    }
+    if (manifest.getUserPreferences() != null) {
+      for (PSComponentPackageManifest.UserPreference p : manifest.getUserPreferences()) {
+        if (p != null && p.getEnumValues() == null) {
+          p.setEnumValues(new java.util.ArrayList<>());
+        }
+      }
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
@@ -35,10 +35,12 @@ public final class PSComponentPackageManifestValidator {
 
   /**
    * Package-relative path: non-empty, no drive letter / UNC / leading root, no backslashes, no
-   * {@code ..} segments. URL / zip entry style only.
+   * {@code ..} path segments. URL / zip entry style only. Double-dot <em>filenames</em> (e.g.
+   * {@code logo..png}) are allowed; only segment-shaped {@code ..} is rejected.
    */
   private static final Pattern RELATIVE_PACKAGE_PATH =
-      Pattern.compile("^(?!/)(?!\\\\)(?![A-Za-z]:)(?!\\\\\\\\)(?!.*\\.\\.)[A-Za-z0-9_./\\-]+$");
+      Pattern.compile(
+          "^(?!/)(?!\\\\)(?![A-Za-z]:)(?!\\\\\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9_./\\-]+$");
 
   private PSComponentPackageManifestValidator() {
     // utility
@@ -96,9 +98,14 @@ public final class PSComponentPackageManifestValidator {
           && manifest.getPublisher().getName().isBlank()) {
         errors.add("publisher.name must not be blank when present");
       }
-      if (manifest.getPublisher().getUrl() != null && containsBackslash(manifest.getPublisher().getUrl())) {
-        // URL may use http(s); backslash is never valid in URLs we accept
-        errors.add("publisher.url must not contain backslash characters");
+      if (manifest.getPublisher().getUrl() != null) {
+        if (manifest.getPublisher().getUrl().isBlank()) {
+          // Present but empty — reject so we do not store meaningless empty values
+          errors.add("publisher.url must not be blank when present");
+        } else if (containsBackslash(manifest.getPublisher().getUrl())) {
+          // URL may use http(s); backslash is never valid in URLs we accept
+          errors.add("publisher.url must not contain backslash characters");
+        }
       }
     }
 
@@ -245,8 +252,8 @@ public final class PSComponentPackageManifestValidator {
       errors.add(
           field
               + " must be a package-relative path using '/' separators"
-              + " (no absolute OS paths, no '..', no backslashes): '"
-              + path
+              + " (no absolute OS paths, no '..' segments, no backslashes): '"
+              + p
               + "'");
     }
   }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Structural validation for {@link PSComponentPackageManifest}.
+ *
+ * <p>Enforces schema version, required identity fields, non-blank nested names, portable
+ * package-relative path refs (URL-style {@code /} separators; no absolute OS paths), and the
+ * presence of at least one content type or template (a component must ship something installable).
+ */
+public final class PSComponentPackageManifestValidator {
+
+  private static final Pattern SCHEMA_VERSION = Pattern.compile("^\\d+\\.\\d+$");
+
+  /**
+   * Package-relative path: non-empty, no drive letter / UNC / leading root, no backslashes, no
+   * {@code ..} segments. URL / zip entry style only.
+   */
+  private static final Pattern RELATIVE_PACKAGE_PATH =
+      Pattern.compile("^(?!/)(?!\\\\)(?![A-Za-z]:)(?!\\\\\\\\)(?!.*\\.\\.)[A-Za-z0-9_./\\-]+$");
+
+  private PSComponentPackageManifestValidator() {
+    // utility
+  }
+
+  /**
+   * Validate a manifest; throw on the first failure.
+   *
+   * @param manifest non-null model
+   * @throws PSComponentPackageManifestException when invalid
+   */
+  public static void validate(PSComponentPackageManifest manifest)
+      throws PSComponentPackageManifestException {
+    List<String> errors = validateCollecting(manifest);
+    if (!errors.isEmpty()) {
+      throw new PSComponentPackageManifestException(
+          "Invalid component package manifest: " + String.join("; ", errors));
+    }
+  }
+
+  /**
+   * Validate and return all errors (empty list when valid).
+   *
+   * @param manifest non-null model
+   * @return list of human-readable error messages (never null)
+   */
+  public static List<String> validateCollecting(PSComponentPackageManifest manifest) {
+    Objects.requireNonNull(manifest, "manifest");
+    List<String> errors = new ArrayList<>();
+
+    requireText(errors, "schemaVersion", manifest.getSchemaVersion());
+    if (manifest.getSchemaVersion() != null
+        && !manifest.getSchemaVersion().isBlank()
+        && !SCHEMA_VERSION.matcher(manifest.getSchemaVersion().trim()).matches()) {
+      errors.add("schemaVersion must be major.minor (e.g. 1.0)");
+    }
+    if (manifest.getSchemaVersion() != null
+        && !PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION.equals(
+            manifest.getSchemaVersion().trim())) {
+      errors.add(
+          "unsupported schemaVersion '"
+              + manifest.getSchemaVersion()
+              + "' (supported: "
+              + PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION
+              + ")");
+    }
+
+    requireText(errors, "id", manifest.getId());
+    requireText(errors, "name", manifest.getName());
+    requireText(errors, "version", manifest.getVersion());
+
+    if (manifest.getPublisher() != null) {
+      // Publisher name optional but if present must be non-blank when set
+      if (manifest.getPublisher().getName() != null
+          && manifest.getPublisher().getName().isBlank()) {
+        errors.add("publisher.name must not be blank when present");
+      }
+      if (manifest.getPublisher().getUrl() != null && containsBackslash(manifest.getPublisher().getUrl())) {
+        // URL may use http(s); backslash is never valid in URLs we accept
+        errors.add("publisher.url must not contain backslash characters");
+      }
+    }
+
+    if (manifest.getDependencies() != null) {
+      int i = 0;
+      for (PSComponentPackageManifest.Dependency dep : manifest.getDependencies()) {
+        if (dep == null) {
+          errors.add("dependencies[" + i + "] is null");
+        } else {
+          requireText(errors, "dependencies[" + i + "].name", dep.getName());
+        }
+        i++;
+      }
+    }
+
+    if (manifest.getCatalog() != null) {
+      PSComponentPackageManifest.Catalog cat = manifest.getCatalog();
+      if (cat.getThumbnail() != null && !cat.getThumbnail().isBlank()) {
+        requireRelativePath(errors, "catalog.thumbnail", cat.getThumbnail());
+      }
+      if (cat.getIcon() != null && !cat.getIcon().isBlank()) {
+        requireRelativePath(errors, "catalog.icon", cat.getIcon());
+      }
+    }
+
+    int ctIndex = 0;
+    if (manifest.getContentTypes() != null) {
+      for (PSComponentPackageManifest.ContentTypeRef ct : manifest.getContentTypes()) {
+        if (ct == null) {
+          errors.add("contentTypes[" + ctIndex + "] is null");
+        } else {
+          requireText(errors, "contentTypes[" + ctIndex + "].name", ct.getName());
+          if (ct.getRef() != null && !ct.getRef().isBlank()) {
+            requireRelativePath(errors, "contentTypes[" + ctIndex + "].ref", ct.getRef());
+          }
+        }
+        ctIndex++;
+      }
+    }
+
+    int tIndex = 0;
+    if (manifest.getTemplates() != null) {
+      for (PSComponentPackageManifest.TemplateRef t : manifest.getTemplates()) {
+        if (t == null) {
+          errors.add("templates[" + tIndex + "] is null");
+        } else {
+          requireText(errors, "templates[" + tIndex + "].name", t.getName());
+          if (t.getSourceRef() != null && !t.getSourceRef().isBlank()) {
+            requireRelativePath(errors, "templates[" + tIndex + "].sourceRef", t.getSourceRef());
+          }
+          if (t.getBindings() != null) {
+            int b = 0;
+            for (PSComponentPackageManifest.Binding binding : t.getBindings()) {
+              if (binding == null) {
+                errors.add("templates[" + tIndex + "].bindings[" + b + "] is null");
+              } else {
+                requireText(
+                    errors, "templates[" + tIndex + "].bindings[" + b + "].variable", binding.getVariable());
+              }
+              b++;
+            }
+          }
+        }
+        tIndex++;
+      }
+    }
+
+    int sIndex = 0;
+    if (manifest.getSlots() != null) {
+      for (PSComponentPackageManifest.SlotRef slot : manifest.getSlots()) {
+        if (slot == null) {
+          errors.add("slots[" + sIndex + "] is null");
+        } else {
+          requireText(errors, "slots[" + sIndex + "].name", slot.getName());
+        }
+        sIndex++;
+      }
+    }
+
+    int rIndex = 0;
+    if (manifest.getResources() != null) {
+      for (PSComponentPackageManifest.ResourceRef res : manifest.getResources()) {
+        if (res == null) {
+          errors.add("resources[" + rIndex + "] is null");
+        } else {
+          requireText(errors, "resources[" + rIndex + "].path", res.getPath());
+          if (res.getPath() != null && !res.getPath().isBlank()) {
+            requireRelativePath(errors, "resources[" + rIndex + "].path", res.getPath());
+          }
+          if (res.getTarget() != null && !res.getTarget().isBlank()) {
+            requireRelativePath(errors, "resources[" + rIndex + "].target", res.getTarget());
+          }
+        }
+        rIndex++;
+      }
+    }
+
+    if (manifest.getUserPreferences() != null) {
+      int u = 0;
+      for (PSComponentPackageManifest.UserPreference pref : manifest.getUserPreferences()) {
+        if (pref == null) {
+          errors.add("userPreferences[" + u + "] is null");
+        } else {
+          requireText(errors, "userPreferences[" + u + "].name", pref.getName());
+        }
+        u++;
+      }
+    }
+
+    if (manifest.getCssPreferences() != null) {
+      int c = 0;
+      for (PSComponentPackageManifest.CssPreference pref : manifest.getCssPreferences()) {
+        if (pref == null) {
+          errors.add("cssPreferences[" + c + "] is null");
+        } else {
+          requireText(errors, "cssPreferences[" + c + "].name", pref.getName());
+        }
+        c++;
+      }
+    }
+
+    boolean hasCt =
+        manifest.getContentTypes() != null
+            && manifest.getContentTypes().stream().anyMatch(Objects::nonNull);
+    boolean hasTpl =
+        manifest.getTemplates() != null
+            && manifest.getTemplates().stream().anyMatch(Objects::nonNull);
+    if (!hasCt && !hasTpl) {
+      errors.add("manifest must declare at least one contentTypes[] or templates[] entry");
+    }
+
+    return errors;
+  }
+
+  private static void requireText(List<String> errors, String field, String value) {
+    if (value == null || value.isBlank()) {
+      errors.add(field + " is required");
+    }
+  }
+
+  private static void requireRelativePath(List<String> errors, String field, String path) {
+    String p = path.trim();
+    if (!RELATIVE_PACKAGE_PATH.matcher(p).matches()) {
+      errors.add(
+          field
+              + " must be a package-relative path using '/' separators"
+              + " (no absolute OS paths, no '..', no backslashes): '"
+              + path
+              + "'");
+    }
+  }
+
+  private static boolean containsBackslash(String s) {
+    return s.indexOf('\\') >= 0;
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/manifest/PSComponentPackageManifestTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/manifest/PSComponentPackageManifestTest.java
@@ -160,6 +160,64 @@ class PSComponentPackageManifestTest {
     assertTrue(
         backslashErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
         () -> "expected backslash path error, got: " + backslashErrors);
+
+    // Unix absolute path (cross-platform regression)
+    manifest.getResources().get(0).setPath("/etc/passwd");
+    List<String> unixAbsoluteErrors =
+        PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        unixAbsoluteErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
+        () -> "expected Unix absolute path error, got: " + unixAbsoluteErrors);
+
+    // Windows UNC path (cross-platform regression)
+    manifest.getResources().get(0).setPath("\\\\server\\share\\evil.png");
+    List<String> uncErrors = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        uncErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
+        () -> "expected UNC path error, got: " + uncErrors);
+  }
+
+  @Test
+  void validate_allowsDoubleDotFilenamesButRejectsDotDotSegments() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    // Double-dot in a filename is legal (not a path segment)
+    manifest.getResources().get(0).setPath("assets/logo..png");
+    List<String> ok = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        ok.stream().noneMatch(e -> e.contains("resources[0].path")),
+        () -> "expected logo..png allowed, got: " + ok);
+
+    // Segment-shaped .. must still be rejected
+    manifest.getResources().get(0).setPath("assets/../evil.png");
+    List<String> segmentErrors =
+        PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        segmentErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
+        () -> "expected .. segment rejection, got: " + segmentErrors);
+  }
+
+  @Test
+  void validate_rejectsBlankPublisherUrlWhenPresent() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    manifest.getPublisher().setUrl("");
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        errors.stream().anyMatch(e -> e.contains("publisher.url") && e.contains("blank")),
+        () -> "expected blank publisher.url error, got: " + errors);
+  }
+
+  @Test
+  void validate_relativePathErrorUsesTrimmedValue() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    // Leading/trailing whitespace: validation trims; error message must quote the trimmed form
+    manifest.getResources().get(0).setPath("  /etc/passwd  ");
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        errors.stream().anyMatch(e -> e.contains("'/etc/passwd'")),
+        () -> "expected trimmed path in error message, got: " + errors);
+    assertTrue(
+        errors.stream().noneMatch(e -> e.contains("'  /etc/passwd  '")),
+        () -> "untrimmed path should not appear in error, got: " + errors);
   }
 
   @Test

--- a/modules/perc-packages/src/test/java/com/percussion/packages/manifest/PSComponentPackageManifestTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/manifest/PSComponentPackageManifestTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Parse / validate / round-trip coverage for the Component Package Manifest ship format (issue
+ * #2750 / ADR-004 Phase 3 slice 1).
+ */
+class PSComponentPackageManifestTest {
+
+  private static final String MINIMAL_FIXTURE = "/manifests/minimal-component-package.json";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parseMinimalFixture_populatesIdentityCatalogAndArtifacts() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+
+    assertEquals("1.0", manifest.getSchemaVersion());
+    assertEquals("perc.widget.title", manifest.getId());
+    assertEquals("Title", manifest.getName());
+    assertEquals("1.1.4", manifest.getVersion());
+    assertNotNull(manifest.getPublisher());
+    assertEquals("Percussion Software Inc", manifest.getPublisher().getName());
+    assertEquals("https://www.percussion.com", manifest.getPublisher().getUrl());
+    assertNotNull(manifest.getCmsVersion());
+    assertEquals("1.9.0", manifest.getCmsVersion().getMin());
+    assertEquals("9.0.0", manifest.getCmsVersion().getMax());
+
+    assertEquals(1, manifest.getDependencies().size());
+    assertEquals("perc.Baseline", manifest.getDependencies().get(0).getName());
+    assertFalse(manifest.getDependencies().get(0).isImplied());
+
+    assertNotNull(manifest.getCatalog());
+    assertEquals("component", manifest.getCatalog().getKind());
+    assertEquals("content", manifest.getCatalog().getCategory());
+    assertEquals(Integer.valueOf(780), manifest.getCatalog().getPreferredEditorWidth());
+    assertEquals(Boolean.TRUE, manifest.getCatalog().getResponsive());
+
+    assertEquals(1, manifest.getContentTypes().size());
+    assertEquals("percTitleAsset", manifest.getContentTypes().get(0).getName());
+    assertEquals("contentTypes/percTitleAsset", manifest.getContentTypes().get(0).getRef());
+
+    assertEquals(1, manifest.getTemplates().size());
+    PSComponentPackageManifest.TemplateRef tpl = manifest.getTemplates().get(0);
+    assertEquals("percTitleSnippet", tpl.getName());
+    assertEquals("snippet", tpl.getType());
+    assertEquals("velocityAssembler", tpl.getAssembler());
+    assertEquals(1, tpl.getBindings().size());
+    assertEquals("wrapper", tpl.getBindings().get(0).getVariable());
+
+    assertEquals(1, manifest.getSlots().size());
+    assertEquals("titleContent", manifest.getSlots().get(0).getName());
+    assertTrue(manifest.getSlots().get(0).getAllowedContentTypes().contains("percTitleAsset"));
+    assertEquals("vertical", manifest.getSlots().get(0).getLayout().get("orientation"));
+
+    assertEquals(1, manifest.getResources().size());
+    assertEquals("image", manifest.getResources().get(0).getType());
+
+    assertEquals(1, manifest.getUserPreferences().size());
+    assertEquals("wrapper", manifest.getUserPreferences().get(0).getName());
+    assertEquals(2, manifest.getUserPreferences().get(0).getEnumValues().size());
+
+    assertEquals(1, manifest.getCssPreferences().size());
+    assertEquals("rootclass", manifest.getCssPreferences().get(0).getName());
+  }
+
+  @Test
+  void validateMinimalFixture_passes() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(errors.isEmpty(), () -> "unexpected errors: " + errors);
+    PSComponentPackageManifestValidator.validate(manifest);
+  }
+
+  @Test
+  void roundTrip_jsonString_preservesModelEquality() throws Exception {
+    PSComponentPackageManifest original = parseFixture();
+    String json = PSComponentPackageManifestIo.toJson(original);
+    PSComponentPackageManifest roundTripped = PSComponentPackageManifestIo.parse(json);
+    assertEquals(original, roundTripped);
+  }
+
+  @Test
+  void roundTrip_pathWriteRead_preservesModelEquality() throws Exception {
+    PSComponentPackageManifest original = parseFixture();
+    Path out = tempDir.resolve("component-package.json");
+    PSComponentPackageManifestIo.write(original, out);
+    assertTrue(Files.isRegularFile(out));
+    PSComponentPackageManifest roundTripped = PSComponentPackageManifestIo.read(out);
+    assertEquals(original, roundTripped);
+  }
+
+  @Test
+  void validate_rejectsMissingIdentityAndEmptyArtifacts() {
+    PSComponentPackageManifest empty = new PSComponentPackageManifest();
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(empty);
+    assertTrue(errors.stream().anyMatch(e -> e.contains("id is required")));
+    assertTrue(errors.stream().anyMatch(e -> e.contains("name is required")));
+    assertTrue(errors.stream().anyMatch(e -> e.contains("version is required")));
+    assertTrue(
+        errors.stream()
+            .anyMatch(e -> e.contains("at least one contentTypes") || e.contains("templates")));
+    assertThrows(
+        PSComponentPackageManifestException.class,
+        () -> PSComponentPackageManifestValidator.validate(empty));
+  }
+
+  @Test
+  void validate_rejectsUnsupportedSchemaVersion() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    manifest.setSchemaVersion("99.0");
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(errors.stream().anyMatch(e -> e.contains("unsupported schemaVersion")));
+  }
+
+  @Test
+  void validate_rejectsAbsoluteOsPathsInResourceRefs() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    manifest.getResources().get(0).setPath("C:/Windows/system32/evil.png");
+    List<String> driveLetterErrors =
+        PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        driveLetterErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
+        () -> "expected path error, got: " + driveLetterErrors);
+
+    manifest.getResources().get(0).setPath("resources\\windows\\style.css");
+    List<String> backslashErrors =
+        PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        backslashErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
+        () -> "expected backslash path error, got: " + backslashErrors);
+  }
+
+  @Test
+  void parse_rejectsEmptyAndMalformedJson() {
+    assertThrows(
+        PSComponentPackageManifestException.class, () -> PSComponentPackageManifestIo.parse(""));
+    assertThrows(
+        PSComponentPackageManifestException.class,
+        () -> PSComponentPackageManifestIo.parse("{not-json"));
+  }
+
+  @Test
+  void defaultManifestFileName_isComponentPackageJson() {
+    assertEquals("component-package.json", PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    assertEquals("1.0", PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION);
+  }
+
+  private static PSComponentPackageManifest parseFixture()
+      throws PSComponentPackageManifestException, IOException {
+    try (InputStream in = PSComponentPackageManifestTest.class.getResourceAsStream(MINIMAL_FIXTURE)) {
+      assertNotNull(in, "classpath fixture missing: " + MINIMAL_FIXTURE);
+      String json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      // Normalize any accidental Windows line endings from the fixture checkout.
+      json = json.replace("\r\n", "\n");
+      return PSComponentPackageManifestIo.parse(json);
+    }
+  }
+}

--- a/modules/perc-packages/src/test/resources/manifests/minimal-component-package.json
+++ b/modules/perc-packages/src/test/resources/manifests/minimal-component-package.json
@@ -1,0 +1,105 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.widget.title",
+  "name": "Title",
+  "version": "1.1.4",
+  "description": "Widget to enter the Page title",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Title",
+    "category": "content",
+    "description": "Widget to enter the Page title",
+    "thumbnail": "resources/images/widgetTitle.png",
+    "icon": "resources/images/widgetTitle.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 302,
+    "createSharedAsset": false,
+    "editableOnTemplate": false,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTitleAsset",
+      "ref": "contentTypes/percTitleAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTitleSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTitleSnippet.vm",
+      "contentType": "percTitleAsset",
+      "bindings": [
+        {
+          "variable": "wrapper",
+          "expression": "$perc.widget.item.properties.get('wrapper')"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "titleContent",
+      "allowedContentTypes": [
+        "percTitleAsset"
+      ],
+      "layout": {
+        "orientation": "vertical"
+      },
+      "styles": {
+        "rootClass": "perc-title-slot"
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/images/widgetTitle.png",
+      "target": "rx_resources/widgets/title/images/widgetTitle.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "wrapper",
+      "displayName": "Choose format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "h1",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements **Phase 3 slice 1** of parent **#2630** (epic **#2626**, ADR-004): Component Package Manifest ship-format model + schema docs + unit tests.

- Typed model `com.percussion.packages.manifest.PSComponentPackageManifest` (content types, templates + JEXL bindings, slots with layout/styles maps, catalog metadata, resources, transitional user/css prefs)
- JSON IO (Gson) and structural validator (schema `1.0`, required identity, portable package-relative paths)
- Minimal Title-shaped fixture + parse / validate / round-trip tests
- Schema doc + cross-links from ADR-004, plan Phase 3, task README

**Out of scope (siblings):** Widget XML compiler (#2751), runtime legacy shim (#2752). No full widget conversion.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2750
Refs #2630 #2626

## Test plan

- [x] `cd modules/perc-packages && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] Tests run: **13**, Failures: **0** (includes 9 new manifest tests)
- [x] No new compiler/surefire/dependency-analyze warnings on the module (javadoc `doclint` excludes `-missing` for DTO accessors)
- [ ] Review schema doc ship-format vs upgrade-input table
- [ ] Confirm siblings #2751/#2752 remain the only follow-ons

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang self-review | Pass — portable Path/Files I/O; package paths use URL `/`; no absolute OS paths accepted |
| Module clean install | `cd modules/perc-packages` → `..\..\mvnw.cmd clean install` → BUILD SUCCESS |
| Change-class companions | model + IO + validator + fixture tests + schema docs + ADR/plan links |
| Human QA | Not required — pure model/docs/tech debt; no UI/install behavior change |

> Co-Authored by Grok Build using grok-4.5 with agent main.