### PR TITLE
feat(perc-packages): Widget XML compiler for baseWidgets + golden parity (#2751)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -49,6 +49,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Doc | Purpose |
 |-----|---------|
 | [plan.md](./plan.md) | Full strategic plan (canonical) |
+| [component-package-manifest.md](./component-package-manifest.md) | Phase 3 ship-format manifest schema v1.0 + Java model |
 | [widget-xml-inventory.md](./widget-xml-inventory.md) | Product widget matrix (48 defs) |
 | [widget-xml-inventory.csv](./widget-xml-inventory.csv) | Machine-readable inventory |
 | [gadget-definition-inventory.md](./gadget-definition-inventory.md) | Gadget XML / SPA survey |
@@ -71,6 +72,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | CM1 page assembler | `projects/sitemanage/.../assembler/PSPageAssembler.java` |
 | Widget model | `projects/sitemanage/.../data/PSWidgetDefinition.java` |
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
+| Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 
 ## Immediate next work

--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -73,6 +73,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Widget model | `projects/sitemanage/.../data/PSWidgetDefinition.java` |
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
+| Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751) |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 
 ## Immediate next work

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -47,3 +47,15 @@ Ship-format model and docs landed as Phase 3 slice 1 (#2750):
 | Minimal fixture | `modules/perc-packages/src/test/resources/manifests/minimal-component-package.json` |
 
 **Upgrade-input XML** remains compiler/shim only; **product ship format** is `component-package.json` plus content types, templates, slots, catalog metadata, and resources.
+
+## Widget XML compiler (slice #2751)
+
+Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidgets / simple subset first):
+
+| Artifact | Location |
+|----------|----------|
+| Parser / compiler / package scanner | `modules/perc-packages/.../widgetxml/PSWidgetXml*.java` |
+| Golden parity (percSimpleText) | `modules/perc-packages/src/test/resources/widgetxml/golden/` |
+| Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
+
+High-traffic package conversion and product XML removal remain residual under #2630; runtime shim is #2752.

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -35,3 +35,15 @@ Content types + Templates (assembler + JEXL bindings + source)
 - Compiler/upgrade tooling is mandatory before deleting package XML.
 - Widget Builder / Design tools write modern format only.
 - Package install/export paths must understand the new manifest shape (prefer extending existing package system).
+
+## Component Package Manifest (schema v1.0)
+
+Ship-format model and docs landed as Phase 3 slice 1 (#2750):
+
+| Artifact | Location |
+|----------|----------|
+| Schema / field docs | [../component-package-manifest.md](../component-package-manifest.md) |
+| Java model + IO + validation | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
+| Minimal fixture | `modules/perc-packages/src/test/resources/manifests/minimal-component-package.json` |
+
+**Upgrade-input XML** remains compiler/shim only; **product ship format** is `component-package.json` plus content types, templates, slots, catalog metadata, and resources.

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/README.md
@@ -7,8 +7,11 @@
 | [003](./003-slot-layout-styles.md) | Slot layout and slot styles | Accepted (direction) |
 | [004](./004-no-definition-xml-packaging.md) | No Page/Widget/Gadget XML for product packaging | Accepted |
 
-Open follow-ups before Phase 1 coding freezes:
+Related schema (not a separate ADR):
 
-- HTML-first placeholder syntax choice (ADR-002)
+- [Component Package Manifest v1.0](../component-package-manifest.md) — ship format + Java model (Phase 3 / #2750); grounded in ADR-004
+
+Open follow-ups:
+
 - Exact assembly context keys for slot layout/styles (ADR-003)
-- Component package manifest format (new ADR when drafted)
+- Compiler (#2751) and runtime shim (#2752) consumption of the manifest

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -1,0 +1,191 @@
+# Component Package Manifest (schema v1.0)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Accepted for Phase 3 slice 1 (#2750) |
+| **Schema version** | `1.0` |
+| **Ship file name** | `component-package.json` |
+| **Java model** | `com.percussion.packages.manifest.PSComponentPackageManifest` (`modules/perc-packages`) |
+| **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
+| **Plan** | [plan.md § Phase 3](./plan.md) |
+
+## Purpose
+
+Product **source of truth** for a packaged component (former Widget / Page-definition / Gadget XML role):
+
+```text
+Content types + Templates (assembler + JEXL bindings + source)
+  + Slots (incl. layout/styles) + Catalog metadata + Resources
+```
+
+This document describes the **ship format** (what product packages author and install) versus **upgrade-input XML** (legacy Widget / Page meta / Gadget definition files consumed only by compilers and a time-boxed runtime shim).
+
+## Ship format vs upgrade-input XML
+
+| Concern | Ship format (modern) | Upgrade input (legacy) |
+|---------|----------------------|------------------------|
+| Identity / deps | `component-package.json` fields `id`, `version`, `dependencies`, `publisher`, `cmsVersion` | `psx_archiveInfo.xml` / `PSXDescriptor` |
+| Palette metadata | `catalog` object | Widget `WidgetPrefs` (title, category, thumbnail, …) or gadget registry |
+| Content types | `contentTypes[]` + package-relative CT artifacts | `*.contentType` trees inside `.ppkg` |
+| Templates + JEXL | `templates[]` (`assembler`, `sourceRef`, `bindings[]`) | Widget `Code` (jexl) + `Content` (velocity/html) and/or `*.templateDef` |
+| Slots + layout/styles | `slots[]` with `layout` / `styles` maps (ADR-003) | CM1 region tree + widget instance css/user prefs |
+| Static assets | `resources[]` (`path` → install `target`) | `SupportFile-*` / `sys__UserDependency--*` trees |
+| Instance prefs | `userPreferences[]` / `cssPreferences[]` (transitional) | Widget `UserPref` / `CssPref` |
+| Definition XML | **Not present** in product source | `rxconfig/Widgets/*.xml`, page meta XML, gadget definition XML |
+
+**Rules (ADR-004):**
+
+1. Product packages **ship** without Page / Widget / Gadget definition XML as the authoring format.
+2. Upgrade / compiler tools **read** legacy XML and **emit** this manifest + artifacts (sibling slice #2751).
+3. Runtime may keep a **time-boxed shim** when modern package is absent (sibling slice #2752).
+
+## File placement
+
+```text
+<package-source>/
+  component-package.json          ← this manifest (schemaVersion 1.0)
+  contentTypes/<typeName>/…       ← optional; refs from contentTypes[].ref
+  templates/<templateName>.vm     ← optional; refs from templates[].sourceRef
+  resources/…                     ← optional; refs from resources[].path
+  … legacy .ppkg staging files may coexist during migration …
+```
+
+Paths inside the manifest are **package-relative**, always with `/` separators (URL / zip entry style). Absolute OS paths (`C:\…`, `/tmp/…`, UNC) and `..` segments are invalid.
+
+## Root object
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schemaVersion` | string | yes | Must be `"1.0"` for this model |
+| `id` | string | yes | Stable package id (e.g. `perc.widget.title`) |
+| `name` | string | yes | Display name |
+| `version` | string | yes | Package semver / product version string |
+| `description` | string | no | Human summary |
+| `publisher` | object | no | `{ "name", "url" }` |
+| `cmsVersion` | object | no | `{ "min", "max" }` compatible CMS range |
+| `dependencies` | array | no | `{ "name", "version", "implied" }` |
+| `catalog` | object | no | Palette / UI metadata (see below) |
+| `contentTypes` | array | * | At least one of `contentTypes` or `templates` required |
+| `templates` | array | * | At least one of `contentTypes` or `templates` required |
+| `slots` | array | no | Composition holes with optional layout/styles |
+| `resources` | array | no | CSS/JS/images |
+| `userPreferences` | array | no | Transitional from Widget `UserPref` |
+| `cssPreferences` | array | no | Transitional from Widget `CssPref`; prefer slot styles long-term |
+
+## `catalog`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | string | Default `component`; also `page`, `gadget`, … |
+| `title` | string | Palette title |
+| `category` | string | e.g. `content` |
+| `description` | string | |
+| `thumbnail` / `icon` | string | Package-relative resource path |
+| `author` | string | |
+| `preferredEditorWidth` / `preferredEditorHeight` | number | Editor chrome |
+| `createSharedAsset` | boolean | |
+| `editableOnTemplate` | boolean | |
+| `responsive` | boolean | |
+| `paletteVisible` | boolean | Default `true` |
+
+## `contentTypes[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Content type name |
+| `ref` | string | no | Package-relative path to CT artifact tree |
+
+## `templates[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Template name |
+| `type` | string | no | `snippet` (default), `page`, `global`, `binary`, `resource` |
+| `assembler` | string | no | e.g. `velocityAssembler`, `htmlAssembler`, `markdownAssembler` |
+| `sourceRef` | string | no | Package-relative path to source |
+| `contentType` | string | no | Associated content type name |
+| `bindings` | array | no | Ordered JEXL `{ "variable", "expression" }` (ADR-001 — JEXL only) |
+
+## `slots[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Slot name |
+| `allowedContentTypes` | string[] | no | |
+| `layout` | object | no | Free-form map → Phase 2 `slot_layout` |
+| `styles` | object | no | Free-form map → Phase 2 `slot_styles` |
+
+## `resources[]`
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | yes | Package-relative source path |
+| `target` | string | no | Install-relative target (URL-style `/`) |
+| `type` | string | no | `css`, `js`, `image`, … |
+
+## `userPreferences[]` / `cssPreferences[]`
+
+Transitional mirrors of Widget `UserPref` / `CssPref` so the XML compiler can land without inventing a second preference dialect. New design tools should prefer **slot layout/styles** for presentational concerns (ADR-003).
+
+### User preference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | required |
+| `displayName` | string | |
+| `datatype` | string | e.g. `enum`, `string` |
+| `required` | boolean | |
+| `defaultValue` | string | |
+| `enumValues` | array | `{ "value", "displayValue" }` |
+
+### CSS preference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | required |
+| `displayName` | string | |
+| `datatype` | string | |
+| `defaultValue` | string | |
+
+## Minimal example
+
+See test fixture:
+
+`modules/perc-packages/src/test/resources/manifests/minimal-component-package.json`
+
+(Title widget-shaped minimal package: one content type, one snippet template, one slot, one image resource, one user pref, one css pref.)
+
+## Java API
+
+| Type | Role |
+|------|------|
+| `PSComponentPackageManifest` | Typed model + nested types |
+| `PSComponentPackageManifestIo` | JSON parse / write / Path I/O |
+| `PSComponentPackageManifestValidator` | Structural validation |
+| `PSComponentPackageManifestException` | Parse / validation failure |
+
+```java
+PSComponentPackageManifest m = PSComponentPackageManifestIo.read(path);
+PSComponentPackageManifestValidator.validate(m);
+String json = PSComponentPackageManifestIo.toJson(m);
+```
+
+## Relationship to existing package system
+
+- **Today:** `PSPackageBuilder` zips legacy package source trees into `.ppkg` for the deployer (`psx_archiveInfo.xml` / dependency trees). That path remains for install compatibility.
+- **This manifest:** extends the packaging story with an explicit, tool-friendly **component** model that does not require Widget/Page/Gadget XML. Future slices wire compiler output and install recognition; this slice lands model + schema + tests only.
+
+## Out of scope (sibling slices)
+
+| Slice | Issue | Role |
+|-------|-------|------|
+| Widget XML compiler | #2751 | XML → manifest + artifacts |
+| Runtime legacy shim | #2752 | Load customer XML when modern package absent |
+
+## Validation summary
+
+- `schemaVersion` must be `1.0`
+- `id`, `name`, `version` required non-blank
+- At least one `contentTypes[]` or `templates[]` entry
+- Nested names required when entries present
+- Package-relative paths: `/` only, no `..`, no absolute OS forms

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -175,12 +175,26 @@ String json = PSComponentPackageManifestIo.toJson(m);
 - **Today:** `PSPackageBuilder` zips legacy package source trees into `.ppkg` for the deployer (`psx_archiveInfo.xml` / dependency trees). That path remains for install compatibility.
 - **This manifest:** extends the packaging story with an explicit, tool-friendly **component** model that does not require Widget/Page/Gadget XML. Future slices wire compiler output and install recognition; this slice lands model + schema + tests only.
 
-## Out of scope (sibling slices)
+## Widget XML compiler (slice #2751)
+
+Upgrade-input path for simple / **baseWidgets** widgets:
+
+| Type | Role |
+|------|------|
+| `PSWidgetXmlParser` | Secure DOM parse of `<Widget>` definition XML |
+| `PSWidgetXmlCompiler` | XML model → `PSComponentPackageManifest` + template text artifacts |
+| `PSWidgetXmlPackageCompiler` | Scan `sys__UserDependency--rxconfig/Widgets/*.xml` under a package root |
+| Golden fixtures | `modules/perc-packages/src/test/resources/widgetxml/golden/` (percSimpleText) |
+
+Inventory + residual packages: [widget-xml-inventory.md](./widget-xml-inventory.md).
+
+## Out of scope (sibling / residual)
 
 | Slice | Issue | Role |
 |-------|-------|------|
-| Widget XML compiler | #2751 | XML → manifest + artifacts |
 | Runtime legacy shim | #2752 | Load customer XML when modern package absent |
+| High-traffic package conversion | residual under #2630 | nav, blog, lists, forms, … (see inventory) |
+| Delete product Widget XML from source | later | After install path consumes modern artifacts |
 
 ## Validation summary
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -357,12 +357,13 @@ This is multi-quarter work even if labeled “8.2.” Split so 8.2 can ship **fo
 
 **Goals:** **ship product out of XML definition files.**
 
-1. Define **Component Package Manifest** (reuse package system where possible) listing content types, templates, slots, catalog metadata, resources.
-2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles).
+1. Define **Component Package Manifest** (reuse package system where possible) listing content types, templates, slots, catalog metadata, resources.  
+   **Done (slice 1 / #2750):** schema docs + Java model + parse/validate/round-trip tests — see [component-package-manifest.md](./component-package-manifest.md) and `com.percussion.packages.manifest` in `modules/perc-packages`.
+2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles). *(#2751)*
 3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.
 4. **Gadget XML** conversion path for remaining XML-defined gadgets.
 5. Convert **baseline / baseWidgets** first; then high-traffic packages (nav, blog, lists, rich text).
-6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format.
+6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format. *(#2752)*
 7. Widget Builder / Design tools write modern package format only.
 
 **Exit criterion for “ship”:** product packages in repo/install are **not** defined by Page/Widget/Gadget XML files; upgrade converts customer XML; shim optional and time-boxed.

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -4,6 +4,18 @@
 **Source:** `modules/perc-packages/src/main/resources/Packages/**/rxconfig/Widgets/*.xml`  
 **Machine-readable:** [widget-xml-inventory.csv](./widget-xml-inventory.csv)
 
+## Compiler status (#2751 / parent #2630)
+
+| Area | Status | Notes |
+|------|--------|-------|
+| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets / simple subset** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
+| Golden parity | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
+| **Product packages still ship Widget XML** | Yes (this slice) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
+| Residual high-traffic packages | Open | nav, blog, lists, rich media lists, forms, calendar, directory, social, etc. — use this inventory as the residual backlog (sibling/follow-on issues under #2630) |
+| Runtime legacy XML shim | Open | #2752 |
+
+Ship format: [component-package-manifest.md](./component-package-manifest.md). ADR: [004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md).
+
 ## Summary
 
 | Metric | Value |

--- a/modules/perc-packages/pom.xml
+++ b/modules/perc-packages/pom.xml
@@ -15,6 +15,11 @@
         <skipTests>false</skipTests>
     </properties>
     <dependencies>
+        <!-- Manifest JSON codec for Component Package Manifest (Phase 3 / ADR-004). -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -84,6 +89,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
+            </plugin>
+            <!-- Manifest DTOs are Gson beans; skip -missing doclint noise on accessors. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <doclint>all,-missing</doclint>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
@@ -1,0 +1,978 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Typed model for a <strong>Component Package Manifest</strong> — the modern product packaging
+ * shape for content types, templates, slots, catalog metadata, and resources (ADR-004 / plan Phase
+ * 3).
+ *
+ * <p>Ship format is JSON (default file name {@value #DEFAULT_MANIFEST_FILE_NAME}) living beside
+ * package artifacts. This model does <em>not</em> replace the legacy {@code .ppkg} / {@code
+ * PSXArchiveInfo} deployer format yet; it is the authoring and future install source of truth so
+ * product packages no longer need Page / Widget / Gadget definition XML.
+ *
+ * <p>Upgrade-input Widget XML is out of band: compilers (sibling slice) read XML and emit this
+ * manifest plus CT/template/slot/resource artifacts.
+ *
+ * @see PSComponentPackageManifestIo
+ * @see PSComponentPackageManifestValidator
+ */
+public final class PSComponentPackageManifest {
+
+  /** Default ship-format file name inside a component package source tree. */
+  public static final String DEFAULT_MANIFEST_FILE_NAME = "component-package.json";
+
+  /** Schema version supported by this model (semver major.minor). */
+  public static final String SUPPORTED_SCHEMA_VERSION = "1.0";
+
+  private String schemaVersion = SUPPORTED_SCHEMA_VERSION;
+  private String id;
+  private String name;
+  private String version;
+  private String description;
+  private Publisher publisher;
+  private CmsVersionRange cmsVersion;
+  private List<Dependency> dependencies = new ArrayList<>();
+  private Catalog catalog;
+  private List<ContentTypeRef> contentTypes = new ArrayList<>();
+  private List<TemplateRef> templates = new ArrayList<>();
+  private List<SlotRef> slots = new ArrayList<>();
+  private List<ResourceRef> resources = new ArrayList<>();
+  private List<UserPreference> userPreferences = new ArrayList<>();
+  private List<CssPreference> cssPreferences = new ArrayList<>();
+
+  public String getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  public void setSchemaVersion(String schemaVersion) {
+    this.schemaVersion = schemaVersion;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Publisher getPublisher() {
+    return publisher;
+  }
+
+  public void setPublisher(Publisher publisher) {
+    this.publisher = publisher;
+  }
+
+  public CmsVersionRange getCmsVersion() {
+    return cmsVersion;
+  }
+
+  public void setCmsVersion(CmsVersionRange cmsVersion) {
+    this.cmsVersion = cmsVersion;
+  }
+
+  public List<Dependency> getDependencies() {
+    return dependencies;
+  }
+
+  public void setDependencies(List<Dependency> dependencies) {
+    this.dependencies = dependencies != null ? dependencies : new ArrayList<>();
+  }
+
+  public Catalog getCatalog() {
+    return catalog;
+  }
+
+  public void setCatalog(Catalog catalog) {
+    this.catalog = catalog;
+  }
+
+  public List<ContentTypeRef> getContentTypes() {
+    return contentTypes;
+  }
+
+  public void setContentTypes(List<ContentTypeRef> contentTypes) {
+    this.contentTypes = contentTypes != null ? contentTypes : new ArrayList<>();
+  }
+
+  public List<TemplateRef> getTemplates() {
+    return templates;
+  }
+
+  public void setTemplates(List<TemplateRef> templates) {
+    this.templates = templates != null ? templates : new ArrayList<>();
+  }
+
+  public List<SlotRef> getSlots() {
+    return slots;
+  }
+
+  public void setSlots(List<SlotRef> slots) {
+    this.slots = slots != null ? slots : new ArrayList<>();
+  }
+
+  public List<ResourceRef> getResources() {
+    return resources;
+  }
+
+  public void setResources(List<ResourceRef> resources) {
+    this.resources = resources != null ? resources : new ArrayList<>();
+  }
+
+  public List<UserPreference> getUserPreferences() {
+    return userPreferences;
+  }
+
+  public void setUserPreferences(List<UserPreference> userPreferences) {
+    this.userPreferences = userPreferences != null ? userPreferences : new ArrayList<>();
+  }
+
+  public List<CssPreference> getCssPreferences() {
+    return cssPreferences;
+  }
+
+  public void setCssPreferences(List<CssPreference> cssPreferences) {
+    this.cssPreferences = cssPreferences != null ? cssPreferences : new ArrayList<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSComponentPackageManifest that)) {
+      return false;
+    }
+    return Objects.equals(schemaVersion, that.schemaVersion)
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(version, that.version)
+        && Objects.equals(description, that.description)
+        && Objects.equals(publisher, that.publisher)
+        && Objects.equals(cmsVersion, that.cmsVersion)
+        && Objects.equals(dependencies, that.dependencies)
+        && Objects.equals(catalog, that.catalog)
+        && Objects.equals(contentTypes, that.contentTypes)
+        && Objects.equals(templates, that.templates)
+        && Objects.equals(slots, that.slots)
+        && Objects.equals(resources, that.resources)
+        && Objects.equals(userPreferences, that.userPreferences)
+        && Objects.equals(cssPreferences, that.cssPreferences);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        schemaVersion,
+        id,
+        name,
+        version,
+        description,
+        publisher,
+        cmsVersion,
+        dependencies,
+        catalog,
+        contentTypes,
+        templates,
+        slots,
+        resources,
+        userPreferences,
+        cssPreferences);
+  }
+
+  /** Publisher identity (maps from legacy {@code PSXDescriptor/Publisher}). */
+  public static final class Publisher {
+    private String name;
+    private String url;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Publisher that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name) && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, url);
+    }
+  }
+
+  /** Compatible CMS product version range (maps from {@code CmsVersion min/max}). */
+  public static final class CmsVersionRange {
+    private String min;
+    private String max;
+
+    public String getMin() {
+      return min;
+    }
+
+    public void setMin(String min) {
+      this.min = min;
+    }
+
+    public String getMax() {
+      return max;
+    }
+
+    public void setMax(String max) {
+      this.max = max;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CmsVersionRange that)) {
+        return false;
+      }
+      return Objects.equals(min, that.min) && Objects.equals(max, that.max);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(min, max);
+    }
+  }
+
+  /** Package dependency (maps from {@code PKGDependency}). */
+  public static final class Dependency {
+    private String name;
+    private String version;
+    private boolean implied;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+
+    public boolean isImplied() {
+      return implied;
+    }
+
+    public void setImplied(boolean implied) {
+      this.implied = implied;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Dependency that)) {
+        return false;
+      }
+      return implied == that.implied
+          && Objects.equals(name, that.name)
+          && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, version, implied);
+    }
+  }
+
+  /**
+   * Palette / catalog metadata formerly carried by Widget {@code WidgetPrefs} (and gadget
+   * registry entries).
+   */
+  public static final class Catalog {
+    /** Logical kind: {@code component}, {@code page}, {@code gadget}, etc. */
+    private String kind = "component";
+
+    private String title;
+    private String category;
+    private String description;
+    private String thumbnail;
+    private String icon;
+    private String author;
+    private Integer preferredEditorWidth;
+    private Integer preferredEditorHeight;
+    private Boolean createSharedAsset;
+    private Boolean editableOnTemplate;
+    private Boolean responsive;
+    private Boolean paletteVisible = Boolean.TRUE;
+
+    public String getKind() {
+      return kind;
+    }
+
+    public void setKind(String kind) {
+      this.kind = kind;
+    }
+
+    public String getTitle() {
+      return title;
+    }
+
+    public void setTitle(String title) {
+      this.title = title;
+    }
+
+    public String getCategory() {
+      return category;
+    }
+
+    public void setCategory(String category) {
+      this.category = category;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public String getThumbnail() {
+      return thumbnail;
+    }
+
+    public void setThumbnail(String thumbnail) {
+      this.thumbnail = thumbnail;
+    }
+
+    public String getIcon() {
+      return icon;
+    }
+
+    public void setIcon(String icon) {
+      this.icon = icon;
+    }
+
+    public String getAuthor() {
+      return author;
+    }
+
+    public void setAuthor(String author) {
+      this.author = author;
+    }
+
+    public Integer getPreferredEditorWidth() {
+      return preferredEditorWidth;
+    }
+
+    public void setPreferredEditorWidth(Integer preferredEditorWidth) {
+      this.preferredEditorWidth = preferredEditorWidth;
+    }
+
+    public Integer getPreferredEditorHeight() {
+      return preferredEditorHeight;
+    }
+
+    public void setPreferredEditorHeight(Integer preferredEditorHeight) {
+      this.preferredEditorHeight = preferredEditorHeight;
+    }
+
+    public Boolean getCreateSharedAsset() {
+      return createSharedAsset;
+    }
+
+    public void setCreateSharedAsset(Boolean createSharedAsset) {
+      this.createSharedAsset = createSharedAsset;
+    }
+
+    public Boolean getEditableOnTemplate() {
+      return editableOnTemplate;
+    }
+
+    public void setEditableOnTemplate(Boolean editableOnTemplate) {
+      this.editableOnTemplate = editableOnTemplate;
+    }
+
+    public Boolean getResponsive() {
+      return responsive;
+    }
+
+    public void setResponsive(Boolean responsive) {
+      this.responsive = responsive;
+    }
+
+    public Boolean getPaletteVisible() {
+      return paletteVisible;
+    }
+
+    public void setPaletteVisible(Boolean paletteVisible) {
+      this.paletteVisible = paletteVisible;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Catalog that)) {
+        return false;
+      }
+      return Objects.equals(kind, that.kind)
+          && Objects.equals(title, that.title)
+          && Objects.equals(category, that.category)
+          && Objects.equals(description, that.description)
+          && Objects.equals(thumbnail, that.thumbnail)
+          && Objects.equals(icon, that.icon)
+          && Objects.equals(author, that.author)
+          && Objects.equals(preferredEditorWidth, that.preferredEditorWidth)
+          && Objects.equals(preferredEditorHeight, that.preferredEditorHeight)
+          && Objects.equals(createSharedAsset, that.createSharedAsset)
+          && Objects.equals(editableOnTemplate, that.editableOnTemplate)
+          && Objects.equals(responsive, that.responsive)
+          && Objects.equals(paletteVisible, that.paletteVisible);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          kind,
+          title,
+          category,
+          description,
+          thumbnail,
+          icon,
+          author,
+          preferredEditorWidth,
+          preferredEditorHeight,
+          createSharedAsset,
+          editableOnTemplate,
+          responsive,
+          paletteVisible);
+    }
+  }
+
+  /** Reference to a content type definition packaged with (or required by) this component. */
+  public static final class ContentTypeRef {
+    private String name;
+    /** Package-relative path (URL-style {@code /} separators) to the CT artifact tree. */
+    private String ref;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getRef() {
+      return ref;
+    }
+
+    public void setRef(String ref) {
+      this.ref = ref;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ContentTypeRef that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name) && Objects.equals(ref, that.ref);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, ref);
+    }
+  }
+
+  /** Assembly template packaged with this component (snippet / page / binary / resource). */
+  public static final class TemplateRef {
+    private String name;
+    /** Template kind: {@code snippet}, {@code page}, {@code global}, {@code binary}, {@code resource}. */
+    private String type = "snippet";
+    /** Assembler extension name, e.g. {@code velocityAssembler}, {@code htmlAssembler}. */
+    private String assembler;
+    /** Package-relative path to template source (URL-style separators). */
+    private String sourceRef;
+    private String contentType;
+    private List<Binding> bindings = new ArrayList<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getAssembler() {
+      return assembler;
+    }
+
+    public void setAssembler(String assembler) {
+      this.assembler = assembler;
+    }
+
+    public String getSourceRef() {
+      return sourceRef;
+    }
+
+    public void setSourceRef(String sourceRef) {
+      this.sourceRef = sourceRef;
+    }
+
+    public String getContentType() {
+      return contentType;
+    }
+
+    public void setContentType(String contentType) {
+      this.contentType = contentType;
+    }
+
+    public List<Binding> getBindings() {
+      return bindings;
+    }
+
+    public void setBindings(List<Binding> bindings) {
+      this.bindings = bindings != null ? bindings : new ArrayList<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof TemplateRef that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name)
+          && Objects.equals(type, that.type)
+          && Objects.equals(assembler, that.assembler)
+          && Objects.equals(sourceRef, that.sourceRef)
+          && Objects.equals(contentType, that.contentType)
+          && Objects.equals(bindings, that.bindings);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, type, assembler, sourceRef, contentType, bindings);
+    }
+  }
+
+  /** Ordered JEXL binding (variable + expression). Language is always JEXL (ADR-001). */
+  public static final class Binding {
+    private String variable;
+    private String expression;
+
+    public String getVariable() {
+      return variable;
+    }
+
+    public void setVariable(String variable) {
+      this.variable = variable;
+    }
+
+    public String getExpression() {
+      return expression;
+    }
+
+    public void setExpression(String expression) {
+      this.expression = expression;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Binding that)) {
+        return false;
+      }
+      return Objects.equals(variable, that.variable) && Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(variable, expression);
+    }
+  }
+
+  /**
+   * Slot definition reference. Layout/styles map to Phase 2 {@code slot_layout} / {@code
+   * slot_styles} (ADR-003).
+   */
+  public static final class SlotRef {
+    private String name;
+    private List<String> allowedContentTypes = new ArrayList<>();
+    private Map<String, Object> layout = new LinkedHashMap<>();
+    private Map<String, Object> styles = new LinkedHashMap<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public List<String> getAllowedContentTypes() {
+      return allowedContentTypes;
+    }
+
+    public void setAllowedContentTypes(List<String> allowedContentTypes) {
+      this.allowedContentTypes =
+          allowedContentTypes != null ? allowedContentTypes : new ArrayList<>();
+    }
+
+    public Map<String, Object> getLayout() {
+      return layout;
+    }
+
+    public void setLayout(Map<String, Object> layout) {
+      this.layout = layout != null ? layout : new LinkedHashMap<>();
+    }
+
+    public Map<String, Object> getStyles() {
+      return styles;
+    }
+
+    public void setStyles(Map<String, Object> styles) {
+      this.styles = styles != null ? styles : new LinkedHashMap<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SlotRef that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name)
+          && Objects.equals(allowedContentTypes, that.allowedContentTypes)
+          && Objects.equals(layout, that.layout)
+          && Objects.equals(styles, that.styles);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, allowedContentTypes, layout, styles);
+    }
+  }
+
+  /**
+   * Static resource (CSS/JS/image) packaged with the component. Paths use URL-style {@code /}
+   * separators (not OS filesystem separators).
+   */
+  public static final class ResourceRef {
+    private String path;
+    private String target;
+    private String type;
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(String path) {
+      this.path = path;
+    }
+
+    public String getTarget() {
+      return target;
+    }
+
+    public void setTarget(String target) {
+      this.target = target;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ResourceRef that)) {
+        return false;
+      }
+      return Objects.equals(path, that.path)
+          && Objects.equals(target, that.target)
+          && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, target, type);
+    }
+  }
+
+  /**
+   * Instance preference formerly expressed as Widget {@code UserPref}. Survives in the manifest so
+   * the Widget XML compiler can land without a parallel format.
+   */
+  public static final class UserPreference {
+    private String name;
+    private String displayName;
+    private String datatype;
+    private boolean required;
+    private String defaultValue;
+    private List<EnumValue> enumValues = new ArrayList<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDatatype() {
+      return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+      this.datatype = datatype;
+    }
+
+    public boolean isRequired() {
+      return required;
+    }
+
+    public void setRequired(boolean required) {
+      this.required = required;
+    }
+
+    public String getDefaultValue() {
+      return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    public List<EnumValue> getEnumValues() {
+      return enumValues;
+    }
+
+    public void setEnumValues(List<EnumValue> enumValues) {
+      this.enumValues = enumValues != null ? enumValues : new ArrayList<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof UserPreference that)) {
+        return false;
+      }
+      return required == that.required
+          && Objects.equals(name, that.name)
+          && Objects.equals(displayName, that.displayName)
+          && Objects.equals(datatype, that.datatype)
+          && Objects.equals(defaultValue, that.defaultValue)
+          && Objects.equals(enumValues, that.enumValues);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, displayName, datatype, required, defaultValue, enumValues);
+    }
+  }
+
+  /** Enumerated value for a user preference. */
+  public static final class EnumValue {
+    private String value;
+    private String displayValue;
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public String getDisplayValue() {
+      return displayValue;
+    }
+
+    public void setDisplayValue(String displayValue) {
+      this.displayValue = displayValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof EnumValue that)) {
+        return false;
+      }
+      return Objects.equals(value, that.value) && Objects.equals(displayValue, that.displayValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, displayValue);
+    }
+  }
+
+  /**
+   * Presentational preference formerly Widget {@code CssPref}. Prefer promoting layout/styles to
+   * slots (ADR-003) over growing this list indefinitely.
+   */
+  public static final class CssPreference {
+    private String name;
+    private String displayName;
+    private String datatype;
+    private String defaultValue;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDatatype() {
+      return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+      this.datatype = datatype;
+    }
+
+    public String getDefaultValue() {
+      return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CssPreference that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name)
+          && Objects.equals(displayName, that.displayName)
+          && Objects.equals(datatype, that.datatype)
+          && Objects.equals(defaultValue, that.defaultValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, displayName, datatype, defaultValue);
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+/**
+ * Thrown when a Component Package Manifest cannot be parsed or fails validation.
+ *
+ * @see PSComponentPackageManifest
+ * @see PSComponentPackageManifestValidator
+ */
+public class PSComponentPackageManifestException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSComponentPackageManifestException(String message) {
+    super(message);
+  }
+
+  public PSComponentPackageManifestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestIo.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestIo.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Parse and write {@link PSComponentPackageManifest} as JSON (ship format).
+ *
+ * <p>Uses portable {@link Path} / {@link Files} I/O and UTF-8. Does not validate structural rules —
+ * call {@link PSComponentPackageManifestValidator} after parse when required.
+ */
+public final class PSComponentPackageManifestIo {
+
+  private static final Gson GSON =
+      new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+  private PSComponentPackageManifestIo() {
+    // utility
+  }
+
+  /**
+   * Parse a JSON string into a manifest. Does not validate.
+   *
+   * @param json non-null JSON document
+   * @return parsed model (never null)
+   * @throws PSComponentPackageManifestException if JSON is empty or not a valid document
+   */
+  public static PSComponentPackageManifest parse(String json)
+      throws PSComponentPackageManifestException {
+    Objects.requireNonNull(json, "json");
+    if (json.isBlank()) {
+      throw new PSComponentPackageManifestException("Manifest JSON is empty");
+    }
+    try {
+      PSComponentPackageManifest manifest = GSON.fromJson(json, PSComponentPackageManifest.class);
+      if (manifest == null) {
+        throw new PSComponentPackageManifestException("Manifest JSON parsed to null");
+      }
+      // Gson leaves collection fields null when omitted; normalize for callers.
+      normalizeCollections(manifest);
+      return manifest;
+    } catch (JsonSyntaxException e) {
+      throw new PSComponentPackageManifestException("Invalid manifest JSON: " + e.getMessage(), e);
+    } catch (JsonParseException e) {
+      throw new PSComponentPackageManifestException("Failed to parse manifest JSON", e);
+    }
+  }
+
+  /**
+   * Parse UTF-8 JSON from a reader.
+   *
+   * @param reader non-null reader
+   * @return parsed model
+   * @throws PSComponentPackageManifestException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSComponentPackageManifest parse(Reader reader)
+      throws PSComponentPackageManifestException, IOException {
+    Objects.requireNonNull(reader, "reader");
+    StringBuilder sb = new StringBuilder();
+    char[] buf = new char[4096];
+    int n;
+    while ((n = reader.read(buf)) >= 0) {
+      sb.append(buf, 0, n);
+    }
+    return parse(sb.toString());
+  }
+
+  /**
+   * Read and parse a UTF-8 JSON file.
+   *
+   * @param path non-null path to the manifest file
+   * @return parsed model
+   * @throws PSComponentPackageManifestException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSComponentPackageManifest read(Path path)
+      throws PSComponentPackageManifestException, IOException {
+    Objects.requireNonNull(path, "path");
+    String json = Files.readString(path, StandardCharsets.UTF_8);
+    return parse(json);
+  }
+
+  /**
+   * Serialize a manifest to pretty-printed JSON.
+   *
+   * @param manifest non-null model
+   * @return JSON text (never null)
+   */
+  public static String toJson(PSComponentPackageManifest manifest) {
+    Objects.requireNonNull(manifest, "manifest");
+    normalizeCollections(manifest);
+    return GSON.toJson(manifest);
+  }
+
+  /**
+   * Write a manifest as UTF-8 JSON to a path (creates parent directories if needed).
+   *
+   * @param manifest non-null model
+   * @param path non-null destination path
+   * @throws IOException on I/O failure
+   */
+  public static void write(PSComponentPackageManifest manifest, Path path) throws IOException {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(path, "path");
+    Path parent = path.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.writeString(path, toJson(manifest), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Write a manifest as UTF-8 JSON to a writer.
+   *
+   * @param manifest non-null model
+   * @param writer non-null writer
+   * @throws IOException on I/O failure
+   */
+  public static void write(PSComponentPackageManifest manifest, Writer writer) throws IOException {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(writer, "writer");
+    writer.write(toJson(manifest));
+  }
+
+  private static void normalizeCollections(PSComponentPackageManifest manifest) {
+    if (manifest.getDependencies() == null) {
+      manifest.setDependencies(new java.util.ArrayList<>());
+    }
+    if (manifest.getContentTypes() == null) {
+      manifest.setContentTypes(new java.util.ArrayList<>());
+    }
+    if (manifest.getTemplates() == null) {
+      manifest.setTemplates(new java.util.ArrayList<>());
+    }
+    if (manifest.getSlots() == null) {
+      manifest.setSlots(new java.util.ArrayList<>());
+    }
+    if (manifest.getResources() == null) {
+      manifest.setResources(new java.util.ArrayList<>());
+    }
+    if (manifest.getUserPreferences() == null) {
+      manifest.setUserPreferences(new java.util.ArrayList<>());
+    }
+    if (manifest.getCssPreferences() == null) {
+      manifest.setCssPreferences(new java.util.ArrayList<>());
+    }
+    if (manifest.getTemplates() != null) {
+      for (PSComponentPackageManifest.TemplateRef t : manifest.getTemplates()) {
+        if (t != null && t.getBindings() == null) {
+          t.setBindings(new java.util.ArrayList<>());
+        }
+      }
+    }
+    if (manifest.getSlots() != null) {
+      for (PSComponentPackageManifest.SlotRef s : manifest.getSlots()) {
+        if (s == null) {
+          continue;
+        }
+        if (s.getAllowedContentTypes() == null) {
+          s.setAllowedContentTypes(new java.util.ArrayList<>());
+        }
+        if (s.getLayout() == null) {
+          s.setLayout(new java.util.LinkedHashMap<>());
+        }
+        if (s.getStyles() == null) {
+          s.setStyles(new java.util.LinkedHashMap<>());
+        }
+      }
+    }
+    if (manifest.getUserPreferences() != null) {
+      for (PSComponentPackageManifest.UserPreference p : manifest.getUserPreferences()) {
+        if (p != null && p.getEnumValues() == null) {
+          p.setEnumValues(new java.util.ArrayList<>());
+        }
+      }
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Structural validation for {@link PSComponentPackageManifest}.
+ *
+ * <p>Enforces schema version, required identity fields, non-blank nested names, portable
+ * package-relative path refs (URL-style {@code /} separators; no absolute OS paths), and the
+ * presence of at least one content type or template (a component must ship something installable).
+ */
+public final class PSComponentPackageManifestValidator {
+
+  private static final Pattern SCHEMA_VERSION = Pattern.compile("^\\d+\\.\\d+$");
+
+  /**
+   * Package-relative path: non-empty, no drive letter / UNC / leading root, no backslashes, no
+   * {@code ..} segments. URL / zip entry style only.
+   */
+  private static final Pattern RELATIVE_PACKAGE_PATH =
+      Pattern.compile("^(?!/)(?!\\\\)(?![A-Za-z]:)(?!\\\\\\\\)(?!.*\\.\\.)[A-Za-z0-9_./\\-]+$");
+
+  private PSComponentPackageManifestValidator() {
+    // utility
+  }
+
+  /**
+   * Validate a manifest; throw on the first failure.
+   *
+   * @param manifest non-null model
+   * @throws PSComponentPackageManifestException when invalid
+   */
+  public static void validate(PSComponentPackageManifest manifest)
+      throws PSComponentPackageManifestException {
+    List<String> errors = validateCollecting(manifest);
+    if (!errors.isEmpty()) {
+      throw new PSComponentPackageManifestException(
+          "Invalid component package manifest: " + String.join("; ", errors));
+    }
+  }
+
+  /**
+   * Validate and return all errors (empty list when valid).
+   *
+   * @param manifest non-null model
+   * @return list of human-readable error messages (never null)
+   */
+  public static List<String> validateCollecting(PSComponentPackageManifest manifest) {
+    Objects.requireNonNull(manifest, "manifest");
+    List<String> errors = new ArrayList<>();
+
+    requireText(errors, "schemaVersion", manifest.getSchemaVersion());
+    if (manifest.getSchemaVersion() != null
+        && !manifest.getSchemaVersion().isBlank()
+        && !SCHEMA_VERSION.matcher(manifest.getSchemaVersion().trim()).matches()) {
+      errors.add("schemaVersion must be major.minor (e.g. 1.0)");
+    }
+    if (manifest.getSchemaVersion() != null
+        && !PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION.equals(
+            manifest.getSchemaVersion().trim())) {
+      errors.add(
+          "unsupported schemaVersion '"
+              + manifest.getSchemaVersion()
+              + "' (supported: "
+              + PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION
+              + ")");
+    }
+
+    requireText(errors, "id", manifest.getId());
+    requireText(errors, "name", manifest.getName());
+    requireText(errors, "version", manifest.getVersion());
+
+    if (manifest.getPublisher() != null) {
+      // Publisher name optional but if present must be non-blank when set
+      if (manifest.getPublisher().getName() != null
+          && manifest.getPublisher().getName().isBlank()) {
+        errors.add("publisher.name must not be blank when present");
+      }
+      if (manifest.getPublisher().getUrl() != null && containsBackslash(manifest.getPublisher().getUrl())) {
+        // URL may use http(s); backslash is never valid in URLs we accept
+        errors.add("publisher.url must not contain backslash characters");
+      }
+    }
+
+    if (manifest.getDependencies() != null) {
+      int i = 0;
+      for (PSComponentPackageManifest.Dependency dep : manifest.getDependencies()) {
+        if (dep == null) {
+          errors.add("dependencies[" + i + "] is null");
+        } else {
+          requireText(errors, "dependencies[" + i + "].name", dep.getName());
+        }
+        i++;
+      }
+    }
+
+    if (manifest.getCatalog() != null) {
+      PSComponentPackageManifest.Catalog cat = manifest.getCatalog();
+      if (cat.getThumbnail() != null && !cat.getThumbnail().isBlank()) {
+        requireRelativePath(errors, "catalog.thumbnail", cat.getThumbnail());
+      }
+      if (cat.getIcon() != null && !cat.getIcon().isBlank()) {
+        requireRelativePath(errors, "catalog.icon", cat.getIcon());
+      }
+    }
+
+    int ctIndex = 0;
+    if (manifest.getContentTypes() != null) {
+      for (PSComponentPackageManifest.ContentTypeRef ct : manifest.getContentTypes()) {
+        if (ct == null) {
+          errors.add("contentTypes[" + ctIndex + "] is null");
+        } else {
+          requireText(errors, "contentTypes[" + ctIndex + "].name", ct.getName());
+          if (ct.getRef() != null && !ct.getRef().isBlank()) {
+            requireRelativePath(errors, "contentTypes[" + ctIndex + "].ref", ct.getRef());
+          }
+        }
+        ctIndex++;
+      }
+    }
+
+    int tIndex = 0;
+    if (manifest.getTemplates() != null) {
+      for (PSComponentPackageManifest.TemplateRef t : manifest.getTemplates()) {
+        if (t == null) {
+          errors.add("templates[" + tIndex + "] is null");
+        } else {
+          requireText(errors, "templates[" + tIndex + "].name", t.getName());
+          if (t.getSourceRef() != null && !t.getSourceRef().isBlank()) {
+            requireRelativePath(errors, "templates[" + tIndex + "].sourceRef", t.getSourceRef());
+          }
+          if (t.getBindings() != null) {
+            int b = 0;
+            for (PSComponentPackageManifest.Binding binding : t.getBindings()) {
+              if (binding == null) {
+                errors.add("templates[" + tIndex + "].bindings[" + b + "] is null");
+              } else {
+                requireText(
+                    errors, "templates[" + tIndex + "].bindings[" + b + "].variable", binding.getVariable());
+              }
+              b++;
+            }
+          }
+        }
+        tIndex++;
+      }
+    }
+
+    int sIndex = 0;
+    if (manifest.getSlots() != null) {
+      for (PSComponentPackageManifest.SlotRef slot : manifest.getSlots()) {
+        if (slot == null) {
+          errors.add("slots[" + sIndex + "] is null");
+        } else {
+          requireText(errors, "slots[" + sIndex + "].name", slot.getName());
+        }
+        sIndex++;
+      }
+    }
+
+    int rIndex = 0;
+    if (manifest.getResources() != null) {
+      for (PSComponentPackageManifest.ResourceRef res : manifest.getResources()) {
+        if (res == null) {
+          errors.add("resources[" + rIndex + "] is null");
+        } else {
+          requireText(errors, "resources[" + rIndex + "].path", res.getPath());
+          if (res.getPath() != null && !res.getPath().isBlank()) {
+            requireRelativePath(errors, "resources[" + rIndex + "].path", res.getPath());
+          }
+          if (res.getTarget() != null && !res.getTarget().isBlank()) {
+            requireRelativePath(errors, "resources[" + rIndex + "].target", res.getTarget());
+          }
+        }
+        rIndex++;
+      }
+    }
+
+    if (manifest.getUserPreferences() != null) {
+      int u = 0;
+      for (PSComponentPackageManifest.UserPreference pref : manifest.getUserPreferences()) {
+        if (pref == null) {
+          errors.add("userPreferences[" + u + "] is null");
+        } else {
+          requireText(errors, "userPreferences[" + u + "].name", pref.getName());
+        }
+        u++;
+      }
+    }
+
+    if (manifest.getCssPreferences() != null) {
+      int c = 0;
+      for (PSComponentPackageManifest.CssPreference pref : manifest.getCssPreferences()) {
+        if (pref == null) {
+          errors.add("cssPreferences[" + c + "] is null");
+        } else {
+          requireText(errors, "cssPreferences[" + c + "].name", pref.getName());
+        }
+        c++;
+      }
+    }
+
+    boolean hasCt =
+        manifest.getContentTypes() != null
+            && manifest.getContentTypes().stream().anyMatch(Objects::nonNull);
+    boolean hasTpl =
+        manifest.getTemplates() != null
+            && manifest.getTemplates().stream().anyMatch(Objects::nonNull);
+    if (!hasCt && !hasTpl) {
+      errors.add("manifest must declare at least one contentTypes[] or templates[] entry");
+    }
+
+    return errors;
+  }
+
+  private static void requireText(List<String> errors, String field, String value) {
+    if (value == null || value.isBlank()) {
+      errors.add(field + " is required");
+    }
+  }
+
+  private static void requireRelativePath(List<String> errors, String field, String path) {
+    String p = path.trim();
+    if (!RELATIVE_PACKAGE_PATH.matcher(p).matches()) {
+      errors.add(
+          field
+              + " must be a package-relative path using '/' separators"
+              + " (no absolute OS paths, no '..', no backslashes): '"
+              + path
+              + "'");
+    }
+  }
+
+  private static boolean containsBackslash(String s) {
+    return s.indexOf('\\') >= 0;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompileResult.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompileResult.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Output of compiling a single Widget XML definition: modern manifest + package-relative text
+ * artifacts (template sources keyed by the same paths referenced from the manifest).
+ */
+public final class PSWidgetXmlCompileResult {
+
+  private final PSWidgetXmlModel source;
+  private final PSComponentPackageManifest manifest;
+  /** Package-relative path → UTF-8 text (e.g. {@code templates/percSimpleTextSnippet.vm}). */
+  private final Map<String, String> textArtifacts;
+
+  public PSWidgetXmlCompileResult(
+      PSWidgetXmlModel source,
+      PSComponentPackageManifest manifest,
+      Map<String, String> textArtifacts) {
+    this.source = Objects.requireNonNull(source, "source");
+    this.manifest = Objects.requireNonNull(manifest, "manifest");
+    this.textArtifacts =
+        textArtifacts == null
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(textArtifacts));
+  }
+
+  public PSWidgetXmlModel getSource() {
+    return source;
+  }
+
+  public PSComponentPackageManifest getManifest() {
+    return manifest;
+  }
+
+  public Map<String, String> getTextArtifacts() {
+    return textArtifacts;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Compiles legacy Widget definition XML into a modern {@link PSComponentPackageManifest} plus
+ * template source artifacts (Phase 3 / ADR-004 / issue #2751).
+ *
+ * <p><strong>Scope:</strong> simple / baseWidgets-shaped widgets (JEXL code + Velocity content +
+ * optional asset content type + UserPref/CssPref). High-traffic packages (nav, blog, lists) remain
+ * residual work; see {@code docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
+ *
+ * <p>Assembler mapping: {@code Content type="velocity"} → {@code velocityAssembler}; {@code html}
+ * → {@code htmlAssembler}; {@code markdown} → {@code markdownAssembler}. Code language is always
+ * preserved as JEXL bindings (ADR-001).
+ */
+public final class PSWidgetXmlCompiler {
+
+  /**
+   * Binding variable used when the full JEXL {@code <Code>} body is stored as a single script
+   * binding (control-flow safe). Simple top-level {@code $var = expr} assignments are also emitted
+   * as individual bindings for ergonomics.
+   */
+  public static final String FULL_CODE_BINDING_VARIABLE = "__widgetCode";
+
+  private static final Pattern SIMPLE_ASSIGNMENT =
+      Pattern.compile(
+          "(?m)^\\s*\\$([A-Za-z_][\\w.]*)\\s*=\\s*(.+?)\\s*;\\s*$");
+
+  private static final String DEFAULT_VERSION = "0.0.0";
+
+  private PSWidgetXmlCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile a widget XML file into a modern component package result.
+   *
+   * @param widgetXmlPath path to Widget definition XML
+   * @param packageContext optional package metadata (version, publisher, deps); may be null
+   * @return compile result with validated manifest and text artifacts
+   * @throws PSWidgetXmlException on parse/compile/validation failure
+   * @throws IOException on I/O failure
+   */
+  public static PSWidgetXmlCompileResult compile(Path widgetXmlPath, PSWidgetXmlPackageContext packageContext)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(widgetXmlPath, "widgetXmlPath");
+    PSWidgetXmlModel model = PSWidgetXmlParser.parse(widgetXmlPath);
+    return compile(model, packageContext);
+  }
+
+  /**
+   * Compile a previously parsed widget model.
+   *
+   * @param model non-null parsed widget
+   * @param packageContext optional package metadata; may be null
+   * @return compile result
+   * @throws PSWidgetXmlException on compile/validation failure
+   */
+  public static PSWidgetXmlCompileResult compile(
+      PSWidgetXmlModel model, PSWidgetXmlPackageContext packageContext) throws PSWidgetXmlException {
+    Objects.requireNonNull(model, "model");
+
+    String stem = model.widgetStem();
+    if (stem == null || stem.isBlank()) {
+      throw new PSWidgetXmlException(
+          "Widget model is missing source file name; cannot derive widget stem / component id");
+    }
+
+    PSComponentPackageManifest manifest = new PSComponentPackageManifest();
+    manifest.setSchemaVersion(PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION);
+    manifest.setId(stem);
+    manifest.setName(
+        model.getTitle() != null && !model.getTitle().isBlank() ? model.getTitle() : stem);
+    applyPackageIdentity(manifest, packageContext, model);
+
+    PSComponentPackageManifest.Catalog catalog = new PSComponentPackageManifest.Catalog();
+    catalog.setKind("component");
+    catalog.setTitle(model.getTitle());
+    catalog.setCategory(model.getCategory());
+    catalog.setDescription(model.getDescription());
+    catalog.setAuthor(model.getAuthor());
+    catalog.setPreferredEditorWidth(model.getPreferredEditorWidth());
+    catalog.setPreferredEditorHeight(model.getPreferredEditorHeight());
+    catalog.setCreateSharedAsset(model.getCreateSharedAsset());
+    catalog.setEditableOnTemplate(model.getEditableOnTemplate());
+    catalog.setResponsive(model.getResponsive());
+    catalog.setPaletteVisible(Boolean.TRUE);
+
+    String packageRelativeThumbnail = toPackageRelativePath(model.getThumbnail());
+    if (packageRelativeThumbnail != null) {
+      catalog.setThumbnail(packageRelativeThumbnail);
+      catalog.setIcon(packageRelativeThumbnail);
+    }
+    manifest.setCatalog(catalog);
+
+    // Content type (optional for logic/chrome widgets).
+    String ctName = model.getContentTypeName();
+    if (ctName != null && !ctName.isBlank()) {
+      PSComponentPackageManifest.ContentTypeRef ct = new PSComponentPackageManifest.ContentTypeRef();
+      ct.setName(ctName);
+      ct.setRef("contentTypes/" + ctName);
+      List<PSComponentPackageManifest.ContentTypeRef> cts = new ArrayList<>();
+      cts.add(ct);
+      manifest.setContentTypes(cts);
+    }
+
+    // Template + JEXL bindings + Velocity (or other) source.
+    PSComponentPackageManifest.TemplateRef template = new PSComponentPackageManifest.TemplateRef();
+    String templateName = stem + "Snippet";
+    template.setName(templateName);
+    template.setType("snippet");
+    template.setAssembler(mapAssembler(model.getContentType()));
+    String sourceRef = "templates/" + templateName + assemblerExtension(template.getAssembler());
+    template.setSourceRef(sourceRef);
+    if (ctName != null && !ctName.isBlank()) {
+      template.setContentType(ctName);
+    }
+    template.setBindings(buildBindings(model.getCodeBody()));
+    List<PSComponentPackageManifest.TemplateRef> templates = new ArrayList<>();
+    templates.add(template);
+    manifest.setTemplates(templates);
+
+    // Default slot for the asset content type (simple widgets).
+    if (ctName != null && !ctName.isBlank()) {
+      PSComponentPackageManifest.SlotRef slot = new PSComponentPackageManifest.SlotRef();
+      slot.setName(stem + "Content");
+      List<String> allowed = new ArrayList<>();
+      allowed.add(ctName);
+      slot.setAllowedContentTypes(allowed);
+      // CssPrefs that look like class names land in slot styles (ADR-003 direction).
+      Map<String, Object> styles = new LinkedHashMap<>();
+      for (PSWidgetXmlModel.CssPref css : model.getCssPrefs()) {
+        if (css != null && css.getName() != null && !css.getName().isBlank()) {
+          styles.put(css.getName(), css.getDefaultValue() != null ? css.getDefaultValue() : "");
+        }
+      }
+      slot.setStyles(styles);
+      List<PSComponentPackageManifest.SlotRef> slots = new ArrayList<>();
+      slots.add(slot);
+      manifest.setSlots(slots);
+    }
+
+    // Resources: thumbnail as installable image when present.
+    if (packageRelativeThumbnail != null) {
+      PSComponentPackageManifest.ResourceRef res = new PSComponentPackageManifest.ResourceRef();
+      // Package-local staging path for the resource (URL-style separators).
+      String localPath = "resources/" + fileNameOf(packageRelativeThumbnail);
+      res.setPath(localPath);
+      res.setTarget(packageRelativeThumbnail);
+      res.setType(guessResourceType(packageRelativeThumbnail));
+      List<PSComponentPackageManifest.ResourceRef> resources = new ArrayList<>();
+      resources.add(res);
+      manifest.setResources(resources);
+      // Point catalog at the package-local staging path (validator prefers relative refs).
+      catalog.setThumbnail(localPath);
+      catalog.setIcon(localPath);
+    }
+
+    // Transitional UserPref / CssPref mirrors.
+    List<PSComponentPackageManifest.UserPreference> userPrefs = new ArrayList<>();
+    for (PSWidgetXmlModel.UserPref up : model.getUserPrefs()) {
+      if (up == null || up.getName() == null || up.getName().isBlank()) {
+        continue;
+      }
+      PSComponentPackageManifest.UserPreference p = new PSComponentPackageManifest.UserPreference();
+      p.setName(up.getName());
+      p.setDisplayName(up.getDisplayName());
+      p.setDatatype(up.getDatatype());
+      p.setRequired(up.isRequired());
+      p.setDefaultValue(up.getDefaultValue());
+      List<PSComponentPackageManifest.EnumValue> enums = new ArrayList<>();
+      for (PSWidgetXmlModel.EnumValue ev : up.getEnumValues()) {
+        if (ev == null) {
+          continue;
+        }
+        PSComponentPackageManifest.EnumValue e = new PSComponentPackageManifest.EnumValue();
+        e.setValue(ev.getValue());
+        e.setDisplayValue(ev.getDisplayValue());
+        enums.add(e);
+      }
+      p.setEnumValues(enums);
+      userPrefs.add(p);
+    }
+    manifest.setUserPreferences(userPrefs);
+
+    List<PSComponentPackageManifest.CssPreference> cssPrefs = new ArrayList<>();
+    for (PSWidgetXmlModel.CssPref cp : model.getCssPrefs()) {
+      if (cp == null || cp.getName() == null || cp.getName().isBlank()) {
+        continue;
+      }
+      PSComponentPackageManifest.CssPreference p = new PSComponentPackageManifest.CssPreference();
+      p.setName(cp.getName());
+      p.setDisplayName(cp.getDisplayName());
+      p.setDatatype(cp.getDatatype());
+      p.setDefaultValue(cp.getDefaultValue());
+      cssPrefs.add(p);
+    }
+    manifest.setCssPreferences(cssPrefs);
+
+    try {
+      PSComponentPackageManifestValidator.validate(manifest);
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSWidgetXmlException("Compiled manifest failed validation: " + e.getMessage(), e);
+    }
+
+    Map<String, String> artifacts = new LinkedHashMap<>();
+    String templateSource = model.getContentBody() != null ? model.getContentBody() : "";
+    artifacts.put(sourceRef, templateSource);
+
+    return new PSWidgetXmlCompileResult(model, manifest, artifacts);
+  }
+
+  /**
+   * Write a compile result under {@code outputDir}: {@code component-package.json} plus text
+   * artifacts using package-relative paths. Parent directories are created as needed.
+   *
+   * @param result non-null compile result
+   * @param outputDir non-null destination package root
+   * @throws IOException on I/O failure
+   */
+  public static void writeArtifacts(PSWidgetXmlCompileResult result, Path outputDir)
+      throws IOException {
+    Objects.requireNonNull(result, "result");
+    Objects.requireNonNull(outputDir, "outputDir");
+    Files.createDirectories(outputDir);
+    Path manifestPath = outputDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    PSComponentPackageManifestIo.write(result.getManifest(), manifestPath);
+    for (Map.Entry<String, String> entry : result.getTextArtifacts().entrySet()) {
+      Path artifact = resolvePackageRelative(outputDir, entry.getKey());
+      Path parent = artifact.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      Files.writeString(artifact, entry.getValue(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void applyPackageIdentity(
+      PSComponentPackageManifest manifest,
+      PSWidgetXmlPackageContext ctx,
+      PSWidgetXmlModel model) {
+    if (ctx != null) {
+      if (ctx.getVersion() != null && !ctx.getVersion().isBlank()) {
+        manifest.setVersion(ctx.getVersion());
+      }
+      if (ctx.getDescription() != null && !ctx.getDescription().isBlank()) {
+        // Prefer widget description for component; keep package description only if widget empty.
+        if (model.getDescription() == null || model.getDescription().isBlank()) {
+          manifest.setDescription(ctx.getDescription());
+        } else {
+          manifest.setDescription(model.getDescription());
+        }
+      } else if (model.getDescription() != null) {
+        manifest.setDescription(model.getDescription());
+      }
+      if (ctx.getPublisherName() != null || ctx.getPublisherUrl() != null) {
+        PSComponentPackageManifest.Publisher pub = new PSComponentPackageManifest.Publisher();
+        pub.setName(ctx.getPublisherName());
+        pub.setUrl(ctx.getPublisherUrl());
+        manifest.setPublisher(pub);
+      }
+      if (ctx.getCmsMin() != null || ctx.getCmsMax() != null) {
+        PSComponentPackageManifest.CmsVersionRange range =
+            new PSComponentPackageManifest.CmsVersionRange();
+        range.setMin(ctx.getCmsMin());
+        range.setMax(ctx.getCmsMax());
+        manifest.setCmsVersion(range);
+      }
+      if (ctx.getDependencies() != null && !ctx.getDependencies().isEmpty()) {
+        List<PSComponentPackageManifest.Dependency> deps = new ArrayList<>();
+        for (PSWidgetXmlPackageContext.Dependency d : ctx.getDependencies()) {
+          if (d == null || d.getName() == null || d.getName().isBlank()) {
+            continue;
+          }
+          PSComponentPackageManifest.Dependency dep = new PSComponentPackageManifest.Dependency();
+          dep.setName(d.getName());
+          dep.setVersion(d.getVersion());
+          dep.setImplied(d.isImplied());
+          deps.add(dep);
+        }
+        manifest.setDependencies(deps);
+      }
+    } else if (model.getDescription() != null) {
+      manifest.setDescription(model.getDescription());
+    }
+
+    if (manifest.getVersion() == null || manifest.getVersion().isBlank()) {
+      manifest.setVersion(DEFAULT_VERSION);
+    }
+    if (manifest.getDescription() == null && model.getDescription() != null) {
+      manifest.setDescription(model.getDescription());
+    }
+    // Author from widget becomes publisher when package context has none.
+    if (manifest.getPublisher() == null
+        && model.getAuthor() != null
+        && !model.getAuthor().isBlank()) {
+      PSComponentPackageManifest.Publisher pub = new PSComponentPackageManifest.Publisher();
+      pub.setName(model.getAuthor());
+      manifest.setPublisher(pub);
+    }
+  }
+
+  static List<PSComponentPackageManifest.Binding> buildBindings(String codeBody) {
+    List<PSComponentPackageManifest.Binding> bindings = new ArrayList<>();
+    if (codeBody == null || codeBody.isBlank()) {
+      return bindings;
+    }
+    String normalized = PSWidgetXmlParser.normalizeBody(codeBody);
+    // Individual simple assignments first (ergonomic; mirrors common widget patterns).
+    Matcher m = SIMPLE_ASSIGNMENT.matcher(normalized);
+    while (m.find()) {
+      PSComponentPackageManifest.Binding b = new PSComponentPackageManifest.Binding();
+      b.setVariable(m.group(1));
+      b.setExpression(m.group(2).trim());
+      bindings.add(b);
+    }
+    // Always retain full script so control-flow (if/else) is not lost.
+    PSComponentPackageManifest.Binding full = new PSComponentPackageManifest.Binding();
+    full.setVariable(FULL_CODE_BINDING_VARIABLE);
+    full.setExpression(normalized);
+    bindings.add(full);
+    return bindings;
+  }
+
+  static String mapAssembler(String contentType) {
+    if (contentType == null || contentType.isBlank()) {
+      return "velocityAssembler";
+    }
+    String t = contentType.trim().toLowerCase(Locale.ROOT);
+    return switch (t) {
+      case "velocity", "vm" -> "velocityAssembler";
+      case "html", "html-first", "htmlfirst" -> "htmlAssembler";
+      case "markdown", "md" -> "markdownAssembler";
+      default -> t.endsWith("assembler") ? t : t + "Assembler";
+    };
+  }
+
+  static String assemblerExtension(String assembler) {
+    if (assembler == null) {
+      return ".vm";
+    }
+    String a = assembler.toLowerCase(Locale.ROOT);
+    if (a.contains("html")) {
+      return ".html";
+    }
+    if (a.contains("markdown") || a.contains("md")) {
+      return ".md";
+    }
+    return ".vm";
+  }
+
+  /**
+   * Convert a Widget thumbnail path (often absolute install path starting with {@code /}) into a
+   * package-relative path for the manifest validator.
+   */
+  static String toPackageRelativePath(String path) {
+    if (path == null || path.isBlank()) {
+      return null;
+    }
+    String p = path.trim().replace('\\', '/');
+    while (p.startsWith("/")) {
+      p = p.substring(1);
+    }
+    if (p.isEmpty() || p.contains("..")) {
+      return null;
+    }
+    return p;
+  }
+
+  static String fileNameOf(String packageRelativePath) {
+    int idx = packageRelativePath.lastIndexOf('/');
+    return idx >= 0 ? packageRelativePath.substring(idx + 1) : packageRelativePath;
+  }
+
+  static String guessResourceType(String path) {
+    String lower = path.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".css")) {
+      return "css";
+    }
+    if (lower.endsWith(".js")) {
+      return "js";
+    }
+    if (lower.endsWith(".png")
+        || lower.endsWith(".jpg")
+        || lower.endsWith(".jpeg")
+        || lower.endsWith(".gif")
+        || lower.endsWith(".svg")
+        || lower.endsWith(".webp")) {
+      return "image";
+    }
+    return "file";
+  }
+
+  /**
+   * Resolve a package-relative path (URL-style {@code /}) under {@code base} using portable {@link
+   * Path#resolve(String)} per segment — never string-concatenate OS separators.
+   */
+  static Path resolvePackageRelative(Path base, String packageRelative) {
+    Path p = base;
+    for (String segment : packageRelative.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment)) {
+        continue;
+      }
+      if ("..".equals(segment)) {
+        throw new IllegalArgumentException("Package-relative path must not contain '..': " + packageRelative);
+      }
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+/**
+ * Thrown when Widget definition XML cannot be parsed or compiled into a Component Package Manifest.
+ *
+ * @see PSWidgetXmlParser
+ * @see PSWidgetXmlCompiler
+ */
+public class PSWidgetXmlException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSWidgetXmlException(String message) {
+    super(message);
+  }
+
+  public PSWidgetXmlException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlModel.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlModel.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Parsed upgrade-input Widget definition XML (legacy {@code rxconfig/Widgets/*.xml}).
+ *
+ * <p>This is an intermediate model used only by the compiler; product ship format is {@link
+ * com.percussion.packages.manifest.PSComponentPackageManifest}.
+ */
+public final class PSWidgetXmlModel {
+
+  private String sourceFileName;
+  private String title;
+  private String contentTypeName;
+  private String category;
+  private String description;
+  private String author;
+  private String thumbnail;
+  private Integer preferredEditorWidth;
+  private Integer preferredEditorHeight;
+  private Boolean createSharedAsset;
+  private Boolean editableOnTemplate;
+  private Boolean responsive;
+  private String codeType;
+  private String codeBody;
+  private String contentType;
+  private String contentBody;
+  private List<UserPref> userPrefs = new ArrayList<>();
+  private List<CssPref> cssPrefs = new ArrayList<>();
+
+  public String getSourceFileName() {
+    return sourceFileName;
+  }
+
+  public void setSourceFileName(String sourceFileName) {
+    this.sourceFileName = sourceFileName;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getContentTypeName() {
+    return contentTypeName;
+  }
+
+  public void setContentTypeName(String contentTypeName) {
+    this.contentTypeName = contentTypeName;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(String category) {
+    this.category = category;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+
+  public void setAuthor(String author) {
+    this.author = author;
+  }
+
+  public String getThumbnail() {
+    return thumbnail;
+  }
+
+  public void setThumbnail(String thumbnail) {
+    this.thumbnail = thumbnail;
+  }
+
+  public Integer getPreferredEditorWidth() {
+    return preferredEditorWidth;
+  }
+
+  public void setPreferredEditorWidth(Integer preferredEditorWidth) {
+    this.preferredEditorWidth = preferredEditorWidth;
+  }
+
+  public Integer getPreferredEditorHeight() {
+    return preferredEditorHeight;
+  }
+
+  public void setPreferredEditorHeight(Integer preferredEditorHeight) {
+    this.preferredEditorHeight = preferredEditorHeight;
+  }
+
+  public Boolean getCreateSharedAsset() {
+    return createSharedAsset;
+  }
+
+  public void setCreateSharedAsset(Boolean createSharedAsset) {
+    this.createSharedAsset = createSharedAsset;
+  }
+
+  public Boolean getEditableOnTemplate() {
+    return editableOnTemplate;
+  }
+
+  public void setEditableOnTemplate(Boolean editableOnTemplate) {
+    this.editableOnTemplate = editableOnTemplate;
+  }
+
+  public Boolean getResponsive() {
+    return responsive;
+  }
+
+  public void setResponsive(Boolean responsive) {
+    this.responsive = responsive;
+  }
+
+  /** Code language from {@code <Code type="...">} (expected {@code jexl}). */
+  public String getCodeType() {
+    return codeType;
+  }
+
+  public void setCodeType(String codeType) {
+    this.codeType = codeType;
+  }
+
+  public String getCodeBody() {
+    return codeBody;
+  }
+
+  public void setCodeBody(String codeBody) {
+    this.codeBody = codeBody;
+  }
+
+  /** Content markup from {@code <Content type="...">} (expected {@code velocity}). */
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public String getContentBody() {
+    return contentBody;
+  }
+
+  public void setContentBody(String contentBody) {
+    this.contentBody = contentBody;
+  }
+
+  public List<UserPref> getUserPrefs() {
+    return userPrefs;
+  }
+
+  public void setUserPrefs(List<UserPref> userPrefs) {
+    this.userPrefs = userPrefs != null ? userPrefs : new ArrayList<>();
+  }
+
+  public List<CssPref> getCssPrefs() {
+    return cssPrefs;
+  }
+
+  public void setCssPrefs(List<CssPref> cssPrefs) {
+    this.cssPrefs = cssPrefs != null ? cssPrefs : new ArrayList<>();
+  }
+
+  /**
+   * Widget stem derived from the source file name (e.g. {@code percSimpleText} from {@code
+   * percSimpleText.xml}).
+   */
+  public String widgetStem() {
+    if (sourceFileName == null || sourceFileName.isBlank()) {
+      return null;
+    }
+    String name = sourceFileName;
+    int slash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+    if (slash >= 0) {
+      name = name.substring(slash + 1);
+    }
+    if (name.toLowerCase().endsWith(".xml")) {
+      name = name.substring(0, name.length() - 4);
+    }
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSWidgetXmlModel that)) {
+      return false;
+    }
+    return Objects.equals(sourceFileName, that.sourceFileName)
+        && Objects.equals(title, that.title)
+        && Objects.equals(contentTypeName, that.contentTypeName)
+        && Objects.equals(category, that.category)
+        && Objects.equals(description, that.description)
+        && Objects.equals(author, that.author)
+        && Objects.equals(thumbnail, that.thumbnail)
+        && Objects.equals(preferredEditorWidth, that.preferredEditorWidth)
+        && Objects.equals(preferredEditorHeight, that.preferredEditorHeight)
+        && Objects.equals(createSharedAsset, that.createSharedAsset)
+        && Objects.equals(editableOnTemplate, that.editableOnTemplate)
+        && Objects.equals(responsive, that.responsive)
+        && Objects.equals(codeType, that.codeType)
+        && Objects.equals(codeBody, that.codeBody)
+        && Objects.equals(contentType, that.contentType)
+        && Objects.equals(contentBody, that.contentBody)
+        && Objects.equals(userPrefs, that.userPrefs)
+        && Objects.equals(cssPrefs, that.cssPrefs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        sourceFileName,
+        title,
+        contentTypeName,
+        category,
+        description,
+        author,
+        thumbnail,
+        preferredEditorWidth,
+        preferredEditorHeight,
+        createSharedAsset,
+        editableOnTemplate,
+        responsive,
+        codeType,
+        codeBody,
+        contentType,
+        contentBody,
+        userPrefs,
+        cssPrefs);
+  }
+
+  /** Parsed {@code <UserPref>} element. */
+  public static final class UserPref {
+    private String name;
+    private String displayName;
+    private String datatype;
+    private boolean required;
+    private String defaultValue;
+    private List<EnumValue> enumValues = new ArrayList<>();
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDatatype() {
+      return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+      this.datatype = datatype;
+    }
+
+    public boolean isRequired() {
+      return required;
+    }
+
+    public void setRequired(boolean required) {
+      this.required = required;
+    }
+
+    public String getDefaultValue() {
+      return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    public List<EnumValue> getEnumValues() {
+      return enumValues;
+    }
+
+    public void setEnumValues(List<EnumValue> enumValues) {
+      this.enumValues = enumValues != null ? enumValues : new ArrayList<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof UserPref that)) {
+        return false;
+      }
+      return required == that.required
+          && Objects.equals(name, that.name)
+          && Objects.equals(displayName, that.displayName)
+          && Objects.equals(datatype, that.datatype)
+          && Objects.equals(defaultValue, that.defaultValue)
+          && Objects.equals(enumValues, that.enumValues);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, displayName, datatype, required, defaultValue, enumValues);
+    }
+  }
+
+  /** Enumerated value under a user preference. */
+  public static final class EnumValue {
+    private String value;
+    private String displayValue;
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public String getDisplayValue() {
+      return displayValue;
+    }
+
+    public void setDisplayValue(String displayValue) {
+      this.displayValue = displayValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof EnumValue that)) {
+        return false;
+      }
+      return Objects.equals(value, that.value) && Objects.equals(displayValue, that.displayValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, displayValue);
+    }
+  }
+
+  /** Parsed {@code <CssPref>} element. */
+  public static final class CssPref {
+    private String name;
+    private String displayName;
+    private String datatype;
+    private String defaultValue;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDatatype() {
+      return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+      this.datatype = datatype;
+    }
+
+    public String getDefaultValue() {
+      return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof CssPref that)) {
+        return false;
+      }
+      return Objects.equals(name, that.name)
+          && Objects.equals(displayName, that.displayName)
+          && Objects.equals(datatype, that.datatype)
+          && Objects.equals(defaultValue, that.defaultValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, displayName, datatype, defaultValue);
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Compiles all Widget definition XML files found in a legacy product package source directory.
+ *
+ * <p>Looks under {@code sys__UserDependency--rxconfig/Widgets/*.xml} (product packaging layout used
+ * by {@code modules/perc-packages}). Suitable for the baseWidgets subset first; residual packages
+ * are tracked in the widget XML inventory.
+ */
+public final class PSWidgetXmlPackageCompiler {
+
+  /** Legacy staging folder name for user-dependency config inside a package source tree. */
+  public static final String WIDGETS_RELATIVE =
+      "sys__UserDependency--rxconfig/Widgets";
+
+  private PSWidgetXmlPackageCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile every Widget XML under the package's Widgets directory.
+   *
+   * @param packageDir non-null package source root (e.g. {@code …/Packages/perc.baseWidgets})
+   * @return compile results sorted by widget stem (stable for golden tests)
+   * @throws PSWidgetXmlException on parse/compile failure
+   * @throws IOException on I/O failure
+   */
+  public static List<PSWidgetXmlCompileResult> compilePackage(Path packageDir)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (!Files.isDirectory(packageDir)) {
+      throw new PSWidgetXmlException("Package directory does not exist: " + packageDir);
+    }
+
+    PSWidgetXmlPackageContext ctx = PSWidgetXmlPackageContext.fromPackageDir(packageDir);
+    Path widgetsDir = resolveWidgetsDir(packageDir);
+    if (!Files.isDirectory(widgetsDir)) {
+      throw new PSWidgetXmlException(
+          "Widgets directory not found under package (expected "
+              + WIDGETS_RELATIVE
+              + "): "
+              + packageDir);
+    }
+
+    List<Path> widgetFiles = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(widgetsDir, "*.xml")) {
+      for (Path p : stream) {
+        if (Files.isRegularFile(p)) {
+          widgetFiles.add(p);
+        }
+      }
+    }
+    widgetFiles.sort(
+        Comparator.comparing(p -> p.getFileName().toString().toLowerCase(Locale.ROOT)));
+
+    if (widgetFiles.isEmpty()) {
+      throw new PSWidgetXmlException("No Widget XML files found in: " + widgetsDir);
+    }
+
+    List<PSWidgetXmlCompileResult> results = new ArrayList<>();
+    for (Path widgetXml : widgetFiles) {
+      results.add(PSWidgetXmlCompiler.compile(widgetXml, ctx));
+    }
+    return results;
+  }
+
+  /**
+   * Write each widget compile result under {@code outputRoot/<widgetStem>/}.
+   *
+   * @param results non-null list of compile results
+   * @param outputRoot non-null output root directory
+   * @throws IOException on I/O failure
+   */
+  public static void writeAll(List<PSWidgetXmlCompileResult> results, Path outputRoot)
+      throws IOException {
+    Objects.requireNonNull(results, "results");
+    Objects.requireNonNull(outputRoot, "outputRoot");
+    Files.createDirectories(outputRoot);
+    for (PSWidgetXmlCompileResult result : results) {
+      String stem = result.getSource().widgetStem();
+      if (stem == null || stem.isBlank()) {
+        stem = result.getManifest().getId();
+      }
+      Path widgetOut = outputRoot.resolve(stem);
+      PSWidgetXmlCompiler.writeArtifacts(result, widgetOut);
+    }
+  }
+
+  /**
+   * Resolve the Widgets directory under a package using portable path segments (not string
+   * concatenation with hardcoded separators).
+   */
+  static Path resolveWidgetsDir(Path packageDir) {
+    Path p = packageDir;
+    for (String segment : WIDGETS_RELATIVE.split("/")) {
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageContext.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageContext.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Optional package-level metadata used when compiling a Widget XML that lives inside a legacy
+ * product package source tree (e.g. {@code perc.baseWidgets}).
+ *
+ * <p>Populated from {@code psx_archiveInfo.xml} when present. Lightweight regex/string extraction is
+ * intentional: archive descriptors are large nested trees; only identity fields are needed here.
+ */
+public final class PSWidgetXmlPackageContext {
+
+  private String packageId;
+  private String packageName;
+  private String version;
+  private String description;
+  private String publisherName;
+  private String publisherUrl;
+  private String cmsMin;
+  private String cmsMax;
+  private List<Dependency> dependencies = new ArrayList<>();
+
+  public String getPackageId() {
+    return packageId;
+  }
+
+  public void setPackageId(String packageId) {
+    this.packageId = packageId;
+  }
+
+  public String getPackageName() {
+    return packageName;
+  }
+
+  public void setPackageName(String packageName) {
+    this.packageName = packageName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getPublisherName() {
+    return publisherName;
+  }
+
+  public void setPublisherName(String publisherName) {
+    this.publisherName = publisherName;
+  }
+
+  public String getPublisherUrl() {
+    return publisherUrl;
+  }
+
+  public void setPublisherUrl(String publisherUrl) {
+    this.publisherUrl = publisherUrl;
+  }
+
+  public String getCmsMin() {
+    return cmsMin;
+  }
+
+  public void setCmsMin(String cmsMin) {
+    this.cmsMin = cmsMin;
+  }
+
+  public String getCmsMax() {
+    return cmsMax;
+  }
+
+  public void setCmsMax(String cmsMax) {
+    this.cmsMax = cmsMax;
+  }
+
+  public List<Dependency> getDependencies() {
+    return dependencies;
+  }
+
+  public void setDependencies(List<Dependency> dependencies) {
+    this.dependencies = dependencies != null ? dependencies : new ArrayList<>();
+  }
+
+  /**
+   * Load package context from a package source directory (looks for {@code psx_archiveInfo.xml}).
+   *
+   * @param packageDir non-null package root
+   * @return context (may have only packageId from the directory name when archive info is absent)
+   * @throws IOException on I/O failure
+   * @throws PSWidgetXmlException if archive info is present but unreadable as UTF-8 text
+   */
+  public static PSWidgetXmlPackageContext fromPackageDir(Path packageDir)
+      throws IOException, PSWidgetXmlException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    PSWidgetXmlPackageContext ctx = new PSWidgetXmlPackageContext();
+    Path name = packageDir.getFileName();
+    if (name != null) {
+      ctx.setPackageId(name.toString());
+      ctx.setPackageName(name.toString());
+    }
+    Path archiveInfo = packageDir.resolve("psx_archiveInfo.xml");
+    if (Files.isRegularFile(archiveInfo)) {
+      String xml = Files.readString(archiveInfo, StandardCharsets.UTF_8);
+      applyArchiveInfo(ctx, xml);
+    }
+    return ctx;
+  }
+
+  /**
+   * Apply selected fields from {@code psx_archiveInfo.xml} text into {@code ctx}.
+   *
+   * @param ctx non-null context to mutate
+   * @param archiveXml non-null archive info document text
+   */
+  static void applyArchiveInfo(PSWidgetXmlPackageContext ctx, String archiveXml) {
+    Objects.requireNonNull(ctx, "ctx");
+    Objects.requireNonNull(archiveXml, "archiveXml");
+
+    String descriptorName = firstAttr(archiveXml, "PSXDescriptor", "name");
+    if (descriptorName != null && !descriptorName.isBlank()) {
+      ctx.setPackageId(descriptorName);
+      ctx.setPackageName(descriptorName);
+    }
+
+    String archiveRef = firstAttr(archiveXml, "PSXArchiveInfo", "archiveRef");
+    if ((ctx.getPackageId() == null || ctx.getPackageId().isBlank())
+        && archiveRef != null
+        && !archiveRef.isBlank()) {
+      ctx.setPackageId(archiveRef);
+      ctx.setPackageName(archiveRef);
+    }
+
+    // <Description>…</Description> immediately under PSXDescriptor (first match is package desc).
+    Matcher desc = Pattern.compile("<Description>([^<]*)</Description>").matcher(archiveXml);
+    if (desc.find()) {
+      String d = desc.group(1).trim();
+      if (!d.isEmpty()) {
+        ctx.setDescription(d);
+      }
+    }
+
+    Matcher pub =
+        Pattern.compile(
+                "<Publisher\\s+name=\"([^\"]*)\"\\s+url=\"([^\"]*)\"\\s*/?>",
+                Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    if (pub.find()) {
+      ctx.setPublisherName(emptyToNull(pub.group(1)));
+      ctx.setPublisherUrl(emptyToNull(pub.group(2)));
+    }
+
+    Matcher cms =
+        Pattern.compile(
+                "<CmsVersion\\s+max=\"([^\"]*)\"\\s+min=\"([^\"]*)\"\\s*/?>",
+                Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    if (!cms.find()) {
+      cms =
+          Pattern.compile(
+                  "<CmsVersion\\s+min=\"([^\"]*)\"\\s+max=\"([^\"]*)\"\\s*/?>",
+                  Pattern.CASE_INSENSITIVE)
+              .matcher(archiveXml);
+      if (cms.find()) {
+        ctx.setCmsMin(emptyToNull(cms.group(1)));
+        ctx.setCmsMax(emptyToNull(cms.group(2)));
+      }
+    } else {
+      ctx.setCmsMax(emptyToNull(cms.group(1)));
+      ctx.setCmsMin(emptyToNull(cms.group(2)));
+    }
+
+    Matcher ver = Pattern.compile("<Version>([^<]+)</Version>").matcher(archiveXml);
+    if (ver.find()) {
+      ctx.setVersion(ver.group(1).trim());
+    }
+
+    List<Dependency> deps = new ArrayList<>();
+    Matcher dep =
+        Pattern.compile(
+                "<PKGDependency\\s+([^>]+)/?>", Pattern.CASE_INSENSITIVE).matcher(archiveXml);
+    while (dep.find()) {
+      Map<String, String> attrs = parseAttrBag(dep.group(1));
+      Dependency d = new Dependency();
+      d.setName(attrs.get("name"));
+      d.setVersion(attrs.get("pkgVersion"));
+      String implied = attrs.get("PKGDepImplied");
+      d.setImplied(implied != null && Boolean.parseBoolean(implied));
+      if (d.getName() != null && !d.getName().isBlank()) {
+        deps.add(d);
+      }
+    }
+    ctx.setDependencies(deps);
+  }
+
+  private static String firstAttr(String xml, String element, String attr) {
+    Pattern p =
+        Pattern.compile(
+            "<" + element + "\\b([^>]*)>", Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher(xml);
+    if (!m.find()) {
+      return null;
+    }
+    return parseAttrBag(m.group(1)).get(attr);
+  }
+
+  private static Map<String, String> parseAttrBag(String bag) {
+    Map<String, String> map = new LinkedHashMap<>();
+    Matcher m = Pattern.compile("([A-Za-z_][\\w:.-]*)\\s*=\\s*\"([^\"]*)\"").matcher(bag);
+    while (m.find()) {
+      map.put(m.group(1), m.group(2));
+    }
+    return map;
+  }
+
+  private static String emptyToNull(String s) {
+    if (s == null) {
+      return null;
+    }
+    String t = s.trim();
+    return t.isEmpty() ? null : t;
+  }
+
+  /** Package dependency row. */
+  public static final class Dependency {
+    private String name;
+    private String version;
+    private boolean implied;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+
+    public boolean isImplied() {
+      return implied;
+    }
+
+    public void setImplied(boolean implied) {
+      this.implied = implied;
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlParser.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlParser.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Parses legacy Widget definition XML ({@code <Widget>…</Widget>}) into {@link PSWidgetXmlModel}.
+ *
+ * <p>Uses a hardened {@link DocumentBuilderFactory} (no external DTDs / schemas / XInclude). Paths
+ * are read via portable NIO {@link Files}.
+ */
+public final class PSWidgetXmlParser {
+
+  private PSWidgetXmlParser() {
+    // utility
+  }
+
+  /**
+   * Parse Widget XML from a UTF-8 file.
+   *
+   * @param path non-null path to a {@code .xml} widget definition
+   * @return parsed model
+   * @throws PSWidgetXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSWidgetXmlModel parse(Path path) throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(path, "path");
+    String xml = Files.readString(path, StandardCharsets.UTF_8);
+    PSWidgetXmlModel model = parse(xml);
+    Path fileName = path.getFileName();
+    if (fileName != null) {
+      model.setSourceFileName(fileName.toString());
+    }
+    return model;
+  }
+
+  /**
+   * Parse Widget XML from a string.
+   *
+   * @param xml non-null document text
+   * @return parsed model
+   * @throws PSWidgetXmlException on parse failure
+   */
+  public static PSWidgetXmlModel parse(String xml) throws PSWidgetXmlException {
+    Objects.requireNonNull(xml, "xml");
+    if (xml.isBlank()) {
+      throw new PSWidgetXmlException("Widget XML is empty");
+    }
+    try {
+      Document doc = parseDocument(new InputSource(new StringReader(xml)));
+      return fromDocument(doc, null);
+    } catch (PSWidgetXmlException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSWidgetXmlException("Failed to parse Widget XML: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Parse Widget XML from a reader.
+   *
+   * @param reader non-null reader
+   * @param sourceFileName optional file name for stem derivation
+   * @return parsed model
+   * @throws PSWidgetXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSWidgetXmlModel parse(Reader reader, String sourceFileName)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(reader, "reader");
+    try {
+      Document doc = parseDocument(new InputSource(reader));
+      return fromDocument(doc, sourceFileName);
+    } catch (PSWidgetXmlException e) {
+      throw e;
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSWidgetXmlException("Failed to parse Widget XML: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Parse Widget XML from an input stream (UTF-8 assumed by the XML decoder).
+   *
+   * @param in non-null stream
+   * @param sourceFileName optional file name for stem derivation
+   * @return parsed model
+   * @throws PSWidgetXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSWidgetXmlModel parse(InputStream in, String sourceFileName)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(in, "in");
+    try {
+      Document doc = parseDocument(new InputSource(in));
+      return fromDocument(doc, sourceFileName);
+    } catch (PSWidgetXmlException e) {
+      throw e;
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSWidgetXmlException("Failed to parse Widget XML: " + e.getMessage(), e);
+    }
+  }
+
+  private static Document parseDocument(InputSource source)
+      throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setExpandEntityReferences(false);
+    factory.setXIncludeAware(false);
+    // Harden against XXE / external entity expansion.
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    return factory.newDocumentBuilder().parse(source);
+  }
+
+  private static PSWidgetXmlModel fromDocument(Document doc, String sourceFileName)
+      throws PSWidgetXmlException {
+    Element root = doc.getDocumentElement();
+    if (root == null || !"Widget".equals(root.getTagName())) {
+      throw new PSWidgetXmlException(
+          "Expected root element <Widget>, found: "
+              + (root == null ? "null" : root.getTagName()));
+    }
+
+    PSWidgetXmlModel model = new PSWidgetXmlModel();
+    if (sourceFileName != null && !sourceFileName.isBlank()) {
+      model.setSourceFileName(sourceFileName);
+    }
+
+    Element prefs = firstChildElement(root, "WidgetPrefs");
+    if (prefs != null) {
+      model.setTitle(attr(prefs, "title"));
+      model.setContentTypeName(attr(prefs, "contenttype_name"));
+      model.setCategory(attr(prefs, "category"));
+      model.setDescription(attr(prefs, "description"));
+      model.setAuthor(attr(prefs, "author"));
+      model.setThumbnail(attr(prefs, "thumbnail"));
+      model.setPreferredEditorWidth(intAttr(prefs, "preferred_editor_width"));
+      model.setPreferredEditorHeight(intAttr(prefs, "preferred_editor_height"));
+      model.setCreateSharedAsset(boolAttr(prefs, "create_shared_asset"));
+      model.setEditableOnTemplate(boolAttr(prefs, "is_editable_on_template"));
+      model.setResponsive(boolAttr(prefs, "is_responsive"));
+    }
+
+    List<PSWidgetXmlModel.UserPref> userPrefs = new ArrayList<>();
+    for (Element el : childElements(root, "UserPref")) {
+      userPrefs.add(parseUserPref(el));
+    }
+    model.setUserPrefs(userPrefs);
+
+    List<PSWidgetXmlModel.CssPref> cssPrefs = new ArrayList<>();
+    for (Element el : childElements(root, "CssPref")) {
+      cssPrefs.add(parseCssPref(el));
+    }
+    model.setCssPrefs(cssPrefs);
+
+    Element code = firstChildElement(root, "Code");
+    if (code != null) {
+      model.setCodeType(attr(code, "type"));
+      model.setCodeBody(normalizeBody(textContent(code)));
+    }
+
+    Element content = firstChildElement(root, "Content");
+    if (content != null) {
+      model.setContentType(attr(content, "type"));
+      model.setContentBody(normalizeBody(textContent(content)));
+    }
+
+    return model;
+  }
+
+  private static PSWidgetXmlModel.UserPref parseUserPref(Element el) {
+    PSWidgetXmlModel.UserPref pref = new PSWidgetXmlModel.UserPref();
+    pref.setName(attr(el, "name"));
+    pref.setDisplayName(attr(el, "display_name"));
+    pref.setDatatype(attr(el, "datatype"));
+    pref.setDefaultValue(attr(el, "default_value"));
+    Boolean required = boolAttr(el, "required");
+    pref.setRequired(required != null && required);
+    List<PSWidgetXmlModel.EnumValue> enums = new ArrayList<>();
+    for (Element ev : childElements(el, "EnumValue")) {
+      PSWidgetXmlModel.EnumValue enumValue = new PSWidgetXmlModel.EnumValue();
+      enumValue.setValue(attr(ev, "value"));
+      enumValue.setDisplayValue(attr(ev, "display_value"));
+      enums.add(enumValue);
+    }
+    pref.setEnumValues(enums);
+    return pref;
+  }
+
+  private static PSWidgetXmlModel.CssPref parseCssPref(Element el) {
+    PSWidgetXmlModel.CssPref pref = new PSWidgetXmlModel.CssPref();
+    pref.setName(attr(el, "name"));
+    pref.setDisplayName(attr(el, "display_name"));
+    pref.setDatatype(attr(el, "datatype"));
+    pref.setDefaultValue(attr(el, "default_value"));
+    return pref;
+  }
+
+  private static Element firstChildElement(Element parent, String name) {
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE && name.equals(n.getNodeName())) {
+        return (Element) n;
+      }
+    }
+    return null;
+  }
+
+  private static List<Element> childElements(Element parent, String name) {
+    List<Element> out = new ArrayList<>();
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE && name.equals(n.getNodeName())) {
+        out.add((Element) n);
+      }
+    }
+    return out;
+  }
+
+  private static String attr(Element el, String name) {
+    if (!el.hasAttribute(name)) {
+      return null;
+    }
+    String v = el.getAttribute(name);
+    return v.isEmpty() ? null : v;
+  }
+
+  private static Integer intAttr(Element el, String name) {
+    String v = attr(el, name);
+    if (v == null) {
+      return null;
+    }
+    try {
+      return Integer.valueOf(v.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private static Boolean boolAttr(Element el, String name) {
+    String v = attr(el, name);
+    if (v == null) {
+      return null;
+    }
+    return Boolean.valueOf(v.trim());
+  }
+
+  private static String textContent(Element el) {
+    // Prefer concatenated text/CDATA children only (ignore nested elements if any).
+    StringBuilder sb = new StringBuilder();
+    NodeList children = el.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      short type = n.getNodeType();
+      if (type == Node.TEXT_NODE || type == Node.CDATA_SECTION_NODE) {
+        sb.append(n.getNodeValue());
+      }
+    }
+    if (sb.length() == 0) {
+      // Fallback: DOM textContent (covers unusual nesting).
+      return el.getTextContent();
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Normalize body text for cross-platform golden parity: CRLF/CR → LF, strip leading/trailing
+   * whitespace (pretty-printed CDATA often starts with newline + indent), preserve internal
+   * relative indentation between non-blank lines.
+   */
+  static String normalizeBody(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String s = raw.replace("\r\n", "\n").replace('\r', '\n');
+    // stripLeading/stripTrailing remove all leading/trailing whitespace including newlines.
+    return s.stripLeading().stripTrailing();
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/manifest/PSComponentPackageManifestTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/manifest/PSComponentPackageManifestTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.manifest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Parse / validate / round-trip coverage for the Component Package Manifest ship format (issue
+ * #2750 / ADR-004 Phase 3 slice 1).
+ */
+class PSComponentPackageManifestTest {
+
+  private static final String MINIMAL_FIXTURE = "/manifests/minimal-component-package.json";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parseMinimalFixture_populatesIdentityCatalogAndArtifacts() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+
+    assertEquals("1.0", manifest.getSchemaVersion());
+    assertEquals("perc.widget.title", manifest.getId());
+    assertEquals("Title", manifest.getName());
+    assertEquals("1.1.4", manifest.getVersion());
+    assertNotNull(manifest.getPublisher());
+    assertEquals("Percussion Software Inc", manifest.getPublisher().getName());
+    assertEquals("https://www.percussion.com", manifest.getPublisher().getUrl());
+    assertNotNull(manifest.getCmsVersion());
+    assertEquals("1.9.0", manifest.getCmsVersion().getMin());
+    assertEquals("9.0.0", manifest.getCmsVersion().getMax());
+
+    assertEquals(1, manifest.getDependencies().size());
+    assertEquals("perc.Baseline", manifest.getDependencies().get(0).getName());
+    assertFalse(manifest.getDependencies().get(0).isImplied());
+
+    assertNotNull(manifest.getCatalog());
+    assertEquals("component", manifest.getCatalog().getKind());
+    assertEquals("content", manifest.getCatalog().getCategory());
+    assertEquals(Integer.valueOf(780), manifest.getCatalog().getPreferredEditorWidth());
+    assertEquals(Boolean.TRUE, manifest.getCatalog().getResponsive());
+
+    assertEquals(1, manifest.getContentTypes().size());
+    assertEquals("percTitleAsset", manifest.getContentTypes().get(0).getName());
+    assertEquals("contentTypes/percTitleAsset", manifest.getContentTypes().get(0).getRef());
+
+    assertEquals(1, manifest.getTemplates().size());
+    PSComponentPackageManifest.TemplateRef tpl = manifest.getTemplates().get(0);
+    assertEquals("percTitleSnippet", tpl.getName());
+    assertEquals("snippet", tpl.getType());
+    assertEquals("velocityAssembler", tpl.getAssembler());
+    assertEquals(1, tpl.getBindings().size());
+    assertEquals("wrapper", tpl.getBindings().get(0).getVariable());
+
+    assertEquals(1, manifest.getSlots().size());
+    assertEquals("titleContent", manifest.getSlots().get(0).getName());
+    assertTrue(manifest.getSlots().get(0).getAllowedContentTypes().contains("percTitleAsset"));
+    assertEquals("vertical", manifest.getSlots().get(0).getLayout().get("orientation"));
+
+    assertEquals(1, manifest.getResources().size());
+    assertEquals("image", manifest.getResources().get(0).getType());
+
+    assertEquals(1, manifest.getUserPreferences().size());
+    assertEquals("wrapper", manifest.getUserPreferences().get(0).getName());
+    assertEquals(2, manifest.getUserPreferences().get(0).getEnumValues().size());
+
+    assertEquals(1, manifest.getCssPreferences().size());
+    assertEquals("rootclass", manifest.getCssPreferences().get(0).getName());
+  }
+
+  @Test
+  void validateMinimalFixture_passes() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(errors.isEmpty(), () -> "unexpected errors: " + errors);
+    PSComponentPackageManifestValidator.validate(manifest);
+  }
+
+  @Test
+  void roundTrip_jsonString_preservesModelEquality() throws Exception {
+    PSComponentPackageManifest original = parseFixture();
+    String json = PSComponentPackageManifestIo.toJson(original);
+    PSComponentPackageManifest roundTripped = PSComponentPackageManifestIo.parse(json);
+    assertEquals(original, roundTripped);
+  }
+
+  @Test
+  void roundTrip_pathWriteRead_preservesModelEquality() throws Exception {
+    PSComponentPackageManifest original = parseFixture();
+    Path out = tempDir.resolve("component-package.json");
+    PSComponentPackageManifestIo.write(original, out);
+    assertTrue(Files.isRegularFile(out));
+    PSComponentPackageManifest roundTripped = PSComponentPackageManifestIo.read(out);
+    assertEquals(original, roundTripped);
+  }
+
+  @Test
+  void validate_rejectsMissingIdentityAndEmptyArtifacts() {
+    PSComponentPackageManifest empty = new PSComponentPackageManifest();
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(empty);
+    assertTrue(errors.stream().anyMatch(e -> e.contains("id is required")));
+    assertTrue(errors.stream().anyMatch(e -> e.contains("name is required")));
+    assertTrue(errors.stream().anyMatch(e -> e.contains("version is required")));
+    assertTrue(
+        errors.stream()
+            .anyMatch(e -> e.contains("at least one contentTypes") || e.contains("templates")));
+    assertThrows(
+        PSComponentPackageManifestException.class,
+        () -> PSComponentPackageManifestValidator.validate(empty));
+  }
+
+  @Test
+  void validate_rejectsUnsupportedSchemaVersion() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    manifest.setSchemaVersion("99.0");
+    List<String> errors = PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(errors.stream().anyMatch(e -> e.contains("unsupported schemaVersion")));
+  }
+
+  @Test
+  void validate_rejectsAbsoluteOsPathsInResourceRefs() throws Exception {
+    PSComponentPackageManifest manifest = parseFixture();
+    manifest.getResources().get(0).setPath("C:/Windows/system32/evil.png");
+    List<String> driveLetterErrors =
+        PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        driveLetterErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
+        () -> "expected path error, got: " + driveLetterErrors);
+
+    manifest.getResources().get(0).setPath("resources\\windows\\style.css");
+    List<String> backslashErrors =
+        PSComponentPackageManifestValidator.validateCollecting(manifest);
+    assertTrue(
+        backslashErrors.stream().anyMatch(e -> e.contains("resources[0].path")),
+        () -> "expected backslash path error, got: " + backslashErrors);
+  }
+
+  @Test
+  void parse_rejectsEmptyAndMalformedJson() {
+    assertThrows(
+        PSComponentPackageManifestException.class, () -> PSComponentPackageManifestIo.parse(""));
+    assertThrows(
+        PSComponentPackageManifestException.class,
+        () -> PSComponentPackageManifestIo.parse("{not-json"));
+  }
+
+  @Test
+  void defaultManifestFileName_isComponentPackageJson() {
+    assertEquals("component-package.json", PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    assertEquals("1.0", PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION);
+  }
+
+  private static PSComponentPackageManifest parseFixture()
+      throws PSComponentPackageManifestException, IOException {
+    try (InputStream in = PSComponentPackageManifestTest.class.getResourceAsStream(MINIMAL_FIXTURE)) {
+      assertNotNull(in, "classpath fixture missing: " + MINIMAL_FIXTURE);
+      String json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      // Normalize any accidental Windows line endings from the fixture checkout.
+      json = json.replace("\r\n", "\n");
+      return PSComponentPackageManifestIo.parse(json);
+    }
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751). */
+class PSWidgetXmlCompilerTest {
+
+  private static final String FIXTURE_SIMPLE = "/widgetxml/percSimpleText.xml";
+  private static final String GOLDEN_SIMPLE_MANIFEST =
+      "/widgetxml/golden/percSimpleText.component-package.json";
+  private static final String GOLDEN_SIMPLE_TEMPLATE =
+      "/widgetxml/golden/percSimpleTextSnippet.vm";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parseSimpleText_populatesPrefsCodeAndContent() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_SIMPLE, "percSimpleText.xml");
+
+    assertEquals("Simple Text", model.getTitle());
+    assertEquals("percSimpleTextAsset", model.getContentTypeName());
+    assertEquals("content", model.getCategory());
+    assertEquals("jexl", model.getCodeType());
+    assertEquals("velocity", model.getContentType());
+    assertNotNull(model.getCodeBody());
+    assertTrue(model.getCodeBody().contains("$rootclass"));
+    assertNotNull(model.getContentBody());
+    assertTrue(model.getContentBody().contains("#loadRelatedWidgetContents()"));
+    assertEquals(1, model.getCssPrefs().size());
+    assertEquals("rootclass", model.getCssPrefs().get(0).getName());
+    assertEquals("percSimpleText", model.widgetStem());
+  }
+
+  @Test
+  void compileSimpleText_matchesGoldenManifestAndTemplate() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_SIMPLE, "percSimpleText.xml");
+    PSWidgetXmlPackageContext ctx = baseWidgetsLikeContext();
+
+    PSWidgetXmlCompileResult result = PSWidgetXmlCompiler.compile(model, ctx);
+    PSComponentPackageManifest manifest = result.getManifest();
+
+    PSComponentPackageManifestValidator.validate(manifest);
+
+    String expectedJson = readClasspath(GOLDEN_SIMPLE_MANIFEST);
+    PSComponentPackageManifest golden = PSComponentPackageManifestIo.parse(expectedJson);
+
+    assertEquals(golden.getSchemaVersion(), manifest.getSchemaVersion());
+    assertEquals(golden.getId(), manifest.getId());
+    assertEquals(golden.getName(), manifest.getName());
+    assertEquals(golden.getVersion(), manifest.getVersion());
+    assertEquals(golden.getDescription(), manifest.getDescription());
+    assertEquals(golden.getPublisher(), manifest.getPublisher());
+    assertEquals(golden.getCmsVersion(), manifest.getCmsVersion());
+    assertEquals(golden.getCatalog(), manifest.getCatalog());
+    assertEquals(golden.getContentTypes(), manifest.getContentTypes());
+    assertEquals(golden.getTemplates().size(), manifest.getTemplates().size());
+    assertEquals(golden.getTemplates().get(0).getName(), manifest.getTemplates().get(0).getName());
+    assertEquals(
+        golden.getTemplates().get(0).getAssembler(),
+        manifest.getTemplates().get(0).getAssembler());
+    assertEquals(
+        golden.getTemplates().get(0).getSourceRef(),
+        manifest.getTemplates().get(0).getSourceRef());
+    assertEquals(
+        golden.getTemplates().get(0).getContentType(),
+        manifest.getTemplates().get(0).getContentType());
+    assertEquals(
+        golden.getTemplates().get(0).getBindings(),
+        manifest.getTemplates().get(0).getBindings());
+    assertEquals(golden.getSlots(), manifest.getSlots());
+    assertEquals(golden.getResources(), manifest.getResources());
+    assertEquals(golden.getCssPreferences(), manifest.getCssPreferences());
+    assertEquals(golden.getUserPreferences(), manifest.getUserPreferences());
+
+    // Full structural equality (after collection normalize via toJson/parse).
+    PSComponentPackageManifest reparsed =
+        PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(manifest));
+    assertEquals(
+        PSComponentPackageManifestIo.parse(expectedJson),
+        reparsed,
+        "compiled manifest must equal golden fixture");
+
+    String expectedTemplate = normalizeNewlines(readClasspath(GOLDEN_SIMPLE_TEMPLATE));
+    String actualTemplate =
+        normalizeNewlines(result.getTextArtifacts().get("templates/percSimpleTextSnippet.vm"));
+    assertEquals(expectedTemplate, actualTemplate, "template source golden parity");
+  }
+
+  @Test
+  void compileSimpleText_writeArtifacts_roundTrips() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_SIMPLE, "percSimpleText.xml");
+    PSWidgetXmlCompileResult result =
+        PSWidgetXmlCompiler.compile(model, baseWidgetsLikeContext());
+
+    Path out = tempDir.resolve("simple-out");
+    PSWidgetXmlCompiler.writeArtifacts(result, out);
+
+    Path manifestPath = out.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    assertTrue(Files.isRegularFile(manifestPath));
+    PSComponentPackageManifest loaded = PSComponentPackageManifestIo.read(manifestPath);
+    PSComponentPackageManifestValidator.validate(loaded);
+    assertEquals(result.getManifest().getId(), loaded.getId());
+
+    Path template = out.resolve("templates").resolve("percSimpleTextSnippet.vm");
+    assertTrue(Files.isRegularFile(template));
+    assertEquals(
+        normalizeNewlines(result.getTextArtifacts().get("templates/percSimpleTextSnippet.vm")),
+        normalizeNewlines(Files.readString(template, StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void compileRawHtml_noCodeStillValid_withContentTypeAndTemplate() throws Exception {
+    PSWidgetXmlModel model = parseClasspath("/widgetxml/percRawHtml.xml", "percRawHtml.xml");
+    PSWidgetXmlCompileResult result =
+        PSWidgetXmlCompiler.compile(model, baseWidgetsLikeContext());
+
+    PSComponentPackageManifestValidator.validate(result.getManifest());
+    assertEquals("percRawHtml", result.getManifest().getId());
+    assertEquals("HTML", result.getManifest().getName());
+    assertEquals(1, result.getManifest().getContentTypes().size());
+    assertEquals("percRawHtmlAsset", result.getManifest().getContentTypes().get(0).getName());
+    assertEquals(1, result.getManifest().getTemplates().size());
+    assertTrue(result.getManifest().getTemplates().get(0).getBindings().isEmpty());
+    assertTrue(
+        result
+            .getTextArtifacts()
+            .get("templates/percRawHtmlSnippet.vm")
+            .contains("#loadRelatedWidgetContents()"));
+  }
+
+  @Test
+  void compileBaseWidgetsPackage_threeWidgetsAllValid() throws Exception {
+    Path packageDir = locateBaseWidgetsPackage();
+    if (packageDir == null) {
+      // Module resources layout not present in this environment — skip with explicit fail soft.
+      // Night/CI worktree always has package sources under modules/perc-packages.
+      System.err.println("WARN: perc.baseWidgets package sources not found; skipping package test");
+      return;
+    }
+
+    List<PSWidgetXmlCompileResult> results = PSWidgetXmlPackageCompiler.compilePackage(packageDir);
+    assertEquals(3, results.size(), "baseWidgets should have RawHtml, RichText, SimpleText");
+
+    Map<String, PSWidgetXmlCompileResult> byId =
+        results.stream()
+            .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+    assertTrue(byId.containsKey("percRawHtml"));
+    assertTrue(byId.containsKey("percRichText"));
+    assertTrue(byId.containsKey("percSimpleText"));
+
+    for (PSWidgetXmlCompileResult r : results) {
+      PSComponentPackageManifestValidator.validate(r.getManifest());
+      assertEquals("1.1.9", r.getManifest().getVersion());
+      assertNotNull(r.getManifest().getPublisher());
+      assertEquals("velocityAssembler", r.getManifest().getTemplates().get(0).getAssembler());
+      assertFalse(r.getTextArtifacts().isEmpty());
+    }
+
+    // Rich Text carries CssPref + JEXL code.
+    PSWidgetXmlCompileResult rich = byId.get("percRichText");
+    assertEquals(1, rich.getManifest().getCssPreferences().size());
+    assertEquals("rootclass", rich.getManifest().getCssPreferences().get(0).getName());
+    assertTrue(
+        rich.getManifest().getTemplates().get(0).getBindings().stream()
+            .anyMatch(
+                b -> PSWidgetXmlCompiler.FULL_CODE_BINDING_VARIABLE.equals(b.getVariable())));
+    assertTrue(
+        rich.getTextArtifacts()
+            .get("templates/percRichTextSnippet.vm")
+            .contains("$node.getProperty('rx:text')"));
+
+    Path outRoot = tempDir.resolve("baseWidgets-out");
+    PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
+    assertTrue(
+        Files.isRegularFile(
+            outRoot
+                .resolve("percSimpleText")
+                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+  }
+
+  @Test
+  void parseEmptyXml_throws() {
+    assertThrows(PSWidgetXmlException.class, () -> PSWidgetXmlParser.parse("   "));
+  }
+
+  @Test
+  void parseNonWidgetRoot_throws() {
+    assertThrows(
+        PSWidgetXmlException.class, () -> PSWidgetXmlParser.parse("<NotWidget/>"));
+  }
+
+  @Test
+  void toPackageRelativePath_stripsLeadingSlash() {
+    assertEquals(
+        "rx_resources/widgets/x.png",
+        PSWidgetXmlCompiler.toPackageRelativePath("/rx_resources/widgets/x.png"));
+    assertEquals(
+        "rx_resources/widgets/x.png",
+        PSWidgetXmlCompiler.toPackageRelativePath("rx_resources/widgets/x.png"));
+  }
+
+  @Test
+  void mapAssembler_velocityHtmlMarkdown() {
+    assertEquals("velocityAssembler", PSWidgetXmlCompiler.mapAssembler("velocity"));
+    assertEquals("htmlAssembler", PSWidgetXmlCompiler.mapAssembler("html"));
+    assertEquals("markdownAssembler", PSWidgetXmlCompiler.mapAssembler("markdown"));
+  }
+
+  private static PSWidgetXmlPackageContext baseWidgetsLikeContext() {
+    PSWidgetXmlPackageContext ctx = new PSWidgetXmlPackageContext();
+    ctx.setPackageId("perc.baseWidgets");
+    ctx.setPackageName("perc.baseWidgets");
+    ctx.setVersion("1.1.9");
+    ctx.setDescription("The base widgets plugin for Percussion CM.");
+    ctx.setPublisherName("Percussion Software Inc.");
+    ctx.setPublisherUrl("http://www.percussion.com");
+    ctx.setCmsMin("1.0.0");
+    ctx.setCmsMax("9.0.0");
+    return ctx;
+  }
+
+  private static PSWidgetXmlModel parseClasspath(String resource, String fileName)
+      throws Exception {
+    try (InputStream in = PSWidgetXmlCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return PSWidgetXmlParser.parse(in, fileName);
+    }
+  }
+
+  private static String readClasspath(String resource) throws Exception {
+    try (InputStream in = PSWidgetXmlCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  /**
+   * Locate product {@code perc.baseWidgets} sources relative to the module working directory (Maven
+   * surefire cwd = module root).
+   */
+  private static Path locateBaseWidgetsPackage() {
+    Path candidate =
+        Path.of("src", "main", "resources", "Packages", "perc.baseWidgets");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    // Fallback: walk up from user.dir (rarely needed).
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src")
+            .resolve("main")
+            .resolve("resources")
+            .resolve("Packages")
+            .resolve("perc.baseWidgets");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}

--- a/modules/perc-packages/src/test/resources/manifests/minimal-component-package.json
+++ b/modules/perc-packages/src/test/resources/manifests/minimal-component-package.json
@@ -1,0 +1,105 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.widget.title",
+  "name": "Title",
+  "version": "1.1.4",
+  "description": "Widget to enter the Page title",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Title",
+    "category": "content",
+    "description": "Widget to enter the Page title",
+    "thumbnail": "resources/images/widgetTitle.png",
+    "icon": "resources/images/widgetTitle.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 302,
+    "createSharedAsset": false,
+    "editableOnTemplate": false,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTitleAsset",
+      "ref": "contentTypes/percTitleAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTitleSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTitleSnippet.vm",
+      "contentType": "percTitleAsset",
+      "bindings": [
+        {
+          "variable": "wrapper",
+          "expression": "$perc.widget.item.properties.get('wrapper')"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "titleContent",
+      "allowedContentTypes": [
+        "percTitleAsset"
+      ],
+      "layout": {
+        "orientation": "vertical"
+      },
+      "styles": {
+        "rootClass": "perc-title-slot"
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/images/widgetTitle.png",
+      "target": "rx_resources/widgets/title/images/widgetTitle.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "wrapper",
+      "displayName": "Choose format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "h1",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percSimpleText.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percSimpleText.component-package.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percSimpleText",
+  "name": "Simple Text",
+  "version": "1.1.9",
+  "description": "Widget used for entering plain text",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Simple Text",
+    "category": "content",
+    "description": "Widget used for entering plain text",
+    "thumbnail": "resources/widgetIconSimpleText.png",
+    "icon": "resources/widgetIconSimpleText.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 640,
+    "preferredEditorHeight": 500,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSimpleTextAsset",
+      "ref": "contentTypes/percSimpleTextAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percSimpleTextSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percSimpleTextSnippet.vm",
+      "contentType": "percSimpleTextAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percSimpleTextContent",
+      "allowedContentTypes": [
+        "percSimpleTextAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconSimpleText.png",
+      "target": "rx_resources/widgets/PSWidget_SimpleText/images/widgetIconSimpleText.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percSimpleTextSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percSimpleTextSnippet.vm
@@ -1,0 +1,9 @@
+<div$!{classAttribute}>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+$rx.pageutils.html($node,'rx:text')##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("simple-text-sample-content", "This simple text widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/percRawHtml.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percRawHtml.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="HTML"
+		contenttype_name="percRawHtmlAsset" category="integration"
+		description="Widget to accept and render raw html code."
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/PSWidget_RawHtml/images/widgetIconHtm.png"
+		preferred_editor_width="785" preferred_editor_height="405"
+		is_responsive="true" />
+	<Content type="velocity"><![CDATA[#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set( $node = $perc.widgetContents.get(0).node )##
+#set ( $widgetHtml = $node.getProperty('rx:html').getString() )##
+#set ( $widgetHtml = $rx.pageutils.updateManagedLinks($perc.linkContext, $widgetHtml,  $sys.assemblyItem.PubServerId,$node.getProperty('sys_contentid').String ) )##
+#set ( $widgetHtml = $widgetHtml.replace("<PRESERVE>", "" ) )##
+#set ( $widgetHtml = $widgetHtml.replace("</PRESERVE>", "" ) )##
+$!{widgetHtml}
+#elseif ( $perc.isEditMode() )##
+#createEmptyWidgetContent( "html-sample-content", "This HTML widget is showing sample content." )##
+#end##
+]]></Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/percSimpleText.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percSimpleText.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Simple Text"
+		contenttype_name="percSimpleTextAsset" category="content"
+		description="Widget used for entering plain text"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/PSWidget_SimpleText/images/widgetIconSimpleText.png"
+		preferred_editor_width="640" preferred_editor_height="500"
+		is_responsive="true" />
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+	<Code type="jexl">
+        <![CDATA[
+    $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+    if (!empty($rootclass))
+        $classAttribute = ' class="' + $rootclass + '"';
+    ]]>
+	</Code>
+	<Content type="velocity"><![CDATA[<div$!{classAttribute}>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+$rx.pageutils.html($node,'rx:text')##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("simple-text-sample-content", "This simple text widget is showing sample content.")##
+#end##
+</div>]]></Content>
+</Widget>


### PR DESCRIPTION
## Summary

Implements **Phase 3 slice 2** of parent **#2630** (epic **#2626**, ADR-004): **Widget XML → Component Package Manifest compiler** for **baseWidgets / simple widgets**, with golden parity for Simple Text.

- `PSWidgetXmlParser` — XXE-hardened DOM parse of upgrade-input `<Widget>` XML
- `PSWidgetXmlCompiler` — emits `PSComponentPackageManifest` + template text artifacts (JEXL bindings + Velocity source)
- `PSWidgetXmlPackageCompiler` — scans `sys__UserDependency--rxconfig/Widgets/*.xml` under a package root
- Golden parity: `percSimpleText` manifest + `.vm` template; package test covers all 3 baseWidgets
- Inventory + schema docs note residual high-traffic packages (nav/blog/lists/…)

**Depends on #2754** (Component Package Manifest model, #2750). This branch is based on `feat/issue-2750-component-package-manifest` so the shared types compile. Prefer merge **after** #2754 (or rebase once #2754 lands) to avoid thrash.

**Out of scope:** product Widget XML removal, high-traffic package conversion, runtime legacy shim (#2752).

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2751
Refs #2630 #2626 #2750
Parent: #2630

## Test plan

- [x] `cd modules/perc-packages && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] Tests run: **22**, Failures: **0** (includes 9 new `PSWidgetXmlCompilerTest`)
- [x] Golden parity for percSimpleText manifest + template source
- [x] Package compile of product `perc.baseWidgets` (3 widgets) validates
- [ ] Review residual inventory note for high-traffic packages
- [ ] Coordinate merge order with #2754

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang self-review | Pass — portable Path/Files; package paths URL `/`; XXE-hardened XML; no product XML deletion |
| Module clean install | `cd modules/perc-packages` → `..\..\mvnw.cmd clean install` → BUILD SUCCESS |
| Change-class companions | parser + compiler + package scanner + golden fixtures + inventory/schema docs |
| Human QA | Not required — compiler/unit golden only; no UI/install path change yet |

> Co-Authored by Grok Build using grok-4.5 with agent main.
