### PR TITLE
cluster(perc-packages): absorb page/gadget/widget XML compilers (#2785 #2787 #2790)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -76,8 +76,10 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
 | Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751) |
+| Gadget registry compiler | `modules/perc-packages/.../gadgetxml/PSGadgetRegistryCompiler.java` (#2771) |
+| Modern gadget catalog (ship) | `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` |
 | Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |
-| Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
+| Gadget registry (legacy upgrade input) | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 
 ## Immediate next work
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -75,7 +75,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Widget DAO (legacy XML load) | `projects/sitemanage/.../dao/impl/PSWidgetDao.java` (`rxconfig/Widgets`) |
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
-| Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751) |
+| Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751 baseWidgets, #2772 high-traffic) |
 | Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -52,6 +52,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | [component-package-manifest.md](./component-package-manifest.md) | Phase 3 ship-format manifest schema v1.0 + Java model |
 | [widget-xml-inventory.md](./widget-xml-inventory.md) | Product widget matrix (48 defs) |
 | [widget-xml-inventory.csv](./widget-xml-inventory.csv) | Machine-readable inventory |
+| [page-definition-inventory.md](./page-definition-inventory.md) | Product page `*.templateDef` inventory + compiler (#2770) |
 | [gadget-definition-inventory.md](./gadget-definition-inventory.md) | Gadget XML / SPA survey |
 | [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) | Phase 3 dual-run operator policy + runtime shim selection (#2752) |
 | [adr/](./adr/) | Architecture decision records |
@@ -76,6 +77,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Widget packages | `modules/perc-packages/.../rxconfig/Widgets/` |
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
 | Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751) |
+| Page templateDef compiler | `modules/perc-packages/.../pagexml/PSPageXmlCompiler.java` (#2770) |
 | Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |
 | Gadget registry | `WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml` |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -60,3 +60,16 @@ Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidget
 | Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
 
 High-traffic package conversion and product XML removal remain residual under #2630.
+
+## Gadget registry compiler (slice #2771)
+
+Compiler for upgrade-input `GadgetRegistry.xml` → aggregate `gadget-catalog.json` + per-gadget `component-package.json` (`catalog.kind = "gadget"`):
+
+| Artifact | Location |
+|----------|----------|
+| Parser / compiler / catalog IO | `modules/perc-packages/.../gadgetxml/PSGadgetRegistry*.java`, `PSGadgetCatalog*.java` |
+| Product modern catalog | `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` |
+| Golden parity (Welcome + full catalog) | `modules/perc-packages/src/test/resources/gadgetxml/golden/` |
+| Inventory + residuals | [../gadget-definition-inventory.md](../gadget-definition-inventory.md) |
+
+Gadgets are SPA/dashboard hosts (not assembly templates). Validator allows gadget packages without `contentTypes[]` / `templates[]` when `catalog.kind = "gadget"` and `catalog.title` is set. WebUI dual-load of JSON catalog (retire `GadgetRegistry.xml` at runtime) remains residual.

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -49,14 +49,14 @@ Ship-format model and docs landed as Phase 3 slice 1 (#2750):
 
 **Upgrade-input XML** remains compiler/shim only; **product ship format** is `component-package.json` plus content types, templates, slots, catalog metadata, and resources.
 
-## Widget XML compiler (slice #2751)
+## Widget XML compiler (slices #2751 / #2772)
 
-Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidgets / simple subset first):
+Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidgets + high-traffic batch):
 
 | Artifact | Location |
 |----------|----------|
 | Parser / compiler / package scanner | `modules/perc-packages/.../widgetxml/PSWidgetXml*.java` |
-| Golden parity (percSimpleText) | `modules/perc-packages/src/test/resources/widgetxml/golden/` |
+| Golden parity (simple + high-traffic) | `modules/perc-packages/src/test/resources/widgetxml/golden/` |
 | Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
 
-High-traffic package conversion and product XML removal remain residual under #2630.
+Remaining long-tail product packages and product Widget XML removal remain residual under #2630.

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -60,3 +60,15 @@ Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidget
 | Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
 
 High-traffic package conversion and product XML removal remain residual under #2630.
+
+## Page templateDef compiler (slice #2770)
+
+Compiler for upgrade-input Page / assembly `*.templateDef` → Component Package Manifest (product page layout packages first):
+
+| Artifact | Location |
+|----------|----------|
+| Parser / compiler / package scanner | `modules/perc-packages/.../pagexml/PSPageXml*.java` |
+| Golden parity (`perc.base.plain`) | `modules/perc-packages/src/test/resources/pagexml/golden/` |
+| Inventory + dual-run note | [../page-definition-inventory.md](../page-definition-inventory.md) |
+
+Product packages may still **ship** `*.templateDef` during dual-run; modern `component-package.json` is the compiler output and future authoring format. Full product dual-run exit (delete package templateDefs) remains residual under #2630.

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -65,8 +65,8 @@ Paths inside the manifest are **package-relative**, always with `/` separators (
 | `cmsVersion` | object | no | `{ "min", "max" }` compatible CMS range |
 | `dependencies` | array | no | `{ "name", "version", "implied" }` |
 | `catalog` | object | no | Palette / UI metadata (see below) |
-| `contentTypes` | array | * | At least one of `contentTypes` or `templates` required |
-| `templates` | array | * | At least one of `contentTypes` or `templates` required |
+| `contentTypes` | array | * | Required (with templates) for non-gadget packages; optional when `catalog.kind = "gadget"` (#2771) |
+| `templates` | array | * | Required (with contentTypes) for non-gadget packages; optional when `catalog.kind = "gadget"` |
 | `slots` | array | no | Composition holes with optional layout/styles |
 | `resources` | array | no | CSS/JS/images |
 | `userPreferences` | array | no | Transitional from Widget `UserPref` |
@@ -77,8 +77,8 @@ Paths inside the manifest are **package-relative**, always with `/` separators (
 | Field | Type | Notes |
 |-------|------|-------|
 | `kind` | string | Default `component`; also `page`, `gadget`, … |
-| `title` | string | Palette title |
-| `category` | string | e.g. `content` |
+| `title` | string | Palette title (**required** when `kind = "gadget"`) |
+| `category` | string | e.g. `content` (gadget registry **group** maps here) |
 | `description` | string | |
 | `thumbnail` / `icon` | string | Package-relative resource path |
 | `author` | string | |

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -175,16 +175,16 @@ String json = PSComponentPackageManifestIo.toJson(m);
 - **Today:** `PSPackageBuilder` zips legacy package source trees into `.ppkg` for the deployer (`psx_archiveInfo.xml` / dependency trees). That path remains for install compatibility.
 - **This manifest:** extends the packaging story with an explicit, tool-friendly **component** model that does not require Widget/Page/Gadget XML. Future slices wire compiler output and install recognition; this slice lands model + schema + tests only.
 
-## Widget XML compiler (slice #2751)
+## Widget XML compiler (slices #2751 / #2772)
 
-Upgrade-input path for simple / **baseWidgets** widgets:
+Upgrade-input path for **baseWidgets** and the **high-traffic residual batch**:
 
 | Type | Role |
 |------|------|
-| `PSWidgetXmlParser` | Secure DOM parse of `<Widget>` definition XML |
+| `PSWidgetXmlParser` | Secure DOM parse of `<Widget>` definition XML (prefs, code, content, **Resource**) |
 | `PSWidgetXmlCompiler` | XML model → `PSComponentPackageManifest` + template text artifacts |
-| `PSWidgetXmlPackageCompiler` | Scan `sys__UserDependency--rxconfig/Widgets/*.xml` under a package root |
-| Golden fixtures | `modules/perc-packages/src/test/resources/widgetxml/golden/` (percSimpleText) |
+| `PSWidgetXmlPackageCompiler` | Scan `sys__UserDependency--rxconfig/Widgets/*.xml` under a package root; `compileHighTrafficPackages` |
+| Golden fixtures | `modules/perc-packages/src/test/resources/widgetxml/golden/` (percSimpleText, percTitle, simplePageAutoList, percNavBreadcrumb) |
 
 Inventory + residual packages: [widget-xml-inventory.md](./widget-xml-inventory.md).
 
@@ -193,7 +193,7 @@ Inventory + residual packages: [widget-xml-inventory.md](./widget-xml-inventory.
 | Slice | Issue | Role |
 |-------|-------|------|
 | Runtime legacy shim | #2752 | Load customer XML when modern package absent |
-| High-traffic package conversion | residual under #2630 | nav, blog, lists, forms, … (see inventory) |
+| Remaining high-traffic / long-tail widgets | residual under #2630 | blog, calendar, directory, social, forms, auto-lists, … (see inventory) |
 | Delete product Widget XML from source | later | After install path consumes modern artifacts |
 
 ## Validation summary

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -48,7 +48,7 @@ Hard order for a package root or definition id:
 | Widget definitions (install) | `${rxdeploydir}/rxconfig/Widgets/*.xml` via `PSWidgetDao` (`projects/sitemanage/.../dao/impl/PSWidgetDao`) | Loads legacy Widget XML by file id | Prefer modern package when present; XML remains fallback for unconverted customer defs |
 | Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; product source of truth moves off XML (ADR-004) |
 | Package staging Widgets | `sys__UserDependency--rxconfig/Widgets/` or `rxconfig/Widgets/` under a package root | Upgrade-input / deploy layout | Shim package-root API resolves either layout |
-| Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Treat remaining definition XML as legacy only |
+| Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Modern: `gadget-catalog.json` + per-gadget packages (#2771); dual-load residual for WebUI |
 | Page meta / definition XML | Site/page storage dialects | Composition authoring legacy | Page conversion is Phase 3 residual; shim recognizes `rxconfig/Pages` if present |
 
 **Selection API (no Spring wiring required for unit use):**

--- a/docs/ai-generated/tasks/template-assembler-normalization/gadget-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/gadget-definition-inventory.md
@@ -82,8 +82,24 @@ Redirect Management gadget assets already removed (issue #715 note in registry).
 3. Do **not** fold gadgets into assembly assemblers — separate “dashboard component catalog” track, same anti-XML packaging goal.
 4. Cross-link Home acceptance / gadget SPA work so this track only owns **packaging/registry** cleanup, not full gadget UX rewrite.
 
+## Gadget registry → catalog / package model (slice #2771)
+
+Compiler for upgrade-input `GadgetRegistry.xml` → modern ship format (landed after cluster #2766):
+
+| Artifact | Location |
+|----------|----------|
+| Parser / compiler / catalog IO | `modules/perc-packages/.../gadgetxml/PSGadgetRegistry*.java`, `PSGadgetCatalog*.java` |
+| Aggregate catalog ship file | `gadget-catalog.json` (`PSGadgetCatalog.DEFAULT_CATALOG_FILE_NAME`) |
+| Product modern catalog (authoring) | `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` |
+| Per-gadget packages | `component-package.json` with `catalog.kind = "gadget"` (no CT/templates required) |
+| Golden parity | Welcome (`cm1_welcome_gadget`) + full product catalog (21 entries) under `src/test/resources/gadgetxml/golden/` |
+| Validator rule | `PSComponentPackageManifestValidator` — `catalog.kind=gadget` requires `catalog.title`; CT/templates optional |
+
+**Still residual (not this slice):** WebUI runtime dual-load of `gadget-catalog.json` instead of `GadgetRegistry.xml` (SPA Home already has a parallel TS catalog); delete product `GadgetRegistry.xml` only after dual-load + QA.
+
 ## Related docs
 
 - `docs/ai-generated/tasks/completed/GADGET-MODERNIZATION-ANALYSIS.md`
 - `docs/ai-generated/tasks/home-acceptance-status.md`
 - `docs/ai-generated/tasks/design-templates-item-types/README.md` (Home/Gadgets dependencies)
+- [component-package-manifest.md](./component-package-manifest.md) (`catalog.kind = gadget`)

--- a/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
@@ -1,0 +1,96 @@
+# Page definition packaging inventory (Phase 3 / #2770)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Inventory + compiler landed (#2770) |
+| **Parent** | #2630 · Grandparent #2626 |
+| **Code** | `modules/perc-packages/.../pagexml/PSPageXml*.java` |
+| **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
+| **Manifest** | [component-package-manifest.md](./component-package-manifest.md) |
+
+## What “Page definition XML” is in product packages
+
+Unlike widgets (`rxconfig/Widgets/*.xml`), product **page layout** packaging is primarily **assembly template definitions**:
+
+| Artifact | Extension / root | Role |
+|----------|------------------|------|
+| Assembly template def | `*.templateDef` / `<assembly-template>` | Page (or Global) layout Velocity body + `pageAssembler` + `#region` holes |
+| ACL side-car | `*.templateDef.aclDef` | ACL for the template dependency (out of compiler scope) |
+| Thumbnail resources | `sys__UserDependency--rx_resources/images/TemplateImages/…` | Palette thumbs (not compiled in #2770) |
+| Package identity | `psx_archiveInfo.xml` | Version / publisher / CMS range for compiler context |
+
+There is **no** product tree under `rxconfig/Pages/*.xml` in `modules/perc-packages` today. The dual-run shim still recognizes `rxconfig/Pages` for customer installs (see [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md)).
+
+CM1 **page item** region trees / widget instances live in site storage (sitemanage domain), not as package `*.templateDef` files. This slice covers **packaged page templates** only; page-item composition upgrade remains a residual under #2630 when storage write-path is ready.
+
+## Product packages with Page layout templateDefs
+
+| Package | `*.templateDef` count (approx) | Assembler (typical) | Output format | Notes |
+|---------|--------------------------------:|---------------------|---------------|-------|
+| `perc.baseTemplates` | 20 | `pageAssembler` | Page | Primary golden target (`perc.base.plain`) |
+| `perc.responsiveTemplates` | 3 | `pageAssembler` | Page | Banded / Basic / plain |
+| `perc.Baseline` | 4+ page-related | mix (`pageAssembler`, `velocityAssembler`, …) | Page / Global | System templates (`perc.page`, `perc.pageXml`, …) — convert carefully |
+
+Snippet-style `*.templateDef` files also appear inside **widget** packages (e.g. file/image binary templates). Those are **not** page layout packages; leave them to widget conversion residuals unless inventory shows Page `output-format`.
+
+### `perc.baseTemplates` (layout catalog)
+
+| Template name | Label (sample) | Regions (`#region`) |
+|---------------|----------------|---------------------|
+| `perc.base.plain` | Plain | `perc-content` |
+| `perc.base.header` | Header | header-shaped |
+| `perc.base.footer` | Footer | footer-shaped |
+| `perc.base.headerFooter` | Header Footer | `header`, `content`, `footer` |
+| `perc.base.Box` | Box | `header`, `leftsidebar`, `content`, `rightsidebar`, `footer` |
+| `perc.base.leftSidebar` / `rightSidebar` / `rightLeftSidebar` | sidebars | multi-region |
+| `perc.base.lLeft*` / `lRight*` / `invertedL*` / `cClamp*` | L / clamp layouts | multi-region |
+
+Full file list: `modules/perc-packages/src/main/resources/Packages/perc.baseTemplates/*.templateDef`.
+
+### `perc.responsiveTemplates`
+
+| Template name | Label |
+|---------------|-------|
+| `perc.resp.plain` | (plain responsive) |
+| `perc.resp.Basic` | Basic |
+| `perc.resp.Banded` | Banded |
+
+## Compiler mapping (upgrade-input → modern package)
+
+| Source (`*.templateDef`) | Target (Component Package Manifest) |
+|--------------------------|-------------------------------------|
+| `<name>` | `id`, `templates[0].name` |
+| `<label>` | `name`, `catalog.title` |
+| `<description>` | `description` / `catalog.description` |
+| Package `psx_archiveInfo` | `version`, `publisher`, `cmsVersion`, `dependencies` |
+| `<assembler>` extension path | short assembler id (`pageAssembler`, `velocityAssembler`, …) |
+| `<output-format>` Page/Global/… | `templates[].type` (`page` / `global` / …) |
+| `<template>` body (entity-decoded) | `templates/<name>.vm` text artifact + `sourceRef` |
+| `#region("id" …)` | `slots[]` named by region id |
+| Matching `id="…" class="perc-region perc-vertical …"` | `slots[].layout.orientation`, `slots[].styles.rootclass` (+ span hints) |
+| `catalog.kind` | always `page` for this compiler |
+
+**Dual-run (documented):** product packages **still ship** `*.templateDef` as install input until a residual removes them. The compiler emits modern `component-package.json` + template sources for upgrade tooling and future authoring; install recognition of the modern format is a follow-on.
+
+## Golden fixtures
+
+| Fixture | Path |
+|---------|------|
+| Input | `modules/perc-packages/src/test/resources/pagexml/perc.base.plain.templateDef` |
+| Manifest golden | `…/pagexml/golden/perc.base.plain.component-package.json` |
+| Template golden | `…/pagexml/golden/perc.base.plain.vm` |
+| Tests | `com.percussion.packages.pagexml.PSPageXmlCompilerTest` |
+
+## Residuals (not this PR)
+
+1. **Remove product `*.templateDef` authoring** after install path consumes modern packages (and dual-run exit criteria).
+2. **Thumbnails / resources** wiring for template images into `resources[]`.
+3. **Baseline system templates** conversion matrix (Global / Xml / Database / Dispatcher).
+4. **Page item composition** (site storage region trees) → slot composition IR — depends on Phase 2 storage / REST (#2690 family).
+5. **Gadget registry** conversion (sibling slice).
+
+## Related
+
+- Widget XML inventory: [widget-xml-inventory.md](./widget-xml-inventory.md)
+- Region ↔ slot: [region-slot-mapping.md](./region-slot-mapping.md)
+- Plan Phase 3: [plan.md](./plan.md)

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -361,7 +361,7 @@ This is multi-quarter work even if labeled “8.2.” Split so 8.2 can ship **fo
    **Done (slice 1 / #2750):** schema docs + Java model + parse/validate/round-trip tests — see [component-package-manifest.md](./component-package-manifest.md) and `com.percussion.packages.manifest` in `modules/perc-packages`.
 2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles). *(#2751)*
 3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.
-4. **Gadget XML** conversion path for remaining XML-defined gadgets.
+4. **Gadget registry** conversion path → `gadget-catalog.json` + per-gadget packages (`catalog.kind=gadget`) (#2771; per-gadget definition XML already largely gone).
 5. Convert **baseline / baseWidgets** first; then high-traffic packages (nav, blog, lists, rich text).
 6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format. *(#2752)*
 7. Widget Builder / Design tools write modern package format only.

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -360,7 +360,8 @@ This is multi-quarter work even if labeled “8.2.” Split so 8.2 can ship **fo
 1. Define **Component Package Manifest** (reuse package system where possible) listing content types, templates, slots, catalog metadata, resources.  
    **Done (slice 1 / #2750):** schema docs + Java model + parse/validate/round-trip tests — see [component-package-manifest.md](./component-package-manifest.md) and `com.percussion.packages.manifest` in `modules/perc-packages`.
 2. **Compiler/upgrade tool:** Widget XML → manifest + templates + slots (incl. layout/styles). *(#2751)*
-3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.
+3. **Page meta upgrade:** region/widget instances → composition + templates; assembler source canonical.  
+   **Done (slice 4 / #2770 — product page templateDefs):** inventory + compiler `PSPageXml*` for `*.templateDef` → Component Package Manifest + golden `perc.base.plain` (see [page-definition-inventory.md](./page-definition-inventory.md)). Dual-run: product may still ship templateDefs until residual removal. **Still residual:** site-storage page item composition IR, Baseline system templates matrix, thumbnail resources, delete package templateDefs after install path.
 4. **Gadget XML** conversion path for remaining XML-defined gadgets.
 5. Convert **baseline / baseWidgets** first; then high-traffic packages (nav, blog, lists, rich text).
 6. Runtime **compatibility shim:** if old XML still present and no modern package, load as today; product **source tree** no longer maintains those XML files as the authoring format. *(#2752)*

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -4,15 +4,29 @@
 **Source:** `modules/perc-packages/src/main/resources/Packages/**/rxconfig/Widgets/*.xml`  
 **Machine-readable:** [widget-xml-inventory.csv](./widget-xml-inventory.csv)
 
-## Compiler status (#2751 / parent #2630)
+## Compiler status (#2751 / #2772 / parent #2630)
 
 | Area | Status | Notes |
 |------|--------|-------|
-| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets / simple subset** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
-| Golden parity | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
-| **Product packages still ship Widget XML** | Yes (this slice) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
-| Residual high-traffic packages | Open | nav, blog, lists, rich media lists, forms, calendar, directory, social, etc. — use this inventory as the residual backlog (sibling/follow-on issues under #2630) |
-| Runtime legacy XML shim | Open | #2752 |
+| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic batch** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
+| Golden parity (baseWidgets) | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
+| Golden parity (high-traffic #2772) | **percTitle**, **simplePageAutoList**, **percNavBreadcrumb** | Plus package compile of title, lists×2, nav×2, file, image (7 widgets) |
+| Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT) |
+| **Product packages still ship Widget XML** | Yes (dual-run) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
+| Residual product packages | Open | blog, calendar, directory, social, forms, auto-lists (image/page/file), jquery, poll, login, etc. — see matrix below |
+| Runtime legacy XML shim | Landed (cluster #2766) | #2752 |
+
+### High-traffic batch covered by #2772
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.widget.title` | percTitle | UserPref enum (wrapper) + content CT |
+| `perc.widgets.lists` | simplePageAutoList, simpleTextAutoList | `<Resource>` CSS + layout/maxlength → slot.layout |
+| `perc.widgets.nav` | percNavBar, percNavBreadcrumb | Chrome (no CT); chrome slot + CSS resource on breadcrumb |
+| `perc.FileAssetWidget` | percFile | Content + rich media |
+| `perc.widgets.image` | percImage | Content + rich media + CSS resource |
+
+Measurable reduction: **7** product widget definition XMLs now have a validated modern compile path with goldens (beyond the original 3 baseWidgets).
 
 Ship format: [component-package-manifest.md](./component-package-manifest.md). ADR: [004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md).
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalog.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalog.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Modern <strong>gadget catalog</strong> ship format (JSON) — product replacement for {@code
+ * GadgetRegistry.xml} grouping / listing (ADR-004 / issue #2771).
+ *
+ * <p>Default file name: {@value #DEFAULT_CATALOG_FILE_NAME}. Per-gadget install/authoring still uses
+ * {@code component-package.json} with {@code catalog.kind = "gadget"}; this aggregate catalog is the
+ * registry equivalent consumed by packaging tools and (eventually) SPA Home/Dashboard loaders.
+ */
+public final class PSGadgetCatalog {
+
+  /** Default ship-format file name for the aggregate gadget catalog. */
+  public static final String DEFAULT_CATALOG_FILE_NAME = "gadget-catalog.json";
+
+  /** Schema version supported by this model (semver major.minor). */
+  public static final String SUPPORTED_SCHEMA_VERSION = "1.0";
+
+  private String schemaVersion = SUPPORTED_SCHEMA_VERSION;
+  private String id = "perc.gadgetCatalog";
+  private String name = "Product Gadget Catalog";
+  private String version = "0.0.0";
+  private String description;
+  private List<Entry> gadgets = new ArrayList<>();
+
+  public String getSchemaVersion() {
+    return schemaVersion;
+  }
+
+  public void setSchemaVersion(String schemaVersion) {
+    this.schemaVersion = schemaVersion;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public List<Entry> getGadgets() {
+    return gadgets;
+  }
+
+  public void setGadgets(List<Entry> gadgets) {
+    this.gadgets = gadgets != null ? gadgets : new ArrayList<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSGadgetCatalog that)) {
+      return false;
+    }
+    return Objects.equals(schemaVersion, that.schemaVersion)
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(version, that.version)
+        && Objects.equals(description, that.description)
+        && Objects.equals(gadgets, that.gadgets);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schemaVersion, id, name, version, description, gadgets);
+  }
+
+  /** One catalog row (modern equivalent of a registry {@code <gadget/>}). */
+  public static final class Entry {
+    private String id;
+    private String name;
+    private String group;
+    private String baseUri;
+    /** Legacy OpenSocial definition file name (upgrade-input only; product no longer ships XML). */
+    private String legacyDefinitionFile;
+    private boolean deprecated;
+    /** Package-relative path to this gadget's {@code component-package.json} when packaged alone. */
+    private String componentPackageRef;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getGroup() {
+      return group;
+    }
+
+    public void setGroup(String group) {
+      this.group = group;
+    }
+
+    public String getBaseUri() {
+      return baseUri;
+    }
+
+    public void setBaseUri(String baseUri) {
+      this.baseUri = baseUri;
+    }
+
+    public String getLegacyDefinitionFile() {
+      return legacyDefinitionFile;
+    }
+
+    public void setLegacyDefinitionFile(String legacyDefinitionFile) {
+      this.legacyDefinitionFile = legacyDefinitionFile;
+    }
+
+    public boolean isDeprecated() {
+      return deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+      this.deprecated = deprecated;
+    }
+
+    public String getComponentPackageRef() {
+      return componentPackageRef;
+    }
+
+    public void setComponentPackageRef(String componentPackageRef) {
+      this.componentPackageRef = componentPackageRef;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Entry that)) {
+        return false;
+      }
+      return deprecated == that.deprecated
+          && Objects.equals(id, that.id)
+          && Objects.equals(name, that.name)
+          && Objects.equals(group, that.group)
+          && Objects.equals(baseUri, that.baseUri)
+          && Objects.equals(legacyDefinitionFile, that.legacyDefinitionFile)
+          && Objects.equals(componentPackageRef, that.componentPackageRef);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          id, name, group, baseUri, legacyDefinitionFile, deprecated, componentPackageRef);
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * Parse and write {@link PSGadgetCatalog} as JSON (modern gadget registry ship format).
+ *
+ * <p>Uses portable {@link Path} / {@link Files} I/O and UTF-8.
+ */
+public final class PSGadgetCatalogIo {
+
+  private static final Gson GSON =
+      new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+
+  private PSGadgetCatalogIo() {
+    // utility
+  }
+
+  /**
+   * Parse a JSON string into a catalog.
+   *
+   * @param json non-null JSON document
+   * @return parsed model (never null)
+   * @throws PSGadgetRegistryException if JSON is empty or not a valid document
+   */
+  public static PSGadgetCatalog parse(String json) throws PSGadgetRegistryException {
+    Objects.requireNonNull(json, "json");
+    if (json.isBlank()) {
+      throw new PSGadgetRegistryException("Gadget catalog JSON is empty");
+    }
+    try {
+      PSGadgetCatalog catalog = GSON.fromJson(json, PSGadgetCatalog.class);
+      if (catalog == null) {
+        throw new PSGadgetRegistryException("Gadget catalog JSON parsed to null");
+      }
+      if (catalog.getGadgets() == null) {
+        catalog.setGadgets(new ArrayList<>());
+      }
+      return catalog;
+    } catch (JsonSyntaxException e) {
+      throw new PSGadgetRegistryException("Invalid gadget catalog JSON: " + e.getMessage(), e);
+    } catch (JsonParseException e) {
+      throw new PSGadgetRegistryException("Failed to parse gadget catalog JSON", e);
+    }
+  }
+
+  /**
+   * Parse UTF-8 JSON from a reader.
+   *
+   * @param reader non-null reader
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetCatalog read(Reader reader) throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(reader, "reader");
+    StringBuilder sb = new StringBuilder();
+    char[] buf = new char[4096];
+    int n;
+    while ((n = reader.read(buf)) >= 0) {
+      sb.append(buf, 0, n);
+    }
+    return parse(sb.toString());
+  }
+
+  /**
+   * Read UTF-8 JSON from a file path.
+   *
+   * @param path non-null path
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetCatalog read(Path path) throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(path, "path");
+    return parse(Files.readString(path, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Serialize catalog to pretty-printed JSON.
+   *
+   * @param catalog non-null model
+   * @return JSON text
+   */
+  public static String toJson(PSGadgetCatalog catalog) {
+    Objects.requireNonNull(catalog, "catalog");
+    return GSON.toJson(catalog);
+  }
+
+  /**
+   * Write UTF-8 pretty JSON to a path (parent directories created as needed).
+   *
+   * @param catalog non-null model
+   * @param path non-null destination
+   * @throws IOException on I/O failure
+   */
+  public static void write(PSGadgetCatalog catalog, Path path) throws IOException {
+    Objects.requireNonNull(catalog, "catalog");
+    Objects.requireNonNull(path, "path");
+    Path parent = path.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    try (Writer w = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+      GSON.toJson(catalog, w);
+      w.write(System.lineSeparator());
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetCatalogIo.java
@@ -129,9 +129,9 @@ public final class PSGadgetCatalogIo {
     if (parent != null) {
       Files.createDirectories(parent);
     }
+    // UTF-8 JSON body only (no trailing newline) — matches PSComponentPackageManifestIo.write.
     try (Writer w = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
       GSON.toJson(catalog, w);
-      w.write(System.lineSeparator());
     }
   }
 }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompileResult.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompileResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Output of compiling a gadget registry: aggregate modern catalog + per-gadget component package
+ * manifests keyed by gadget id.
+ */
+public final class PSGadgetRegistryCompileResult {
+
+  private final PSGadgetRegistryModel source;
+  private final PSGadgetCatalog catalog;
+  /** gadget id → validated component package manifest ({@code catalog.kind = "gadget"}). */
+  private final Map<String, PSComponentPackageManifest> gadgetPackages;
+
+  public PSGadgetRegistryCompileResult(
+      PSGadgetRegistryModel source,
+      PSGadgetCatalog catalog,
+      Map<String, PSComponentPackageManifest> gadgetPackages) {
+    this.source = Objects.requireNonNull(source, "source");
+    this.catalog = Objects.requireNonNull(catalog, "catalog");
+    this.gadgetPackages =
+        gadgetPackages == null
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(gadgetPackages));
+  }
+
+  public PSGadgetRegistryModel getSource() {
+    return source;
+  }
+
+  public PSGadgetCatalog getCatalog() {
+    return catalog;
+  }
+
+  public Map<String, PSComponentPackageManifest> getGadgetPackages() {
+    return gadgetPackages;
+  }
+
+  /** Convenience: package for a single gadget id, or null. */
+  public PSComponentPackageManifest getGadgetPackage(String gadgetId) {
+    return gadgetPackages.get(gadgetId);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
@@ -248,15 +248,18 @@ public final class PSGadgetRegistryCompiler {
             Files.createDirectories(parent);
           }
           // host-ref.txt body is the package-relative install target (URL-style).
-          Files.writeString(artifact, res.getTarget() + System.lineSeparator());
+          Files.writeString(artifact, res.getTarget() + "\n");
         }
       }
     }
   }
 
   /**
-   * Strip leading {@code /cm/gadgets/repository/} (or any leading slash) so the target is a
-   * package-relative install path using {@code /} separators only.
+   * Normalize a gadget registry {@code baseUri} to a package-relative host path using {@code /}
+   * separators only. Strips all leading slashes (so both {@code /cm/gadgets/repository/x} and
+   * {@code cm/gadgets/repository/x} work). Rejects blank paths and any segment containing
+   * {@code ..}. Does not rewrite or inject the {@code cm/gadgets/repository/} prefix — the
+   * registry {@code baseUri} is expected to already identify the install target.
    */
   static String toPackageRelativeHostPath(String baseUri) {
     if (baseUri == null || baseUri.isBlank()) {
@@ -269,7 +272,6 @@ public final class PSGadgetRegistryCompiler {
     if (p.isEmpty() || p.contains("..")) {
       return null;
     }
-    // Prefer cm/gadgets/repository/<id> as install target when that prefix is present.
     return p;
   }
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompiler.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Compiles legacy product {@code GadgetRegistry.xml} into:
+ *
+ * <ul>
+ *   <li>an aggregate modern {@link PSGadgetCatalog} ({@code gadget-catalog.json})
+ *   <li>per-gadget {@link PSComponentPackageManifest} instances with {@code catalog.kind =
+ *       "gadget"} (SPA / dashboard host components — no assembly templates)
+ * </ul>
+ *
+ * <p>Gadgets are <strong>not</strong> Velocity/JEXL assembly templates; they share only the ADR-004
+ * anti-XML packaging goal with widgets/pages. Per-gadget definition XML is already largely absent
+ * from the tree — this compiler finishes the registry half of the migration path (issue #2771 /
+ * parent #2630).
+ */
+public final class PSGadgetRegistryCompiler {
+
+  /** Default package version when none is supplied. */
+  public static final String DEFAULT_VERSION = "0.0.0";
+
+  /** Catalog kind for dashboard gadgets (see component-package-manifest.md). */
+  public static final String CATALOG_KIND_GADGET = "gadget";
+
+  private PSGadgetRegistryCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile a registry XML file.
+   *
+   * @param registryXmlPath path to {@code GadgetRegistry.xml}
+   * @param version optional catalog / package version (may be null → {@value #DEFAULT_VERSION})
+   * @return compile result with catalog + per-gadget packages
+   * @throws PSGadgetRegistryException on parse/compile/validation failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetRegistryCompileResult compile(Path registryXmlPath, String version)
+      throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(registryXmlPath, "registryXmlPath");
+    PSGadgetRegistryModel model = PSGadgetRegistryParser.parse(registryXmlPath);
+    return compile(model, version);
+  }
+
+  /**
+   * Compile a previously parsed registry model.
+   *
+   * @param model non-null parsed registry
+   * @param version optional version string
+   * @return compile result
+   * @throws PSGadgetRegistryException on compile/validation failure
+   */
+  public static PSGadgetRegistryCompileResult compile(PSGadgetRegistryModel model, String version)
+      throws PSGadgetRegistryException {
+    Objects.requireNonNull(model, "model");
+    if (model.getGadgets().isEmpty()) {
+      throw new PSGadgetRegistryException("Cannot compile empty gadget registry");
+    }
+
+    String ver =
+        version != null && !version.isBlank() ? version.trim() : DEFAULT_VERSION;
+
+    PSGadgetCatalog catalog = new PSGadgetCatalog();
+    catalog.setSchemaVersion(PSGadgetCatalog.SUPPORTED_SCHEMA_VERSION);
+    catalog.setId("perc.gadgetCatalog");
+    catalog.setName("Product Gadget Catalog");
+    catalog.setVersion(ver);
+    catalog.setDescription(
+        "Modern product gadget catalog compiled from GadgetRegistry.xml (ADR-004 / #2771)");
+
+    Map<String, PSComponentPackageManifest> packages = new LinkedHashMap<>();
+    List<PSGadgetCatalog.Entry> entries = new ArrayList<>();
+
+    for (PSGadgetRegistryEntry src : model.getGadgets()) {
+      if (src == null) {
+        continue;
+      }
+      String id = src.gadgetId();
+      if (id == null || id.isBlank()) {
+        throw new PSGadgetRegistryException(
+            "Cannot derive gadget id for entry name='" + src.getName() + "'");
+      }
+      if (packages.containsKey(id)) {
+        throw new PSGadgetRegistryException("Duplicate gadget id in registry: " + id);
+      }
+
+      PSComponentPackageManifest manifest = compileGadgetPackage(src, ver);
+      packages.put(id, manifest);
+
+      PSGadgetCatalog.Entry entry = new PSGadgetCatalog.Entry();
+      entry.setId(id);
+      entry.setName(src.getName());
+      entry.setGroup(src.getGroup());
+      entry.setBaseUri(src.getBaseUri());
+      entry.setLegacyDefinitionFile(src.getLegacyDefinitionFile());
+      entry.setDeprecated(src.isDeprecated());
+      // Package-relative path when gadgets are written under gadgets/<id>/
+      entry.setComponentPackageRef(
+          "gadgets/" + id + "/" + PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+      entries.add(entry);
+    }
+    catalog.setGadgets(entries);
+
+    return new PSGadgetRegistryCompileResult(model, catalog, packages);
+  }
+
+  /**
+   * Compile a single registry entry into a gadget-kind component package manifest.
+   *
+   * @param entry non-null registry entry
+   * @param version package version
+   * @return validated manifest
+   * @throws PSGadgetRegistryException on validation failure
+   */
+  public static PSComponentPackageManifest compileGadgetPackage(
+      PSGadgetRegistryEntry entry, String version) throws PSGadgetRegistryException {
+    Objects.requireNonNull(entry, "entry");
+    String id = entry.gadgetId();
+    if (id == null || id.isBlank()) {
+      throw new PSGadgetRegistryException("Gadget entry missing id (name/baseuri)");
+    }
+
+    String ver =
+        version != null && !version.isBlank() ? version.trim() : DEFAULT_VERSION;
+
+    PSComponentPackageManifest manifest = new PSComponentPackageManifest();
+    manifest.setSchemaVersion(PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION);
+    manifest.setId(id);
+    manifest.setName(entry.getName() != null && !entry.getName().isBlank() ? entry.getName() : id);
+    manifest.setVersion(ver);
+    manifest.setDescription(
+        "Dashboard gadget package for '"
+            + manifest.getName()
+            + "' (group="
+            + (entry.getGroup() != null ? entry.getGroup() : "Custom")
+            + ")");
+
+    PSComponentPackageManifest.Publisher publisher = new PSComponentPackageManifest.Publisher();
+    publisher.setName("Intersoft Data Labs, Inc.");
+    publisher.setUrl("https://www.intsof.com");
+    manifest.setPublisher(publisher);
+
+    PSComponentPackageManifest.Catalog cat = new PSComponentPackageManifest.Catalog();
+    cat.setKind(CATALOG_KIND_GADGET);
+    cat.setTitle(manifest.getName());
+    cat.setCategory(entry.getGroup() != null ? entry.getGroup() : "Custom");
+    cat.setDescription(manifest.getDescription());
+    cat.setAuthor("Intersoft Data Labs, Inc.");
+    // Deprecated gadgets stay listed but are not palette-default visible.
+    cat.setPaletteVisible(!entry.isDeprecated());
+    manifest.setCatalog(cat);
+
+    // Logical host resource: base URI folder under the classic repository tree (URL-style path).
+    // Not an assembly template — validator allows catalog.kind=gadget without CT/templates.
+    if (entry.getBaseUri() != null && !entry.getBaseUri().isBlank()) {
+      String packageRelativeHost = toPackageRelativeHostPath(entry.getBaseUri());
+      if (packageRelativeHost != null) {
+        PSComponentPackageManifest.ResourceRef res = new PSComponentPackageManifest.ResourceRef();
+        res.setPath("resources/host-ref.txt");
+        res.setTarget(packageRelativeHost);
+        res.setType("file");
+        List<PSComponentPackageManifest.ResourceRef> resources = new ArrayList<>();
+        resources.add(res);
+        manifest.setResources(resources);
+      }
+    }
+
+    try {
+      PSComponentPackageManifestValidator.validate(manifest);
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSGadgetRegistryException(
+          "Compiled gadget package failed validation for id=" + id + ": " + e.getMessage(), e);
+    }
+    return manifest;
+  }
+
+  /**
+   * Write compile result under {@code outputDir}:
+   *
+   * <pre>
+   *   gadget-catalog.json
+   *   gadgets/&lt;id&gt;/component-package.json
+   *   gadgets/&lt;id&gt;/resources/host-ref.txt   (when baseUri present)
+   * </pre>
+   *
+   * @param result non-null compile result
+   * @param outputDir non-null destination root
+   * @throws IOException on I/O failure
+   */
+  public static void writeArtifacts(PSGadgetRegistryCompileResult result, Path outputDir)
+      throws IOException {
+    Objects.requireNonNull(result, "result");
+    Objects.requireNonNull(outputDir, "outputDir");
+    Files.createDirectories(outputDir);
+
+    Path catalogPath = outputDir.resolve(PSGadgetCatalog.DEFAULT_CATALOG_FILE_NAME);
+    PSGadgetCatalogIo.write(result.getCatalog(), catalogPath);
+
+    for (Map.Entry<String, PSComponentPackageManifest> e : result.getGadgetPackages().entrySet()) {
+      String id = e.getKey();
+      PSComponentPackageManifest manifest = e.getValue();
+      Path gadgetDir = outputDir.resolve("gadgets").resolve(id);
+      Files.createDirectories(gadgetDir);
+      Path manifestPath = gadgetDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+      PSComponentPackageManifestIo.write(manifest, manifestPath);
+
+      if (manifest.getResources() != null) {
+        for (PSComponentPackageManifest.ResourceRef res : manifest.getResources()) {
+          if (res == null || res.getPath() == null || res.getPath().isBlank()) {
+            continue;
+          }
+          if (res.getTarget() == null) {
+            continue;
+          }
+          Path artifact = resolvePackageRelative(gadgetDir, res.getPath());
+          Path parent = artifact.getParent();
+          if (parent != null) {
+            Files.createDirectories(parent);
+          }
+          // host-ref.txt body is the package-relative install target (URL-style).
+          Files.writeString(artifact, res.getTarget() + System.lineSeparator());
+        }
+      }
+    }
+  }
+
+  /**
+   * Strip leading {@code /cm/gadgets/repository/} (or any leading slash) so the target is a
+   * package-relative install path using {@code /} separators only.
+   */
+  static String toPackageRelativeHostPath(String baseUri) {
+    if (baseUri == null || baseUri.isBlank()) {
+      return null;
+    }
+    String p = baseUri.trim().replace('\\', '/');
+    while (p.startsWith("/")) {
+      p = p.substring(1);
+    }
+    if (p.isEmpty() || p.contains("..")) {
+      return null;
+    }
+    // Prefer cm/gadgets/repository/<id> as install target when that prefix is present.
+    return p;
+  }
+
+  /**
+   * Resolve a package-relative path (URL-style {@code /}) under {@code base} using portable {@link
+   * Path#resolve(String)} per segment.
+   */
+  static Path resolvePackageRelative(Path base, String packageRelative) {
+    Path p = base;
+    for (String segment : packageRelative.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment)) {
+        continue;
+      }
+      if ("..".equals(segment)) {
+        throw new IllegalArgumentException(
+            "Package-relative path must not contain '..': " + packageRelative);
+      }
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryEntry.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryEntry.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.util.Objects;
+
+/**
+ * One gadget row from legacy {@code GadgetRegistry.xml} ({@code <gadget name baseuri file/>} inside
+ * a named {@code <group>}).
+ */
+public final class PSGadgetRegistryEntry {
+
+  private String name;
+  private String group;
+  private String baseUri;
+  private String legacyDefinitionFile;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  public String getBaseUri() {
+    return baseUri;
+  }
+
+  public void setBaseUri(String baseUri) {
+    this.baseUri = baseUri;
+  }
+
+  public String getLegacyDefinitionFile() {
+    return legacyDefinitionFile;
+  }
+
+  public void setLegacyDefinitionFile(String legacyDefinitionFile) {
+    this.legacyDefinitionFile = legacyDefinitionFile;
+  }
+
+  /**
+   * Stable gadget id derived from the last segment of {@code baseUri} (classic OpenSocial folder
+   * name), falling back to a slug of the display name.
+   */
+  public String gadgetId() {
+    String fromUri = lastUriSegment(baseUri);
+    if (fromUri != null && !fromUri.isBlank()) {
+      return fromUri;
+    }
+    return slugify(name);
+  }
+
+  /**
+   * Whether this entry is under a Deprecated (or similarly retired) group — product still ships the
+   * row for layout prefs but palette defaults hide it.
+   */
+  public boolean isDeprecated() {
+    if (group == null) {
+      return false;
+    }
+    return "deprecated".equalsIgnoreCase(group.trim());
+  }
+
+  static String lastUriSegment(String baseUri) {
+    if (baseUri == null || baseUri.isBlank()) {
+      return null;
+    }
+    String p = baseUri.trim().replace('\\', '/');
+    while (p.endsWith("/")) {
+      p = p.substring(0, p.length() - 1);
+    }
+    int idx = p.lastIndexOf('/');
+    return idx >= 0 ? p.substring(idx + 1) : p;
+  }
+
+  static String slugify(String displayName) {
+    if (displayName == null || displayName.isBlank()) {
+      return "gadget";
+    }
+    String s =
+        displayName
+            .trim()
+            .toLowerCase(java.util.Locale.ROOT)
+            .replaceAll("[^a-z0-9]+", "-")
+            .replaceAll("^-+|-+$", "");
+    return s.isEmpty() ? "gadget" : s;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSGadgetRegistryEntry that)) {
+      return false;
+    }
+    return Objects.equals(name, that.name)
+        && Objects.equals(group, that.group)
+        && Objects.equals(baseUri, that.baseUri)
+        && Objects.equals(legacyDefinitionFile, that.legacyDefinitionFile);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, group, baseUri, legacyDefinitionFile);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+/**
+ * Thrown when gadget registry XML cannot be parsed or compiled into the modern catalog / component
+ * package model.
+ *
+ * @see PSGadgetRegistryParser
+ * @see PSGadgetRegistryCompiler
+ */
+public class PSGadgetRegistryException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSGadgetRegistryException(String message) {
+    super(message);
+  }
+
+  public PSGadgetRegistryException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryModel.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryModel.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Parsed product gadget registry (upgrade-input {@code GadgetRegistry.xml}).
+ *
+ * <p>Order of entries matches document order within each group; groups themselves are document
+ * order. Used only as compiler input — modern ship format is {@link PSGadgetCatalog} + per-gadget
+ * {@code component-package.json}.
+ */
+public final class PSGadgetRegistryModel {
+
+  private String sourceFileName;
+  private final List<PSGadgetRegistryEntry> gadgets = new ArrayList<>();
+
+  public String getSourceFileName() {
+    return sourceFileName;
+  }
+
+  public void setSourceFileName(String sourceFileName) {
+    this.sourceFileName = sourceFileName;
+  }
+
+  public List<PSGadgetRegistryEntry> getGadgets() {
+    return gadgets;
+  }
+
+  public void addGadget(PSGadgetRegistryEntry entry) {
+    if (entry != null) {
+      gadgets.add(entry);
+    }
+  }
+
+  /** Display name → group (first wins). */
+  public Map<String, String> toNameGroupMap() {
+    Map<String, String> map = new LinkedHashMap<>();
+    for (PSGadgetRegistryEntry g : gadgets) {
+      if (g == null || g.getName() == null || g.getName().isBlank()) {
+        continue;
+      }
+      map.putIfAbsent(g.getName(), g.getGroup() != null ? g.getGroup() : "Custom");
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  public PSGadgetRegistryEntry findById(String gadgetId) {
+    if (gadgetId == null || gadgetId.isBlank()) {
+      return null;
+    }
+    for (PSGadgetRegistryEntry g : gadgets) {
+      if (g != null && gadgetId.equals(g.gadgetId())) {
+        return g;
+      }
+    }
+    return null;
+  }
+
+  public PSGadgetRegistryEntry findByName(String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    for (PSGadgetRegistryEntry g : gadgets) {
+      if (g != null && name.equals(g.getName())) {
+        return g;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PSGadgetRegistryModel that)) {
+      return false;
+    }
+    return Objects.equals(sourceFileName, that.sourceFileName)
+        && Objects.equals(gadgets, that.gadgets);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceFileName, gadgets);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryParser.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/gadgetxml/PSGadgetRegistryParser.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Parses product {@code GadgetRegistry.xml} ({@code <gadgets><group name="…"><gadget …/>}) into
+ * {@link PSGadgetRegistryModel}.
+ *
+ * <p>Uses a hardened {@link DocumentBuilderFactory} (no external DTDs / schemas / XInclude). Paths
+ * are read via portable NIO {@link Files}.
+ */
+public final class PSGadgetRegistryParser {
+
+  private PSGadgetRegistryParser() {
+    // utility
+  }
+
+  /**
+   * Parse registry XML from a UTF-8 file.
+   *
+   * @param path non-null path to {@code GadgetRegistry.xml}
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSGadgetRegistryModel parse(Path path)
+      throws PSGadgetRegistryException, IOException {
+    Objects.requireNonNull(path, "path");
+    String xml = Files.readString(path, StandardCharsets.UTF_8);
+    PSGadgetRegistryModel model = parse(xml);
+    Path fileName = path.getFileName();
+    if (fileName != null) {
+      model.setSourceFileName(fileName.toString());
+    }
+    return model;
+  }
+
+  /**
+   * Parse registry XML from a string.
+   *
+   * @param xml non-null document text
+   * @return parsed model
+   * @throws PSGadgetRegistryException on parse failure
+   */
+  public static PSGadgetRegistryModel parse(String xml) throws PSGadgetRegistryException {
+    Objects.requireNonNull(xml, "xml");
+    if (xml.isBlank()) {
+      throw new PSGadgetRegistryException("Gadget registry XML is empty");
+    }
+    try {
+      Document doc = parseDocument(new InputSource(new StringReader(xml)));
+      return fromDocument(doc);
+    } catch (PSGadgetRegistryException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSGadgetRegistryException(
+          "Failed to parse Gadget registry XML: " + e.getMessage(), e);
+    }
+  }
+
+  static PSGadgetRegistryModel fromDocument(Document doc) throws PSGadgetRegistryException {
+    Objects.requireNonNull(doc, "doc");
+    Element root = doc.getDocumentElement();
+    if (root == null) {
+      throw new PSGadgetRegistryException("Gadget registry XML has no document element");
+    }
+    String rootName = root.getLocalName() != null ? root.getLocalName() : root.getTagName();
+    if (!"gadgets".equalsIgnoreCase(rootName)) {
+      throw new PSGadgetRegistryException(
+          "Expected root element <gadgets>, found <" + rootName + ">");
+    }
+
+    PSGadgetRegistryModel model = new PSGadgetRegistryModel();
+    NodeList children = root.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() != Node.ELEMENT_NODE) {
+        continue;
+      }
+      Element el = (Element) n;
+      String tag = el.getLocalName() != null ? el.getLocalName() : el.getTagName();
+      if (!"group".equalsIgnoreCase(tag)) {
+        continue;
+      }
+      String groupName = el.getAttribute("name");
+      if (groupName == null || groupName.isBlank()) {
+        groupName = "Custom";
+      }
+      NodeList gadgetElems = el.getElementsByTagName("gadget");
+      // Also accept no-namespace children listed directly under group.
+      if (gadgetElems.getLength() == 0) {
+        NodeList groupKids = el.getChildNodes();
+        for (int j = 0; j < groupKids.getLength(); j++) {
+          Node gn = groupKids.item(j);
+          if (gn.getNodeType() != Node.ELEMENT_NODE) {
+            continue;
+          }
+          Element ge = (Element) gn;
+          String gtag = ge.getLocalName() != null ? ge.getLocalName() : ge.getTagName();
+          if ("gadget".equalsIgnoreCase(gtag)) {
+            model.addGadget(readGadget(ge, groupName));
+          }
+        }
+      } else {
+        for (int j = 0; j < gadgetElems.getLength(); j++) {
+          Element ge = (Element) gadgetElems.item(j);
+          model.addGadget(readGadget(ge, groupName));
+        }
+      }
+    }
+
+    if (model.getGadgets().isEmpty()) {
+      throw new PSGadgetRegistryException("Gadget registry contains no <gadget> entries");
+    }
+    return model;
+  }
+
+  private static PSGadgetRegistryEntry readGadget(Element ge, String groupName)
+      throws PSGadgetRegistryException {
+    PSGadgetRegistryEntry entry = new PSGadgetRegistryEntry();
+    entry.setGroup(groupName);
+    String name = ge.getAttribute("name");
+    if (name == null || name.isBlank()) {
+      throw new PSGadgetRegistryException(
+          "Gadget entry in group '" + groupName + "' is missing required name attribute");
+    }
+    entry.setName(name.trim());
+    String baseUri = ge.getAttribute("baseuri");
+    if (baseUri == null || baseUri.isBlank()) {
+      // Some historic rows used baseUri camelCase — accept both.
+      baseUri = ge.getAttribute("baseUri");
+    }
+    if (baseUri != null) {
+      entry.setBaseUri(baseUri.trim());
+    }
+    String file = ge.getAttribute("file");
+    if (file != null && !file.isBlank()) {
+      entry.setLegacyDefinitionFile(file.trim());
+    }
+    return entry;
+  }
+
+  static Document parseDocument(InputSource source)
+      throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    try {
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    } catch (ParserConfigurationException ignored) {
+      // Some JDK / provider combinations reject features; continue with other hardening.
+    }
+    try {
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    } catch (ParserConfigurationException ignored) {
+      // optional
+    }
+    try {
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    } catch (ParserConfigurationException ignored) {
+      // optional
+    }
+    try {
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    } catch (IllegalArgumentException ignored) {
+      // optional
+    }
+    return factory.newDocumentBuilder().parse(source);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifest.java
@@ -750,6 +750,8 @@ public final class PSComponentPackageManifest {
     private String path;
     private String target;
     private String type;
+    /** Optional HTML placement (e.g. {@code head}, {@code body}) from Widget XML Resource. */
+    private String placement;
 
     public String getPath() {
       return path;
@@ -775,6 +777,14 @@ public final class PSComponentPackageManifest {
       this.type = type;
     }
 
+    public String getPlacement() {
+      return placement;
+    }
+
+    public void setPlacement(String placement) {
+      this.placement = placement;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -785,12 +795,13 @@ public final class PSComponentPackageManifest {
       }
       return Objects.equals(path, that.path)
           && Objects.equals(target, that.target)
-          && Objects.equals(type, that.type);
+          && Objects.equals(type, that.type)
+          && Objects.equals(placement, that.placement);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(path, target, type);
+      return Objects.hash(path, target, type, placement);
     }
   }
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/manifest/PSComponentPackageManifestValidator.java
@@ -27,7 +27,14 @@ import java.util.regex.Pattern;
  *
  * <p>Enforces schema version, required identity fields, non-blank nested names, portable
  * package-relative path refs (URL-style {@code /} separators; no absolute OS paths), and the
- * presence of at least one content type or template (a component must ship something installable).
+ * presence of installable material:
+ *
+ * <ul>
+ *   <li>Default components / pages: at least one {@code contentTypes[]} or {@code templates[]}
+ *       entry
+ *   <li>Gadget packages ({@code catalog.kind = "gadget"}): catalog title required; content types /
+ *       templates optional (dashboard gadgets are SPA hosts, not assembly templates) — issue #2771
+ * </ul>
  */
 public final class PSComponentPackageManifestValidator {
 
@@ -121,13 +128,21 @@ public final class PSComponentPackageManifestValidator {
       }
     }
 
+    boolean isGadgetKind = false;
     if (manifest.getCatalog() != null) {
       PSComponentPackageManifest.Catalog cat = manifest.getCatalog();
+      if (cat.getKind() != null && "gadget".equalsIgnoreCase(cat.getKind().trim())) {
+        isGadgetKind = true;
+      }
       if (cat.getThumbnail() != null && !cat.getThumbnail().isBlank()) {
         requireRelativePath(errors, "catalog.thumbnail", cat.getThumbnail());
       }
       if (cat.getIcon() != null && !cat.getIcon().isBlank()) {
         requireRelativePath(errors, "catalog.icon", cat.getIcon());
+      }
+      if (isGadgetKind) {
+        // Dashboard gadgets ship as catalog + optional host resources (no assembly CT/templates).
+        requireText(errors, "catalog.title", cat.getTitle());
       }
     }
 
@@ -233,7 +248,9 @@ public final class PSComponentPackageManifestValidator {
     boolean hasTpl =
         manifest.getTemplates() != null
             && manifest.getTemplates().stream().anyMatch(Objects::nonNull);
-    if (!hasCt && !hasTpl) {
+    // Gadget packages are SPA/dashboard hosts — catalog.kind=gadget + title is sufficient.
+    // Components and pages still require content types or templates.
+    if (!isGadgetKind && !hasCt && !hasTpl) {
       errors.add("manifest must declare at least one contentTypes[] or templates[] entry");
     }
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompileResult.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompileResult.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Output of compiling a single Page {@code *.templateDef}: modern manifest + package-relative text
+ * artifacts (template sources keyed by the same paths referenced from the manifest).
+ */
+public final class PSPageXmlCompileResult {
+
+  private final PSPageXmlModel source;
+  private final PSComponentPackageManifest manifest;
+  /** Package-relative path → UTF-8 text (e.g. {@code templates/perc.base.plain.vm}). */
+  private final Map<String, String> textArtifacts;
+
+  public PSPageXmlCompileResult(
+      PSPageXmlModel source,
+      PSComponentPackageManifest manifest,
+      Map<String, String> textArtifacts) {
+    this.source = Objects.requireNonNull(source, "source");
+    this.manifest = Objects.requireNonNull(manifest, "manifest");
+    this.textArtifacts =
+        textArtifacts == null
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(textArtifacts));
+  }
+
+  public PSPageXmlModel getSource() {
+    return source;
+  }
+
+  public PSComponentPackageManifest getManifest() {
+    return manifest;
+  }
+
+  public Map<String, String> getTextArtifacts() {
+    return textArtifacts;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompiler.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Compiles legacy Page / assembly {@code *.templateDef} XML into a modern {@link
+ * PSComponentPackageManifest} plus template source artifacts (Phase 3 / ADR-004 / issue #2770).
+ *
+ * <p><strong>Scope:</strong> product page layout templates (e.g. {@code perc.baseTemplates}, {@code
+ * perc.responsiveTemplates}) and simple Baseline assembly templates. Region holes become slots;
+ * assembler extension short-names map to the Component Package Manifest assembler field; Velocity
+ * body is the canonical template source.
+ *
+ * <p>Product packages may still ship dual-run {@code *.templateDef} until a residual removes them;
+ * this compiler is the upgrade / modern authoring path.
+ */
+public final class PSPageXmlCompiler {
+
+  private static final String DEFAULT_VERSION = "0.0.0";
+
+  private PSPageXmlCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile a {@code *.templateDef} file into a modern component package result.
+   *
+   * @param templateDefPath path to assembly-template XML
+   * @param packageContext optional package metadata; may be null
+   * @return compile result with validated manifest and text artifacts
+   * @throws PSPageXmlException on parse/compile/validation failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlCompileResult compile(
+      Path templateDefPath, PSPageXmlPackageContext packageContext)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(templateDefPath, "templateDefPath");
+    PSPageXmlModel model = PSPageXmlParser.parse(templateDefPath);
+    return compile(model, packageContext);
+  }
+
+  /**
+   * Compile a previously parsed page template model.
+   *
+   * @param model non-null parsed template
+   * @param packageContext optional package metadata; may be null
+   * @return compile result
+   * @throws PSPageXmlException on compile/validation failure
+   */
+  public static PSPageXmlCompileResult compile(
+      PSPageXmlModel model, PSPageXmlPackageContext packageContext) throws PSPageXmlException {
+    Objects.requireNonNull(model, "model");
+
+    String stem = model.pageStem();
+    if (stem == null || stem.isBlank()) {
+      throw new PSPageXmlException(
+          "Page template model is missing name / source file; cannot derive component id");
+    }
+
+    PSComponentPackageManifest manifest = new PSComponentPackageManifest();
+    manifest.setSchemaVersion(PSComponentPackageManifest.SUPPORTED_SCHEMA_VERSION);
+    manifest.setId(stem);
+    String displayName =
+        model.getLabel() != null && !model.getLabel().isBlank() ? model.getLabel() : stem;
+    manifest.setName(displayName);
+    applyPackageIdentity(manifest, packageContext, model);
+
+    PSComponentPackageManifest.Catalog catalog = new PSComponentPackageManifest.Catalog();
+    catalog.setKind("page");
+    catalog.setTitle(displayName);
+    catalog.setDescription(model.getDescription());
+    catalog.setCategory("page");
+    catalog.setPaletteVisible(Boolean.TRUE);
+    if (packageContext != null
+        && packageContext.getPackageId() != null
+        && packageContext.getPackageId().toLowerCase(Locale.ROOT).contains("responsive")) {
+      catalog.setResponsive(Boolean.TRUE);
+    }
+    manifest.setCatalog(catalog);
+
+    String assembler = mapAssembler(model.getAssembler());
+    String templateType = mapTemplateType(model.getOutputFormat(), assembler);
+    String sourceRef = "templates/" + stem + assemblerExtension(assembler);
+
+    PSComponentPackageManifest.TemplateRef template = new PSComponentPackageManifest.TemplateRef();
+    template.setName(stem);
+    template.setType(templateType);
+    template.setAssembler(assembler);
+    template.setSourceRef(sourceRef);
+    template.setBindings(buildBindings(model));
+    List<PSComponentPackageManifest.TemplateRef> templates = new ArrayList<>();
+    templates.add(template);
+    manifest.setTemplates(templates);
+
+    List<PSComponentPackageManifest.SlotRef> slots = new ArrayList<>();
+    for (PSPageXmlModel.RegionHole hole : model.getRegionHoles()) {
+      if (hole == null || hole.getRegionId() == null || hole.getRegionId().isBlank()) {
+        continue;
+      }
+      PSComponentPackageManifest.SlotRef slot = new PSComponentPackageManifest.SlotRef();
+      slot.setName(hole.getRegionId());
+      slot.setAllowedContentTypes(new ArrayList<>());
+      slot.setLayout(
+          hole.getLayoutHints() != null
+              ? new LinkedHashMap<>(hole.getLayoutHints())
+              : new LinkedHashMap<>());
+      slot.setStyles(
+          hole.getStyleHints() != null
+              ? new LinkedHashMap<>(hole.getStyleHints())
+              : new LinkedHashMap<>());
+      slots.add(slot);
+    }
+    manifest.setSlots(slots);
+
+    // Page layout templates do not declare CT in templateDef; leave contentTypes empty.
+    manifest.setContentTypes(new ArrayList<>());
+    manifest.setResources(new ArrayList<>());
+    manifest.setUserPreferences(new ArrayList<>());
+    manifest.setCssPreferences(new ArrayList<>());
+
+    try {
+      PSComponentPackageManifestValidator.validate(manifest);
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSPageXmlException("Compiled manifest failed validation: " + e.getMessage(), e);
+    }
+
+    Map<String, String> artifacts = new LinkedHashMap<>();
+    String templateSource = model.getTemplateBody() != null ? model.getTemplateBody() : "";
+    artifacts.put(sourceRef, templateSource);
+
+    return new PSPageXmlCompileResult(model, manifest, artifacts);
+  }
+
+  /**
+   * Write a compile result under {@code outputDir}: {@code component-package.json} plus text
+   * artifacts using package-relative paths. Parent directories are created as needed.
+   *
+   * @param result non-null compile result
+   * @param outputDir non-null destination package root
+   * @throws IOException on I/O failure
+   */
+  public static void writeArtifacts(PSPageXmlCompileResult result, Path outputDir)
+      throws IOException {
+    Objects.requireNonNull(result, "result");
+    Objects.requireNonNull(outputDir, "outputDir");
+    Files.createDirectories(outputDir);
+    Path manifestPath = outputDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    PSComponentPackageManifestIo.write(result.getManifest(), manifestPath);
+    for (Map.Entry<String, String> entry : result.getTextArtifacts().entrySet()) {
+      Path artifact = resolvePackageRelative(outputDir, entry.getKey());
+      Path parent = artifact.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      Files.writeString(artifact, entry.getValue(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void applyPackageIdentity(
+      PSComponentPackageManifest manifest,
+      PSPageXmlPackageContext ctx,
+      PSPageXmlModel model) {
+    if (ctx != null) {
+      if (ctx.getVersion() != null && !ctx.getVersion().isBlank()) {
+        manifest.setVersion(ctx.getVersion());
+      }
+      if (model.getDescription() != null && !model.getDescription().isBlank()) {
+        manifest.setDescription(model.getDescription());
+      } else if (ctx.getDescription() != null && !ctx.getDescription().isBlank()) {
+        manifest.setDescription(ctx.getDescription());
+      }
+      if (ctx.getPublisherName() != null || ctx.getPublisherUrl() != null) {
+        PSComponentPackageManifest.Publisher pub = new PSComponentPackageManifest.Publisher();
+        pub.setName(ctx.getPublisherName());
+        pub.setUrl(ctx.getPublisherUrl());
+        manifest.setPublisher(pub);
+      }
+      if (ctx.getCmsMin() != null || ctx.getCmsMax() != null) {
+        PSComponentPackageManifest.CmsVersionRange range =
+            new PSComponentPackageManifest.CmsVersionRange();
+        range.setMin(ctx.getCmsMin());
+        range.setMax(ctx.getCmsMax());
+        manifest.setCmsVersion(range);
+      }
+      if (ctx.getDependencies() != null && !ctx.getDependencies().isEmpty()) {
+        List<PSComponentPackageManifest.Dependency> deps = new ArrayList<>();
+        for (PSPageXmlPackageContext.Dependency d : ctx.getDependencies()) {
+          if (d == null || d.getName() == null || d.getName().isBlank()) {
+            continue;
+          }
+          PSComponentPackageManifest.Dependency dep = new PSComponentPackageManifest.Dependency();
+          dep.setName(d.getName());
+          dep.setVersion(d.getVersion());
+          dep.setImplied(d.isImplied());
+          deps.add(dep);
+        }
+        manifest.setDependencies(deps);
+      }
+    } else if (model.getDescription() != null) {
+      manifest.setDescription(model.getDescription());
+    }
+
+    if (manifest.getVersion() == null || manifest.getVersion().isBlank()) {
+      manifest.setVersion(DEFAULT_VERSION);
+    }
+  }
+
+  static List<PSComponentPackageManifest.Binding> buildBindings(PSPageXmlModel model) {
+    List<PSComponentPackageManifest.Binding> bindings = new ArrayList<>();
+    if (model.getBindings() == null) {
+      return bindings;
+    }
+    for (PSPageXmlModel.Binding b : model.getBindings()) {
+      if (b == null || b.getVariable() == null || b.getVariable().isBlank()) {
+        continue;
+      }
+      PSComponentPackageManifest.Binding out = new PSComponentPackageManifest.Binding();
+      out.setVariable(b.getVariable());
+      out.setExpression(b.getExpression() != null ? b.getExpression() : "");
+      bindings.add(out);
+    }
+    return bindings;
+  }
+
+  /**
+   * Map assembly-template {@code <assembler>} (often a Java extension path) to a short Component
+   * Package Manifest assembler id.
+   */
+  static String mapAssembler(String assembler) {
+    if (assembler == null || assembler.isBlank()) {
+      return "pageAssembler";
+    }
+    String a = assembler.trim();
+    String lower = a.toLowerCase(Locale.ROOT);
+    // Extension path: Java/global/percussion/assembly/pageAssembler
+    int slash = lower.lastIndexOf('/');
+    String leaf = slash >= 0 ? a.substring(slash + 1) : a;
+    String leafLower = leaf.toLowerCase(Locale.ROOT);
+    if (leafLower.endsWith("assembler")) {
+      // normalize casing for known product assemblers
+      if (leafLower.equals("pageassembler")) {
+        return "pageAssembler";
+      }
+      if (leafLower.equals("pagevariantassembler")) {
+        return "pageVariantAssembler";
+      }
+      if (leafLower.equals("velocityassembler")) {
+        return "velocityAssembler";
+      }
+      if (leafLower.equals("htmlassembler")) {
+        return "htmlAssembler";
+      }
+      if (leafLower.equals("markdownassembler")) {
+        return "markdownAssembler";
+      }
+      if (leafLower.equals("legacyassembler") || leafLower.equals("xslassembler")) {
+        return "legacyAssembler";
+      }
+      return leaf;
+    }
+    return leaf + "Assembler";
+  }
+
+  /**
+   * Map {@code <output-format>} to Component Package Manifest template type (page / snippet /
+   * global / binary / resource).
+   */
+  static String mapTemplateType(String outputFormat, String assembler) {
+    if (outputFormat != null && !outputFormat.isBlank()) {
+      String o = outputFormat.trim().toLowerCase(Locale.ROOT);
+      return switch (o) {
+        case "page" -> "page";
+        case "snippet" -> "snippet";
+        case "global" -> "global";
+        case "binary" -> "binary";
+        case "database", "db" -> "binary";
+        case "resource" -> "resource";
+        default -> o;
+      };
+    }
+    if (assembler != null && assembler.toLowerCase(Locale.ROOT).contains("page")) {
+      return "page";
+    }
+    return "page";
+  }
+
+  static String assemblerExtension(String assembler) {
+    if (assembler == null) {
+      return ".vm";
+    }
+    String a = assembler.toLowerCase(Locale.ROOT);
+    if (a.contains("html") && !a.contains("page")) {
+      return ".html";
+    }
+    if (a.contains("markdown") || a.endsWith("mdassembler")) {
+      return ".md";
+    }
+    // pageAssembler is Velocity-based (PSPageAssembler extends PSVelocityAssembler)
+    return ".vm";
+  }
+
+  /**
+   * Resolve a package-relative path (URL-style {@code /}) under {@code base} using portable {@link
+   * Path#resolve(String)} per segment — never string-concatenate OS separators.
+   */
+  static Path resolvePackageRelative(Path base, String packageRelative) {
+    Path p = base;
+    for (String segment : packageRelative.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment)) {
+        continue;
+      }
+      if ("..".equals(segment)) {
+        throw new IllegalArgumentException(
+            "Package-relative path must not contain '..': " + packageRelative);
+      }
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlException.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+/**
+ * Thrown when Page / assembly {@code *.templateDef} definition XML cannot be parsed or compiled
+ * into a Component Package Manifest.
+ *
+ * @see PSPageXmlParser
+ * @see PSPageXmlCompiler
+ */
+public class PSPageXmlException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSPageXmlException(String message) {
+    super(message);
+  }
+
+  public PSPageXmlException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlModel.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlModel.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Parsed upgrade-input Page / assembly template definition ({@code *.templateDef} / {@code
+ * <assembly-template>}).
+ *
+ * <p>Intermediate model used only by the compiler; product ship format is {@link
+ * com.percussion.packages.manifest.PSComponentPackageManifest}.
+ */
+public final class PSPageXmlModel {
+
+  private String sourceFileName;
+  private String name;
+  private String label;
+  private String description;
+  private String guid;
+  private String assembler;
+  private String outputFormat;
+  private String templateType;
+  private String mimeType;
+  private String charset;
+  private String activeAssemblyType;
+  private String templateBody;
+  private List<Binding> bindings = new ArrayList<>();
+  private List<RegionHole> regionHoles = new ArrayList<>();
+
+  public String getSourceFileName() {
+    return sourceFileName;
+  }
+
+  public void setSourceFileName(String sourceFileName) {
+    this.sourceFileName = sourceFileName;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(String label) {
+    this.label = label;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getGuid() {
+    return guid;
+  }
+
+  public void setGuid(String guid) {
+    this.guid = guid;
+  }
+
+  public String getAssembler() {
+    return assembler;
+  }
+
+  public void setAssembler(String assembler) {
+    this.assembler = assembler;
+  }
+
+  public String getOutputFormat() {
+    return outputFormat;
+  }
+
+  public void setOutputFormat(String outputFormat) {
+    this.outputFormat = outputFormat;
+  }
+
+  public String getTemplateType() {
+    return templateType;
+  }
+
+  public void setTemplateType(String templateType) {
+    this.templateType = templateType;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  public void setMimeType(String mimeType) {
+    this.mimeType = mimeType;
+  }
+
+  public String getCharset() {
+    return charset;
+  }
+
+  public void setCharset(String charset) {
+    this.charset = charset;
+  }
+
+  public String getActiveAssemblyType() {
+    return activeAssemblyType;
+  }
+
+  public void setActiveAssemblyType(String activeAssemblyType) {
+    this.activeAssemblyType = activeAssemblyType;
+  }
+
+  public String getTemplateBody() {
+    return templateBody;
+  }
+
+  public void setTemplateBody(String templateBody) {
+    this.templateBody = templateBody;
+  }
+
+  public List<Binding> getBindings() {
+    return bindings;
+  }
+
+  public void setBindings(List<Binding> bindings) {
+    this.bindings = bindings != null ? bindings : new ArrayList<>();
+  }
+
+  public List<RegionHole> getRegionHoles() {
+    return regionHoles;
+  }
+
+  public void setRegionHoles(List<RegionHole> regionHoles) {
+    this.regionHoles = regionHoles != null ? regionHoles : new ArrayList<>();
+  }
+
+  /**
+   * Stable component id: template {@code name}, else source file stem without {@code .templateDef}.
+   */
+  public String pageStem() {
+    if (name != null && !name.isBlank()) {
+      return name.trim();
+    }
+    if (sourceFileName == null || sourceFileName.isBlank()) {
+      return null;
+    }
+    String f = sourceFileName.trim();
+    String lower = f.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".templatedef")) {
+      return f.substring(0, f.length() - ".templateDef".length());
+    }
+    int dot = f.lastIndexOf('.');
+    return dot > 0 ? f.substring(0, dot) : f;
+  }
+
+  /** Ordered JEXL binding from {@code <bindings>} children when present. */
+  public static final class Binding {
+    private String variable;
+    private String expression;
+
+    public String getVariable() {
+      return variable;
+    }
+
+    public void setVariable(String variable) {
+      this.variable = variable;
+    }
+
+    public String getExpression() {
+      return expression;
+    }
+
+    public void setExpression(String expression) {
+      this.expression = expression;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Binding that)) {
+        return false;
+      }
+      return Objects.equals(variable, that.variable)
+          && Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(variable, expression);
+    }
+  }
+
+  /**
+   * A composition hole discovered from a Velocity {@code #region("id" …)} macro, optionally
+   * enriched with CSS class hints from a matching {@code id="…"} markup container.
+   */
+  public static final class RegionHole {
+    private String regionId;
+    private String cssClass;
+    private Map<String, Object> layoutHints = new LinkedHashMap<>();
+    private Map<String, Object> styleHints = new LinkedHashMap<>();
+
+    public String getRegionId() {
+      return regionId;
+    }
+
+    public void setRegionId(String regionId) {
+      this.regionId = regionId;
+    }
+
+    public String getCssClass() {
+      return cssClass;
+    }
+
+    public void setCssClass(String cssClass) {
+      this.cssClass = cssClass;
+    }
+
+    public Map<String, Object> getLayoutHints() {
+      return layoutHints;
+    }
+
+    public void setLayoutHints(Map<String, Object> layoutHints) {
+      this.layoutHints = layoutHints != null ? layoutHints : new LinkedHashMap<>();
+    }
+
+    public Map<String, Object> getStyleHints() {
+      return styleHints;
+    }
+
+    public void setStyleHints(Map<String, Object> styleHints) {
+      this.styleHints = styleHints != null ? styleHints : new LinkedHashMap<>();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof RegionHole that)) {
+        return false;
+      }
+      return Objects.equals(regionId, that.regionId)
+          && Objects.equals(cssClass, that.cssClass)
+          && Objects.equals(layoutHints, that.layoutHints)
+          && Objects.equals(styleHints, that.styleHints);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(regionId, cssClass, layoutHints, styleHints);
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageCompiler.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Compiles all Page / assembly {@code *.templateDef} files found in a legacy product package source
+ * directory (e.g. {@code perc.baseTemplates}, {@code perc.responsiveTemplates}).
+ *
+ * <p>Looks for {@code *.templateDef} at the package root (product packaging layout used by {@code
+ * modules/perc-packages}). Suitable for simple page layout packages first; full product dual-run
+ * removal remains residual under #2630.
+ */
+public final class PSPageXmlPackageCompiler {
+
+  private PSPageXmlPackageCompiler() {
+    // utility
+  }
+
+  /**
+   * Compile every {@code *.templateDef} under the package root.
+   *
+   * @param packageDir non-null package source root (e.g. {@code …/Packages/perc.baseTemplates})
+   * @return compile results sorted by template name (stable for golden tests)
+   * @throws PSPageXmlException on parse/compile failure
+   * @throws IOException on I/O failure
+   */
+  public static List<PSPageXmlCompileResult> compilePackage(Path packageDir)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (!Files.isDirectory(packageDir)) {
+      throw new PSPageXmlException("Package directory does not exist: " + packageDir);
+    }
+
+    PSPageXmlPackageContext ctx = PSPageXmlPackageContext.fromPackageDir(packageDir);
+    List<Path> templateFiles = listTemplateDefs(packageDir);
+    if (templateFiles.isEmpty()) {
+      throw new PSPageXmlException(
+          "No *.templateDef files found in package root: " + packageDir);
+    }
+
+    List<PSPageXmlCompileResult> results = new ArrayList<>();
+    for (Path templateDef : templateFiles) {
+      results.add(PSPageXmlCompiler.compile(templateDef, ctx));
+    }
+    return results;
+  }
+
+  /**
+   * Write each page compile result under {@code outputRoot/<templateStem>/}.
+   *
+   * @param results non-null list of compile results
+   * @param outputRoot non-null output root directory
+   * @throws IOException on I/O failure
+   */
+  public static void writeAll(List<PSPageXmlCompileResult> results, Path outputRoot)
+      throws IOException {
+    Objects.requireNonNull(results, "results");
+    Objects.requireNonNull(outputRoot, "outputRoot");
+    Files.createDirectories(outputRoot);
+    for (PSPageXmlCompileResult result : results) {
+      String stem = result.getSource().pageStem();
+      if (stem == null || stem.isBlank()) {
+        stem = result.getManifest().getId();
+      }
+      Path pageOut = outputRoot.resolve(stem);
+      PSPageXmlCompiler.writeArtifacts(result, pageOut);
+    }
+  }
+
+  /**
+   * List {@code *.templateDef} files at package root, sorted by file name (case-insensitive).
+   * Portable: uses {@link DirectoryStream} + {@link Path}, not hardcoded separators.
+   */
+  static List<Path> listTemplateDefs(Path packageDir) throws IOException {
+    List<Path> files = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(packageDir, "*.templateDef")) {
+      for (Path p : stream) {
+        if (Files.isRegularFile(p)) {
+          files.add(p);
+        }
+      }
+    }
+    files.sort(Comparator.comparing(p -> p.getFileName().toString().toLowerCase(Locale.ROOT)));
+    return files;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageContext.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageContext.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Optional package-level metadata used when compiling a Page {@code *.templateDef} that lives
+ * inside a legacy product package source tree (e.g. {@code perc.baseTemplates}).
+ *
+ * <p>Populated from {@code psx_archiveInfo.xml} when present. Lightweight regex/string extraction is
+ * intentional: archive descriptors are large nested trees; only identity fields are needed here.
+ */
+public final class PSPageXmlPackageContext {
+
+  private String packageId;
+  private String packageName;
+  private String version;
+  private String description;
+  private String publisherName;
+  private String publisherUrl;
+  private String cmsMin;
+  private String cmsMax;
+  private List<Dependency> dependencies = new ArrayList<>();
+
+  public String getPackageId() {
+    return packageId;
+  }
+
+  public void setPackageId(String packageId) {
+    this.packageId = packageId;
+  }
+
+  public String getPackageName() {
+    return packageName;
+  }
+
+  public void setPackageName(String packageName) {
+    this.packageName = packageName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getPublisherName() {
+    return publisherName;
+  }
+
+  public void setPublisherName(String publisherName) {
+    this.publisherName = publisherName;
+  }
+
+  public String getPublisherUrl() {
+    return publisherUrl;
+  }
+
+  public void setPublisherUrl(String publisherUrl) {
+    this.publisherUrl = publisherUrl;
+  }
+
+  public String getCmsMin() {
+    return cmsMin;
+  }
+
+  public void setCmsMin(String cmsMin) {
+    this.cmsMin = cmsMin;
+  }
+
+  public String getCmsMax() {
+    return cmsMax;
+  }
+
+  public void setCmsMax(String cmsMax) {
+    this.cmsMax = cmsMax;
+  }
+
+  public List<Dependency> getDependencies() {
+    return dependencies;
+  }
+
+  public void setDependencies(List<Dependency> dependencies) {
+    this.dependencies = dependencies != null ? dependencies : new ArrayList<>();
+  }
+
+  /**
+   * Load package context from a package source directory (looks for {@code psx_archiveInfo.xml}).
+   *
+   * @param packageDir non-null package root
+   * @return context (may have only packageId from the directory name when archive info is absent)
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlPackageContext fromPackageDir(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    PSPageXmlPackageContext ctx = new PSPageXmlPackageContext();
+    Path name = packageDir.getFileName();
+    if (name != null) {
+      ctx.setPackageId(name.toString());
+      ctx.setPackageName(name.toString());
+    }
+    Path archiveInfo = packageDir.resolve("psx_archiveInfo.xml");
+    if (Files.isRegularFile(archiveInfo)) {
+      String xml = Files.readString(archiveInfo, StandardCharsets.UTF_8);
+      applyArchiveInfo(ctx, xml);
+    }
+    return ctx;
+  }
+
+  /**
+   * Apply selected fields from {@code psx_archiveInfo.xml} text into {@code ctx}.
+   *
+   * @param ctx non-null context to mutate
+   * @param archiveXml non-null archive info document text
+   */
+  static void applyArchiveInfo(PSPageXmlPackageContext ctx, String archiveXml) {
+    Objects.requireNonNull(ctx, "ctx");
+    Objects.requireNonNull(archiveXml, "archiveXml");
+
+    String descriptorName = firstAttr(archiveXml, "PSXDescriptor", "name");
+    if (descriptorName != null && !descriptorName.isBlank()) {
+      ctx.setPackageId(descriptorName);
+      ctx.setPackageName(descriptorName);
+    }
+
+    String archiveRef = firstAttr(archiveXml, "PSXArchiveInfo", "archiveRef");
+    if ((ctx.getPackageId() == null || ctx.getPackageId().isBlank())
+        && archiveRef != null
+        && !archiveRef.isBlank()) {
+      ctx.setPackageId(archiveRef);
+      ctx.setPackageName(archiveRef);
+    }
+
+    Matcher desc = Pattern.compile("<Description>([^<]*)</Description>").matcher(archiveXml);
+    if (desc.find()) {
+      String d = desc.group(1).trim();
+      if (!d.isEmpty()) {
+        ctx.setDescription(d);
+      }
+    }
+
+    Matcher pub =
+        Pattern.compile(
+                "<Publisher\\s+name=\"([^\"]*)\"\\s+url=\"([^\"]*)\"\\s*/?>",
+                Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    if (pub.find()) {
+      ctx.setPublisherName(emptyToNull(pub.group(1)));
+      ctx.setPublisherUrl(emptyToNull(pub.group(2)));
+    }
+
+    Matcher cms =
+        Pattern.compile(
+                "<CmsVersion\\s+max=\"([^\"]*)\"\\s+min=\"([^\"]*)\"\\s*/?>",
+                Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    if (!cms.find()) {
+      cms =
+          Pattern.compile(
+                  "<CmsVersion\\s+min=\"([^\"]*)\"\\s+max=\"([^\"]*)\"\\s*/?>",
+                  Pattern.CASE_INSENSITIVE)
+              .matcher(archiveXml);
+      if (cms.find()) {
+        ctx.setCmsMin(emptyToNull(cms.group(1)));
+        ctx.setCmsMax(emptyToNull(cms.group(2)));
+      }
+    } else {
+      ctx.setCmsMax(emptyToNull(cms.group(1)));
+      ctx.setCmsMin(emptyToNull(cms.group(2)));
+    }
+
+    Matcher ver = Pattern.compile("<Version>([^<]+)</Version>").matcher(archiveXml);
+    if (ver.find()) {
+      ctx.setVersion(ver.group(1).trim());
+    }
+
+    List<Dependency> deps = new ArrayList<>();
+    Matcher dep =
+        Pattern.compile("<PKGDependency\\s+([^>]+)/?>", Pattern.CASE_INSENSITIVE)
+            .matcher(archiveXml);
+    while (dep.find()) {
+      Map<String, String> attrs = parseAttrBag(dep.group(1));
+      Dependency d = new Dependency();
+      d.setName(attrs.get("name"));
+      d.setVersion(attrs.get("pkgVersion"));
+      String implied = attrs.get("PKGDepImplied");
+      d.setImplied(implied != null && Boolean.parseBoolean(implied));
+      if (d.getName() != null && !d.getName().isBlank()) {
+        deps.add(d);
+      }
+    }
+    ctx.setDependencies(deps);
+  }
+
+  private static String firstAttr(String xml, String element, String attr) {
+    Pattern p = Pattern.compile("<" + element + "\\b([^>]*)>", Pattern.CASE_INSENSITIVE);
+    Matcher m = p.matcher(xml);
+    if (!m.find()) {
+      return null;
+    }
+    return parseAttrBag(m.group(1)).get(attr);
+  }
+
+  private static Map<String, String> parseAttrBag(String bag) {
+    Map<String, String> map = new LinkedHashMap<>();
+    Matcher m = Pattern.compile("([A-Za-z_][\\w:.-]*)\\s*=\\s*\"([^\"]*)\"").matcher(bag);
+    while (m.find()) {
+      map.put(m.group(1), m.group(2));
+    }
+    return map;
+  }
+
+  private static String emptyToNull(String s) {
+    if (s == null) {
+      return null;
+    }
+    String t = s.trim();
+    return t.isEmpty() ? null : t;
+  }
+
+  /** Package dependency row. */
+  public static final class Dependency {
+    private String name;
+    private String version;
+    private boolean implied;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public void setVersion(String version) {
+      this.version = version;
+    }
+
+    public boolean isImplied() {
+      return implied;
+    }
+
+    public void setImplied(boolean implied) {
+      this.implied = implied;
+    }
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlParser.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlParser.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Parses legacy Page / assembly {@code *.templateDef} XML ({@code <assembly-template>}) into {@link
+ * PSPageXmlModel}.
+ *
+ * <p>Uses a hardened {@link DocumentBuilderFactory} (no external DTDs / schemas / XInclude). Paths
+ * are read via portable NIO {@link Files}.
+ */
+public final class PSPageXmlParser {
+
+  /** Velocity {@code #region("id" …)} macro — first arg is the region / slot id. */
+  private static final Pattern REGION_MACRO =
+      Pattern.compile("#region\\(\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Markup container that often wraps a region hole: {@code id="regionId" class="…"}. Captures the
+   * class attribute for layout/style hints (region-slot mapping / ADR-003 direction).
+   */
+  private static final Pattern ID_CLASS =
+      Pattern.compile(
+          "id\\s*=\\s*\"([^\"]+)\"\\s+class\\s*=\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern CLASS_ID =
+      Pattern.compile(
+          "class\\s*=\\s*\"([^\"]+)\"\\s+id\\s*=\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE);
+
+  private PSPageXmlParser() {
+    // utility
+  }
+
+  /**
+   * Parse a {@code *.templateDef} file as UTF-8.
+   *
+   * @param path non-null path
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlModel parse(Path path) throws PSPageXmlException, IOException {
+    Objects.requireNonNull(path, "path");
+    String xml = Files.readString(path, StandardCharsets.UTF_8);
+    PSPageXmlModel model = parse(xml);
+    Path fileName = path.getFileName();
+    if (fileName != null) {
+      model.setSourceFileName(fileName.toString());
+    }
+    return model;
+  }
+
+  /**
+   * Parse assembly-template XML from a string.
+   *
+   * @param xml non-null document text
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   */
+  public static PSPageXmlModel parse(String xml) throws PSPageXmlException {
+    Objects.requireNonNull(xml, "xml");
+    if (xml.isBlank()) {
+      throw new PSPageXmlException("Page templateDef XML is empty");
+    }
+    try {
+      Document doc = parseDocument(new InputSource(new StringReader(xml)));
+      return fromDocument(doc, null);
+    } catch (PSPageXmlException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSPageXmlException("Failed to parse Page templateDef XML: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Parse from a reader.
+   *
+   * @param reader non-null reader
+   * @param sourceFileName optional file name for stem derivation
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlModel parse(Reader reader, String sourceFileName)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(reader, "reader");
+    try {
+      Document doc = parseDocument(new InputSource(reader));
+      return fromDocument(doc, sourceFileName);
+    } catch (PSPageXmlException e) {
+      throw e;
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSPageXmlException("Failed to parse Page templateDef XML: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Parse from an input stream.
+   *
+   * @param in non-null stream
+   * @param sourceFileName optional file name for stem derivation
+   * @return parsed model
+   * @throws PSPageXmlException on parse failure
+   * @throws IOException on I/O failure
+   */
+  public static PSPageXmlModel parse(InputStream in, String sourceFileName)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(in, "in");
+    try {
+      Document doc = parseDocument(new InputSource(in));
+      return fromDocument(doc, sourceFileName);
+    } catch (PSPageXmlException e) {
+      throw e;
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSPageXmlException("Failed to parse Page templateDef XML: " + e.getMessage(), e);
+    }
+  }
+
+  private static Document parseDocument(InputSource source)
+      throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setExpandEntityReferences(false);
+    factory.setXIncludeAware(false);
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    return factory.newDocumentBuilder().parse(source);
+  }
+
+  private static PSPageXmlModel fromDocument(Document doc, String sourceFileName)
+      throws PSPageXmlException {
+    Element root = doc.getDocumentElement();
+    if (root == null || !"assembly-template".equals(root.getTagName())) {
+      throw new PSPageXmlException(
+          "Expected root element <assembly-template>, found: "
+              + (root == null ? "null" : root.getTagName()));
+    }
+
+    PSPageXmlModel model = new PSPageXmlModel();
+    if (sourceFileName != null && !sourceFileName.isBlank()) {
+      model.setSourceFileName(sourceFileName);
+    }
+
+    model.setName(childText(root, "name"));
+    model.setLabel(childText(root, "label"));
+    model.setDescription(childText(root, "description"));
+    model.setGuid(childText(root, "guid"));
+    model.setAssembler(childText(root, "assembler"));
+    model.setOutputFormat(childText(root, "output-format"));
+    model.setTemplateType(childText(root, "template-type"));
+    model.setMimeType(childText(root, "mime-type"));
+    model.setCharset(childText(root, "charset"));
+    model.setActiveAssemblyType(childText(root, "active-assembly-type"));
+
+    Element templateEl = firstChildElement(root, "template");
+    String body = templateEl != null ? normalizeBody(textContent(templateEl)) : null;
+    model.setTemplateBody(body);
+
+    List<PSPageXmlModel.Binding> bindings = new ArrayList<>();
+    Element bindingsEl = firstChildElement(root, "bindings");
+    if (bindingsEl != null) {
+      for (Element b : childElements(bindingsEl, "binding")) {
+        PSPageXmlModel.Binding binding = new PSPageXmlModel.Binding();
+        // Common shapes: <binding variable="x" expression="…"/> or nested <variable>/<expression>
+        binding.setVariable(firstNonBlank(attr(b, "variable"), attr(b, "name"), childText(b, "variable")));
+        binding.setExpression(
+            firstNonBlank(attr(b, "expression"), attr(b, "value"), childText(b, "expression")));
+        if (binding.getVariable() != null && !binding.getVariable().isBlank()) {
+          bindings.add(binding);
+        }
+      }
+    }
+    model.setBindings(bindings);
+
+    model.setRegionHoles(extractRegionHoles(body));
+    return model;
+  }
+
+  /**
+   * Discover {@code #region} holes and attach CSS class / layout hints from matching markup {@code
+   * id} containers when present.
+   */
+  static List<PSPageXmlModel.RegionHole> extractRegionHoles(String templateBody) {
+    List<PSPageXmlModel.RegionHole> holes = new ArrayList<>();
+    if (templateBody == null || templateBody.isBlank()) {
+      return holes;
+    }
+
+    Map<String, String> idToClass = new LinkedHashMap<>();
+    Matcher idClass = ID_CLASS.matcher(templateBody);
+    while (idClass.find()) {
+      idToClass.putIfAbsent(idClass.group(1), idClass.group(2));
+    }
+    Matcher classId = CLASS_ID.matcher(templateBody);
+    while (classId.find()) {
+      idToClass.putIfAbsent(classId.group(2), classId.group(1));
+    }
+
+    Set<String> seen = new LinkedHashSet<>();
+    Matcher region = REGION_MACRO.matcher(templateBody);
+    while (region.find()) {
+      String id = region.group(1).trim();
+      if (id.isEmpty() || !seen.add(id)) {
+        continue;
+      }
+      PSPageXmlModel.RegionHole hole = new PSPageXmlModel.RegionHole();
+      hole.setRegionId(id);
+      String css = idToClass.get(id);
+      hole.setCssClass(css);
+      applyClassHints(hole, css);
+      holes.add(hole);
+    }
+    return holes;
+  }
+
+  /**
+   * Map CM1 region CSS class tokens onto layout / style hint maps (ADR-003 direction).
+   *
+   * <ul>
+   *   <li>{@code perc-vertical} / {@code perc-horizontal} → {@code layout.orientation}
+   *   <li>{@code vspan_N} / {@code hspan_N} → layout span hints
+   *   <li>full class string → {@code styles.rootclass}
+   * </ul>
+   */
+  static void applyClassHints(PSPageXmlModel.RegionHole hole, String cssClass) {
+    Map<String, Object> layout = new LinkedHashMap<>();
+    Map<String, Object> styles = new LinkedHashMap<>();
+    if (cssClass != null && !cssClass.isBlank()) {
+      styles.put("rootclass", cssClass.trim());
+      for (String token : cssClass.trim().split("\\s+")) {
+        if (token.isEmpty()) {
+          continue;
+        }
+        String t = token.toLowerCase(Locale.ROOT);
+        if ("perc-vertical".equals(t)) {
+          layout.put("orientation", "vertical");
+        } else if ("perc-horizontal".equals(t)) {
+          layout.put("orientation", "horizontal");
+        } else if (t.startsWith("vspan_")) {
+          layout.put("vspan", token.substring("vspan_".length()));
+        } else if (t.startsWith("hspan_")) {
+          layout.put("hspan", token.substring("hspan_".length()));
+        }
+      }
+    }
+    hole.setLayoutHints(layout);
+    hole.setStyleHints(styles);
+  }
+
+  /**
+   * Normalize body text for cross-platform golden parity: CRLF/CR → LF, strip leading/trailing
+   * whitespace.
+   */
+  static String normalizeBody(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String s = raw.replace("\r\n", "\n").replace('\r', '\n');
+    return s.stripLeading().stripTrailing();
+  }
+
+  private static Element firstChildElement(Element parent, String name) {
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE && name.equals(n.getNodeName())) {
+        return (Element) n;
+      }
+    }
+    return null;
+  }
+
+  private static List<Element> childElements(Element parent, String name) {
+    List<Element> out = new ArrayList<>();
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE && name.equals(n.getNodeName())) {
+        out.add((Element) n);
+      }
+    }
+    return out;
+  }
+
+  private static String childText(Element parent, String name) {
+    Element el = firstChildElement(parent, name);
+    if (el == null) {
+      return null;
+    }
+    String t = textContent(el);
+    if (t == null) {
+      return null;
+    }
+    String trimmed = t.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private static String attr(Element el, String name) {
+    if (!el.hasAttribute(name)) {
+      return null;
+    }
+    String v = el.getAttribute(name);
+    return v.isEmpty() ? null : v;
+  }
+
+  private static String firstNonBlank(String... values) {
+    if (values == null) {
+      return null;
+    }
+    for (String v : values) {
+      if (v != null && !v.isBlank()) {
+        return v.trim();
+      }
+    }
+    return null;
+  }
+
+  private static String textContent(Element el) {
+    StringBuilder sb = new StringBuilder();
+    NodeList children = el.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      short type = n.getNodeType();
+      if (type == Node.TEXT_NODE || type == Node.CDATA_SECTION_NODE) {
+        sb.append(n.getNodeValue());
+      }
+    }
+    if (sb.length() == 0) {
+      return el.getTextContent();
+    }
+    return sb.toString();
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -217,6 +217,9 @@ public final class PSWidgetXmlCompiler {
               ? declared.getType().trim().toLowerCase(Locale.ROOT)
               : guessResourceType(packageRelative);
       res.setType(type);
+      if (declared.getPlacement() != null && !declared.getPlacement().isBlank()) {
+        res.setPlacement(declared.getPlacement().trim());
+      }
       resources.add(res);
     }
     manifest.setResources(resources);

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -36,11 +36,13 @@ import java.util.regex.Pattern;
 
 /**
  * Compiles legacy Widget definition XML into a modern {@link PSComponentPackageManifest} plus
- * template source artifacts (Phase 3 / ADR-004 / issue #2751).
+ * template source artifacts (Phase 3 / ADR-004 / issues #2751, #2772).
  *
- * <p><strong>Scope:</strong> simple / baseWidgets-shaped widgets (JEXL code + Velocity content +
- * optional asset content type + UserPref/CssPref). High-traffic packages (nav, blog, lists) remain
- * residual work; see {@code docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
+ * <p><strong>Scope:</strong> baseWidgets-shaped widgets plus high-traffic product packages (title,
+ * lists, nav chrome, file, image): JEXL code + Velocity content + optional asset content type +
+ * UserPref/CssPref + {@code <Resource>} CSS/JS refs. Remaining residual packages (blog, calendar,
+ * directory, social, forms, auto-lists, …) are tracked in {@code
+ * docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
  *
  * <p>Assembler mapping: {@code Content type="velocity"} → {@code velocityAssembler}; {@code html}
  * → {@code htmlAssembler}; {@code markdown} → {@code markdownAssembler}. Code language is always
@@ -153,27 +155,34 @@ public final class PSWidgetXmlCompiler {
     templates.add(template);
     manifest.setTemplates(templates);
 
-    // Default slot for the asset content type (simple widgets).
+    // Default slot: asset content type when present; chrome/logic widgets (nav) still get a styles
+    // slot when CssPref is declared so ADR-003 layout/styles has a home without inventing a CT.
+    Map<String, Object> styles = cssPrefStyles(model);
+    Map<String, Object> layout = layoutFromUserPrefs(model);
     if (ctName != null && !ctName.isBlank()) {
       PSComponentPackageManifest.SlotRef slot = new PSComponentPackageManifest.SlotRef();
       slot.setName(stem + "Content");
       List<String> allowed = new ArrayList<>();
       allowed.add(ctName);
       slot.setAllowedContentTypes(allowed);
-      // CssPrefs that look like class names land in slot styles (ADR-003 direction).
-      Map<String, Object> styles = new LinkedHashMap<>();
-      for (PSWidgetXmlModel.CssPref css : model.getCssPrefs()) {
-        if (css != null && css.getName() != null && !css.getName().isBlank()) {
-          styles.put(css.getName(), css.getDefaultValue() != null ? css.getDefaultValue() : "");
-        }
-      }
       slot.setStyles(styles);
+      slot.setLayout(layout);
+      List<PSComponentPackageManifest.SlotRef> slots = new ArrayList<>();
+      slots.add(slot);
+      manifest.setSlots(slots);
+    } else if (!styles.isEmpty() || !layout.isEmpty()) {
+      PSComponentPackageManifest.SlotRef slot = new PSComponentPackageManifest.SlotRef();
+      slot.setName(stem + "Chrome");
+      slot.setAllowedContentTypes(new ArrayList<>());
+      slot.setStyles(styles);
+      slot.setLayout(layout);
       List<PSComponentPackageManifest.SlotRef> slots = new ArrayList<>();
       slots.add(slot);
       manifest.setSlots(slots);
     }
 
-    // Resources: thumbnail as installable image when present.
+    // Resources: thumbnail + <Resource href=…> (CSS/JS) declared on high-traffic widgets.
+    List<PSComponentPackageManifest.ResourceRef> resources = new ArrayList<>();
     if (packageRelativeThumbnail != null) {
       PSComponentPackageManifest.ResourceRef res = new PSComponentPackageManifest.ResourceRef();
       // Package-local staging path for the resource (URL-style separators).
@@ -181,13 +190,36 @@ public final class PSWidgetXmlCompiler {
       res.setPath(localPath);
       res.setTarget(packageRelativeThumbnail);
       res.setType(guessResourceType(packageRelativeThumbnail));
-      List<PSComponentPackageManifest.ResourceRef> resources = new ArrayList<>();
       resources.add(res);
-      manifest.setResources(resources);
       // Point catalog at the package-local staging path (validator prefers relative refs).
       catalog.setThumbnail(localPath);
       catalog.setIcon(localPath);
     }
+    for (PSWidgetXmlModel.Resource declared : model.getResources()) {
+      if (declared == null) {
+        continue;
+      }
+      String packageRelative = toPackageRelativePath(declared.getHref());
+      if (packageRelative == null) {
+        continue;
+      }
+      PSComponentPackageManifest.ResourceRef res = new PSComponentPackageManifest.ResourceRef();
+      final String candidatePath = "resources/" + fileNameOf(packageRelative);
+      // Avoid duplicate path keys when thumbnail and Resource share a file name (rare).
+      final String localPath =
+          resources.stream().anyMatch(r -> candidatePath.equals(r.getPath()))
+              ? "resources/" + packageRelative.replace('/', '_')
+              : candidatePath;
+      res.setPath(localPath);
+      res.setTarget(packageRelative);
+      String type =
+          declared.getType() != null && !declared.getType().isBlank()
+              ? declared.getType().trim().toLowerCase(Locale.ROOT)
+              : guessResourceType(packageRelative);
+      res.setType(type);
+      resources.add(res);
+    }
+    manifest.setResources(resources);
 
     // Transitional UserPref / CssPref mirrors.
     List<PSComponentPackageManifest.UserPreference> userPrefs = new ArrayList<>();
@@ -353,6 +385,35 @@ public final class PSWidgetXmlCompiler {
     full.setExpression(normalized);
     bindings.add(full);
     return bindings;
+  }
+
+  /** CssPrefs that look like class names land in slot styles (ADR-003 direction). */
+  static Map<String, Object> cssPrefStyles(PSWidgetXmlModel model) {
+    Map<String, Object> styles = new LinkedHashMap<>();
+    for (PSWidgetXmlModel.CssPref css : model.getCssPrefs()) {
+      if (css != null && css.getName() != null && !css.getName().isBlank()) {
+        styles.put(css.getName(), css.getDefaultValue() != null ? css.getDefaultValue() : "");
+      }
+    }
+    return styles;
+  }
+
+  /**
+   * Map layout-ish UserPrefs ({@code layout}, {@code maxlength}) into the slot {@code layout} map
+   * (region-slot mapping guidance for list widgets).
+   */
+  static Map<String, Object> layoutFromUserPrefs(PSWidgetXmlModel model) {
+    Map<String, Object> layout = new LinkedHashMap<>();
+    for (PSWidgetXmlModel.UserPref up : model.getUserPrefs()) {
+      if (up == null || up.getName() == null || up.getName().isBlank()) {
+        continue;
+      }
+      String name = up.getName().trim();
+      if ("layout".equalsIgnoreCase(name) || "maxlength".equalsIgnoreCase(name)) {
+        layout.put(name, up.getDefaultValue() != null ? up.getDefaultValue() : "");
+      }
+    }
+    return layout;
   }
 
   static String mapAssembler(String contentType) {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlModel.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlModel.java
@@ -47,6 +47,7 @@ public final class PSWidgetXmlModel {
   private String contentBody;
   private List<UserPref> userPrefs = new ArrayList<>();
   private List<CssPref> cssPrefs = new ArrayList<>();
+  private List<Resource> resources = new ArrayList<>();
 
   public String getSourceFileName() {
     return sourceFileName;
@@ -195,6 +196,18 @@ public final class PSWidgetXmlModel {
   }
 
   /**
+   * Parsed {@code <Resource href="..." type="..." placement="..."/>} entries (CSS/JS/etc. declared
+   * on the widget definition). High-traffic widgets (lists, nav, image) commonly declare these.
+   */
+  public List<Resource> getResources() {
+    return resources;
+  }
+
+  public void setResources(List<Resource> resources) {
+    this.resources = resources != null ? resources : new ArrayList<>();
+  }
+
+  /**
    * Widget stem derived from the source file name (e.g. {@code percSimpleText} from {@code
    * percSimpleText.xml}).
    */
@@ -238,7 +251,8 @@ public final class PSWidgetXmlModel {
         && Objects.equals(contentType, that.contentType)
         && Objects.equals(contentBody, that.contentBody)
         && Objects.equals(userPrefs, that.userPrefs)
-        && Objects.equals(cssPrefs, that.cssPrefs);
+        && Objects.equals(cssPrefs, that.cssPrefs)
+        && Objects.equals(resources, that.resources);
   }
 
   @Override
@@ -261,7 +275,8 @@ public final class PSWidgetXmlModel {
         contentType,
         contentBody,
         userPrefs,
-        cssPrefs);
+        cssPrefs,
+        resources);
   }
 
   /** Parsed {@code <UserPref>} element. */
@@ -437,6 +452,57 @@ public final class PSWidgetXmlModel {
     @Override
     public int hashCode() {
       return Objects.hash(name, displayName, datatype, defaultValue);
+    }
+  }
+
+  /**
+   * Parsed {@code <Resource>} element (static CSS/JS/etc. referenced from the widget definition).
+   */
+  public static final class Resource {
+    private String href;
+    private String type;
+    private String placement;
+
+    public String getHref() {
+      return href;
+    }
+
+    public void setHref(String href) {
+      this.href = href;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getPlacement() {
+      return placement;
+    }
+
+    public void setPlacement(String placement) {
+      this.placement = placement;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Resource that)) {
+        return false;
+      }
+      return Objects.equals(href, that.href)
+          && Objects.equals(type, that.type)
+          && Objects.equals(placement, that.placement);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(href, type, placement);
     }
   }
 }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -31,14 +31,26 @@ import java.util.Objects;
  * Compiles all Widget definition XML files found in a legacy product package source directory.
  *
  * <p>Looks under {@code sys__UserDependency--rxconfig/Widgets/*.xml} (product packaging layout used
- * by {@code modules/perc-packages}). Suitable for the baseWidgets subset first; residual packages
- * are tracked in the widget XML inventory.
+ * by {@code modules/perc-packages}). Covers baseWidgets and high-traffic product packages (#2772);
+ * residual packages are tracked in the widget XML inventory.
  */
 public final class PSWidgetXmlPackageCompiler {
 
   /** Legacy staging folder name for user-dependency config inside a package source tree. */
   public static final String WIDGETS_RELATIVE =
       "sys__UserDependency--rxconfig/Widgets";
+
+  /**
+   * Named high-traffic product package directory names under {@code Packages/} covered by the
+   * residual batch in issue #2772 (beyond {@code perc.baseWidgets}).
+   */
+  public static final List<String> HIGH_TRAFFIC_PACKAGE_DIRS =
+      List.of(
+          "perc.widget.title",
+          "perc.widgets.lists",
+          "perc.widgets.nav",
+          "perc.FileAssetWidget",
+          "perc.widgets.image");
 
   private PSWidgetXmlPackageCompiler() {
     // utility
@@ -89,6 +101,33 @@ public final class PSWidgetXmlPackageCompiler {
       results.add(PSWidgetXmlCompiler.compile(widgetXml, ctx));
     }
     return results;
+  }
+
+  /**
+   * Compile every high-traffic product package under a {@code Packages/} root directory.
+   *
+   * @param packagesRoot non-null directory containing package folders (e.g. {@code
+   *     src/main/resources/Packages})
+   * @return compile results sorted by package then widget stem
+   * @throws PSWidgetXmlException on parse/compile failure
+   * @throws IOException on I/O failure
+   */
+  public static List<PSWidgetXmlCompileResult> compileHighTrafficPackages(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packagesRoot, "packagesRoot");
+    if (!Files.isDirectory(packagesRoot)) {
+      throw new PSWidgetXmlException("Packages root does not exist: " + packagesRoot);
+    }
+    List<PSWidgetXmlCompileResult> all = new ArrayList<>();
+    for (String dirName : HIGH_TRAFFIC_PACKAGE_DIRS) {
+      Path packageDir = packagesRoot.resolve(dirName);
+      if (!Files.isDirectory(packageDir)) {
+        throw new PSWidgetXmlException(
+            "High-traffic package directory missing under Packages root: " + dirName);
+      }
+      all.addAll(compilePackage(packageDir));
+    }
+    return all;
   }
 
   /**

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -105,11 +105,13 @@ public final class PSWidgetXmlPackageCompiler {
 
   /**
    * Compile every high-traffic product package under a {@code Packages/} root directory.
+   * Missing package directories under the root are skipped (soft) so partial checkouts can
+   * still exercise available packages.
    *
    * @param packagesRoot non-null directory containing package folders (e.g. {@code
    *     src/main/resources/Packages})
-   * @return compile results sorted by package then widget stem
-   * @throws PSWidgetXmlException on parse/compile failure
+   * @return compile results sorted by package then widget stem (may be empty if none present)
+   * @throws PSWidgetXmlException on parse/compile failure of a present package
    * @throws IOException on I/O failure
    */
   public static List<PSWidgetXmlCompileResult> compileHighTrafficPackages(Path packagesRoot)
@@ -121,9 +123,10 @@ public final class PSWidgetXmlPackageCompiler {
     List<PSWidgetXmlCompileResult> all = new ArrayList<>();
     for (String dirName : HIGH_TRAFFIC_PACKAGE_DIRS) {
       Path packageDir = packagesRoot.resolve(dirName);
+      // Soft-skip missing package dirs so partial checkouts / CI fixtures still exercise
+      // the packages that are present (matches baseWidgets soft-skip tests).
       if (!Files.isDirectory(packageDir)) {
-        throw new PSWidgetXmlException(
-            "High-traffic package directory missing under Packages root: " + dirName);
+        continue;
       }
       all.addAll(compilePackage(packageDir));
     }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlParser.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlParser.java
@@ -195,6 +195,12 @@ public final class PSWidgetXmlParser {
     }
     model.setCssPrefs(cssPrefs);
 
+    List<PSWidgetXmlModel.Resource> resources = new ArrayList<>();
+    for (Element el : childElements(root, "Resource")) {
+      resources.add(parseResource(el));
+    }
+    model.setResources(resources);
+
     Element code = firstChildElement(root, "Code");
     if (code != null) {
       model.setCodeType(attr(code, "type"));
@@ -236,6 +242,14 @@ public final class PSWidgetXmlParser {
     pref.setDatatype(attr(el, "datatype"));
     pref.setDefaultValue(attr(el, "default_value"));
     return pref;
+  }
+
+  private static PSWidgetXmlModel.Resource parseResource(Element el) {
+    PSWidgetXmlModel.Resource resource = new PSWidgetXmlModel.Resource();
+    resource.setHref(attr(el, "href"));
+    resource.setType(attr(el, "type"));
+    resource.setPlacement(attr(el, "placement"));
+    return resource;
   }
 
   private static Element firstChildElement(Element parent, String name) {

--- a/modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json
+++ b/modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json
@@ -1,0 +1,198 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.gadgetCatalog",
+  "name": "Product Gadget Catalog",
+  "version": "8.2.0",
+  "description": "Modern product gadget catalog compiled from GadgetRegistry.xml (ADR-004 / #2771)",
+  "gadgets": [
+    {
+      "id": "PercAssetStatusGadget",
+      "name": "Assets By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercAssetStatusGadget",
+      "legacyDefinitionFile": "PercAssetStatusGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercAssetStatusGadget/component-package.json"
+    },
+    {
+      "id": "PercBlogsGadget",
+      "name": "Blogs",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercBlogsGadget",
+      "legacyDefinitionFile": "PercBlogsGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercBlogsGadget/component-package.json"
+    },
+    {
+      "id": "perc_bulk_file_upload_gadget",
+      "name": "Bulk Upload",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_bulk_file_upload_gadget",
+      "legacyDefinitionFile": "perc_bulk_file_upload_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_bulk_file_upload_gadget/component-package.json"
+    },
+    {
+      "id": "perc_comments_gadget",
+      "name": "Comments",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_comments_gadget",
+      "legacyDefinitionFile": "perc_comments_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_comments_gadget/component-package.json"
+    },
+    {
+      "id": "perc_cookie_consent_gadget",
+      "name": "Cookie Consent",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_cookie_consent_gadget",
+      "legacyDefinitionFile": "perc_cookie_consent_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_cookie_consent_gadget/component-package.json"
+    },
+    {
+      "id": "PercFormTrackerGadget",
+      "name": "Forms Tracker",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercFormTrackerGadget",
+      "legacyDefinitionFile": "PercFormTrackerGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercFormTrackerGadget/component-package.json"
+    },
+    {
+      "id": "PercGlobalVariablesGadget",
+      "name": "Global Variables",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercGlobalVariablesGadget",
+      "legacyDefinitionFile": "PercGlobalVariablesGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercGlobalVariablesGadget/component-package.json"
+    },
+    {
+      "id": "perc_google_setup_gadget",
+      "name": "Google Setup",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_google_setup_gadget",
+      "legacyDefinitionFile": "perc_google_setup_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_google_setup_gadget/component-package.json"
+    },
+    {
+      "id": "perc_iframe_gadget",
+      "name": "Iframe",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_iframe_gadget",
+      "legacyDefinitionFile": "perc_iframe_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_iframe_gadget/component-package.json"
+    },
+    {
+      "id": "perc_workflow_status_gadget",
+      "name": "Pages By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_workflow_status_gadget",
+      "legacyDefinitionFile": "perc_workflow_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_workflow_status_gadget/component-package.json"
+    },
+    {
+      "id": "PercProcessorMonitorGadget",
+      "name": "Process Monitor",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercProcessorMonitorGadget",
+      "legacyDefinitionFile": "PercProcessorMonitorGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercProcessorMonitorGadget/component-package.json"
+    },
+    {
+      "id": "perc_reports_gadget",
+      "name": "Reports",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_reports_gadget",
+      "legacyDefinitionFile": "perc_reports_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_reports_gadget/component-package.json"
+    },
+    {
+      "id": "perc_seo_gadget",
+      "name": "SEO Audit",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_seo_gadget",
+      "legacyDefinitionFile": "perc_seo_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_seo_gadget/component-package.json"
+    },
+    {
+      "id": "PercSiteFrameworkGadget",
+      "name": "Sitewide Framework",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercSiteFrameworkGadget",
+      "legacyDefinitionFile": "perc_sitewide_framework_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercSiteFrameworkGadget/component-package.json"
+    },
+    {
+      "id": "perc_traffic_gadget",
+      "name": "Traffic",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_traffic_gadget",
+      "legacyDefinitionFile": "perc_traffic_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_traffic_gadget/component-package.json"
+    },
+    {
+      "id": "cm1_welcome_gadget",
+      "name": "Welcome",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/cm1_welcome_gadget",
+      "legacyDefinitionFile": "perc_welcome_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/cm1_welcome_gadget/component-package.json"
+    },
+    {
+      "id": "perc_effectiveness_gadget",
+      "name": "What's Working",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_effectiveness_gadget",
+      "legacyDefinitionFile": "perc_effectiveness_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_effectiveness_gadget/component-package.json"
+    },
+    {
+      "id": "perc_activity_gadget",
+      "name": "Activity",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_activity_gadget",
+      "legacyDefinitionFile": "perc_activity_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_activity_gadget/component-package.json"
+    },
+    {
+      "id": "perc_site_improve_gadget",
+      "name": "Siteimprove",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_site_improve_gadget",
+      "legacyDefinitionFile": "perc_site_improve_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_site_improve_gadget/component-package.json"
+    },
+    {
+      "id": "perc_membership_gadget",
+      "name": "Membership",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_membership_gadget",
+      "legacyDefinitionFile": "perc_membership_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_membership_gadget/component-package.json"
+    },
+    {
+      "id": "PercWidgetConfigGadget",
+      "name": "Widget Configuration",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/PercWidgetConfigGadget",
+      "legacyDefinitionFile": "PercWidgetConfigGadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/PercWidgetConfigGadget/component-package.json"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/gadgetxml/PSGadgetRegistryCompilerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.gadgetxml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit + golden parity tests for GadgetRegistry.xml → modern gadget catalog / component packages
+ * (#2771 / ADR-004 Phase 3).
+ */
+class PSGadgetRegistryCompilerTest {
+
+  private static final String FIXTURE_REGISTRY = "/gadgetxml/GadgetRegistry.xml";
+  private static final String GOLDEN_WELCOME =
+      "/gadgetxml/golden/cm1_welcome_gadget.component-package.json";
+  private static final String GOLDEN_CATALOG = "/gadgetxml/golden/gadget-catalog.json";
+  private static final String PRODUCT_VERSION = "8.2.0";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parseProductRegistry_populatesGroupsAndEntries() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+
+    assertEquals(21, model.getGadgets().size(), "product registry has 21 gadgets");
+    assertEquals("Percussion", model.toNameGroupMap().get("Welcome"));
+    assertEquals("Deprecated", model.toNameGroupMap().get("Activity"));
+    assertFalse(model.toNameGroupMap().containsKey("Redirect Management"));
+
+    PSGadgetRegistryEntry welcome = model.findByName("Welcome");
+    assertNotNull(welcome);
+    assertEquals("cm1_welcome_gadget", welcome.gadgetId());
+    assertEquals("/cm/gadgets/repository/cm1_welcome_gadget", welcome.getBaseUri());
+    assertEquals("perc_welcome_gadget.xml", welcome.getLegacyDefinitionFile());
+    assertFalse(welcome.isDeprecated());
+
+    PSGadgetRegistryEntry activity = model.findById("perc_activity_gadget");
+    assertNotNull(activity);
+    assertTrue(activity.isDeprecated());
+  }
+
+  @Test
+  void compileWelcome_matchesGoldenManifest() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+    PSGadgetRegistryCompileResult result =
+        PSGadgetRegistryCompiler.compile(model, PRODUCT_VERSION);
+
+    PSComponentPackageManifest welcome = result.getGadgetPackage("cm1_welcome_gadget");
+    assertNotNull(welcome, "Welcome gadget package must be present");
+    PSComponentPackageManifestValidator.validate(welcome);
+
+    String expectedJson = readClasspath(GOLDEN_WELCOME);
+    PSComponentPackageManifest golden = PSComponentPackageManifestIo.parse(expectedJson);
+    PSComponentPackageManifest reparsed =
+        PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(welcome));
+
+    assertEquals(golden.getSchemaVersion(), reparsed.getSchemaVersion());
+    assertEquals(golden.getId(), reparsed.getId());
+    assertEquals(golden.getName(), reparsed.getName());
+    assertEquals(golden.getVersion(), reparsed.getVersion());
+    assertEquals(golden.getDescription(), reparsed.getDescription());
+    assertEquals(golden.getPublisher(), reparsed.getPublisher());
+    assertEquals(golden.getCatalog(), reparsed.getCatalog());
+    assertEquals(golden.getResources(), reparsed.getResources());
+    assertEquals(
+        PSComponentPackageManifestIo.parse(expectedJson),
+        reparsed,
+        "compiled Welcome gadget package must equal golden fixture");
+  }
+
+  @Test
+  void compileProductRegistry_matchesGoldenCatalog() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+    PSGadgetRegistryCompileResult result =
+        PSGadgetRegistryCompiler.compile(model, PRODUCT_VERSION);
+
+    PSGadgetCatalog catalog = result.getCatalog();
+    assertEquals(21, catalog.getGadgets().size());
+    assertEquals(PRODUCT_VERSION, catalog.getVersion());
+    assertEquals("perc.gadgetCatalog", catalog.getId());
+
+    String expectedJson = readClasspath(GOLDEN_CATALOG);
+    PSGadgetCatalog golden = PSGadgetCatalogIo.parse(expectedJson);
+    PSGadgetCatalog reparsed = PSGadgetCatalogIo.parse(PSGadgetCatalogIo.toJson(catalog));
+    assertEquals(golden, reparsed, "compiled gadget catalog must equal golden fixture");
+
+    // All packages validate; deprecated ones hide from palette.
+    for (Map.Entry<String, PSComponentPackageManifest> e : result.getGadgetPackages().entrySet()) {
+      PSComponentPackageManifestValidator.validate(e.getValue());
+      assertEquals(
+          PSGadgetRegistryCompiler.CATALOG_KIND_GADGET, e.getValue().getCatalog().getKind());
+    }
+    assertEquals(Boolean.FALSE, result.getGadgetPackage("perc_activity_gadget").getCatalog().getPaletteVisible());
+    assertEquals(Boolean.TRUE, result.getGadgetPackage("cm1_welcome_gadget").getCatalog().getPaletteVisible());
+  }
+
+  @Test
+  void writeArtifacts_roundTripsCatalogAndWelcomePackage() throws Exception {
+    PSGadgetRegistryModel model = parseClasspath(FIXTURE_REGISTRY, "GadgetRegistry.xml");
+    PSGadgetRegistryCompileResult result =
+        PSGadgetRegistryCompiler.compile(model, PRODUCT_VERSION);
+
+    Path out = tempDir.resolve("gadget-out");
+    PSGadgetRegistryCompiler.writeArtifacts(result, out);
+
+    Path catalogPath = out.resolve(PSGadgetCatalog.DEFAULT_CATALOG_FILE_NAME);
+    assertTrue(Files.isRegularFile(catalogPath));
+    PSGadgetCatalog loaded = PSGadgetCatalogIo.read(catalogPath);
+    assertEquals(21, loaded.getGadgets().size());
+
+    Path welcomeManifest =
+        out.resolve("gadgets")
+            .resolve("cm1_welcome_gadget")
+            .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    assertTrue(Files.isRegularFile(welcomeManifest));
+    PSComponentPackageManifest welcome = PSComponentPackageManifestIo.read(welcomeManifest);
+    PSComponentPackageManifestValidator.validate(welcome);
+    assertEquals("cm1_welcome_gadget", welcome.getId());
+
+    Path hostRef =
+        out.resolve("gadgets")
+            .resolve("cm1_welcome_gadget")
+            .resolve("resources")
+            .resolve("host-ref.txt");
+    assertTrue(Files.isRegularFile(hostRef));
+    String hostBody = normalizeNewlines(Files.readString(hostRef, StandardCharsets.UTF_8)).trim();
+    assertEquals("cm/gadgets/repository/cm1_welcome_gadget", hostBody);
+  }
+
+  @Test
+  void parseEmptyRegistry_throws() {
+    assertThrows(PSGadgetRegistryException.class, () -> PSGadgetRegistryParser.parse(""));
+    assertThrows(
+        PSGadgetRegistryException.class,
+        () -> PSGadgetRegistryParser.parse("<gadgets></gadgets>"));
+  }
+
+  @Test
+  void gadgetPackageWithoutTitle_failsValidation() {
+    PSComponentPackageManifest m = new PSComponentPackageManifest();
+    m.setSchemaVersion("1.0");
+    m.setId("bad-gadget");
+    m.setName("Bad");
+    m.setVersion("1.0.0");
+    PSComponentPackageManifest.Catalog cat = new PSComponentPackageManifest.Catalog();
+    cat.setKind("gadget");
+    // title missing
+    m.setCatalog(cat);
+    assertThrows(
+        Exception.class, () -> PSComponentPackageManifestValidator.validate(m));
+  }
+
+  private static PSGadgetRegistryModel parseClasspath(String resource, String sourceFileName)
+      throws Exception {
+    String xml = readClasspath(resource);
+    PSGadgetRegistryModel model = PSGadgetRegistryParser.parse(xml);
+    model.setSourceFileName(sourceFileName);
+    return model;
+  }
+
+  private static String readClasspath(String resource) throws Exception {
+    try (InputStream in = PSGadgetRegistryCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing classpath resource: " + resource);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlCompilerTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit + golden parity tests for Page {@code *.templateDef} → Component Package Manifest compiler
+ * (#2770 / parent #2630).
+ */
+class PSPageXmlCompilerTest {
+
+  private static final String FIXTURE_PLAIN = "/pagexml/perc.base.plain.templateDef";
+  private static final String FIXTURE_HEADER_FOOTER =
+      "/pagexml/perc.base.headerFooter.templateDef";
+  private static final String GOLDEN_PLAIN_MANIFEST =
+      "/pagexml/golden/perc.base.plain.component-package.json";
+  private static final String GOLDEN_PLAIN_TEMPLATE = "/pagexml/golden/perc.base.plain.vm";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parsePlain_populatesNameAssemblerRegionsAndBody() throws Exception {
+    PSPageXmlModel model = parseClasspath(FIXTURE_PLAIN, "perc.base.plain.templateDef");
+
+    assertEquals("perc.base.plain", model.getName());
+    assertEquals("Plain", model.getLabel());
+    assertEquals("Java/global/percussion/assembly/pageAssembler", model.getAssembler());
+    assertEquals("Page", model.getOutputFormat());
+    assertEquals("perc.base.plain", model.pageStem());
+    assertNotNull(model.getTemplateBody());
+    assertTrue(model.getTemplateBody().contains("#region(\"perc-content\""));
+    assertTrue(model.getTemplateBody().contains("<div id=\"perc-content\""));
+    assertEquals(1, model.getRegionHoles().size());
+    assertEquals("perc-content", model.getRegionHoles().get(0).getRegionId());
+    assertEquals("vertical", model.getRegionHoles().get(0).getLayoutHints().get("orientation"));
+    assertEquals(
+        "perc-region perc-vertical",
+        model.getRegionHoles().get(0).getStyleHints().get("rootclass"));
+  }
+
+  @Test
+  void parseHeaderFooter_threeRegionsInOrder() throws Exception {
+    PSPageXmlModel model =
+        parseClasspath(FIXTURE_HEADER_FOOTER, "perc.base.headerFooter.templateDef");
+
+    assertEquals("perc.base.headerFooter", model.getName());
+    List<String> ids =
+        model.getRegionHoles().stream()
+            .map(PSPageXmlModel.RegionHole::getRegionId)
+            .collect(Collectors.toList());
+    assertEquals(List.of("header", "content", "footer"), ids);
+  }
+
+  @Test
+  void compilePlain_matchesGoldenManifestAndTemplate() throws Exception {
+    PSPageXmlModel model = parseClasspath(FIXTURE_PLAIN, "perc.base.plain.templateDef");
+    PSPageXmlPackageContext ctx = baseTemplatesLikeContext();
+
+    PSPageXmlCompileResult result = PSPageXmlCompiler.compile(model, ctx);
+    PSComponentPackageManifest manifest = result.getManifest();
+
+    PSComponentPackageManifestValidator.validate(manifest);
+
+    String expectedJson = readClasspath(GOLDEN_PLAIN_MANIFEST);
+    PSComponentPackageManifest golden = PSComponentPackageManifestIo.parse(expectedJson);
+
+    assertEquals(golden.getSchemaVersion(), manifest.getSchemaVersion());
+    assertEquals(golden.getId(), manifest.getId());
+    assertEquals(golden.getName(), manifest.getName());
+    assertEquals(golden.getVersion(), manifest.getVersion());
+    assertEquals(golden.getDescription(), manifest.getDescription());
+    assertEquals(golden.getPublisher(), manifest.getPublisher());
+    assertEquals(golden.getCmsVersion(), manifest.getCmsVersion());
+    assertEquals(golden.getCatalog(), manifest.getCatalog());
+    assertEquals(golden.getTemplates().size(), manifest.getTemplates().size());
+    assertEquals(golden.getTemplates().get(0).getName(), manifest.getTemplates().get(0).getName());
+    assertEquals(
+        golden.getTemplates().get(0).getType(), manifest.getTemplates().get(0).getType());
+    assertEquals(
+        golden.getTemplates().get(0).getAssembler(),
+        manifest.getTemplates().get(0).getAssembler());
+    assertEquals(
+        golden.getTemplates().get(0).getSourceRef(),
+        manifest.getTemplates().get(0).getSourceRef());
+    assertEquals(golden.getSlots(), manifest.getSlots());
+
+    PSComponentPackageManifest reparsed =
+        PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(manifest));
+    assertEquals(
+        PSComponentPackageManifestIo.parse(expectedJson),
+        reparsed,
+        "compiled manifest must equal golden fixture");
+
+    String expectedTemplate = normalizeNewlines(readClasspath(GOLDEN_PLAIN_TEMPLATE));
+    String actualTemplate =
+        normalizeNewlines(result.getTextArtifacts().get("templates/perc.base.plain.vm"));
+    assertEquals(expectedTemplate, actualTemplate, "template source golden parity");
+  }
+
+  @Test
+  void compilePlain_writeArtifacts_roundTrips() throws Exception {
+    PSPageXmlModel model = parseClasspath(FIXTURE_PLAIN, "perc.base.plain.templateDef");
+    PSPageXmlCompileResult result = PSPageXmlCompiler.compile(model, baseTemplatesLikeContext());
+
+    Path out = tempDir.resolve("plain-out");
+    PSPageXmlCompiler.writeArtifacts(result, out);
+
+    Path manifestPath = out.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    assertTrue(Files.isRegularFile(manifestPath));
+    PSComponentPackageManifest loaded = PSComponentPackageManifestIo.read(manifestPath);
+    PSComponentPackageManifestValidator.validate(loaded);
+    assertEquals(result.getManifest().getId(), loaded.getId());
+
+    Path template = out.resolve("templates").resolve("perc.base.plain.vm");
+    assertTrue(Files.isRegularFile(template));
+    assertEquals(
+        normalizeNewlines(result.getTextArtifacts().get("templates/perc.base.plain.vm")),
+        normalizeNewlines(Files.readString(template, StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void compileBaseTemplatesPackage_allValidPageTemplates() throws Exception {
+    Path packageDir = locateBaseTemplatesPackage();
+    if (packageDir == null) {
+      System.err.println(
+          "WARN: perc.baseTemplates package sources not found; skipping package test");
+      return;
+    }
+
+    List<PSPageXmlCompileResult> results = PSPageXmlPackageCompiler.compilePackage(packageDir);
+    assertTrue(results.size() >= 20, "baseTemplates should ship many layout templates");
+
+    Map<String, PSPageXmlCompileResult> byId =
+        results.stream()
+            .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+    assertTrue(byId.containsKey("perc.base.plain"));
+    assertTrue(byId.containsKey("perc.base.headerFooter"));
+    assertTrue(byId.containsKey("perc.base.Box"));
+
+    for (PSPageXmlCompileResult r : results) {
+      PSComponentPackageManifestValidator.validate(r.getManifest());
+      assertEquals("1.1.5", r.getManifest().getVersion());
+      assertNotNull(r.getManifest().getPublisher());
+      assertEquals("page", r.getManifest().getCatalog().getKind());
+      assertEquals("page", r.getManifest().getTemplates().get(0).getType());
+      assertEquals("pageAssembler", r.getManifest().getTemplates().get(0).getAssembler());
+      assertFalse(r.getTextArtifacts().isEmpty());
+      assertFalse(r.getManifest().getSlots().isEmpty(), r.getManifest().getId());
+    }
+
+    PSPageXmlCompileResult plain = byId.get("perc.base.plain");
+    assertEquals(1, plain.getManifest().getSlots().size());
+    assertEquals("perc-content", plain.getManifest().getSlots().get(0).getName());
+
+    Path outRoot = tempDir.resolve("baseTemplates-out");
+    PSPageXmlPackageCompiler.writeAll(results, outRoot);
+    assertTrue(
+        Files.isRegularFile(
+            outRoot
+                .resolve("perc.base.plain")
+                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+  }
+
+  @Test
+  void parseEmptyXml_throws() {
+    assertThrows(PSPageXmlException.class, () -> PSPageXmlParser.parse("   "));
+  }
+
+  @Test
+  void parseNonAssemblyRoot_throws() {
+    assertThrows(PSPageXmlException.class, () -> PSPageXmlParser.parse("<Widget/>"));
+  }
+
+  @Test
+  void mapAssembler_extensionPathAndShortNames() {
+    assertEquals(
+        "pageAssembler",
+        PSPageXmlCompiler.mapAssembler("Java/global/percussion/assembly/pageAssembler"));
+    assertEquals(
+        "velocityAssembler",
+        PSPageXmlCompiler.mapAssembler("Java/global/percussion/assembly/velocityAssembler"));
+    assertEquals("htmlAssembler", PSPageXmlCompiler.mapAssembler("htmlAssembler"));
+  }
+
+  @Test
+  void mapTemplateType_outputFormat() {
+    assertEquals("page", PSPageXmlCompiler.mapTemplateType("Page", "pageAssembler"));
+    assertEquals("global", PSPageXmlCompiler.mapTemplateType("Global", "velocityAssembler"));
+    assertEquals("snippet", PSPageXmlCompiler.mapTemplateType("Snippet", "velocityAssembler"));
+  }
+
+  private static PSPageXmlPackageContext baseTemplatesLikeContext() {
+    PSPageXmlPackageContext ctx = new PSPageXmlPackageContext();
+    ctx.setPackageId("perc.baseTemplates");
+    ctx.setPackageName("perc.baseTemplates");
+    ctx.setVersion("1.1.5");
+    ctx.setDescription("Percussion base layout templates.");
+    ctx.setPublisherName("Percussion Software Inc.");
+    ctx.setPublisherUrl("http://www.percussion.com");
+    ctx.setCmsMin("1.0.0");
+    ctx.setCmsMax("9.0.0");
+    return ctx;
+  }
+
+  private static PSPageXmlModel parseClasspath(String resource, String fileName) throws Exception {
+    try (InputStream in = PSPageXmlCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return PSPageXmlParser.parse(in, fileName);
+    }
+  }
+
+  private static String readClasspath(String resource) throws Exception {
+    try (InputStream in = PSPageXmlCompilerTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  /**
+   * Locate product {@code perc.baseTemplates} sources relative to the module working directory
+   * (Maven surefire cwd = module root).
+   */
+  private static Path locateBaseTemplatesPackage() {
+    Path candidate =
+        Path.of("src", "main", "resources", "Packages", "perc.baseTemplates");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src")
+            .resolve("main")
+            .resolve("resources")
+            .resolve("Packages")
+            .resolve("perc.baseTemplates");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -395,11 +395,22 @@ class PSWidgetXmlCompilerTest {
 
     Path outRoot = tempDir.resolve("high-traffic-out");
     PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
-    assertTrue(
-        Files.isRegularFile(
-            outRoot
-                .resolve("percTitle")
-                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+    for (String stem :
+        List.of(
+            "percTitle",
+            "simplePageAutoList",
+            "simpleTextAutoList",
+            "percNavBar",
+            "percNavBreadcrumb",
+            "percFile",
+            "percImage")) {
+      assertTrue(
+          Files.isRegularFile(
+              outRoot
+                  .resolve(stem)
+                  .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)),
+          "writeAll missing manifest for " + stem);
+    }
   }
 
   private static PSWidgetXmlCompileResult assertGoldenParity(

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -36,7 +36,10 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-/** Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751). */
+/**
+ * Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751 baseWidgets,
+ * #2772 high-traffic residual batch).
+ */
 class PSWidgetXmlCompilerTest {
 
   private static final String FIXTURE_SIMPLE = "/widgetxml/percSimpleText.xml";
@@ -44,6 +47,23 @@ class PSWidgetXmlCompilerTest {
       "/widgetxml/golden/percSimpleText.component-package.json";
   private static final String GOLDEN_SIMPLE_TEMPLATE =
       "/widgetxml/golden/percSimpleTextSnippet.vm";
+
+  private static final String FIXTURE_TITLE = "/widgetxml/percTitle.xml";
+  private static final String GOLDEN_TITLE_MANIFEST =
+      "/widgetxml/golden/percTitle.component-package.json";
+  private static final String GOLDEN_TITLE_TEMPLATE = "/widgetxml/golden/percTitleSnippet.vm";
+
+  private static final String FIXTURE_LIST = "/widgetxml/simplePageAutoList.xml";
+  private static final String GOLDEN_LIST_MANIFEST =
+      "/widgetxml/golden/simplePageAutoList.component-package.json";
+  private static final String GOLDEN_LIST_TEMPLATE =
+      "/widgetxml/golden/simplePageAutoListSnippet.vm";
+
+  private static final String FIXTURE_BREADCRUMB = "/widgetxml/percNavBreadcrumb.xml";
+  private static final String GOLDEN_BREADCRUMB_MANIFEST =
+      "/widgetxml/golden/percNavBreadcrumb.component-package.json";
+  private static final String GOLDEN_BREADCRUMB_TEMPLATE =
+      "/widgetxml/golden/percNavBreadcrumbSnippet.vm";
 
   @TempDir Path tempDir;
 
@@ -241,6 +261,177 @@ class PSWidgetXmlCompilerTest {
     assertEquals("markdownAssembler", PSWidgetXmlCompiler.mapAssembler("markdown"));
   }
 
+  @Test
+  void parseTitle_userPrefEnumsAndCreateSharedAsset() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_TITLE, "percTitle.xml");
+    assertEquals("Title", model.getTitle());
+    assertEquals("percTitleAsset", model.getContentTypeName());
+    assertEquals(1, model.getUserPrefs().size());
+    assertEquals("wrapper", model.getUserPrefs().get(0).getName());
+    assertEquals("enum", model.getUserPrefs().get(0).getDatatype());
+    assertEquals(8, model.getUserPrefs().get(0).getEnumValues().size());
+    assertEquals(Boolean.FALSE, model.getCreateSharedAsset());
+    assertTrue(model.getResources().isEmpty());
+  }
+
+  @Test
+  void compileTitle_matchesGoldenManifestAndTemplate() throws Exception {
+    assertGoldenParity(
+        FIXTURE_TITLE,
+        "percTitle.xml",
+        "perc.widget.title",
+        GOLDEN_TITLE_MANIFEST,
+        GOLDEN_TITLE_TEMPLATE,
+        "templates/percTitleSnippet.vm");
+  }
+
+  @Test
+  void parseSimplePageAutoList_resourcesAndLayoutPrefs() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_LIST, "simplePageAutoList.xml");
+    assertEquals("Auto List", model.getTitle());
+    assertEquals(1, model.getResources().size());
+    assertEquals("/rx_resources/widgets/simpleList/css/style.css", model.getResources().get(0).getHref());
+    assertEquals("css", model.getResources().get(0).getType());
+    assertEquals("head", model.getResources().get(0).getPlacement());
+    assertTrue(model.getUserPrefs().stream().anyMatch(p -> "layout".equals(p.getName())));
+    assertTrue(model.getUserPrefs().stream().anyMatch(p -> "maxlength".equals(p.getName())));
+  }
+
+  @Test
+  void compileSimplePageAutoList_matchesGolden_andEmitsCssResource() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_LIST,
+            "simplePageAutoList.xml",
+            "perc.widgets.lists",
+            GOLDEN_LIST_MANIFEST,
+            GOLDEN_LIST_TEMPLATE,
+            "templates/simplePageAutoListSnippet.vm");
+    assertTrue(
+        result.getManifest().getResources().stream()
+            .anyMatch(r -> "css".equals(r.getType()) && r.getTarget().endsWith("style.css")),
+        "list widget must emit declared CSS Resource");
+    assertEquals(
+        "0",
+        String.valueOf(result.getManifest().getSlots().get(0).getLayout().get("maxlength")));
+  }
+
+  @Test
+  void parseNavBreadcrumb_chromeWidgetNoContentType_withResource() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_BREADCRUMB, "percNavBreadcrumb.xml");
+    assertEquals("Breadcrumb", model.getTitle());
+    assertTrue(
+        model.getContentTypeName() == null || model.getContentTypeName().isBlank(),
+        "nav breadcrumb is chrome (no asset CT)");
+    assertEquals(1, model.getResources().size());
+    assertEquals("css", model.getResources().get(0).getType());
+    assertFalse(model.getUserPrefs().isEmpty());
+  }
+
+  @Test
+  void compileNavBreadcrumb_matchesGolden_chromeSlotAndCssResource() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_BREADCRUMB,
+            "percNavBreadcrumb.xml",
+            "perc.widgets.nav",
+            GOLDEN_BREADCRUMB_MANIFEST,
+            GOLDEN_BREADCRUMB_TEMPLATE,
+            "templates/percNavBreadcrumbSnippet.vm");
+    assertTrue(
+        result.getManifest().getContentTypes() == null
+            || result.getManifest().getContentTypes().isEmpty());
+    assertEquals("percNavBreadcrumbChrome", result.getManifest().getSlots().get(0).getName());
+    assertTrue(
+        result.getManifest().getResources().stream().anyMatch(r -> "css".equals(r.getType())));
+  }
+
+  @Test
+  void compileHighTrafficPackages_allValidate() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping high-traffic package test");
+      return;
+    }
+
+    List<PSWidgetXmlCompileResult> results =
+        PSWidgetXmlPackageCompiler.compileHighTrafficPackages(packagesRoot);
+    // title(1) + lists(2) + nav(2) + file(1) + image(1) = 7 widgets
+    assertEquals(
+        7,
+        results.size(),
+        "high-traffic batch should compile title, lists×2, nav×2, file, image");
+
+    Map<String, PSWidgetXmlCompileResult> byId =
+        results.stream()
+            .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+    for (String id :
+        List.of(
+            "percTitle",
+            "simplePageAutoList",
+            "simpleTextAutoList",
+            "percNavBar",
+            "percNavBreadcrumb",
+            "percFile",
+            "percImage")) {
+      assertTrue(byId.containsKey(id), "missing compiled widget: " + id);
+      PSComponentPackageManifestValidator.validate(byId.get(id).getManifest());
+      assertFalse(byId.get(id).getTextArtifacts().isEmpty());
+      assertEquals("velocityAssembler", byId.get(id).getManifest().getTemplates().get(0).getAssembler());
+    }
+
+    // Image declares CSS Resource + asset CT.
+    assertTrue(
+        byId.get("percImage").getManifest().getResources().stream()
+            .anyMatch(r -> "css".equals(r.getType())));
+    assertEquals("percImageAsset", byId.get("percImage").getManifest().getContentTypes().get(0).getName());
+
+    // NavBar is chrome (no CT) with styles slot.
+    assertTrue(
+        byId.get("percNavBar").getManifest().getContentTypes() == null
+            || byId.get("percNavBar").getManifest().getContentTypes().isEmpty());
+    assertEquals("percNavBarChrome", byId.get("percNavBar").getManifest().getSlots().get(0).getName());
+
+    Path outRoot = tempDir.resolve("high-traffic-out");
+    PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
+    assertTrue(
+        Files.isRegularFile(
+            outRoot
+                .resolve("percTitle")
+                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+  }
+
+  private static PSWidgetXmlCompileResult assertGoldenParity(
+      String fixtureResource,
+      String fileName,
+      String packageDirName,
+      String goldenManifestResource,
+      String goldenTemplateResource,
+      String templateArtifactKey)
+      throws Exception {
+    Path packageDir = locatePackage(packageDirName);
+    assertNotNull(packageDir, "package sources missing: " + packageDirName);
+    PSWidgetXmlPackageContext ctx = PSWidgetXmlPackageContext.fromPackageDir(packageDir);
+    PSWidgetXmlModel model = parseClasspath(fixtureResource, fileName);
+    PSWidgetXmlCompileResult result = PSWidgetXmlCompiler.compile(model, ctx);
+    PSComponentPackageManifestValidator.validate(result.getManifest());
+
+    String expectedJson = readClasspath(goldenManifestResource);
+    PSComponentPackageManifest reparsed =
+        PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(result.getManifest()));
+    assertEquals(
+        PSComponentPackageManifestIo.parse(expectedJson),
+        reparsed,
+        "compiled manifest must equal golden for " + fileName);
+
+    String expectedTemplate = normalizeNewlines(readClasspath(goldenTemplateResource));
+    String actualTemplate =
+        normalizeNewlines(result.getTextArtifacts().get(templateArtifactKey));
+    assertEquals(expectedTemplate, actualTemplate, "template source golden parity for " + fileName);
+    return result;
+  }
+
   private static PSWidgetXmlPackageContext baseWidgetsLikeContext() {
     PSWidgetXmlPackageContext ctx = new PSWidgetXmlPackageContext();
     ctx.setPackageId("perc.baseWidgets");
@@ -278,19 +469,26 @@ class PSWidgetXmlCompilerTest {
    * surefire cwd = module root).
    */
   private static Path locateBaseWidgetsPackage() {
-    Path candidate =
-        Path.of("src", "main", "resources", "Packages", "perc.baseWidgets");
+    return locatePackage("perc.baseWidgets");
+  }
+
+  private static Path locatePackage(String packageDirName) {
+    Path packages = locatePackagesRoot();
+    if (packages == null) {
+      return null;
+    }
+    Path candidate = packages.resolve(packageDirName);
+    return Files.isDirectory(candidate) ? candidate : null;
+  }
+
+  private static Path locatePackagesRoot() {
+    Path candidate = Path.of("src", "main", "resources", "Packages");
     if (Files.isDirectory(candidate)) {
       return candidate.toAbsolutePath().normalize();
     }
-    // Fallback: walk up from user.dir (rarely needed).
     Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
     Path alt =
-        cwd.resolve("src")
-            .resolve("main")
-            .resolve("resources")
-            .resolve("Packages")
-            .resolve("perc.baseWidgets");
+        cwd.resolve("src").resolve("main").resolve("resources").resolve("Packages");
     return Files.isDirectory(alt) ? alt : null;
   }
 }

--- a/modules/perc-packages/src/test/resources/gadgetxml/GadgetRegistry.xml
+++ b/modules/perc-packages/src/test/resources/gadgetxml/GadgetRegistry.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gadgets>
+	<group name="Percussion">
+		<gadget name="Assets By Status"
+			baseuri="/cm/gadgets/repository/PercAssetStatusGadget"
+			file="PercAssetStatusGadget.xml" />
+		<gadget name="Blogs"
+			baseuri="/cm/gadgets/repository/PercBlogsGadget"
+			file="PercBlogsGadget.xml" />
+		<gadget name="Bulk Upload"
+			baseuri="/cm/gadgets/repository/perc_bulk_file_upload_gadget"
+			file="perc_bulk_file_upload_gadget.xml" />
+		<gadget name="Comments"
+			baseuri="/cm/gadgets/repository/perc_comments_gadget"
+			file="perc_comments_gadget.xml" />
+		<gadget name="Cookie Consent"
+			baseuri="/cm/gadgets/repository/perc_cookie_consent_gadget"
+			file="perc_cookie_consent_gadget.xml" />
+		<gadget name="Forms Tracker"
+			baseuri="/cm/gadgets/repository/PercFormTrackerGadget"
+			file="PercFormTrackerGadget.xml" />
+		<gadget name="Global Variables"
+			baseuri="/cm/gadgets/repository/PercGlobalVariablesGadget"
+			file="PercGlobalVariablesGadget.xml" />
+		<gadget name="Google Setup"
+			baseuri="/cm/gadgets/repository/perc_google_setup_gadget"
+			file="perc_google_setup_gadget.xml" />
+		<gadget name="Iframe"
+			baseuri="/cm/gadgets/repository/perc_iframe_gadget"
+			file="perc_iframe_gadget.xml" />
+		<gadget name="Pages By Status"
+			baseuri="/cm/gadgets/repository/perc_workflow_status_gadget"
+			file="perc_workflow_status_gadget.xml" />
+		<gadget name="Process Monitor"
+			baseuri="/cm/gadgets/repository/PercProcessorMonitorGadget"
+			file="PercProcessorMonitorGadget.xml" />
+		<gadget name="Reports"
+			baseuri="/cm/gadgets/repository/perc_reports_gadget"
+			file="perc_reports_gadget.xml" />
+		<gadget name="SEO Audit"
+			baseuri="/cm/gadgets/repository/perc_seo_gadget"
+			file="perc_seo_status_gadget.xml" />
+		<gadget name="Sitewide Framework"
+			baseuri="/cm/gadgets/repository/PercSiteFrameworkGadget"
+			file="perc_sitewide_framework_gadget.xml" />
+		<gadget name="Traffic"
+			baseuri="/cm/gadgets/repository/perc_traffic_gadget"
+			file="perc_traffic_gadget.xml" />
+		<gadget name="Welcome"
+			baseuri="/cm/gadgets/repository/cm1_welcome_gadget"
+			file="perc_welcome_gadget.xml" />
+		<gadget name="What's Working"
+			baseuri="/cm/gadgets/repository/perc_effectiveness_gadget"
+			file="perc_effectiveness_gadget.xml" />
+	</group>
+	<group name="Deprecated">
+		<gadget name="Activity"
+			baseuri="/cm/gadgets/repository/perc_activity_gadget"
+			file="perc_activity_gadget.xml" />
+		<gadget name="Siteimprove"
+			baseuri="/cm/gadgets/repository/perc_site_improve_gadget"
+			file="perc_site_improve_gadget.xml" />
+		<gadget name="Membership"
+			baseuri="/cm/gadgets/repository/perc_membership_gadget"
+			file="perc_membership_gadget.xml" />
+		<!-- Redirect Management removed entirely (issue #715): product discontinued;
+			legacy perc_website_config_gadget assets are no longer shipped. -->
+		<gadget name="Widget Configuration"
+			baseuri="/cm/gadgets/repository/PercWidgetConfigGadget"
+			file="PercWidgetConfigGadget.xml" />
+	</group>
+</gadgets>

--- a/modules/perc-packages/src/test/resources/gadgetxml/golden/cm1_welcome_gadget.component-package.json
+++ b/modules/perc-packages/src/test/resources/gadgetxml/golden/cm1_welcome_gadget.component-package.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "1.0",
+  "id": "cm1_welcome_gadget",
+  "name": "Welcome",
+  "version": "8.2.0",
+  "description": "Dashboard gadget package for 'Welcome' (group=Percussion)",
+  "publisher": {
+    "name": "Intersoft Data Labs, Inc.",
+    "url": "https://www.intsof.com"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "gadget",
+    "title": "Welcome",
+    "category": "Percussion",
+    "description": "Dashboard gadget package for 'Welcome' (group=Percussion)",
+    "author": "Intersoft Data Labs, Inc.",
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [],
+  "slots": [],
+  "resources": [
+    {
+      "path": "resources/host-ref.txt",
+      "target": "cm/gadgets/repository/cm1_welcome_gadget",
+      "type": "file"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/test/resources/gadgetxml/golden/gadget-catalog.json
+++ b/modules/perc-packages/src/test/resources/gadgetxml/golden/gadget-catalog.json
@@ -1,0 +1,198 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.gadgetCatalog",
+  "name": "Product Gadget Catalog",
+  "version": "8.2.0",
+  "description": "Modern product gadget catalog compiled from GadgetRegistry.xml (ADR-004 / #2771)",
+  "gadgets": [
+    {
+      "id": "PercAssetStatusGadget",
+      "name": "Assets By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercAssetStatusGadget",
+      "legacyDefinitionFile": "PercAssetStatusGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercAssetStatusGadget/component-package.json"
+    },
+    {
+      "id": "PercBlogsGadget",
+      "name": "Blogs",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercBlogsGadget",
+      "legacyDefinitionFile": "PercBlogsGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercBlogsGadget/component-package.json"
+    },
+    {
+      "id": "perc_bulk_file_upload_gadget",
+      "name": "Bulk Upload",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_bulk_file_upload_gadget",
+      "legacyDefinitionFile": "perc_bulk_file_upload_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_bulk_file_upload_gadget/component-package.json"
+    },
+    {
+      "id": "perc_comments_gadget",
+      "name": "Comments",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_comments_gadget",
+      "legacyDefinitionFile": "perc_comments_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_comments_gadget/component-package.json"
+    },
+    {
+      "id": "perc_cookie_consent_gadget",
+      "name": "Cookie Consent",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_cookie_consent_gadget",
+      "legacyDefinitionFile": "perc_cookie_consent_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_cookie_consent_gadget/component-package.json"
+    },
+    {
+      "id": "PercFormTrackerGadget",
+      "name": "Forms Tracker",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercFormTrackerGadget",
+      "legacyDefinitionFile": "PercFormTrackerGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercFormTrackerGadget/component-package.json"
+    },
+    {
+      "id": "PercGlobalVariablesGadget",
+      "name": "Global Variables",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercGlobalVariablesGadget",
+      "legacyDefinitionFile": "PercGlobalVariablesGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercGlobalVariablesGadget/component-package.json"
+    },
+    {
+      "id": "perc_google_setup_gadget",
+      "name": "Google Setup",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_google_setup_gadget",
+      "legacyDefinitionFile": "perc_google_setup_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_google_setup_gadget/component-package.json"
+    },
+    {
+      "id": "perc_iframe_gadget",
+      "name": "Iframe",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_iframe_gadget",
+      "legacyDefinitionFile": "perc_iframe_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_iframe_gadget/component-package.json"
+    },
+    {
+      "id": "perc_workflow_status_gadget",
+      "name": "Pages By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_workflow_status_gadget",
+      "legacyDefinitionFile": "perc_workflow_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_workflow_status_gadget/component-package.json"
+    },
+    {
+      "id": "PercProcessorMonitorGadget",
+      "name": "Process Monitor",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercProcessorMonitorGadget",
+      "legacyDefinitionFile": "PercProcessorMonitorGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercProcessorMonitorGadget/component-package.json"
+    },
+    {
+      "id": "perc_reports_gadget",
+      "name": "Reports",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_reports_gadget",
+      "legacyDefinitionFile": "perc_reports_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_reports_gadget/component-package.json"
+    },
+    {
+      "id": "perc_seo_gadget",
+      "name": "SEO Audit",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_seo_gadget",
+      "legacyDefinitionFile": "perc_seo_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_seo_gadget/component-package.json"
+    },
+    {
+      "id": "PercSiteFrameworkGadget",
+      "name": "Sitewide Framework",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercSiteFrameworkGadget",
+      "legacyDefinitionFile": "perc_sitewide_framework_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercSiteFrameworkGadget/component-package.json"
+    },
+    {
+      "id": "perc_traffic_gadget",
+      "name": "Traffic",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_traffic_gadget",
+      "legacyDefinitionFile": "perc_traffic_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_traffic_gadget/component-package.json"
+    },
+    {
+      "id": "cm1_welcome_gadget",
+      "name": "Welcome",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/cm1_welcome_gadget",
+      "legacyDefinitionFile": "perc_welcome_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/cm1_welcome_gadget/component-package.json"
+    },
+    {
+      "id": "perc_effectiveness_gadget",
+      "name": "What's Working",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_effectiveness_gadget",
+      "legacyDefinitionFile": "perc_effectiveness_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_effectiveness_gadget/component-package.json"
+    },
+    {
+      "id": "perc_activity_gadget",
+      "name": "Activity",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_activity_gadget",
+      "legacyDefinitionFile": "perc_activity_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_activity_gadget/component-package.json"
+    },
+    {
+      "id": "perc_site_improve_gadget",
+      "name": "Siteimprove",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_site_improve_gadget",
+      "legacyDefinitionFile": "perc_site_improve_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_site_improve_gadget/component-package.json"
+    },
+    {
+      "id": "perc_membership_gadget",
+      "name": "Membership",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_membership_gadget",
+      "legacyDefinitionFile": "perc_membership_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_membership_gadget/component-package.json"
+    },
+    {
+      "id": "PercWidgetConfigGadget",
+      "name": "Widget Configuration",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/PercWidgetConfigGadget",
+      "legacyDefinitionFile": "PercWidgetConfigGadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/PercWidgetConfigGadget/component-package.json"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.component-package.json
+++ b/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.component-package.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.base.plain",
+  "name": "Plain",
+  "version": "1.1.5",
+  "description": "Percussion base layout templates.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "page",
+    "title": "Plain",
+    "category": "page",
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "perc.base.plain",
+      "type": "page",
+      "assembler": "pageAssembler",
+      "sourceRef": "templates/perc.base.plain.vm",
+      "bindings": []
+    }
+  ],
+  "slots": [
+    {
+      "name": "perc-content",
+      "allowedContentTypes": [],
+      "layout": {
+        "orientation": "vertical"
+      },
+      "styles": {
+        "rootclass": "perc-region perc-vertical"
+      }
+    }
+  ],
+  "resources": [],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.vm
+++ b/modules/perc-packages/src/test/resources/pagexml/golden/perc.base.plain.vm
@@ -1,0 +1,11 @@
+#perc_templateHeader()##
+  <div id="perc-container" class="perc-region perc-vertical">
+      <div class="perc-vertical">
+		<div id="perc-content" class="perc-region perc-vertical">
+			<div class="perc-vertical">
+                        #region("perc-content" '' '' '' '')##
+			</div>
+		</div>
+	  </div>
+  </div>
+#perc_templateFooter()

--- a/modules/perc-packages/src/test/resources/pagexml/perc.base.headerFooter.templateDef
+++ b/modules/perc-packages/src/test/resources/pagexml/perc.base.headerFooter.templateDef
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>  <assembly-template id="1">
+    <bindings/>
+    <template-slot-ids/>
+    <guid>0-4-571</guid>
+    <active-assembly-type>Normal</active-assembly-type>
+    <assembler>Java/global/percussion/assembly/pageAssembler</assembler>
+    <assembly-url>../assembler/render</assembly-url>
+    <charset>UTF-8</charset>
+    <description/>
+    <global-template/>
+    <global-template-usage>None</global-template-usage>
+    <label>Header Footer</label>
+    <location-prefix/>
+    <location-suffix/>
+    <mime-type>text/html</mime-type>
+    <name>perc.base.headerFooter</name>
+    <output-format>Page</output-format>
+    <publish-when>Default</publish-when>
+    <style-sheet-path/>
+    <template>#perc_templateHeader()##
+&lt;div id="container" class="perc-region perc-vertical hspan_12"&gt;
+     &lt;div class="perc-vertical"&gt;
+        &lt;div id="header" class="perc-region perc-vertical vspan_2"&gt;
+           &lt;div class="perc-vertical"&gt;
+			  #region("header" '' '' '' '')##
+           &lt;/div&gt;
+        &lt;/div&gt;		
+        &lt;div id="content" class="perc-region perc-vertical vspan_6"&gt;
+           &lt;div class="perc-vertical"&gt;
+			  #region("content" '' '' '' '')##
+           &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div id="footer" class="perc-region perc-vertical vspan_2"&gt;
+           &lt;div class="perc-vertical"&gt;
+			  #region("footer" '' '' '' '')##
+           &lt;/div&gt;
+        &lt;/div&gt;              
+     &lt;/div&gt;
+  &lt;/div&gt;
+#perc_templateFooter()</template>
+    <template-type>Shared</template-type>
+    <type>TEMPLATE</type>
+    <variant>false</variant>
+  </assembly-template>

--- a/modules/perc-packages/src/test/resources/pagexml/perc.base.plain.templateDef
+++ b/modules/perc-packages/src/test/resources/pagexml/perc.base.plain.templateDef
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>  <assembly-template id="1">
+    <bindings/>
+    <template-slot-ids/>
+    <guid>0-4-591</guid>
+    <active-assembly-type>Normal</active-assembly-type>
+    <assembler>Java/global/percussion/assembly/pageAssembler</assembler>
+    <assembly-url>../assembler/render</assembly-url>
+    <charset>UTF-8</charset>
+    <description/>
+    <global-template/>
+    <global-template-usage>None</global-template-usage>
+    <label>Plain</label>
+    <location-prefix/>
+    <location-suffix/>
+    <mime-type>text/html</mime-type>
+    <name>perc.base.plain</name>
+    <output-format>Page</output-format>
+    <publish-when>Default</publish-when>
+    <style-sheet-path/>
+    <template>#perc_templateHeader()##
+  &lt;div id="perc-container" class="perc-region perc-vertical"&gt;
+      &lt;div class="perc-vertical"&gt;
+		&lt;div id="perc-content" class="perc-region perc-vertical"&gt;
+			&lt;div class="perc-vertical"&gt;
+                        #region("perc-content" '' '' '' '')##
+			&lt;/div&gt;
+		&lt;/div&gt;
+	  &lt;/div&gt;
+  &lt;/div&gt;
+#perc_templateFooter()</template>
+    <template-type>Shared</template-type>
+    <type>TEMPLATE</type>
+    <variant>false</variant>
+  </assembly-template>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
@@ -1,0 +1,164 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percNavBreadcrumb",
+  "name": "Breadcrumb",
+  "version": "1.3.3",
+  "description": "Display a navigation breadcrumb in your site",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Breadcrumb",
+    "category": "navigation",
+    "description": "Display a navigation breadcrumb in your site",
+    "thumbnail": "resources/widgetIconBreadcrumb.png",
+    "icon": "resources/widgetIconBreadcrumb.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percNavBreadcrumbSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percNavBreadcrumbSnippet.vm",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "showHome",
+          "expression": "$perc.widget.item.properties.get('showHome')"
+        },
+        {
+          "variable": "showCurrentPage",
+          "expression": "$perc.widget.item.properties.get('showCurrentPage')"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$perc.widget.item.properties.get('ariaLabel')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "separator",
+          "expression": "$perc.widget.item.properties.get('separator')"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true)"
+        },
+        {
+          "variable": "navSelf",
+          "expression": "$assetItems.get(0).getNode()"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "''"
+        },
+        {
+          "variable": "navTooltip",
+          "expression": "$rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navBreadCrumb is showing sample content.\")"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "' title=\"' + $navTooltip + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n    $showHome = $perc.widget.item.properties.get('showHome');\n    $showCurrentPage = $perc.widget.item.properties.get('showCurrentPage');\n    $ariaLabel = $perc.widget.item.properties.get('ariaLabel');\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $rootclass = $rootclass + \" \";\n    $separator = $perc.widget.item.properties.get('separator');\n    $finderName=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true);\n    if ( ! $assetItems.isEmpty() ) {\n        $navSelf = $assetItems.get(0).getNode();\n        $sampleTooltip = '';\n    }\n    else if ($perc.isEditMode()){\n\t\t$navTooltip = $rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navBreadCrumb is showing sample content.\");\n        $sampleTooltip = ' title=\"' + $navTooltip + '\"';\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percNavBreadcrumbChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconBreadcrumb.png",
+      "target": "web_resources/widgets/navBar/images/widgetIconBreadcrumb.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/breadcrumb.css",
+      "target": "web_resources/widgets/navBar/css/breadcrumb.css",
+      "type": "css"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "showHome",
+      "displayName": "Show home",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "showCurrentPage",
+      "displayName": "Show current page",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "separator",
+      "displayName": "Separator",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": " > ",
+      "enumValues": []
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Aria Label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "navLabel",
+      "displayName": "Navigation Label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Breadcrumb Navigation",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumb.component-package.json
@@ -110,7 +110,8 @@
     {
       "path": "resources/breadcrumb.css",
       "target": "web_resources/widgets/navBar/css/breadcrumb.css",
-      "type": "css"
+      "type": "css",
+      "placement": "head"
     }
   ],
   "userPreferences": [

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumbSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percNavBreadcrumbSnippet.vm
@@ -1,0 +1,69 @@
+<div class="$!{rootclass}perc-breadcrumb" aria-label="$!{ariaLabel}" role="navigation">
+#if ($navSelf)##
+#set($ancestors = $navSelf.getAncestors())##
+#if($ancestors.size()>0 && !$showHome)##
+#set($d=$ancestors.remove(0))##
+#end##
+#if($showCurrentPage)##
+#set($d=$ancestors.add($navSelf))##
+#end##
+#if ($ancestors.size() > 0)##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main">
+#foreach($node in $ancestors)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $ancestors.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($landing_page = $tools.esc.html($rx.pageutils.navLink($linkContext, $node)))##
+#set($title = $rx.pageutils.html($node,"displaytitle"))##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+<a href="$landing_page">$!{title}</a>##
+#else##
+<a href="$landing_page">$!{title}</a>##
+#end##
+</li>
+#end##
+</ul>
+</nav>
+#end##
+#elseif ($perc.isEditMode())##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main" $sampleTooltip>
+#set ($sampleContent = ["Section 1", "Section 2"])##
+#foreach($node in $sampleContent)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $sampleContent.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($title = $node)##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+$!{title}
+#else##
+<a href="#">$title</a>##
+#end</li>##
+#end##
+</ul>
+</nav>
+#end##
+</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percTitle.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percTitle.component-package.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percTitle",
+  "name": "Title",
+  "version": "1.1.4",
+  "description": "Widget to enter the Page title",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Title",
+    "category": "content",
+    "description": "Widget to enter the Page title",
+    "thumbnail": "resources/widgetTitle.png",
+    "icon": "resources/widgetTitle.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 302,
+    "createSharedAsset": false,
+    "editableOnTemplate": false,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTitleAsset",
+      "ref": "contentTypes/percTitleAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTitleSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTitleSnippet.vm",
+      "contentType": "percTitleAsset",
+      "bindings": [
+        {
+          "variable": "wrapper",
+          "expression": "$perc.widget.item.properties.get('wrapper')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$wrapper = $perc.widget.item.properties.get('wrapper');\n    $rootclass= $perc.widget.item.cssProperties.get('rootclass');\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';\n\n\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n    if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t    $dsUrl = \"\";\n    $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percTitleContent",
+      "allowedContentTypes": [
+        "percTitleAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetTitle.png",
+      "target": "rx_resources/widgets/title/images/widgetTitle.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "wrapper",
+      "displayName": "Choose format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "h1",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "paragraph",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percTitleSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percTitleSnippet.vm
@@ -1,0 +1,13 @@
+<div>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+#if(! $sys.assemblyItem.getNode().hasProperty("resource_link_title"))##
+#createEmptyWidgetContent("title-sample-content", "This title widget is showing sample content.")##
+#elseif ($assets.isEmpty())##
+<$!{wrapper}$!{classAttribute}>$tools.esc.html($!{perc.page.linkTitle})</$!{wrapper}>
+#else##
+<$!{wrapper}$!{classAttribute}>$rx.pageutils.html($node,'rx:text')</$!{wrapper}>
+#end##
+</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "1.0",
+  "id": "simplePageAutoList",
+  "name": "Auto List",
+  "version": "1.1.5",
+  "description": "Simple List widget for page links",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Auto List",
+    "category": "content,search",
+    "description": "Simple List widget for page links",
+    "thumbnail": "resources/widgetIconLinkAutoList.png",
+    "icon": "resources/widgetIconLinkAutoList.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSimpleAutoList",
+      "ref": "contentTypes/percSimpleAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "simplePageAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/simplePageAutoListSnippet.vm",
+      "contentType": "percSimpleAutoList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even')"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n   $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n   if (empty($rootclass)) {\n      $rootclass = \"\";\n   }\n   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $perc.setWidgetContents($assetItems);\n   if ( ! $assetItems.isEmpty() ) {\n      $assetItem = $assetItems.get(0);\n      $params = $rx.string.stringToMap(null);\n      $params.put('query', $assetItem.getNode().getProperty('query').String);\n      $params.put('max_results', $assetItem.node.getProperty('max_results').Long);\n      $finderName = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n      $title = $rx.pageutils.html($assetItem,'displaytitle');\n      $rowtag = $tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even');\n   }\n   else {\n      ;\n   }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "simplePageAutoListContent",
+      "allowedContentTypes": [
+        "percSimpleAutoList"
+      ],
+      "layout": {
+        "maxlength": "0",
+        "layout": ""
+      },
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLinkAutoList.png",
+      "target": "rx_resources/widgets/simpleList/images/widgetIconLinkAutoList.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/simpleList/css/style.css",
+      "type": "css"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "maxlength",
+      "displayName": "Max List Length",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "0",
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "string",
+      "required": true,
+      "enumValues": [
+        {
+          "value": "ui-perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "ui-perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    },
+    {
+      "name": "target",
+      "displayName": "Link Target",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoList.component-package.json
@@ -109,7 +109,8 @@
     {
       "path": "resources/style.css",
       "target": "rx_resources/widgets/simpleList/css/style.css",
-      "type": "css"
+      "type": "css",
+      "placement": "head"
     }
   ],
   "userPreferences": [

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoListSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/simplePageAutoListSnippet.vm
@@ -1,0 +1,40 @@
+<div class="$rootclass $layout .ui-widget .ui-widget-content .ui-perc-list-widget">
+#if (!$assetItems.isEmpty())
+    #if($title && $title.length() > 0)##
+       <div class=".ui-perc-list-title">$title</div>
+    #end
+    #if($relresults && $relresults.size() > 0)
+       #if($rendering == "ordered")##
+          <ol class=".ui-perc-list-main">##
+       #else##
+	  <ul class=".ui-perc-list-main">##
+       #end##
+       #foreach($result in $relresults)
+          #if($velocityCount == 1)##
+             #set($firstrow = '.ui-perc-list-first')##
+          #else##
+             #set($firstrow = ' ')##
+          #end##
+          #if($velocityCount == $relresults.size())##
+             #set($lastrow = '.ui-perc-list-last')##
+          #else
+             #set($lastrow = ' ')##
+          #end
+             #set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+             #set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+             <li class="$rowtag $firstrow $lastrow .ui-perc-list-element"><a href="$!{pagelink}"
+             #if($target.length() > 0)##
+                target="${target}"
+             #end
+                >$!{linkTitle}</a></li>
+       #end##
+       #if($rendering == "ordered")##
+          </ol>##
+       #else##
+          </ul>##
+       #end##
+    #end##
+#elseif ($perc.isEditMode())
+        Insert list of links based on query here.
+#end
+    </div>

--- a/modules/perc-packages/src/test/resources/widgetxml/percNavBreadcrumb.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percNavBreadcrumb.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Breadcrumb" contenttype_name=""
+		category="navigation"
+		description="Display a navigation breadcrumb in your site"
+		author="Percussion Software Inc"
+		thumbnail="/web_resources/widgets/navBar/images/widgetIconBreadcrumb.png"
+		is_responsive="true" />
+	<Resource
+		href="/web_resources/widgets/navBar/css/breadcrumb.css" type="css"
+		placement="head" />
+	<UserPref name="showHome" display_name="Show home"
+		default_value="true" datatype="bool" />
+	<UserPref name="showCurrentPage"
+		display_name="Show current page" default_value="true" datatype="bool" />
+	<UserPref name="separator" display_name="Separator"
+		default_value=" &gt; " datatype="string" />
+	<UserPref name="ariaLabel" display_name="Aria Label"
+		default_value="" datatype="string" />
+	<UserPref name="navLabel" display_name="Navigation Label"
+		default_value="Breadcrumb Navigation" datatype="string" />
+	<CssPref name="rootclass" display_name="CSS root class"
+		datatype="string" />
+	<Code type="jexl">
+        <![CDATA[
+    $linkContext = $perc.linkContext;
+    $showHome = $perc.widget.item.properties.get('showHome');
+    $showCurrentPage = $perc.widget.item.properties.get('showCurrentPage');
+    $ariaLabel = $perc.widget.item.properties.get('ariaLabel');
+    $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+    if (!empty($rootclass))
+        $rootclass = $rootclass + " ";
+    $separator = $perc.widget.item.properties.get('separator');
+    $finderName="Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder";
+    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true);
+    if ( ! $assetItems.isEmpty() ) {
+        $navSelf = $assetItems.get(0).getNode();
+        $sampleTooltip = '';
+    }
+    else if ($perc.isEditMode()){
+		$navTooltip = $rx.pageutils.getWidgetTooltip($perc, $perc.widget, "This navBreadCrumb is showing sample content.");
+        $sampleTooltip = ' title="' + $navTooltip + '"';
+    }
+    ]]>
+	</Code>
+	<Content type="velocity">
+        <![CDATA[
+<div class="$!{rootclass}perc-breadcrumb" aria-label="$!{ariaLabel}" role="navigation">
+#if ($navSelf)##
+#set($ancestors = $navSelf.getAncestors())##
+#if($ancestors.size()>0 && !$showHome)##
+#set($d=$ancestors.remove(0))##
+#end##
+#if($showCurrentPage)##
+#set($d=$ancestors.add($navSelf))##
+#end##
+#if ($ancestors.size() > 0)##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main">
+#foreach($node in $ancestors)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $ancestors.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($landing_page = $tools.esc.html($rx.pageutils.navLink($linkContext, $node)))##
+#set($title = $rx.pageutils.html($node,"displaytitle"))##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+<a href="$landing_page">$!{title}</a>##
+#else##
+<a href="$landing_page">$!{title}</a>##
+#end##
+</li>
+#end##
+</ul>
+</nav>
+#end##
+#elseif ($perc.isEditMode())##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main" $sampleTooltip>
+#set ($sampleContent = ["Section 1", "Section 2"])##
+#foreach($node in $sampleContent)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $sampleContent.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($title = $node)##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+$!{title}
+#else##
+<a href="#">$title</a>##
+#end</li>##
+#end##
+</ul>
+</nav>
+#end##
+</div>]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/percTitle.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percTitle.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Title"
+		contenttype_name="percTitleAsset" category="content"
+		description="Widget to enter the Page title"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/title/images/widgetTitle.png"
+		preferred_editor_width="780" preferred_editor_height="302"
+		create_shared_asset="false" is_editable_on_template="false"
+		is_responsive="true" />
+	<UserPref name="wrapper" display_name="Choose format"
+		required="true" datatype="enum" default_value="h1">
+		<EnumValue value="h1" display_value="Heading 1" />
+		<EnumValue value="h2" display_value="Heading 2" />
+		<EnumValue value="h3" display_value="Heading 3" />
+		<EnumValue value="h4" display_value="Heading 4" />
+		<EnumValue value="h5" display_value="Heading 5" />
+		<EnumValue value="h6" display_value="Heading 6" />
+		<EnumValue value="paragraph" display_value="Paragraph" />
+		<EnumValue value="div" display_value="Div" />
+	</UserPref>
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+
+
+	<Code type="jexl">
+        <![CDATA[
+    $wrapper = $perc.widget.item.properties.get('wrapper');
+    $rootclass= $perc.widget.item.cssProperties.get('rootclass');
+    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);
+    if (!empty($rootclass))
+        $classAttribute = ' class="' + $rootclass + '"';
+
+	$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+    if ($dsUrl.indexOf("http://localhost") != -1 )
+	    $dsUrl = "";
+    $dynamicListData = $tools.esc.html("{ deliveryurl : '" + $dsUrl + "'}");
+    ]]>
+	</Code>
+	<Content type="velocity">
+        <![CDATA[
+<div>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+#if(! $sys.assemblyItem.getNode().hasProperty("resource_link_title"))##
+#createEmptyWidgetContent("title-sample-content", "This title widget is showing sample content.")##
+#elseif ($assets.isEmpty())##
+<$!{wrapper}$!{classAttribute}>$tools.esc.html($!{perc.page.linkTitle})</$!{wrapper}>
+#else##
+<$!{wrapper}$!{classAttribute}>$rx.pageutils.html($node,'rx:text')</$!{wrapper}>
+#end##
+</div>
+    ]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/simplePageAutoList.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/simplePageAutoList.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Widget>
+	<WidgetPrefs title="Auto List"
+		contenttype_name="percSimpleAutoList" category="content,search"
+		description="Simple List widget for page links"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/simpleList/images/widgetIconLinkAutoList.png"
+		is_responsive="true" />
+	<Resource
+		href="/rx_resources/widgets/simpleList/css/style.css" type="css"
+		placement="head" />
+	<UserPref name="maxlength" display_name="Max List Length"
+		default_value="0" datatype="number" />
+	<UserPref name="layout" display_name="Layout" required="true"
+		datatype="string">
+		<EnumValue value="ui-perc-list-horizontal"
+			display_value="Horizontal" />
+		<EnumValue value="ui-perc-list-vertical"
+			display_value="Vertical" />
+	</UserPref>
+	<UserPref name="target" display_name="Link Target"
+		datatype="string" />
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+	<Code type="jexl">
+    <![CDATA[
+   $linkContext = $perc.linkContext;
+   $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+   if (empty($rootclass)) {
+      $rootclass = "";
+   }
+   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);
+   $perc.setWidgetContents($assetItems);
+   if ( ! $assetItems.isEmpty() ) {
+      $assetItem = $assetItems.get(0);
+      $params = $rx.string.stringToMap(null);
+      $params.put('query', $assetItem.getNode().getProperty('query').String);
+      $params.put('max_results', $assetItem.node.getProperty('max_results').Long);
+      $finderName = "Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder";
+      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);
+      $title = $rx.pageutils.html($assetItem,'displaytitle');
+      $rowtag = $tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even');
+   }
+   else {
+      ;
+   }
+
+    ]]>
+	</Code>
+	<Content type="velocity">
+    <![CDATA[
+    <div class="$rootclass $layout .ui-widget .ui-widget-content .ui-perc-list-widget">
+#if (!$assetItems.isEmpty())
+    #if($title && $title.length() > 0)##
+       <div class=".ui-perc-list-title">$title</div>
+    #end
+    #if($relresults && $relresults.size() > 0)
+       #if($rendering == "ordered")##
+          <ol class=".ui-perc-list-main">##
+       #else##
+	  <ul class=".ui-perc-list-main">##
+       #end##
+       #foreach($result in $relresults)
+          #if($velocityCount == 1)##
+             #set($firstrow = '.ui-perc-list-first')##
+          #else##
+             #set($firstrow = ' ')##
+          #end##
+          #if($velocityCount == $relresults.size())##
+             #set($lastrow = '.ui-perc-list-last')##
+          #else
+             #set($lastrow = ' ')##
+          #end
+             #set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+             #set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+             <li class="$rowtag $firstrow $lastrow .ui-perc-list-element"><a href="$!{pagelink}"
+             #if($target.length() > 0)##
+                target="${target}"
+             #end
+                >$!{linkTitle}</a></li>
+       #end##
+       #if($rendering == "ordered")##
+          </ol>##
+       #else##
+          </ul>##
+       #end##
+    #end##
+#elseif ($perc.isEditMode())
+        Insert list of links based on query here.
+#end
+    </div>
+    ]]>
+	</Content>
+</Widget>


### PR DESCRIPTION
## Summary

Overnight **same-file thrash absorption** for Phase 3 template-assembler / perc-packages XML compilers. Three sequential issue PRs all edited the shared docs under `docs/ai-generated/tasks/template-assembler-normalization/` (README, ADR-004, plan, component-package-manifest). Landing them independently would re-conflict on every merge to `main`.

This cluster unions product code from each PR (page templateDef, gadget registry, high-traffic widget XML compilers) and **union-resolves** thrash docs so all three feature narratives remain.

### Thrash files

- `docs/ai-generated/tasks/template-assembler-normalization/README.md`
- `docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md`
- `docs/ai-generated/tasks/template-assembler-normalization/plan.md`
- `docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md` (auto-merged)

### Absorbed content (union)

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #2785 | `feat/issue-2770-page-definition-xml-package` | yes | Page `*.templateDef` → component package (`PSPageXml*`) + goldens |
| yes | #2787 | `feat/issue-2771-gadget-registry-catalog` | yes | Gadget registry → catalog + packages (`PSGadgetRegistry*`) + goldens |
| yes | #2790 | `fix/issue-2772-high-traffic-widget-xml-compiler` | yes | High-traffic widget XML compiler residual + Resource/chrome/layout + goldens |

### What is not in this PR

- Explorer shell thrash group (#2775 / #2777) is only 2 MERGEABLE PRs — below `cluster_min_prs=3` and not CONFLICTING; left alone.
- Unrelated open PRs (#2782 explorer menus, etc.) left alone.

## Test plan / gates evidence

```text
cd modules/perc-packages
..\..\mvnw.cmd clean install
→ BUILD SUCCESS
→ Tests run: 60, Failures: 0, Errors: 0, Skipped: 0
  (includes PSPageXmlCompilerTest 9, PSGadgetRegistryCompilerTest 6, PSWidgetXmlCompilerTest high-traffic goldens)
```

Doc conflicts resolved with **union** semantics (keep page + gadget + high-traffic residual notes).

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok CLI using grok-4.5 with agent night-issue-prs-cluster.