### PR TITLE
feat(explorer): Relationships view in Explorer shell (#2769)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -19,8 +19,9 @@
  *
  * <p>Composes DCE-style top menu bar (Content / View / Help), tree, detail
  * list, reduced actions, server-driven action toolbar (with nested MENU
- * dropdowns), context menu, search panel, and display-format selector so the
- * SPA route approaches Desktop Content Explorer parity (#2400 / #2731).</p>
+ * dropdowns), context menu, search panel, IA relationships panel, and
+ * display-format selector so the SPA route approaches Desktop Content Explorer
+ * parity (#2400 / #2731 / #2769).</p>
  */
 
 import React, {
@@ -87,6 +88,7 @@ import {
 } from "./styles";
 import { TranslationsPanel } from "./TranslationsPanel";
 import { SiteCopyWizard } from "./wizards/SiteCopyWizard";
+import { RelationshipsView } from "./views/RelationshipsView";
 import {
   buildWorkflowTransitionMenu,
   mergeWorkflowMenuActions,
@@ -307,6 +309,7 @@ export function ContentExplorerShell({
   const [showTranslations, setShowTranslations] = useState(false);
   /** Content → Site Copy wizard panel (#2767 / parent #2400). */
   const [showSiteCopy, setShowSiteCopy] = useState(false);
+  const [showRelationships, setShowRelationships] = useState(false);
   const [displayFormats, setDisplayFormats] = useState<DisplayFormat[]>([]);
   const [selectedFormatKey, setSelectedFormatKey] = useState<string>("");
   const [menuActions, setMenuActions] = useState<MenuAction[]>([]);
@@ -621,6 +624,9 @@ export function ContentExplorerShell({
         case "view-translations":
           setShowTranslations((v) => !v);
           break;
+        case "view-relationships":
+          setShowRelationships((v) => !v);
+          break;
         case "view-clipboard":
           setShowClipboard((v) => !v);
           break;
@@ -704,6 +710,7 @@ export function ContentExplorerShell({
             showSearch={showSearch}
             showSecurity={showSecurity}
             showTranslations={showTranslations}
+            showRelationships={showRelationships}
             showClipboard={showClipboard}
             showSiteCopy={showSiteCopy}
             multiSelectedCount={multiSelectedIds.size}
@@ -929,6 +936,41 @@ export function ContentExplorerShell({
           {message(EXPLORER_MSG.SITE_COPY_SELECT_SITE)}
         </div>
       )}
+      {showRelationships &&
+        selection.item &&
+        selection.item.id != null &&
+        String(selection.item.id).trim() !== "" && (
+          <section
+            id="explorer-relationships-panel"
+            style={sidePanelStyle}
+            data-testid="explorer-relationships-panel"
+            aria-label={message(EXPLORER_MSG.RELATIONSHIPS_PANEL_REGION)}
+          >
+            <RelationshipsView
+              item={{
+                id: String(selection.item.id),
+                path: selection.item.path,
+                folderPath: selection.folderPath || undefined,
+              }}
+            />
+          </section>
+        )}
+      {showRelationships &&
+        !(
+          selection.item &&
+          selection.item.id != null &&
+          String(selection.item.id).trim() !== ""
+        ) && (
+          <div
+            id="explorer-relationships-panel"
+            style={sidePanelStyle}
+            data-testid="explorer-relationships-hint"
+            role="status"
+            aria-live="polite"
+          >
+            {message(EXPLORER_MSG.RELATIONSHIPS_SELECT_ITEM)}
+          </div>
+        )}
       {contextMenu && (
         <div
           style={{

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -938,8 +938,8 @@ export function ContentExplorerShell({
       )}
       {showRelationships &&
         selection.item &&
-        selection.item.id != null &&
-        String(selection.item.id).trim() !== "" && (
+        selection.item.type !== "folder" &&
+        parseContentId(selection.item.id) != null && (
           <section
             id="explorer-relationships-panel"
             style={sidePanelStyle}
@@ -958,8 +958,8 @@ export function ContentExplorerShell({
       {showRelationships &&
         !(
           selection.item &&
-          selection.item.id != null &&
-          String(selection.item.id).trim() !== ""
+          selection.item.type !== "folder" &&
+          parseContentId(selection.item.id) != null
         ) && (
           <div
             id="explorer-relationships-panel"

--- a/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
@@ -39,6 +39,7 @@ export interface ExplorerMenuBarProps {
   showSearch: boolean;
   showSecurity: boolean;
   showTranslations: boolean;
+  showRelationships: boolean;
   showClipboard: boolean;
   /** Content → Site Copy panel open (#2767). */
   showSiteCopy?: boolean;
@@ -122,6 +123,7 @@ function isToggleChecked(
     | "showSearch"
     | "showSecurity"
     | "showTranslations"
+    | "showRelationships"
     | "showClipboard"
     | "showSiteCopy"
   >,
@@ -133,6 +135,8 @@ function isToggleChecked(
       return props.showSecurity;
     case "view-translations":
       return props.showTranslations;
+    case "view-relationships":
+      return props.showRelationships;
     case "view-clipboard":
       return props.showClipboard;
     case "content-site-copy":
@@ -165,6 +169,7 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
     showSearch,
     showSecurity,
     showTranslations,
+    showRelationships,
     showClipboard,
     showSiteCopy = false,
     multiSelectedCount,
@@ -293,6 +298,7 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                           showSearch,
                           showSecurity,
                           showTranslations,
+                          showRelationships,
                           showClipboard,
                           showSiteCopy,
                         })
@@ -322,13 +328,15 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                                 ? "explorer-security-panel"
                                 : item.id === "view-translations"
                                   ? "explorer-translations-panel"
-                                  : item.id === "view-clipboard"
-                                    ? "explorer-clipboard-panel"
-                                    : item.id === "content-site-copy"
-                                      ? hasSiteContext
-                                        ? "explorer-site-copy-panel"
-                                        : "explorer-site-copy-hint"
-                                      : undefined
+                                  : item.id === "view-relationships"
+                                    ? "explorer-relationships-panel"
+                                    : item.id === "view-clipboard"
+                                      ? "explorer-clipboard-panel"
+                                      : item.id === "content-site-copy"
+                                        ? hasSiteContext
+                                          ? "explorer-site-copy-panel"
+                                          : "explorer-site-copy-hint"
+                                        : undefined
                           }
                           data-testid={
                             item.testId ?? `explorer-menu-item-${item.id}`

--- a/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
@@ -34,6 +34,7 @@ export type ExplorerMenuCommandId =
   | "view-search"
   | "view-security"
   | "view-translations"
+  | "view-relationships"
   | "view-clipboard"
   | "help-explorer"
   | "help-about";
@@ -128,6 +129,13 @@ export function buildExplorerMenuBarGroups(): ReadonlyArray<ExplorerMenuBarGroup
           labelKey: EXPLORER_MSG.TRANSLATIONS_TITLE,
           ariaLabelKey: EXPLORER_MSG.TOGGLE_TRANSLATIONS_ARIA,
           testId: "explorer-toggle-translations",
+          toggle: true,
+        },
+        {
+          id: "view-relationships",
+          labelKey: EXPLORER_MSG.RELATIONSHIPS_TITLE,
+          ariaLabelKey: EXPLORER_MSG.TOGGLE_RELATIONSHIPS_ARIA,
+          testId: "explorer-toggle-relationships",
           toggle: true,
         },
         {

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -119,6 +119,11 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Client-side preview (full graph pending rest enhancement)",
   RELATIONSHIPS_LOADING: "perc.ui.explorer@Loading IA relationships…",
   RELATIONSHIPS_ERROR: "perc.ui.explorer@Could not load IA relationships",
+  /** Product shell: View → IA Relationships panel (#2769 / #2400). */
+  TOGGLE_RELATIONSHIPS_ARIA: "perc.ui.explorer@Show or hide IA relationships",
+  RELATIONSHIPS_PANEL_REGION: "perc.ui.explorer@IA relationships panel",
+  RELATIONSHIPS_SELECT_ITEM:
+    "perc.ui.explorer@Select a content item to view IA relationships.",
   // US5 P-Search / search panel (FR-017, FR-018, SC-005)
   SEARCH_TITLE: "perc.ui.explorer@Search",
   SEARCH_PLACEHOLDER: "perc.ui.explorer@Type to search…",

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -677,7 +677,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       });
     });
 
-    renderShell(
+    const { container } = renderShell(
       <ContentExplorerShell
         initialPath="/Sites/Demo"
         loadDisplayFormats={async () => []}
@@ -707,6 +707,111 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     });
     expect(screen.getByTestId("relationships-row-outgoing")).toBeInTheDocument();
     expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+    // T082a — a11y gate with relationships panel expanded (search-panel peer).
+    await renderA11yGate(container);
+  });
+
+  it("relationships toggle second click turns panel off (#2769)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-hint"),
+      ).toBeInTheDocument();
+    });
+    // View toggles keep the dropdown open (ExplorerMenuBar) — second click
+    // without re-toggling the View menuitem collapses relationships.
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
+      expect(screen.queryByTestId("explorer-relationships-panel")).toBeNull();
+      expect(screen.queryByTestId("relationships-view")).toBeNull();
+    });
+  });
+
+  it("relationships panel shows select-item hint when selection becomes a folder (#2769)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "42",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "READ",
+                },
+                {
+                  id: "99",
+                  name: "AssetsFolder",
+                  path: "/Sites/Demo/AssetsFolder",
+                  type: "folder",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 2,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 1, byType: [{ type: "related", count: 1 }] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-42")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-42"));
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+    await waitFor(() => {
+      expect(screen.getByTestId("relationships-view")).toBeInTheDocument();
+    });
+
+    // Switch selection to a folder → content-id panel unmounts, hint appears.
+    fireEvent.click(screen.getByTestId("detail-row-99"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-hint"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("relationships-view")).toBeNull();
+    expect(screen.queryByTestId("explorer-relationships-panel")).toBeNull();
   });
 
   it("security stays on hint when resolveFolderId rejects (#2410)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -113,6 +113,9 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(
       screen.getByTestId("explorer-toggle-translations"),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("explorer-toggle-relationships"),
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
@@ -598,6 +601,112 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("site-copy-wizard")).toBeNull();
     // T082a — shell remains accessible when Site Copy is disabled (no panel).
     await renderA11yGate(container);
+  });
+
+  it("relationships toggle shows select-item hint without a selection (#2769)", async () => {
+    stubPathFetch();
+    renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-hint"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("relationships-view")).toBeNull();
+    expect(screen.queryByTestId("explorer-relationships-panel")).toBeNull();
+  });
+
+  it("relationships panel mounts RelationshipsView for a selected item (#2769)", async () => {
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "42",
+                  name: "Home",
+                  path: "/Sites/Demo/Home",
+                  type: "page",
+                  accessLevel: "READ",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 0,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      // RelationshipsView → fetchNodeSummary (content-explorer/relationships)
+      if (url.includes("relationships") && url.includes("/summary")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 1, byType: [{ type: "related", count: 1 }] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("relationships")) {
+        return new Response(
+          JSON.stringify({
+            outgoing: { count: 1, byType: [{ type: "related", count: 1 }] },
+            incoming: { count: 0, byType: [] },
+            taxonomy: { count: 0, nodes: [] },
+            local: { count: 0, links: [] },
+            reverse: { count: 0, byType: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites/Demo"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={async () => []}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-42")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("detail-row-42"));
+
+    openViewMenu();
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("explorer-relationships-panel"),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("relationships-view")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("relationships-view")).toHaveAttribute(
+        "data-testid-state",
+        "ok",
+      );
+    });
+    expect(screen.getByTestId("relationships-row-outgoing")).toBeInTheDocument();
+    expect(screen.queryByTestId("explorer-relationships-hint")).toBeNull();
   });
 
   it("security stays on hint when resolveFolderId rejects (#2410)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
@@ -30,6 +30,7 @@ function renderBar(
       showSearch={false}
       showSecurity={false}
       showTranslations={false}
+      showRelationships={false}
       showClipboard={false}
       multiSelectedCount={0}
       clipboardItemCount={0}
@@ -63,8 +64,16 @@ describe("ExplorerMenuBar (#2731)", () => {
     expect(screen.getByTestId("explorer-menu-view-dropdown")).toBeTruthy();
     expect(screen.getByTestId("explorer-toggle-search")).toBeTruthy();
     expect(screen.getByTestId("explorer-toggle-security")).toBeTruthy();
+    expect(screen.getByTestId("explorer-toggle-relationships")).toBeTruthy();
     fireEvent.click(screen.getByTestId("explorer-toggle-search"));
     expect(onCommand).toHaveBeenCalledWith("view-search");
+  });
+
+  it("View → IA Relationships toggle invokes view-relationships (#2769)", () => {
+    const { onCommand } = renderBar();
+    fireEvent.click(screen.getByTestId("explorer-menu-view"));
+    fireEvent.click(screen.getByTestId("explorer-toggle-relationships"));
+    expect(onCommand).toHaveBeenCalledWith("view-relationships");
   });
 
   it("Content → Add to clipboard is disabled without multi-select", () => {

--- a/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
@@ -48,6 +48,7 @@ describe("buildExplorerMenuBarGroups (#2731 DCE ContentExplorerMenu.xml)", () =>
     expect(byId["view-search"]).toBe("explorer-toggle-search");
     expect(byId["view-security"]).toBe("explorer-toggle-security");
     expect(byId["view-translations"]).toBe("explorer-toggle-translations");
+    expect(byId["view-relationships"]).toBe("explorer-toggle-relationships");
     expect(byId["view-clipboard"]).toBe("explorer-toggle-clipboard");
   });
 

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -591,6 +591,36 @@ npm run test:surface:list -- --path tests/explorer-translations.spec.js
 npm run test:surface:list -- --tag explorer-translations
 ```
 
+#### Explorer IA relationships (#2769 / parent #2400)
+
+Surface-filtered companion for mounting `RelationshipsView` from product
+Explorer chrome (View → IA Relationships). Consumes public REST
+`GET /rest/content-explorer/relationships/{itemId}/summary`. Asserts shell
+toggle chrome, select-item hint, and optional panel load (4 primary IA rows)
+when a list row with an id is selected. Dependency viewer is a sibling slice
+(#2768) — not this surface.
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/explorer-relationships.spec.js` |
+| Tags | `@explorer-relationships` `@p-adv` `@smoke` |
+| Vitest peer | `WebUI` `RelationshipsView` / shell / `ExplorerMenuBar` / `menuBarModel` |
+
+```bash
+# After qa-up — path-filtered only (do not run full suite)
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-docker-exec> \
+  npm run test:surface -- --path tests/explorer-relationships.spec.js
+
+# Tag form
+npm run test:surface -- --tag explorer-relationships
+
+# List only (no live CMS)
+npm run test:surface:list -- --path tests/explorer-relationships.spec.js
+npm run test:surface:list -- --tag explorer-relationships
+```
+
 #### Profile shell + axe WCAG + locale title (#2393 / #2425 / #2427 / #2497 / #2498 / #2499 / #2501 / parent #2374)
 
 Smoke opens the **My profile** hub via deep link and user-menu entry (Admin,

--- a/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
@@ -31,6 +31,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { expectNoSeriousA11yViolations } = require("./helpers/a11y");
 
 /** Wait until the detail list region is present (folder navigation settled). */
 async function listWaitReady(page) {
@@ -53,6 +54,11 @@ test.describe("modern React Content Explorer — IA relationships (#2769)", () =
     async ({ page }) => {
       const shell = page.locator('[data-testid="content-explorer-shell"]');
       await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      // T082b / WebUI AGENTS.md — a11y gate on product Explorer shell surface.
+      await expectNoSeriousA11yViolations(page, {
+        scope: '[data-testid="content-explorer-shell"]',
+      });
 
       // #2731: relationships toggle lives under the View menu dropdown.
       await page.locator('[data-testid="explorer-menu-view"]').click();

--- a/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-relationships.spec.js
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Playwright surface: #2769 / parent #2400 — Explorer IA Relationships view.
+ *
+ * <p>Verifies the modern React Content Explorer shell exposes the Relationships
+ * panel chrome (View → IA Relationships) and mounts {@code RelationshipsView}
+ * for a selected item (or shows the select-item hint when none). Consumes
+ * public REST {@code GET /rest/content-explorer/relationships/{id}/summary}.</p>
+ *
+ * <p>Tags: {@code @explorer-relationships} {@code @p-adv} {@code @smoke}</p>
+ *
+ * <p>Run (QA mode after {@code perc-devctl qa-up}):
+ * {@code npm run test:surface -- --path tests/explorer-relationships.spec.js}
+ * from {@code modules/perc-qa-automation/frontend}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+/** Wait until the detail list region is present (folder navigation settled). */
+async function listWaitReady(page) {
+  await page.locator('[data-testid="detail-list"]').waitFor({ timeout: 15_000 });
+}
+
+test.describe("modern React Content Explorer — IA relationships (#2769)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(45_000);
+    await loginAsAdmin(page);
+    await page.goto(
+      `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`,
+    );
+    await page.waitForLoadState("networkidle");
+  });
+
+  test(
+    "shell mounts relationships toggle and select-item hint",
+    { tag: ["@explorer-relationships", "@p-adv", "@smoke"] },
+    async ({ page }) => {
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      // #2731: relationships toggle lives under the View menu dropdown.
+      await page.locator('[data-testid="explorer-menu-view"]').click();
+      const toggle = page.locator(
+        '[data-testid="explorer-toggle-relationships"]',
+      );
+      await expect(toggle).toBeVisible();
+      await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+      // No content item selected yet → select-item hint (not the live panel).
+      const hint = page.locator(
+        '[data-testid="explorer-relationships-hint"]',
+      );
+      await expect(hint).toBeVisible({ timeout: 5_000 });
+      await expect(
+        page.locator('[data-testid="relationships-view"]'),
+      ).toHaveCount(0);
+    },
+  );
+
+  test(
+    "selecting a list row opens relationships panel or select-item hint",
+    { tag: ["@explorer-relationships", "@p-adv"] },
+    async ({ page }) => {
+      test.setTimeout(60_000);
+      const shell = page.locator('[data-testid="content-explorer-shell"]');
+      await expect(shell).toBeVisible({ timeout: 15_000 });
+
+      // Navigate into a structural root so the list has selectable children.
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      await expect(tree).toBeVisible({ timeout: 15_000 });
+      const sitesNode = page
+        .locator(
+          '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node"][data-testid*="Sites"]',
+        )
+        .first();
+      if ((await sitesNode.count()) > 0) {
+        await sitesNode.click({ force: true, timeout: 10_000 }).catch(() => {});
+        await listWaitReady(page);
+        await page.waitForLoadState("networkidle").catch(() => {});
+      }
+
+      const list = page.locator('[data-testid="detail-list"]');
+      await expect(list).toBeVisible({ timeout: 15_000 });
+
+      // Prefer an enabled row; force-click to survive list re-renders (H2 QA).
+      const enabledRows = list.locator(
+        'tbody tr[data-testid^="detail-row-"]:not([aria-disabled="true"])',
+      );
+      const anyRows = list.locator('tbody tr[data-testid^="detail-row-"]');
+      const enabledCount = await enabledRows.count();
+      const anyCount = await anyRows.count();
+      if (enabledCount === 0 && anyCount === 0) {
+        await page.locator('[data-testid="explorer-menu-view"]').click();
+        await page
+          .locator('[data-testid="explorer-toggle-relationships"]')
+          .click();
+        await expect(
+          page.locator('[data-testid="explorer-relationships-hint"]'),
+        ).toBeVisible({ timeout: 5_000 });
+        return;
+      }
+
+      const target = enabledCount > 0 ? enabledRows.first() : anyRows.first();
+      await target.click({ force: true, timeout: 10_000 }).catch(async () => {
+        // Re-query after detach from folder refresh.
+        const again = list
+          .locator('tbody tr[data-testid^="detail-row-"]')
+          .first();
+        await again.click({ force: true, timeout: 10_000 }).catch(() => {});
+      });
+
+      await page.locator('[data-testid="explorer-menu-view"]').click();
+      await page
+        .locator('[data-testid="explorer-toggle-relationships"]')
+        .click();
+
+      // Either full panel (item with id) or select-item hint (folder / no id).
+      const panel = page.locator('[data-testid="relationships-view"]');
+      const region = page.locator(
+        '[data-testid="explorer-relationships-panel"]',
+      );
+      const hint = page.locator(
+        '[data-testid="explorer-relationships-hint"]',
+      );
+      await expect(panel.or(hint).or(region)).toBeVisible({ timeout: 15_000 });
+
+      if ((await panel.count()) > 0) {
+        await expect(panel).toHaveAttribute(
+          "data-testid-state",
+          /ok|loading|auth|error/,
+        );
+        await expect(panel).not.toHaveAttribute("data-testid-state", "loading", {
+          timeout: 20_000,
+        });
+        const state = await panel.getAttribute("data-testid-state");
+        if (state === "ok") {
+          await expect(
+            page.locator('[data-testid="relationships-primary"]'),
+          ).toBeVisible();
+          await expect(
+            page.locator('[data-testid="relationships-row-outgoing"]'),
+          ).toBeVisible();
+          await expect(
+            page.locator('[data-testid="relationships-row-incoming"]'),
+          ).toBeVisible();
+        }
+      }
+    },
+  );
+});

--- a/specs/2400-dce-explorer-parity/contracts/gap-matrix.md
+++ b/specs/2400-dce-explorer-parity/contracts/gap-matrix.md
@@ -46,7 +46,7 @@ Legend: **Present** | **Partial** | **Missing** | **OUT**
 | Site copy wizard | CE wizards | `SiteCopyWizard` on product shell via Content → Site Copy (`content-site-copy`); source prefilled from `/Sites/<name>` | **Present** | #2767 |
 | Subfolder copy wizard | CE wizards | `SubfolderCopyWizard`; not in shell | **Partial** | advanced chrome (phase 4) |
 | Dependency viewer | `PSDependencyViewer` | Components + `rest` relationship summary; not in shell | **Partial** | advanced chrome (phase 4) |
-| IA / relationships view | Managers | `RelationshipsView`; not in shell | **Partial** | advanced chrome (phase 4) |
+| IA / relationships view | Managers | `RelationshipsView` on product shell (View → IA Relationships; selected item + REST summary) | **Present** | #2769 · advanced chrome (phase 4) |
 | Translation workflow | CE translation | **REST Present:** `GET|POST /rest/content-explorer/translations` (#2429 / [PR #2601](https://github.com/intersoftdatalabs-in/percussioncms/pull/2601)). **Explorer UI Present (slice C #2430):** `TranslationsPanel` in `ContentExplorerShell` (locale list + create-variant; Vitest + Playwright `explorer-translations.spec.js`). In-flight queue + session content-locale **OUT** pending product sign-off (not exposed by REST). See [p-trans-api-inventory.md](../research/p-trans-api-inventory.md). | **Partial** (item locales + create **Present**; in-flight/session **OUT/Missing**) | #2411 → #2428 inventory, #2429 REST, #2430 UI |
 | Workflow transitions in menus | CE workflow | Actions path partial | **Partial** | workflow actions (under menus / future residual) |
 
@@ -64,9 +64,10 @@ Legend: **Present** | **Partial** | **Missing** | **OUT**
 
 - **#2767 Site copy wizard in Explorer shell chrome:** Content → Site Copy mounts `SiteCopyWizard` on `ContentExplorerShell` when selection is under `/Sites/<name>` (pure `sitePath` helper). Vitest shell/menu wiring + Playwright `explorer-site-copy.spec.js` (soft-skip multi-site submit on H2). Matrix row **Present**.
 
-### 2026-08-10 refresh (menu bar #2731)
+### 2026-08-10 refresh (menu bar #2731 + relationships #2769)
 
 - **#2731 Explorer DCE top menu bar:** `ExplorerMenuBar` (Content / View / Help) on `ContentExplorerShell`; view tools nested under View (not multi-row flat buttons). `ActionToolbar` renders `children[]` as nested dropdowns (coordinates with #2730). Vitest + Playwright `explorer-menu-bar.spec.js`. Matrix row **Present**.
+- **#2769 Relationships view in Explorer shell:** View → IA Relationships toggles `RelationshipsView` for the selected item (REST `/content-explorer/relationships/{id}/summary`); select-item hint when none. Vitest shell + menu bar; Playwright `explorer-relationships.spec.js`. Matrix row **Present**. Sibling DependencyViewer shell mount remains **Partial** (#2768).
 
 ### 2026-08-09 refresh (P-Trans UI #2430)
 


### PR DESCRIPTION
## Summary

Mount existing **RelationshipsView** (IA / relationships) into the product Explorer shell chrome for a selected item.

Parent epic: #2400 · Slice: #2769  
Does **not** include DependencyViewer shell mount (sibling #2768).

### Changes
- View → **IA Relationships** menu toggle (`view-relationships`) on `ExplorerMenuBar`
- `ContentExplorerShell` shows `RelationshipsView` when a selected item has an id; otherwise select-item hint
- Vitest companions on shell / menu bar / menu model
- Playwright surface `explorer-relationships.spec.js` (`@explorer-relationships`)
- gap-matrix: IA / relationships **Partial → Present**

## Test plan
1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Vitest 1687 passed; Surefire 31 passed)
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
3. `npm run test:surface:list -- --path tests/explorer-relationships.spec.js` — 2 tests listed
4. QA mode (human/QA H2): `perc-devctl qa-up` → `npm run test:surface -- --path tests/explorer-relationships.spec.js`

## Gates evidence
- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**  
  - `cd WebUI; ..\mvnw.cmd clean install` → BUILD SUCCESS; Vitest `Test Files 248 passed`, `Tests 1687 passed`; Surefire `Tests run: 31, Failures: 0`
  - `cd modules/perc-qa-automation; ..\..\mvnw.cmd clean install` → BUILD SUCCESS
- **downstream_checked:** none (no public Java API / final/sealed shape changes; UI-only shell mount)
- Erlang self-review: no bugs; portable paths N/A (no new FS I/O); companions complete (Vitest + Playwright + matrix)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2769  
Parent: #2400

> Co-Authored by Grok Build using grok-4.5 with agent main.
