### PR TITLE
fix(utils): stabilize InstallUtil.portAvailable Windows UDP race (#2779)

### DIFF
--- a/modules/utils/src/main/java/com/percussion/install/InstallUtil.java
+++ b/modules/utils/src/main/java/com/percussion/install/InstallUtil.java
@@ -811,24 +811,48 @@ public class InstallUtil {
   /**
    * Checks whether a TCP port can be bound.
    *
+   * <p>This is a <strong>TCP-only</strong> probe. Callers (DTS Tomcat connector / Server shutdown
+   * ports, Derby JDBC, CMS Jetty bind checks) care about TCP listeners only. A UDP-only binding on
+   * the same port number must not make the port look unavailable.
+   *
+   * <p>Implementation uses a two-phase bind to stay deterministic on Windows Winsock (GH-2779):
+   *
+   * <ol>
+   *   <li>Bind without {@code SO_REUSEADDR}. Succeeds when no TCP socket holds the port (including
+   *       when only UDP is bound). Avoids the flaky {@code SO_REUSEADDR}+UDP exclusive-use race on
+   *       Windows.
+   *   <li>If that fails, bind with {@code SO_REUSEADDR} so a port briefly in {@code TIME_WAIT} from
+   *       a previous close is still reported available (Linux holds TIME_WAIT ~60s; without this
+   *       path offline-detection tests flake after a recent DTS close on the same host).
+   * </ol>
+   *
    * @param port the TCP port to check for availability
    * @return {@code true} when the TCP port can be bound, otherwise {@code false}
    */
   public static boolean portAvailable(int port) {
+    InetSocketAddress address = new InetSocketAddress(port);
+
+    // Phase 1: exclusive-style TCP bind (SO_REUSEADDR off). UDP-only holders do not block this
+    // path; active TCP listeners and TIME_WAIT do.
     try (ServerSocket ss = new ServerSocket()) {
-      // SO_REUSEADDR must be set BEFORE bind() so a probe can succeed on a port that is
-      // briefly in TIME_WAIT from a previous close (including on Linux where the OS holds
-      // the socket for ~60s). Without this, an immediately re-probed port appears busy
-      // and unrelated offline-detection tests fail when a deployed DTS server is running
-      // on the same host.
+      ss.setReuseAddress(false);
+      ss.bind(address);
+      return true;
+    } catch (IOException ignored) {
+      // occupied by TCP listener or TIME_WAIT — try reuse path below
+    }
+
+    // Phase 2: SO_REUSEADDR before bind so TIME_WAIT ports probe as free. Still fails when a live
+    // TCP listener holds the port. Do not use this phase alone: on Windows, SO_REUSEADDR + a
+    // concurrent UDP bind on the same port number can intermittently throw BindException.
+    try (ServerSocket ss = new ServerSocket()) {
       ss.setReuseAddress(true);
-      ss.bind(new InetSocketAddress(port));
+      ss.bind(address);
       return true;
     } catch (IOException e) {
       logError("Port Availability Check Failed." + e.getMessage());
+      return false;
     }
-
-    return false;
   }
 
   /**

--- a/modules/utils/src/test/java/com/percussion/install/InstallUtilRunningServerTest.java
+++ b/modules/utils/src/test/java/com/percussion/install/InstallUtilRunningServerTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -113,10 +114,32 @@ public class InstallUtilRunningServerTest {
     assertNull(InstallUtil.resolveTomcatPortToken(null, p));
   }
 
+  /**
+   * UDP-only holders must not make a TCP port look unavailable (install/DTS probes are TCP-only).
+   * Repeat several iterations so intermittent Windows Winsock SO_REUSEADDR+UDP races surface in
+   * CI rather than only occasionally (GH-2779).
+   */
   @Test
   void portAvailable_ignoresUdpBinding() throws Exception {
-    try (DatagramSocket hold = new DatagramSocket(0)) {
-      assertTrue(InstallUtil.portAvailable(hold.getLocalPort()));
+    final int iterations = 25;
+    for (int i = 0; i < iterations; i++) {
+      final int iteration = i;
+      // Bind explicitly (reuse off) so the hold is a pure UDP exclusive binding.
+      try (DatagramSocket hold = new DatagramSocket(null)) {
+        hold.setReuseAddress(false);
+        hold.bind(new InetSocketAddress(0));
+        final int port = hold.getLocalPort();
+        assertTrue(
+            InstallUtil.portAvailable(port),
+            () ->
+                "UDP-only binding on port "
+                    + port
+                    + " must leave TCP available (iteration "
+                    + iteration
+                    + " of "
+                    + iterations
+                    + ")");
+      }
     }
   }
 
@@ -124,10 +147,20 @@ public class InstallUtilRunningServerTest {
   void portAvailable_roundTrip() throws Exception {
     int free = findFreePort();
     assertTrue(InstallUtil.portAvailable(free));
-    try (ServerSocket hold = new ServerSocket(free)) {
-      hold.setReuseAddress(true);
-      assertFalse(InstallUtil.portAvailable(free));
+    try (ServerSocket hold = new ServerSocket()) {
+      // Bind first without reuse so the hold is an exclusive TCP listener (matches product
+      // sockets and avoids Windows dual-SO_REUSEADDR ambiguity).
+      hold.setReuseAddress(false);
+      hold.bind(new InetSocketAddress(free));
+      assertFalse(
+          InstallUtil.portAvailable(free),
+          "exclusive TCP listener must make portAvailable return false");
     }
+    // After close, TIME_WAIT may briefly hold the port; phase-2 SO_REUSEADDR should still
+    // report available so offline detection is not stuck busy.
+    assertTrue(
+        InstallUtil.portAvailable(free),
+        "port must look available again after TCP holder closed (TIME_WAIT tolerant)");
   }
 
   /**


### PR DESCRIPTION
## Summary

Stabilizes `InstallUtil.portAvailable` / `InstallUtilRunningServerTest.portAvailable_ignoresUdpBinding` on Windows (GH-2779).

**Root cause:** A single TCP bind probe with `SO_REUSEADDR` can intermittently fail under Winsock when a UDP `DatagramSocket` holds the same port number (exclusive-use / address-reuse interaction). Callers only care about **TCP** availability (Tomcat connectors, Derby, CMS bind checks).

**Fix:** Two-phase TCP bind probe:

1. Bind **without** `SO_REUSEADDR` — succeeds when the port is free for TCP, including when only UDP is bound (avoids the flaky reuse+UDP path).
2. If that fails, bind **with** `SO_REUSEADDR` — still reports available for ports briefly in `TIME_WAIT` after a prior close.

**Tests:**

- `portAvailable_ignoresUdpBinding` — 25 exclusive UDP-hold iterations, assert TCP still available.
- `portAvailable_roundTrip` — exclusive TCP hold → unavailable; after close → available (TIME_WAIT tolerant).

## Test plan

- [x] `cd modules/utils && ../../mvnw.cmd clean install`
- [x] Confirm `InstallUtilRunningServerTest` green (9 tests)
- [x] Full utils suite: 326 tests, 0 failures, 9 skipped

## Build evidence (C3)

- **modules_built:** `modules/utils`
- **build_evidence:** `cd modules/utils && ../../mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: **326**, Failures: **0**, Errors: **0**, Skipped: **9**
- **downstream_checked:** none (method body only; public signature `portAvailable(int)` unchanged; not made final/sealed)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2779

Fixes #2779

> Co-Authored by Grok Build using grok-4.5 with agent main.