### PR TITLE
feat(perc-packages): residual product widget XML compiler batch + goldens (#2789)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -4,16 +4,17 @@
 **Source:** `modules/perc-packages/src/main/resources/Packages/**/rxconfig/Widgets/*.xml`  
 **Machine-readable:** [widget-xml-inventory.csv](./widget-xml-inventory.csv)
 
-## Compiler status (#2751 / #2772 / parent #2630)
+## Compiler status (#2751 / #2772 / #2789 / parent #2630)
 
 | Area | Status | Notes |
 |------|--------|-------|
-| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic batch** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
+| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic + residual long-tail batch** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
 | Golden parity (baseWidgets) | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
 | Golden parity (high-traffic #2772) | **percTitle**, **simplePageAutoList**, **percNavBreadcrumb** | Plus package compile of title, lists×2, nav×2, file, image (7 widgets) |
-| Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT) |
+| Golden parity (residual #2789) | **percForm**, **percPoll**, **percIframe** | Plus package compile of blog/calendar×2/directory×4/social/form/poll/login/rss/iframe (**13** widgets) |
+| Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT); residual batch needed no new shapes |
 | **Product packages still ship Widget XML** | Yes (dual-run) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
-| Residual product packages | Open | blog, calendar, directory, social, forms, auto-lists (image/page/file), jquery, poll, login, etc. — see matrix below |
+| Residual product packages (after #2789) | Open | auto-lists (image/page/file), jquery/jqueryUI, comments/liked, event, social cards, blog index, etc. — see matrix |
 | Runtime legacy XML shim | Landed (cluster #2766) | #2752 |
 
 ### High-traffic batch covered by #2772
@@ -26,7 +27,23 @@
 | `perc.FileAssetWidget` | percFile | Content + rich media |
 | `perc.widgets.image` | percImage | Content + rich media + CSS resource |
 
-Measurable reduction: **7** product widget definition XMLs now have a validated modern compile path with goldens (beyond the original 3 baseWidgets).
+Measurable reduction (#2772): **7** product widget definition XMLs with validated modern compile path + goldens (beyond 3 baseWidgets).
+
+### Residual long-tail batch covered by #2789
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.widgets.blog` | percBlogPost | Blog content CT + large UserPref set |
+| `perc.widget.calendar` | percCalendar, percCalendarTwo | Shared CT `percCalendarAsset` |
+| `perc.widget.directory` | percDepartment, percDirectory, percOrganization, percPerson | Multi-widget directory package |
+| `perc.widget.socialButtons` | percSocialButtons | Social CT + placement UserPrefs |
+| `perc.widget.form` | percForm | Integration form; golden |
+| `perc.widget.poll` | percPoll | Social/blog poll; golden |
+| `perc.widget.login` | percLogin | Membership login |
+| `perc.widget.rss` | percRss | Blog/social RSS |
+| `perc.widget.iframe` | percIframe | Chrome (no CT); golden |
+
+Measurable reduction (#2789): **+13** product widget definition XMLs on the validated modern compile path (cumulative product widgets with package compile coverage: **3 base + 7 high-traffic + 13 residual = 23**, excluding `perc.Test`).
 
 Ship format: [component-package-manifest.md](./component-package-manifest.md). ADR: [004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md).
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -38,10 +38,11 @@ import java.util.regex.Pattern;
  * Compiles legacy Widget definition XML into a modern {@link PSComponentPackageManifest} plus
  * template source artifacts (Phase 3 / ADR-004 / issues #2751, #2772).
  *
- * <p><strong>Scope:</strong> baseWidgets-shaped widgets plus high-traffic product packages (title,
- * lists, nav chrome, file, image): JEXL code + Velocity content + optional asset content type +
- * UserPref/CssPref + {@code <Resource>} CSS/JS refs. Remaining residual packages (blog, calendar,
- * directory, social, forms, auto-lists, …) are tracked in {@code
+ * <p><strong>Scope:</strong> baseWidgets-shaped widgets, high-traffic product packages (title,
+ * lists, nav chrome, file, image — #2772), and residual long-tail product packages (blog, calendar,
+ * directory, social, forms, poll, login, rss, iframe — #2789): JEXL code + Velocity content +
+ * optional asset content type + UserPref/CssPref + {@code <Resource>} CSS/JS refs. Further residual
+ * packages (auto-lists, jquery, comments, …) remain dual-run Widget XML and are tracked in {@code
  * docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
  *
  * <p>Assembler mapping: {@code Content type="velocity"} → {@code velocityAssembler}; {@code html}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -31,8 +31,9 @@ import java.util.Objects;
  * Compiles all Widget definition XML files found in a legacy product package source directory.
  *
  * <p>Looks under {@code sys__UserDependency--rxconfig/Widgets/*.xml} (product packaging layout used
- * by {@code modules/perc-packages}). Covers baseWidgets and high-traffic product packages (#2772);
- * residual packages are tracked in the widget XML inventory.
+ * by {@code modules/perc-packages}). Covers baseWidgets, high-traffic product packages (#2772), and
+ * the residual long-tail batch (#2789). Further residual packages remain in the widget XML
+ * inventory until dual-run exit.
  */
 public final class PSWidgetXmlPackageCompiler {
 
@@ -51,6 +52,24 @@ public final class PSWidgetXmlPackageCompiler {
           "perc.widgets.nav",
           "perc.FileAssetWidget",
           "perc.widgets.image");
+
+  /**
+   * Residual long-tail product package directory names under {@code Packages/} covered by issue
+   * #2789 (blog / calendar / directory / social / forms / poll / login / rss / iframe). Beyond
+   * {@link #HIGH_TRAFFIC_PACKAGE_DIRS} and {@code perc.baseWidgets}. Dual-run: product Widget XML
+   * remains until install consumes modern packages.
+   */
+  public static final List<String> RESIDUAL_PRODUCT_PACKAGE_DIRS =
+      List.of(
+          "perc.widgets.blog",
+          "perc.widget.calendar",
+          "perc.widget.directory",
+          "perc.widget.socialButtons",
+          "perc.widget.form",
+          "perc.widget.poll",
+          "perc.widget.login",
+          "perc.widget.rss",
+          "perc.widget.iframe");
 
   private PSWidgetXmlPackageCompiler() {
     // utility
@@ -116,12 +135,44 @@ public final class PSWidgetXmlPackageCompiler {
    */
   public static List<PSWidgetXmlCompileResult> compileHighTrafficPackages(Path packagesRoot)
       throws PSWidgetXmlException, IOException {
+    return compileNamedPackages(packagesRoot, HIGH_TRAFFIC_PACKAGE_DIRS);
+  }
+
+  /**
+   * Compile residual long-tail product packages under a {@code Packages/} root directory (issue
+   * #2789). Missing package directories are soft-skipped (same policy as high-traffic).
+   *
+   * @param packagesRoot non-null directory containing package folders
+   * @return compile results sorted by package then widget stem (may be empty if none present)
+   * @throws PSWidgetXmlException on parse/compile failure of a present package
+   * @throws IOException on I/O failure
+   */
+  public static List<PSWidgetXmlCompileResult> compileResidualProductPackages(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    return compileNamedPackages(packagesRoot, RESIDUAL_PRODUCT_PACKAGE_DIRS);
+  }
+
+  /**
+   * Compile every package directory name listed under {@code packagesRoot}. Missing package
+   * directories are soft-skipped so partial checkouts can still exercise available packages.
+   *
+   * @param packagesRoot non-null Packages root
+   * @param packageDirNames non-null ordered package directory names
+   * @return compile results in package-list then widget-stem order
+   */
+  public static List<PSWidgetXmlCompileResult> compileNamedPackages(
+      Path packagesRoot, List<String> packageDirNames)
+      throws PSWidgetXmlException, IOException {
     Objects.requireNonNull(packagesRoot, "packagesRoot");
+    Objects.requireNonNull(packageDirNames, "packageDirNames");
     if (!Files.isDirectory(packagesRoot)) {
       throw new PSWidgetXmlException("Packages root does not exist: " + packagesRoot);
     }
     List<PSWidgetXmlCompileResult> all = new ArrayList<>();
-    for (String dirName : HIGH_TRAFFIC_PACKAGE_DIRS) {
+    for (String dirName : packageDirNames) {
+      if (dirName == null || dirName.isBlank()) {
+        continue;
+      }
       Path packageDir = packagesRoot.resolve(dirName);
       // Soft-skip missing package dirs so partial checkouts / CI fixtures still exercise
       // the packages that are present (matches baseWidgets soft-skip tests).

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751 baseWidgets,
- * #2772 high-traffic residual batch).
+ * Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751
+ * baseWidgets, #2772 high-traffic residual batch, #2789 remaining product residual batch).
  */
 class PSWidgetXmlCompilerTest {
 
@@ -64,6 +64,21 @@ class PSWidgetXmlCompilerTest {
       "/widgetxml/golden/percNavBreadcrumb.component-package.json";
   private static final String GOLDEN_BREADCRUMB_TEMPLATE =
       "/widgetxml/golden/percNavBreadcrumbSnippet.vm";
+
+  private static final String FIXTURE_FORM = "/widgetxml/percForm.xml";
+  private static final String GOLDEN_FORM_MANIFEST =
+      "/widgetxml/golden/percForm.component-package.json";
+  private static final String GOLDEN_FORM_TEMPLATE = "/widgetxml/golden/percFormSnippet.vm";
+
+  private static final String FIXTURE_POLL = "/widgetxml/percPoll.xml";
+  private static final String GOLDEN_POLL_MANIFEST =
+      "/widgetxml/golden/percPoll.component-package.json";
+  private static final String GOLDEN_POLL_TEMPLATE = "/widgetxml/golden/percPollSnippet.vm";
+
+  private static final String FIXTURE_IFRAME = "/widgetxml/percIframe.xml";
+  private static final String GOLDEN_IFRAME_MANIFEST =
+      "/widgetxml/golden/percIframe.component-package.json";
+  private static final String GOLDEN_IFRAME_TEMPLATE = "/widgetxml/golden/percIframeSnippet.vm";
 
   @TempDir Path tempDir;
 
@@ -411,6 +426,197 @@ class PSWidgetXmlCompilerTest {
                   .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)),
           "writeAll missing manifest for " + stem);
     }
+  }
+
+  @Test
+  void parseForm_integrationWidgetWithLabelAlignPref() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_FORM, "percForm.xml");
+    assertEquals("Form", model.getTitle());
+    assertEquals("percFormAsset", model.getContentTypeName());
+    assertEquals("integration", model.getCategory());
+    assertEquals(1, model.getUserPrefs().size());
+    assertEquals("labelalign", model.getUserPrefs().get(0).getName());
+    assertEquals(1, model.getCssPrefs().size());
+  }
+
+  @Test
+  void compileForm_matchesGoldenManifestAndTemplate() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_FORM,
+            "percForm.xml",
+            "perc.widget.form",
+            GOLDEN_FORM_MANIFEST,
+            GOLDEN_FORM_TEMPLATE,
+            "templates/percFormSnippet.vm");
+    assertEquals("percFormAsset", result.getManifest().getContentTypes().get(0).getName());
+    assertEquals("percFormContent", result.getManifest().getSlots().get(0).getName());
+    assertTrue(
+        result
+            .getTextArtifacts()
+            .get("templates/percFormSnippet.vm")
+            .contains("perc-form"));
+  }
+
+  @Test
+  void parsePoll_socialBlogWidgetWithRestrictionPref() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_POLL, "percPoll.xml");
+    assertEquals("Polls", model.getTitle());
+    assertEquals("percPollAsset", model.getContentTypeName());
+    assertTrue(model.getCategory() != null && model.getCategory().contains("social"));
+    assertEquals(7, model.getUserPrefs().size());
+    assertTrue(
+        model.getUserPrefs().stream().anyMatch(p -> "pollRestrictionType".equals(p.getName())));
+  }
+
+  @Test
+  void compilePoll_matchesGoldenManifestAndTemplate() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_POLL,
+            "percPoll.xml",
+            "perc.widget.poll",
+            GOLDEN_POLL_MANIFEST,
+            GOLDEN_POLL_TEMPLATE,
+            "templates/percPollSnippet.vm");
+    assertEquals("percPollAsset", result.getManifest().getContentTypes().get(0).getName());
+    assertTrue(
+        result.getManifest().getUserPreferences().stream()
+            .anyMatch(p -> "pollRestrictionType".equals(p.getName())));
+    assertTrue(
+        result
+            .getTextArtifacts()
+            .get("templates/percPollSnippet.vm")
+            .contains("perc-polls"));
+  }
+
+  @Test
+  void parseIframe_chromeWidgetNoContentType_withUserPrefs() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_IFRAME, "percIframe.xml");
+    assertEquals("Iframe", model.getTitle());
+    assertTrue(
+        model.getContentTypeName() == null || model.getContentTypeName().isBlank(),
+        "iframe is chrome/logic (no asset CT)");
+    assertEquals(11, model.getUserPrefs().size());
+    assertEquals(1, model.getCssPrefs().size());
+  }
+
+  @Test
+  void compileIframe_matchesGolden_chromeSlotWithoutContentType() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_IFRAME,
+            "percIframe.xml",
+            "perc.widget.iframe",
+            GOLDEN_IFRAME_MANIFEST,
+            GOLDEN_IFRAME_TEMPLATE,
+            "templates/percIframeSnippet.vm");
+    assertTrue(
+        result.getManifest().getContentTypes() == null
+            || result.getManifest().getContentTypes().isEmpty());
+    assertEquals("percIframeChrome", result.getManifest().getSlots().get(0).getName());
+    assertTrue(
+        result.getManifest().getSlots().get(0).getStyles().containsKey("rootclass"));
+  }
+
+  @Test
+  void compileResidualProductPackages_allValidate() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping residual product package test");
+      return;
+    }
+
+    List<PSWidgetXmlCompileResult> results =
+        PSWidgetXmlPackageCompiler.compileResidualProductPackages(packagesRoot);
+    // blog(1)+calendar(2)+directory(4)+social(1)+form(1)+poll(1)+login(1)+rss(1)+iframe(1)=13
+    assertEquals(
+        13,
+        results.size(),
+        "residual #2789 batch should compile blog, calendar×2, directory×4, social, form, poll,"
+            + " login, rss, iframe");
+
+    Map<String, PSWidgetXmlCompileResult> byId =
+        results.stream()
+            .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+    for (String id :
+        List.of(
+            "percBlogPost",
+            "percCalendar",
+            "percCalendarTwo",
+            "percDepartment",
+            "percDirectory",
+            "percOrganization",
+            "percPerson",
+            "percSocialButtons",
+            "percForm",
+            "percPoll",
+            "percLogin",
+            "percRss",
+            "percIframe")) {
+      assertTrue(byId.containsKey(id), "missing compiled residual widget: " + id);
+      PSComponentPackageManifestValidator.validate(byId.get(id).getManifest());
+      assertFalse(byId.get(id).getTextArtifacts().isEmpty());
+      assertEquals(
+          "velocityAssembler",
+          byId.get(id).getManifest().getTemplates().get(0).getAssembler());
+    }
+
+    // Blog post is content CT with many user prefs (title format, locales, …).
+    assertEquals(
+        "percBlogPostAsset",
+        byId.get("percBlogPost").getManifest().getContentTypes().get(0).getName());
+    assertTrue(byId.get("percBlogPost").getManifest().getUserPreferences().size() >= 10);
+
+    // Directory multi-widget package shares package context version.
+    String dirVersion = byId.get("percDirectory").getManifest().getVersion();
+    assertEquals(dirVersion, byId.get("percPerson").getManifest().getVersion());
+    assertEquals(dirVersion, byId.get("percDepartment").getManifest().getVersion());
+
+    // Iframe residual golden shape: chrome slot, no CT.
+    assertTrue(
+        byId.get("percIframe").getManifest().getContentTypes() == null
+            || byId.get("percIframe").getManifest().getContentTypes().isEmpty());
+    assertEquals(
+        "percIframeChrome", byId.get("percIframe").getManifest().getSlots().get(0).getName());
+
+    Path outRoot = tempDir.resolve("residual-out");
+    PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
+    for (String stem :
+        List.of(
+            "percBlogPost",
+            "percCalendar",
+            "percCalendarTwo",
+            "percDepartment",
+            "percDirectory",
+            "percOrganization",
+            "percPerson",
+            "percSocialButtons",
+            "percForm",
+            "percPoll",
+            "percLogin",
+            "percRss",
+            "percIframe")) {
+      assertTrue(
+          Files.isRegularFile(
+              outRoot
+                  .resolve(stem)
+                  .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)),
+          "writeAll missing residual manifest for " + stem);
+    }
+  }
+
+  @Test
+  void residualProductPackageDirs_disjointFromHighTrafficAndBase() {
+    assertFalse(
+        PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS.contains("perc.baseWidgets"));
+    for (String high : PSWidgetXmlPackageCompiler.HIGH_TRAFFIC_PACKAGE_DIRS) {
+      assertFalse(
+          PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS.contains(high),
+          "residual must not re-list high-traffic package: " + high);
+    }
+    assertEquals(9, PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS.size());
   }
 
   private static PSWidgetXmlCompileResult assertGoldenParity(

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percForm.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percForm.component-package.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percForm",
+  "name": "Form",
+  "version": "1.4.8",
+  "description": "Widget to build and render form data.",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Form",
+    "category": "integration",
+    "description": "Widget to build and render form data.",
+    "thumbnail": "resources/widgetIconForm.gif",
+    "icon": "resources/widgetIconForm.gif",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 965,
+    "preferredEditorHeight": 600,
+    "responsive": false,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percFormAsset",
+      "ref": "contentTypes/percFormAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percFormSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percFormSnippet.vm",
+      "contentType": "percFormAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"perc-label-location-top\""
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"perc-label-location-left\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n            if(!empty($rootclass)) {\n                $rootclass = $rootclass;\n            }\n            $props = $perc.widget.item.properties;\n            $labelalignclass = \"perc-label-location-top\";\n            if($props.get(\"labelalign\") != null && $props.get(\"labelalign\").equals(\"left\"))\n                $labelalignclass = \"perc-label-location-left\";\n\n\t\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n            $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percFormContent",
+      "allowedContentTypes": [
+        "percFormAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconForm.gif",
+      "target": "rx_resources/widgets/form/images/widgetIconForm.gif",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "labelalign",
+      "displayName": "Label align",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "top",
+      "enumValues": [
+        {
+          "value": "top",
+          "displayValue": "Top of the control"
+        },
+        {
+          "value": "left",
+          "displayValue": "Left of the control"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percFormSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percFormSnippet.vm
@@ -1,0 +1,47 @@
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty())##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+<div class = "perc-form $!{rootclass} $!{labelalignclass}" data="$!{dynamicListData}">
+#if( ! $perc.widgetContents.isEmpty())##
+#set($formString = $node.getProperty('rx:renderedform').getString())##
+#set($returnString = $rx.pageutils.processForm($sys.assemblyItem, $perc.widget, $formString))##
+<div class = "perc-form-name">$returnString </div>
+#set($formData = $node.getProperty('rx:formdata').String)##
+#if($formData.contains('honeypot') || $formData.contains('recaptcha'))##
+<script>
+    function validatePercForm() {
+        var ret = false;
+        #if($formData.contains('honeypot'))##
+        if(!document.getElementById('topyenoh').value) {
+            ret=true;
+        }
+        else {
+            ret=false;
+        }
+        #end##
+        #if($formData.contains('recaptcha'))##
+         if (grecaptcha.getResponse() === '') {
+         	ret = false;
+         }else {
+         	ret = true;
+         }
+        #end##
+        return ret;
+    }
+</script>
+#end##
+
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("form-sample-content", "This Form widget is showing sample content.")
+#end
+
+#if($perc.isPreviewMode())
+<script>
+window.addEventListener('DOMContentLoaded', function() {
+jQuery("form").on('submit',function(){return false;});
+jQuery("input[type = 'submit']").attr('disabled', 'disabled');
+});
+</script>
+#end
+</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percIframe.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percIframe.component-package.json
@@ -1,0 +1,330 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percIframe",
+  "name": "Iframe",
+  "version": "1.1.4",
+  "description": "Embed an external web page within a Percussion page",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Iframe",
+    "category": "integration",
+    "description": "Embed an external web page within a Percussion page",
+    "thumbnail": "resources/widgetIconIframe.jpg",
+    "icon": "resources/widgetIconIframe.jpg",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percIframeSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percIframeSnippet.vm",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "iframeurl",
+          "expression": "$props.get(\"iframeurl\")"
+        },
+        {
+          "variable": "referalPolicy",
+          "expression": "$props.get(\"referalPolicy\")"
+        },
+        {
+          "variable": "iframeurl",
+          "expression": "\"http://\" + $iframeurl"
+        },
+        {
+          "variable": "height",
+          "expression": "$props.get(\"height\")"
+        },
+        {
+          "variable": "defaultHeight",
+          "expression": "$props.get(\"height\")"
+        },
+        {
+          "variable": "width",
+          "expression": "$props.get(\"width\")"
+        },
+        {
+          "variable": "defaultWidth",
+          "expression": "$props.get(\"width\")"
+        },
+        {
+          "variable": "frameborder",
+          "expression": "$props.get(\"frameborder\")"
+        },
+        {
+          "variable": "scrollbar",
+          "expression": "$props.get(\"scrollbar\")"
+        },
+        {
+          "variable": "iframeid",
+          "expression": "\"perc-iframe-\" + $perc.widget.item.id"
+        },
+        {
+          "variable": "title",
+          "expression": "$props.get(\"title\")"
+        },
+        {
+          "variable": "marginheight",
+          "expression": "$props.get(\"marginheight\")"
+        },
+        {
+          "variable": "marginwidth",
+          "expression": "$props.get(\"marginwidth\")"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$props.get(\"ariaLabel\")"
+        },
+        {
+          "variable": "alternateContent",
+          "expression": "$props.get(\"alternateContent\")"
+        },
+        {
+          "variable": "frameborder",
+          "expression": "\"0\""
+        },
+        {
+          "variable": "frameborder",
+          "expression": "\"1\""
+        },
+        {
+          "variable": "overflow",
+          "expression": "\"auto\""
+        },
+        {
+          "variable": "overflow",
+          "expression": "'visible'"
+        },
+        {
+          "variable": "overflow",
+          "expression": "'hidden'"
+        },
+        {
+          "variable": "height",
+          "expression": "'100%'"
+        },
+        {
+          "variable": "width",
+          "expression": "'100%'"
+        },
+        {
+          "variable": "marginheight",
+          "expression": "'0px'"
+        },
+        {
+          "variable": "marginwidth",
+          "expression": "'0px'"
+        },
+        {
+          "variable": "width",
+          "expression": "$width + 'px'"
+        },
+        {
+          "variable": "height",
+          "expression": "$height + 'px'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n\t\t\tif(!empty($rootclass)) {\n\t\t\t\t$rootclass = $rootclass;\n\t\t\t}\n\t\t\t$props = $perc.widget.item.properties;\n\t\t\t$iframeurl = $props.get(\"iframeurl\");\n\t\t\t$referalPolicy = $props.get(\"referalPolicy\");\n\t\t\tif($iframeurl.startsWith(\"www\"))\n\t\t\t\t$iframeurl = \"http://\" + $iframeurl;\n\t\t\t$height = $props.get(\"height\");\n\t\t\t$defaultHeight = $props.get(\"height\");\n\t\t\t$width = $props.get(\"width\");\n\t\t\t$defaultWidth = $props.get(\"width\");\n\t\t\t$frameborder = $props.get(\"frameborder\");\n\t\t\t$scrollbar = $props.get(\"scrollbar\");\n\t\t\t$iframeid=\"perc-iframe-\" + $perc.widget.item.id;\n\t\t\t$title = $props.get(\"title\");\n\t\t\t$marginheight = $props.get(\"marginheight\");\n\t\t\t$marginwidth = $props.get(\"marginwidth\");\n\t\t\t$ariaLabel = $props.get(\"ariaLabel\");\n\t\t\t$alternateContent = $props.get(\"alternateContent\");\n\n\t\t\tif($frameborder == \"disable\"){\n\t\t\t\t$frameborder = \"0\";\n\t\t\t}\n\t\t\telse{\n\t\t\t\t$frameborder = \"1\";\n\t\t\t}\n\t\t\t$overflow = \"auto\";\n\t\t\tif($scrollbar == \"yes\"){\n\t\t\t\t$overflow='visible';\n\t\t\t}\n\t\t\telse if($scrollbar == \"no\"){\n\t\t\t\t$overflow='hidden';\n\t\t\t}\n\n\t\t\tif(empty($height)){\n\t\t\t\t$height='100%';\n\t\t\t}\n\t\t\tif(empty($width)){\n\t\t\t\t$width='100%';\n\t\t\t}\n\n\t\t\tif(empty($marginheight)){\n\t\t\t\t$marginheight = '0px';\n\t\t\t}\n\t\t\tif(empty($marginwidth)){\n\t\t\t\t$marginwidth = '0px';\n\t\t\t}\n\n\t\t\tif($width.indexOf('p') == -1 && $width.indexOf('%') == -1){\n\t\t\t\t$width = $width + 'px';\n\t\t\t}\n\t\t\tif($height.indexOf('p') == -1 && $height.indexOf('%') == -1){\n\t\t\t\t$height = $height + 'px';\n\t\t\t}\n\n            $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        \tif ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t    $dsUrl = \"\";\n            $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percIframeChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconIframe.jpg",
+      "target": "rx_resources/widgets/iframe/images/widgetIconIframe.jpg",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "title",
+      "displayName": "Title",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "iframeurl",
+      "displayName": "URL",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "height",
+      "displayName": "Height in pixels or percent",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "width",
+      "displayName": "Width in pixels or percent",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "marginheight",
+      "displayName": "Top and Bottom margin in pixels",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "marginwidth",
+      "displayName": "Left and Right margin in pixels",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "frameborder",
+      "displayName": "Frame border",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "disable",
+      "enumValues": [
+        {
+          "value": "disable",
+          "displayValue": "Disable border"
+        },
+        {
+          "value": "enable",
+          "displayValue": "Enable border"
+        }
+      ]
+    },
+    {
+      "name": "referalPolicy",
+      "displayName": "Referrer-Policy",
+      "datatype": "enum",
+      "required": false,
+      "enumValues": [
+        {
+          "value": "no-referrer",
+          "displayValue": "no-referrer"
+        },
+        {
+          "value": "no-referrer-when-downgrade",
+          "displayValue": "no-referrer-when-downgrade"
+        },
+        {
+          "value": "origin",
+          "displayValue": "origin"
+        },
+        {
+          "value": "origin-when-cross-origin",
+          "displayValue": "origin-when-cross-origin"
+        },
+        {
+          "value": "same-origin",
+          "displayValue": "same-origin"
+        },
+        {
+          "value": "strict-origin",
+          "displayValue": "strict-origin"
+        },
+        {
+          "value": "strict-origin-when-cross-origin",
+          "displayValue": "strict-origin-when-cross-origin"
+        },
+        {
+          "value": "unsafe-url",
+          "displayValue": "unsafe-url"
+        }
+      ]
+    },
+    {
+      "name": "scrollbar",
+      "displayName": "Scrolling",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "auto",
+      "enumValues": [
+        {
+          "value": "auto",
+          "displayValue": "Auto"
+        },
+        {
+          "value": "no",
+          "displayValue": "No"
+        },
+        {
+          "value": "yes",
+          "displayValue": "Yes"
+        }
+      ]
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Aria Label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "alternateContent",
+      "displayName": "Alternate Content",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percIframeSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percIframeSnippet.vm
@@ -1,0 +1,32 @@
+<div class = "perc-iframe $!{rootclass}" data="$!{dynamicListData}">
+				#if ($perc.isEditMode())
+					#if($iframeurl.isEmpty())
+                        #createEmptyWidgetContent("iframe-sample-content", "This iframe widget is showing sample content.")
+					#else
+						#if($defaultHeight.isEmpty()|| $defaultWidth.isEmpty() )
+                            #createEmptyWidgetContent("iframe-edit-content", "Preview the page or asset to view this iframe.")
+						#else
+                            #createEmptyWidgetContent("iframe-edit-content", "Preview the page or asset to view this iframe.", "width:$!{width} ; height:$!{height}")
+						#end
+                    #end
+
+				#else
+                    ## Absolute paths must be start with http:// or https://
+                    #if($perc.isPreviewMode() && (!$iframeurl.isEmpty() && !$iframeurl.startsWith("http://") && !$iframeurl.startsWith("https://")))
+                        <div style = "width:$!{width}; height:$!{height}; border: $!{frameborder}px solid" class="iframe-relative-url" title="$!{title}">
+						#if("$!alternateContent" != "")<p #if("$!ariaLabel" != "")aria-label="$ariaLabel"#end>$alternateContent</p>#end
+
+                            <p>Relative page urls are not supported in preview mode</p>
+                        </div>
+                    #else
+                        <iframe src = "$!{iframeurl}"   referrerpolicy="$!{referalPolicy}" style = "width: $!{width}; height: $!{height}; overflow: $!{overflow} !important; border: $!{frameborder}; margin-top: $!{marginheight}; margin-bottom: $!{marginheight}; margin-left: $!{marginwidth}; margin-right: $!{marginwidth};" title="$!{title}" #if($title.isEmpty() && "$!ariaLabel" != "")aria-label="$!{ariaLabel}"#end >
+
+						#if("$!alternateContent" != "")<p #if("$!ariaLabel" != "")aria-label="$ariaLabel"#end>$alternateContent</p>#end
+
+							<p>Your browser does not support frames or is currently configured
+                            not to display frames. However, you may browse the content of frames by
+                            <a href="$!{iframeurl}">clicking here.</a></p>
+                        </iframe>
+                    #end
+			   #end
+			</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percPoll.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percPoll.component-package.json
@@ -1,0 +1,239 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percPoll",
+  "name": "Polls",
+  "version": "1.2.0",
+  "description": "Widget to build and render polls.",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.5.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Polls",
+    "category": "social,blog",
+    "description": "Widget to build and render polls.",
+    "thumbnail": "resources/widgetIconPoll.png",
+    "icon": "resources/widgetIconPoll.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percPollAsset",
+      "ref": "contentTypes/percPollAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percPollSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percPollSnippet.vm",
+      "contentType": "percPollAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "viewResultsLink",
+          "expression": "$props.get(\"viewResultsLink\")"
+        },
+        {
+          "variable": "viewResultsLinkText",
+          "expression": "$props.get(\"viewResultsLinkText\")"
+        },
+        {
+          "variable": "pollSubmitLabel",
+          "expression": "$props.get(\"submitLabel\")"
+        },
+        {
+          "variable": "restrictionType",
+          "expression": "$props.get(\"pollRestrictionType\")"
+        },
+        {
+          "variable": "validationText",
+          "expression": "$props.get(\"validationText\")"
+        },
+        {
+          "variable": "backToPollText",
+          "expression": "$props.get(\"backToPollText\")"
+        },
+        {
+          "variable": "totalVotesText",
+          "expression": "$props.get(\"totalVotesText\")"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "pollQuestion",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "pollName",
+          "expression": "$assetItem.Node.getProperty('rx:sys_title').getString()"
+        },
+        {
+          "variable": "pollTitle",
+          "expression": "$assetItem.Node.getProperty('rx:pollTitle').getString()"
+        },
+        {
+          "variable": "pollQuestion",
+          "expression": "$assetItem.Node.getProperty('rx:pollQuestion').getString()"
+        },
+        {
+          "variable": "qJson",
+          "expression": "$rx.pageutils.createJsonObject($pollQuestion)"
+        },
+        {
+          "variable": "question",
+          "expression": "$qJson.getString(\"question\")"
+        },
+        {
+          "variable": "answerType",
+          "expression": "$qJson.getString(\"answerType\")"
+        },
+        {
+          "variable": "inputType",
+          "expression": "\"radio\""
+        },
+        {
+          "variable": "inputType",
+          "expression": "\"checkbox\""
+        },
+        {
+          "variable": "ansArray",
+          "expression": "$qJson.getJSONArray(\"answerChoices\").toArray()"
+        },
+        {
+          "variable": "dataJson",
+          "expression": "$rx.pageutils.createJsonObject(\"{}\")"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "## Widget Properties\n\t\t\t$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n            $props = $perc.widget.item.properties;\n            $viewResultsLink = $props.get(\"viewResultsLink\");\n            $viewResultsLinkText = $props.get(\"viewResultsLinkText\");\n\t\t\t$pollSubmitLabel = $props.get(\"submitLabel\");\n\t\t\t$restrictionType = $props.get(\"pollRestrictionType\");\n\t\t\t$validationText = $props.get(\"validationText\");\n\t\t\t$backToPollText = $props.get(\"backToPollText\");\n\t\t\t$totalVotesText = $props.get(\"totalVotesText\");\n\n\t\t\t## Asset properties\n\t\t\t$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\t\t\t$perc.setWidgetContents($assetItems);\n\t\t\t$pollQuestion = \"\";\n\t        if ( ! $assetItems.isEmpty() ) {\n\t\t\t\t$assetItem = $assetItems.get(0);\n\t\t\t\t$pollName = $assetItem.Node.getProperty('rx:sys_title').getString();\n\t\t\t\t$pollTitle = $assetItem.Node.getProperty('rx:pollTitle').getString();\n\t\t\t\t$pollQuestion = $assetItem.Node.getProperty('rx:pollQuestion').getString();\n\t\t\t\t$qJson = $rx.pageutils.createJsonObject($pollQuestion);\n\t\t\t\t$question = $qJson.getString(\"question\");\n\t\t\t\t$answerType = $qJson.getString(\"answerType\");\n\t\t\t\t$inputType = \"radio\";\n\t\t\t\tif($answerType.equals(\"multi\"))\n\t\t\t\t\t$inputType = \"checkbox\";\n\t\t\t\t$ansArray = $qJson.getJSONArray(\"answerChoices\").toArray();\n\n\t\t\t\t## Create data JSON object\n\t\t\t\t$dataJson = $rx.pageutils.createJsonObject(\"{}\");\n\t\t\t\t$dataJson.put(\"pollName\",$pollName);\n\t\t\t\t$dataJson.put(\"restrictionType\",$restrictionType);\n\t\t\t}\n\n\t\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percPollContent",
+      "allowedContentTypes": [
+        "percPollAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconPoll.png",
+      "target": "rx_resources/widgets/percPoll/images/widgetIconPoll.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "pollRestrictionType",
+      "displayName": "Restrict poll submission by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "Unrestricted",
+      "enumValues": [
+        {
+          "value": "Unrestricted",
+          "displayValue": "Unrestricted"
+        },
+        {
+          "value": "Session",
+          "displayValue": "Session"
+        },
+        {
+          "value": "Cookie",
+          "displayValue": "Cookie"
+        }
+      ]
+    },
+    {
+      "name": "submitLabel",
+      "displayName": "Submit button label",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Vote",
+      "enumValues": []
+    },
+    {
+      "name": "viewResultsLink",
+      "displayName": "Show view results link",
+      "datatype": "bool",
+      "required": true,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "viewResultsLinkText",
+      "displayName": "Text for view results",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "View results",
+      "enumValues": []
+    },
+    {
+      "name": "validationText",
+      "displayName": "Validation text",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Please choose an answer first!",
+      "enumValues": []
+    },
+    {
+      "name": "totalVotesText",
+      "displayName": "Text for total votes",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Total votes",
+      "enumValues": []
+    },
+    {
+      "name": "backToPollText",
+      "displayName": "Text to return",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Back to poll",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percPollSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percPollSnippet.vm
@@ -1,0 +1,54 @@
+#if( ! $perc.widgetContents.isEmpty())
+			<div class = "perc-polls $!{rootclass}" data-poll='{"pollName":"$pollName","restrictionType":"$restrictionType","deliveryurl":"$dsUrl"}'>
+				#if($perc.isEditMode())
+					<div class="perc-poll-render-container">
+				#else
+					<div class="perc-poll-render-container" style="display:none">
+				#end
+					<div class="perc-poll-title">$!{pollTitle}</div>
+					<div class="perc-poll-question">$!{question}</div>
+					#foreach($ans in $ansArray)
+						<div class="perc-poll-answer-container"><input type="$inputType" name="perc-poll-answer"/><span class="perc-poll-answer">$ans</span></div>
+					#end
+					#if($perc.isEditMode() || $perc.isPreviewMode() )
+						#set($subspanclass = "perc-poll-submit-button-span")
+					#else
+						#set($subspanclass = "perc-poll-submit-button-span perc-poll-submit-button-span-action")
+					#end
+					<div class="poll-submit-button"><input type="button" value="$pollSubmitLabel" name="perc-poll-submit-button"/><span class="$subspanclass" >$pollSubmitLabel</span></div>
+					#if($viewResultsLink)
+						#if($perc.isEditMode() || $perc.isPreviewMode() )
+							#set($rlclass = "view-results-link")
+						#else
+							#set($rlclass = "view-results-link view-results-link-action")
+						#end
+						<div class="$rlclass"><a href="javascript:void(0)">$viewResultsLinkText</a></div>
+					#else
+						#set($rlclass = "view-results-link view-results-link-action")
+						<div class="$rlclass"></div>
+					#end
+					<div class="poll-validation-text" style="display:none;">$validationText</div>
+				</div>
+				<div class="perc-poll-results-container" style="display:none">
+					<div class="perc-poll-title">$!{pollTitle}</div>
+					<div class="perc-poll-question">$!{question}</div>
+					#foreach($ans in $ansArray)
+						<div class="perc-poll-answer-container"><span class="perc-poll-answer">$ans</span><span class="perc-poll-result-percent"></span><span class="perc-poll-result-count"></span></div>
+						<div class="perc-poll-result-container"><span class="perc-poll-result-fill"></span><span class="perc-poll-result-empty"></span></div>
+					#end
+					<div class="perc-poll-total-votes">$totalVotesText:<span></span></div>
+					<div class="perc-poll-backto-poll"><a href="javascript:void(0)">$backToPollText</a></div>
+				</div>
+
+			</div>
+		#elseif ($perc.isEditMode())
+            #createEmptyWidgetContent("poll-sample-content", "This polls widget is showing sample content.")
+		#end
+		#if($perc.isPreviewMode())
+				<script>
+				window.addEventListener('DOMContentLoaded', function() {
+					jQuery("input[name = 'perc-poll-submit-button']").attr('disabled', 'disabled');
+					jQuery(".perc-poll-render-container").show();
+				});
+				</script>
+		#end

--- a/modules/perc-packages/src/test/resources/widgetxml/percForm.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percForm.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Form" contenttype_name="percFormAsset"
+		category="integration"
+		description="Widget to build and render form data."
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/form/images/widgetIconForm.gif"
+		preferred_editor_width="965" preferred_editor_height="600"
+		is_responsive="false" />
+	<UserPref name="labelalign" display_name="Label align"
+		required="true" default_value="top" datatype="enum">
+		<EnumValue value="top" display_value="Top of the control" />
+		<EnumValue value="left" display_value="Left of the control" />
+	</UserPref>
+
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+
+	<Code type="jexl">
+        <![CDATA[
+            $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+            if(!empty($rootclass)) {
+                $rootclass = $rootclass;
+            }
+            $props = $perc.widget.item.properties;
+            $labelalignclass = "perc-label-location-top";
+            if($props.get("labelalign") != null && $props.get("labelalign").equals("left"))
+                $labelalignclass = "perc-label-location-left";
+
+			$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+
+            $dynamicListData = $tools.esc.html("{ deliveryurl : '" + $dsUrl + "'}");
+
+        ]]>
+	</Code>
+
+	<Content type="velocity">
+        <![CDATA[
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty())##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+<div class = "perc-form $!{rootclass} $!{labelalignclass}" data="$!{dynamicListData}">
+#if( ! $perc.widgetContents.isEmpty())##
+#set($formString = $node.getProperty('rx:renderedform').getString())##
+#set($returnString = $rx.pageutils.processForm($sys.assemblyItem, $perc.widget, $formString))##
+<div class = "perc-form-name">$returnString </div>
+#set($formData = $node.getProperty('rx:formdata').String)##
+#if($formData.contains('honeypot') || $formData.contains('recaptcha'))##
+<script>
+    function validatePercForm() {
+        var ret = false;
+        #if($formData.contains('honeypot'))##
+        if(!document.getElementById('topyenoh').value) {
+            ret=true;
+        }
+        else {
+            ret=false;
+        }
+        #end##
+        #if($formData.contains('recaptcha'))##
+         if (grecaptcha.getResponse() === '') {
+         	ret = false;
+         }else {
+         	ret = true;
+         }
+        #end##
+        return ret;
+    }
+</script>
+#end##
+
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("form-sample-content", "This Form widget is showing sample content.")
+#end
+
+#if($perc.isPreviewMode())
+<script>
+window.addEventListener('DOMContentLoaded', function() {
+jQuery("form").on('submit',function(){return false;});
+jQuery("input[type = 'submit']").attr('disabled', 'disabled');
+});
+</script>
+#end
+</div>
+]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/percIframe.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percIframe.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Iframe" contenttype_name=""
+		category="integration"
+		description="Embed an external web page within a Percussion page"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/iframe/images/widgetIconIframe.jpg"
+		is_responsive="true" />
+
+	<UserPref name="title" display_name="Title" default_value=""
+		datatype="string" />
+
+	<UserPref name="iframeurl" display_name="URL" default_value=""
+		datatype="string" />
+
+	<UserPref name="height"
+		display_name="Height in pixels or percent" datatype="string" />
+
+	<UserPref name="width"
+		display_name="Width in pixels or percent" datatype="string" />
+
+	<UserPref name="marginheight"
+		display_name="Top and Bottom margin in pixels" default_value=""
+		datatype="string" />
+
+	<UserPref name="marginwidth"
+		display_name="Left and Right margin in pixels" default_value=""
+		datatype="string" />
+
+	<UserPref name="frameborder" display_name="Frame border"
+		default_value="disable" datatype="enum">
+		<EnumValue value="disable" display_value="Disable border" />
+		<EnumValue value="enable" display_value="Enable border" />
+	</UserPref>
+
+	<UserPref name="referalPolicy" display_name="Referrer-Policy"
+		datatype="enum">
+		<EnumValue value="no-referrer" display_value="no-referrer" />
+		<EnumValue value="no-referrer-when-downgrade"
+			display_value="no-referrer-when-downgrade" />
+		<EnumValue value="origin" display_value="origin" />
+		<EnumValue value="origin-when-cross-origin"
+			display_value="origin-when-cross-origin" />
+		<EnumValue value="same-origin" display_value="same-origin" />
+		<EnumValue value="strict-origin"
+			display_value="strict-origin" />
+		<EnumValue value="strict-origin-when-cross-origin"
+			display_value="strict-origin-when-cross-origin" />
+		<EnumValue value="unsafe-url" display_value="unsafe-url" />
+	</UserPref>
+
+	<UserPref name="scrollbar" display_name="Scrolling"
+		default_value="auto" datatype="enum">
+		<EnumValue value="auto" display_value="Auto" />
+		<EnumValue value="no" display_value="No" />
+		<EnumValue value="yes" display_value="Yes" />
+	</UserPref>
+
+	<UserPref name="ariaLabel" display_name="Aria Label"
+		datatype="string" />
+
+	<UserPref name="alternateContent"
+		display_name="Alternate Content" datatype="string" />
+
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+
+	<Code type="jexl">
+		<![CDATA[
+			$rootclass = $perc.widget.item.cssProperties.get('rootclass');
+			if(!empty($rootclass)) {
+				$rootclass = $rootclass;
+			}
+			$props = $perc.widget.item.properties;
+			$iframeurl = $props.get("iframeurl");
+			$referalPolicy = $props.get("referalPolicy");
+			if($iframeurl.startsWith("www"))
+				$iframeurl = "http://" + $iframeurl;
+			$height = $props.get("height");
+			$defaultHeight = $props.get("height");
+			$width = $props.get("width");
+			$defaultWidth = $props.get("width");
+			$frameborder = $props.get("frameborder");
+			$scrollbar = $props.get("scrollbar");
+			$iframeid="perc-iframe-" + $perc.widget.item.id;
+			$title = $props.get("title");
+			$marginheight = $props.get("marginheight");
+			$marginwidth = $props.get("marginwidth");
+			$ariaLabel = $props.get("ariaLabel");
+			$alternateContent = $props.get("alternateContent");
+
+			if($frameborder == "disable"){
+				$frameborder = "0";
+			}
+			else{
+				$frameborder = "1";
+			}
+			$overflow = "auto";
+			if($scrollbar == "yes"){
+				$overflow='visible';
+			}
+			else if($scrollbar == "no"){
+				$overflow='hidden';
+			}
+
+			if(empty($height)){
+				$height='100%';
+			}
+			if(empty($width)){
+				$width='100%';
+			}
+
+			if(empty($marginheight)){
+				$marginheight = '0px';
+			}
+			if(empty($marginwidth)){
+				$marginwidth = '0px';
+			}
+
+			if($width.indexOf('p') == -1 && $width.indexOf('%') == -1){
+				$width = $width + 'px';
+			}
+			if($height.indexOf('p') == -1 && $height.indexOf('%') == -1){
+				$height = $height + 'px';
+			}
+
+            $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+        	if ($dsUrl.indexOf("http://localhost") != -1 )
+			    $dsUrl = "";
+            $dynamicListData = $tools.esc.html("{ deliveryurl : '" + $dsUrl + "'}");
+		]]>
+	</Code>
+
+	<Content type="velocity">
+		<![CDATA[
+			<div class = "perc-iframe $!{rootclass}" data="$!{dynamicListData}">
+				#if ($perc.isEditMode())
+					#if($iframeurl.isEmpty())
+                        #createEmptyWidgetContent("iframe-sample-content", "This iframe widget is showing sample content.")
+					#else
+						#if($defaultHeight.isEmpty()|| $defaultWidth.isEmpty() )
+                            #createEmptyWidgetContent("iframe-edit-content", "Preview the page or asset to view this iframe.")
+						#else
+                            #createEmptyWidgetContent("iframe-edit-content", "Preview the page or asset to view this iframe.", "width:$!{width} ; height:$!{height}")
+						#end
+                    #end
+
+				#else
+                    ## Absolute paths must be start with http:// or https://
+                    #if($perc.isPreviewMode() && (!$iframeurl.isEmpty() && !$iframeurl.startsWith("http://") && !$iframeurl.startsWith("https://")))
+                        <div style = "width:$!{width}; height:$!{height}; border: $!{frameborder}px solid" class="iframe-relative-url" title="$!{title}">
+						#if("$!alternateContent" != "")<p #if("$!ariaLabel" != "")aria-label="$ariaLabel"#end>$alternateContent</p>#end
+
+                            <p>Relative page urls are not supported in preview mode</p>
+                        </div>
+                    #else
+                        <iframe src = "$!{iframeurl}"   referrerpolicy="$!{referalPolicy}" style = "width: $!{width}; height: $!{height}; overflow: $!{overflow} !important; border: $!{frameborder}; margin-top: $!{marginheight}; margin-bottom: $!{marginheight}; margin-left: $!{marginwidth}; margin-right: $!{marginwidth};" title="$!{title}" #if($title.isEmpty() && "$!ariaLabel" != "")aria-label="$!{ariaLabel}"#end >
+
+						#if("$!alternateContent" != "")<p #if("$!ariaLabel" != "")aria-label="$ariaLabel"#end>$alternateContent</p>#end
+
+							<p>Your browser does not support frames or is currently configured
+                            not to display frames. However, you may browse the content of frames by
+                            <a href="$!{iframeurl}">clicking here.</a></p>
+                        </iframe>
+                    #end
+			   #end
+			</div>
+		]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/percPoll.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percPoll.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Polls" category="social,blog"
+		contenttype_name="percPollAsset"
+		description="Widget to build and render polls."
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/percPoll/images/widgetIconPoll.png"
+		preferred_editor_width="780" preferred_editor_height="600"
+		is_responsive="true" />
+	<UserPref name="pollRestrictionType"
+		display_name="Restrict poll submission by" required="true"
+		default_value="Unrestricted" datatype="enum">
+		<EnumValue value="Unrestricted" display_value="Unrestricted" />
+		<EnumValue value="Session" display_value="Session" />
+		<EnumValue value="Cookie" display_value="Cookie" />
+	</UserPref>
+	<UserPref name="submitLabel"
+		display_name="Submit button label" required="true"
+		default_value="Vote" datatype="string" />
+	<UserPref name="viewResultsLink"
+		display_name="Show view results link" required="true"
+		default_value="true" datatype="bool" />
+	<UserPref name="viewResultsLinkText"
+		display_name="Text for view results" required="true"
+		default_value="View results" datatype="string" />
+	<UserPref name="validationText" display_name="Validation text"
+		required="true" default_value="Please choose an answer first!"
+		datatype="string" />
+	<UserPref name="totalVotesText"
+		display_name="Text for total votes" required="true"
+		default_value="Total votes" datatype="string" />
+	<UserPref name="backToPollText" display_name="Text to return"
+		required="true" default_value="Back to poll" datatype="string" />
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+	<Code type="jexl"><![CDATA[
+			## Widget Properties
+			$rootclass = $perc.widget.item.cssProperties.get('rootclass');
+            $props = $perc.widget.item.properties;
+            $viewResultsLink = $props.get("viewResultsLink");
+            $viewResultsLinkText = $props.get("viewResultsLinkText");
+			$pollSubmitLabel = $props.get("submitLabel");
+			$restrictionType = $props.get("pollRestrictionType");
+			$validationText = $props.get("validationText");
+			$backToPollText = $props.get("backToPollText");
+			$totalVotesText = $props.get("totalVotesText");
+
+			## Asset properties
+			$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);
+			$perc.setWidgetContents($assetItems);
+			$pollQuestion = "";
+	        if ( ! $assetItems.isEmpty() ) {
+				$assetItem = $assetItems.get(0);
+				$pollName = $assetItem.Node.getProperty('rx:sys_title').getString();
+				$pollTitle = $assetItem.Node.getProperty('rx:pollTitle').getString();
+				$pollQuestion = $assetItem.Node.getProperty('rx:pollQuestion').getString();
+				$qJson = $rx.pageutils.createJsonObject($pollQuestion);
+				$question = $qJson.getString("question");
+				$answerType = $qJson.getString("answerType");
+				$inputType = "radio";
+				if($answerType.equals("multi"))
+					$inputType = "checkbox";
+				$ansArray = $qJson.getJSONArray("answerChoices").toArray();
+
+				## Create data JSON object
+				$dataJson = $rx.pageutils.createJsonObject("{}");
+				$dataJson.put("pollName",$pollName);
+				$dataJson.put("restrictionType",$restrictionType);
+			}
+
+			$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+
+        ]]></Code>
+	<Content type="velocity"><![CDATA[
+		#if( ! $perc.widgetContents.isEmpty())
+			<div class = "perc-polls $!{rootclass}" data-poll='{"pollName":"$pollName","restrictionType":"$restrictionType","deliveryurl":"$dsUrl"}'>
+				#if($perc.isEditMode())
+					<div class="perc-poll-render-container">
+				#else
+					<div class="perc-poll-render-container" style="display:none">
+				#end
+					<div class="perc-poll-title">$!{pollTitle}</div>
+					<div class="perc-poll-question">$!{question}</div>
+					#foreach($ans in $ansArray)
+						<div class="perc-poll-answer-container"><input type="$inputType" name="perc-poll-answer"/><span class="perc-poll-answer">$ans</span></div>
+					#end
+					#if($perc.isEditMode() || $perc.isPreviewMode() )
+						#set($subspanclass = "perc-poll-submit-button-span")
+					#else
+						#set($subspanclass = "perc-poll-submit-button-span perc-poll-submit-button-span-action")
+					#end
+					<div class="poll-submit-button"><input type="button" value="$pollSubmitLabel" name="perc-poll-submit-button"/><span class="$subspanclass" >$pollSubmitLabel</span></div>
+					#if($viewResultsLink)
+						#if($perc.isEditMode() || $perc.isPreviewMode() )
+							#set($rlclass = "view-results-link")
+						#else
+							#set($rlclass = "view-results-link view-results-link-action")
+						#end
+						<div class="$rlclass"><a href="javascript:void(0)">$viewResultsLinkText</a></div>
+					#else
+						#set($rlclass = "view-results-link view-results-link-action")
+						<div class="$rlclass"></div>
+					#end
+					<div class="poll-validation-text" style="display:none;">$validationText</div>
+				</div>
+				<div class="perc-poll-results-container" style="display:none">
+					<div class="perc-poll-title">$!{pollTitle}</div>
+					<div class="perc-poll-question">$!{question}</div>
+					#foreach($ans in $ansArray)
+						<div class="perc-poll-answer-container"><span class="perc-poll-answer">$ans</span><span class="perc-poll-result-percent"></span><span class="perc-poll-result-count"></span></div>
+						<div class="perc-poll-result-container"><span class="perc-poll-result-fill"></span><span class="perc-poll-result-empty"></span></div>
+					#end
+					<div class="perc-poll-total-votes">$totalVotesText:<span></span></div>
+					<div class="perc-poll-backto-poll"><a href="javascript:void(0)">$backToPollText</a></div>
+				</div>
+
+			</div>
+		#elseif ($perc.isEditMode())
+            #createEmptyWidgetContent("poll-sample-content", "This polls widget is showing sample content.")
+		#end
+		#if($perc.isPreviewMode())
+				<script>
+				window.addEventListener('DOMContentLoaded', function() {
+					jQuery("input[name = 'perc-poll-submit-button']").attr('disabled', 'disabled');
+					jQuery(".perc-poll-render-container").show();
+				});
+				</script>
+		#end
+    ]]></Content>
+</Widget>


### PR DESCRIPTION
## Summary
Parent epic **#2630** (Phase 3 product Widget XML → package model). Continues after baseWidgets (#2751) and high-traffic (#2772 / cluster #2791).

Adds a **PR-sized residual long-tail batch** of product Widget XML packages to the modern compiler path with golden parity, without removing product Widget XML (dual-run).

### Batch (#2789) — 9 packages / 13 widgets
| Package | Widgets |
|---------|---------|
| `perc.widgets.blog` | percBlogPost |
| `perc.widget.calendar` | percCalendar, percCalendarTwo |
| `perc.widget.directory` | percDepartment, percDirectory, percOrganization, percPerson |
| `perc.widget.socialButtons` | percSocialButtons |
| `perc.widget.form` | percForm |
| `perc.widget.poll` | percPoll |
| `perc.widget.login` | percLogin |
| `perc.widget.rss` | percRss |
| `perc.widget.iframe` | percIframe |

### Goldens
- `percForm` (integration + CT)
- `percPoll` (social + CT + UserPrefs)
- `percIframe` (chrome / no CT)

### Code
- `RESIDUAL_PRODUCT_PACKAGE_DIRS` + `compileResidualProductPackages` / shared `compileNamedPackages`
- No compiler shape extensions required (existing JEXL + Velocity + CT/chrome path covers residual)
- Inventory doc updated for measurable reduction + remaining residual list
- Further residual filed as **#2802** for auto-lists / jquery / comments / etc.

Fixes #2789  
Partial of #2630 (further residual #2802)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
1. `cd modules/perc-packages && ../../mvnw.cmd clean install`
2. Confirm `PSWidgetXmlCompilerTest` residual suite green (package compile 13 widgets + 3 goldens)
3. Confirm product `rxconfig/Widgets/*.xml` still present (dual-run)

## C3 build evidence
- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages; ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **68**, Failures: 0 (widgetxml tests: 24)
- **downstream_checked:** none (no public API shape change; no types made final/sealed; reverse-dep compile not required)

> Co-Authored by Grok Build using grok-4.5 with agent main.
