### PR TITLE
fix(rest): UserPreferenceList JAXB @XmlSeeAlso for Preferences load (#2746)

### DIFF
--- a/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/profile-preferences.spec.js
@@ -25,7 +25,8 @@
  *
  * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
  *
- * Covers: Preferences form mounts; change default landing; reload persists.
+ * Covers: Preferences form mounts (no #2746 load JAXB / retry error);
+ * change default landing; reload persists.
  * Axe: zero serious/critical on [data-testid="perc-profile-preferences"].
  */
 
@@ -56,6 +57,13 @@ async function expectPreferencesMounted(page) {
   await expect(page.getByTestId("perc-profile-preferences")).toBeVisible({
     timeout: 30_000,
   });
+  // #2746: GET /preferences/ JAXB failure left load-error + Try again.
+  await expect(
+    page.getByTestId("perc-profile-preferences-load-error"),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("perc-profile-preferences-retry")).toHaveCount(
+    0,
+  );
   await expect(
     page.getByTestId("perc-profile-preferences-landing"),
   ).toBeVisible({ timeout: 30_000 });

--- a/rest/src/main/java/com/percussion/rest/preferences/UserPreferenceList.java
+++ b/rest/src/main/java/com/percussion/rest/preferences/UserPreferenceList.java
@@ -23,12 +23,22 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
 
-/** List wrapper for UserPreference objects. Sunny Sal: "Preference list ka boss!" */
+/**
+ * List wrapper for UserPreference objects. Sunny Sal: "Preference list ka boss!"
+ *
+ * <p>{@link XmlSeeAlso} registers {@link UserPreference} in the JAXB context so
+ * GET {@code /preferences/} can marshal list elements. Without it, the profile
+ * Preferences load path fails with {@code JAXBException}: {@code UserPreference
+ * nor any of its super class is known to this context} (#2746). Peer pattern:
+ * {@code RoleList}, {@code CommunityList}, ACL list wrappers.
+ */
 @XmlRootElement(name = "UserPreferenceList")
 @ArraySchema(schema = @Schema(implementation = UserPreference.class))
+@XmlSeeAlso(UserPreference.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserPreferenceList extends ArrayList<UserPreference> {
 

--- a/rest/src/test/java/com/percussion/rest/preferences/UserPreferenceSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/preferences/UserPreferenceSerialDeserialTest.java
@@ -18,8 +18,13 @@
 package com.percussion.rest.preferences;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DeserializationFeature;
@@ -29,23 +34,33 @@ import tools.jackson.databind.json.JsonMapper;
 /**
  * Wire shape for PreferenceResource single-pref PUT/GET must use Jackson root wrap {@code
  * UserPreference} (matches WebUI #2708 and {@code JacksonContextResolver}).
+ *
+ * <p>List GET {@code /preferences/} requires {@link UserPreferenceList} JAXB context
+ * registration of {@link UserPreference} via {@code @XmlSeeAlso} (#2746).
  */
 public class UserPreferenceSerialDeserialTest {
 
-  @Test
-  public void serializeAndDeserializeWrapsRootNameUserPreference() throws JacksonException {
-    var mapper =
-        JsonMapper.builder()
-            .enable(SerializationFeature.WRAP_ROOT_VALUE)
-            .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
-            .build();
-
+  private static UserPreference samplePreference() {
     var pref = new UserPreference();
     pref.setName("perc_profile_gravatar_email");
     pref.setValue("avatar@example.com");
     pref.setCategory("sys_preferences");
     pref.setContext("private");
     pref.setUserName("Admin");
+    return pref;
+  }
+
+  private static JsonMapper wrapRootMapper() {
+    return JsonMapper.builder()
+        .enable(SerializationFeature.WRAP_ROOT_VALUE)
+        .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+        .build();
+  }
+
+  @Test
+  public void serializeAndDeserializeWrapsRootNameUserPreference() throws JacksonException {
+    var mapper = wrapRootMapper();
+    var pref = samplePreference();
 
     var json = mapper.writeValueAsString(pref);
     assertTrue(
@@ -61,11 +76,7 @@ public class UserPreferenceSerialDeserialTest {
 
   @Test
   public void deserializeRejectsFlatNameRootWhenUnwrapping() {
-    var mapper =
-        JsonMapper.builder()
-            .enable(SerializationFeature.WRAP_ROOT_VALUE)
-            .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
-            .build();
+    var mapper = wrapRootMapper();
 
     // Flat body that WebUI previously sent — root key is "name", not "UserPreference"
     var flat = "{\"name\":\"perc_profile_gravatar_email\",\"value\":\"x\",\"userName\":\"Admin\"}";
@@ -88,5 +99,65 @@ public class UserPreferenceSerialDeserialTest {
                   || expected.getMessage().contains("name")),
           "unexpected failure: " + expected);
     }
+  }
+
+  /**
+   * Profile Preferences load uses GET all → {@link UserPreferenceList}. Jackson root wrap
+   * must round-trip list envelope + element fields (#2746 load path).
+   */
+  @Test
+  public void serializeAndDeserializeUserPreferenceList() throws JacksonException {
+    var mapper = wrapRootMapper();
+    var list = new UserPreferenceList();
+    list.add(samplePreference());
+
+    var json = mapper.writeValueAsString(list);
+    assertTrue(
+        json.contains("UserPreferenceList") || json.contains("["),
+        "expected list wire shape, got: " + json);
+    assertTrue(
+        json.contains("perc_profile_gravatar_email"),
+        "list JSON must include preference name, got: " + json);
+
+    var roundTrip = mapper.readValue(json, UserPreferenceList.class);
+    assertEquals(1, roundTrip.size(), "list size after round-trip");
+    assertEquals("perc_profile_gravatar_email", roundTrip.get(0).getName());
+    assertEquals("avatar@example.com", roundTrip.get(0).getValue());
+    assertEquals("Admin", roundTrip.get(0).getUserName());
+  }
+
+  /**
+   * Regression for #2746: without {@code @XmlSeeAlso(UserPreference.class)} on {@link
+   * UserPreferenceList}, JAXB context for the list does not know {@link UserPreference}
+   * and GET /preferences/ fails with "nor any of its super class is known to this context".
+   */
+  @Test
+  public void jaxbContextKnowsUserPreferenceFromList() throws Exception {
+    JAXBContext ctx = JAXBContext.newInstance(UserPreferenceList.class);
+    // Context creation alone is not enough on all providers — marshal a non-empty list.
+    var list = new UserPreferenceList();
+    list.add(samplePreference());
+
+    Marshaller marshaller = ctx.createMarshaller();
+    marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
+    var writer = new StringWriter();
+    try {
+      marshaller.marshal(list, writer);
+    } catch (Exception e) {
+      fail(
+          "JAXB must marshal UserPreferenceList containing UserPreference (#2746); got: "
+              + e.getMessage(),
+          e);
+    }
+    var xml = writer.toString();
+    assertFalse(xml.isBlank(), "marshalled XML must not be empty");
+    assertTrue(
+        xml.contains("UserPreferenceList") || xml.contains("userPreferenceList"),
+        "expected UserPreferenceList root in XML, got: " + xml);
+    // Element type registration is the critical #2746 gate; name may appear as
+    // attribute or child depending on property accessors / XmlAccessType defaults.
+    assertTrue(
+        xml.toLowerCase().contains("preference") || xml.contains("Admin"),
+        "marshalled payload should reference preference content, got: " + xml);
   }
 }


### PR DESCRIPTION
## Summary

Fixes My Profile → Preferences load failure where GET `/services/preferences/` returned `InternalServerErrorException` / error 99:

```
JAXBException: class com.percussion.rest.preferences.UserPreference nor any of its super class is known to this context.
```

Root cause: `UserPreferenceList` extends `ArrayList<UserPreference>` but was missing `@XmlSeeAlso(UserPreference.class)`, so the JAXB context for the list envelope did not know the element type. Same historical fix family as ACL/community/role list wrappers (commits that added missing `@XmlSeeAlso`). Distinct from #2708 / PR #2723 (single-pref *save* root wrap); this is the *list load* path.

### Fix

- **rest** `UserPreferenceList`: add `@XmlSeeAlso(UserPreference.class)`
- **rest** unit tests: Jackson list round-trip + JAXB marshal of non-empty list
- **perc-qa-automation**: profile preferences mount asserts no load-error / retry UI (#2746)

No sitemanage / WebUI product code changes (adaptor and client already correct).

Fixes #2746

## Test plan

- [x] `UserPreferenceSerialDeserialTest` — Tests run: 4, Failures: 0
- [x] `cd rest` → `..\mvnw.cmd clean install` — **BUILD SUCCESS** (Tests run: 274, Failures: 0)
- [x] Playwright surface path updated: `tests/profile-preferences.spec.js` (no load-error)
- [ ] Human QA: My Profile → Preferences loads landing control; no JAXB / Try again; count visible

## Gates evidence

| Gate | Result |
|------|--------|
| Change class | REST list DTO JAXB context registration for GET preferences |
| Companions | Serial unit tests + existing Playwright surface assertion |
| Erlang self-review | No bugs; portable; no path I/O |
| Pre-PR Maven | `cd rest` standalone clean install **BUILD SUCCESS** |
| Cross-platform | Annotation/test only |

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
