### PR TITLE
feat(perc-packages): Page templateDef XML to package model + goldens (#2770)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -52,6 +52,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | [component-package-manifest.md](./component-package-manifest.md) | Phase 3 ship-format manifest schema v1.0 + Java model |
 | [widget-xml-inventory.md](./widget-xml-inventory.md) | Product widget matrix (48 defs) |
 | [widget-xml-inventory.csv](./widget-xml-inventory.csv) | Machine-readable inventory |
+| [page-definition-inventory.md](./page-definition-inventory.md) | Product page `*.templateDef` inventory + compiler (#2770) |
 | [gadget-definition-inventory.md](./gadget-definition-inventory.md) | Gadget XML / SPA survey |
 | [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) | Phase 3 dual-run operator policy + runtime shim selection (#2752) |
 | [adr/](./adr/) | Architecture decision records |
@@ -76,6 +77,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
 | Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751) |
+| Page templateDef compiler | `modules/perc-packages/.../pagexml/PSPageXmlCompiler.java` (#2770) |
 | Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -60,3 +60,15 @@ Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidget
 | Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
 
 High-traffic package conversion and product XML removal remain residual under #2630.
+
+## Page templateDef compiler (slice #2770)
+
+Compiler for upgrade-input Page / assembly `*.templateDef` → Component Package Manifest (product page layout packages first):
+
+| Artifact | Location |
+|----------|----------|
+| Parser / compiler / package scanner | `modules/perc-packages/.../pagexml/PSPageXml*.java` |
+| Golden parity (`perc.base.plain`) | `modules/perc-packages/src/test/resources/pagexml/golden/` |
+| Inventory + dual-run note | [../page-definition-inventory.md](../page-definition-inventory.md) |
+
+Product packages may still **ship** `*.templateDef` during dual-run; modern `component-package.json` is the compiler output and future authoring format. Full product dual-run exit (delete package templateDefs) remains residual under #2630.

--- a/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
@@ -1,0 +1,96 @@
+# Page definition packaging inventory (Phase 3 / #2770)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Inventory + compiler landed (#2770) |
+| **Parent** | #2630 · Grandparent #2626 |
+| **Code** | `modules/perc-packages/.../pagexml/PSPageXml*.java` |
+| **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
+| **Manifest** | [component-package-manifest.md](./component-package-manifest.md) |
+
+## What “Page definition XML” is in product packages
+
+Unlike widgets (`rxconfig/Widgets/*.xml`), product **page layout** packaging is primarily **assembly template definitions**:
+
+| Artifact | Extension / root | Role |
+|----------|------------------|------|
+| Assembly template def | `*.templateDef` / `<assembly-template>` | Page (or Global) layout Velocity body + `pageAssembler` + `#region` holes |
+| ACL side-car | `*.templateDef.aclDef` | ACL for the template dependency (out of compiler scope) |
+| Thumbnail resources | `sys__UserDependency--rx_resources/images/TemplateImages/…` | Palette thumbs (not compiled in #2770) |
+| Package identity | `psx_archiveInfo.xml` | Version / publisher / CMS range for compiler context |
+
+There is **no** product tree under `rxconfig/Pages/*.xml` in `modules/perc-packages` today. The dual-run shim still recognizes `rxconfig/Pages` for customer installs (see [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md)).
+
+CM1 **page item** region trees / widget instances live in site storage (sitemanage domain), not as package `*.templateDef` files. This slice covers **packaged page templates** only; page-item composition upgrade remains a residual under #2630 when storage write-path is ready.
+
+## Product packages with Page layout templateDefs
+
+| Package | `*.templateDef` count (approx) | Assembler (typical) | Output format | Notes |
+|---------|--------------------------------:|---------------------|---------------|-------|
+| `perc.baseTemplates` | 20 | `pageAssembler` | Page | Primary golden target (`perc.base.plain`) |
+| `perc.responsiveTemplates` | 3 | `pageAssembler` | Page | Banded / Basic / plain |
+| `perc.Baseline` | 4+ page-related | mix (`pageAssembler`, `velocityAssembler`, …) | Page / Global | System templates (`perc.page`, `perc.pageXml`, …) — convert carefully |
+
+Snippet-style `*.templateDef` files also appear inside **widget** packages (e.g. file/image binary templates). Those are **not** page layout packages; leave them to widget conversion residuals unless inventory shows Page `output-format`.
+
+### `perc.baseTemplates` (layout catalog)
+
+| Template name | Label (sample) | Regions (`#region`) |
+|---------------|----------------|---------------------|
+| `perc.base.plain` | Plain | `perc-content` |
+| `perc.base.header` | Header | header-shaped |
+| `perc.base.footer` | Footer | footer-shaped |
+| `perc.base.headerFooter` | Header Footer | `header`, `content`, `footer` |
+| `perc.base.Box` | Box | `header`, `leftsidebar`, `content`, `rightsidebar`, `footer` |
+| `perc.base.leftSidebar` / `rightSidebar` / `rightLeftSidebar` | sidebars | multi-region |
+| `perc.base.lLeft*` / `lRight*` / `invertedL*` / `cClamp*` | L / clamp layouts | multi-region |
+
+Full file list: `modules/perc-packages/src/main/resources/Packages/perc.baseTemplates/*.templateDef`.
+
+### `perc.responsiveTemplates`
+
+| Template name | Label |
+|---------------|-------|
+| `perc.resp.plain` | (plain responsive) |
+| `perc.resp.Basic` | Basic |
+| `perc.resp.Banded` | Banded |
+
+## Compiler mapping (upgrade-input → modern package)
+
+| Source (`*.templateDef`) | Target (Component Package Manifest) |
+|--------------------------|-------------------------------------|
+| `<name>` | `id`, `templates[0].name` |
+| `<label>` | `name`, `catalog.title` |
+| `<description>` | `description` / `catalog.description` |
+| Package `psx_archiveInfo` | `version`, `publisher`, `cmsVersion`, `dependencies` |
+| `<assembler>` extension path | short assembler id (`pageAssembler`, `velocityAssembler`, …) |
+| `<output-format>` Page/Global/… | `templates[].type` (`page` / `global` / …) |
+| `<template>` body (entity-decoded) | `templates/<name>.vm` text artifact + `sourceRef` |
+| `#region("id" …)` | `slots[]` named by region id |
+| Matching `id="…" class="perc-region perc-vertical …"` | `slots[].layout.orientation`, `slots[].styles.rootclass` (+ span hints) |
+| `catalog.kind` | always `page` for this compiler |
+
+**Dual-run (documented):** product packages **still ship** `*.templateDef` as install input until a residual removes them. The compiler emits modern `component-package.json` + template sources for upgrade tooling and future authoring; install recognition of the modern format is a follow-on.
+
+## Golden fixtures
+
+| Fixture | Path |
+|---------|------|
+| Input | `modules/perc-packages/src/test/resources/pagexml/perc.base.plain.templateDef` |
+| Manifest golden | `…/pagexml/golden/perc.base.plain.component-package.json` |
+| Template golden | `…/pagexml/golden/perc.base.plain.vm` |
+| Tests | `com.percussion.packages.pagexml.PSPageXmlCompilerTest` |
+
+## Residuals (not this PR)
+
+1. **Remove product `*.templateDef` authoring** after install path consumes modern packages (and dual-run exit criteria).
+2. **Thumbnails / resources** wiring for template images into `resources[]`.
+3. **Baseline system templates** conversion matrix (Global / Xml / Database / Dispatcher).
+4. **Page item composition** (site storage region trees) → slot composition IR — depends on Phase 2 storage / REST (#2690 family).
+5. **Gadget registry** conversion (sibling slice).
+
+## Related
+
+- Widget XML inventory: [widget-xml-inventory.md](./widget-xml-inventory.md)
+- Region ↔ slot: [region-slot-mapping.md](./region-slot-mapping.md)
+- Plan Phase 3: [plan.md](./plan.md)

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -360,7 +360,8 @@ This is multi-quarter work even if labeled “8.2.” Split so 8.2 can ship **fo
 1. Define **Component Package Manifest** (reuse package system where possible) listing content types, templates, slots, catalog metadata, resources.  
    **Done (slice 1 / #2750):** schema docs + Java model + parse/validate/round-trip tests — see [component-package-manifest.md](./component-package-manifest.md) and `com.percussion.packages.manifest` in `modules/perc-packages`.
 2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles). *(#2751)*
-3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.
+3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.  
+   **Done (slice 4 / #2770 — product page templateDefs):** inventory + compiler `PSPageXml*` for `*.templateDef` → Component Package Manifest + golden `perc.base.plain` (see [page-definition-inventory.md](./page-definition-inventory.md)). Dual-run: product may still ship templateDefs until residual removal. **Still residual:** site-storage page item composition IR, Baseline system templates matrix, thumbnail resources, delete package templateDefs after install path.
 4. **Gadget XML** conversion path for remaining XML-defined gadgets.
 5. Convert **baseline / baseWidgets** first; then high-traffic packages (nav, blog, lists, rich text).
 6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format. *(#2752)*

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompileResult.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompileResult.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Output of compiling a single Page {@code *.templateDef}: modern manifest + package-relative text
+ * artifacts (template sources keyed by the same paths referenced from the manifest).
+ */
+public final class PSPageXmlCompileResult {
+
+  private final PSPageXmlModel source;
+  private final PSComponentPackageManifest manifest;
+  /** Package-relative path → UTF-8 text (e.g. {@code templates/perc.base.plain.vm}). */
+  private final Map<String, String> textArtifacts;
+
+  public PSPageXmlCompileResult(
+      PSPageXmlModel source,
+      PSComponentPackageManifest manifest,
+      Map<String, String> textArtifacts) {
+    this.source = Objects.requireNonNull(source, "source");
+    this.manifest = Objects.requireNonNull(manifest, "manifest");
+    this.textArtifacts =
+        textArtifacts == null
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(textArtifacts));
+  }
+
+  public PSPageXmlModel getSource() {
+    return source;
+  }
+
+  public PSComponentPackageManifest getManifest() {
+    return manifest;
+  }
+
+  public Map<String, String> getTextArtifacts() {
+    return textArtifacts;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompiler.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Compiles legacy Page / assembly {@code *.templateDef} XML into a modern {@link
+ * PSComponentPackageManifest} plus template source artifacts (Phase 3 / ADR-004 / issue #2770).
+ *
+ * <p><strong>Scope:</strong> product page layout templates (e.g. {@code perc.baseTemplates}, {@code
+ * perc.responsiveTemplates}) and simple Baseline assembly templates. Region holes become slots;
+ * assembler extension short-names map to the Component Package Manifest assembler field; Velocity
+ * body is the canonical template source.
+ *
+ * <p>Product packages may still ship dual-run {@code *.templateDef} until a residual removes them;
+ * this compiler is the upgrade / modern authoring path.
+ */
+public final class PSPageXmlCompiler {
+
+  private static final String DEFAULT_VERSION = "0.0.0";
+
+  private PSPageXmlCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile a {@code *.templateDef} file into a modern component package result.
+   *
+   * @param templateDefPath path to assembly-template XML
+   * @param packageContext optional package metadata; may be null
+   * @return compile result with validated manifest and text artifacts
+   * @throws PSPageXmlException on parse/compile/validation failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlCompileResult compile(
+      Path templateDefPath, PSPageXmlPackageContext packageContext)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(templateDefPath, "templateDefPath");
+    PSPageXmlModel model = PSPageXmlParser.parse(templateDefPath);
+    return compile(model, packageContext);
+  }
+
+  /**
+   * Compile a previously parsed page template model.
+   *
+   * @param model non-null parsed template
+   * @param packageContext optional package metadata; may be null
+   * @return compile result
+   * @throws PSPageXmlException on compile/validation failure
+   */
+  public static PSPageXmlCompileResult compile(
+      PSPageXmlModel model, PSPageXmlPackageContext packageContext) throws PSPageXmlException {
+    Objects.requireNonNull(model, "model");
+
+    String stem = model.pageStem();
+    if (stem == null || stem.isBlank()) {
+      throw new PSPageXmlException(
+          "Page template model is missing name / source file; cannot derive component id");
+    }
+
+    PSComponentPackageManifest manifest = new PSComponentPackageManifest();
+    manifest.setSchemaVersion(PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION);
+    manifest.setId(stem);
+    String displayName =
+        model.getLabel() != null && !model.getLabel().isBlank() ? model.getLabel() : stem;
+    manifest.setName(displayName);
+    applyPackageIdentity(manifest, packageContext, model);
+
+    PSComponentPackageManifest.Catalog catalog = new PSComponentPackageManifest.Catalog();
+    catalog.setKind("page");
+    catalog.setTitle(displayName);
+    catalog.setDescription(model.getDescription());
+    catalog.setCategory("page");
+    catalog.setPaletteVisible(Boolean.TRUE);
+    if (packageContext != null
+        && packageContext.getPackageId() != null
+        && packageContext.getPackageId().toLowerCase(Locale.ROOT).contains("responsive")) {
+      catalog.setResponsive(Boolean.TRUE);
+    }
+    manifest.setCatalog(catalog);
+
+    String assembler = mapAssembler(model.getAssembler());
+    String templateType = mapTemplateType(model.getOutputFormat(), assembler);
+    String sourceRef = "templates/" + stem + assemblerExtension(assembler);
+
+    PSComponentPackageManifest.TemplateRef template = new PSComponentPackageManifest.TemplateRef();
+    template.setName(stem);
+    template.setType(templateType);
+    template.setAssembler(assembler);
+    template.setSourceRef(sourceRef);
+    template.setBindings(buildBindings(model));
+    List<PSComponentPackageManifest.TemplateRef> templates = new ArrayList<>();
+    templates.add(template);
+    manifest.setTemplates(templates);
+
+    List<PSComponentPackageManifest.SlotRef> slots = new ArrayList<>();
+    for (PSPageXmlModel.RegionHole hole : model.getRegionHoles()) {
+      if (hole == null || hole.getRegionId() == null || hole.getRegionId().isBlank()) {
+        continue;
+      }
+      PSComponentPackageManifest.SlotRef slot = new PSComponentPackageManifest.SlotRef();
+      slot.setName(hole.getRegionId());
+      slot.setAllowedContentTypes(new ArrayList<>());
+      slot.setLayout(
+          hole.getLayoutHints() != null
+              ? new LinkedHashMap<>(hole.getLayoutHints())
+              : new LinkedHashMap<>());
+      slot.setStyles(
+          hole.getStyleHints() != null
+              ? new LinkedHashMap<>(hole.getStyleHints())
+              : new LinkedHashMap<>());
+      slots.add(slot);
+    }
+    manifest.setSlots(slots);
+
+    // Page layout templates do not declare CT in templateDef; leave contentTypes empty.
+    manifest.setContentTypes(new ArrayList<>());
+    manifest.setResources(new ArrayList<>());
+    manifest.setUserPreferences(new ArrayList<>());
+    manifest.setCssPreferences(new ArrayList<>());
+
+    try {
+      PSComponentPackageManifestValidator.validate(manifest);
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSPageXmlException("Compiled manifest failed validation: " + e.getMessage(), e);
+    }
+
+    Map<String, String> artifacts = new LinkedHashMap<>();
+    String templateSource = model.getTemplateBody() != null ? model.getTemplateBody() : "";
+    artifacts.put(sourceRef, templateSource);
+
+    return new PSPageXmlCompileResult(model, manifest, artifacts);
+  }
+
+  /**
+   * Write a compile result under {@code outputDir}: {@code component-package.json} plus text
+   * artifacts using package-relative paths. Parent directories are created as needed.
+   *
+   * @param result non-null compile result
+   * @param outputDir non-null destination package root
+   * @throws IOException on I/O failure
+   */
+  public static void writeArtifacts(PSPageXmlCompileResult result, Path outputDir)
+      throws IOException {
+    Objects.requireNonNull(result, "result");
+    Objects.requireNonNull(outputDir, "outputDir");
+    Files.createDirectories(outputDir);
+    Path manifestPath = outputDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    PSComponentPackageManifestIo.write(result.getManifest(), manifestPath);
+    for (Map.Entry<String, String> entry : result.getTextArtifacts().entrySet()) {
+      Path artifact = resolvePackageRelative(outputDir, entry.getKey());
+      Path parent = artifact.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      Files.writeString(artifact, entry.getValue(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void applyPackageIdentity(
+      PSComponentPackageManifest manifest,
+      PSPageXmlPackageContext ctx,
+      PSPageXmlModel model) {
+    if (ctx != null) {
+      if (ctx.getVersion() != null && !ctx.getVersion().isBlank()) {
+        manifest.setVersion(ctx.getVersion());
+      }
+      if (model.getDescription() != null && !model.getDescription().isBlank()) {
+        manifest.setDescription(model.getDescription());
+      } else if (ctx.getDescription() != null && !ctx.getDescription().isBlank()) {
+        manifest.setDescription(ctx.getDescription());
+      }
+      if (ctx.getPublisherName() != null || ctx.getPublisherUrl() != null) {
+        PSComponentPackageManifest.Publisher pub = new PSComponentPackageManifest.Publisher();
+        pub.setName(ctx.getPublisherName());
+        pub.setUrl(ctx.getPublisherUrl());
+        manifest.setPublisher(pub);
+      }
+      if (ctx.getCmsMin() != null || ctx.getCmsMax() != null) {
+        PSComponentPackageManifest.CmsVersionRange range =
+            new PSComponentPackageManifest.CmsVersionRange();
+        range.setMin(ctx.getCmsMin());
+        range.setMax(ctx.getCmsMax());
+        manifest.setCmsVersion(range);
+      }
+      if (ctx.getDependencies() != null && !ctx.getDependencies().isEmpty()) {
+        List<PSComponentPackageManifest.Dependency> deps = new ArrayList<>();
+        for (PSPageXmlPackageContext.Dependency d : ctx.getDependencies()) {
+          if (d == null || d.getName() == null || d.getName().isBlank()) {
+            continue;
+          }
+          PSComponentPackageManifest.Dependency dep = new PSComponentPackageManifest.Dependency();
+          dep.setName(d.getName());
+          dep.setVersion(d.getVersion());
+          dep.setImplied(d.isImplied());
+          deps.add(dep);
+        }
+        manifest.setDependencies(deps);
+      }
+    } else if (model.getDescription() != null) {
+      manifest.setDescription(model.getDescription());
+    }
+
+    if (manifest.getVersion() == null || manifest.getVersion().isBlank()) {
+      manifest.setVersion(DEFAULT_VERSION);
+    }
+  }
+
+  static List<PSComponentPackageManifest.Binding> buildBindings(PSPageXmlModel model) {
+    List<PSComponentPackageManifest.Binding> bindings = new ArrayList<>();
+    if (model.getBindings() == null) {
+      return bindings;
+    }
+    for (PSPageXmlModel.Binding b : model.getBindings()) {
+      if (b == null || b.getVariable() == null || b.getVariable().isBlank()) {
+        continue;
+      }
+      PSComponentPackageManifest.Binding out = new PSComponentPackageManifest.Binding();
+      out.setVariable(b.getVariable());
+      out.setExpression(b.getExpression() != null ? b.getExpression() : "");
+      bindings.add(out);
+    }
+    return bindings;
+  }
+
+  /**
+   * Map assembly-template {@code <assembler>} (often a Java extension path) to a short Component
+   * Package Manifest assembler id.
+   */
+  static String mapAssembler(String assembler) {
+    if (assembler == null || assembler.isBlank()) {
+      return "pageAssembler";
+    }
+    String a = assembler.trim();
+    String lower = a.toLowerCase(Locale.ROOT);
+    // Extension path: Java/global/percussion/assembly/pageAssembler
+    int slash = lower.lastIndexOf('/');
+    String leaf = slash >= 0 ? a.substring(slash + 1) : a;
+    String leafLower = leaf.toLowerCase(Locale.ROOT);
+    if (leafLower.endsWith("assembler")) {
+      // normalize casing for known product assemblers
+      if (leafLower.equals("pageassembler")) {
+        return "pageAssembler";
+      }
+      if (leafLower.equals("pagevariantassembler")) {
+        return "pageVariantAssembler";
+      }
+      if (leafLower.equals("velocityassembler")) {
+        return "velocityAssembler";
+      }
+      if (leafLower.equals("htmlassembler")) {
+        return "htmlAssembler";
+      }
+      if (leafLower.equals("markdownassembler")) {
+        return "markdownAssembler";
+      }
+      if (leafLower.equals("legacyassembler") || leafLower.equals("xslassembler")) {
+        return "legacyAssembler";
+      }
+      return leaf;
+    }
+    return leaf + "Assembler";
+  }
+
+  /**
+   * Map {@code <output-format>} to Component Package Manifest template type (page / snippet /
+   * global / binary / resource).
+   */
+  static String mapTemplateType(String outputFormat, String assembler) {
+    if (outputFormat != null && !outputFormat.isBlank()) {
+      String o = outputFormat.trim().toLowerCase(Locale.ROOT);
+      return switch (o) {
+        case "page" -> "page";
+        case "snippet" -> "snippet";
+        case "global" -> "global";
+        case "binary" -> "binary";
+        case "database", "db" -> "binary";
+        case "resource" -> "resource";
+        default -> o;
+      };
+    }
+    if (assembler != null && assembler.toLowerCase(Locale.ROOT).contains("page")) {
+      return "page";
+    }
+    return "page";
+  }
+
+  static String assemblerExtension(String assembler) {
+    if (assembler == null) {
+      return ".vm";
+    }
+    String a = assembler.toLowerCase(Locale.ROOT);
+    if (a.contains("html") && !a.contains("page")) {
+      return ".html";
+    }
+    if (a.contains("markdown") || a.endsWith("mdassembler")) {
+      return ".md";
+    }
+    // pageAssembler is Velocity-based (PSPageAssembler extends PSVelocityAssembler)
+    return ".vm";
+  }
+
+  /**
+   * Resolve a package-relative path (URL-style {@code /}) under {@code base} using portable {@link
+   * Path#resolve(String)} per segment — never string-concatenate OS separators.
+   */
+  static Path resolvePackageRelative(Path base, String packageRelative) {
+    Path p = base;
+    for (String segment : packageRelative.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment)) {
+        continue;
+      }
+      if ("..".equals(segment)) {
+        throw new IllegalArgumentException(
+            "Package-relative path must not contain '..': " + packageRelative);
+      }
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+/**
+ * Thrown when Page / assembly {@code *.templateDef} definition XML cannot be parsed or compiled
+ * into a Component Package Manifest.
+ *
+ * @see PSPageXmlParser
+ * @see PSPageXmlCompiler
+ */
+public class PSPageXmlException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSPageXmlException(String message) {
+    super(message);
+  }
+
+  public PSPageXmlException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlModel.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlModel.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Parsed upgrade-input Page / assembly template definition ({@code *.templateDef} / {@code
+ * <assembly-template>}).
+ *
+ * <p>Intermediate model used only by the compiler; product ship format is {@link
+ * com.percussion.packages.manifest.PSComponentPackageManifest}.
+ */
+public final class PSPageXmlModel {
+
+  private String sourceFileName;
+  private String name;
+  private String label;
+  private String description;
+  private String guid;
+  private String assembler;
+  private String outputFormat;
+  private String templateType;
+  private String mimeType;
+  private String charset;
+  private String activeAssemblyType;
+  private String templateBody;
+  private List<Binding> bindings = new ArrayList<>();
+  private List<RegionHole> regionHoles = new ArrayList<>();
+
+  public String getSourceFileName() {
+    return sourceFileName;
+  }
+
+  public void setSourceFileName(String sourceFileName) {
+    this.sourceFileName = sourceFileName;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(String label) {
+    this.label = label;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getGuid() {
+    return guid;
+  }
+
+  public void setGuid(String guid) {
+    this.guid = guid;
+  }
+
+  public String getAssembler() {
+    return assembler;
+  }
+
+  public void setAssembler(String assembler) {
+    this.assembler = assembler;
+  }
+
+  public String getOutputFormat() {
+    return outputFormat;
+  }
+
+  public void setOutputFormat(String outputFormat) {
+    this.outputFormat = outputFormat;
+  }
+
+  public String getTemplateType() {
+    return templateType;
+  }
+
+  public void setTemplateType(String templateType) {
+    this.templateType = templateType;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  public void setMimeType(String mimeType) {
+    this.mimeType = mimeType;
+  }
+
+  public String getCharset() {
+    return charset;
+  }
+
+  public void setCharset(String charset) {
+    this.charset = charset;
+  }
+
+  public String getActiveAssemblyType() {
+    return activeAssemblyType;
+  }
+
+  public void setActiveAssemblyType(String activeAssemblyType) {
+    this.activeAssemblyType = activeAssemblyType;
+  }
+
+  public String getTemplateBody() {
+    return templateBody;
+  }
+
+  public void setTemplateBody(String templateBody) {
+    this.templateBody = templateBody;
+  }
+
+  public List<Binding> getBindings() {
+    return bindings;
+  }
+
+  public void setBindings(List<Binding> bindings) {
+    this.bindings = bindings != null ? bindings : new ArrayList<>();
+  }
+
+  public List<RegionHole> getRegionHoles() {
+    return regionHoles;
+  }
+
+  public void setRegionHoles(List<RegionHole> regionHoles) {
+    this.regionHoles = regionHoles != null ? regionHoles : new ArrayList<>();
+  }
+
+  /**
+   * Stable component id: template {@code name}, else source file stem without {@code .templateDef}.
+   */
+  public String pageStem() {
+    if (name != null && !name.isBlank()) {
+      return name.trim();
+    }
+    if (sourceFileName == null || sourceFileName.isBlank()) {
+      return null;
+    }
+    String f = sourceFileName.trim();
+    String lower = f.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".templatedef")) {
+      return f.substring(0, f.length() - ".templateDef".length());
+    }
+    int dot = f.lastIndexOf('.');
+    return dot > 0 ? f.substring(0, dot) : f;
+  }
+
+  /** Ordered JEXL binding from {@code <bindings>} children when present. */
+  public static final class Binding {
+    private String variable;
+    private String expression;
+
+    public String getVariable() {
+      return variable;
+    }
+
+    public void setVariable(String variable) {
+      this.variable = variable;
+    }
+
+    public String getExpression() {
+      return expression;
+    }
+
+    public void setExpression(String expression) {
+      this.expression = expression;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Binding that)) {
+        return false;
+      }
+      return Objects.equals(variable, that.variable)
+          && Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(variable, expression);
+    }
+  }
+
+  /**
+   * A composition hole discovered from a Velocity {@code #region("id" …)} macro, optionally
+   * enriched with CSS class hints from a matching {@code id="…"} markup container.
+   */
+  public static final class RegionHole {
+    private String regionId;
+    private String cssClass;
+    private Map<String, Object> layoutHints = new LinkedHashMap<>();
+    private Map<String, Object> styleHints = new LinkedHashMap<>();
+
+    public String getRegionId() {
+      return regionId;
+    }
+
+    public void setRegionId(String regionId) {
+      this.regionId = regionId;
+    }
+
+    public String getCssClass() {
+      return cssClass;
+    }
+
+    public void setCssClass(String cssClass) {
+      this.cssClass = cssClass;
+    }
+
+    public Map<String, Object> getLayoutHints() {
+      return layoutHints;
+    }
+
+    public void setLayoutHints(Map<String, Object> layoutHints) {
+      this.layoutHints = layoutHints != null ? layoutHints : new LinkedHashMap<>();
+    }
+
+    public Map<String, Object> getStyleHints() {
+      return styleHints;
+    }
+
+    public void setStyleHints(Map<String, Object> styleHints) {
+      this.styleHints = styleHints != null ? styleHints : new LinkedHashMap<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof RegionHole that)) {
+        return false;
+      }
+      return Objects.equals(regionId, that.regionId)
+          && Objects.equals(cssClass, that.cssClass)
+          && Objects.equals(layoutHints, that.layoutHints)
+          && Objects.equals(styleHints, that.styleHints);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(regionId, cssClass, layoutHints, styleHints);
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageCompiler.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Compiles all Page / assembly {@code *.templateDef} files found in a legacy product package source
+ * directory (e.g. {@code perc.baseTemplates}, {@code perc.responsiveTemplates}).
+ *
+ * <p>Looks for {@code *.templateDef} at the package root (product packaging layout used by {@code
+ * modules/perc-packages}). Suitable for simple page layout packages first; full product dual-run
+ * removal remains residual under #2630.
+ */
+public final class PSPageXmlPackageCompiler {
+
+  private PSPageXmlPackageCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile every {@code *.templateDef} under the package root.
+   *
+   * @param packageDir non-null package source root (e.g. {@code …/Packages/perc.baseTemplates})
+   * @return compile results sorted by template name (stable for golden tests)
+   * @throws PSPageXmlException on parse/compile failure
+   * @throws IOException on I/O failure
+   */
+  public static List<PSPageXmlCompileResult> compilePackage(Path packageDir)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (!Files.isDirectory(packageDir)) {
+      throw new PSPageXmlException("Package directory does not exist: " + packageDir);
+    }
+
+    PSPageXmlPackageContext ctx = PSPageXmlPackageContext.fromPackageDir(packageDir);
+    List<Path> templateFiles = listTemplateDefs(packageDir);
+    if (templateFiles.isEmpty()) {
+      throw new PSPageXmlException(
+          "No *.templateDef files found in package root: " + packageDir);
+    }
+
+    List<PSPageXmlCompileResult> results = new ArrayList<>();
+    for (Path templateDef : templateFiles) {
+      results.add(PSPageXmlCompiler.compile(templateDef, ctx));
+    }
+    return results;
+  }
+
+  /**
+   * Write each page compile result under {@code outputRoot/<templateStem>/}.
+   *
+   * @param results non-null list of compile results
+   * @param outputRoot non-null output root directory
+   * @throws IOException on I/O failure
+   */
+  public static void writeAll(List<PSPageXmlCompileResult> results, Path outputRoot)
+      throws IOException {
+    Objects.requireNonNull(results, "results");
+    Objects.requireNonNull(outputRoot, "outputRoot");
+    Files.createDirectories(outputRoot);
+    for (PSPageXmlCompileResult result : results) {
+      String stem = result.getSource().pageStem();
+      if (stem == null || stem.isBlank()) {
+        stem = result.getManifest().getId();
+      }
+      Path pageOut = outputRoot.resolve(stem);
+      PSPageXmlCompiler.writeArtifacts(result, pageOut);
+    }
+  }
+
+  /**
+   * List {@code *.templateDef} files at package root, sorted by file name (case-insensitive).
+   * Portable: uses {@link DirectoryStream} + {@link Path}, not hardcoded separators.
+   */
+  static List<Path> listTemplateDefs(Path packageDir) throws IOException {
+    List<Path> files = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(packageDir, "*.templateDef")) {
+      for (Path p : stream) {
+        if (Files.isRegularFile(p)) {
+          files.add(p);
+        }
+      }
+    }
+    files.sort(Comparator.comparing(p -> p.getFileName().toString().toLowerCase(Locale.ROOT)));
+    return files;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageContext.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageContext.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Optional package-level metadata used when compiling a Page {@code *.templateDef} that lives
+ * inside a legacy product package source tree (e.g. {@code perc.baseTemplates}).
+ *
+ * <p>Populated from {@code psx_archiveInfo.xml} when present. Lightweight regex/string extraction is
+ * intentional: archive descriptors are large nested trees; only identity fields are needed here.
+ */
+public final class PSPageXmlPackageContext {
+
+  private String packageId;
+  private String packageName;
+  private String version;
+  private String description;
+  private String publisherName;
+  private String publisherUrl;
+  private String cmsMin;
+  private String cmsMax;
+  private List<Dependency> dependencies = new ArrayList<>();
+
+  public String getPackageId() {
+    return packageId;
+  }
+
+  public void setPackageId(String packageId) {
+    this.packageId = packageId;
+  }
+
+  public String getPackageName() {
+    return packageName;
+  }
+
+  public void setPackageName(String packageName) {
+    this.packageName = packageName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getPublisherName() {
+    return publisherName;
+  }
+
+  public void setPublisherName(String publisherName) {
+    this.publisherName = publisherName;
+  }
+
+  public String getPublisherUrl() {
+    return publisherUrl;
+  }
+
+  public void setPublisherUrl(String publisherUrl) {
+    this.publisherUrl = publisherUrl;
+  }
+
+  public String getCmsMin() {
+    return cmsMin;
+  }
+
+  public void setCmsMin(String cmsMin) {
+    this.cmsMin = cmsMin;
+  }
+
+  public String getCmsMax() {
+    return cmsMax;
+  }
+
+  public void setCmsMax(String cmsMax) {
+    this.cmsMax = cmsMax;
+  }
+
+  public List<Dependency> getDependencies() {
+    return dependencies;
+  }
+
+  public void setDependencies(List<Dependency> dependencies) {
+    this.dependencies = dependencies != null ? dependencies : new ArrayList<>();
+  }
+
+  /**
+   * Load package context from a package source directory (looks for {@code psx_archiveInfo.xml}).
+   *
+   * @param packageDir non-null package root
+   * @return context (may have only packageId from the directory name when archive info is absent)
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlPackageContext fromPackageDir(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    PSPageXmlPackageContext ctx = new PSPageXmlPackageContext();
+    Path name = packageDir.getFileName();
+    if (name != null) {
+      ctx.setPackageId(name.toString());
+      ctx.setPackageName(name.toString());
+    }
+    Path archiveInfo = packageDir.resolve("psx_archiveInfo.xml");
+    if (Files.isRegularFile(archiveInfo)) {
+      String xml = Files.readString(archiveInfo, StandardCharsets.UTF_8);
+      applyArchiveInfo(ctx, xml);
+    }
+    return ctx;
+  }
+
+  /**
+   * Apply selected fields from {@code psx_archiveInfo.xml} text into {@code ctx}.
+   *
+   * @param ctx non-null context to mutate
+   * @param archiveXml non-null archive info document text
+   */
+  static void applyArchiveInfo(PSPageXmlPackageContext ctx, String archiveXml) {
+    Objects.requireNonNull(ctx, "ctx");
+    Objects.requireNonNull(archiveXml, "archiveXml");
+
+    String descriptorName = firstAttr(archiveXml, "PSXDescriptor", "name");
+    if (descriptorName != null && !descriptorName.isBlank()) {
+      ctx.setPackageId(descriptorName);
+      ctx.setPackageName(descriptorName);
+    }
+
+    String archiveRef = firstAttr(archiveXml, "PSXArchiveInfo", "archiveRef");
+    if ((ctx.getPackageId() == null || ctx.getPackageId().isBlank())
+        && archiveRef != null
+        && !archiveRef.isBlank()) {
+      ctx.setPackageId(archiveRef);
+      ctx.setPackageName(archiveRef);
+    }
+
+    Matcher desc = Pattern.compile("<Description>([^<]*)</Description>").matcher(archiveXml);
+    if (desc.find()) {
+      String d = desc.group(1).trim();
+      if (!d.isEmpty()) {
+        ctx.setDescription(d);
+      }
+    }
+
+    Matcher pub =
+        Pattern.compile(
+                "<Publisher\\s+name=\"([^\"]*)\"\\s+url=\"([^\"]*)\"\\s*/?>",
+                Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    if (pub.find()) {
+      ctx.setPublisherName(emptyToNull(pub.group(1)));
+      ctx.setPublisherUrl(emptyToNull(pub.group(2)));
+    }
+
+    Matcher cms =
+        Pattern.compile(
+                "<CmsVersion\\s+max=\"([^\"]*)\"\\s+min=\"([^\"]*)\"\\s*/?>",
+                Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    if (!cms.find()) {
+      cms =
+          Pattern.compile(
+                  "<CmsVersion\\s+min=\"([^\"]*)\"\\s+max=\"([^\"]*)\"\\s*/?>",
+                  Pattern.CASE_INSENSITIVE)
+              .matcher(archiveXml);
+      if (cms.find()) {
+        ctx.setCmsMin(emptyToNull(cms.group(1)));
+        ctx.setCmsMax(emptyToNull(cms.group(2)));
+      }
+    } else {
+      ctx.setCmsMax(emptyToNull(cms.group(1)));
+      ctx.setCmsMin(emptyToNull(cms.group(2)));
+    }
+
+    Matcher ver = Pattern.compile("<Version>([^<]+)</Version>").matcher(archiveXml);
+    if (ver.find()) {
+      ctx.setVersion(ver.group(1).trim());
+    }
+
+    List<Dependency> deps = new ArrayList<>();
+    Matcher dep =
+        Pattern.compile("<PKGDependency\\s+([^>]+)/?>", Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    while (dep.find()) {
+      Map<String, String> attrs = parseAttrBag(dep.group(1));
+      Dependency d = new Dependency();
+      d.setName(attrs.get("name"));
+      d.setVersion(attrs.get("pkgVersion"));
+      String implied = attrs.get("PKGDepImplied");
+      d.setImplied(implied != null && Boolean.parseBoolean(implied));
+      if (d.getName() != null && !d.getName().isBlank()) {
+        deps.add(d);
+      }
+    }
+    ctx.setDependencies(deps);
+  }
+
+  private static String firstAttr(String xml, String element, String attr) {
+    Pattern p = Pattern.compile("<" + element + "\\b([^>]*)>", Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher(xml);
+    if (!m.find()) {
+      return null;
+    }
+    return parseAttrBag(m.group(1)).get(attr);
+  }
+
+  private static Map<String, String> parseAttrBag(String bag) {
+    Map<String, String> map = new LinkedHashMap<>();
+    Matcher m = Pattern.compile("([A-Za-z_][\\w:.-]*)\\s*=\\s*\"([^\"]*)\"").matcher(bag);
+    while (m.find()) {
+      map.put(m.group(1), m.group(2));
+    }
+    return map;
+  }
+
+  private static String emptyToNull(String s) {
+    if (s == null) {
+      return null;
+    }
+    String t = s.trim();
+    return t.isEmpty() ? null : t;
+  }
+
+  /** Package dependency row. */
+  public static final class Dependency {
+    private String name;
+    private String version;
+    private boolean implied;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+
+    public boolean isImplied() {
+      return implied;
+    }
+
+    public void setImplied(boolean implied) {
+      this.implied = implied;
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlParser.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlParser.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Parses legacy Page / assembly {@code *.templateDef} XML ({@code <assembly-template>}) into {@link
+ * PSPageXmlModel}.
+ *
+ * <p>Uses a hardened {@link DocumentBuilderFactory} (no external DTDs / schemas / XInclude). Paths
+ * are read via portable NIO {@link Files}.
+ */
+public final class PSPageXmlParser {
+
+  /** Velocity {@code #region("id" …)} macro — first arg is the region / slot id. */
+  private static final Pattern REGION_MACRO =
+      Pattern.compile("#region\\(\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Markup container that often wraps a region hole: {@code id="regionId" class="…"}. Captures the
+   * class attribute for layout/style hints (region-slot mapping / ADR-003 direction).
+   */
+  private static final Pattern ID_CLASS =
+      Pattern.compile(
+          "id\\s*=\\s*\"([^\"]+)\"\\s+class\\s*=\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern CLASS_ID =
+      Pattern.compile(
+          "class\\s*=\\s*\"([^\"]+)\"\\s+id\\s*=\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE);
+
+  private PSPageXmlParser() {
+    // utility
+  }
+
+  /**
+   * Parse a {@code *.templateDef} file as UTF-8.
+   *
+   * @param path non-null path
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlModel parse(Path path) throws PSPageXmlException, IOException {
+    Objects.requireNonNull(path, "path");
+    String xml = Files.readString(path, StandardCharsets.UTF_8);
+    PSPageXmlModel model = parse(xml);
+    Path fileName = path.getFileName();
+    if (fileName != null) {
+      model.setSourceFileName(fileName.toString());
+    }
+    return model;
+  }
+
+  /**
+   * Parse assembly-template XML from a string.
+   *
+   * @param xml non-null document text
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   */
+  public static PSPageXmlModel parse(String xml) throws PSPageXmlException {
+    Objects.requireNonNull(xml, "xml");
+    if (xml.isBlank()) {
+      throw new PSPageXmlException("Page templateDef XML is empty");
+    }
+    try {
+      Document doc = parseDocument(new InputSource(new StringReader(xml)));
+      return fromDocument(doc, null);
+    } catch (PSPageXmlException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSPageXmlException("Failed to parse Page templateDef XML: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Parse from a reader.
+   *
+   * @param reader non-null reader
+   * @param sourceFileName optional file name for stem derivation
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlModel parse(Reader reader, String sourceFileName)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(reader, "reader");
+    try {
+      Document doc = parseDocument(new InputSource(reader));
+      return fromDocument(doc, sourceFileName);
+    } catch (PSPageXmlException e) {
+      throw e;
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSPageXmlException("Failed to parse Page templateDef XML: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Parse from an input stream.
+   *
+   * @param in non-null stream
+   * @param sourceFileName optional file name for stem derivation
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlModel parse(InputStream in, String sourceFileName)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(in, "in");
+    try {
+      Document doc = parseDocument(new InputSource(in));
+      return fromDocument(doc, sourceFileName);
+    } catch (PSPageXmlException e) {
+      throw e;
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSPageXmlException("Failed to parse Page templateDef XML: " + e.getMessage(), e);
+    }
+  }
+
+  private static Document parseDocument(InputSource source)
+      throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setExpandEntityReferences(false);
+    factory.setXIncludeAware(false);
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    return factory.newDocumentBuilder().parse(source);
+  }
+
+  private static PSPageXmlModel fromDocument(Document doc, String sourceFileName)
+      throws PSPageXmlException {
+    Element root = doc.getDocumentElement();
+    if (root == null || !"assembly-template".equals(root.getTagName())) {
+      throw new PSPageXmlException(
+          "Expected root element <assembly-template>, found: "
+              + (root == null ? "null" : root.getTagName()));
+    }
+
+    PSPageXmlModel model = new PSPageXmlModel();
+    if (sourceFileName != null && !sourceFileName.isBlank()) {
+      model.setSourceFileName(sourceFileName);
+    }
+
+    model.setName(childText(root, "name"));
+    model.setLabel(childText(root, "label"));
+    model.setDescription(childText(root, "description"));
+    model.setGuid(childText(root, "guid"));
+    model.setAssembler(childText(root, "assembler"));
+    model.setOutputFormat(childText(root, "output-format"));
+    model.setTemplateType(childText(root, "template-type"));
+    model.setMimeType(childText(root, "mime-type"));
+    model.setCharset(childText(root, "charset"));
+    model.setActiveAssemblyType(childText(root, "active-assembly-type"));
+
+    Element templateEl = firstChildElement(root, "template");
+    String body = templateEl != null ? normalizeBody(textContent(templateEl)) : null;
+    model.setTemplateBody(body);
+
+    List<PSPageXmlModel.Binding> bindings = new ArrayList<>();
+    Element bindingsEl = firstChildElement(root, "bindings");
+    if (bindingsEl != null) {
+      for (Element b : childElements(bindingsEl, "binding")) {
+        PSPageXmlModel.Binding binding = new PSPageXmlModel.Binding();
+        // Common shapes: <binding variable="x" expression="…"/> or nested <variable>/<expression>
+        binding.setVariable(firstNonBlank(attr(b, "variable"), attr(b, "name"), childText(b, "variable")));
+        binding.setExpression(
+            firstNonBlank(attr(b, "expression"), attr(b, "value"), childText(b, "expression")));
+        if (binding.getVariable() != null && !binding.getVariable().isBlank()) {
+          bindings.add(binding);
+        }
+      }
+    }
+    model.setBindings(bindings);
+
+    model.setRegionHoles(extractRegionHoles(body));
+    return model;
+  }
+
+  /**
+   * Discover {@code #region} holes and attach CSS class / layout hints from matching markup {@code
+   * id} containers when present.
+   */
+  static List<PSPageXmlModel.RegionHole> extractRegionHoles(String templateBody) {
+    List<PSPageXmlModel.RegionHole> holes = new ArrayList<>();
+    if (templateBody == null || templateBody.isBlank()) {
+      return holes;
+    }
+
+    Map<String, String> idToClass = new LinkedHashMap<>();
+    Matcher idClass = ID_CLASS.matcher(templateBody);
+    while (idClass.find()) {
+      idToClass.putIfAbsent(idClass.group(1), idClass.group(2));
+    }
+    Matcher classId = CLASS_ID.matcher(templateBody);
+    while (classId.find()) {
+      idToClass.putIfAbsent(classId.group(2), classId.group(1));
+    }
+
+    Set<String> seen = new LinkedHashSet<>();
+    Matcher region = REGION_MACRO.matcher(templateBody);
+    while (region.find()) {
+      String id = region.group(1).trim();
+      if (id.isEmpty() || !seen.add(id)) {
+        continue;
+      }
+      PSPageXmlModel.RegionHole hole = new PSPageXmlModel.RegionHole();
+      hole.setRegionId(id);
+      String css = idToClass.get(id);
+      hole.setCssClass(css);
+      applyClassHints(hole, css);
+      holes.add(hole);
+    }
+    return holes;
+  }
+
+  /**
+   * Map CM1 region CSS class tokens onto layout / style hint maps (ADR-003 direction).
+   *
+   * <ul>
+   *   <li>{@code perc-vertical} / {@code perc-horizontal} → {@code layout.orientation}
+   *   <li>{@code vspan_N} / {@code hspan_N} → layout span hints
+   *   <li>full class string → {@code styles.rootclass}
+   * </ul>
+   */
+  static void applyClassHints(PSPageXmlModel.RegionHole hole, String cssClass) {
+    Map<String, Object> layout = new LinkedHashMap<>();
+    Map<String, Object> styles = new LinkedHashMap<>();
+    if (cssClass != null && !cssClass.isBlank()) {
+      styles.put("rootclass", cssClass.trim());
+      for (String token : cssClass.trim().split("\\s+")) {
+        if (token.isEmpty()) {
+          continue;
+        }
+        String t = token.toLowerCase(Locale.ROOT);
+        if ("perc-vertical".equals(t)) {
+          layout.put("orientation", "vertical");
+        } else if ("perc-horizontal".equals(t)) {
+          layout.put("orientation", "horizontal");
+        } else if (t.startsWith("vspan_")) {
+          layout.put("vspan", token.substring("vspan_".length()));
+        } else if (t.startsWith("hspan_")) {
+          layout.put("hspan", token.substring("hspan_".length()));
+        }
+      }
+    }
+    hole.setLayoutHints(layout);
+    hole.setStyleHints(styles);
+  }
+
+  /**
+   * Normalize body text for cross-platform golden parity: CRLF/CR → LF, strip leading/trailing
+   * whitespace.
+   */
+  static String normalizeBody(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String s = raw.replace("\r\n", "\n").replace('\r', '\n');
+    return s.stripLeading().stripTrailing();
+  }
+
+  private static Element firstChildElement(Element parent, String name) {
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE && name.equals(n.getNodeName())) {
+        return (Element) n;
+      }
+    }
+    return null;
+  }
+
+  private static List<Element> childElements(Element parent, String name) {
+    List<Element> out = new ArrayList<>();
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE && name.equals(n.getNodeName())) {
+        out.add((Element) n);
+      }
+    }
+    return out;
+  }
+
+  private static String childText(Element parent, String name) {
+    Element el = firstChildElement(parent, name);
+    if (el == null) {
+      return null;
+    }
+    String t = textContent(el);
+    if (t == null) {
+      return null;
+    }
+    String trimmed = t.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private static String attr(Element el, String name) {
+    if (!el.hasAttribute(name)) {
+      return null;
+    }
+    String v = el.getAttribute(name);
+    return v.isEmpty() ? null : v;
+  }
+
+  private static String firstNonBlank(String... values) {
+    if (values == null) {
+      return null;
+    }
+    for (String v : values) {
+      if (v != null && !v.isBlank()) {
+        return v.trim();
+      }
+    }
+    return null;
+  }
+
+  private static String textContent(Element el) {
+    StringBuilder sb = new StringBuilder();
+    NodeList children = el.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      short type = n.getNodeType();
+      if (type == Node.TEXT_NODE || type == Node.CDATA_SECTION_NODE) {
+        sb.append(n.getNodeValue());
+      }
+    }
+    if (sb.length() == 0) {
+      return el.getTextContent();
+    }
+    return sb.toString();
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlCompilerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit + golden parity tests for Page {@code *.templateDef} → Component Package Manifest compiler
+ * (#2770 / parent #2630).
+ */
+class PSPageXmlCompilerTest {
+
+  private static final String FIXTURE_PLAIN = "/pagexml/perc.base.plain.templateDef";
+  private static final String FIXTURE_HEADER_FOOTER =
+      "/pagexml/perc.base.headerFooter.templateDef";
+  private static final String GOLDEN_PLAIN_MANIFEST =
+      "/pagexml/golden/perc.base.plain.component-package.json";
+  private static final String GOLDEN_PLAIN_TEMPLATE = "/pagexml/golden/perc.base.plain.vm";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parsePlain_populatesNameAssemblerRegionsAndBody() throws Exception {
+    PSPageXmlModel model = parseClasspath(FIXTURE_PLAIN, "perc.base.plain.templateDef");
+
+    assertEquals("perc.base.plain", model.getName());
+    assertEquals("Plain", model.getLabel());
+    assertEquals("Java/global/percussion/assembly/pageAssembler", model.getAssembler());
+    assertEquals("Page", model.getOutputFormat());
+    assertEquals("perc.base.plain", model.pageStem());
+    assertNotNull(model.getTemplateBody());
+    assertTrue(model.getTemplateBody().contains("#region(\"perc-content\""));
+    assertTrue(model.getTemplateBody().contains("<div id=\"perc-content\""));
+    assertEquals(1, model.getRegionHoles().size());
+    assertEquals("perc-content", model.getRegionHoles().get(0).getRegionId());
+    assertEquals("vertical", model.getRegionHoles().get(0).getLayoutHints().get("orientation"));
+    assertEquals(
+        "perc-region perc-vertical",
+        model.getRegionHoles().get(0).getStyleHints().get("rootclass"));
+  }
+
+  @Test
+  void parseHeaderFooter_threeRegionsInOrder() throws Exception {
+    PSPageXmlModel model =
+        parseClasspath(FIXTURE_HEADER_FOOTER, "perc.base.headerFooter.templateDef");
+
+    assertEquals("perc.base.headerFooter", model.getName());
+    List<String> ids =
+        model.getRegionHoles().stream()
+            .map(PSPageXmlModel.RegionHole::getRegionId)
+            .collect(Collectors.toList());
+    assertEquals(List.of("header", "content", "footer"), ids);
+  }
+
+  @Test
+  void compilePlain_matchesGoldenManifestAndTemplate() throws Exception {
+    PSPageXmlModel model = parseClasspath(FIXTURE_PLAIN, "perc.base.plain.templateDef");
+    PSPageXmlPackageContext ctx = baseTemplatesLikeContext();
+
+    PSPageXmlCompileResult result = PSPageXmlCompiler.compile(model, ctx);
+    PSComponentPackageManifest manifest = result.getManifest();
+
+    PSComponentPackageManifestValidator.validate(manifest);
+
+    String expectedJson = readClasspath(GOLDEN_PLAIN_MANIFEST);
+    PSComponentPackageManifest golden = PSComponentPackageManifestIo.parse(expectedJson);
+
+    assertEquals(golden.getSchemaVersion(), manifest.getSchemaVersion());
+    assertEquals(golden.getId(), manifest.getId());
+    assertEquals(golden.getName(), manifest.getName());
+    assertEquals(golden.getVersion(), manifest.getVersion());
+    assertEquals(golden.getDescription(), manifest.getDescription());
+    assertEquals(golden.getPublisher(), manifest.getPublisher());
+    assertEquals(golden.getCmsVersion(), manifest.getCmsVersion());
+    assertEquals(golden.getCatalog(), manifest.getCatalog());
+    assertEquals(golden.getTemplates().size(), manifest.getTemplates().size());
+    assertEquals(golden.getTemplates().get(0).getName(), manifest.getTemplates().get(0).getName());
+    assertEquals(
+        golden.getTemplates().get(0).getType(), manifest.getTemplates().get(0).getType());
+    assertEquals(
+        golden.getTemplates().get(0).getAssembler(),
+        manifest.getTemplates().get(0).getAssembler());
+    assertEquals(
+        golden.getTemplates().get(0).getSourceRef(),
+        manifest.getTemplates().get(0).getSourceRef());
+    assertEquals(golden.getSlots(), manifest.getSlots());
+
+    PSComponentPackageManifest reparsed =
+        PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(manifest));
+    assertEquals(
+        PSComponentPackageManifestIo.parse(expectedJson),
+        reparsed,
+        "compiled manifest must equal golden fixture");
+
+    String expectedTemplate = normalizeNewlines(readClasspath(GOLDEN_PLAIN_TEMPLATE));
+    String actualTemplate =
+        normalizeNewlines(result.getTextArtifacts().get("templates/perc.base.plain.vm"));
+    assertEquals(expectedTemplate, actualTemplate, "template source golden parity");
+  }
+
+  @Test
+  void compilePlain_writeArtifacts_roundTrips() throws Exception {
+    PSPageXmlModel model = parseClasspath(FIXTURE_PLAIN, "perc.base.plain.templateDef");
+    PSPageXmlCompileResult result = PSPageXmlCompiler.compile(model, baseTemplatesLikeContext());
+
+    Path out = tempDir.resolve("plain-out");
+    PSPageXmlCompiler.writeArtifacts(result, out);
+
+    Path manifestPath = out.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    assertTrue(Files.isRegularFile(manifestPath));
+    PSComponentPackageManifest loaded = PSComponentPackageManifestIo.read(manifestPath);
+    PSComponentPackageManifestValidator.validate(loaded);
+    assertEquals(result.getManifest().getId(), loaded.getId());
+
+    Path template = out.resolve("templates").resolve("perc.base.plain.vm");
+    assertTrue(Files.isRegularFile(template));
+    assertEquals(
+        normalizeNewlines(result.getTextArtifacts().get("templates/perc.base.plain.vm")),
+        normalizeNewlines(Files.readString(template, StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void compileBaseTemplatesPackage_allValidPageTemplates() throws Exception {
+    Path packageDir = locateBaseTemplatesPackage();
+    if (packageDir == null) {
+      System.err.println(
+          "WARN: perc.baseTemplates package sources not found; skipping package test");
+      return;
+    }
+
+    List<PSPageXmlCompileResult> results = PSPageXmlPackageCompiler.compilePackage(packageDir);
+    assertTrue(results.size() >= 20, "baseTemplates should ship many layout templates");
+
+    Map<String, PSPageXmlCompileResult> byId =
+        results.stream()
+            .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+    assertTrue(byId.containsKey("perc.base.plain"));
+    assertTrue(byId.containsKey("perc.base.headerFooter"));
+    assertTrue(byId.containsKey("perc.base.Box"));
+
+    for (PSPageXmlCompileResult r : results) {
+      PSComponentPackageManifestValidator.validate(r.getManifest());
+      assertEquals("1.1.5", r.getManifest().getVersion());
+      assertNotNull(r.getManifest().getPublisher());
+      assertEquals("page", r.getManifest().getCatalog().getKind());
+      assertEquals("page", r.getManifest().getTemplates().get(0).getType());
+      assertEquals("pageAssembler", r.getManifest().getTemplates().get(0).getAssembler());
+      assertFalse(r.getTextArtifacts().isEmpty());
+      assertFalse(r.getManifest().getSlots().isEmpty(), r.getManifest().getId());
+    }
+
+    PSPageXmlCompileResult plain = byId.get("perc.base.plain");
+    assertEquals(1, plain.getManifest().getSlots().size());
+    assertEquals("perc-content", plain.getManifest().getSlots().get(0).getName());
+
+    Path outRoot = tempDir.resolve("baseTemplates-out");
+    PSPageXmlPackageCompiler.writeAll(results, outRoot);
+    assertTrue(
+        Files.isRegularFile(
+            outRoot
+                .resolve("perc.base.plain")
+                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+  }
+
+  @Test
+  void parseEmptyXml_throws() {
+    assertThrows(PSPageXmlException.class, () -> PSPageXmlParser.parse("   "));
+  }
+
+  @Test
+  void parseNonAssemblyRoot_throws() {
+    assertThrows(PSPageXmlException.class, () -> PSPageXmlParser.parse("<Widget/>"));
+  }
+
+  @Test
+  void mapAssembler_extensionPathAndShortNames() {
+    assertEquals(
+        "pageAssembler",
+        PSPageXmlCompiler.mapAssembler("Java/global/percussion/assembly/pageAssembler"));
+    assertEquals(
+        "velocityAssembler",
+        PSPageXmlCompiler.mapAssembler("Java/global/percussion/assembly/velocityAssembler"));
+    assertEquals("htmlAssembler", PSPageXmlCompiler.mapAssembler("htmlAssembler"));
+  }
+
+  @Test
+  void mapTemplateType_outputFormat() {
+    assertEquals("page", PSPageXmlCompiler.mapTemplateType("Page", "pageAssembler"));
+    assertEquals("global", PSPageXmlCompiler.mapTemplateType("Global", "velocityAssembler"));
+    assertEquals("snippet", PSPageXmlCompiler.mapTemplateType("Snippet", "velocityAssembler"));
+  }
+
+  private static PSPageXmlPackageContext baseTemplatesLikeContext() {
+    PSPageXmlPackageContext ctx = new PSPageXmlPackageContext();
+    ctx.setPackageId("perc.baseTemplates");
+    ctx.setPackageName("perc.baseTemplates");
+    ctx.setVersion("1.1.5");
+    ctx.setDescription("Percussion base layout templates.");
+    ctx.setPublisherName("Percussion Software Inc.");
+    ctx.setPublisherUrl("http://www.percussion.com");
+    ctx.setCmsMin("1.0.0");
+    ctx.setCmsMax("9.0.0");
+    return ctx;
+  }
+
+  private static PSPageXmlModel parseClasspath(String resource, String fileName) throws Exception {
+    try (InputStream in = PSPageXmlCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return PSPageXmlParser.parse(in, fileName);
+    }
+  }
+
+  private static String readClasspath(String resource) throws Exception {
+    try (InputStream in = PSPageXmlCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  /**
+   * Locate product {@code perc.baseTemplates} sources relative to the module working directory
+   * (Maven surefire cwd = module root).
+   */
+  private static Path locateBaseTemplatesPackage() {
+    Path candidate =
+        Path.of("src", "main", "resources", "Packages", "perc.baseTemplates");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src")
+            .resolve("main")
+            .resolve("resources")
+            .resolve("Packages")
+            .resolve("perc.baseTemplates");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}

--- a/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.component-package.json
+++ b/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.component-package.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.base.plain",
+  "name": "Plain",
+  "version": "1.1.5",
+  "description": "Percussion base layout templates.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "page",
+    "title": "Plain",
+    "category": "page",
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "perc.base.plain",
+      "type": "page",
+      "assembler": "pageAssembler",
+      "sourceRef": "templates/perc.base.plain.vm",
+      "bindings": []
+    }
+  ],
+  "slots": [
+    {
+      "name": "perc-content",
+      "allowedContentTypes": [],
+      "layout": {
+        "orientation": "vertical"
+      },
+      "styles": {
+        "rootclass": "perc-region perc-vertical"
+      }
+    }
+  ],
+  "resources": [],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.vm
+++ b/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.vm
@@ -1,0 +1,11 @@
+#perc_templateHeader()##
+  <div id="perc-container" class="perc-region perc-vertical">
+      <div class="perc-vertical">
+		<div id="perc-content" class="perc-region perc-vertical">
+			<div class="perc-vertical">
+                        #region("perc-content" '' '' '' '')##
+			</div>
+		</div>
+	  </div>
+  </div>
+#perc_templateFooter()

--- a/modules/perc-packages/src/test/resources/pagexml/perc.base.headerFooter.templateDef
+++ b/modules/perc-packages/src/test/resources/pagexml/perc.base.headerFooter.templateDef
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>  <assembly-template id="1">
+    <bindings/>
+    <template-slot-ids/>
+    <guid>0-4-571</guid>
+    <active-assembly-type>Normal</active-assembly-type>
+    <assembler>Java/global/percussion/assembly/pageAssembler</assembler>
+    <assembly-url>../assembler/render</assembly-url>
+    <charset>UTF-8</charset>
+    <description/>
+    <global-template/>
+    <global-template-usage>None</global-template-usage>
+    <label>Header Footer</label>
+    <location-prefix/>
+    <location-suffix/>
+    <mime-type>text/html</mime-type>
+    <name>perc.base.headerFooter</name>
+    <output-format>Page</output-format>
+    <publish-when>Default</publish-when>
+    <style-sheet-path/>
+    <template>#perc_templateHeader()##
+&lt;div id="container" class="perc-region perc-vertical hspan_12"&gt;
+     &lt;div class="perc-vertical"&gt;
+        &lt;div id="header" class="perc-region perc-vertical vspan_2"&gt;
+           &lt;div class="perc-vertical"&gt;
+			  #region("header" '' '' '' '')##
+           &lt;/div&gt;
+        &lt;/div&gt;		
+        &lt;div id="content" class="perc-region perc-vertical vspan_6"&gt;
+           &lt;div class="perc-vertical"&gt;
+			  #region("content" '' '' '' '')##
+           &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div id="footer" class="perc-region perc-vertical vspan_2"&gt;
+           &lt;div class="perc-vertical"&gt;
+			  #region("footer" '' '' '' '')##
+           &lt;/div&gt;
+        &lt;/div&gt;              
+     &lt;/div&gt;
+  &lt;/div&gt;
+#perc_templateFooter()</template>
+    <template-type>Shared</template-type>
+    <type>TEMPLATE</type>
+    <variant>false</variant>
+  </assembly-template>

--- a/modules/perc-packages/src/test/resources/pagexml/perc.base.plain.templateDef
+++ b/modules/perc-packages/src/test/resources/pagexml/perc.base.plain.templateDef
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>  <assembly-template id="1">
+    <bindings/>
+    <template-slot-ids/>
+    <guid>0-4-591</guid>
+    <active-assembly-type>Normal</active-assembly-type>
+    <assembler>Java/global/percussion/assembly/pageAssembler</assembler>
+    <assembly-url>../assembler/render</assembly-url>
+    <charset>UTF-8</charset>
+    <description/>
+    <global-template/>
+    <global-template-usage>None</global-template-usage>
+    <label>Plain</label>
+    <location-prefix/>
+    <location-suffix/>
+    <mime-type>text/html</mime-type>
+    <name>perc.base.plain</name>
+    <output-format>Page</output-format>
+    <publish-when>Default</publish-when>
+    <style-sheet-path/>
+    <template>#perc_templateHeader()##
+  &lt;div id="perc-container" class="perc-region perc-vertical"&gt;
+      &lt;div class="perc-vertical"&gt;
+		&lt;div id="perc-content" class="perc-region perc-vertical"&gt;
+			&lt;div class="perc-vertical"&gt;
+                        #region("perc-content" '' '' '' '')##
+			&lt;/div&gt;
+		&lt;/div&gt;
+	  &lt;/div&gt;
+  &lt;/div&gt;
+#perc_templateFooter()</template>
+    <template-type>Shared</template-type>
+    <type>TEMPLATE</type>
+    <variant>false</variant>
+  </assembly-template>


### PR DESCRIPTION
## Summary

Phase 3 slice 4 for parent **#2630** (grandparent **#2626**, ADR-004): Page product packaging upgrade-input path.

Product page layout packages use `*.templateDef` (`<assembly-template>`), not `rxconfig/Pages/*.xml`. This PR adds a compiler peer to the Widget XML compiler:

- **`com.percussion.packages.pagexml`**: parse / compile / package-scan for `*.templateDef`
- Maps `pageAssembler` + Velocity body + `#region` holes → Component Package Manifest (`catalog.kind=page`, slots from regions)
- Golden parity: `perc.base.plain` (manifest + `.vm`)
- Package test: `perc.baseTemplates` (≥20 layout templates) all validate
- Inventory + dual-run docs: `docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md`

**Dual-run:** product packages still ship `*.templateDef` as install input; modern `component-package.json` is the compiler output and future authoring format. Full dual-run exit (delete package templateDefs after install consumes modern packages) is residual under #2630.

### Out of scope (residuals / siblings)
- Widget baseWidgets / high-traffic (#2751 cluster)
- Gadget registry conversion
- Site-storage page item composition IR
- Install-path recognition of modern page packages + product templateDef deletion

## Test plan
1. `cd modules/perc-packages && ../../mvnw clean install` (JDK 21)
2. Confirm `PSPageXmlCompilerTest` green (golden + package scan)
3. No product package tree rewrite in this PR (dual-run)

## Build gates evidence
- **modules_built:** `modules/perc-packages`
- **Command:** `cd modules/perc-packages; $env:JAVA_HOME='C:\Program Files\Microsoft\jdk-21.0.12.8-hotspot'; ..\..\mvnw.cmd clean install`
- **Result:** BUILD SUCCESS
- **Tests:** Tests run: 47, Failures: 0 (includes 9 new `PSPageXmlCompilerTest`)
- **downstream_checked:** none (new package-local types only; no public type made final/signature-changed for reverse deps)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2770  
Refs #2630 #2626

> Co-Authored by Grok Build using grok-4.5 with agent main.
