### PR TITLE
feat(perc-packages): Gadget registry to catalog/package model + goldens (#2771)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -76,8 +76,10 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
 | Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751) |
+| Gadget registry compiler | `modules/perc-packages/.../gadgetxml/PSGadgetRegistryCompiler.java` (#2771) |
+| Modern gadget catalog (ship) | `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` |
 | Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |
-| Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
+| Gadget registry (legacy upgrade input) | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 
 ## Immediate next work
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -60,3 +60,16 @@ Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidget
 | Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
 
 High-traffic package conversion and product XML removal remain residual under #2630.
+
+## Gadget registry compiler (slice #2771)
+
+Compiler for upgrade-input `GadgetRegistry.xml` → aggregate `gadget-catalog.json` + per-gadget `component-package.json` (`catalog.kind = "gadget"`):
+
+| Artifact | Location |
+|----------|----------|
+| Parser / compiler / catalog IO | `modules/perc-packages/.../gadgetxml/PSGadgetRegistry*.java`, `PSGadgetCatalog*.java` |
+| Product modern catalog | `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` |
+| Golden parity (Welcome + full catalog) | `modules/perc-packages/src/test/resources/gadgetxml/golden/` |
+| Inventory + residuals | [../gadget-definition-inventory.md](../gadget-definition-inventory.md) |
+
+Gadgets are SPA/dashboard hosts (not assembly templates). Validator allows gadget packages without `contentTypes[]` / `templates[]` when `catalog.kind = "gadget"` and `catalog.title` is set. WebUI dual-load of JSON catalog (retire `GadgetRegistry.xml` at runtime) remains residual.

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -65,8 +65,8 @@ Paths inside the manifest are **package-relative**, always with `/` separators (
 | `cmsVersion` | object | no | `{ "min", "max" }` compatible CMS range |
 | `dependencies` | array | no | `{ "name", "version", "implied" }` |
 | `catalog` | object | no | Palette / UI metadata (see below) |
-| `contentTypes` | array | * | At least one of `contentTypes` or `templates` required |
-| `templates` | array | * | At least one of `contentTypes` or `templates` required |
+| `contentTypes` | array | * | Required (with templates) for non-gadget packages; optional when `catalog.kind = "gadget"` (#2771) |
+| `templates` | array | * | Required (with contentTypes) for non-gadget packages; optional when `catalog.kind = "gadget"` |
 | `slots` | array | no | Composition holes with optional layout/styles |
 | `resources` | array | no | CSS/JS/images |
 | `userPreferences` | array | no | Transitional from Widget `UserPref` |
@@ -77,8 +77,8 @@ Paths inside the manifest are **package-relative**, always with `/` separators (
 | Field | Type | Notes |
 |-------|------|-------|
 | `kind` | string | Default `component`; also `page`, `gadget`, … |
-| `title` | string | Palette title |
-| `category` | string | e.g. `content` |
+| `title` | string | Palette title (**required** when `kind = "gadget"`) |
+| `category` | string | e.g. `content` (gadget registry **group** maps here) |
 | `description` | string | |
 | `thumbnail` / `icon` | string | Package-relative resource path |
 | `author` | string | |

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -48,7 +48,7 @@ Hard order for a package root or definition id:
 | Widget definitions (install) | `${rxdeploydir}/rxconfig/Widgets/*.xml` via `PSWidgetDao` (`projects/sitemanage/.../dao/impl/PSWidgetDao`) | Loads legacy Widget XML by file id | Prefer modern package when present; XML remains fallback for unconverted customer defs |
 | Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; product source of truth moves off XML (ADR-004) |
 | Package staging Widgets | `sys__UserDependency--rxconfig/Widgets/` or `rxconfig/Widgets/` under a package root | Upgrade-input / deploy layout | Shim package-root API resolves either layout |
-| Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Treat remaining definition XML as legacy only |
+| Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Modern: `gadget-catalog.json` + per-gadget packages (#2771); dual-load residual for WebUI |
 | Page meta / definition XML | Site/page storage dialects | Composition authoring legacy | Page conversion is Phase 3 residual; shim recognizes `rxconfig/Pages` if present |
 
 **Selection API (no Spring wiring required for unit use):**

--- a/docs/ai-generated/tasks/template-assembler-normalization/gadget-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/gadget-definition-inventory.md
@@ -82,8 +82,24 @@ Redirect Management gadget assets already removed (issue #715 note in registry).
 3. Do **not** fold gadgets into assembly assemblers — separate “dashboard component catalog” track, same anti-XML packaging goal.
 4. Cross-link Home acceptance / gadget SPA work so this track only owns **packaging/registry** cleanup, not full gadget UX rewrite.
 
+## Gadget registry → catalog / package model (slice #2771)
+
+Compiler for upgrade-input `GadgetRegistry.xml` → modern ship format (landed after cluster #2766):
+
+| Artifact | Location |
+|----------|----------|
+| Parser / compiler / catalog IO | `modules/perc-packages/.../gadgetxml/PSGadgetRegistry*.java`, `PSGadgetCatalog*.java` |
+| Aggregate catalog ship file | `gadget-catalog.json` (`PSGadgetCatalog.DEFAULT_CATALOG_FILE_NAME`) |
+| Product modern catalog (authoring) | `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` |
+| Per-gadget packages | `component-package.json` with `catalog.kind = "gadget"` (no CT/templates required) |
+| Golden parity | Welcome (`cm1_welcome_gadget`) + full product catalog (21 entries) under `src/test/resources/gadgetxml/golden/` |
+| Validator rule | `PSComponentPackageManifestValidator` — `catalog.kind=gadget` requires `catalog.title`; CT/templates optional |
+
+**Still residual (not this slice):** WebUI runtime dual-load of `gadget-catalog.json` instead of `GadgetRegistry.xml` (SPA Home already has a parallel TS catalog); delete product `GadgetRegistry.xml` only after dual-load + QA.
+
 ## Related docs
 
 - `docs/ai-generated/tasks/completed/GADGET-MODERNIZATION-ANALYSIS.md`
 - `docs/ai-generated/tasks/home-acceptance-status.md`
 - `docs/ai-generated/tasks/design-templates-item-types/README.md` (Home/Gadgets dependencies)
+- [component-package-manifest.md](./component-package-manifest.md) (`catalog.kind = gadget`)

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -361,7 +361,7 @@ This is multi-quarter work even if labeled “8.2.” Split so 8.2 can ship **fo
    **Done (slice 1 / #2750):** schema docs + Java model + parse/validate/round-trip tests — see [component-package-manifest.md](./component-package-manifest.md) and `com.percussion.packages.manifest` in `modules/perc-packages`.
 2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles). *(#2751)*
 3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.
-4. **Gadget XML** conversion path for remaining XML-defined gadgets.
+4. **Gadget registry** conversion path → `gadget-catalog.json` + per-gadget packages (`catalog.kind=gadget`) (#2771; per-gadget definition XML already largely gone).
 5. Convert **baseline / baseWidgets** first; then high-traffic packages (nav, blog, lists, rich text).
 6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format. *(#2752)*
 7. Widget Builder / Design tools write modern package format only.

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalog.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalog.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Modern <strong>gadget catalog</strong> ship format (JSON) — product replacement for {@code
+ * GadgetRegistry.xml} grouping / listing (ADR-004 / issue #2771).
+ *
+ * <p>Default file name: {@value #DEFAULT_CATALOG_FILE_NAME}. Per-gadget install/authoring still uses
+ * {@code component-package.json} with {@code catalog.kind = "gadget"}; this aggregate catalog is the
+ * registry equivalent consumed by packaging tools and (eventually) SPA Home/Dashboard loaders.
+ */
+public final class PSGadgetCatalog {
+
+  /** Default ship-format file name for the aggregate gadget catalog. */
+  public static final String DEFAULT_CATALOG_FILE_NAME = "gadget-catalog.json";
+
+  /** Schema version supported by this model (semver major.minor). */
+  public static final String SUPPORTED_SCHEMA_VERSION = "1.0";
+
+  private String schemaVersion = SUPPORTED_SCHEMA_VERSION;
+  private String id = "perc.gadgetCatalog";
+  private String name = "Product Gadget Catalog";
+  private String version = "0.0.0";
+  private String description;
+  private List<Entry> gadgets = new ArrayList<>();
+
+  public String getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  public void setSchemaVersion(String schemaVersion) {
+    this.schemaVersion = schemaVersion;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public List<Entry> getGadgets() {
+    return gadgets;
+  }
+
+  public void setGadgets(List<Entry> gadgets) {
+    this.gadgets = gadgets != null ? gadgets : new ArrayList<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSGadgetCatalog that)) {
+      return false;
+    }
+    return Objects.equals(schemaVersion, that.schemaVersion)
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(version, that.version)
+        && Objects.equals(description, that.description)
+        && Objects.equals(gadgets, that.gadgets);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schemaVersion, id, name, version, description, gadgets);
+  }
+
+  /** One catalog row (modern equivalent of a registry {@code <gadget/>}). */
+  public static final class Entry {
+    private String id;
+    private String name;
+    private String group;
+    private String baseUri;
+    /** Legacy OpenSocial definition file name (upgrade-input only; product no longer ships XML). */
+    private String legacyDefinitionFile;
+    private boolean deprecated;
+    /** Package-relative path to this gadget's {@code component-package.json} when packaged alone. */
+    private String componentPackageRef;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getGroup() {
+      return group;
+    }
+
+    public void setGroup(String group) {
+      this.group = group;
+    }
+
+    public String getBaseUri() {
+      return baseUri;
+    }
+
+    public void setBaseUri(String baseUri) {
+      this.baseUri = baseUri;
+    }
+
+    public String getLegacyDefinitionFile() {
+      return legacyDefinitionFile;
+    }
+
+    public void setLegacyDefinitionFile(String legacyDefinitionFile) {
+      this.legacyDefinitionFile = legacyDefinitionFile;
+    }
+
+    public boolean isDeprecated() {
+      return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+      this.deprecated = deprecated;
+    }
+
+    public String getComponentPackageRef() {
+      return componentPackageRef;
+    }
+
+    public void setComponentPackageRef(String componentPackageRef) {
+      this.componentPackageRef = componentPackageRef;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Entry that)) {
+        return false;
+      }
+      return deprecated == that.deprecated
+          && Objects.equals(id, that.id)
+          && Objects.equals(name, that.name)
+          && Objects.equals(group, that.group)
+          && Objects.equals(baseUri, that.baseUri)
+          && Objects.equals(legacyDefinitionFile, that.legacyDefinitionFile)
+          && Objects.equals(componentPackageRef, that.componentPackageRef);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          id, name, group, baseUri, legacyDefinitionFile, deprecated, componentPackageRef);
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * Parse and write {@link PSGadgetCatalog} as JSON (modern gadget registry ship format).
+ *
+ * <p>Uses portable {@link Path} / {@link Files} I/O and UTF-8.
+ */
+public final class PSGadgetCatalogIo {
+
+  private static final Gson GSON =
+      new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+  private PSGadgetCatalogIo() {
+    // utility
+  }
+
+  /**
+   * Parse a JSON string into a catalog.
+   *
+   * @param json non-null JSON document
+   * @return parsed model (never null)
+   * @throws PSGadgetRegistryException if JSON is empty or not a valid document
+   */
+  public static PSGadgetCatalog parse(String json) throws PSGadgetRegistryException {
+    Objects.requireNonNull(json, "json");
+    if (json.isBlank()) {
+      throw new PSGadgetRegistryException("Gadget catalog JSON is empty");
+    }
+    try {
+      PSGadgetCatalog catalog = GSON.fromJson(json, PSGadgetCatalog.class);
+      if (catalog == null) {
+        throw new PSGadgetRegistryException("Gadget catalog JSON parsed to null");
+      }
+      if (catalog.getGadgets() == null) {
+        catalog.setGadgets(new ArrayList<>());
+      }
+      return catalog;
+    } catch (JsonSyntaxException e) {
+      throw new PSGadgetRegistryException("Invalid gadget catalog JSON: " + e.getMessage(), e);
+    } catch (JsonParseException e) {
+      throw new PSGadgetRegistryException("Failed to parse gadget catalog JSON", e);
+    }
+  }
+
+  /**
+   * Parse UTF-8 JSON from a reader.
+   *
+   * @param reader non-null reader
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetCatalog read(Reader reader) throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(reader, "reader");
+    StringBuilder sb = new StringBuilder();
+    char[] buf = new char[4096];
+    int n;
+    while ((n = reader.read(buf)) >= 0) {
+      sb.append(buf, 0, n);
+    }
+    return parse(sb.toString());
+  }
+
+  /**
+   * Read UTF-8 JSON from a file path.
+   *
+   * @param path non-null path
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetCatalog read(Path path) throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(path, "path");
+    return parse(Files.readString(path, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Serialize catalog to pretty-printed JSON.
+   *
+   * @param catalog non-null model
+   * @return JSON text
+   */
+  public static String toJson(PSGadgetCatalog catalog) {
+    Objects.requireNonNull(catalog, "catalog");
+    return GSON.toJson(catalog);
+  }
+
+  /**
+   * Write UTF-8 pretty JSON to a path (parent directories created as needed).
+   *
+   * @param catalog non-null model
+   * @param path non-null destination
+   * @throws IOException on I/O failure
+   */
+  public static void write(PSGadgetCatalog catalog, Path path) throws IOException {
+    Objects.requireNonNull(catalog, "catalog");
+    Objects.requireNonNull(path, "path");
+    Path parent = path.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    try (Writer w = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+      GSON.toJson(catalog, w);
+      w.write(System.lineSeparator());
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
@@ -129,9 +129,9 @@ public final class PSGadgetCatalogIo {
     if (parent != null) {
       Files.createDirectories(parent);
     }
+    // UTF-8 JSON body only (no trailing newline) — matches PSComponentPackageManifestIo.write.
     try (Writer w = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
       GSON.toJson(catalog, w);
-      w.write(System.lineSeparator());
     }
   }
 }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompileResult.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompileResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Output of compiling a gadget registry: aggregate modern catalog + per-gadget component package
+ * manifests keyed by gadget id.
+ */
+public final class PSGadgetRegistryCompileResult {
+
+  private final PSGadgetRegistryModel source;
+  private final PSGadgetCatalog catalog;
+  /** gadget id → validated component package manifest ({@code catalog.kind = "gadget"}). */
+  private final Map<String, PSComponentPackageManifest> gadgetPackages;
+
+  public PSGadgetRegistryCompileResult(
+      PSGadgetRegistryModel source,
+      PSGadgetCatalog catalog,
+      Map<String, PSComponentPackageManifest> gadgetPackages) {
+    this.source = Objects.requireNonNull(source, "source");
+    this.catalog = Objects.requireNonNull(catalog, "catalog");
+    this.gadgetPackages =
+        gadgetPackages == null
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(gadgetPackages));
+  }
+
+  public PSGadgetRegistryModel getSource() {
+    return source;
+  }
+
+  public PSGadgetCatalog getCatalog() {
+    return catalog;
+  }
+
+  public Map<String, PSComponentPackageManifest> getGadgetPackages() {
+    return gadgetPackages;
+  }
+
+  /** Convenience: package for a single gadget id, or null. */
+  public PSComponentPackageManifest getGadgetPackage(String gadgetId) {
+    return gadgetPackages.get(gadgetId);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
@@ -248,15 +248,18 @@ public final class PSGadgetRegistryCompiler {
             Files.createDirectories(parent);
           }
           // host-ref.txt body is the package-relative install target (URL-style).
-          Files.writeString(artifact, res.getTarget() + System.lineSeparator());
+          Files.writeString(artifact, res.getTarget() + "\n");
         }
       }
     }
   }
 
   /**
-   * Strip leading {@code /cm/gadgets/repository/} (or any leading slash) so the target is a
-   * package-relative install path using {@code /} separators only.
+   * Normalize a gadget registry {@code baseUri} to a package-relative host path using {@code /}
+   * separators only. Strips all leading slashes (so both {@code /cm/gadgets/repository/x} and
+   * {@code cm/gadgets/repository/x} work). Rejects blank paths and any segment containing
+   * {@code ..}. Does not rewrite or inject the {@code cm/gadgets/repository/} prefix — the
+   * registry {@code baseUri} is expected to already identify the install target.
    */
   static String toPackageRelativeHostPath(String baseUri) {
     if (baseUri == null || baseUri.isBlank()) {
@@ -269,7 +272,6 @@ public final class PSGadgetRegistryCompiler {
     if (p.isEmpty() || p.contains("..")) {
       return null;
     }
-    // Prefer cm/gadgets/repository/<id> as install target when that prefix is present.
     return p;
   }
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Compiles legacy product {@code GadgetRegistry.xml} into:
+ *
+ * <ul>
+ *   <li>an aggregate modern {@link PSGadgetCatalog} ({@code gadget-catalog.json})
+ *   <li>per-gadget {@link PSComponentPackageManifest} instances with {@code catalog.kind =
+ *       "gadget"} (SPA / dashboard host components — no assembly templates)
+ * </ul>
+ *
+ * <p>Gadgets are <strong>not</strong> Velocity/JEXL assembly templates; they share only the ADR-004
+ * anti-XML packaging goal with widgets/pages. Per-gadget definition XML is already largely absent
+ * from the tree — this compiler finishes the registry half of the migration path (issue #2771 /
+ * parent #2630).
+ */
+public final class PSGadgetRegistryCompiler {
+
+  /** Default package version when none is supplied. */
+  public static final String DEFAULT_VERSION = "0.0.0";
+
+  /** Catalog kind for dashboard gadgets (see component-package-manifest.md). */
+  public static final String CATALOG_KIND_GADGET = "gadget";
+
+  private PSGadgetRegistryCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile a registry XML file.
+   *
+   * @param registryXmlPath path to {@code GadgetRegistry.xml}
+   * @param version optional catalog / package version (may be null → {@value #DEFAULT_VERSION})
+   * @return compile result with catalog + per-gadget packages
+   * @throws PSGadgetRegistryException on parse/compile/validation failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetRegistryCompileResult compile(Path registryXmlPath, String version)
+      throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(registryXmlPath, "registryXmlPath");
+    PSGadgetRegistryModel model = PSGadgetRegistryParser.parse(registryXmlPath);
+    return compile(model, version);
+  }
+
+  /**
+   * Compile a previously parsed registry model.
+   *
+   * @param model non-null parsed registry
+   * @param version optional version string
+   * @return compile result
+   * @throws PSGadgetRegistryException on compile/validation failure
+   */
+  public static PSGadgetRegistryCompileResult compile(PSGadgetRegistryModel model, String version)
+      throws PSGadgetRegistryException {
+    Objects.requireNonNull(model, "model");
+    if (model.getGadgets().isEmpty()) {
+      throw new PSGadgetRegistryException("Cannot compile empty gadget registry");
+    }
+
+    String ver =
+        version != null && !version.isBlank() ? version.trim() : DEFAULT_VERSION;
+
+    PSGadgetCatalog catalog = new PSGadgetCatalog();
+    catalog.setSchemaVersion(PSGadgetCatalog.SUPPORTED_SCHEMA_VERSION);
+    catalog.setId("perc.gadgetCatalog");
+    catalog.setName("Product Gadget Catalog");
+    catalog.setVersion(ver);
+    catalog.setDescription(
+        "Modern product gadget catalog compiled from GadgetRegistry.xml (ADR-004 / #2771)");
+
+    Map<String, PSComponentPackageManifest> packages = new LinkedHashMap<>();
+    List<PSGadgetCatalog.Entry> entries = new ArrayList<>();
+
+    for (PSGadgetRegistryEntry src : model.getGadgets()) {
+      if (src == null) {
+        continue;
+      }
+      String id = src.gadgetId();
+      if (id == null || id.isBlank()) {
+        throw new PSGadgetRegistryException(
+            "Cannot derive gadget id for entry name='" + src.getName() + "'");
+      }
+      if (packages.containsKey(id)) {
+        throw new PSGadgetRegistryException("Duplicate gadget id in registry: " + id);
+      }
+
+      PSComponentPackageManifest manifest = compileGadgetPackage(src, ver);
+      packages.put(id, manifest);
+
+      PSGadgetCatalog.Entry entry = new PSGadgetCatalog.Entry();
+      entry.setId(id);
+      entry.setName(src.getName());
+      entry.setGroup(src.getGroup());
+      entry.setBaseUri(src.getBaseUri());
+      entry.setLegacyDefinitionFile(src.getLegacyDefinitionFile());
+      entry.setDeprecated(src.isDeprecated());
+      // Package-relative path when gadgets are written under gadgets/<id>/
+      entry.setComponentPackageRef(
+          "gadgets/" + id + "/" + PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+      entries.add(entry);
+    }
+    catalog.setGadgets(entries);
+
+    return new PSGadgetRegistryCompileResult(model, catalog, packages);
+  }
+
+  /**
+   * Compile a single registry entry into a gadget-kind component package manifest.
+   *
+   * @param entry non-null registry entry
+   * @param version package version
+   * @return validated manifest
+   * @throws PSGadgetRegistryException on validation failure
+   */
+  public static PSComponentPackageManifest compileGadgetPackage(
+      PSGadgetRegistryEntry entry, String version) throws PSGadgetRegistryException {
+    Objects.requireNonNull(entry, "entry");
+    String id = entry.gadgetId();
+    if (id == null || id.isBlank()) {
+      throw new PSGadgetRegistryException("Gadget entry missing id (name/baseuri)");
+    }
+
+    String ver =
+        version != null && !version.isBlank() ? version.trim() : DEFAULT_VERSION;
+
+    PSComponentPackageManifest manifest = new PSComponentPackageManifest();
+    manifest.setSchemaVersion(PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION);
+    manifest.setId(id);
+    manifest.setName(entry.getName() != null && !entry.getName().isBlank() ? entry.getName() : id);
+    manifest.setVersion(ver);
+    manifest.setDescription(
+        "Dashboard gadget package for '"
+            + manifest.getName()
+            + "' (group="
+            + (entry.getGroup() != null ? entry.getGroup() : "Custom")
+            + ")");
+
+    PSComponentPackageManifest.Publisher publisher = new PSComponentPackageManifest.Publisher();
+    publisher.setName("Intersoft Data Labs, Inc.");
+    publisher.setUrl("https://www.intsof.com");
+    manifest.setPublisher(publisher);
+
+    PSComponentPackageManifest.Catalog cat = new PSComponentPackageManifest.Catalog();
+    cat.setKind(CATALOG_KIND_GADGET);
+    cat.setTitle(manifest.getName());
+    cat.setCategory(entry.getGroup() != null ? entry.getGroup() : "Custom");
+    cat.setDescription(manifest.getDescription());
+    cat.setAuthor("Intersoft Data Labs, Inc.");
+    // Deprecated gadgets stay listed but are not palette-default visible.
+    cat.setPaletteVisible(!entry.isDeprecated());
+    manifest.setCatalog(cat);
+
+    // Logical host resource: base URI folder under the classic repository tree (URL-style path).
+    // Not an assembly template — validator allows catalog.kind=gadget without CT/templates.
+    if (entry.getBaseUri() != null && !entry.getBaseUri().isBlank()) {
+      String packageRelativeHost = toPackageRelativeHostPath(entry.getBaseUri());
+      if (packageRelativeHost != null) {
+        PSComponentPackageManifest.ResourceRef res = new PSComponentPackageManifest.ResourceRef();
+        res.setPath("resources/host-ref.txt");
+        res.setTarget(packageRelativeHost);
+        res.setType("file");
+        List<PSComponentPackageManifest.ResourceRef> resources = new ArrayList<>();
+        resources.add(res);
+        manifest.setResources(resources);
+      }
+    }
+
+    try {
+      PSComponentPackageManifestValidator.validate(manifest);
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSGadgetRegistryException(
+          "Compiled gadget package failed validation for id=" + id + ": " + e.getMessage(), e);
+    }
+    return manifest;
+  }
+
+  /**
+   * Write compile result under {@code outputDir}:
+   *
+   * <pre>
+   *   gadget-catalog.json
+   *   gadgets/&lt;id&gt;/component-package.json
+   *   gadgets/&lt;id&gt;/resources/host-ref.txt   (when baseUri present)
+   * </pre>
+   *
+   * @param result non-null compile result
+   * @param outputDir non-null destination root
+   * @throws IOException on I/O failure
+   */
+  public static void writeArtifacts(PSGadgetRegistryCompileResult result, Path outputDir)
+      throws IOException {
+    Objects.requireNonNull(result, "result");
+    Objects.requireNonNull(outputDir, "outputDir");
+    Files.createDirectories(outputDir);
+
+    Path catalogPath = outputDir.resolve(PSGadgetCatalog.DEFAULT_CATALOG_FILE_NAME);
+    PSGadgetCatalogIo.write(result.getCatalog(), catalogPath);
+
+    for (Map.Entry<String, PSComponentPackageManifest> e : result.getGadgetPackages().entrySet()) {
+      String id = e.getKey();
+      PSComponentPackageManifest manifest = e.getValue();
+      Path gadgetDir = outputDir.resolve("gadgets").resolve(id);
+      Files.createDirectories(gadgetDir);
+      Path manifestPath = gadgetDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+      PSComponentPackageManifestIo.write(manifest, manifestPath);
+
+      if (manifest.getResources() != null) {
+        for (PSComponentPackageManifest.ResourceRef res : manifest.getResources()) {
+          if (res == null || res.getPath() == null || res.getPath().isBlank()) {
+            continue;
+          }
+          if (res.getTarget() == null) {
+            continue;
+          }
+          Path artifact = resolvePackageRelative(gadgetDir, res.getPath());
+          Path parent = artifact.getParent();
+          if (parent != null) {
+            Files.createDirectories(parent);
+          }
+          // host-ref.txt body is the package-relative install target (URL-style).
+          Files.writeString(artifact, res.getTarget() + System.lineSeparator());
+        }
+      }
+    }
+  }
+
+  /**
+   * Strip leading {@code /cm/gadgets/repository/} (or any leading slash) so the target is a
+   * package-relative install path using {@code /} separators only.
+   */
+  static String toPackageRelativeHostPath(String baseUri) {
+    if (baseUri == null || baseUri.isBlank()) {
+      return null;
+    }
+    String p = baseUri.trim().replace('\\', '/');
+    while (p.startsWith("/")) {
+      p = p.substring(1);
+    }
+    if (p.isEmpty() || p.contains("..")) {
+      return null;
+    }
+    // Prefer cm/gadgets/repository/<id> as install target when that prefix is present.
+    return p;
+  }
+
+  /**
+   * Resolve a package-relative path (URL-style {@code /}) under {@code base} using portable {@link
+   * Path#resolve(String)} per segment.
+   */
+  static Path resolvePackageRelative(Path base, String packageRelative) {
+    Path p = base;
+    for (String segment : packageRelative.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment)) {
+        continue;
+      }
+      if ("..".equals(segment)) {
+        throw new IllegalArgumentException(
+            "Package-relative path must not contain '..': " + packageRelative);
+      }
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryEntry.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryEntry.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.util.Objects;
+
+/**
+ * One gadget row from legacy {@code GadgetRegistry.xml} ({@code <gadget name baseuri file/>} inside
+ * a named {@code <group>}).
+ */
+public final class PSGadgetRegistryEntry {
+
+  private String name;
+  private String group;
+  private String baseUri;
+  private String legacyDefinitionFile;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  public String getBaseUri() {
+    return baseUri;
+  }
+
+  public void setBaseUri(String baseUri) {
+    this.baseUri = baseUri;
+  }
+
+  public String getLegacyDefinitionFile() {
+    return legacyDefinitionFile;
+  }
+
+  public void setLegacyDefinitionFile(String legacyDefinitionFile) {
+    this.legacyDefinitionFile = legacyDefinitionFile;
+  }
+
+  /**
+   * Stable gadget id derived from the last segment of {@code baseUri} (classic OpenSocial folder
+   * name), falling back to a slug of the display name.
+   */
+  public String gadgetId() {
+    String fromUri = lastUriSegment(baseUri);
+    if (fromUri != null && !fromUri.isBlank()) {
+      return fromUri;
+    }
+    return slugify(name);
+  }
+
+  /**
+   * Whether this entry is under a Deprecated (or similarly retired) group — product still ships the
+   * row for layout prefs but palette defaults hide it.
+   */
+  public boolean isDeprecated() {
+    if (group == null) {
+      return false;
+    }
+    return "deprecated".equalsIgnoreCase(group.trim());
+  }
+
+  static String lastUriSegment(String baseUri) {
+    if (baseUri == null || baseUri.isBlank()) {
+      return null;
+    }
+    String p = baseUri.trim().replace('\\', '/');
+    while (p.endsWith("/")) {
+      p = p.substring(0, p.length() - 1);
+    }
+    int idx = p.lastIndexOf('/');
+    return idx >= 0 ? p.substring(idx + 1) : p;
+  }
+
+  static String slugify(String displayName) {
+    if (displayName == null || displayName.isBlank()) {
+      return "gadget";
+    }
+    String s =
+        displayName
+            .trim()
+            .toLowerCase(java.util.Locale.ROOT)
+            .replaceAll("[^a-z0-9]+", "-")
+            .replaceAll("^-+|-+$", "");
+    return s.isEmpty() ? "gadget" : s;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSGadgetRegistryEntry that)) {
+      return false;
+    }
+    return Objects.equals(name, that.name)
+        && Objects.equals(group, that.group)
+        && Objects.equals(baseUri, that.baseUri)
+        && Objects.equals(legacyDefinitionFile, that.legacyDefinitionFile);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, group, baseUri, legacyDefinitionFile);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+/**
+ * Thrown when gadget registry XML cannot be parsed or compiled into the modern catalog / component
+ * package model.
+ *
+ * @see PSGadgetRegistryParser
+ * @see PSGadgetRegistryCompiler
+ */
+public class PSGadgetRegistryException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSGadgetRegistryException(String message) {
+    super(message);
+  }
+
+  public PSGadgetRegistryException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryModel.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryModel.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Parsed product gadget registry (upgrade-input {@code GadgetRegistry.xml}).
+ *
+ * <p>Order of entries matches document order within each group; groups themselves are document
+ * order. Used only as compiler input — modern ship format is {@link PSGadgetCatalog} + per-gadget
+ * {@code component-package.json}.
+ */
+public final class PSGadgetRegistryModel {
+
+  private String sourceFileName;
+  private final List<PSGadgetRegistryEntry> gadgets = new ArrayList<>();
+
+  public String getSourceFileName() {
+    return sourceFileName;
+  }
+
+  public void setSourceFileName(String sourceFileName) {
+    this.sourceFileName = sourceFileName;
+  }
+
+  public List<PSGadgetRegistryEntry> getGadgets() {
+    return gadgets;
+  }
+
+  public void addGadget(PSGadgetRegistryEntry entry) {
+    if (entry != null) {
+      gadgets.add(entry);
+    }
+  }
+
+  /** Display name → group (first wins). */
+  public Map<String, String> toNameGroupMap() {
+    Map<String, String> map = new LinkedHashMap<>();
+    for (PSGadgetRegistryEntry g : gadgets) {
+      if (g == null || g.getName() == null || g.getName().isBlank()) {
+        continue;
+      }
+      map.putIfAbsent(g.getName(), g.getGroup() != null ? g.getGroup() : "Custom");
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  public PSGadgetRegistryEntry findById(String gadgetId) {
+    if (gadgetId == null || gadgetId.isBlank()) {
+      return null;
+    }
+    for (PSGadgetRegistryEntry g : gadgets) {
+      if (g != null && gadgetId.equals(g.gadgetId())) {
+        return g;
+      }
+    }
+    return null;
+  }
+
+  public PSGadgetRegistryEntry findByName(String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    for (PSGadgetRegistryEntry g : gadgets) {
+      if (g != null && name.equals(g.getName())) {
+        return g;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSGadgetRegistryModel that)) {
+      return false;
+    }
+    return Objects.equals(sourceFileName, that.sourceFileName)
+        && Objects.equals(gadgets, that.gadgets);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceFileName, gadgets);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryParser.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryParser.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Parses product {@code GadgetRegistry.xml} ({@code <gadgets><group name="…"><gadget …/>}) into
+ * {@link PSGadgetRegistryModel}.
+ *
+ * <p>Uses a hardened {@link DocumentBuilderFactory} (no external DTDs / schemas / XInclude). Paths
+ * are read via portable NIO {@link Files}.
+ */
+public final class PSGadgetRegistryParser {
+
+  private PSGadgetRegistryParser() {
+    // utility
+  }
+
+  /**
+   * Parse registry XML from a UTF-8 file.
+   *
+   * @param path non-null path to {@code GadgetRegistry.xml}
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetRegistryModel parse(Path path)
+      throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(path, "path");
+    String xml = Files.readString(path, StandardCharsets.UTF_8);
+    PSGadgetRegistryModel model = parse(xml);
+    Path fileName = path.getFileName();
+    if (fileName != null) {
+      model.setSourceFileName(fileName.toString());
+    }
+    return model;
+  }
+
+  /**
+   * Parse registry XML from a string.
+   *
+   * @param xml non-null document text
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   */
+  public static PSGadgetRegistryModel parse(String xml) throws PSGadgetRegistryException {
+    Objects.requireNonNull(xml, "xml");
+    if (xml.isBlank()) {
+      throw new PSGadgetRegistryException("Gadget registry XML is empty");
+    }
+    try {
+      Document doc = parseDocument(new InputSource(new StringReader(xml)));
+      return fromDocument(doc);
+    } catch (PSGadgetRegistryException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSGadgetRegistryException(
+          "Failed to parse Gadget registry XML: " + e.getMessage(), e);
+    }
+  }
+
+  static PSGadgetRegistryModel fromDocument(Document doc) throws PSGadgetRegistryException {
+    Objects.requireNonNull(doc, "doc");
+    Element root = doc.getDocumentElement();
+    if (root == null) {
+      throw new PSGadgetRegistryException("Gadget registry XML has no document element");
+    }
+    String rootName = root.getLocalName() != null ? root.getLocalName() : root.getTagName();
+    if (!"gadgets".equalsIgnoreCase(rootName)) {
+      throw new PSGadgetRegistryException(
+          "Expected root element <gadgets>, found <" + rootName + ">");
+    }
+
+    PSGadgetRegistryModel model = new PSGadgetRegistryModel();
+    NodeList children = root.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() != Node.ELEMENT_NODE) {
+        continue;
+      }
+      Element el = (Element) n;
+      String tag = el.getLocalName() != null ? el.getLocalName() : el.getTagName();
+      if (!"group".equalsIgnoreCase(tag)) {
+        continue;
+      }
+      String groupName = el.getAttribute("name");
+      if (groupName == null || groupName.isBlank()) {
+        groupName = "Custom";
+      }
+      NodeList gadgetElems = el.getElementsByTagName("gadget");
+      // Also accept no-namespace children listed directly under group.
+      if (gadgetElems.getLength() == 0) {
+        NodeList groupKids = el.getChildNodes();
+        for (int j = 0; j < groupKids.getLength(); j++) {
+          Node gn = groupKids.item(j);
+          if (gn.getNodeType() != Node.ELEMENT_NODE) {
+            continue;
+          }
+          Element ge = (Element) gn;
+          String gtag = ge.getLocalName() != null ? ge.getLocalName() : ge.getTagName();
+          if ("gadget".equalsIgnoreCase(gtag)) {
+            model.addGadget(readGadget(ge, groupName));
+          }
+        }
+      } else {
+        for (int j = 0; j < gadgetElems.getLength(); j++) {
+          Element ge = (Element) gadgetElems.item(j);
+          model.addGadget(readGadget(ge, groupName));
+        }
+      }
+    }
+
+    if (model.getGadgets().isEmpty()) {
+      throw new PSGadgetRegistryException("Gadget registry contains no <gadget> entries");
+    }
+    return model;
+  }
+
+  private static PSGadgetRegistryEntry readGadget(Element ge, String groupName)
+      throws PSGadgetRegistryException {
+    PSGadgetRegistryEntry entry = new PSGadgetRegistryEntry();
+    entry.setGroup(groupName);
+    String name = ge.getAttribute("name");
+    if (name == null || name.isBlank()) {
+      throw new PSGadgetRegistryException(
+          "Gadget entry in group '" + groupName + "' is missing required name attribute");
+    }
+    entry.setName(name.trim());
+    String baseUri = ge.getAttribute("baseuri");
+    if (baseUri == null || baseUri.isBlank()) {
+      // Some historic rows used baseUri camelCase — accept both.
+      baseUri = ge.getAttribute("baseUri");
+    }
+    if (baseUri != null) {
+      entry.setBaseUri(baseUri.trim());
+    }
+    String file = ge.getAttribute("file");
+    if (file != null && !file.isBlank()) {
+      entry.setLegacyDefinitionFile(file.trim());
+    }
+    return entry;
+  }
+
+  static Document parseDocument(InputSource source)
+      throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    try {
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    } catch (ParserConfigurationException ignored) {
+      // Some JDK / provider combinations reject features; continue with other hardening.
+    }
+    try {
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    } catch (ParserConfigurationException ignored) {
+      // optional
+    }
+    try {
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    } catch (ParserConfigurationException ignored) {
+      // optional
+    }
+    try {
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    } catch (IllegalArgumentException ignored) {
+      // optional
+    }
+    return factory.newDocumentBuilder().parse(source);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
@@ -27,7 +27,14 @@ import java.util.regex.Pattern;
  *
  * <p>Enforces schema version, required identity fields, non-blank nested names, portable
  * package-relative path refs (URL-style {@code /} separators; no absolute OS paths), and the
- * presence of at least one content type or template (a component must ship something installable).
+ * presence of installable material:
+ *
+ * <ul>
+ *   <li>Default components / pages: at least one {@code contentTypes[]} or {@code templates[]}
+ *       entry
+ *   <li>Gadget packages ({@code catalog.kind = "gadget"}): catalog title required; content types /
+ *       templates optional (dashboard gadgets are SPA hosts, not assembly templates) — issue #2771
+ * </ul>
  */
 public final class PSComponentPackageManifestValidator {
 
@@ -121,13 +128,21 @@ public final class PSComponentPackageManifestValidator {
       }
     }
 
+    boolean isGadgetKind = false;
     if (manifest.getCatalog() != null) {
       PSComponentPackageManifest.Catalog cat = manifest.getCatalog();
+      if (cat.getKind() != null && "gadget".equalsIgnoreCase(cat.getKind().trim())) {
+        isGadgetKind = true;
+      }
       if (cat.getThumbnail() != null && !cat.getThumbnail().isBlank()) {
         requireRelativePath(errors, "catalog.thumbnail", cat.getThumbnail());
       }
       if (cat.getIcon() != null && !cat.getIcon().isBlank()) {
         requireRelativePath(errors, "catalog.icon", cat.getIcon());
+      }
+      if (isGadgetKind) {
+        // Dashboard gadgets ship as catalog + optional host resources (no assembly CT/templates).
+        requireText(errors, "catalog.title", cat.getTitle());
       }
     }
 
@@ -233,7 +248,9 @@ public final class PSComponentPackageManifestValidator {
     boolean hasTpl =
         manifest.getTemplates() != null
             && manifest.getTemplates().stream().anyMatch(Objects::nonNull);
-    if (!hasCt && !hasTpl) {
+    // Gadget packages are SPA/dashboard hosts — catalog.kind=gadget + title is sufficient.
+    // Components and pages still require content types or templates.
+    if (!isGadgetKind && !hasCt && !hasTpl) {
       errors.add("manifest must declare at least one contentTypes[] or templates[] entry");
     }
 

--- a/modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json
+++ b/modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json
@@ -1,0 +1,198 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.gadgetCatalog",
+  "name": "Product Gadget Catalog",
+  "version": "8.2.0",
+  "description": "Modern product gadget catalog compiled from GadgetRegistry.xml (ADR-004 / #2771)",
+  "gadgets": [
+    {
+      "id": "PercAssetStatusGadget",
+      "name": "Assets By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercAssetStatusGadget",
+      "legacyDefinitionFile": "PercAssetStatusGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercAssetStatusGadget/component-package.json"
+    },
+    {
+      "id": "PercBlogsGadget",
+      "name": "Blogs",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercBlogsGadget",
+      "legacyDefinitionFile": "PercBlogsGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercBlogsGadget/component-package.json"
+    },
+    {
+      "id": "perc_bulk_file_upload_gadget",
+      "name": "Bulk Upload",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_bulk_file_upload_gadget",
+      "legacyDefinitionFile": "perc_bulk_file_upload_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_bulk_file_upload_gadget/component-package.json"
+    },
+    {
+      "id": "perc_comments_gadget",
+      "name": "Comments",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_comments_gadget",
+      "legacyDefinitionFile": "perc_comments_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_comments_gadget/component-package.json"
+    },
+    {
+      "id": "perc_cookie_consent_gadget",
+      "name": "Cookie Consent",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_cookie_consent_gadget",
+      "legacyDefinitionFile": "perc_cookie_consent_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_cookie_consent_gadget/component-package.json"
+    },
+    {
+      "id": "PercFormTrackerGadget",
+      "name": "Forms Tracker",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercFormTrackerGadget",
+      "legacyDefinitionFile": "PercFormTrackerGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercFormTrackerGadget/component-package.json"
+    },
+    {
+      "id": "PercGlobalVariablesGadget",
+      "name": "Global Variables",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercGlobalVariablesGadget",
+      "legacyDefinitionFile": "PercGlobalVariablesGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercGlobalVariablesGadget/component-package.json"
+    },
+    {
+      "id": "perc_google_setup_gadget",
+      "name": "Google Setup",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_google_setup_gadget",
+      "legacyDefinitionFile": "perc_google_setup_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_google_setup_gadget/component-package.json"
+    },
+    {
+      "id": "perc_iframe_gadget",
+      "name": "Iframe",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_iframe_gadget",
+      "legacyDefinitionFile": "perc_iframe_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_iframe_gadget/component-package.json"
+    },
+    {
+      "id": "perc_workflow_status_gadget",
+      "name": "Pages By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_workflow_status_gadget",
+      "legacyDefinitionFile": "perc_workflow_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_workflow_status_gadget/component-package.json"
+    },
+    {
+      "id": "PercProcessorMonitorGadget",
+      "name": "Process Monitor",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercProcessorMonitorGadget",
+      "legacyDefinitionFile": "PercProcessorMonitorGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercProcessorMonitorGadget/component-package.json"
+    },
+    {
+      "id": "perc_reports_gadget",
+      "name": "Reports",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_reports_gadget",
+      "legacyDefinitionFile": "perc_reports_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_reports_gadget/component-package.json"
+    },
+    {
+      "id": "perc_seo_gadget",
+      "name": "SEO Audit",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_seo_gadget",
+      "legacyDefinitionFile": "perc_seo_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_seo_gadget/component-package.json"
+    },
+    {
+      "id": "PercSiteFrameworkGadget",
+      "name": "Sitewide Framework",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercSiteFrameworkGadget",
+      "legacyDefinitionFile": "perc_sitewide_framework_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercSiteFrameworkGadget/component-package.json"
+    },
+    {
+      "id": "perc_traffic_gadget",
+      "name": "Traffic",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_traffic_gadget",
+      "legacyDefinitionFile": "perc_traffic_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_traffic_gadget/component-package.json"
+    },
+    {
+      "id": "cm1_welcome_gadget",
+      "name": "Welcome",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/cm1_welcome_gadget",
+      "legacyDefinitionFile": "perc_welcome_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/cm1_welcome_gadget/component-package.json"
+    },
+    {
+      "id": "perc_effectiveness_gadget",
+      "name": "What's Working",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_effectiveness_gadget",
+      "legacyDefinitionFile": "perc_effectiveness_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_effectiveness_gadget/component-package.json"
+    },
+    {
+      "id": "perc_activity_gadget",
+      "name": "Activity",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_activity_gadget",
+      "legacyDefinitionFile": "perc_activity_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_activity_gadget/component-package.json"
+    },
+    {
+      "id": "perc_site_improve_gadget",
+      "name": "Siteimprove",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_site_improve_gadget",
+      "legacyDefinitionFile": "perc_site_improve_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_site_improve_gadget/component-package.json"
+    },
+    {
+      "id": "perc_membership_gadget",
+      "name": "Membership",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_membership_gadget",
+      "legacyDefinitionFile": "perc_membership_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_membership_gadget/component-package.json"
+    },
+    {
+      "id": "PercWidgetConfigGadget",
+      "name": "Widget Configuration",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/PercWidgetConfigGadget",
+      "legacyDefinitionFile": "PercWidgetConfigGadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/PercWidgetConfigGadget/component-package.json"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompilerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit + golden parity tests for GadgetRegistry.xml → modern gadget catalog / component packages
+ * (#2771 / ADR-004 Phase 3).
+ */
+class PSGadgetRegistryCompilerTest {
+
+  private static final String FIXTURE_REGISTRY = "/gadgetxml/GadgetRegistry.xml";
+  private static final String GOLDEN_WELCOME =
+      "/gadgetxml/golden/cm1_welcome_gadget.component-package.json";
+  private static final String GOLDEN_CATALOG = "/gadgetxml/golden/gadget-catalog.json";
+  private static final String PRODUCT_VERSION = "8.2.0";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parseProductRegistry_populatesGroupsAndEntries() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+
+    assertEquals(21, model.getGadgets().size(), "product registry has 21 gadgets");
+    assertEquals("Percussion", model.toNameGroupMap().get("Welcome"));
+    assertEquals("Deprecated", model.toNameGroupMap().get("Activity"));
+    assertFalse(model.toNameGroupMap().containsKey("Redirect Management"));
+
+    PSGadgetRegistryEntry welcome = model.findByName("Welcome");
+    assertNotNull(welcome);
+    assertEquals("cm1_welcome_gadget", welcome.gadgetId());
+    assertEquals("/cm/gadgets/repository/cm1_welcome_gadget", welcome.getBaseUri());
+    assertEquals("perc_welcome_gadget.xml", welcome.getLegacyDefinitionFile());
+    assertFalse(welcome.isDeprecated());
+
+    PSGadgetRegistryEntry activity = model.findById("perc_activity_gadget");
+    assertNotNull(activity);
+    assertTrue(activity.isDeprecated());
+  }
+
+  @Test
+  void compileWelcome_matchesGoldenManifest() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+    PSGadgetRegistryCompileResult result =
+        PSGadgetRegistryCompiler.compile(model, PRODUCT_VERSION);
+
+    PSComponentPackageManifest welcome = result.getGadgetPackage("cm1_welcome_gadget");
+    assertNotNull(welcome, "Welcome gadget package must be present");
+    PSComponentPackageManifestValidator.validate(welcome);
+
+    String expectedJson = readClasspath(GOLDEN_WELCOME);
+    PSComponentPackageManifest golden = PSComponentPackageManifestIo.parse(expectedJson);
+    PSComponentPackageManifest reparsed =
+        PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(welcome));
+
+    assertEquals(golden.getSchemaVersion(), reparsed.getSchemaVersion());
+    assertEquals(golden.getId(), reparsed.getId());
+    assertEquals(golden.getName(), reparsed.getName());
+    assertEquals(golden.getVersion(), reparsed.getVersion());
+    assertEquals(golden.getDescription(), reparsed.getDescription());
+    assertEquals(golden.getPublisher(), reparsed.getPublisher());
+    assertEquals(golden.getCatalog(), reparsed.getCatalog());
+    assertEquals(golden.getResources(), reparsed.getResources());
+    assertEquals(
+        PSComponentPackageManifestIo.parse(expectedJson),
+        reparsed,
+        "compiled Welcome gadget package must equal golden fixture");
+  }
+
+  @Test
+  void compileProductRegistry_matchesGoldenCatalog() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+    PSGadgetRegistryCompileResult result =
+        PSGadgetRegistryCompiler.compile(model, PRODUCT_VERSION);
+
+    PSGadgetCatalog catalog = result.getCatalog();
+    assertEquals(21, catalog.getGadgets().size());
+    assertEquals(PRODUCT_VERSION, catalog.getVersion());
+    assertEquals("perc.gadgetCatalog", catalog.getId());
+
+    String expectedJson = readClasspath(GOLDEN_CATALOG);
+    PSGadgetCatalog golden = PSGadgetCatalogIo.parse(expectedJson);
+    PSGadgetCatalog reparsed = PSGadgetCatalogIo.parse(PSGadgetCatalogIo.toJson(catalog));
+    assertEquals(golden, reparsed, "compiled gadget catalog must equal golden fixture");
+
+    // All packages validate; deprecated ones hide from palette.
+    for (Map.Entry<String, PSComponentPackageManifest> e : result.getGadgetPackages().entrySet()) {
+      PSComponentPackageManifestValidator.validate(e.getValue());
+      assertEquals(
+          PSGadgetRegistryCompiler.CATALOG_KIND_GADGET, e.getValue().getCatalog().getKind());
+    }
+    assertEquals(Boolean.FALSE, result.getGadgetPackage("perc_activity_gadget").getCatalog().getPaletteVisible());
+    assertEquals(Boolean.TRUE, result.getGadgetPackage("cm1_welcome_gadget").getCatalog().getPaletteVisible());
+  }
+
+  @Test
+  void writeArtifacts_roundTripsCatalogAndWelcomePackage() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+    PSGadgetRegistryCompileResult result =
+        PSGadgetRegistryCompiler.compile(model, PRODUCT_VERSION);
+
+    Path out = tempDir.resolve("gadget-out");
+    PSGadgetRegistryCompiler.writeArtifacts(result, out);
+
+    Path catalogPath = out.resolve(PSGadgetCatalog.DEFAULT_CATALOG_FILE_NAME);
+    assertTrue(Files.isRegularFile(catalogPath));
+    PSGadgetCatalog loaded = PSGadgetCatalogIo.read(catalogPath);
+    assertEquals(21, loaded.getGadgets().size());
+
+    Path welcomeManifest =
+        out.resolve("gadgets")
+            .resolve("cm1_welcome_gadget")
+            .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    assertTrue(Files.isRegularFile(welcomeManifest));
+    PSComponentPackageManifest welcome = PSComponentPackageManifestIo.read(welcomeManifest);
+    PSComponentPackageManifestValidator.validate(welcome);
+    assertEquals("cm1_welcome_gadget", welcome.getId());
+
+    Path hostRef =
+        out.resolve("gadgets")
+            .resolve("cm1_welcome_gadget")
+            .resolve("resources")
+            .resolve("host-ref.txt");
+    assertTrue(Files.isRegularFile(hostRef));
+    String hostBody = normalizeNewlines(Files.readString(hostRef, StandardCharsets.UTF_8)).trim();
+    assertEquals("cm/gadgets/repository/cm1_welcome_gadget", hostBody);
+  }
+
+  @Test
+  void parseEmptyRegistry_throws() {
+    assertThrows(PSGadgetRegistryException.class, () -> PSGadgetRegistryParser.parse(""));
+    assertThrows(
+        PSGadgetRegistryException.class,
+        () -> PSGadgetRegistryParser.parse("<gadgets></gadgets>"));
+  }
+
+  @Test
+  void gadgetPackageWithoutTitle_failsValidation() {
+    PSComponentPackageManifest m = new PSComponentPackageManifest();
+    m.setSchemaVersion("1.0");
+    m.setId("bad-gadget");
+    m.setName("Bad");
+    m.setVersion("1.0.0");
+    PSComponentPackageManifest.Catalog cat = new PSComponentPackageManifest.Catalog();
+    cat.setKind("gadget");
+    // title missing
+    m.setCatalog(cat);
+    assertThrows(
+        Exception.class, () -> PSComponentPackageManifestValidator.validate(m));
+  }
+
+  private static PSGadgetRegistryModel parseClasspath(String resource, String sourceFileName)
+      throws Exception {
+    String xml = readClasspath(resource);
+    PSGadgetRegistryModel model = PSGadgetRegistryParser.parse(xml);
+    model.setSourceFileName(sourceFileName);
+    return model;
+  }
+
+  private static String readClasspath(String resource) throws Exception {
+    try (InputStream in = PSGadgetRegistryCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing classpath resource: " + resource);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+}

--- a/modules/perc-packages/src/test/resources/gadgetxml/GadgetRegistry.xml
+++ b/modules/perc-packages/src/test/resources/gadgetxml/GadgetRegistry.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gadgets>
+	<group name="Percussion">
+		<gadget name="Assets By Status"
+			baseuri="/cm/gadgets/repository/PercAssetStatusGadget"
+			file="PercAssetStatusGadget.xml" />
+		<gadget name="Blogs"
+			baseuri="/cm/gadgets/repository/PercBlogsGadget"
+			file="PercBlogsGadget.xml" />
+		<gadget name="Bulk Upload"
+			baseuri="/cm/gadgets/repository/perc_bulk_file_upload_gadget"
+			file="perc_bulk_file_upload_gadget.xml" />
+		<gadget name="Comments"
+			baseuri="/cm/gadgets/repository/perc_comments_gadget"
+			file="perc_comments_gadget.xml" />
+		<gadget name="Cookie Consent"
+			baseuri="/cm/gadgets/repository/perc_cookie_consent_gadget"
+			file="perc_cookie_consent_gadget.xml" />
+		<gadget name="Forms Tracker"
+			baseuri="/cm/gadgets/repository/PercFormTrackerGadget"
+			file="PercFormTrackerGadget.xml" />
+		<gadget name="Global Variables"
+			baseuri="/cm/gadgets/repository/PercGlobalVariablesGadget"
+			file="PercGlobalVariablesGadget.xml" />
+		<gadget name="Google Setup"
+			baseuri="/cm/gadgets/repository/perc_google_setup_gadget"
+			file="perc_google_setup_gadget.xml" />
+		<gadget name="Iframe"
+			baseuri="/cm/gadgets/repository/perc_iframe_gadget"
+			file="perc_iframe_gadget.xml" />
+		<gadget name="Pages By Status"
+			baseuri="/cm/gadgets/repository/perc_workflow_status_gadget"
+			file="perc_workflow_status_gadget.xml" />
+		<gadget name="Process Monitor"
+			baseuri="/cm/gadgets/repository/PercProcessorMonitorGadget"
+			file="PercProcessorMonitorGadget.xml" />
+		<gadget name="Reports"
+			baseuri="/cm/gadgets/repository/perc_reports_gadget"
+			file="perc_reports_gadget.xml" />
+		<gadget name="SEO Audit"
+			baseuri="/cm/gadgets/repository/perc_seo_gadget"
+			file="perc_seo_status_gadget.xml" />
+		<gadget name="Sitewide Framework"
+			baseuri="/cm/gadgets/repository/PercSiteFrameworkGadget"
+			file="perc_sitewide_framework_gadget.xml" />
+		<gadget name="Traffic"
+			baseuri="/cm/gadgets/repository/perc_traffic_gadget"
+			file="perc_traffic_gadget.xml" />
+		<gadget name="Welcome"
+			baseuri="/cm/gadgets/repository/cm1_welcome_gadget"
+			file="perc_welcome_gadget.xml" />
+		<gadget name="What's Working"
+			baseuri="/cm/gadgets/repository/perc_effectiveness_gadget"
+			file="perc_effectiveness_gadget.xml" />
+	</group>
+	<group name="Deprecated">
+		<gadget name="Activity"
+			baseuri="/cm/gadgets/repository/perc_activity_gadget"
+			file="perc_activity_gadget.xml" />
+		<gadget name="Siteimprove"
+			baseuri="/cm/gadgets/repository/perc_site_improve_gadget"
+			file="perc_site_improve_gadget.xml" />
+		<gadget name="Membership"
+			baseuri="/cm/gadgets/repository/perc_membership_gadget"
+			file="perc_membership_gadget.xml" />
+		<!-- Redirect Management removed entirely (issue #715): product discontinued;
+			legacy perc_website_config_gadget assets are no longer shipped. -->
+		<gadget name="Widget Configuration"
+			baseuri="/cm/gadgets/repository/PercWidgetConfigGadget"
+			file="PercWidgetConfigGadget.xml" />
+	</group>
+</gadgets>

--- a/modules/perc-packages/src/test/resources/gadgetxml/golden/cm1_welcome_gadget.component-package.json
+++ b/modules/perc-packages/src/test/resources/gadgetxml/golden/cm1_welcome_gadget.component-package.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "1.0",
+  "id": "cm1_welcome_gadget",
+  "name": "Welcome",
+  "version": "8.2.0",
+  "description": "Dashboard gadget package for 'Welcome' (group=Percussion)",
+  "publisher": {
+    "name": "Intersoft Data Labs, Inc.",
+    "url": "https://www.intsof.com"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "gadget",
+    "title": "Welcome",
+    "category": "Percussion",
+    "description": "Dashboard gadget package for 'Welcome' (group=Percussion)",
+    "author": "Intersoft Data Labs, Inc.",
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [],
+  "slots": [],
+  "resources": [
+    {
+      "path": "resources/host-ref.txt",
+      "target": "cm/gadgets/repository/cm1_welcome_gadget",
+      "type": "file"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/test/resources/gadgetxml/golden/gadget-catalog.json
+++ b/modules/perc-packages/src/test/resources/gadgetxml/golden/gadget-catalog.json
@@ -1,0 +1,198 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.gadgetCatalog",
+  "name": "Product Gadget Catalog",
+  "version": "8.2.0",
+  "description": "Modern product gadget catalog compiled from GadgetRegistry.xml (ADR-004 / #2771)",
+  "gadgets": [
+    {
+      "id": "PercAssetStatusGadget",
+      "name": "Assets By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercAssetStatusGadget",
+      "legacyDefinitionFile": "PercAssetStatusGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercAssetStatusGadget/component-package.json"
+    },
+    {
+      "id": "PercBlogsGadget",
+      "name": "Blogs",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercBlogsGadget",
+      "legacyDefinitionFile": "PercBlogsGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercBlogsGadget/component-package.json"
+    },
+    {
+      "id": "perc_bulk_file_upload_gadget",
+      "name": "Bulk Upload",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_bulk_file_upload_gadget",
+      "legacyDefinitionFile": "perc_bulk_file_upload_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_bulk_file_upload_gadget/component-package.json"
+    },
+    {
+      "id": "perc_comments_gadget",
+      "name": "Comments",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_comments_gadget",
+      "legacyDefinitionFile": "perc_comments_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_comments_gadget/component-package.json"
+    },
+    {
+      "id": "perc_cookie_consent_gadget",
+      "name": "Cookie Consent",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_cookie_consent_gadget",
+      "legacyDefinitionFile": "perc_cookie_consent_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_cookie_consent_gadget/component-package.json"
+    },
+    {
+      "id": "PercFormTrackerGadget",
+      "name": "Forms Tracker",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercFormTrackerGadget",
+      "legacyDefinitionFile": "PercFormTrackerGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercFormTrackerGadget/component-package.json"
+    },
+    {
+      "id": "PercGlobalVariablesGadget",
+      "name": "Global Variables",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercGlobalVariablesGadget",
+      "legacyDefinitionFile": "PercGlobalVariablesGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercGlobalVariablesGadget/component-package.json"
+    },
+    {
+      "id": "perc_google_setup_gadget",
+      "name": "Google Setup",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_google_setup_gadget",
+      "legacyDefinitionFile": "perc_google_setup_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_google_setup_gadget/component-package.json"
+    },
+    {
+      "id": "perc_iframe_gadget",
+      "name": "Iframe",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_iframe_gadget",
+      "legacyDefinitionFile": "perc_iframe_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_iframe_gadget/component-package.json"
+    },
+    {
+      "id": "perc_workflow_status_gadget",
+      "name": "Pages By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_workflow_status_gadget",
+      "legacyDefinitionFile": "perc_workflow_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_workflow_status_gadget/component-package.json"
+    },
+    {
+      "id": "PercProcessorMonitorGadget",
+      "name": "Process Monitor",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercProcessorMonitorGadget",
+      "legacyDefinitionFile": "PercProcessorMonitorGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercProcessorMonitorGadget/component-package.json"
+    },
+    {
+      "id": "perc_reports_gadget",
+      "name": "Reports",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_reports_gadget",
+      "legacyDefinitionFile": "perc_reports_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_reports_gadget/component-package.json"
+    },
+    {
+      "id": "perc_seo_gadget",
+      "name": "SEO Audit",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_seo_gadget",
+      "legacyDefinitionFile": "perc_seo_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_seo_gadget/component-package.json"
+    },
+    {
+      "id": "PercSiteFrameworkGadget",
+      "name": "Sitewide Framework",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercSiteFrameworkGadget",
+      "legacyDefinitionFile": "perc_sitewide_framework_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercSiteFrameworkGadget/component-package.json"
+    },
+    {
+      "id": "perc_traffic_gadget",
+      "name": "Traffic",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_traffic_gadget",
+      "legacyDefinitionFile": "perc_traffic_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_traffic_gadget/component-package.json"
+    },
+    {
+      "id": "cm1_welcome_gadget",
+      "name": "Welcome",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/cm1_welcome_gadget",
+      "legacyDefinitionFile": "perc_welcome_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/cm1_welcome_gadget/component-package.json"
+    },
+    {
+      "id": "perc_effectiveness_gadget",
+      "name": "What's Working",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_effectiveness_gadget",
+      "legacyDefinitionFile": "perc_effectiveness_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_effectiveness_gadget/component-package.json"
+    },
+    {
+      "id": "perc_activity_gadget",
+      "name": "Activity",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_activity_gadget",
+      "legacyDefinitionFile": "perc_activity_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_activity_gadget/component-package.json"
+    },
+    {
+      "id": "perc_site_improve_gadget",
+      "name": "Siteimprove",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_site_improve_gadget",
+      "legacyDefinitionFile": "perc_site_improve_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_site_improve_gadget/component-package.json"
+    },
+    {
+      "id": "perc_membership_gadget",
+      "name": "Membership",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_membership_gadget",
+      "legacyDefinitionFile": "perc_membership_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_membership_gadget/component-package.json"
+    },
+    {
+      "id": "PercWidgetConfigGadget",
+      "name": "Widget Configuration",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/PercWidgetConfigGadget",
+      "legacyDefinitionFile": "PercWidgetConfigGadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/PercWidgetConfigGadget/component-package.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements **Phase 3 slice 5** of parent **#2630** (epic **#2626**, ADR-004): **Gadget registry → modern catalog + package model** with golden parity.

- `PSGadgetRegistryParser` — XXE-hardened parse of product `GadgetRegistry.xml`
- `PSGadgetRegistryCompiler` — emits aggregate `gadget-catalog.json` + per-gadget `component-package.json` (`catalog.kind = "gadget"`)
- `PSGadgetCatalog` / `PSGadgetCatalogIo` — modern registry ship format
- Validator: gadget packages require `catalog.title`; CT/templates optional (SPA hosts, not assembly)
- Product modern catalog: `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` (21 gadgets)
- Goldens: Welcome (`cm1_welcome_gadget`) package + full catalog
- Docs updated under `template-assembler-normalization`

**Depends on #2766** (manifest + widget compiler cluster) — already merged on `main`.

**Out of scope / residual:** WebUI runtime dual-load of `gadget-catalog.json` (retire classpath `GadgetRegistry.xml` after dual-load); SPA UX; per-gadget definition XML (already largely gone).

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2771
Refs #2630 #2626 #2766
Parent: #2630

## Test plan

- [x] `cd modules/perc-packages && ../../mvnw clean install` — **BUILD SUCCESS**
- [x] Tests run: **44**, Failures: **0** (includes new `PSGadgetRegistryCompilerTest`)
- [x] Golden parity for Welcome package + full product catalog (21 entries)
- [x] Validator accepts gadget packages without contentTypes/templates
- [ ] Residual: WebUI dual-load of modern catalog (follow-up issue)

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang self-review | Pass — portable Path/Files; XXE-hardened XML; URL-style package paths; no product GadgetRegistry.xml deletion |
| Module clean install | `cd modules/perc-packages` → `..\..\mvnw.cmd clean install` → BUILD SUCCESS |
| Tests | Tests run: 44, Failures: 0 |
| Change-class companions | parser + compiler + catalog IO + validator rule + product catalog resource + goldens + inventory/ADR docs |
| Human QA | Not required — packaging compiler/unit only; no installer/UI runtime cutover |
| Downstream (C2) | none — additive APIs + validator relaxation for gadget kind only |

> Co-Authored by Grok Build using grok-4.5 with agent main.
