### PR TITLE
fix(perc-toolkit): testCompile after PSComponentSummary made final (#2700)

### DIFF
--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/demandpreview/service/impl/DefaultPageTemplateBeanTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/demandpreview/service/impl/DefaultPageTemplateBeanTest.java
@@ -71,12 +71,9 @@ public class DefaultPageTemplateBeanTest {
         };
     IPSGuid t1ID = new PSGuid(PSTypeEnum.TEMPLATE, 1L);
     IPSGuid ctypeId = new PSGuid(PSTypeEnum.NODEDEF, 42L);
-    PSComponentSummary summ =
-        new PSComponentSummary() {
-          {
-            setContentTypeId(42L);
-          }
-        };
+    // PSComponentSummary is final (this-escape #2700) — do not double-brace subclass.
+    PSComponentSummary summ = new PSComponentSummary();
+    summ.setContentTypeId(42L);
     IPSSite site = mock(IPSSite.class);
     IPSGuid contentId = mock(IPSGuid.class);
 
@@ -125,12 +122,9 @@ public class DefaultPageTemplateBeanTest {
     IPSGuid t2ID = new PSGuid(PSTypeEnum.TEMPLATE, 2L);
     IPSGuid t3ID = new PSGuid(PSTypeEnum.TEMPLATE, 3L);
     IPSGuid ctypeId = new PSGuid(PSTypeEnum.NODEDEF, 42L);
-    PSComponentSummary summ =
-        new PSComponentSummary() {
-          {
-            setContentTypeId(42L);
-          }
-        };
+    // PSComponentSummary is final (this-escape #2700) — do not double-brace subclass.
+    PSComponentSummary summ = new PSComponentSummary();
+    summ.setContentTypeId(42L);
     IPSSite site = mock(IPSSite.class);
     IPSGuid contentId = mock(IPSGuid.class);
     Set<IPSAssemblyTemplate> siteTemplates =
@@ -201,12 +195,9 @@ public class DefaultPageTemplateBeanTest {
     IPSGuid t2ID = new PSGuid(PSTypeEnum.TEMPLATE, 2L);
     IPSGuid t3ID = new PSGuid(PSTypeEnum.TEMPLATE, 3L);
     IPSGuid ctypeId = new PSGuid(PSTypeEnum.NODEDEF, 42L);
-    PSComponentSummary summ =
-        new PSComponentSummary() {
-          {
-            setContentTypeId(42L);
-          }
-        };
+    // PSComponentSummary is final (this-escape #2700) — do not double-brace subclass.
+    PSComponentSummary summ = new PSComponentSummary();
+    summ.setContentTypeId(42L);
     IPSSite site = mock(IPSSite.class);
     IPSGuid contentId = mock(IPSGuid.class);
     Set<IPSAssemblyTemplate> siteTemplates =


### PR DESCRIPTION
## Summary
- **Breakage:** PR #2700 (this-escape / #2652) made `PSComponentSummary` `final`.
- `DefaultPageTemplateBeanTest` used double-brace anonymous subclasses (`new PSComponentSummary() {{ setContentTypeId(...) }}`), which is subclassing → `testCompile` fails in `perc-toolkit`.
- **Fix:** normal construct + `setContentTypeId(42L)` in all 3 tests.
- Repo grep: only this file subclassed `PSComponentSummary`.

## Why night/p8 missed it
- Night Work only required **changed-module** standalone `mvnw clean install`.
- #2700 changed **system** only; agent verified system, not **downstream** consumers (`perc-toolkit`).
- GitHub CI on these PRs is largely **CodeQL** — not monorepo Maven `testCompile`.
- Making types `final` is a classic cross-module testCompile footgun.

## Verification
`cd modules/perc-toolkit && ../../mvnw clean install` → **BUILD SUCCESS** (exit 0)

## Test plan
- [x] perc-toolkit clean install green
- [x] No remaining `new PSComponentSummary() {` in tree

Refs #2700 #2652 #2022