### PR TITLE
feat(perc-packages): high-traffic widget XML compiler residual + goldens (#2772)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -75,7 +75,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Widget DAO (legacy XML load) | `projects/sitemanage/.../dao/impl/PSWidgetDao.java` (`rxconfig/Widgets`) |
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
-| Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751) |
+| Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751 baseWidgets, #2772 high-traffic) |
 | Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -49,14 +49,14 @@ Ship-format model and docs landed as Phase 3 slice 1 (#2750):
 
 **Upgrade-input XML** remains compiler/shim only; **product ship format** is `component-package.json` plus content types, templates, slots, catalog metadata, and resources.
 
-## Widget XML compiler (slice #2751)
+## Widget XML compiler (slices #2751 / #2772)
 
-Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidgets / simple subset first):
+Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidgets + high-traffic batch):
 
 | Artifact | Location |
 |----------|----------|
 | Parser / compiler / package scanner | `modules/perc-packages/.../widgetxml/PSWidgetXml*.java` |
-| Golden parity (percSimpleText) | `modules/perc-packages/src/test/resources/widgetxml/golden/` |
+| Golden parity (simple + high-traffic) | `modules/perc-packages/src/test/resources/widgetxml/golden/` |
 | Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
 
-High-traffic package conversion and product XML removal remain residual under #2630.
+Remaining long-tail product packages and product Widget XML removal remain residual under #2630.

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -175,16 +175,16 @@ String json = PSComponentPackageManifestIo.toJson(m);
 - **Today:** `PSPackageBuilder` zips legacy package source trees into `.ppkg` for the deployer (`psx_archiveInfo.xml` / dependency trees). That path remains for install compatibility.
 - **This manifest:** extends the packaging story with an explicit, tool-friendly **component** model that does not require Widget/Page/Gadget XML. Future slices wire compiler output and install recognition; this slice lands model + schema + tests only.
 
-## Widget XML compiler (slice #2751)
+## Widget XML compiler (slices #2751 / #2772)
 
-Upgrade-input path for simple / **baseWidgets** widgets:
+Upgrade-input path for **baseWidgets** and the **high-traffic residual batch**:
 
 | Type | Role |
 |------|------|
-| `PSWidgetXmlParser` | Secure DOM parse of `<Widget>` definition XML |
+| `PSWidgetXmlParser` | Secure DOM parse of `<Widget>` definition XML (prefs, code, content, **Resource**) |
 | `PSWidgetXmlCompiler` | XML model → `PSComponentPackageManifest` + template text artifacts |
-| `PSWidgetXmlPackageCompiler` | Scan `sys__UserDependency--rxconfig/Widgets/*.xml` under a package root |
-| Golden fixtures | `modules/perc-packages/src/test/resources/widgetxml/golden/` (percSimpleText) |
+| `PSWidgetXmlPackageCompiler` | Scan `sys__UserDependency--rxconfig/Widgets/*.xml` under a package root; `compileHighTrafficPackages` |
+| Golden fixtures | `modules/perc-packages/src/test/resources/widgetxml/golden/` (percSimpleText, percTitle, simplePageAutoList, percNavBreadcrumb) |
 
 Inventory + residual packages: [widget-xml-inventory.md](./widget-xml-inventory.md).
 
@@ -193,7 +193,7 @@ Inventory + residual packages: [widget-xml-inventory.md](./widget-xml-inventory.
 | Slice | Issue | Role |
 |-------|-------|------|
 | Runtime legacy shim | #2752 | Load customer XML when modern package absent |
-| High-traffic package conversion | residual under #2630 | nav, blog, lists, forms, … (see inventory) |
+| Remaining high-traffic / long-tail widgets | residual under #2630 | blog, calendar, directory, social, forms, auto-lists, … (see inventory) |
 | Delete product Widget XML from source | later | After install path consumes modern artifacts |
 
 ## Validation summary

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -4,15 +4,29 @@
 **Source:** `modules/perc-packages/src/main/resources/Packages/**/rxconfig/Widgets/*.xml`  
 **Machine-readable:** [widget-xml-inventory.csv](./widget-xml-inventory.csv)
 
-## Compiler status (#2751 / parent #2630)
+## Compiler status (#2751 / #2772 / parent #2630)
 
 | Area | Status | Notes |
 |------|--------|-------|
-| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets / simple subset** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
-| Golden parity | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
-| **Product packages still ship Widget XML** | Yes (this slice) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
-| Residual high-traffic packages | Open | nav, blog, lists, rich media lists, forms, calendar, directory, social, etc. — use this inventory as the residual backlog (sibling/follow-on issues under #2630) |
-| Runtime legacy XML shim | Open | #2752 |
+| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic batch** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
+| Golden parity (baseWidgets) | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
+| Golden parity (high-traffic #2772) | **percTitle**, **simplePageAutoList**, **percNavBreadcrumb** | Plus package compile of title, lists×2, nav×2, file, image (7 widgets) |
+| Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT) |
+| **Product packages still ship Widget XML** | Yes (dual-run) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
+| Residual product packages | Open | blog, calendar, directory, social, forms, auto-lists (image/page/file), jquery, poll, login, etc. — see matrix below |
+| Runtime legacy XML shim | Landed (cluster #2766) | #2752 |
+
+### High-traffic batch covered by #2772
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.widget.title` | percTitle | UserPref enum (wrapper) + content CT |
+| `perc.widgets.lists` | simplePageAutoList, simpleTextAutoList | `<Resource>` CSS + layout/maxlength → slot.layout |
+| `perc.widgets.nav` | percNavBar, percNavBreadcrumb | Chrome (no CT); chrome slot + CSS resource on breadcrumb |
+| `perc.FileAssetWidget` | percFile | Content + rich media |
+| `perc.widgets.image` | percImage | Content + rich media + CSS resource |
+
+Measurable reduction: **7** product widget definition XMLs now have a validated modern compile path with goldens (beyond the original 3 baseWidgets).
 
 Ship format: [component-package-manifest.md](./component-package-manifest.md). ADR: [004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md).
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
@@ -750,6 +750,8 @@ public final class PSComponentPackageManifest {
     private String path;
     private String target;
     private String type;
+    /** Optional HTML placement (e.g. {@code head}, {@code body}) from Widget XML Resource. */
+    private String placement;
 
     public String getPath() {
       return path;
@@ -775,6 +777,14 @@ public final class PSComponentPackageManifest {
       this.type = type;
     }
 
+    public String getPlacement() {
+      return placement;
+    }
+
+    public void setPlacement(String placement) {
+      this.placement = placement;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -785,12 +795,13 @@ public final class PSComponentPackageManifest {
       }
       return Objects.equals(path, that.path)
           && Objects.equals(target, that.target)
-          && Objects.equals(type, that.type);
+          && Objects.equals(type, that.type)
+          && Objects.equals(placement, that.placement);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(path, target, type);
+      return Objects.hash(path, target, type, placement);
     }
   }
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -217,6 +217,9 @@ public final class PSWidgetXmlCompiler {
               ? declared.getType().trim().toLowerCase(Locale.ROOT)
               : guessResourceType(packageRelative);
       res.setType(type);
+      if (declared.getPlacement() != null && !declared.getPlacement().isBlank()) {
+        res.setPlacement(declared.getPlacement().trim());
+      }
       resources.add(res);
     }
     manifest.setResources(resources);

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -36,11 +36,13 @@ import java.util.regex.Pattern;
 
 /**
  * Compiles legacy Widget definition XML into a modern {@link PSComponentPackageManifest} plus
- * template source artifacts (Phase 3 / ADR-004 / issue #2751).
+ * template source artifacts (Phase 3 / ADR-004 / issues #2751, #2772).
  *
- * <p><strong>Scope:</strong> simple / baseWidgets-shaped widgets (JEXL code + Velocity content +
- * optional asset content type + UserPref/CssPref). High-traffic packages (nav, blog, lists) remain
- * residual work; see {@code docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
+ * <p><strong>Scope:</strong> baseWidgets-shaped widgets plus high-traffic product packages (title,
+ * lists, nav chrome, file, image): JEXL code + Velocity content + optional asset content type +
+ * UserPref/CssPref + {@code <Resource>} CSS/JS refs. Remaining residual packages (blog, calendar,
+ * directory, social, forms, auto-lists, …) are tracked in {@code
+ * docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
  *
  * <p>Assembler mapping: {@code Content type="velocity"} → {@code velocityAssembler}; {@code html}
  * → {@code htmlAssembler}; {@code markdown} → {@code markdownAssembler}. Code language is always
@@ -153,27 +155,34 @@ public final class PSWidgetXmlCompiler {
     templates.add(template);
     manifest.setTemplates(templates);
 
-    // Default slot for the asset content type (simple widgets).
+    // Default slot: asset content type when present; chrome/logic widgets (nav) still get a styles
+    // slot when CssPref is declared so ADR-003 layout/styles has a home without inventing a CT.
+    Map<String, Object> styles = cssPrefStyles(model);
+    Map<String, Object> layout = layoutFromUserPrefs(model);
     if (ctName != null && !ctName.isBlank()) {
       PSComponentPackageManifest.SlotRef slot = new PSComponentPackageManifest.SlotRef();
       slot.setName(stem + "Content");
       List<String> allowed = new ArrayList<>();
       allowed.add(ctName);
       slot.setAllowedContentTypes(allowed);
-      // CssPrefs that look like class names land in slot styles (ADR-003 direction).
-      Map<String, Object> styles = new LinkedHashMap<>();
-      for (PSWidgetXmlModel.CssPref css : model.getCssPrefs()) {
-        if (css != null && css.getName() != null && !css.getName().isBlank()) {
-          styles.put(css.getName(), css.getDefaultValue() != null ? css.getDefaultValue() : "");
-        }
-      }
       slot.setStyles(styles);
+      slot.setLayout(layout);
+      List<PSComponentPackageManifest.SlotRef> slots = new ArrayList<>();
+      slots.add(slot);
+      manifest.setSlots(slots);
+    } else if (!styles.isEmpty() || !layout.isEmpty()) {
+      PSComponentPackageManifest.SlotRef slot = new PSComponentPackageManifest.SlotRef();
+      slot.setName(stem + "Chrome");
+      slot.setAllowedContentTypes(new ArrayList<>());
+      slot.setStyles(styles);
+      slot.setLayout(layout);
       List<PSComponentPackageManifest.SlotRef> slots = new ArrayList<>();
       slots.add(slot);
       manifest.setSlots(slots);
     }
 
-    // Resources: thumbnail as installable image when present.
+    // Resources: thumbnail + <Resource href=…> (CSS/JS) declared on high-traffic widgets.
+    List<PSComponentPackageManifest.ResourceRef> resources = new ArrayList<>();
     if (packageRelativeThumbnail != null) {
       PSComponentPackageManifest.ResourceRef res = new PSComponentPackageManifest.ResourceRef();
       // Package-local staging path for the resource (URL-style separators).
@@ -181,13 +190,36 @@ public final class PSWidgetXmlCompiler {
       res.setPath(localPath);
       res.setTarget(packageRelativeThumbnail);
       res.setType(guessResourceType(packageRelativeThumbnail));
-      List<PSComponentPackageManifest.ResourceRef> resources = new ArrayList<>();
       resources.add(res);
-      manifest.setResources(resources);
       // Point catalog at the package-local staging path (validator prefers relative refs).
       catalog.setThumbnail(localPath);
       catalog.setIcon(localPath);
     }
+    for (PSWidgetXmlModel.Resource declared : model.getResources()) {
+      if (declared == null) {
+        continue;
+      }
+      String packageRelative = toPackageRelativePath(declared.getHref());
+      if (packageRelative == null) {
+        continue;
+      }
+      PSComponentPackageManifest.ResourceRef res = new PSComponentPackageManifest.ResourceRef();
+      final String candidatePath = "resources/" + fileNameOf(packageRelative);
+      // Avoid duplicate path keys when thumbnail and Resource share a file name (rare).
+      final String localPath =
+          resources.stream().anyMatch(r -> candidatePath.equals(r.getPath()))
+              ? "resources/" + packageRelative.replace('/', '_')
+              : candidatePath;
+      res.setPath(localPath);
+      res.setTarget(packageRelative);
+      String type =
+          declared.getType() != null && !declared.getType().isBlank()
+              ? declared.getType().trim().toLowerCase(Locale.ROOT)
+              : guessResourceType(packageRelative);
+      res.setType(type);
+      resources.add(res);
+    }
+    manifest.setResources(resources);
 
     // Transitional UserPref / CssPref mirrors.
     List<PSComponentPackageManifest.UserPreference> userPrefs = new ArrayList<>();
@@ -353,6 +385,35 @@ public final class PSWidgetXmlCompiler {
     full.setExpression(normalized);
     bindings.add(full);
     return bindings;
+  }
+
+  /** CssPrefs that look like class names land in slot styles (ADR-003 direction). */
+  static Map<String, Object> cssPrefStyles(PSWidgetXmlModel model) {
+    Map<String, Object> styles = new LinkedHashMap<>();
+    for (PSWidgetXmlModel.CssPref css : model.getCssPrefs()) {
+      if (css != null && css.getName() != null && !css.getName().isBlank()) {
+        styles.put(css.getName(), css.getDefaultValue() != null ? css.getDefaultValue() : "");
+      }
+    }
+    return styles;
+  }
+
+  /**
+   * Map layout-ish UserPrefs ({@code layout}, {@code maxlength}) into the slot {@code layout} map
+   * (region-slot mapping guidance for list widgets).
+   */
+  static Map<String, Object> layoutFromUserPrefs(PSWidgetXmlModel model) {
+    Map<String, Object> layout = new LinkedHashMap<>();
+    for (PSWidgetXmlModel.UserPref up : model.getUserPrefs()) {
+      if (up == null || up.getName() == null || up.getName().isBlank()) {
+        continue;
+      }
+      String name = up.getName().trim();
+      if ("layout".equalsIgnoreCase(name) || "maxlength".equalsIgnoreCase(name)) {
+        layout.put(name, up.getDefaultValue() != null ? up.getDefaultValue() : "");
+      }
+    }
+    return layout;
   }
 
   static String mapAssembler(String contentType) {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlModel.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlModel.java
@@ -47,6 +47,7 @@ public final class PSWidgetXmlModel {
   private String contentBody;
   private List<UserPref> userPrefs = new ArrayList<>();
   private List<CssPref> cssPrefs = new ArrayList<>();
+  private List<Resource> resources = new ArrayList<>();
 
   public String getSourceFileName() {
     return sourceFileName;
@@ -195,6 +196,18 @@ public final class PSWidgetXmlModel {
   }
 
   /**
+   * Parsed {@code <Resource href="..." type="..." placement="..."/>} entries (CSS/JS/etc. declared
+   * on the widget definition). High-traffic widgets (lists, nav, image) commonly declare these.
+   */
+  public List<Resource> getResources() {
+    return resources;
+  }
+
+  public void setResources(List<Resource> resources) {
+    this.resources = resources != null ? resources : new ArrayList<>();
+  }
+
+  /**
    * Widget stem derived from the source file name (e.g. {@code percSimpleText} from {@code
    * percSimpleText.xml}).
    */
@@ -238,7 +251,8 @@ public final class PSWidgetXmlModel {
         && Objects.equals(contentType, that.contentType)
         && Objects.equals(contentBody, that.contentBody)
         && Objects.equals(userPrefs, that.userPrefs)
-        && Objects.equals(cssPrefs, that.cssPrefs);
+        && Objects.equals(cssPrefs, that.cssPrefs)
+        && Objects.equals(resources, that.resources);
   }
 
   @Override
@@ -261,7 +275,8 @@ public final class PSWidgetXmlModel {
         contentType,
         contentBody,
         userPrefs,
-        cssPrefs);
+        cssPrefs,
+        resources);
   }
 
   /** Parsed {@code <UserPref>} element. */
@@ -437,6 +452,57 @@ public final class PSWidgetXmlModel {
     @Override
     public int hashCode() {
       return Objects.hash(name, displayName, datatype, defaultValue);
+    }
+  }
+
+  /**
+   * Parsed {@code <Resource>} element (static CSS/JS/etc. referenced from the widget definition).
+   */
+  public static final class Resource {
+    private String href;
+    private String type;
+    private String placement;
+
+    public String getHref() {
+      return href;
+    }
+
+    public void setHref(String href) {
+      this.href = href;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getPlacement() {
+      return placement;
+    }
+
+    public void setPlacement(String placement) {
+      this.placement = placement;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Resource that)) {
+        return false;
+      }
+      return Objects.equals(href, that.href)
+          && Objects.equals(type, that.type)
+          && Objects.equals(placement, that.placement);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(href, type, placement);
     }
   }
 }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -31,14 +31,26 @@ import java.util.Objects;
  * Compiles all Widget definition XML files found in a legacy product package source directory.
  *
  * <p>Looks under {@code sys__UserDependency--rxconfig/Widgets/*.xml} (product packaging layout used
- * by {@code modules/perc-packages}). Suitable for the baseWidgets subset first; residual packages
- * are tracked in the widget XML inventory.
+ * by {@code modules/perc-packages}). Covers baseWidgets and high-traffic product packages (#2772);
+ * residual packages are tracked in the widget XML inventory.
  */
 public final class PSWidgetXmlPackageCompiler {
 
   /** Legacy staging folder name for user-dependency config inside a package source tree. */
   public static final String WIDGETS_RELATIVE =
       "sys__UserDependency--rxconfig/Widgets";
+
+  /**
+   * Named high-traffic product package directory names under {@code Packages/} covered by the
+   * residual batch in issue #2772 (beyond {@code perc.baseWidgets}).
+   */
+  public static final List<String> HIGH_TRAFFIC_PACKAGE_DIRS =
+      List.of(
+          "perc.widget.title",
+          "perc.widgets.lists",
+          "perc.widgets.nav",
+          "perc.FileAssetWidget",
+          "perc.widgets.image");
 
   private PSWidgetXmlPackageCompiler() {
     // utility
@@ -89,6 +101,33 @@ public final class PSWidgetXmlPackageCompiler {
       results.add(PSWidgetXmlCompiler.compile(widgetXml, ctx));
     }
     return results;
+  }
+
+  /**
+   * Compile every high-traffic product package under a {@code Packages/} root directory.
+   *
+   * @param packagesRoot non-null directory containing package folders (e.g. {@code
+   *     src/main/resources/Packages})
+   * @return compile results sorted by package then widget stem
+   * @throws PSWidgetXmlException on parse/compile failure
+   * @throws IOException on I/O failure
+   */
+  public static List<PSWidgetXmlCompileResult> compileHighTrafficPackages(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packagesRoot, "packagesRoot");
+    if (!Files.isDirectory(packagesRoot)) {
+      throw new PSWidgetXmlException("Packages root does not exist: " + packagesRoot);
+    }
+    List<PSWidgetXmlCompileResult> all = new ArrayList<>();
+    for (String dirName : HIGH_TRAFFIC_PACKAGE_DIRS) {
+      Path packageDir = packagesRoot.resolve(dirName);
+      if (!Files.isDirectory(packageDir)) {
+        throw new PSWidgetXmlException(
+            "High-traffic package directory missing under Packages root: " + dirName);
+      }
+      all.addAll(compilePackage(packageDir));
+    }
+    return all;
   }
 
   /**

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -105,11 +105,13 @@ public final class PSWidgetXmlPackageCompiler {
 
   /**
    * Compile every high-traffic product package under a {@code Packages/} root directory.
+   * Missing package directories under the root are skipped (soft) so partial checkouts can
+   * still exercise available packages.
    *
    * @param packagesRoot non-null directory containing package folders (e.g. {@code
    *     src/main/resources/Packages})
-   * @return compile results sorted by package then widget stem
-   * @throws PSWidgetXmlException on parse/compile failure
+   * @return compile results sorted by package then widget stem (may be empty if none present)
+   * @throws PSWidgetXmlException on parse/compile failure of a present package
    * @throws IOException on I/O failure
    */
   public static List<PSWidgetXmlCompileResult> compileHighTrafficPackages(Path packagesRoot)
@@ -121,9 +123,10 @@ public final class PSWidgetXmlPackageCompiler {
     List<PSWidgetXmlCompileResult> all = new ArrayList<>();
     for (String dirName : HIGH_TRAFFIC_PACKAGE_DIRS) {
       Path packageDir = packagesRoot.resolve(dirName);
+      // Soft-skip missing package dirs so partial checkouts / CI fixtures still exercise
+      // the packages that are present (matches baseWidgets soft-skip tests).
       if (!Files.isDirectory(packageDir)) {
-        throw new PSWidgetXmlException(
-            "High-traffic package directory missing under Packages root: " + dirName);
+        continue;
       }
       all.addAll(compilePackage(packageDir));
     }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlParser.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlParser.java
@@ -195,6 +195,12 @@ public final class PSWidgetXmlParser {
     }
     model.setCssPrefs(cssPrefs);
 
+    List<PSWidgetXmlModel.Resource> resources = new ArrayList<>();
+    for (Element el : childElements(root, "Resource")) {
+      resources.add(parseResource(el));
+    }
+    model.setResources(resources);
+
     Element code = firstChildElement(root, "Code");
     if (code != null) {
       model.setCodeType(attr(code, "type"));
@@ -236,6 +242,14 @@ public final class PSWidgetXmlParser {
     pref.setDatatype(attr(el, "datatype"));
     pref.setDefaultValue(attr(el, "default_value"));
     return pref;
+  }
+
+  private static PSWidgetXmlModel.Resource parseResource(Element el) {
+    PSWidgetXmlModel.Resource resource = new PSWidgetXmlModel.Resource();
+    resource.setHref(attr(el, "href"));
+    resource.setType(attr(el, "type"));
+    resource.setPlacement(attr(el, "placement"));
+    return resource;
   }
 
   private static Element firstChildElement(Element parent, String name) {

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -395,11 +395,22 @@ class PSWidgetXmlCompilerTest {
 
     Path outRoot = tempDir.resolve("high-traffic-out");
     PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
-    assertTrue(
-        Files.isRegularFile(
-            outRoot
-                .resolve("percTitle")
-                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+    for (String stem :
+        List.of(
+            "percTitle",
+            "simplePageAutoList",
+            "simpleTextAutoList",
+            "percNavBar",
+            "percNavBreadcrumb",
+            "percFile",
+            "percImage")) {
+      assertTrue(
+          Files.isRegularFile(
+              outRoot
+                  .resolve(stem)
+                  .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)),
+          "writeAll missing manifest for " + stem);
+    }
   }
 
   private static PSWidgetXmlCompileResult assertGoldenParity(

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -36,7 +36,10 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-/** Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751). */
+/**
+ * Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751 baseWidgets,
+ * #2772 high-traffic residual batch).
+ */
 class PSWidgetXmlCompilerTest {
 
   private static final String FIXTURE_SIMPLE = "/widgetxml/percSimpleText.xml";
@@ -44,6 +47,23 @@ class PSWidgetXmlCompilerTest {
       "/widgetxml/golden/percSimpleText.component-package.json";
   private static final String GOLDEN_SIMPLE_TEMPLATE =
       "/widgetxml/golden/percSimpleTextSnippet.vm";
+
+  private static final String FIXTURE_TITLE = "/widgetxml/percTitle.xml";
+  private static final String GOLDEN_TITLE_MANIFEST =
+      "/widgetxml/golden/percTitle.component-package.json";
+  private static final String GOLDEN_TITLE_TEMPLATE = "/widgetxml/golden/percTitleSnippet.vm";
+
+  private static final String FIXTURE_LIST = "/widgetxml/simplePageAutoList.xml";
+  private static final String GOLDEN_LIST_MANIFEST =
+      "/widgetxml/golden/simplePageAutoList.component-package.json";
+  private static final String GOLDEN_LIST_TEMPLATE =
+      "/widgetxml/golden/simplePageAutoListSnippet.vm";
+
+  private static final String FIXTURE_BREADCRUMB = "/widgetxml/percNavBreadcrumb.xml";
+  private static final String GOLDEN_BREADCRUMB_MANIFEST =
+      "/widgetxml/golden/percNavBreadcrumb.component-package.json";
+  private static final String GOLDEN_BREADCRUMB_TEMPLATE =
+      "/widgetxml/golden/percNavBreadcrumbSnippet.vm";
 
   @TempDir Path tempDir;
 
@@ -241,6 +261,177 @@ class PSWidgetXmlCompilerTest {
     assertEquals("markdownAssembler", PSWidgetXmlCompiler.mapAssembler("markdown"));
   }
 
+  @Test
+  void parseTitle_userPrefEnumsAndCreateSharedAsset() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_TITLE, "percTitle.xml");
+    assertEquals("Title", model.getTitle());
+    assertEquals("percTitleAsset", model.getContentTypeName());
+    assertEquals(1, model.getUserPrefs().size());
+    assertEquals("wrapper", model.getUserPrefs().get(0).getName());
+    assertEquals("enum", model.getUserPrefs().get(0).getDatatype());
+    assertEquals(8, model.getUserPrefs().get(0).getEnumValues().size());
+    assertEquals(Boolean.FALSE, model.getCreateSharedAsset());
+    assertTrue(model.getResources().isEmpty());
+  }
+
+  @Test
+  void compileTitle_matchesGoldenManifestAndTemplate() throws Exception {
+    assertGoldenParity(
+        FIXTURE_TITLE,
+        "percTitle.xml",
+        "perc.widget.title",
+        GOLDEN_TITLE_MANIFEST,
+        GOLDEN_TITLE_TEMPLATE,
+        "templates/percTitleSnippet.vm");
+  }
+
+  @Test
+  void parseSimplePageAutoList_resourcesAndLayoutPrefs() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_LIST, "simplePageAutoList.xml");
+    assertEquals("Auto List", model.getTitle());
+    assertEquals(1, model.getResources().size());
+    assertEquals("/rx_resources/widgets/simpleList/css/style.css", model.getResources().get(0).getHref());
+    assertEquals("css", model.getResources().get(0).getType());
+    assertEquals("head", model.getResources().get(0).getPlacement());
+    assertTrue(model.getUserPrefs().stream().anyMatch(p -> "layout".equals(p.getName())));
+    assertTrue(model.getUserPrefs().stream().anyMatch(p -> "maxlength".equals(p.getName())));
+  }
+
+  @Test
+  void compileSimplePageAutoList_matchesGolden_andEmitsCssResource() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_LIST,
+            "simplePageAutoList.xml",
+            "perc.widgets.lists",
+            GOLDEN_LIST_MANIFEST,
+            GOLDEN_LIST_TEMPLATE,
+            "templates/simplePageAutoListSnippet.vm");
+    assertTrue(
+        result.getManifest().getResources().stream()
+            .anyMatch(r -> "css".equals(r.getType()) && r.getTarget().endsWith("style.css")),
+        "list widget must emit declared CSS Resource");
+    assertEquals(
+        "0",
+        String.valueOf(result.getManifest().getSlots().get(0).getLayout().get("maxlength")));
+  }
+
+  @Test
+  void parseNavBreadcrumb_chromeWidgetNoContentType_withResource() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_BREADCRUMB, "percNavBreadcrumb.xml");
+    assertEquals("Breadcrumb", model.getTitle());
+    assertTrue(
+        model.getContentTypeName() == null || model.getContentTypeName().isBlank(),
+        "nav breadcrumb is chrome (no asset CT)");
+    assertEquals(1, model.getResources().size());
+    assertEquals("css", model.getResources().get(0).getType());
+    assertFalse(model.getUserPrefs().isEmpty());
+  }
+
+  @Test
+  void compileNavBreadcrumb_matchesGolden_chromeSlotAndCssResource() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_BREADCRUMB,
+            "percNavBreadcrumb.xml",
+            "perc.widgets.nav",
+            GOLDEN_BREADCRUMB_MANIFEST,
+            GOLDEN_BREADCRUMB_TEMPLATE,
+            "templates/percNavBreadcrumbSnippet.vm");
+    assertTrue(
+        result.getManifest().getContentTypes() == null
+            || result.getManifest().getContentTypes().isEmpty());
+    assertEquals("percNavBreadcrumbChrome", result.getManifest().getSlots().get(0).getName());
+    assertTrue(
+        result.getManifest().getResources().stream().anyMatch(r -> "css".equals(r.getType())));
+  }
+
+  @Test
+  void compileHighTrafficPackages_allValidate() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping high-traffic package test");
+      return;
+    }
+
+    List<PSWidgetXmlCompileResult> results =
+        PSWidgetXmlPackageCompiler.compileHighTrafficPackages(packagesRoot);
+    // title(1) + lists(2) + nav(2) + file(1) + image(1) = 7 widgets
+    assertEquals(
+        7,
+        results.size(),
+        "high-traffic batch should compile title, lists×2, nav×2, file, image");
+
+    Map<String, PSWidgetXmlCompileResult> byId =
+        results.stream()
+            .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+    for (String id :
+        List.of(
+            "percTitle",
+            "simplePageAutoList",
+            "simpleTextAutoList",
+            "percNavBar",
+            "percNavBreadcrumb",
+            "percFile",
+            "percImage")) {
+      assertTrue(byId.containsKey(id), "missing compiled widget: " + id);
+      PSComponentPackageManifestValidator.validate(byId.get(id).getManifest());
+      assertFalse(byId.get(id).getTextArtifacts().isEmpty());
+      assertEquals("velocityAssembler", byId.get(id).getManifest().getTemplates().get(0).getAssembler());
+    }
+
+    // Image declares CSS Resource + asset CT.
+    assertTrue(
+        byId.get("percImage").getManifest().getResources().stream()
+            .anyMatch(r -> "css".equals(r.getType())));
+    assertEquals("percImageAsset", byId.get("percImage").getManifest().getContentTypes().get(0).getName());
+
+    // NavBar is chrome (no CT) with styles slot.
+    assertTrue(
+        byId.get("percNavBar").getManifest().getContentTypes() == null
+            || byId.get("percNavBar").getManifest().getContentTypes().isEmpty());
+    assertEquals("percNavBarChrome", byId.get("percNavBar").getManifest().getSlots().get(0).getName());
+
+    Path outRoot = tempDir.resolve("high-traffic-out");
+    PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
+    assertTrue(
+        Files.isRegularFile(
+            outRoot
+                .resolve("percTitle")
+                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+  }
+
+  private static PSWidgetXmlCompileResult assertGoldenParity(
+      String fixtureResource,
+      String fileName,
+      String packageDirName,
+      String goldenManifestResource,
+      String goldenTemplateResource,
+      String templateArtifactKey)
+      throws Exception {
+    Path packageDir = locatePackage(packageDirName);
+    assertNotNull(packageDir, "package sources missing: " + packageDirName);
+    PSWidgetXmlPackageContext ctx = PSWidgetXmlPackageContext.fromPackageDir(packageDir);
+    PSWidgetXmlModel model = parseClasspath(fixtureResource, fileName);
+    PSWidgetXmlCompileResult result = PSWidgetXmlCompiler.compile(model, ctx);
+    PSComponentPackageManifestValidator.validate(result.getManifest());
+
+    String expectedJson = readClasspath(goldenManifestResource);
+    PSComponentPackageManifest reparsed =
+        PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(result.getManifest()));
+    assertEquals(
+        PSComponentPackageManifestIo.parse(expectedJson),
+        reparsed,
+        "compiled manifest must equal golden for " + fileName);
+
+    String expectedTemplate = normalizeNewlines(readClasspath(goldenTemplateResource));
+    String actualTemplate =
+        normalizeNewlines(result.getTextArtifacts().get(templateArtifactKey));
+    assertEquals(expectedTemplate, actualTemplate, "template source golden parity for " + fileName);
+    return result;
+  }
+
   private static PSWidgetXmlPackageContext baseWidgetsLikeContext() {
     PSWidgetXmlPackageContext ctx = new PSWidgetXmlPackageContext();
     ctx.setPackageId("perc.baseWidgets");
@@ -278,19 +469,26 @@ class PSWidgetXmlCompilerTest {
    * surefire cwd = module root).
    */
   private static Path locateBaseWidgetsPackage() {
-    Path candidate =
-        Path.of("src", "main", "resources", "Packages", "perc.baseWidgets");
+    return locatePackage("perc.baseWidgets");
+  }
+
+  private static Path locatePackage(String packageDirName) {
+    Path packages = locatePackagesRoot();
+    if (packages == null) {
+      return null;
+    }
+    Path candidate = packages.resolve(packageDirName);
+    return Files.isDirectory(candidate) ? candidate : null;
+  }
+
+  private static Path locatePackagesRoot() {
+    Path candidate = Path.of("src", "main", "resources", "Packages");
     if (Files.isDirectory(candidate)) {
       return candidate.toAbsolutePath().normalize();
     }
-    // Fallback: walk up from user.dir (rarely needed).
     Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
     Path alt =
-        cwd.resolve("src")
-            .resolve("main")
-            .resolve("resources")
-            .resolve("Packages")
-            .resolve("perc.baseWidgets");
+        cwd.resolve("src").resolve("main").resolve("resources").resolve("Packages");
     return Files.isDirectory(alt) ? alt : null;
   }
 }

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
@@ -1,0 +1,164 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percNavBreadcrumb",
+  "name": "Breadcrumb",
+  "version": "1.3.3",
+  "description": "Display a navigation breadcrumb in your site",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Breadcrumb",
+    "category": "navigation",
+    "description": "Display a navigation breadcrumb in your site",
+    "thumbnail": "resources/widgetIconBreadcrumb.png",
+    "icon": "resources/widgetIconBreadcrumb.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percNavBreadcrumbSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percNavBreadcrumbSnippet.vm",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "showHome",
+          "expression": "$perc.widget.item.properties.get('showHome')"
+        },
+        {
+          "variable": "showCurrentPage",
+          "expression": "$perc.widget.item.properties.get('showCurrentPage')"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$perc.widget.item.properties.get('ariaLabel')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "separator",
+          "expression": "$perc.widget.item.properties.get('separator')"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true)"
+        },
+        {
+          "variable": "navSelf",
+          "expression": "$assetItems.get(0).getNode()"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "''"
+        },
+        {
+          "variable": "navTooltip",
+          "expression": "$rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navBreadCrumb is showing sample content.\")"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "' title=\"' + $navTooltip + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n    $showHome = $perc.widget.item.properties.get('showHome');\n    $showCurrentPage = $perc.widget.item.properties.get('showCurrentPage');\n    $ariaLabel = $perc.widget.item.properties.get('ariaLabel');\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $rootclass = $rootclass + \" \";\n    $separator = $perc.widget.item.properties.get('separator');\n    $finderName=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true);\n    if ( ! $assetItems.isEmpty() ) {\n        $navSelf = $assetItems.get(0).getNode();\n        $sampleTooltip = '';\n    }\n    else if ($perc.isEditMode()){\n\t\t$navTooltip = $rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navBreadCrumb is showing sample content.\");\n        $sampleTooltip = ' title=\"' + $navTooltip + '\"';\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percNavBreadcrumbChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconBreadcrumb.png",
+      "target": "web_resources/widgets/navBar/images/widgetIconBreadcrumb.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/breadcrumb.css",
+      "target": "web_resources/widgets/navBar/css/breadcrumb.css",
+      "type": "css"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "showHome",
+      "displayName": "Show home",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "showCurrentPage",
+      "displayName": "Show current page",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "separator",
+      "displayName": "Separator",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": " > ",
+      "enumValues": []
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Aria Label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "navLabel",
+      "displayName": "Navigation Label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Breadcrumb Navigation",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
@@ -110,7 +110,8 @@
     {
       "path": "resources/breadcrumb.css",
       "target": "web_resources/widgets/navBar/css/breadcrumb.css",
-      "type": "css"
+      "type": "css",
+      "placement": "head"
     }
   ],
   "userPreferences": [

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumbSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumbSnippet.vm
@@ -1,0 +1,69 @@
+<div class="$!{rootclass}perc-breadcrumb" aria-label="$!{ariaLabel}" role="navigation">
+#if ($navSelf)##
+#set($ancestors = $navSelf.getAncestors())##
+#if($ancestors.size()>0 && !$showHome)##
+#set($d=$ancestors.remove(0))##
+#end##
+#if($showCurrentPage)##
+#set($d=$ancestors.add($navSelf))##
+#end##
+#if ($ancestors.size() > 0)##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main">
+#foreach($node in $ancestors)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $ancestors.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($landing_page = $tools.esc.html($rx.pageutils.navLink($linkContext, $node)))##
+#set($title = $rx.pageutils.html($node,"displaytitle"))##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+<a href="$landing_page">$!{title}</a>##
+#else##
+<a href="$landing_page">$!{title}</a>##
+#end##
+</li>
+#end##
+</ul>
+</nav>
+#end##
+#elseif ($perc.isEditMode())##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main" $sampleTooltip>
+#set ($sampleContent = ["Section 1", "Section 2"])##
+#foreach($node in $sampleContent)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $sampleContent.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($title = $node)##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+$!{title}
+#else##
+<a href="#">$title</a>##
+#end</li>##
+#end##
+</ul>
+</nav>
+#end##
+</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percTitle.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percTitle.component-package.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percTitle",
+  "name": "Title",
+  "version": "1.1.4",
+  "description": "Widget to enter the Page title",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Title",
+    "category": "content",
+    "description": "Widget to enter the Page title",
+    "thumbnail": "resources/widgetTitle.png",
+    "icon": "resources/widgetTitle.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 302,
+    "createSharedAsset": false,
+    "editableOnTemplate": false,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTitleAsset",
+      "ref": "contentTypes/percTitleAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTitleSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTitleSnippet.vm",
+      "contentType": "percTitleAsset",
+      "bindings": [
+        {
+          "variable": "wrapper",
+          "expression": "$perc.widget.item.properties.get('wrapper')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$wrapper = $perc.widget.item.properties.get('wrapper');\n    $rootclass= $perc.widget.item.cssProperties.get('rootclass');\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';\n\n\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n    if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t    $dsUrl = \"\";\n    $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percTitleContent",
+      "allowedContentTypes": [
+        "percTitleAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetTitle.png",
+      "target": "rx_resources/widgets/title/images/widgetTitle.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "wrapper",
+      "displayName": "Choose format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "h1",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "paragraph",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percTitleSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percTitleSnippet.vm
@@ -1,0 +1,13 @@
+<div>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+#if(! $sys.assemblyItem.getNode().hasProperty("resource_link_title"))##
+#createEmptyWidgetContent("title-sample-content", "This title widget is showing sample content.")##
+#elseif ($assets.isEmpty())##
+<$!{wrapper}$!{classAttribute}>$tools.esc.html($!{perc.page.linkTitle})</$!{wrapper}>
+#else##
+<$!{wrapper}$!{classAttribute}>$rx.pageutils.html($node,'rx:text')</$!{wrapper}>
+#end##
+</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "1.0",
+  "id": "simplePageAutoList",
+  "name": "Auto List",
+  "version": "1.1.5",
+  "description": "Simple List widget for page links",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Auto List",
+    "category": "content,search",
+    "description": "Simple List widget for page links",
+    "thumbnail": "resources/widgetIconLinkAutoList.png",
+    "icon": "resources/widgetIconLinkAutoList.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSimpleAutoList",
+      "ref": "contentTypes/percSimpleAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "simplePageAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/simplePageAutoListSnippet.vm",
+      "contentType": "percSimpleAutoList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even')"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n   $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n   if (empty($rootclass)) {\n      $rootclass = \"\";\n   }\n   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $perc.setWidgetContents($assetItems);\n   if ( ! $assetItems.isEmpty() ) {\n      $assetItem = $assetItems.get(0);\n      $params = $rx.string.stringToMap(null);\n      $params.put('query', $assetItem.getNode().getProperty('query').String);\n      $params.put('max_results', $assetItem.node.getProperty('max_results').Long);\n      $finderName = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n      $title = $rx.pageutils.html($assetItem,'displaytitle');\n      $rowtag = $tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even');\n   }\n   else {\n      ;\n   }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "simplePageAutoListContent",
+      "allowedContentTypes": [
+        "percSimpleAutoList"
+      ],
+      "layout": {
+        "maxlength": "0",
+        "layout": ""
+      },
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLinkAutoList.png",
+      "target": "rx_resources/widgets/simpleList/images/widgetIconLinkAutoList.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/simpleList/css/style.css",
+      "type": "css"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "maxlength",
+      "displayName": "Max List Length",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "0",
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "string",
+      "required": true,
+      "enumValues": [
+        {
+          "value": "ui-perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "ui-perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    },
+    {
+      "name": "target",
+      "displayName": "Link Target",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
@@ -109,7 +109,8 @@
     {
       "path": "resources/style.css",
       "target": "rx_resources/widgets/simpleList/css/style.css",
-      "type": "css"
+      "type": "css",
+      "placement": "head"
     }
   ],
   "userPreferences": [

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoListSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoListSnippet.vm
@@ -1,0 +1,40 @@
+<div class="$rootclass $layout .ui-widget .ui-widget-content .ui-perc-list-widget">
+#if (!$assetItems.isEmpty())
+    #if($title && $title.length() > 0)##
+       <div class=".ui-perc-list-title">$title</div>
+    #end
+    #if($relresults && $relresults.size() > 0)
+       #if($rendering == "ordered")##
+          <ol class=".ui-perc-list-main">##
+       #else##
+	  <ul class=".ui-perc-list-main">##
+       #end##
+       #foreach($result in $relresults)
+          #if($velocityCount == 1)##
+             #set($firstrow = '.ui-perc-list-first')##
+          #else##
+             #set($firstrow = ' ')##
+          #end##
+          #if($velocityCount == $relresults.size())##
+             #set($lastrow = '.ui-perc-list-last')##
+          #else
+             #set($lastrow = ' ')##
+          #end
+             #set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+             #set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+             <li class="$rowtag $firstrow $lastrow .ui-perc-list-element"><a href="$!{pagelink}"
+             #if($target.length() > 0)##
+                target="${target}"
+             #end
+                >$!{linkTitle}</a></li>
+       #end##
+       #if($rendering == "ordered")##
+          </ol>##
+       #else##
+          </ul>##
+       #end##
+    #end##
+#elseif ($perc.isEditMode())
+        Insert list of links based on query here.
+#end
+    </div>

--- a/modules/perc-packages/src/test/resources/widgetxml/percNavBreadcrumb.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percNavBreadcrumb.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Breadcrumb" contenttype_name=""
+		category="navigation"
+		description="Display a navigation breadcrumb in your site"
+		author="Percussion Software Inc"
+		thumbnail="/web_resources/widgets/navBar/images/widgetIconBreadcrumb.png"
+		is_responsive="true" />
+	<Resource
+		href="/web_resources/widgets/navBar/css/breadcrumb.css" type="css"
+		placement="head" />
+	<UserPref name="showHome" display_name="Show home"
+		default_value="true" datatype="bool" />
+	<UserPref name="showCurrentPage"
+		display_name="Show current page" default_value="true" datatype="bool" />
+	<UserPref name="separator" display_name="Separator"
+		default_value=" &gt; " datatype="string" />
+	<UserPref name="ariaLabel" display_name="Aria Label"
+		default_value="" datatype="string" />
+	<UserPref name="navLabel" display_name="Navigation Label"
+		default_value="Breadcrumb Navigation" datatype="string" />
+	<CssPref name="rootclass" display_name="CSS root class"
+		datatype="string" />
+	<Code type="jexl">
+        <![CDATA[
+    $linkContext = $perc.linkContext;
+    $showHome = $perc.widget.item.properties.get('showHome');
+    $showCurrentPage = $perc.widget.item.properties.get('showCurrentPage');
+    $ariaLabel = $perc.widget.item.properties.get('ariaLabel');
+    $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+    if (!empty($rootclass))
+        $rootclass = $rootclass + " ";
+    $separator = $perc.widget.item.properties.get('separator');
+    $finderName="Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder";
+    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true);
+    if ( ! $assetItems.isEmpty() ) {
+        $navSelf = $assetItems.get(0).getNode();
+        $sampleTooltip = '';
+    }
+    else if ($perc.isEditMode()){
+		$navTooltip = $rx.pageutils.getWidgetTooltip($perc, $perc.widget, "This navBreadCrumb is showing sample content.");
+        $sampleTooltip = ' title="' + $navTooltip + '"';
+    }
+    ]]>
+	</Code>
+	<Content type="velocity">
+        <![CDATA[
+<div class="$!{rootclass}perc-breadcrumb" aria-label="$!{ariaLabel}" role="navigation">
+#if ($navSelf)##
+#set($ancestors = $navSelf.getAncestors())##
+#if($ancestors.size()>0 && !$showHome)##
+#set($d=$ancestors.remove(0))##
+#end##
+#if($showCurrentPage)##
+#set($d=$ancestors.add($navSelf))##
+#end##
+#if ($ancestors.size() > 0)##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main">
+#foreach($node in $ancestors)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $ancestors.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($landing_page = $tools.esc.html($rx.pageutils.navLink($linkContext, $node)))##
+#set($title = $rx.pageutils.html($node,"displaytitle"))##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+<a href="$landing_page">$!{title}</a>##
+#else##
+<a href="$landing_page">$!{title}</a>##
+#end##
+</li>
+#end##
+</ul>
+</nav>
+#end##
+#elseif ($perc.isEditMode())##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main" $sampleTooltip>
+#set ($sampleContent = ["Section 1", "Section 2"])##
+#foreach($node in $sampleContent)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $sampleContent.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($title = $node)##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+$!{title}
+#else##
+<a href="#">$title</a>##
+#end</li>##
+#end##
+</ul>
+</nav>
+#end##
+</div>]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/percTitle.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percTitle.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Title"
+		contenttype_name="percTitleAsset" category="content"
+		description="Widget to enter the Page title"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/title/images/widgetTitle.png"
+		preferred_editor_width="780" preferred_editor_height="302"
+		create_shared_asset="false" is_editable_on_template="false"
+		is_responsive="true" />
+	<UserPref name="wrapper" display_name="Choose format"
+		required="true" datatype="enum" default_value="h1">
+		<EnumValue value="h1" display_value="Heading 1" />
+		<EnumValue value="h2" display_value="Heading 2" />
+		<EnumValue value="h3" display_value="Heading 3" />
+		<EnumValue value="h4" display_value="Heading 4" />
+		<EnumValue value="h5" display_value="Heading 5" />
+		<EnumValue value="h6" display_value="Heading 6" />
+		<EnumValue value="paragraph" display_value="Paragraph" />
+		<EnumValue value="div" display_value="Div" />
+	</UserPref>
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+
+
+	<Code type="jexl">
+        <![CDATA[
+    $wrapper = $perc.widget.item.properties.get('wrapper');
+    $rootclass= $perc.widget.item.cssProperties.get('rootclass');
+    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);
+    if (!empty($rootclass))
+        $classAttribute = ' class="' + $rootclass + '"';
+
+	$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+    if ($dsUrl.indexOf("http://localhost") != -1 )
+	    $dsUrl = "";
+    $dynamicListData = $tools.esc.html("{ deliveryurl : '" + $dsUrl + "'}");
+    ]]>
+	</Code>
+	<Content type="velocity">
+        <![CDATA[
+<div>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+#if(! $sys.assemblyItem.getNode().hasProperty("resource_link_title"))##
+#createEmptyWidgetContent("title-sample-content", "This title widget is showing sample content.")##
+#elseif ($assets.isEmpty())##
+<$!{wrapper}$!{classAttribute}>$tools.esc.html($!{perc.page.linkTitle})</$!{wrapper}>
+#else##
+<$!{wrapper}$!{classAttribute}>$rx.pageutils.html($node,'rx:text')</$!{wrapper}>
+#end##
+</div>
+    ]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/simplePageAutoList.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/simplePageAutoList.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Widget>
+	<WidgetPrefs title="Auto List"
+		contenttype_name="percSimpleAutoList" category="content,search"
+		description="Simple List widget for page links"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/simpleList/images/widgetIconLinkAutoList.png"
+		is_responsive="true" />
+	<Resource
+		href="/rx_resources/widgets/simpleList/css/style.css" type="css"
+		placement="head" />
+	<UserPref name="maxlength" display_name="Max List Length"
+		default_value="0" datatype="number" />
+	<UserPref name="layout" display_name="Layout" required="true"
+		datatype="string">
+		<EnumValue value="ui-perc-list-horizontal"
+			display_value="Horizontal" />
+		<EnumValue value="ui-perc-list-vertical"
+			display_value="Vertical" />
+	</UserPref>
+	<UserPref name="target" display_name="Link Target"
+		datatype="string" />
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+	<Code type="jexl">
+    <![CDATA[
+   $linkContext = $perc.linkContext;
+   $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+   if (empty($rootclass)) {
+      $rootclass = "";
+   }
+   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);
+   $perc.setWidgetContents($assetItems);
+   if ( ! $assetItems.isEmpty() ) {
+      $assetItem = $assetItems.get(0);
+      $params = $rx.string.stringToMap(null);
+      $params.put('query', $assetItem.getNode().getProperty('query').String);
+      $params.put('max_results', $assetItem.node.getProperty('max_results').Long);
+      $finderName = "Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder";
+      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);
+      $title = $rx.pageutils.html($assetItem,'displaytitle');
+      $rowtag = $tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even');
+   }
+   else {
+      ;
+   }
+
+    ]]>
+	</Code>
+	<Content type="velocity">
+    <![CDATA[
+    <div class="$rootclass $layout .ui-widget .ui-widget-content .ui-perc-list-widget">
+#if (!$assetItems.isEmpty())
+    #if($title && $title.length() > 0)##
+       <div class=".ui-perc-list-title">$title</div>
+    #end
+    #if($relresults && $relresults.size() > 0)
+       #if($rendering == "ordered")##
+          <ol class=".ui-perc-list-main">##
+       #else##
+	  <ul class=".ui-perc-list-main">##
+       #end##
+       #foreach($result in $relresults)
+          #if($velocityCount == 1)##
+             #set($firstrow = '.ui-perc-list-first')##
+          #else##
+             #set($firstrow = ' ')##
+          #end##
+          #if($velocityCount == $relresults.size())##
+             #set($lastrow = '.ui-perc-list-last')##
+          #else
+             #set($lastrow = ' ')##
+          #end
+             #set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+             #set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+             <li class="$rowtag $firstrow $lastrow .ui-perc-list-element"><a href="$!{pagelink}"
+             #if($target.length() > 0)##
+                target="${target}"
+             #end
+                >$!{linkTitle}</a></li>
+       #end##
+       #if($rendering == "ordered")##
+          </ol>##
+       #else##
+          </ul>##
+       #end##
+    #end##
+#elseif ($perc.isEditMode())
+        Insert list of links based on query here.
+#end
+    </div>
+    ]]>
+	</Content>
+</Widget>


### PR DESCRIPTION
## Summary

Phase 3 slice 6 for parent **#2630** (grandparent **#2626**, ADR-004): extend the Widget XML → Component Package Manifest compiler beyond baseWidgets (#2751 / cluster #2766) to a **bounded high-traffic product widget batch** with golden parity.

### Compiler extensions
- Parse/compile Widget `<Resource href type placement>` (CSS/JS declared on lists, nav, image, …)
- Chrome widgets with no asset content type (nav) get a `*Chrome` styles slot when CssPref/layout prefs exist
- Map `layout` / `maxlength` UserPref into slot `layout` (list widgets)

### High-traffic batch (7 widgets)
| Package | Widgets |
|---------|---------|
| `perc.widget.title` | percTitle |
| `perc.widgets.lists` | simplePageAutoList, simpleTextAutoList |
| `perc.widgets.nav` | percNavBar, percNavBreadcrumb |
| `perc.FileAssetWidget` | percFile |
| `perc.widgets.image` | percImage |

**Goldens:** percTitle, simplePageAutoList, percNavBreadcrumb (manifest + `.vm`)

**Dual-run:** product packages still ship Widget XML; this PR does not delete product `rxconfig/Widgets/*.xml`. Measurable reduction = 7 more product widgets with validated modern compile path + goldens.

### Residual
Further product packages (blog, calendar, directory, social, forms, auto-lists, …): **#2789**

## Test plan
1. `cd modules/perc-packages && ../../mvnw clean install` (JDK 21)
2. Confirm `PSWidgetXmlCompilerTest` green (16 tests including high-traffic goldens + package batch)
3. No product package tree rewrite expected

## Build gates evidence
- **modules_built:** `modules/perc-packages`
- **Command:** `cd modules/perc-packages; $env:JAVA_HOME='C:\Program Files\Microsoft\jdk-21.0.12.8-hotspot'; ..\..\mvnw.cmd clean install`
- **Result:** BUILD SUCCESS
- **Tests:** Tests run: 45, Failures: 0 (PSWidgetXmlCompilerTest: 16; module total 45)
- **downstream_checked:** none (additive API on package-local types; no public type made final / signature change for reverse deps)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2772  
Refs #2630 #2626 #2751 #2766  
Residual: #2789

> Co-Authored by Grok Build using grok-4.5 with agent main.
