### PR TITLE
feat(perc-packages): runtime legacy definition-XML shim + dual-run docs (#2752)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -52,6 +52,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | [widget-xml-inventory.md](./widget-xml-inventory.md) | Product widget matrix (48 defs) |
 | [widget-xml-inventory.csv](./widget-xml-inventory.csv) | Machine-readable inventory |
 | [gadget-definition-inventory.md](./gadget-definition-inventory.md) | Gadget XML / SPA survey |
+| [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) | Phase 3 dual-run operator policy + runtime shim selection (#2752) |
 | [adr/](./adr/) | Architecture decision records |
 | [parity-notes.md](./parity-notes.md) | Region vs slot, pageAssembler vs velocity, etc. |
 | [region-slot-mapping.md](./region-slot-mapping.md) | Phase 2 residual: region↔slot composition + CssPref upgrade (#2690) |
@@ -70,7 +71,9 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | JEXL | `modules/utils/.../jexl/PSScript.java` |
 | CM1 page assembler | `projects/sitemanage/.../assembler/PSPageAssembler.java` |
 | Widget model | `projects/sitemanage/.../data/PSWidgetDefinition.java` |
+| Widget DAO (legacy XML load) | `projects/sitemanage/.../dao/impl/PSWidgetDao.java` (`rxconfig/Widgets`) |
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
+| Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 
 ## Immediate next work

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -35,3 +35,4 @@ Content types + Templates (assembler + JEXL bindings + source)
 - Compiler/upgrade tooling is mandatory before deleting package XML.
 - Widget Builder / Design tools write modern format only.
 - Package install/export paths must understand the new manifest shape (prefer extending existing package system).
+- **Dual-run runtime shim (time-boxed):** selection prefers modern `component-package.json`, falls back to legacy Widget/Page/Gadget definition XML when modern is absent, and fails clearly when neither exists. Implementation: `com.percussion.packages.shim.PSLegacyDefinitionXmlShim` (#2752). Operator policy, entry points, and exit criteria: [dual-run-legacy-definition-xml-shim.md](../dual-run-legacy-definition-xml-shim.md). Product packages must not depend on the shim long-term; Phase 5 (#2632) removes it when metrics allow.

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -1,0 +1,107 @@
+# Dual-run: legacy definition-XML runtime shim
+
+| Field | Value |
+|-------|--------|
+| **Status** | Accepted for Phase 3 slice 3 (#2752) |
+| **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) (Phase 3) |
+| **Epic** | [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
+| **Code** | `com.percussion.packages.shim.PSLegacyDefinitionXmlShim` (`modules/perc-packages`) |
+| **Related slices** | Manifest model #2750 / PR #2754; Widget XML compiler #2751 / PR #2755 |
+
+## Purpose
+
+During the 8.2 dual-run window, **customer** installs may still have Widget / Page / Gadget **definition XML** while product moves to **Component Package Manifest** (`component-package.json`) + CT / template / slot / catalog artifacts.
+
+This document is the **operator policy** for that window. Selection logic is implemented and unit-tested in `PSLegacyDefinitionXmlShim`. Product packages must **not** treat the shim as a permanent authoring path.
+
+## Selection policy (runtime)
+
+Hard order for a package root or definition id:
+
+1. **Modern preferred** — if `component-package.json` is present (Component Package Manifest, schema v1.0), use the modern package. Do **not** prefer co-located legacy XML when modern exists.
+2. **Legacy XML fallback** — if modern is absent and legacy Widget / Page / Gadget definition XML is present, load as today.
+3. **Neither** — fail with a clear error naming the definition id and expected locations (modern manifest vs legacy `rxconfig/Widgets|Pages|Gadgets` / package staging). Do not invent a silent default.
+
+```text
+                    ┌─────────────────────────┐
+                    │ Resolve definition id / │
+                    │ package root            │
+                    └───────────┬─────────────┘
+                                │
+              modern manifest?  │
+                    ┌───────────┴───────────┐
+                    │ yes                   │ no
+                    ▼                       ▼
+         MODERN_COMPONENT_PACKAGE    legacy Widget/Page/Gadget XML?
+                                            │
+                              ┌─────────────┴─────────────┐
+                              │ yes                       │ no
+                              ▼                           ▼
+                     LEGACY_*_XML          PSDefinitionSourceNotFoundException
+```
+
+## Runtime entry points (document)
+
+| Surface | Path / class | Role today | Dual-run note |
+|---------|--------------|------------|---------------|
+| Widget definitions (install) | `${rxdeploydir}/rxconfig/Widgets/*.xml` via `PSWidgetDao` (`projects/sitemanage/.../dao/impl/PSWidgetDao`) | Loads legacy Widget XML by file id | Prefer modern package when present; XML remains fallback for unconverted customer defs |
+| Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; product source of truth moves off XML (ADR-004) |
+| Package staging Widgets | `sys__UserDependency--rxconfig/Widgets/` or `rxconfig/Widgets/` under a package root | Upgrade-input / deploy layout | Shim package-root API resolves either layout |
+| Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Treat remaining definition XML as legacy only |
+| Page meta / definition XML | Site/page storage dialects | Composition authoring legacy | Page conversion is Phase 3 residual; shim recognizes `rxconfig/Pages` if present |
+
+**Selection API (no Spring wiring required for unit use):**
+
+- `PSLegacyDefinitionXmlShim.selectByPresence(...)` — pure flags (tests / metrics)
+- `PSLegacyDefinitionXmlShim.selectForPackageRoot(Path)` — package directory
+- `PSLegacyDefinitionXmlShim.selectDefinition(id, modernRoots, widgetsDir, pagesDir, gadgetsDir)` — dual-run by id
+
+Deep rewiring of `PSWidgetDao` to call the shim for every load is **incremental** and may land with residual wiring after modern packages appear on disk; this slice ships the **policy + tested selection** and operator docs.
+
+## Time box / deprecation
+
+| Milestone | Expectation |
+|-----------|-------------|
+| **Now (Phase 3 dual-run)** | Shim available; modern preferred; legacy customer XML still loads |
+| **Product packages converted** | Product source trees no longer authored as Widget/Page/Gadget definition XML (#2751 baseWidgets, high-traffic residuals) |
+| **Customer conversion** | Operators run Widget XML compiler / upgrade path; measure remaining XML loads |
+| **Phase 5 (#2632)** | Remove shim when metrics show zero (or accepted residual) legacy definition XML loads; help rewrite |
+
+**Rules for product engineering:**
+
+1. Do **not** add new product features that **require** definition XML.
+2. Widget Builder / Design tools write **modern** format only (ADR-004).
+3. Compilers (#2751) read XML as **upgrade input** only — not as ship format.
+4. Log or metric `wouldUseLegacyShim` / selection kind when wiring is complete so Phase 5 has exit data.
+
+## Operator dual-run checklist
+
+1. **Inventory** customer Widget XML under install `rxconfig/Widgets` (and package archives if applicable).
+2. **Convert** using the Widget XML → Component Package Manifest compiler when available (#2751).
+3. **Deploy** modern packages (`component-package.json` + artifacts) beside or instead of XML.
+4. **Verify** selection: modern present ⇒ modern wins even if old XML remains on disk.
+5. **Remove** legacy XML after smoke/parity for converted definitions.
+6. **Exit dual-run** when no required customer definitions rely on the XML path (Phase 5).
+
+## Exit criteria (shim retirement)
+
+The dual-run window ends when **all** of the following hold:
+
+- [ ] Product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar).
+- [ ] Customer upgrade path documented and used for remaining XML.
+- [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived.
+- [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help.
+
+## Non-goals
+
+- Completing full product package conversion (sibling #2750 / #2751 and residuals)
+- Multi-RDBMS matrix or host-only install validation
+- Phase 4 Design SPA (#2631) or full Phase 5 help rewrite (#2632)
+
+## See also
+
+- [ADR-004](./adr/004-no-definition-xml-packaging.md) — no definition XML for product packaging
+- [component-package-manifest.md](./component-package-manifest.md) — modern ship format (when present on branch)
+- [plan.md](./plan.md) — Phase 3 goals
+- [widget-xml-inventory.md](./widget-xml-inventory.md) — product widget matrix

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSDefinitionSourceKind.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSDefinitionSourceKind.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.shim;
+
+/**
+ * Source kind chosen by the time-boxed legacy definition-XML runtime shim (ADR-004 / issue #2752).
+ *
+ * <p><strong>Prefer modern</strong> component package manifests; fall back to legacy Widget / Page
+ * / Gadget definition XML only when the modern package is absent. Product packages must not depend
+ * on the legacy path long-term.
+ */
+public enum PSDefinitionSourceKind {
+
+  /** Modern ship format: {@code component-package.json} (Component Package Manifest). */
+  MODERN_COMPONENT_PACKAGE,
+
+  /** Legacy Widget definition XML under {@code rxconfig/Widgets} (or package staging equivalent). */
+  LEGACY_WIDGET_XML,
+
+  /** Legacy Page meta / definition XML dialect. */
+  LEGACY_PAGE_XML,
+
+  /** Legacy per-gadget OpenSocial-style definition XML. */
+  LEGACY_GADGET_XML
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSDefinitionSourceNotFoundException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSDefinitionSourceNotFoundException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.shim;
+
+/**
+ * Thrown when neither a modern component package nor legacy definition XML is available for a
+ * definition id / package root. Message is operator-facing and lists expected locations.
+ */
+public final class PSDefinitionSourceNotFoundException extends Exception {
+
+  /** Definition or package id that could not be resolved (may be {@code null}). */
+  private final String definitionId;
+
+  /**
+   * Creates an exception for a missing modern package and missing legacy definition XML.
+   *
+   * @param definitionId definition or package id (may be {@code null})
+   * @param message operator-facing detail (must not be {@code null})
+   */
+  public PSDefinitionSourceNotFoundException(String definitionId, String message) {
+    super(message);
+    this.definitionId = definitionId;
+  }
+
+  /**
+   * Returns the definition or package id that failed resolution.
+   *
+   * @return definition or package id, or {@code null} if unknown
+   */
+  public String getDefinitionId() {
+    return definitionId;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSDefinitionSourceSelection.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSDefinitionSourceSelection.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.shim;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Result of {@link PSLegacyDefinitionXmlShim} selection: which source kind won and the primary path
+ * used for that decision (manifest file, XML file, or package root).
+ */
+public final class PSDefinitionSourceSelection {
+
+  private final PSDefinitionSourceKind kind;
+  private final String definitionId;
+  private final Path primaryPath;
+
+  /**
+   * Creates a selection result for the shim.
+   *
+   * @param kind selected source kind (required)
+   * @param definitionId optional definition or package id
+   * @param primaryPath optional primary path (manifest or XML); may be {@code null} for pure
+   *     presence-based selection
+   */
+  public PSDefinitionSourceSelection(
+      PSDefinitionSourceKind kind, String definitionId, Path primaryPath) {
+    this.kind = Objects.requireNonNull(kind, "kind");
+    this.definitionId = definitionId;
+    this.primaryPath = primaryPath;
+  }
+
+  /**
+   * Returns the selected source kind.
+   *
+   * @return selected source kind
+   */
+  public PSDefinitionSourceKind getKind() {
+    return kind;
+  }
+
+  /**
+   * Returns the optional definition or package id associated with this selection.
+   *
+   * @return optional definition or package id
+   */
+  public Optional<String> getDefinitionId() {
+    return Optional.ofNullable(definitionId);
+  }
+
+  /**
+   * Primary filesystem path for the selected source (e.g. {@code component-package.json} or a
+   * Widget XML file). May be empty only for pure presence-based selection without paths.
+   *
+   * @return optional primary path
+   */
+  public Optional<Path> getPrimaryPath() {
+    return Optional.ofNullable(primaryPath);
+  }
+
+  /**
+   * Whether the modern component package was selected.
+   *
+   * @return {@code true} when modern
+   */
+  public boolean isModern() {
+    return kind == PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE;
+  }
+
+  /**
+   * Whether a legacy Widget/Page/Gadget XML source was selected.
+   *
+   * @return {@code true} when legacy XML
+   */
+  public boolean isLegacyXml() {
+    return !isModern();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSDefinitionSourceSelection that)) {
+      return false;
+    }
+    return kind == that.kind
+        && Objects.equals(definitionId, that.definitionId)
+        && Objects.equals(primaryPath, that.primaryPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(kind, definitionId, primaryPath);
+  }
+
+  @Override
+  public String toString() {
+    return "PSDefinitionSourceSelection{kind="
+        + kind
+        + ", definitionId='"
+        + definitionId
+        + "', primaryPath="
+        + primaryPath
+        + '}';
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.shim;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Time-boxed <strong>runtime compatibility shim</strong> for customer legacy Widget / Page /
+ * Gadget definition XML when no modern Component Package Manifest is present (ADR-004, Phase 3
+ * slice #2752, parent #2630 / epic #2626).
+ *
+ * <h2>Selection policy (hard order)</h2>
+ *
+ * <ol>
+ *   <li><strong>Modern preferred</strong> — if {@value #MODERN_MANIFEST_FILE_NAME} is present for
+ *       the package (or a matching definition id under a modern package root), use {@link
+ *       PSDefinitionSourceKind#MODERN_COMPONENT_PACKAGE}.
+ *   <li><strong>Legacy XML fallback</strong> — when modern is absent, load legacy Widget / Page /
+ *       Gadget definition XML if present (same paths product uses today).
+ *   <li><strong>Neither</strong> — throw {@link PSDefinitionSourceNotFoundException} with a clear
+ *       operator-facing message (do not silently invent a source).
+ * </ol>
+ *
+ * <h2>Time box / deprecation</h2>
+ *
+ * <p>This shim is <strong>transitional</strong>. Product packages must not depend on legacy
+ * definition XML as the authoring source of truth. Operators should convert customer XML via the
+ * Widget XML compiler (#2751) and remove XML loads once conversion metrics allow (Phase 5 / #2632).
+ * Dual-run policy and exit criteria: {@code
+ * docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md}.
+ *
+ * <h2>Runtime entry points (document only — wiring is incremental)</h2>
+ *
+ * <ul>
+ *   <li>Widgets: {@code projects/sitemanage/.../dao/impl/PSWidgetDao} — repository {@code
+ *       ${rxdeploydir}/rxconfig/Widgets} (legacy XML files named by definition id).
+ *   <li>Package source trees: {@code modules/perc-packages/.../Packages/<id>/} with either {@code
+ *       component-package.json} (modern) or {@code sys__UserDependency--rxconfig/Widgets/*.xml}
+ *       (legacy).
+ *   <li>Gadget registry / page meta: see dual-run operator doc for remaining load surfaces.
+ * </ul>
+ *
+ * <p>This class owns <strong>selection logic</strong> only. Full product conversion and DAO
+ * rewrites are sibling / residual slices; callers pass paths and act on the returned {@link
+ * PSDefinitionSourceSelection}.
+ *
+ * <p>Filesystem APIs use {@link Path} / {@link Files} (portable Windows / Linux / macOS).
+ */
+public final class PSLegacyDefinitionXmlShim {
+
+  /** Default modern Component Package Manifest file name (schema v1.0 / #2750). */
+  public static final String MODERN_MANIFEST_FILE_NAME = "component-package.json";
+
+  private PSLegacyDefinitionXmlShim() {
+    // utility
+  }
+
+  /**
+   * Pure selection from presence flags (unit-testable without I/O). Preference order: modern →
+   * widget XML → page XML → gadget XML. If nothing is present, throws.
+   *
+   * @param definitionId optional id for error messages (may be {@code null})
+   * @param modernPresent modern {@code component-package.json} (or equivalent) present
+   * @param legacyWidgetXmlPresent at least one Widget definition XML present
+   * @param legacyPageXmlPresent at least one Page definition XML present
+   * @param legacyGadgetXmlPresent at least one Gadget definition XML present
+   * @return selected kind (never null)
+   * @throws PSDefinitionSourceNotFoundException if no source is present
+   */
+  public static PSDefinitionSourceSelection selectByPresence(
+      String definitionId,
+      boolean modernPresent,
+      boolean legacyWidgetXmlPresent,
+      boolean legacyPageXmlPresent,
+      boolean legacyGadgetXmlPresent)
+      throws PSDefinitionSourceNotFoundException {
+    if (modernPresent) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, definitionId, null);
+    }
+    if (legacyWidgetXmlPresent) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_WIDGET_XML, definitionId, null);
+    }
+    if (legacyPageXmlPresent) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_PAGE_XML, definitionId, null);
+    }
+    if (legacyGadgetXmlPresent) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_GADGET_XML, definitionId, null);
+    }
+    throw notFound(definitionId, null);
+  }
+
+  /**
+   * Select source for a single product / customer <strong>package root</strong> directory.
+   *
+   * <p>Modern wins if {@link #MODERN_MANIFEST_FILE_NAME} exists under the root. Otherwise legacy
+   * Widget XML under package staging or install-relative Widgets is preferred over page/gadget
+   * markers when both exist in the same tree (widgets are the primary dual-run surface).
+   *
+   * @param packageRoot package source or install package directory (must not be null)
+   * @return selection with primary path set to the manifest or first legacy XML found
+   * @throws PSDefinitionSourceNotFoundException if neither modern nor legacy definition material is
+   *     found
+   * @throws IOException if the package root cannot be listed
+   */
+  public static PSDefinitionSourceSelection selectForPackageRoot(Path packageRoot)
+      throws PSDefinitionSourceNotFoundException, IOException {
+    Objects.requireNonNull(packageRoot, "packageRoot");
+    Path root = packageRoot.toAbsolutePath().normalize();
+    String packageName = root.getFileName() != null ? root.getFileName().toString() : root.toString();
+
+    Path modernManifest = root.resolve(MODERN_MANIFEST_FILE_NAME);
+    if (Files.isRegularFile(modernManifest)) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, packageName, modernManifest);
+    }
+
+    Optional<Path> widgetXml = findFirstXml(resolvePackageWidgetsDir(root));
+    if (widgetXml.isPresent()) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_WIDGET_XML, packageName, widgetXml.get());
+    }
+
+    Optional<Path> pageXml = findFirstXml(root.resolve("rxconfig").resolve("Pages"));
+    if (pageXml.isEmpty()) {
+      pageXml = findFirstXml(root.resolve("sys__UserDependency--rxconfig").resolve("Pages"));
+    }
+    if (pageXml.isPresent()) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_PAGE_XML, packageName, pageXml.get());
+    }
+
+    Optional<Path> gadgetXml = findFirstXml(root.resolve("rxconfig").resolve("Gadgets"));
+    if (gadgetXml.isEmpty()) {
+      gadgetXml = findFirstXml(root.resolve("sys__UserDependency--rxconfig").resolve("Gadgets"));
+    }
+    if (gadgetXml.isPresent()) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_GADGET_XML, packageName, gadgetXml.get());
+    }
+
+    throw notFound(
+        packageName,
+        "Package root: "
+            + root
+            + ". Expected either "
+            + MODERN_MANIFEST_FILE_NAME
+            + " (modern) or legacy definition XML under rxconfig/Widgets|Pages|Gadgets (or package staging sys__UserDependency--rxconfig/...).");
+  }
+
+  /**
+   * Resolve a single <strong>definition id</strong> against modern package roots and legacy install
+   * directories (the dual-run runtime path).
+   *
+   * <p>Modern preferred: any {@code modernPackageRoot} that is a directory containing {@link
+   * #MODERN_MANIFEST_FILE_NAME} and whose folder name equals {@code definitionId}, <em>or</em>
+   * whose manifest sibling folder name matches, wins. Legacy fallback: {@code
+   * legacyWidgetsDir/definitionId.xml}, then pages, then gadgets.
+   *
+   * @param definitionId widget / page / gadget definition id (non-empty)
+   * @param modernPackageRoots zero or more package directories that may hold modern manifests
+   * @param legacyWidgetsDir install {@code rxconfig/Widgets} (may be null)
+   * @param legacyPagesDir optional pages definition directory (may be null)
+   * @param legacyGadgetsDir optional gadgets definition directory (may be null)
+   * @return selection with primary path
+   * @throws PSDefinitionSourceNotFoundException if neither modern nor legacy source exists
+   */
+  public static PSDefinitionSourceSelection selectDefinition(
+      String definitionId,
+      List<Path> modernPackageRoots,
+      Path legacyWidgetsDir,
+      Path legacyPagesDir,
+      Path legacyGadgetsDir)
+      throws PSDefinitionSourceNotFoundException {
+    if (definitionId == null || definitionId.isBlank()) {
+      throw new IllegalArgumentException("definitionId must be non-blank");
+    }
+    List<Path> roots =
+        modernPackageRoots != null ? modernPackageRoots : List.of();
+
+    for (Path candidate : roots) {
+      if (candidate == null) {
+        continue;
+      }
+      Path normalized = candidate.toAbsolutePath().normalize();
+      if (!Files.isDirectory(normalized)) {
+        continue;
+      }
+      String folderName =
+          normalized.getFileName() != null ? normalized.getFileName().toString() : "";
+      Path manifest = normalized.resolve(MODERN_MANIFEST_FILE_NAME);
+      if (Files.isRegularFile(manifest)
+          && (definitionId.equals(folderName) || folderMatchesDefinition(folderName, definitionId))) {
+        return new PSDefinitionSourceSelection(
+            PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, definitionId, manifest);
+      }
+    }
+
+    Path widgetXml = resolveLegacyXmlFile(legacyWidgetsDir, definitionId);
+    if (widgetXml != null) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_WIDGET_XML, definitionId, widgetXml);
+    }
+
+    Path pageXml = resolveLegacyXmlFile(legacyPagesDir, definitionId);
+    if (pageXml != null) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_PAGE_XML, definitionId, pageXml);
+    }
+
+    Path gadgetXml = resolveLegacyXmlFile(legacyGadgetsDir, definitionId);
+    if (gadgetXml != null) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.LEGACY_GADGET_XML, definitionId, gadgetXml);
+    }
+
+    List<String> searched = new ArrayList<>();
+    searched.add("modern package roots (" + roots.size() + ") for " + MODERN_MANIFEST_FILE_NAME);
+    if (legacyWidgetsDir != null) {
+      searched.add(legacyWidgetsDir.toAbsolutePath().normalize() + " / " + definitionId + ".xml");
+    }
+    if (legacyPagesDir != null) {
+      searched.add(legacyPagesDir.toAbsolutePath().normalize() + " / " + definitionId + ".xml");
+    }
+    if (legacyGadgetsDir != null) {
+      searched.add(legacyGadgetsDir.toAbsolutePath().normalize() + " / " + definitionId + ".xml");
+    }
+    throw notFound(
+        definitionId,
+        "No modern component package and no legacy definition XML for id '"
+            + definitionId
+            + "'. Searched: "
+            + String.join("; ", searched)
+            + ". Convert legacy XML with the Widget XML compiler or install a modern component package.");
+  }
+
+  /**
+   * Whether the given package root would use the legacy XML shim path (modern absent, legacy
+   * present). Useful for operator metrics / dual-run dashboards.
+   *
+   * @param packageRoot package source or install package directory
+   * @return {@code true} if selection resolves to a legacy XML kind; {@code false} if modern is
+   *     chosen or nothing is found
+   * @throws IOException if the package root cannot be listed while probing
+   */
+  public static boolean wouldUseLegacyShim(Path packageRoot) throws IOException {
+    try {
+      return selectForPackageRoot(packageRoot).isLegacyXml();
+    } catch (PSDefinitionSourceNotFoundException e) {
+      return false;
+    }
+  }
+
+  private static boolean folderMatchesDefinition(String folderName, String definitionId) {
+    // Product packages often use perc.widget.* folder names while XML file is percSimpleText.
+    // Exact folder match is primary; callers that need id-inside-manifest matching will use #2750 IO.
+    return folderName != null && folderName.equalsIgnoreCase(definitionId);
+  }
+
+  private static Path resolvePackageWidgetsDir(Path packageRoot) {
+    Path staging = packageRoot.resolve("sys__UserDependency--rxconfig").resolve("Widgets");
+    if (Files.isDirectory(staging)) {
+      return staging;
+    }
+    return packageRoot.resolve("rxconfig").resolve("Widgets");
+  }
+
+  private static Path resolveLegacyXmlFile(Path dir, String definitionId) {
+    if (dir == null || !Files.isDirectory(dir)) {
+      return null;
+    }
+    Path file = dir.resolve(definitionId + ".xml");
+    return Files.isRegularFile(file) ? file : null;
+  }
+
+  private static Optional<Path> findFirstXml(Path dir) throws IOException {
+    if (dir == null || !Files.isDirectory(dir)) {
+      return Optional.empty();
+    }
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, "*.xml")) {
+      for (Path p : stream) {
+        if (Files.isRegularFile(p)) {
+          return Optional.of(p);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static PSDefinitionSourceNotFoundException notFound(String definitionId, String detail) {
+    String base =
+        "No definition source found"
+            + (definitionId != null && !definitionId.isBlank() ? " for '" + definitionId + "'" : "")
+            + ": neither modern component package ("
+            + MODERN_MANIFEST_FILE_NAME
+            + ") nor legacy Widget/Page/Gadget definition XML is present.";
+    String message = detail == null || detail.isBlank() ? base : base + " " + detail;
+    return new PSDefinitionSourceNotFoundException(definitionId, message);
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShimTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShimTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.shim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral tests for runtime legacy definition-XML shim selection (issue #2752 / ADR-004).
+ *
+ * <p>Policy: modern component package preferred; legacy Widget/Page/Gadget XML when modern absent;
+ * clear error when neither is present.
+ */
+class PSLegacyDefinitionXmlShimTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void selectByPresence_prefersModernEvenWhenLegacyAlsoPresent() throws Exception {
+    PSDefinitionSourceSelection s =
+        PSLegacyDefinitionXmlShim.selectByPresence(
+            "percSimpleText", true, true, true, true);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, s.getKind());
+    assertTrue(s.isModern());
+    assertFalse(s.isLegacyXml());
+  }
+
+  @Test
+  void selectByPresence_fallsBackToWidgetXmlWhenModernAbsent() throws Exception {
+    PSDefinitionSourceSelection s =
+        PSLegacyDefinitionXmlShim.selectByPresence("w1", false, true, true, true);
+    assertEquals(PSDefinitionSourceKind.LEGACY_WIDGET_XML, s.getKind());
+    assertTrue(s.isLegacyXml());
+  }
+
+  @Test
+  void selectByPresence_pageThenGadgetWhenWidgetAbsent() throws Exception {
+    PSDefinitionSourceSelection page =
+        PSLegacyDefinitionXmlShim.selectByPresence("p1", false, false, true, true);
+    assertEquals(PSDefinitionSourceKind.LEGACY_PAGE_XML, page.getKind());
+
+    PSDefinitionSourceSelection gadget =
+        PSLegacyDefinitionXmlShim.selectByPresence("g1", false, false, false, true);
+    assertEquals(PSDefinitionSourceKind.LEGACY_GADGET_XML, gadget.getKind());
+  }
+
+  @Test
+  void selectByPresence_neitherThrowsClearError() {
+    PSDefinitionSourceNotFoundException ex =
+        assertThrows(
+            PSDefinitionSourceNotFoundException.class,
+            () ->
+                PSLegacyDefinitionXmlShim.selectByPresence(
+                    "missingWidget", false, false, false, false));
+    assertEquals("missingWidget", ex.getDefinitionId());
+    assertTrue(ex.getMessage().contains("component-package.json"));
+    assertTrue(ex.getMessage().contains("legacy"));
+    assertTrue(ex.getMessage().contains("missingWidget"));
+  }
+
+  @Test
+  void selectForPackageRoot_modernPreferredWhenBothPresent() throws Exception {
+    Path pkg = tempDir.resolve("perc.widget.demo");
+    Files.createDirectories(pkg);
+    Path manifest = pkg.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME);
+    Files.writeString(manifest, "{\"schemaVersion\":\"1.0\",\"id\":\"demo\"}", StandardCharsets.UTF_8);
+
+    Path widgets = pkg.resolve("sys__UserDependency--rxconfig").resolve("Widgets");
+    Files.createDirectories(widgets);
+    Files.writeString(widgets.resolve("demo.xml"), "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s = PSLegacyDefinitionXmlShim.selectForPackageRoot(pkg);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, s.getKind());
+    assertEquals(manifest, s.getPrimaryPath().orElseThrow());
+    assertEquals("perc.widget.demo", s.getDefinitionId().orElseThrow());
+  }
+
+  @Test
+  void selectForPackageRoot_legacyWidgetWhenModernAbsent() throws Exception {
+    Path pkg = tempDir.resolve("legacyPkg");
+    Path widgets = pkg.resolve("sys__UserDependency--rxconfig").resolve("Widgets");
+    Files.createDirectories(widgets);
+    Path xml = widgets.resolve("percSimpleText.xml");
+    Files.writeString(xml, "<Widget id=\"percSimpleText\"/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s = PSLegacyDefinitionXmlShim.selectForPackageRoot(pkg);
+    assertEquals(PSDefinitionSourceKind.LEGACY_WIDGET_XML, s.getKind());
+    assertEquals(xml, s.getPrimaryPath().orElseThrow());
+    assertTrue(PSLegacyDefinitionXmlShim.wouldUseLegacyShim(pkg));
+  }
+
+  @Test
+  void selectForPackageRoot_installRelativeWidgetsPath() throws Exception {
+    Path pkg = tempDir.resolve("installStyle");
+    Path widgets = pkg.resolve("rxconfig").resolve("Widgets");
+    Files.createDirectories(widgets);
+    Path xml = widgets.resolve("w.xml");
+    Files.writeString(xml, "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s = PSLegacyDefinitionXmlShim.selectForPackageRoot(pkg);
+    assertEquals(PSDefinitionSourceKind.LEGACY_WIDGET_XML, s.getKind());
+    assertEquals(xml, s.getPrimaryPath().orElseThrow());
+  }
+
+  @Test
+  void selectForPackageRoot_neitherThrows() throws Exception {
+    Path pkg = tempDir.resolve("emptyPkg");
+    Files.createDirectories(pkg);
+
+    PSDefinitionSourceNotFoundException ex =
+        assertThrows(
+            PSDefinitionSourceNotFoundException.class,
+            () -> PSLegacyDefinitionXmlShim.selectForPackageRoot(pkg));
+    assertTrue(ex.getMessage().contains(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME));
+    assertFalse(PSLegacyDefinitionXmlShim.wouldUseLegacyShim(pkg));
+  }
+
+  @Test
+  void selectDefinition_modernWinsOverLegacyXml() throws Exception {
+    Path modernRoot = tempDir.resolve("percSimpleText");
+    Files.createDirectories(modernRoot);
+    Path manifest = modernRoot.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME);
+    Files.writeString(manifest, "{}", StandardCharsets.UTF_8);
+
+    Path widgets = tempDir.resolve("Widgets");
+    Files.createDirectories(widgets);
+    Files.writeString(widgets.resolve("percSimpleText.xml"), "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s =
+        PSLegacyDefinitionXmlShim.selectDefinition(
+            "percSimpleText", List.of(modernRoot), widgets, null, null);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, s.getKind());
+    assertEquals(manifest, s.getPrimaryPath().orElseThrow());
+  }
+
+  @Test
+  void selectDefinition_legacyWidgetWhenNoModern() throws Exception {
+    Path widgets = tempDir.resolve("rxconfig").resolve("Widgets");
+    Files.createDirectories(widgets);
+    Path xml = widgets.resolve("percRawHtml.xml");
+    Files.writeString(xml, "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s =
+        PSLegacyDefinitionXmlShim.selectDefinition(
+            "percRawHtml", List.of(), widgets, null, null);
+    assertEquals(PSDefinitionSourceKind.LEGACY_WIDGET_XML, s.getKind());
+    assertEquals(xml, s.getPrimaryPath().orElseThrow());
+  }
+
+  @Test
+  void selectDefinition_neitherThrowsOperatorFacingMessage() {
+    Path widgets = tempDir.resolve("WidgetsEmpty");
+    try {
+      Files.createDirectories(widgets);
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+
+    PSDefinitionSourceNotFoundException ex =
+        assertThrows(
+            PSDefinitionSourceNotFoundException.class,
+            () ->
+                PSLegacyDefinitionXmlShim.selectDefinition(
+                    "noSuchWidget", List.of(), widgets, null, null));
+    assertEquals("noSuchWidget", ex.getDefinitionId());
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("noSuchWidget"));
+    assertTrue(msg.contains("component-package.json") || msg.contains("modern"));
+    assertTrue(msg.contains("legacy") || msg.contains("XML"));
+  }
+
+  @Test
+  void selectDefinition_blankIdRejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSLegacyDefinitionXmlShim.selectDefinition("  ", List.of(), null, null, null));
+  }
+
+  @Test
+  void selectDefinition_fallsBackToPageThenGadget() throws Exception {
+    Path pages = tempDir.resolve("Pages");
+    Files.createDirectories(pages);
+    Path pageXml = pages.resolve("homeMeta.xml");
+    Files.writeString(pageXml, "<Page/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection page =
+        PSLegacyDefinitionXmlShim.selectDefinition("homeMeta", List.of(), null, pages, null);
+    assertEquals(PSDefinitionSourceKind.LEGACY_PAGE_XML, page.getKind());
+
+    Path gadgets = tempDir.resolve("Gadgets");
+    Files.createDirectories(gadgets);
+    Path gadgetXml = gadgets.resolve("myGadget.xml");
+    Files.writeString(gadgetXml, "<Module/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection gadget =
+        PSLegacyDefinitionXmlShim.selectDefinition("myGadget", List.of(), null, null, gadgets);
+    assertEquals(PSDefinitionSourceKind.LEGACY_GADGET_XML, gadget.getKind());
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Phase 3 slice 3** of parent **#2630** (epic **#2626**, ADR-004): **time-boxed runtime compatibility shim** for customer legacy Widget/Page/Gadget definition XML when no modern package is present, plus **dual-run operator docs**.

- `PSLegacyDefinitionXmlShim` — selection policy: **modern preferred** (`component-package.json`) → **legacy Widget/Page/Gadget XML** → **clear error** if neither
- Package-root and by-definition-id resolution using portable `Path` / `Files`
- Documented runtime entry points (`PSWidgetDao` / `rxconfig/Widgets`, package staging layouts)
- Operator dual-run policy + exit criteria under `template-assembler-normalization/`
- ADR-004 consequences link to dual-run doc

**Independent of #2754/#2755 code** (selection does not import unmerged manifest classes). Coordinates via docs/constants (`component-package.json` name matches #2750). Full `PSWidgetDao` Spring wiring deferred until modern packages land on disk (documented as incremental).

**Out of scope:** full product package conversion, Phase 4 Design SPA, multi-RDBMS matrix.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2752
Refs #2630 #2626 #2750 #2751
Parent: #2630

## Test plan

- [x] `cd modules/perc-packages && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] Tests run: **17**, Failures: **0** (includes **13** new `PSLegacyDefinitionXmlShimTest`)
- [x] Cases: modern preferred over XML; legacy when modern absent; neither → clear error; package staging + install-relative Widgets paths
- [x] No new compiler/javadoc warnings on changed module
- [ ] Review dual-run exit criteria with ops when conversion metrics exist

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang self-review | Pass — portable Path/Files; no hardcoded FS separators in path construction; clear errors; no product XML deletion |
| Module clean install | `cd modules/perc-packages` → `..\..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 17, Failures: 0 |
| Change-class companions | selection API + exception + unit tests + operator dual-run doc + ADR-004/README index |
| Human QA | Not required — pure selection library + docs; no UI/install behavior change until DAO wiring residual |

> Co-Authored by Grok Build using grok-4.5 with agent main.
