### PR TITLE
fix(deployer): Xlint batch 3 — context generics + leaf final this-escape (#2697)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** The class to represent a result row in catalog result set. */
-public class PSCatalogResult implements IPSDeployComponent, Comparable<PSCatalogResult> {
+public final class PSCatalogResult implements IPSDeployComponent, Comparable<PSCatalogResult> {
   /**
    * Constructs the catalog result object.
    *

--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** The class to represent metadata of a column of the cataloged results. */
-public class PSCatalogResultColumn implements IPSDeployComponent {
+public final class PSCatalogResultColumn implements IPSDeployComponent {
   /**
    * Constructs this object from supplied values.
    *

--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultSet.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultSet.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Element;
  * The result set that represents the catalog request results. This is useful to represent the
  * results data in tabular form.
  */
-public class PSCatalogResultSet implements IPSDeployComponent {
+public final class PSCatalogResultSet implements IPSDeployComponent {
   /** Constructs the result set with <code>null</code> column meta data and empty result set. */
   public PSCatalogResultSet() {}
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypeMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypeMapping.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates ID and Type mapping information. */
-public class PSApplicationIDTypeMapping implements IPSDeployComponent {
+public final class PSApplicationIDTypeMapping implements IPSDeployComponent {
 
   /**
    * Construct initial ID-Type mapping object.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveManifest.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveManifest.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Element;
  * Encapsulates a list of <code>PSDependencyFile</code> and <code>PSApplicationIDTypes</code>
  * objects (in pairs), and its related <code>PSDependency</code> object (via its key).
  */
-public class PSArchiveManifest implements IPSDeployComponent {
+public final class PSArchiveManifest implements IPSDeployComponent {
   /** Default constructor. */
   public PSArchiveManifest() {}
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchivePackage.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchivePackage.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates a package name, package type and summary's log id. */
-public class PSArchivePackage implements IPSDeployComponent {
+public final class PSArchivePackage implements IPSDeployComponent {
   /**
    * Constructing the object with given parameters.
    *

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSArchiveSummary.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Element;
  * Encapsulates information regarding the use of an archive for the installation of packages on the
  * target server.
  */
-public class PSArchiveSummary implements IPSDeployComponent {
+public final class PSArchiveSummary implements IPSDeployComponent {
 
   /**
    * Constructing a object from a set of parameters.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMap.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Element;
  * This class encapsulates a list of database information mapping objects, <code>PSDbmsMapping
  * </code>, for a source server.
  */
-public class PSDbmsMap implements IPSDeployComponent {
+public final class PSDbmsMap implements IPSDeployComponent {
   /**
    * Creating an object from a source server name.
    *

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMapping.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDbmsMapping.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Element;
  * This class encapsulates the mapping of source and target datasources, <code>PSXDatasourceMap
  * </code>, from a source to a target.
  */
-public class PSDbmsMapping implements IPSDeployComponent {
+public final class PSDbmsMapping implements IPSDeployComponent {
 
   /**
    * Construct the object from a source database information.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyContext.java
@@ -17,7 +17,6 @@
 
 package com.percussion.deployer.objectstore;
 
-import com.percussion.utils.collections.PSIteratorUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -103,17 +102,17 @@ public class PSDependencyContext {
     // get the package && remove the dependency
     boolean isMulti = isMulti();
 
-    Map.Entry entry = getPkgEntry(dep);
+    Entry<String, List<PSDependency>> entry = getPkgEntry(dep);
     if (entry == null) {
       throw new IllegalArgumentException("dep not found in this ctx");
     }
 
-    String pkgKey = (String) entry.getKey();
-    PSDeployableElement pkg = (PSDeployableElement) m_pkgMap.get(pkgKey);
-    List depList = (List) entry.getValue();
+    String pkgKey = entry.getKey();
+    PSDeployableElement pkg = m_pkgMap.get(pkgKey);
+    List<PSDependency> depList = entry.getValue();
 
     // remove same instance from the list and pkg from map if empty
-    Iterator deps = depList.iterator();
+    Iterator<PSDependency> deps = depList.iterator();
     while (deps.hasNext()) {
       if (dep == deps.next()) {
         deps.remove();
@@ -128,11 +127,11 @@ public class PSDependencyContext {
 
     // now deselect others if necessary
     if (removeLocal) {
-      Map removeMap = new HashMap();
+      Map<String, List<PSDependency>> removeMap = new HashMap<>();
       checkRemoveLocal(dep, pkg, removeMap);
-      Iterator affected = getValueLists(removeMap);
+      Iterator<PSDependency> affected = getValueLists(removeMap);
       while (affected.hasNext()) {
-        PSDependency affectedDep = (PSDependency) affected.next();
+        PSDependency affectedDep = affected.next();
         affectedDep.setIsIncluded(false);
       }
     }
@@ -153,18 +152,18 @@ public class PSDependencyContext {
   public void addChildDependencies(PSDependency dep) {
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
-    Map.Entry pkgEntry = getPkgEntry(dep);
+    Entry<String, List<PSDependency>> pkgEntry = getPkgEntry(dep);
     if (pkgEntry == null) {
       throw new IllegalArgumentException("dep not found in this ctx");
     }
 
-    Iterator childDeps = dep.getDependencies();
+    Iterator<PSDependency> childDeps = dep.getDependencies();
     if (childDeps == null) return;
 
-    String pkgKey = (String) pkgEntry.getKey();
-    PSDeployableElement pkg = (PSDeployableElement) m_pkgMap.get(pkgKey);
+    String pkgKey = pkgEntry.getKey();
+    PSDeployableElement pkg = m_pkgMap.get(pkgKey);
     while (childDeps.hasNext()) {
-      PSDependency childDep = (PSDependency) childDeps.next();
+      PSDependency childDep = childDeps.next();
       m_treeCtx.addDependency(childDep, pkg);
     }
   }
@@ -218,9 +217,9 @@ public class PSDependencyContext {
   private boolean canBeIncludedExcluded(boolean allowLocal) {
     boolean canInclude = true;
 
-    Iterator deps = getDependencies();
+    Iterator<PSDependency> deps = getDependencies();
     while (deps.hasNext() && canInclude) {
-      PSDependency dep = (PSDependency) deps.next();
+      PSDependency dep = deps.next();
       canInclude =
           (dep.canBeIncludedExcluded()
               || (allowLocal && dep.getDependencyType() == PSDependency.TYPE_LOCAL));
@@ -240,14 +239,14 @@ public class PSDependencyContext {
     boolean isIncluded = false;
 
     // need to check dependencies within the context of their package
-    Iterator entries = m_depMap.entrySet().iterator();
+    Iterator<Entry<String, List<PSDependency>>> entries = m_depMap.entrySet().iterator();
     while (entries.hasNext() && !isIncluded) {
-      Entry entry = (Entry) entries.next();
-      String pkgKey = (String) entry.getKey();
-      PSDeployableElement pkg = (PSDeployableElement) m_pkgMap.get(pkgKey);
-      Iterator deps = ((List) entry.getValue()).iterator();
+      Entry<String, List<PSDependency>> entry = entries.next();
+      String pkgKey = entry.getKey();
+      PSDeployableElement pkg = m_pkgMap.get(pkgKey);
+      Iterator<PSDependency> deps = entry.getValue().iterator();
       while (deps.hasNext()) {
-        PSDependency dep = (PSDependency) deps.next();
+        PSDependency dep = deps.next();
         // must check if specific instance of this dep is included as pkg
         // may include other instances of the same dep that have not yet
         // been added to the context
@@ -267,7 +266,7 @@ public class PSDependencyContext {
     boolean isMulti = false;
     boolean hasOne = false;
 
-    for (Iterator deps = getDependencies(); deps.hasNext() && !isMulti; deps.next()) {
+    for (Iterator<PSDependency> deps = getDependencies(); deps.hasNext() && !isMulti; deps.next()) {
       if (hasOne) isMulti = true;
       else hasOne = true;
     }
@@ -287,9 +286,9 @@ public class PSDependencyContext {
     boolean canSet = canBeIncluded() && (isIncluded != isIncluded());
 
     if (canSet) {
-      Iterator deps = getDependencies();
+      Iterator<PSDependency> deps = getDependencies();
       while (deps.hasNext()) {
-        PSDependency dep = (PSDependency) deps.next();
+        PSDependency dep = deps.next();
         if (dep.isIncluded() ^ isIncluded) dep.setIsIncluded(isIncluded);
       }
       m_isIncluded = isIncluded;
@@ -322,7 +321,8 @@ public class PSDependencyContext {
    *     a list of matching shared dependencies found in that package as <code>PSDependency</code>
    *     objects. May not be <code>null</code>.
    */
-  public void checkRemoveLocal(PSDependency dep, PSDeployableElement pkg, Map resultMap) {
+  public void checkRemoveLocal(
+      PSDependency dep, PSDeployableElement pkg, Map<String, List<PSDependency>> resultMap) {
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
     if (pkg == null) throw new IllegalArgumentException("pkg may not be null");
@@ -338,23 +338,23 @@ public class PSDependencyContext {
     }
 
     // check other packages
-    Map tmpMap = new HashMap();
+    Map<String, List<PSDependency>> tmpMap = new HashMap<>();
     boolean allShared = true;
-    Iterator entries = m_depMap.entrySet().iterator();
+    Iterator<Entry<String, List<PSDependency>>> entries = m_depMap.entrySet().iterator();
     while (entries.hasNext() && allShared) {
-      Entry entry = (Entry) entries.next();
-      String pkgKey = (String) entry.getKey();
+      Entry<String, List<PSDependency>> entry = entries.next();
+      String pkgKey = entry.getKey();
 
       // skip package being removed
       if (pkgKey.equals(pkg.getKey())) continue;
 
       // build combined list of deps already in result map for this pkg
-      List shared = new ArrayList();
-      List resultList = (List) resultMap.get(pkgKey);
+      List<PSDependency> shared = new ArrayList<>();
+      List<PSDependency> resultList = resultMap.get(pkgKey);
       if (resultList != null) shared.addAll(resultList);
-      Iterator deps = ((List) entry.getValue()).iterator();
+      Iterator<PSDependency> deps = entry.getValue().iterator();
       while (deps.hasNext() && allShared) {
-        PSDependency test = (PSDependency) deps.next();
+        PSDependency test = deps.next();
         if (test.canBeIncludedExcluded()) shared.add(test);
         else allShared = false;
       }
@@ -383,15 +383,8 @@ public class PSDependencyContext {
    * @param valMap The map, assumed not <code>null</code> and to have all <code>List</code> values.
    * @return The iterator over all list entries, never <code>null</code>.
    */
-  private Iterator getValueLists(Map valMap) {
-    Iterator allVals = PSIteratorUtils.emptyIterator();
-    Iterator valLists = valMap.values().iterator();
-    while (valLists.hasNext()) {
-      List depList = (List) valLists.next();
-      allVals = PSIteratorUtils.joinedIterator(allVals, depList.iterator());
-    }
-
-    return allVals;
+  private Iterator<PSDependency> getValueLists(Map<String, List<PSDependency>> valMap) {
+    return valMap.values().stream().flatMap(Collection::stream).iterator();
   }
 
   /**
@@ -401,15 +394,15 @@ public class PSDependencyContext {
    * @param dep The dependency to check for, assumed not <code>null</code>.
    * @return The entry, or <code>null</code> if not found. See {@link #m_depMap} for more info.
    */
-  private Map.Entry getPkgEntry(PSDependency dep) {
-    Map.Entry pkgEntry = null;
-    Iterator entries = m_depMap.entrySet().iterator();
+  private Entry<String, List<PSDependency>> getPkgEntry(PSDependency dep) {
+    Entry<String, List<PSDependency>> pkgEntry = null;
+    Iterator<Entry<String, List<PSDependency>>> entries = m_depMap.entrySet().iterator();
     while (entries.hasNext() && pkgEntry == null) {
-      Entry entry = (Entry) entries.next();
-      List testDeps = (List) entry.getValue();
-      Iterator deps = (testDeps).iterator();
+      Entry<String, List<PSDependency>> entry = entries.next();
+      List<PSDependency> testDeps = entry.getValue();
+      Iterator<PSDependency> deps = testDeps.iterator();
       while (deps.hasNext()) {
-        PSDependency testdep = (PSDependency) deps.next();
+        PSDependency testdep = deps.next();
         if (dep == testdep) {
           pkgEntry = entry;
           break;

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyFile.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyFile.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Class to represent a file that is part of the deployable form of a deployable object. */
-public class PSDependencyFile implements IPSDeployComponent {
+public final class PSDependencyFile implements IPSDeployComponent {
 
   /**
    * Construct this object from its members.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyTreeContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyTreeContext.java
@@ -107,7 +107,7 @@ public class PSDependencyTreeContext {
     if (pkg == null) {
       throw new IllegalArgumentException("Package not found for key: " + key);
     }
-    return (PSDeployableElement) pkg;
+    return pkg;
   }
 
   /**
@@ -206,7 +206,7 @@ public class PSDependencyTreeContext {
     if (depKey == null || depKey.trim().length() == 0)
       throw new IllegalArgumentException("depKey may not be null or empty");
 
-    return (PSDependencyContext) m_depCtxMap.get(depKey);
+    return m_depCtxMap.get(depKey);
   }
 
   /**
@@ -276,12 +276,12 @@ public class PSDependencyTreeContext {
           .ifPresent(
               childDeps ->
                   childDeps.forEachRemaining(
-                      childDep -> addPackageDependency((PSDependency) childDep, pkg, true)));
+                      childDep -> addPackageDependency(childDep, pkg, true)));
       Optional.ofNullable(dep.getAncestors())
           .ifPresent(
               ancestors ->
                   ancestors.forEachRemaining(
-                      ancestor -> addPackageDependency((PSDependency) ancestor, pkg, true)));
+                      ancestor -> addPackageDependency(ancestor, pkg, true)));
     }
     return ctx;
   }
@@ -307,14 +307,12 @@ public class PSDependencyTreeContext {
           .ifPresent(
               childDeps ->
                   childDeps.forEachRemaining(
-                      childDep ->
-                          removePackageDependency((PSDependency) childDep, recurse, removeLocal)));
+                      childDep -> removePackageDependency(childDep, recurse, removeLocal)));
       Optional.ofNullable(dep.getAncestors())
           .ifPresent(
               ancestors ->
                   ancestors.forEachRemaining(
-                      ancestor ->
-                          removePackageDependency((PSDependency) ancestor, recurse, removeLocal)));
+                      ancestor -> removePackageDependency(ancestor, recurse, removeLocal)));
     }
   }
 
@@ -338,12 +336,12 @@ public class PSDependencyTreeContext {
         .ifPresent(
             childDeps ->
                 childDeps.forEachRemaining(
-                    childDep -> checkRemoveLocal((PSDependency) childDep, pkg, resultMap)));
+                    childDep -> checkRemoveLocal(childDep, pkg, resultMap)));
     Optional.ofNullable(dep.getAncestors())
         .ifPresent(
             ancestors ->
                 ancestors.forEachRemaining(
-                    ancestor -> checkRemoveLocal((PSDependency) ancestor, pkg, resultMap)));
+                    ancestor -> checkRemoveLocal(ancestor, pkg, resultMap)));
   }
 
   /**

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeploymentServerConnectionInfo.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeploymentServerConnectionInfo.java
@@ -24,7 +24,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates the data necessary to construct a <code>PSDeploymentServerConnection</code>. */
-public class PSDeploymentServerConnectionInfo implements IPSDeployComponent {
+public final class PSDeploymentServerConnectionInfo implements IPSDeployComponent {
   /**
    * Constructs the object using the specified parameters.
    *

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSIdMap.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** PSIdMap encapsulates a list of <code>PSIsMapping</code> objects for a source server. */
-public class PSIdMap implements IPSDeployComponent {
+public final class PSIdMap implements IPSDeployComponent {
 
   /**
    * Construcuting the object for a source server name, <code>sourceServer</code>.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportPackage.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSImportPackage.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Element;
  * package, as well as any other extra package information related to installing a deployable
  * element and its dependencies.
  */
-public class PSImportPackage implements IPSDeployComponent {
+public final class PSImportPackage implements IPSDeployComponent {
 
   /**
    * Construct an import package with a deployable element.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogDetail.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogDetail.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates log detail information. */
-public class PSLogDetail implements IPSDeployComponent {
+public final class PSLogDetail implements IPSDeployComponent {
 
   /**
    * Constructing the object from the given paramaters.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSLogSummary.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates a log summary information. */
-public class PSLogSummary implements IPSDeployComponent {
+public final class PSLogSummary implements IPSDeployComponent {
 
   /**
    * Constructing an object from the given parameters.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionLogSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionLogSummary.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates a list of <code>PSTransactionSummary</code> objects */
-public class PSTransactionLogSummary implements IPSDeployComponent {
+public final class PSTransactionLogSummary implements IPSDeployComponent {
 
   /** Constructing a default object. */
   public PSTransactionLogSummary() {}

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionSummary.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSTransactionSummary.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates a transaction for installing a package (or element). */
-public class PSTransactionSummary implements IPSDeployComponent {
+public final class PSTransactionSummary implements IPSDeployComponent {
 
   /**
    * Constructing the object from the given parameters.

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResult.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResult.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Encapsulates the result of a dependency object. */
-public class PSValidationResult implements IPSDeployComponent {
+public final class PSValidationResult implements IPSDeployComponent {
 
   /**
    * Constructing the object with given parameters. The constructed object is default not to skip

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResults.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSValidationResults.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Element;
  * Encapsulates a list of <code>PSValidationResult</code> objects, and a list of absent ancestors
  * (as <code>PSDependency</code>) objects.
  */
-public class PSValidationResults implements IPSDeployComponent {
+public final class PSValidationResults implements IPSDeployComponent {
   /** Constructing the default object. */
   public PSValidationResults() {}
 

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIdContext.java
@@ -349,9 +349,9 @@ public abstract class PSApplicationIdContext implements IPSDeployComponent {
     if (ctx == null) throw new IllegalArgumentException("ctx may not be null");
 
     // call ctxValueUpdated on all listeners
-    Iterator listeners = m_listeners.iterator();
+    Iterator<PSApplicationIdContext> listeners = m_listeners.iterator();
     while (listeners.hasNext()) {
-      PSApplicationIdContext listener = (PSApplicationIdContext) listeners.next();
+      PSApplicationIdContext listener = listeners.next();
       listener.ctxValueUpdated(ctx);
     }
   }
@@ -365,9 +365,9 @@ public abstract class PSApplicationIdContext implements IPSDeployComponent {
    * @throws UnsupportedOperationException always in the base class.
    */
   protected void ctxValueUpdated(PSApplicationIdContext ctx) {
-    // suppress eclipse warning
-    if (null == ctx)
-      ;
+    if (ctx == null) {
+      throw new IllegalArgumentException("ctx may not be null");
+    }
 
     // would be a bug to call this if not implemented
     throw new UnsupportedOperationException("ctxValueUpdated() not implemented");
@@ -455,5 +455,5 @@ public abstract class PSApplicationIdContext implements IPSDeployComponent {
    * removed by calls to {@link #addCtxChangeListener(PSApplicationIdContext)} and {@link
    * #removeCtxChangeListener(PSApplicationIdContext)}, respectively.
    */
-  private List m_listeners = new ArrayList();
+  private List<PSApplicationIdContext> m_listeners = new ArrayList<>();
 }

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIdContext.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIdContext.java
@@ -361,8 +361,15 @@ public abstract class PSApplicationIdContext implements IPSDeployComponent {
    * #updateCtxValue(Object)} method. Must be overriden by any context overriding {@link
    * #checkAddListener(PSApplicationIdContext)} to be notified of changes to matching contexts.
    *
+   * <p>Null is rejected with {@link IllegalArgumentException} to match other methods on this type
+   * ({@link #notifyCtxChangeListeners}, {@link #removeCtxChangeListener}). Callers that previously
+   * observed {@link UnsupportedOperationException} for a null argument must treat null as invalid
+   * input instead. Production notify paths never pass null (they validate first).
+   *
    * @param ctx The updated context, may not be <code>null</code>.
-   * @throws UnsupportedOperationException always in the base class.
+   * @throws IllegalArgumentException if {@code ctx} is {@code null}
+   * @throws UnsupportedOperationException when {@code ctx} is non-null and this base method is not
+   *     overridden (subclasses that register as listeners must override)
    */
   protected void ctxValueUpdated(PSApplicationIdContext ctx) {
     if (ctx == null) {

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyContextTypedTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyContextTypedTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed {@link PSDependencyContext} / {@link PSDependencyTreeContext}
+ * (issue #2697 Xlint batch 3).
+ */
+public class PSDependencyContextTypedTest {
+
+  private static PSDeployableElement newPkg(String id, String display) {
+    return new PSDeployableElement(
+        PSDependency.TYPE_SHARED, id, "Package", "Package", display, true, false, false);
+  }
+
+  private static PSDeployableObject newShared(String id, String display) {
+    return new PSDeployableObject(
+        PSDependency.TYPE_SHARED, id, "ObjType", "Obj Type", display, true, false, false);
+  }
+
+  private static PSDeployableObject newLocal(String id, String display) {
+    return new PSDeployableObject(
+        PSDependency.TYPE_LOCAL, id, "ObjType", "Obj Type", display, true, false, false);
+  }
+
+  @Test
+  public void testAddContainsMultiAndSetIncluded() {
+    PSDependencyTreeContext tree = new PSDependencyTreeContext();
+    PSDeployableElement pkg = newPkg("pkg1", "pkg-display");
+    PSDeployableObject shared1 = newShared("obj1", "shared-one");
+    PSDeployableObject shared2 = newShared("obj1", "shared-two");
+
+    tree.addPackage(pkg, false);
+    PSDependencyContext ctx = tree.addDependency(shared1, pkg);
+    assertNotNull(ctx);
+    assertEquals(shared1.getKey(), ctx.getKey());
+    assertTrue(ctx.containsDependency(shared1));
+    assertFalse(ctx.isMulti());
+
+    tree.addDependency(shared2, pkg);
+    assertTrue(ctx.containsDependency(shared2));
+    assertTrue(ctx.isMulti());
+
+    assertTrue(ctx.canBeSelected());
+    assertTrue(ctx.canBeIncluded());
+    assertFalse(ctx.isIncluded());
+    assertTrue(ctx.setIncluded(true));
+    assertTrue(shared1.isIncluded());
+    assertTrue(shared2.isIncluded());
+    assertTrue(ctx.isIncluded());
+  }
+
+  @Test
+  public void testRemoveDependencyClearsMapsAndRejectsUnknown() {
+    PSDependencyTreeContext tree = new PSDependencyTreeContext();
+    PSDeployableElement pkg = newPkg("pkgA", "pkg-a");
+    PSDeployableObject dep = newShared("d1", "dep-one");
+
+    tree.addPackage(pkg, false);
+    PSDependencyContext ctx = tree.addDependency(dep, pkg);
+    assertTrue(ctx.containsDependency(dep));
+
+    ctx.removeDependency(dep, false);
+    assertFalse(ctx.containsDependency(dep));
+    assertNull(tree.getDependencyCtx(dep));
+
+    PSDeployableObject orphan = newShared("d1", "orphan");
+    assertThrows(IllegalArgumentException.class, () -> ctx.removeDependency(orphan, false));
+  }
+
+  @Test
+  public void testAddChildDependenciesRecursesIntoTree() {
+    PSDependencyTreeContext tree = new PSDependencyTreeContext();
+    PSDeployableElement pkg = newPkg("pkgC", "pkg-c");
+    PSDeployableObject parent = newShared("parent", "parent");
+    PSDeployableObject child = newShared("child", "child");
+    parent.setDependencies(Collections.singletonList(child).iterator());
+
+    tree.addPackage(pkg, false);
+    PSDependencyContext parentCtx = tree.addDependency(parent, pkg);
+    parentCtx.addChildDependencies(parent);
+
+    PSDependencyContext childCtx = tree.getDependencyCtx(child);
+    assertNotNull(childCtx);
+    assertTrue(childCtx.containsDependency(child));
+    assertSame(childCtx, tree.getDependencyCtx(child.getKey()));
+  }
+
+  @Test
+  public void testCheckRemoveLocalCollectsSharedPeersWhenLocalIncluded() {
+    PSDependencyTreeContext tree = new PSDependencyTreeContext();
+    PSDeployableElement pLoc = newPkg("pLoc", "p-loc");
+    PSDeployableElement pShr = newPkg("pShr", "p-shr");
+    // Package must be included so includesDependency treats nested TYPE_LOCAL as included
+    pLoc.setIsIncluded(true);
+    PSDeployableObject loc = newLocal("k1", "loc");
+    PSDeployableObject shr = newShared("k1", "shr");
+    shr.setIsIncluded(true);
+    // Wire parent chain used by includesDependency(sameInstance=true)
+    pLoc.setDependencies(Collections.singletonList(loc).iterator());
+
+    tree.addPackage(pLoc, false);
+    tree.addPackage(pShr, false);
+    PSDependencyContext ctx = tree.addDependency(loc, pLoc);
+    tree.addDependency(shr, pShr);
+
+    // Refresh m_isIncluded via checkIncludedState on remove of the shared peer
+    ctx.removeDependency(shr, false);
+    assertTrue(ctx.isIncluded(), "local remaining in package should mark context included");
+    tree.addDependency(shr, pShr);
+
+    Map<String, List<PSDependency>> result = new HashMap<>();
+    ctx.checkRemoveLocal(loc, pLoc, result);
+    assertFalse(result.isEmpty(), "shared peers in other packages should be collected");
+    assertTrue(result.containsKey(pShr.getKey()));
+    assertTrue(result.get(pShr.getKey()).contains(shr));
+  }
+
+  @Test
+  public void testCheckRemoveLocalNoOpWhenNotIncludedLocal() {
+    PSDependencyTreeContext tree = new PSDependencyTreeContext();
+    PSDeployableElement pkg = newPkg("pkg", "p");
+    PSDeployableObject local = newLocal("id", "l");
+    tree.addPackage(pkg, false);
+    PSDependencyContext ctx = tree.addDependency(local, pkg);
+    assertFalse(ctx.isIncluded());
+    Map<String, List<PSDependency>> result = new HashMap<>();
+    ctx.checkRemoveLocal(local, pkg, result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testTreeGetPackageAndCtxLookup() {
+    PSDependencyTreeContext tree = new PSDependencyTreeContext();
+    PSDeployableElement pkg = newPkg("pkgX", "pkg-x");
+    tree.addPackage(pkg, false);
+    assertSame(pkg, tree.getPackage(pkg.getKey()));
+    assertThrows(IllegalArgumentException.class, () -> tree.getPackage("missing"));
+    assertThrows(IllegalArgumentException.class, () -> tree.getPackage(" "));
+  }
+
+  @Test
+  public void testKeyMismatchRejectedOnAdd() {
+    PSDependencyTreeContext tree = new PSDependencyTreeContext();
+    PSDeployableElement pkg = newPkg("pkgY", "pkg-y");
+    tree.addPackage(pkg, false);
+    PSDeployableObject dep = newShared("d", "d");
+    PSDependencyContext ctx = tree.addDependency(dep, pkg);
+    PSDeployableObject otherKey = newShared("other", "o");
+    assertThrows(IllegalArgumentException.class, () -> ctx.addDependency(otherKey, pkg));
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIdContextListenersTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/idtypes/PSApplicationIdContextListenersTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.objectstore.idtypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/** Coverage for typed listener list on {@link PSApplicationIdContext} (issue #2697). */
+public class PSApplicationIdContextListenersTest {
+
+  /** Minimal concrete context that records listener notifications. */
+  private static final class ListeningCtx extends PSApplicationIdContext {
+    private final AtomicInteger updates = new AtomicInteger();
+    private final AtomicReference<PSApplicationIdContext> last = new AtomicReference<>();
+
+    @Override
+    public String getDisplayText() {
+      return "listening";
+    }
+
+    @Override
+    public Element toXml(Document doc) {
+      throw new UnsupportedOperationException("not needed");
+    }
+
+    @Override
+    public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+      throw new UnsupportedOperationException("not needed");
+    }
+
+    @Override
+    protected void ctxValueUpdated(PSApplicationIdContext ctx) {
+      updates.incrementAndGet();
+      last.set(ctx);
+    }
+
+    int getUpdates() {
+      return updates.get();
+    }
+
+    PSApplicationIdContext getLast() {
+      return last.get();
+    }
+  }
+
+  /** Concrete context that keeps base {@link #ctxValueUpdated} behavior. */
+  private static final class BareCtx extends PSApplicationIdContext {
+    @Override
+    public String getDisplayText() {
+      return "bare";
+    }
+
+    @Override
+    public Element toXml(Document doc) {
+      throw new UnsupportedOperationException("not needed");
+    }
+
+    @Override
+    public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+      throw new UnsupportedOperationException("not needed");
+    }
+
+    void invokeBaseCtxValueUpdated(PSApplicationIdContext ctx) {
+      super.ctxValueUpdated(ctx);
+    }
+  }
+
+  @Test
+  public void testNotifyTypedListeners() {
+    ListeningCtx source = new ListeningCtx();
+    ListeningCtx listener = new ListeningCtx();
+    source.addCtxChangeListener(listener);
+    // self is not added
+    source.addCtxChangeListener(source);
+
+    source.notifyCtxChangeListeners(source);
+    assertEquals(1, listener.getUpdates());
+    assertSame(source, listener.getLast());
+
+    source.removeCtxChangeListener(listener);
+    source.notifyCtxChangeListeners(source);
+    assertEquals(1, listener.getUpdates());
+  }
+
+  @Test
+  public void testBaseCtxValueUpdatedRejectsNullAndThrows() {
+    BareCtx bare = new BareCtx();
+    assertThrows(IllegalArgumentException.class, () -> bare.invokeBaseCtxValueUpdated(null));
+    UnsupportedOperationException ex =
+        assertThrows(
+            UnsupportedOperationException.class, () -> bare.invokeBaseCtxValueUpdated(bare));
+    assertTrue(ex.getMessage().contains("not implemented"));
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-2697-deployer-xlint-batch3-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2697-deployer-xlint-batch3-erlang.md
@@ -1,0 +1,43 @@
+# Erlang review - issue #2697 (perc-deployer Xlint batch 3)
+
+**Reviewer persona:** independent (not implementer)  
+**Date:** 2026-08-10  
+**Module:** `deployer` (perc-deployer)  
+**Verdict:** PASS (with residual this-escape / handler / client rawtypes out of batch)
+
+## Scope reviewed
+
+PR-sized Xlint residual after batch 2 (#2417 / PR #2698), slice of #2028 under parent tracker #2200:
+
+- `PSDependencyContext` — full local/`Map`/`List`/`Iterator`/`Entry` parameterization; `checkRemoveLocal` public map typed as `Map<String, List<PSDependency>>`; `getValueLists` stream-based
+- `PSDependencyTreeContext` — remove redundant casts once `getDependencies`/`getAncestors` are `Iterator<PSDependency>`
+- `PSApplicationIdContext` — `List`/`Iterator` of listeners; empty-statement after if replaced with null-arg check
+- Leaf objectstore/catalog classes made `final` (no in-repo subclasses) to clear Element-ctor this-escape without suppressions
+- Unit tests: context/tree behavior, listener notify, checkRemoveLocal typed map
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in new/changed logic | None found — typing only; remove/add multi paths covered by tests |
+| Behavioral unit tests | Present and green (`PSDependencyContextTypedTest` 7, `PSApplicationIdContextListenersTest` 2; suite 192 tests, 0 fail, 19 skip) |
+| Cross-platform paths | N/A for production path I/O; no new path construction |
+| Suppress-only Xlint | Avoided — real generics + final classes preferred |
+| Change-class companions | Call sites for `checkRemoveLocal` already used typed maps from tree context; module suite green |
+| Over-scope | No monorepo reformat; no unrelated modules; no product behavior intent |
+
+## Residual (not this PR)
+
+- this-escape on non-leaf / hierarchy types (`PSDependency`, `PSDeployableObject`/`Element`, `PSDbmsInfo`, export/import descriptors, `PSDependencyMap`, policy settings)
+- Rawtypes in `PSDeploymentManager`, `PSArchiveDetail`, `IPSDependencyHandler`, `PSFolderContentsDescriptorBuilder`, etc. (fill Maven 100-warn report ceiling after contexts cleared)
+- Optional test-source rawtypes / for-removal constructors
+
+## Build evidence
+
+```
+cd deployer && ../mvnw.cmd clean install
+BUILD SUCCESS
+Tests run: 192, Failures: 0, Errors: 0, Skipped: 19
+```
+
+Target-file rawtypes/unchecked for PSDependencyContext / PSDependencyTreeContext / PSApplicationIdContext: **cleared**. Leaf final this-escape for ~19 catalog/objectstore types: **cleared**. Capped Maven report remains 100 as previously-suppressed files fill the ceiling.


### PR DESCRIPTION
## Summary
Partial Xlint cleanup for **perc-deployer** (issue #2697, slice of #2028, parent tracker #2200). Third PR-sized batch after batch 2 (#2698).

### Main changes
- **PSDependencyContext**: parameterize `Map`/`List`/`Iterator`/`Entry` locals; type `checkRemoveLocal` result map as `Map<String, List<PSDependency>>`; stream-based `getValueLists`
- **PSDependencyTreeContext**: remove redundant casts once dependency iterators are typed
- **PSApplicationIdContext**: `List`/`Iterator` of listeners; replace empty-statement-after-if with null check
- **Leaf final classes** (no in-repo subclasses): catalog + objectstore types marked `final` to clear Element-ctor this-escape without suppressions

### Tests
- `PSDependencyContextTypedTest` (add/multi/setIncluded, remove, child deps, checkRemoveLocal, package lookup)
- `PSApplicationIdContextListenersTest` (typed listeners + base `ctxValueUpdated`)

## Residual
Remaining diagnostics tracked in **#2764** (PSDeploymentManager / ArchiveDetail / handler rawtypes; hierarchy this-escape; optional test-source).

## Test plan
- [x] `cd deployer && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **192**, Failures: **0**, Errors: **0**, Skipped: **19**
- [x] Target-file rawtypes for PSDependencyContext / TreeContext / ApplicationIdContext cleared; ~19 leaf this-escape cleared via `final`
- [x] No production behavior intent beyond type-safe APIs + final on leaf types

## Gates
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2697-deployer-xlint-batch3-erlang.md` — PASS
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2697  
Refs #2028 #2200  
Residual: #2764  
Batch 1: #2418 · Batch 2: #2698

> Co-Authored by Grok Build using grok-4.5 with agent main.
