### PR TITLE
fix(WebUI): dual-load gadget-catalog.json (#2788)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/gadget/servlets/GadgetRegistry.java
+++ b/WebUI/src/main/java/com/percussion/webui/gadget/servlets/GadgetRegistry.java
@@ -22,67 +22,121 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.json.JsonFactory;
 
 /**
- * Loads {@code GadgetRegistry.xml} from the classpath. Restored for v8.1.7 PR #722 / #885 grouping
- * (Percussion vs Deprecated). The registry was removed with Shindig cleanup but remains the
- * canonical grouping for dashboard gadget types.
+ * Loads dashboard gadget name → group map for Percussion vs Deprecated grouping (v8.1.7 PR #722 /
+ * #885).
+ *
+ * <p><strong>Dual-load policy (ADR-004 / #2788 / #2630 residual):</strong> prefer modern {@code
+ * gadget-catalog.json} on the classpath; fall back to legacy {@code GadgetRegistry.xml} when the
+ * modern catalog is absent or unreadable. Selection is intentional dual-run shim so product can
+ * retire XML as the sole runtime source without breaking installs that still ship only the
+ * registry.
  */
 public final class GadgetRegistry {
 
   private static final Logger log = LogManager.getLogger(GadgetRegistry.class);
 
-  /** Classpath location of the registry resource. */
+  /**
+   * Classpath location of the modern aggregate catalog (parity with {@code
+   * modules/perc-packages/.../catalogs/gadgets/gadget-catalog.json}).
+   */
+  public static final String CATALOG_RESOURCE =
+      "com/percussion/webui/gadget/servlets/gadget-catalog.json";
+
+  /** Classpath location of the legacy registry resource (fallback). */
   public static final String REGISTRY_RESOURCE =
       "com/percussion/webui/gadget/servlets/GadgetRegistry.xml";
+
+  /** Which resource satisfied the last {@link #loadGadgetTypeMap()} (or overload) call. */
+  public enum Source {
+    /** Modern {@code gadget-catalog.json}. */
+    MODERN_CATALOG,
+    /** Legacy {@code GadgetRegistry.xml}. */
+    LEGACY_REGISTRY_XML,
+    /** Neither source produced entries. */
+    NONE
+  }
+
+  private static final AtomicReference<Source> LAST_SOURCE = new AtomicReference<>(Source.NONE);
+
+  private static final JsonFactory JSON_FACTORY = JsonFactory.builder().build();
 
   private GadgetRegistry() {}
 
   /**
-   * Loads gadget name → group name map from the classpath registry.
+   * Source used by the most recent dual-load attempt (for diagnostics and unit tests).
    *
-   * @return unmodifiable map; empty if the resource is missing or unreadable
+   * @return never null
+   */
+  public static Source getLastLoadSource() {
+    return LAST_SOURCE.get();
+  }
+
+  /**
+   * Loads gadget display-name → group-name map using dual-load selection (modern catalog preferred,
+   * legacy registry XML fallback).
+   *
+   * @return unmodifiable map; empty if both resources are missing or unreadable
    */
   public static Map<String, String> loadGadgetTypeMap() {
-    Map<String, String> gadTypeMap = new LinkedHashMap<>();
-    try (InputStream in =
-        GadgetRegistry.class.getClassLoader().getResourceAsStream(REGISTRY_RESOURCE)) {
-      if (in == null) {
-        log.error("Gadget registry file is missing from classpath: {}", REGISTRY_RESOURCE);
-        return Collections.emptyMap();
-      }
+    return loadGadgetTypeMap(CATALOG_RESOURCE, REGISTRY_RESOURCE);
+  }
 
-      Document doc = PSXmlDocumentBuilder.createXmlDocument(in, false);
-      NodeList groupElems = doc.getElementsByTagName("group");
-      for (int i = 0; i < groupElems.getLength(); i++) {
-        Element groupElem = (Element) groupElems.item(i);
-        String groupName = groupElem.getAttribute("name");
-        NodeList gadgetElems = groupElem.getElementsByTagName("gadget");
-        for (int j = 0; j < gadgetElems.getLength(); j++) {
-          Element gadgetElem = (Element) gadgetElems.item(j);
-          String gdgName = gadgetElem.getAttribute("name");
-          if (gdgName != null && !gdgName.isBlank()) {
-            gadTypeMap.put(gdgName, groupName);
-          }
-        }
+  /**
+   * Dual-load with explicit classpath resource names. Package-visible for unit tests that inject
+   * missing-catalog / missing-xml paths.
+   *
+   * @param catalogResource classpath resource for modern JSON (may be null → skip modern)
+   * @param registryResource classpath resource for legacy XML (may be null → skip legacy)
+   * @return unmodifiable map; empty if both fail
+   */
+  static Map<String, String> loadGadgetTypeMap(String catalogResource, String registryResource) {
+    if (catalogResource != null && !catalogResource.isBlank()) {
+      Map<String, String> fromCatalog = tryLoadCatalog(catalogResource);
+      if (!fromCatalog.isEmpty()) {
+        LAST_SOURCE.set(Source.MODERN_CATALOG);
+        log.debug(
+            "Loaded gadget type map from modern catalog {} ({} entries)",
+            catalogResource,
+            fromCatalog.size());
+        return fromCatalog;
       }
-    } catch (Exception e) {
-      log.error("Failed to load {}: {}", REGISTRY_RESOURCE, PSExceptionUtils.getMessageForLog(e));
-      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      return Collections.emptyMap();
     }
-    return Collections.unmodifiableMap(gadTypeMap);
+
+    if (registryResource != null && !registryResource.isBlank()) {
+      Map<String, String> fromXml = tryLoadRegistryXml(registryResource);
+      if (!fromXml.isEmpty()) {
+        LAST_SOURCE.set(Source.LEGACY_REGISTRY_XML);
+        log.debug(
+            "Loaded gadget type map from legacy registry {} ({} entries)",
+            registryResource,
+            fromXml.size());
+        return fromXml;
+      }
+    }
+
+    LAST_SOURCE.set(Source.NONE);
+    log.error(
+        "No gadget type map available: modern catalog [{}] and legacy registry [{}] both missing or empty",
+        catalogResource,
+        registryResource);
+    return Collections.emptyMap();
   }
 
   /**
    * Maps a gadget display name to its logical group.
    *
-   * @param gadgetName display name from registry (e.g. "Activity")
+   * @param gadgetName display name from catalog/registry (e.g. "Activity")
    * @return group name, or {@code "Custom"} if unknown
    */
   public static String getGadgetType(String gadgetName) {
@@ -91,5 +145,109 @@ public final class GadgetRegistry {
     }
     String type = loadGadgetTypeMap().get(gadgetName);
     return type != null ? type : "Custom";
+  }
+
+  private static Map<String, String> tryLoadCatalog(String resource) {
+    try (InputStream in = openClasspath(resource)) {
+      if (in == null) {
+        log.debug("Modern gadget catalog not on classpath: {}", resource);
+        return Collections.emptyMap();
+      }
+      return parseCatalogJson(in);
+    } catch (Exception e) {
+      log.warn(
+          "Failed to load modern gadget catalog {}: {}",
+          resource,
+          PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      return Collections.emptyMap();
+    }
+  }
+
+  private static Map<String, String> tryLoadRegistryXml(String resource) {
+    try (InputStream in = openClasspath(resource)) {
+      if (in == null) {
+        log.debug("Legacy gadget registry not on classpath: {}", resource);
+        return Collections.emptyMap();
+      }
+      return parseRegistryXml(in);
+    } catch (Exception e) {
+      log.warn(
+          "Failed to load legacy gadget registry {}: {}",
+          resource,
+          PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      return Collections.emptyMap();
+    }
+  }
+
+  private static InputStream openClasspath(String resource) {
+    return GadgetRegistry.class.getClassLoader().getResourceAsStream(resource);
+  }
+
+  /**
+   * Parse modern {@code gadget-catalog.json} into name → group map. Package-visible for unit tests.
+   *
+   * @param in non-null JSON stream
+   * @return unmodifiable map (empty if no gadgets)
+   * @throws Exception on I/O or JSON errors
+   */
+  static Map<String, String> parseCatalogJson(InputStream in) throws Exception {
+    Map<String, String> gadTypeMap = new LinkedHashMap<>();
+    try (JsonParser p = JSON_FACTORY.createParser(in)) {
+      while (p.nextToken() != null) {
+        if (p.currentToken() == JsonToken.PROPERTY_NAME && "gadgets".equals(p.currentName())) {
+          if (p.nextToken() != JsonToken.START_ARRAY) {
+            break;
+          }
+          while (p.nextToken() == JsonToken.START_OBJECT) {
+            String name = null;
+            String group = null;
+            while (p.nextToken() != JsonToken.END_OBJECT) {
+              String field = p.currentName();
+              p.nextToken();
+              if ("name".equals(field)) {
+                name = p.getValueAsString();
+              } else if ("group".equals(field)) {
+                group = p.getValueAsString();
+              } else {
+                p.skipChildren();
+              }
+            }
+            if (name != null && !name.isBlank() && group != null && !group.isBlank()) {
+              gadTypeMap.put(name, group);
+            }
+          }
+          break;
+        }
+      }
+    }
+    return Collections.unmodifiableMap(gadTypeMap);
+  }
+
+  /**
+   * Parse legacy {@code GadgetRegistry.xml} into name → group map. Package-visible for unit tests.
+   *
+   * @param in non-null XML stream
+   * @return unmodifiable map (empty if no gadgets)
+   * @throws Exception on I/O or XML errors
+   */
+  static Map<String, String> parseRegistryXml(InputStream in) throws Exception {
+    Map<String, String> gadTypeMap = new LinkedHashMap<>();
+    Document doc = PSXmlDocumentBuilder.createXmlDocument(in, false);
+    NodeList groupElems = doc.getElementsByTagName("group");
+    for (int i = 0; i < groupElems.getLength(); i++) {
+      Element groupElem = (Element) groupElems.item(i);
+      String groupName = groupElem.getAttribute("name");
+      NodeList gadgetElems = groupElem.getElementsByTagName("gadget");
+      for (int j = 0; j < gadgetElems.getLength(); j++) {
+        Element gadgetElem = (Element) gadgetElems.item(j);
+        String gdgName = gadgetElem.getAttribute("name");
+        if (gdgName != null && !gdgName.isBlank()) {
+          gadTypeMap.put(gdgName, groupName);
+        }
+      }
+    }
+    return Collections.unmodifiableMap(gadTypeMap);
   }
 }

--- a/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/gadget-catalog.json
+++ b/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/gadget-catalog.json
@@ -1,0 +1,198 @@
+{
+  "schemaVersion": "1.0",
+  "id": "perc.gadgetCatalog",
+  "name": "Product Gadget Catalog",
+  "version": "8.2.0",
+  "description": "Modern product gadget catalog compiled from GadgetRegistry.xml (ADR-004 / #2771)",
+  "gadgets": [
+    {
+      "id": "PercAssetStatusGadget",
+      "name": "Assets By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercAssetStatusGadget",
+      "legacyDefinitionFile": "PercAssetStatusGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercAssetStatusGadget/component-package.json"
+    },
+    {
+      "id": "PercBlogsGadget",
+      "name": "Blogs",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercBlogsGadget",
+      "legacyDefinitionFile": "PercBlogsGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercBlogsGadget/component-package.json"
+    },
+    {
+      "id": "perc_bulk_file_upload_gadget",
+      "name": "Bulk Upload",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_bulk_file_upload_gadget",
+      "legacyDefinitionFile": "perc_bulk_file_upload_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_bulk_file_upload_gadget/component-package.json"
+    },
+    {
+      "id": "perc_comments_gadget",
+      "name": "Comments",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_comments_gadget",
+      "legacyDefinitionFile": "perc_comments_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_comments_gadget/component-package.json"
+    },
+    {
+      "id": "perc_cookie_consent_gadget",
+      "name": "Cookie Consent",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_cookie_consent_gadget",
+      "legacyDefinitionFile": "perc_cookie_consent_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_cookie_consent_gadget/component-package.json"
+    },
+    {
+      "id": "PercFormTrackerGadget",
+      "name": "Forms Tracker",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercFormTrackerGadget",
+      "legacyDefinitionFile": "PercFormTrackerGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercFormTrackerGadget/component-package.json"
+    },
+    {
+      "id": "PercGlobalVariablesGadget",
+      "name": "Global Variables",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercGlobalVariablesGadget",
+      "legacyDefinitionFile": "PercGlobalVariablesGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercGlobalVariablesGadget/component-package.json"
+    },
+    {
+      "id": "perc_google_setup_gadget",
+      "name": "Google Setup",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_google_setup_gadget",
+      "legacyDefinitionFile": "perc_google_setup_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_google_setup_gadget/component-package.json"
+    },
+    {
+      "id": "perc_iframe_gadget",
+      "name": "Iframe",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_iframe_gadget",
+      "legacyDefinitionFile": "perc_iframe_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_iframe_gadget/component-package.json"
+    },
+    {
+      "id": "perc_workflow_status_gadget",
+      "name": "Pages By Status",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_workflow_status_gadget",
+      "legacyDefinitionFile": "perc_workflow_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_workflow_status_gadget/component-package.json"
+    },
+    {
+      "id": "PercProcessorMonitorGadget",
+      "name": "Process Monitor",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercProcessorMonitorGadget",
+      "legacyDefinitionFile": "PercProcessorMonitorGadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercProcessorMonitorGadget/component-package.json"
+    },
+    {
+      "id": "perc_reports_gadget",
+      "name": "Reports",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_reports_gadget",
+      "legacyDefinitionFile": "perc_reports_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_reports_gadget/component-package.json"
+    },
+    {
+      "id": "perc_seo_gadget",
+      "name": "SEO Audit",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_seo_gadget",
+      "legacyDefinitionFile": "perc_seo_status_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_seo_gadget/component-package.json"
+    },
+    {
+      "id": "PercSiteFrameworkGadget",
+      "name": "Sitewide Framework",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/PercSiteFrameworkGadget",
+      "legacyDefinitionFile": "perc_sitewide_framework_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/PercSiteFrameworkGadget/component-package.json"
+    },
+    {
+      "id": "perc_traffic_gadget",
+      "name": "Traffic",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_traffic_gadget",
+      "legacyDefinitionFile": "perc_traffic_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_traffic_gadget/component-package.json"
+    },
+    {
+      "id": "cm1_welcome_gadget",
+      "name": "Welcome",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/cm1_welcome_gadget",
+      "legacyDefinitionFile": "perc_welcome_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/cm1_welcome_gadget/component-package.json"
+    },
+    {
+      "id": "perc_effectiveness_gadget",
+      "name": "What's Working",
+      "group": "Percussion",
+      "baseUri": "/cm/gadgets/repository/perc_effectiveness_gadget",
+      "legacyDefinitionFile": "perc_effectiveness_gadget.xml",
+      "deprecated": false,
+      "componentPackageRef": "gadgets/perc_effectiveness_gadget/component-package.json"
+    },
+    {
+      "id": "perc_activity_gadget",
+      "name": "Activity",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_activity_gadget",
+      "legacyDefinitionFile": "perc_activity_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_activity_gadget/component-package.json"
+    },
+    {
+      "id": "perc_site_improve_gadget",
+      "name": "Siteimprove",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_site_improve_gadget",
+      "legacyDefinitionFile": "perc_site_improve_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_site_improve_gadget/component-package.json"
+    },
+    {
+      "id": "perc_membership_gadget",
+      "name": "Membership",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/perc_membership_gadget",
+      "legacyDefinitionFile": "perc_membership_gadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/perc_membership_gadget/component-package.json"
+    },
+    {
+      "id": "PercWidgetConfigGadget",
+      "name": "Widget Configuration",
+      "group": "Deprecated",
+      "baseUri": "/cm/gadgets/repository/PercWidgetConfigGadget",
+      "legacyDefinitionFile": "PercWidgetConfigGadget.xml",
+      "deprecated": true,
+      "componentPackageRef": "gadgets/PercWidgetConfigGadget/component-package.json"
+    }
+  ]
+}

--- a/WebUI/src/test/java/com/percussion/webui/gadget/servlets/GadgetRegistryTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/gadget/servlets/GadgetRegistryTest.java
@@ -20,19 +20,26 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.Test;
 
 /**
- * Regression for v8.1.7 PR #722 / #885: GadgetRegistry.xml on classpath with Percussion +
- * Deprecated groups. Also covers issue #715 (Redirect Management gadget removed).
+ * Regression for v8.1.7 PR #722 / #885: Percussion + Deprecated groups. Issue #715 (Redirect
+ * Management removed). Issue #2788 dual-load: prefer {@code gadget-catalog.json}, fall back to
+ * {@code GadgetRegistry.xml}.
  */
 public class GadgetRegistryTest {
 
   @Test
-  public void registryLoadsWithPercussionAndDeprecatedGroups() {
+  public void dualLoadPrefersModernCatalogWhenPresent() {
     Map<String, String> map = GadgetRegistry.loadGadgetTypeMap();
-    assertFalse("GadgetRegistry.xml must be on the classpath", map.isEmpty());
+    assertFalse("gadget type map must load from modern catalog or legacy registry", map.isEmpty());
+    assertEquals(
+        "product ships modern catalog; dual-load must prefer it",
+        GadgetRegistry.Source.MODERN_CATALOG,
+        GadgetRegistry.getLastLoadSource());
 
     assertEquals("Deprecated", map.get("Activity"));
     assertEquals("Deprecated", map.get("Siteimprove"));
@@ -46,6 +53,75 @@ public class GadgetRegistryTest {
 
     assertEquals("Percussion", map.get("Welcome"));
     assertEquals("Percussion", map.get("Bulk Upload"));
+  }
+
+  @Test
+  public void fallsBackToRegistryXmlWhenModernCatalogAbsent() {
+    Map<String, String> map =
+        GadgetRegistry.loadGadgetTypeMap(
+            "com/percussion/webui/gadget/servlets/does-not-exist-catalog.json",
+            GadgetRegistry.REGISTRY_RESOURCE);
+    assertFalse("legacy GadgetRegistry.xml must still be on the classpath", map.isEmpty());
+    assertEquals(GadgetRegistry.Source.LEGACY_REGISTRY_XML, GadgetRegistry.getLastLoadSource());
+
+    assertEquals("Deprecated", map.get("Activity"));
+    assertEquals("Percussion", map.get("Welcome"));
+    assertEquals("Percussion", map.get("Google Setup"));
+    assertFalse(map.containsKey("Redirect Management"));
+  }
+
+  @Test
+  public void emptyWhenBothSourcesMissing() {
+    Map<String, String> map =
+        GadgetRegistry.loadGadgetTypeMap(
+            "com/percussion/webui/gadget/servlets/missing-a.json",
+            "com/percussion/webui/gadget/servlets/missing-b.xml");
+    assertTrue(map.isEmpty());
+    assertEquals(GadgetRegistry.Source.NONE, GadgetRegistry.getLastLoadSource());
+  }
+
+  @Test
+  public void parseCatalogJsonBuildsNameToGroupMap() throws Exception {
+    String json =
+        """
+        {
+          "schemaVersion": "1.0",
+          "gadgets": [
+            { "id": "g1", "name": "Welcome", "group": "Percussion" },
+            { "id": "g2", "name": "Activity", "group": "Deprecated" },
+            { "id": "g3", "name": "", "group": "Percussion" },
+            { "id": "g4", "name": "NoGroup" }
+          ]
+        }
+        """;
+    Map<String, String> map =
+        GadgetRegistry.parseCatalogJson(
+            new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+    assertEquals(2, map.size());
+    assertEquals("Percussion", map.get("Welcome"));
+    assertEquals("Deprecated", map.get("Activity"));
+    assertFalse(map.containsKey("NoGroup"));
+  }
+
+  @Test
+  public void parseRegistryXmlBuildsNameToGroupMap() throws Exception {
+    String xml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gadgets>
+          <group name="Percussion">
+            <gadget name="Welcome" baseuri="/cm/gadgets/repository/cm1_welcome_gadget" file="x.xml"/>
+          </group>
+          <group name="Deprecated">
+            <gadget name="Activity" baseuri="/cm/gadgets/repository/perc_activity_gadget" file="y.xml"/>
+          </group>
+        </gadgets>
+        """;
+    Map<String, String> map =
+        GadgetRegistry.parseRegistryXml(
+            new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    assertEquals("Percussion", map.get("Welcome"));
+    assertEquals("Deprecated", map.get("Activity"));
   }
 
   /**
@@ -69,5 +145,12 @@ public class GadgetRegistryTest {
   @Test
   public void deprecatedTypeLookup() {
     assertTrue("Deprecated".equals(GadgetRegistry.getGadgetType("Activity")));
+  }
+
+  @Test
+  public void modernCatalogResourceIsOnClasspath() {
+    assertTrue(
+        "shipped gadget-catalog.json must be on the WebUI classpath",
+        GadgetRegistry.class.getClassLoader().getResource(GadgetRegistry.CATALOG_RESOURCE) != null);
   }
 }


### PR DESCRIPTION
## Summary
WebUI runtime **dual-load** for dashboard gadget Percussion/Deprecated grouping (issue #2788 residual of #2630 / #2771 / #2626):

1. Prefer modern classpath `gadget-catalog.json` (shipped under `WebUI/.../gadget/servlets/`, parity with `modules/perc-packages/.../catalogs/gadgets/gadget-catalog.json`)
2. Fall back to legacy `GadgetRegistry.xml` when modern catalog is missing/unreadable
3. Keep `loadGadgetTypeMap()` / `getGadgetType()` behavior (unknown → `Custom`)
4. Extended `GadgetRegistryTest` for prefer/fallback/empty + JSON/XML parsers

**Not in this PR:** SPA `gadgetsCatalog.ts` id realignment (unsafe — SPA uses short stable ids for sessionStorage preferred gadgets; product catalog uses repository folder ids). Delete of `GadgetRegistry.xml` after dual-load QA remains a later residual if product wants sole-JSON authoring.

Parent tracker: #2630  
Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd WebUI && ../mvnw.cmd clean install` (standalone)
- [x] `GadgetRegistryTest` dual-load + grouping regressions
- [ ] Optional human: confirm dashboard gadget grouping still Percussion vs Deprecated with catalog present (no user-visible delta expected when catalog ≡ XML)

## Build evidence (C3)
- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI; ..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 36 total (GadgetRegistryTest 9, Failures: 0)
- **downstream_checked:** none (no public signature / final / sealed API change; package-private overloads only)

Fixes #2788  
Refs #2630 #2771 #2626

> Co-Authored by Grok Build using grok-4.5 with agent main.