### PR TITLE
feat(perc-packages): remaining product widget XML compiler batch + goldens (#2802)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -49,17 +49,17 @@ Ship-format model and docs landed as Phase 3 slice 1 (#2750):
 
 **Upgrade-input XML** remains compiler/shim only; **product ship format** is `component-package.json` plus content types, templates, slots, catalog metadata, and resources.
 
-## Widget XML compiler (slices #2751 / #2772)
+## Widget XML compiler (slices #2751 / #2772 / #2789 / #2802)
 
-Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidgets + high-traffic batch):
+Compiler for upgrade-input Widget XML → Component Package Manifest (baseWidgets + high-traffic + residual + remaining product batches):
 
 | Artifact | Location |
 |----------|----------|
 | Parser / compiler / package scanner | `modules/perc-packages/.../widgetxml/PSWidgetXml*.java` |
-| Golden parity (simple + high-traffic) | `modules/perc-packages/src/test/resources/widgetxml/golden/` |
-| Inventory + residuals | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
+| Golden parity (all product batches) | `modules/perc-packages/src/test/resources/widgetxml/golden/` |
+| Inventory | [../widget-xml-inventory.md](../widget-xml-inventory.md) |
 
-Remaining long-tail product packages and product Widget XML removal remain residual under #2630.
+Product package compile coverage is complete for all product widgets except `perc.Test`. Product Widget XML dual-run exit (delete package Widget XML) remains residual under #2630 / Phase 5 (#2632).
 
 ## Page templateDef compiler (slice #2770)
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/component-package-manifest.md
@@ -175,26 +175,25 @@ String json = PSComponentPackageManifestIo.toJson(m);
 - **Today:** `PSPackageBuilder` zips legacy package source trees into `.ppkg` for the deployer (`psx_archiveInfo.xml` / dependency trees). That path remains for install compatibility.
 - **This manifest:** extends the packaging story with an explicit, tool-friendly **component** model that does not require Widget/Page/Gadget XML. Future slices wire compiler output and install recognition; this slice lands model + schema + tests only.
 
-## Widget XML compiler (slices #2751 / #2772)
+## Widget XML compiler (slices #2751 / #2772 / #2789 / #2802)
 
-Upgrade-input path for **baseWidgets** and the **high-traffic residual batch**:
+Upgrade-input path for **baseWidgets**, **high-traffic**, **#2789 residual**, and **#2802 remaining product** batches:
 
 | Type | Role |
 |------|------|
 | `PSWidgetXmlParser` | Secure DOM parse of `<Widget>` definition XML (prefs, code, content, **Resource**) |
 | `PSWidgetXmlCompiler` | XML model → `PSComponentPackageManifest` + template text artifacts |
-| `PSWidgetXmlPackageCompiler` | Scan `sys__UserDependency--rxconfig/Widgets/*.xml` under a package root; `compileHighTrafficPackages` |
-| Golden fixtures | `modules/perc-packages/src/test/resources/widgetxml/golden/` (percSimpleText, percTitle, simplePageAutoList, percNavBreadcrumb) |
+| `PSWidgetXmlPackageCompiler` | Scan `sys__UserDependency--rxconfig/Widgets/*.xml`; `compileHighTrafficPackages`, `compileResidualProductPackages`, `compileRemainingProductPackages` |
+| Golden fixtures | `modules/perc-packages/src/test/resources/widgetxml/golden/` (base + high-traffic + residual + remaining reps) |
 
-Inventory + residual packages: [widget-xml-inventory.md](./widget-xml-inventory.md).
+Inventory: [widget-xml-inventory.md](./widget-xml-inventory.md). All product widget packages (except `perc.Test`) have package-compile coverage; dual-run product XML deletion is Phase 5.
 
 ## Out of scope (sibling / residual)
 
 | Slice | Issue | Role |
 |-------|-------|------|
 | Runtime legacy shim | #2752 | Load customer XML when modern package absent |
-| Remaining high-traffic / long-tail widgets | residual under #2630 | blog, calendar, directory, social, forms, auto-lists, … (see inventory) |
-| Delete product Widget XML from source | later | After install path consumes modern artifacts |
+| Delete product Widget XML from source | Phase 5 / #2632 | After install path consumes modern artifacts |
 
 ## Validation summary
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -4,17 +4,18 @@
 **Source:** `modules/perc-packages/src/main/resources/Packages/**/rxconfig/Widgets/*.xml`  
 **Machine-readable:** [widget-xml-inventory.csv](./widget-xml-inventory.csv)
 
-## Compiler status (#2751 / #2772 / #2789 / parent #2630)
+## Compiler status (#2751 / #2772 / #2789 / #2802 / parent #2630)
 
 | Area | Status | Notes |
 |------|--------|-------|
-| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic + residual long-tail batch** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
+| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic + residual #2789 + remaining #2802** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
 | Golden parity (baseWidgets) | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
 | Golden parity (high-traffic #2772) | **percTitle**, **simplePageAutoList**, **percNavBreadcrumb** | Plus package compile of title, lists×2, nav×2, file, image (7 widgets) |
 | Golden parity (residual #2789) | **percForm**, **percPoll**, **percIframe** | Plus package compile of blog/calendar×2/directory×4/social/form/poll/login/rss/iframe (**13** widgets) |
-| Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT); residual batch needed no new shapes |
+| Golden parity (remaining #2802) | **percImageAutoList**, **percComments**, **percEvent** | Plus package compile of auto-lists, blog companions, social/comments/cards, event/slider/cookie/jquery, login variants, Result/Redirect, defaultLanguage (**24** widgets / 23 packages) |
+| Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT); residual batches needed no new shapes |
 | **Product packages still ship Widget XML** | Yes (dual-run) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
-| Residual product packages (after #2789) | Open | auto-lists (image/page/file), jquery/jqueryUI, comments/liked, event, social cards, blog index, etc. — see matrix |
+| Residual product packages (after #2802) | **None** (product inventory complete except `perc.Test`) | Dual-run exit / product XML deletion remains Phase 5 (#2632 / parent #2630) |
 | Runtime legacy XML shim | Landed (cluster #2766) | #2752 |
 
 ### High-traffic batch covered by #2772
@@ -44,6 +45,36 @@ Measurable reduction (#2772): **7** product widget definition XMLs with validate
 | `perc.widget.iframe` | percIframe | Chrome (no CT); golden |
 
 Measurable reduction (#2789): **+13** product widget definition XMLs on the validated modern compile path (cumulative product widgets with package compile coverage: **3 base + 7 high-traffic + 13 residual = 23**, excluding `perc.Test`).
+
+### Remaining product residual batch covered by #2802
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.ImageAutoListWidget` | percImageAutoList | Auto-list; golden (many UserPref + CssPref) |
+| `perc.PageAutoListWidget` | percPageAutoList | Auto-list (page search) |
+| `perc.widget.fileAutoList` | percFileAutoList | Auto-list (file) |
+| `perc.widget.blogIndexPage` | percBlogIndexPage | Blog list companion |
+| `perc.widget.archiveList` | percArchiveList | Blog archives |
+| `perc.widget.categoryList` | percCategoryList | Blog categories |
+| `perc.widget.taglist` | percTagList | Blog tags |
+| `perc.widget.MostReadBlogPosts` | percMostReadBlogPosts | Chrome (no CT); search |
+| `perc.widgets.comments` | percComments | Chrome (no CT); golden |
+| `perc.widgets.liked` | percLiked | Chrome (no CT) |
+| `perc.widget.commentForm` | percCommentsForm | Blog/social form CT |
+| `perc.openGraphWidget` | percOpenGraph | Social meta cards |
+| `perc.twitterSummaryCards` | percTwitterSummaryCards | Social meta cards |
+| `perc.eventWidget` | percEvent | Content CT; golden |
+| `perc.widget.imageSlider` | percImageSlider | Rich media slider |
+| `perc.widget.cookieConsent` | percCookieConsent | Consent banner |
+| `perc.widget.jquery` | percJQueryWidget | Chrome (no CT) |
+| `perc.widget.jqueryUI` | percJQueryUIWidget | Chrome (no CT) |
+| `perc.widget.registration` | percRegistration | Deprecated login variant |
+| `perc.widget.secureLogin` | percSecureLogin | Deprecated login variant |
+| `perc.widget.Result` | percResult | Chrome (no CT); search |
+| `perc.widgets.Redirect` | percRedirect | Redirect CT |
+| `perc.defaultLanguage` | percDefaultLang, percLocalLang | Multi-widget language package |
+
+Measurable reduction (#2802): **+24** product widget definition XMLs on the validated modern compile path (cumulative product widgets with package compile coverage: **3 + 7 + 13 + 24 = 47**, excluding `perc.Test`; full product inventory of 48 − test = 47).
 
 Ship format: [component-package-manifest.md](./component-package-manifest.md). ADR: [004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md).
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -36,14 +36,16 @@ import java.util.regex.Pattern;
 
 /**
  * Compiles legacy Widget definition XML into a modern {@link PSComponentPackageManifest} plus
- * template source artifacts (Phase 3 / ADR-004 / issues #2751, #2772).
+ * template source artifacts (Phase 3 / ADR-004 / issues #2751, #2772, #2789, #2802).
  *
  * <p><strong>Scope:</strong> baseWidgets-shaped widgets, high-traffic product packages (title,
- * lists, nav chrome, file, image — #2772), and residual long-tail product packages (blog, calendar,
- * directory, social, forms, poll, login, rss, iframe — #2789): JEXL code + Velocity content +
- * optional asset content type + UserPref/CssPref + {@code <Resource>} CSS/JS refs. Further residual
- * packages (auto-lists, jquery, comments, …) remain dual-run Widget XML and are tracked in {@code
- * docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
+ * lists, nav chrome, file, image — #2772), residual long-tail product packages (blog, calendar,
+ * directory, social, forms, poll, login, rss, iframe — #2789), and remaining product packages
+ * (auto-lists, blog/list companions, comments/liked/cards, event/slider/cookie/jquery, login
+ * variants, Result/Redirect, defaultLanguage — #2802): JEXL code + Velocity content + optional
+ * asset content type + UserPref/CssPref + {@code <Resource>} CSS/JS refs. Product Widget XML
+ * remains dual-run until Phase 5 exit; inventory:
+ * {@code docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
  *
  * <p>Assembler mapping: {@code Content type="velocity"} → {@code velocityAssembler}; {@code html}
  * → {@code htmlAssembler}; {@code markdown} → {@code markdownAssembler}. Code language is always

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -31,9 +31,9 @@ import java.util.Objects;
  * Compiles all Widget definition XML files found in a legacy product package source directory.
  *
  * <p>Looks under {@code sys__UserDependency--rxconfig/Widgets/*.xml} (product packaging layout used
- * by {@code modules/perc-packages}). Covers baseWidgets, high-traffic product packages (#2772), and
- * the residual long-tail batch (#2789). Further residual packages remain in the widget XML
- * inventory until dual-run exit.
+ * by {@code modules/perc-packages}). Covers baseWidgets, high-traffic product packages (#2772), the
+ * residual long-tail batch (#2789), and the remaining product residual batch (#2802). Product Widget
+ * XML remains dual-run until install consumes modern packages (Phase 5 exit).
  */
 public final class PSWidgetXmlPackageCompiler {
 
@@ -70,6 +70,43 @@ public final class PSWidgetXmlPackageCompiler {
           "perc.widget.login",
           "perc.widget.rss",
           "perc.widget.iframe");
+
+  /**
+   * Remaining product package directory names under {@code Packages/} covered by issue #2802
+   * (auto-lists, blog/list companions, social/comments cards, event/slider/cookie/jquery, login
+   * variants, Result/Redirect, defaultLanguage). Beyond {@link #RESIDUAL_PRODUCT_PACKAGE_DIRS},
+   * {@link #HIGH_TRAFFIC_PACKAGE_DIRS}, and {@code perc.baseWidgets}. Excludes {@code perc.Test}.
+   * Dual-run: product Widget XML remains until install consumes modern packages.
+   */
+  public static final List<String> REMAINING_PRODUCT_PACKAGE_DIRS =
+      List.of(
+          // auto-lists
+          "perc.ImageAutoListWidget",
+          "perc.PageAutoListWidget",
+          "perc.widget.fileAutoList",
+          // blog / list companions
+          "perc.widget.blogIndexPage",
+          "perc.widget.archiveList",
+          "perc.widget.categoryList",
+          "perc.widget.taglist",
+          "perc.widget.MostReadBlogPosts",
+          // social / comments / cards
+          "perc.widgets.comments",
+          "perc.widgets.liked",
+          "perc.widget.commentForm",
+          "perc.openGraphWidget",
+          "perc.twitterSummaryCards",
+          // other residual product widgets
+          "perc.eventWidget",
+          "perc.widget.imageSlider",
+          "perc.widget.cookieConsent",
+          "perc.widget.jquery",
+          "perc.widget.jqueryUI",
+          "perc.widget.registration",
+          "perc.widget.secureLogin",
+          "perc.widget.Result",
+          "perc.widgets.Redirect",
+          "perc.defaultLanguage");
 
   private PSWidgetXmlPackageCompiler() {
     // utility
@@ -150,6 +187,21 @@ public final class PSWidgetXmlPackageCompiler {
   public static List<PSWidgetXmlCompileResult> compileResidualProductPackages(Path packagesRoot)
       throws PSWidgetXmlException, IOException {
     return compileNamedPackages(packagesRoot, RESIDUAL_PRODUCT_PACKAGE_DIRS);
+  }
+
+  /**
+   * Compile remaining product packages under a {@code Packages/} root directory (issue #2802 —
+   * residual after #2789). Missing package directories are soft-skipped (same policy as prior
+   * batches).
+   *
+   * @param packagesRoot non-null directory containing package folders
+   * @return compile results sorted by package then widget stem (may be empty if none present)
+   * @throws PSWidgetXmlException on parse/compile failure of a present package
+   * @throws IOException on I/O failure
+   */
+  public static List<PSWidgetXmlCompileResult> compileRemainingProductPackages(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    return compileNamedPackages(packagesRoot, REMAINING_PRODUCT_PACKAGE_DIRS);
   }
 
   /**

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -38,7 +38,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751
- * baseWidgets, #2772 high-traffic residual batch, #2789 remaining product residual batch).
+ * baseWidgets, #2772 high-traffic residual batch, #2789 residual product batch, #2802 remaining
+ * product residual batch).
  */
 class PSWidgetXmlCompilerTest {
 
@@ -79,6 +80,23 @@ class PSWidgetXmlCompilerTest {
   private static final String GOLDEN_IFRAME_MANIFEST =
       "/widgetxml/golden/percIframe.component-package.json";
   private static final String GOLDEN_IFRAME_TEMPLATE = "/widgetxml/golden/percIframeSnippet.vm";
+
+  // #2802 remaining residual representatives
+  private static final String FIXTURE_IMAGE_AUTO_LIST = "/widgetxml/percImageAutoList.xml";
+  private static final String GOLDEN_IMAGE_AUTO_LIST_MANIFEST =
+      "/widgetxml/golden/percImageAutoList.component-package.json";
+  private static final String GOLDEN_IMAGE_AUTO_LIST_TEMPLATE =
+      "/widgetxml/golden/percImageAutoListSnippet.vm";
+
+  private static final String FIXTURE_COMMENTS = "/widgetxml/percComments.xml";
+  private static final String GOLDEN_COMMENTS_MANIFEST =
+      "/widgetxml/golden/percComments.component-package.json";
+  private static final String GOLDEN_COMMENTS_TEMPLATE = "/widgetxml/golden/percCommentsSnippet.vm";
+
+  private static final String FIXTURE_EVENT = "/widgetxml/percEvent.xml";
+  private static final String GOLDEN_EVENT_MANIFEST =
+      "/widgetxml/golden/percEvent.component-package.json";
+  private static final String GOLDEN_EVENT_TEMPLATE = "/widgetxml/golden/percEventSnippet.vm";
 
   @TempDir Path tempDir;
 
@@ -617,6 +635,204 @@ class PSWidgetXmlCompilerTest {
           "residual must not re-list high-traffic package: " + high);
     }
     assertEquals(9, PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS.size());
+  }
+
+  @Test
+  void parseImageAutoList_autoListWithManyPrefsAndCss() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_IMAGE_AUTO_LIST, "percImageAutoList.xml");
+    assertEquals("Image Auto List", model.getTitle());
+    assertEquals("percImageAutoList", model.getContentTypeName());
+    assertTrue(model.getCategory() != null && model.getCategory().contains("search"));
+    assertEquals(16, model.getUserPrefs().size());
+    assertTrue(model.getCssPrefs().size() >= 3);
+  }
+
+  @Test
+  void compileImageAutoList_matchesGoldenManifestAndTemplate() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_IMAGE_AUTO_LIST,
+            "percImageAutoList.xml",
+            "perc.ImageAutoListWidget",
+            GOLDEN_IMAGE_AUTO_LIST_MANIFEST,
+            GOLDEN_IMAGE_AUTO_LIST_TEMPLATE,
+            "templates/percImageAutoListSnippet.vm");
+    assertEquals(
+        "percImageAutoList", result.getManifest().getContentTypes().get(0).getName());
+    assertTrue(result.getManifest().getUserPreferences().size() >= 10);
+    assertTrue(result.getManifest().getCssPreferences().size() >= 3);
+  }
+
+  @Test
+  void parseComments_chromeWidgetNoContentType() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_COMMENTS, "percComments.xml");
+    assertEquals("Comments", model.getTitle());
+    assertTrue(
+        model.getContentTypeName() == null || model.getContentTypeName().isBlank(),
+        "comments is chrome/logic (no asset CT)");
+    assertEquals(1, model.getUserPrefs().size());
+    assertEquals(1, model.getCssPrefs().size());
+  }
+
+  @Test
+  void compileComments_matchesGolden_chromeSlotWithoutContentType() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_COMMENTS,
+            "percComments.xml",
+            "perc.widgets.comments",
+            GOLDEN_COMMENTS_MANIFEST,
+            GOLDEN_COMMENTS_TEMPLATE,
+            "templates/percCommentsSnippet.vm");
+    assertTrue(
+        result.getManifest().getContentTypes() == null
+            || result.getManifest().getContentTypes().isEmpty());
+    assertEquals("percCommentsChrome", result.getManifest().getSlots().get(0).getName());
+  }
+
+  @Test
+  void parseEvent_contentWidgetWithUserPrefs() throws Exception {
+    PSWidgetXmlModel model = parseClasspath(FIXTURE_EVENT, "percEvent.xml");
+    assertEquals("Event", model.getTitle());
+    assertEquals("percEventAsset", model.getContentTypeName());
+    assertEquals(9, model.getUserPrefs().size());
+    assertEquals(1, model.getCssPrefs().size());
+  }
+
+  @Test
+  void compileEvent_matchesGoldenManifestAndTemplate() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_EVENT,
+            "percEvent.xml",
+            "perc.eventWidget",
+            GOLDEN_EVENT_MANIFEST,
+            GOLDEN_EVENT_TEMPLATE,
+            "templates/percEventSnippet.vm");
+    assertEquals("percEventAsset", result.getManifest().getContentTypes().get(0).getName());
+    assertEquals("percEventContent", result.getManifest().getSlots().get(0).getName());
+    assertEquals(9, result.getManifest().getUserPreferences().size());
+  }
+
+  @Test
+  void compileRemainingProductPackages_allValidate() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println(
+          "WARN: Packages root not found; skipping remaining product package test");
+      return;
+    }
+
+    List<PSWidgetXmlCompileResult> results =
+        PSWidgetXmlPackageCompiler.compileRemainingProductPackages(packagesRoot);
+    // auto-lists(3)+blog companions(5)+social/comments/cards(5)+misc(11 widgets in 10 pkgs)
+    // defaultLanguage has 2 widgets; all others 1 → 3+5+5+10+1(defaultLang second)+1? =
+    // 23 packages: 22 single-widget + defaultLanguage(2) = 24 widgets
+    assertEquals(
+        24,
+        results.size(),
+        "remaining #2802 batch should compile 24 product widgets across 23 packages");
+
+    Map<String, PSWidgetXmlCompileResult> byId =
+        results.stream()
+            .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+    for (String id :
+        List.of(
+            "percImageAutoList",
+            "percPageAutoList",
+            "percFileAutoList",
+            "percBlogIndexPage",
+            "percArchiveList",
+            "percCategoryList",
+            "percTagList",
+            "percMostReadBlogPosts",
+            "percComments",
+            "percLiked",
+            "percCommentsForm",
+            "percOpenGraph",
+            "percTwitterSummaryCards",
+            "percEvent",
+            "percImageSlider",
+            "percCookieConsent",
+            "percJQueryWidget",
+            "percJQueryUIWidget",
+            "percRegistration",
+            "percSecureLogin",
+            "percResult",
+            "percRedirect",
+            "percDefaultLang",
+            "percLocalLang")) {
+      assertTrue(byId.containsKey(id), "missing compiled remaining widget: " + id);
+      PSComponentPackageManifestValidator.validate(byId.get(id).getManifest());
+      assertFalse(byId.get(id).getTextArtifacts().isEmpty());
+      assertEquals(
+          "velocityAssembler",
+          byId.get(id).getManifest().getTemplates().get(0).getAssembler());
+    }
+
+    // Auto-list shape: asset CT + many user prefs.
+    assertEquals(
+        "percImageAutoList",
+        byId.get("percImageAutoList").getManifest().getContentTypes().get(0).getName());
+    assertTrue(byId.get("percImageAutoList").getManifest().getUserPreferences().size() >= 10);
+
+    // Chrome widgets without CT.
+    for (String chromeId :
+        List.of(
+            "percComments",
+            "percLiked",
+            "percMostReadBlogPosts",
+            "percResult",
+            "percJQueryWidget",
+            "percJQueryUIWidget")) {
+      assertTrue(
+          byId.get(chromeId).getManifest().getContentTypes() == null
+              || byId.get(chromeId).getManifest().getContentTypes().isEmpty(),
+          chromeId + " should be chrome (no CT)");
+    }
+
+    // defaultLanguage multi-widget package shares version.
+    assertEquals(
+        byId.get("percDefaultLang").getManifest().getVersion(),
+        byId.get("percLocalLang").getManifest().getVersion());
+
+    Path outRoot = tempDir.resolve("remaining-out");
+    PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
+    for (String stem :
+        List.of(
+            "percImageAutoList",
+            "percComments",
+            "percEvent",
+            "percDefaultLang",
+            "percLocalLang",
+            "percRedirect")) {
+      assertTrue(
+          Files.isRegularFile(
+              outRoot
+                  .resolve(stem)
+                  .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)),
+          "writeAll missing remaining manifest for " + stem);
+    }
+  }
+
+  @Test
+  void remainingProductPackageDirs_disjointFromPriorBatches() {
+    assertFalse(
+        PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS.contains("perc.baseWidgets"));
+    assertFalse(
+        PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS.contains("perc.Test"));
+    for (String high : PSWidgetXmlPackageCompiler.HIGH_TRAFFIC_PACKAGE_DIRS) {
+      assertFalse(
+          PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS.contains(high),
+          "remaining must not re-list high-traffic package: " + high);
+    }
+    for (String residual : PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS) {
+      assertFalse(
+          PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS.contains(residual),
+          "remaining must not re-list #2789 residual package: " + residual);
+    }
+    assertEquals(23, PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS.size());
   }
 
   private static PSWidgetXmlCompileResult assertGoldenParity(

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percComments.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percComments.component-package.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percComments",
+  "name": "Comments",
+  "version": "1.1.4",
+  "description": "Display a list of comments submitted to the page",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.7.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Comments",
+    "category": "blog,social",
+    "description": "Display a list of comments submitted to the page",
+    "thumbnail": "resources/WidgetIconComment.png",
+    "icon": "resources/WidgetIconComment.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 965,
+    "preferredEditorHeight": 680,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percCommentsSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percCommentsSnippet.vm",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "titleFormat",
+          "expression": "$perc.widget.item.properties.get('titleFormat')"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "dUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$dUrl + \"/perc-comments-services/comment/jsonp\""
+        },
+        {
+          "variable": "dUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{&quot;serviceurl&quot;: &quot;\" + $dsUrl +\"&quot;, &quot;finderpath&quot;: &quot;\" + $rx.pageutils.getItemPath($pageId) + \"&quot;, &quot;deliveryurl&quot;: &quot;\" + $dUrl + \"&quot;, &quot;titleFormat&quot;: &quot;\" + $titleFormat + \"&quot;}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "if(! $perc.isPreviewMode())\n      {\n          $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n\n          if (empty($rootclass)) {\n            $rootclass = \"\";\n          }\n\n          $titleFormat = $perc.widget.item.properties.get('titleFormat');\n\n          $pageId = $perc.page.id;\n          $widgetId = $perc.widget.item.id;\n\n          $dUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n          $dsUrl = $dUrl + \"/perc-comments-services/comment/jsonp\";\n          if ($dUrl.indexOf(\"http://localhost\") != -1 )\n          $dUrl = \"\";\n           $dynamicListData =\"{&quot;serviceurl&quot;: &quot;\" + $dsUrl +\"&quot;, &quot;finderpath&quot;: &quot;\" + $rx.pageutils.getItemPath($pageId) + \"&quot;, &quot;deliveryurl&quot;: &quot;\" + $dUrl + \"&quot;, &quot;titleFormat&quot;: &quot;\" + $titleFormat + \"&quot;}\";\n      }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percCommentsChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/WidgetIconComment.png",
+      "target": "rx_resources/widgets/comments/images/WidgetIconComment.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "titleFormat",
+      "displayName": "Heading format for Title field",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "h3",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percCommentsSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percCommentsSnippet.vm
@@ -1,0 +1,5 @@
+#if ($perc.isEditMode())
+         #createEmptyWidgetContent("comments-sample-content", "This Comments widget is showing sample content.")
+     #elseif (!$perc.isPreviewMode())
+         <div class="$!rootclass perc-comments perc-comments-view" data-query="$dynamicListData"></div>
+     #end

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percEvent.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percEvent.component-package.json
@@ -1,0 +1,280 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percEvent",
+  "name": "Event",
+  "version": "1.1.7",
+  "description": "Display information about an event",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Event",
+    "category": "content",
+    "description": "Display information about an event",
+    "thumbnail": "resources/widgetIconEvent.png",
+    "icon": "resources/widgetIconEvent.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 710,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percEventAsset",
+      "ref": "contentTypes/percEventAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percEventSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percEventSnippet.vm",
+      "contentType": "percEventAsset",
+      "bindings": [
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "startDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('startDateTimeFormat')"
+        },
+        {
+          "variable": "endDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('endDateTimeFormat')"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "eventTitle",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "eventDescription",
+          "expression": "$rx.pageutils.html($assetItem, 'body')"
+        },
+        {
+          "variable": "eventSummary",
+          "expression": "$rx.pageutils.html($assetItem,'callout')"
+        },
+        {
+          "variable": "eventLocation",
+          "expression": "$rx.pageutils.html($assetItem,'location')"
+        },
+        {
+          "variable": "tmp",
+          "expression": "$assetItem.Node.getProperty('start_time').Date"
+        },
+        {
+          "variable": "ISODateFormat",
+          "expression": "\"yyyy-MM-dd hh:mm a\""
+        },
+        {
+          "variable": "eventStart",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventStartISO",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventStart",
+          "expression": "$tools.date.format($startDateTimeFormat,$tmp.Time)"
+        },
+        {
+          "variable": "eventStartISO",
+          "expression": "$tools.date.format($ISODateFormat,$tmp.Time)"
+        },
+        {
+          "variable": "tmp",
+          "expression": "$assetItem.Node.getProperty('end_time').Date"
+        },
+        {
+          "variable": "eventEnd",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventEndISO",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventEnd",
+          "expression": "$tools.date.format($endDateTimeFormat,$tmp.Time)"
+        },
+        {
+          "variable": "eventEndISO",
+          "expression": "$tools.date.format($ISODateFormat,$tmp.Time)"
+        },
+        {
+          "variable": "perc_hidefield_displaytitle",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_displaytitle')"
+        },
+        {
+          "variable": "perc_hidefield_callout",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_callout')"
+        },
+        {
+          "variable": "perc_hidefield_body",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_body')"
+        },
+        {
+          "variable": "perc_hidefield_location",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_location')"
+        },
+        {
+          "variable": "perc_hidefield_start_time",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_start_time')"
+        },
+        {
+          "variable": "perc_hidefield_end_time",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_end_time')"
+        },
+        {
+          "variable": "renderEmptyFields",
+          "expression": "$perc.widget.item.properties.get('renderEmptyFields')"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    if (! $assets.isEmpty())\n    {\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if (!empty($rootclass))\n            $rootclass = $rootclass + \" \";\n        $startDateTimeFormat = $perc.widget.item.properties.get('startDateTimeFormat');\n        $endDateTimeFormat = $perc.widget.item.properties.get('endDateTimeFormat');\n\n        $assetItem = $assets.get(0);\n        $eventTitle = $rx.pageutils.html($assetItem,'displaytitle');\n        $eventDescription = $rx.pageutils.html($assetItem, 'body');\n        $eventSummary = $rx.pageutils.html($assetItem,'callout');\n        $eventLocation = $rx.pageutils.html($assetItem,'location');\n\n        $tmp = $assetItem.Node.getProperty('start_time').Date;\n        $ISODateFormat=\"yyyy-MM-dd hh:mm a\";\n        if (empty($tmp))\n        {\n            $eventStart = \"\";\n            $eventStartISO = \"\";\n        }\n        else\n        {\n            $eventStart = $tools.date.format($startDateTimeFormat,$tmp.Time);\n            $eventStartISO = $tools.date.format($ISODateFormat,$tmp.Time);\n        }\n\n        $tmp = $assetItem.Node.getProperty('end_time').Date;\n        if (empty($tmp))\n        {\n            $eventEnd = \"\";\n            $eventEndISO = \"\";\n        }\n        else\n        {\n            $eventEnd = $tools.date.format($endDateTimeFormat,$tmp.Time);\n            $eventEndISO = $tools.date.format($ISODateFormat,$tmp.Time);\n        }\n\n        $perc_hidefield_displaytitle = $perc.widget.item.properties.get('perc_hidefield_displaytitle');\n        $perc_hidefield_callout = $perc.widget.item.properties.get('perc_hidefield_callout');\n        $perc_hidefield_body = $perc.widget.item.properties.get('perc_hidefield_body');\n        $perc_hidefield_location = $perc.widget.item.properties.get('perc_hidefield_location');\n        $perc_hidefield_start_time = $perc.widget.item.properties.get('perc_hidefield_start_time');\n        $perc_hidefield_end_time = $perc.widget.item.properties.get('perc_hidefield_end_time');\n        $renderEmptyFields = $perc.widget.item.properties.get('renderEmptyFields');\n\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t$dsUrl = \"\";\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percEventContent",
+      "allowedContentTypes": [
+        "percEventAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconEvent.png",
+      "target": "rx_resources/widgets/event/images/widgetIconEvent.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/event/css/style.css",
+      "type": "css",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_hidefield_displaytitle",
+      "displayName": "Hide title field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_callout",
+      "displayName": "Hide summary field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_body",
+      "displayName": "Hide description field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_location",
+      "displayName": "Hide location field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_start_time",
+      "displayName": "Hide start date field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_end_time",
+      "displayName": "Hide end date field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "renderEmptyFields",
+      "displayName": "Render empty fields",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "startDateTimeFormat",
+      "displayName": "Format of start date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "M/d/yyyy hh:mm a",
+      "enumValues": []
+    },
+    {
+      "name": "endDateTimeFormat",
+      "displayName": "Format of end date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "M/d/yyyy hh:mm a",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percEventSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percEventSnippet.vm
@@ -1,0 +1,25 @@
+#if ($assetItem)
+   <div class="$!{rootclass} perc-event" data="$!{dynamicListData}">
+##  don't need to check for empty on title because it is required
+   #if(! $perc_hidefield_displaytitle)
+      <div class="perc-event-title" >$eventTitle</div>
+   #end
+   #if(!($perc_hidefield_callout || ($eventSummary == "" && ! $renderEmptyFields)))
+      <div class="summary">$eventSummary</div>
+   #end
+   #if(!($perc_hidefield_body || ($eventDescription == "" && ! $renderEmptyFields)))
+      <div class="description">$eventDescription</div>
+   #end
+   #if(!($perc_hidefield_location || ($eventLocation == "" && ! $renderEmptyFields)))
+      <div class="location">$eventLocation</div>
+   #end
+   #if(!($perc_hidefield_start_time || ($eventStart == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtstart" title="$eventStartISO">$eventStart</abbr></div>
+   #end
+   #if(!($perc_hidefield_end_time || ($eventEnd == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtend" title="$eventEndISO">$eventEnd</abbr></div>
+   #end
+   </div>
+#elseif ($perc.isEditMode())  ## if ($assetItem)
+   #createEmptyWidgetContent("event-sample-content", "This event widget is showing sample content.")
+#end

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percImageAutoList.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percImageAutoList.component-package.json
@@ -1,0 +1,991 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percImageAutoList",
+  "name": "Image Auto List",
+  "version": "1.1.12",
+  "description": "Display an automated list of image assets",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Image Auto List",
+    "category": "rich media,search",
+    "description": "Display an automated list of image assets",
+    "thumbnail": "resources/widgetIconImageAutoList.png",
+    "icon": "resources/widgetIconImageAutoList.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 665,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percImageAutoList",
+      "ref": "contentTypes/percImageAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percImageAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percImageAutoListSnippet.vm",
+      "contentType": "percImageAutoList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "listTitleFormat",
+          "expression": "$perc.widget.item.properties.get('listTitleFormat')"
+        },
+        {
+          "variable": "listItemFormat",
+          "expression": "$perc.widget.item.properties.get('listItemFormat')"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "$perc.widget.item.properties.get('listAriaLabel')"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "$perc.widget.item.properties.get('listAriaRole')"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.properties.get('autoListDivId')"
+        },
+        {
+          "variable": "showPostDate",
+          "expression": "$perc.widget.item.properties.get('showPostDate')"
+        },
+        {
+          "variable": "postDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('postDateTimeFormat')"
+        },
+        {
+          "variable": "perc_hide_when_empty",
+          "expression": "$perc.widget.item.properties.get('perc_hide_when_empty')"
+        },
+        {
+          "variable": "target",
+          "expression": "$perc.widget.item.properties.get('target')"
+        },
+        {
+          "variable": "layout",
+          "expression": "$perc.widget.item.properties.get('layout')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "listclass",
+          "expression": "$perc.widget.item.cssProperties.get('listclass')"
+        },
+        {
+          "variable": "listclass",
+          "expression": "$listclass.trim()"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "''"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "'role=\"' + $listAriaRole + '\"'"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.id + \"_list\""
+        },
+        {
+          "variable": "headerId",
+          "expression": "$autoListDivId + '_header'"
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "$perc.widget.item.cssProperties.get('thumblinkclass')"
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "$thumblinkclass.trim()"
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "'class=\"' + $thumblinkclass + '\"'"
+        },
+        {
+          "variable": "caption",
+          "expression": "$perc.widget.item.properties.get('caption')"
+        },
+        {
+          "variable": "captionclass",
+          "expression": "$perc.widget.item.cssProperties.get('captionclass')"
+        },
+        {
+          "variable": "captionclass",
+          "expression": "$captionclass.trim()"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "$perc.widget.item.properties.get('maxlength')"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "500"
+        },
+        {
+          "variable": "sortby",
+          "expression": "$perc.widget.item.properties.get('sortby')"
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "$perc.widget.item.properties.get('sortDirection')"
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "\"desc\""
+        },
+        {
+          "variable": "renderingformat",
+          "expression": "$perc.widget.item.properties.get('renderingformat')"
+        },
+        {
+          "variable": "target",
+          "expression": "$perc.widget.item.properties.get('target')"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "$assetItem.getNode().getProperty('query').String"
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortby + \" \" + $sortDirection"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem, 'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('perc-list-odd', 'perc-list-even')"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "'<' + $listTitleFormat + ' id=\"' + $headerId + '\"' + ' class=\"perc-list-title\" aria-label=\"Image List Title\" title=\"' + $title + '\"' + '>'"
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "'</' + $listTitleFormat + '>'"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "\"\""
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "\"\""
+        },
+        {
+          "variable": "itemFormatStartTag",
+          "expression": "'<' + $listItemFormat + '>'"
+        },
+        {
+          "variable": "itemFormatEndTag",
+          "expression": "'</' + $listItemFormat + '>'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $title + ' image list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"Image list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $listAriaLabel + '\"'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $listTitleFormat = $perc.widget.item.properties.get('listTitleFormat');\n   $listItemFormat = $perc.widget.item.properties.get('listItemFormat');\n   $listAriaLabel = $perc.widget.item.properties.get('listAriaLabel');\n   $listAriaRole = $perc.widget.item.properties.get('listAriaRole');\n   $autoListDivId = $perc.widget.item.properties.get('autoListDivId');\n   $showPostDate = $perc.widget.item.properties.get('showPostDate');\n   $postDateTimeFormat = $perc.widget.item.properties.get('postDateTimeFormat');\n   $perc_hide_when_empty = $perc.widget.item.properties.get('perc_hide_when_empty');\n   $perc.setWidgetContents($assetItems);\n   $target = $perc.widget.item.properties.get('target');\n   $layout = $perc.widget.item.properties.get('layout');\n   $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n   if (!empty($rootclass)) {\n      $rootclass = $rootclass;\n   }\n   $listclass = $perc.widget.item.cssProperties.get('listclass');\n   if (!empty($listclass)) {\n      $listclass = $listclass.trim();\n   }\n   if ($listAriaRole == '' || $listAriaRole == null) {\n      $listAriaRole = '';\n   }\n   else {\n       $listAriaRole = 'role=\"' + $listAriaRole + '\"';\n   }\n   if($autoListDivId == '' || $autoListDivId == null) {\n      $autoListDivId = $perc.widget.item.id + \"_list\";\n   }\n   $headerId = $autoListDivId + '_header';\n   $thumblinkclass = $perc.widget.item.cssProperties.get('thumblinkclass');\n   if (!empty($thumblinkclass)) {\n      $thumblinkclass = $thumblinkclass.trim();\n   }\n   else {\n      $thumblinkclass = \"\";\n   }\n   if (!empty($thumblinkclass)) {\n      $thumblinkclass = 'class=\"' + $thumblinkclass + '\"';\n   }\n   $caption = $perc.widget.item.properties.get('caption');\n   $captionclass = $perc.widget.item.cssProperties.get('captionclass');\n   if (!empty($captionclass)) {\n      $captionclass = $captionclass.trim();\n   }\n   $maxlength = $perc.widget.item.properties.get('maxlength');\n   if (empty($maxlength)) {\n      $maxlength = 500;\n   }\n   $sortby = $perc.widget.item.properties.get('sortby');\n\n   $sortDirection = $perc.widget.item.properties.get('sortDirection');\n   if($sortDirection == null){\n       $sortDirection = \"desc\";\n   }\n   $renderingformat = $perc.widget.item.properties.get('renderingformat');\n   $target = $perc.widget.item.properties.get('target');\n\n   if ( ! $assetItems.isEmpty() ) {\n      $assetItem = $assetItems.get(0);\n      $params = $rx.string.stringToMap(null);\n      $query = $assetItem.getNode().getProperty('query').String;\n\t  if ($sortby != \"none\"  && $sortby != null) {\n        $query = $query + \" order by \" + $sortby + \" \" + $sortDirection;\n      }\n\n      $params.put('query', $query);\n      $params.put('max_results', $maxlength);\n      $finderName =  \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n      $title = $rx.pageutils.html($assetItem, 'displaytitle');\n      $rowtag = $tools.alternator.auto('perc-list-odd', 'perc-list-even');\n\n      if ($listTitleFormat != 'none') {\n         $titleFormatStartTag = '<' + $listTitleFormat + ' id=\"' + $headerId + '\"' + ' class=\"perc-list-title\" aria-label=\"Image List Title\" title=\"' + $title + '\"' + '>';\n         $titleFormatEndTag = '</' + $listTitleFormat + '>';\n      }\n      else {\n         $titleFormatStartTag = \"\";\n         $titleFormatEndTag = \"\";\n      }\n      if ($listItemFormat != 'none') {\n         $itemFormatStartTag = '<' + $listItemFormat + '>';\n         $itemFormatEndTag = '</' + $listItemFormat + '>';\n      }\n      if ($listAriaLabel == '' || $listAriaLabel == null) {\n         if ($title != null && $title != '') {\n             $listAriaLabel = 'aria-label=\"' + $title + ' image list\"';\n         } else {\n             $listAriaLabel = 'aria-label=\"Image list\"';\n         }\n      } else {\n          $listAriaLabel = 'aria-label=\"' + $listAriaLabel + '\"';\n      }\n   }\n   else {\n      ;\n   }\n\n   $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n   if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n      $dsUrl = \"\";\n   $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percImageAutoListContent",
+      "allowedContentTypes": [
+        "percImageAutoList"
+      ],
+      "layout": {
+        "maxlength": "",
+        "layout": "perc-list-vertical"
+      },
+      "styles": {
+        "rootclass": "",
+        "listclass": "",
+        "thumblinkclass": "",
+        "captionclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconImageAutoList.png",
+      "target": "rx_resources/widgets/imageAutoList/images/widgetIconImageAutoList.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "renderingformat",
+      "displayName": "Rendering format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "image",
+      "enumValues": [
+        {
+          "value": "image",
+          "displayValue": "Normal image"
+        },
+        {
+          "value": "thumbnail",
+          "displayValue": "Thumbnail"
+        },
+        {
+          "value": "thumbnail_link",
+          "displayValue": "Thumbnail link"
+        }
+      ]
+    },
+    {
+      "name": "listTitleFormat",
+      "displayName": "Format of list title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    },
+    {
+      "name": "autoListDivId",
+      "displayName": "Image Auto List div id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listItemFormat",
+      "displayName": "Format of list items",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "none",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "none",
+          "displayValue": "None"
+        }
+      ]
+    },
+    {
+      "name": "sortby",
+      "displayName": "Sort by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "rx:sys_contentpostdate",
+      "enumValues": [
+        {
+          "value": "none",
+          "displayValue": "None"
+        },
+        {
+          "value": "rx:displaytitle",
+          "displayValue": "Title"
+        },
+        {
+          "value": "rx:sys_contentpostdate",
+          "displayValue": "Post date"
+        }
+      ]
+    },
+    {
+      "name": "sortDirection",
+      "displayName": "Sort Order",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "desc",
+      "enumValues": [
+        {
+          "value": "desc",
+          "displayValue": "Descending"
+        },
+        {
+          "value": "asc",
+          "displayValue": "Ascending"
+        }
+      ]
+    },
+    {
+      "name": "showPostDate",
+      "displayName": "Show Post Date",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "postDateTimeFormat",
+      "displayName": "Format of image post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEEE MM dd, yyyy",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt)    Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "maxlength",
+      "displayName": "Max list length",
+      "datatype": "number",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "caption",
+      "displayName": "Show caption",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "listAriaLabel",
+      "displayName": "Image Auto List aria-label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listAriaRole",
+      "displayName": "Image Auto List aria-role",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "perc_hide_when_empty",
+      "displayName": "Hide auto list when empty",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "perc-list-vertical",
+      "enumValues": [
+        {
+          "value": "perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    },
+    {
+      "name": "target",
+      "displayName": "Link target",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "_self",
+      "enumValues": [
+        {
+          "value": "_self",
+          "displayValue": "Current window"
+        },
+        {
+          "value": "_blank",
+          "displayValue": "New window"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "listclass",
+      "displayName": "CSS image list class",
+      "datatype": "string"
+    },
+    {
+      "name": "thumblinkclass",
+      "displayName": "CSS thumbnail link class",
+      "datatype": "string"
+    },
+    {
+      "name": "captionclass",
+      "displayName": "CSS caption class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/percImageAutoListSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/percImageAutoListSnippet.vm
@@ -1,0 +1,106 @@
+#define($ariaLabelString)##
+#if($title && $title.length() > 0)##
+aria-labelledby="$!{headerId}"##
+#else##
+$!{listAriaLabel}##
+#end##
+#end##
+##Setup Date Formatting
+#set($formatterOut = $rx.pageutils.getDateFormatFromLocale("$!{postDateTimeFormat}",$locale))##
+#set($postDateObject="")##
+#set($postDate="")##
+<div id="$!{autoListDivId}" class="$!{rootclass} $!{layout} perc-image-auto-list" #if($perc_hide_when_empty && $relresults.size() <= 0)hidden #end $!{ariaLabelString} $!{listAriaRole} data-query="$!{dynamicListData}">
+#if( ! $perc.widgetContents.isEmpty() )
+#if($title && $title.length() > 0)##
+$!{titleFormatStartTag}$title$!{titleFormatEndTag}
+#end
+#if($relresults && $relresults.size() > 0)
+#if($rendering == "ordered")##
+<ol class="$!{listclass} perc-list-main">##
+#else##
+<ul class="$!{listclass} perc-list-main">##
+#end##
+#foreach($result in $relresults)
+#set($postDateObject = $result.node.getProperty('rx:sys_contentpostdate'))##
+#set($postDateObjectString = $result.node.getProperty('rx:sys_contentpostdate').String)##
+#if("$!{postDateObjectString}" == "")##
+#set($postDateObject = $tools.date.getDate())##
+#else##
+#set($postDateObject = $result.node.getProperty('rx:sys_contentpostdate').getDate())##
+#end##
+#if("$!{postDateObject}" != "")##
+#set($postDate = $formatterOut.format($postDateObject.getTime()))##
+#end##
+#if($velocityCount == 1)##
+#set($firstrow = 'perc-list-first')##
+#else##
+#set($firstrow = ' ')##
+#end##
+#if($velocityCount == $relresults.size())##
+#set($lastrow = 'perc-list-last')##
+#else
+#set($lastrow = ' ')##
+#end
+#set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+#set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+#set($link = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result, "percSystem.imageMainBinary")))##
+#set($img_alt = $rx.pageutils.html($result,'alttext'))##
+#if(!$perc.isEditMode())##
+#set($img_title=$rx.pageutils.html($result,'displaytitle'))##
+#else##
+#set($img_title="")##
+#end
+#if($perc.isEditMode() && $img_title == "")##
+#set($img_title_attr = "")##
+#else##
+#set($img_title_attr = 'title="' + $img_title + '"')##
+#end
+$!{itemFormatStartTag}<li class="$rowtag $!{firstrow} $!{lastrow} perc-list-element">
+#if($renderingformat == 'image')
+#set($img_height=$result.node.getProperty('rx:img_height').getString())##
+#set($img_width=$result.node.getProperty('rx:img_width').getString())##
+#if($img_height.length() > 0 && $img_width.length() > 0)
+<img src="$link" $img_title_attr alt="$img_alt" aria-label="$!{img_title}" height="$img_height" width="$img_width" />
+#else##
+<img src="$link" $img_title_attr />
+#end
+#if($showPostDate)##
+#if("$!{postDate}" != "")##
+<span class="perc-image-auto-list-date">$!{postDate}</span>
+#end##
+#end##
+#else##
+#set($img_height=$result.node.getProperty('rx:img2_height').getString())##
+#set($img_width=$result.node.getProperty('rx:img2_width').getString())##
+#set($thumblink=$tools.esc.html($rx.pageutils.itemLink($linkContext, $result, "percSystem.imageThumbBinary")))##
+#if($renderingformat == 'thumbnail')##
+#if($img_height.length() > 0 && $img_width.length() > 0)
+<img src="$thumblink" $img_title_attr alt="$img_alt" height="$img_height" width="$img_width" />
+#else##
+<img src="$thumblink" $img_title_attr />
+#end
+#end
+#if($renderingformat == 'thumbnail_link')
+<a ${thumblinkclass} href="$link" $img_title_attr target="$target">
+<img src="$thumblink"  alt="$img_alt" height="$img_height" width="$img_width"/>
+</a>
+#end
+#end
+#if ($caption)
+#set($caption_text=$result.node.getProperty('rx:resource_link_title').getString())##
+<div class="$!{captionclass} perc-caption">
+${caption_text}
+</div>
+#end
+</li>$!{itemFormatEndTag}
+#end##
+#if($rendering == "ordered")##
+</ol>##
+#else##
+</ul>##
+#end##
+#end##
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("imagelist-sample-content", "This image auto list widget is showing sample content.")
+#end
+</div>

--- a/modules/perc-packages/src/test/resources/widgetxml/percComments.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percComments.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Comments" contenttype_name=""
+		category="blog,social"
+		description="Display a list of comments submitted to the page"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/comments/images/WidgetIconComment.png"
+		preferred_editor_width="965" preferred_editor_height="680"
+		is_responsive="true" />
+	<UserPref name="titleFormat"
+		display_name="Heading format for Title field" required="true"
+		datatype="enum" default_value="h3">
+		<EnumValue value="h1" display_value="Heading 1" />
+		<EnumValue value="h2" display_value="Heading 2" />
+		<EnumValue value="h3" display_value="Heading 3" />
+		<EnumValue value="h4" display_value="Heading 4" />
+		<EnumValue value="h5" display_value="Heading 5" />
+		<EnumValue value="h6" display_value="Heading 6" />
+		<EnumValue value="p" display_value="Paragraph" />
+		<EnumValue value="div" display_value="Div" />
+	</UserPref>
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+	<Code type="jexl">
+        <![CDATA[
+      if(! $perc.isPreviewMode())
+      {
+          $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+
+          if (empty($rootclass)) {
+            $rootclass = "";
+          }
+
+          $titleFormat = $perc.widget.item.properties.get('titleFormat');
+
+          $pageId = $perc.page.id;
+          $widgetId = $perc.widget.item.id;
+
+          $dUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+          $dsUrl = $dUrl + "/perc-comments-services/comment/jsonp";
+          if ($dUrl.indexOf("http://localhost") != -1 )
+          $dUrl = "";
+           $dynamicListData ="{&quot;serviceurl&quot;: &quot;" + $dsUrl +"&quot;, &quot;finderpath&quot;: &quot;" + $rx.pageutils.getItemPath($pageId) + "&quot;, &quot;deliveryurl&quot;: &quot;" + $dUrl + "&quot;, &quot;titleFormat&quot;: &quot;" + $titleFormat + "&quot;}";
+      }
+    ]]>
+	</Code>
+	<Content type="velocity">
+        <![CDATA[
+     #if ($perc.isEditMode())
+         #createEmptyWidgetContent("comments-sample-content", "This Comments widget is showing sample content.")
+     #elseif (!$perc.isPreviewMode())
+         <div class="$!rootclass perc-comments perc-comments-view" data-query="$dynamicListData"></div>
+     #end
+    ]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/percEvent.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percEvent.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Event"
+		contenttype_name="percEventAsset" category="content"
+		description="Display information about an event"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/event/images/widgetIconEvent.png"
+		preferred_editor_width="780" preferred_editor_height="710"
+		is_responsive="true" />
+	<Resource href="/rx_resources/widgets/event/css/style.css"
+		type="css" placement="head" />
+	<UserPref name="perc_hidefield_displaytitle"
+		display_name="Hide title field" default_value="false" datatype="bool" />
+	<UserPref name="perc_hidefield_callout"
+		display_name="Hide summary field" default_value="false"
+		datatype="bool" />
+	<UserPref name="perc_hidefield_body"
+		display_name="Hide description field" default_value="false"
+		datatype="bool" />
+	<UserPref name="perc_hidefield_location"
+		display_name="Hide location field" default_value="false"
+		datatype="bool" />
+	<UserPref name="perc_hidefield_start_time"
+		display_name="Hide start date field" default_value="false"
+		datatype="bool" />
+	<UserPref name="perc_hidefield_end_time"
+		display_name="Hide end date field" default_value="false"
+		datatype="bool" />
+	<UserPref name="renderEmptyFields"
+		display_name="Render empty fields" default_value="false"
+		datatype="bool" />
+	<UserPref name="startDateTimeFormat"
+		display_name="Format of start date" default_value="M/d/yyyy hh:mm a"
+		datatype="string" />
+	<UserPref name="endDateTimeFormat"
+		display_name="Format of end date" default_value="M/d/yyyy hh:mm a"
+		datatype="string" />
+	<CssPref name="rootclass" display_name="CSS Root Class"
+		datatype="string" />
+	<Code type="jexl">
+        <![CDATA[
+    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);
+    $perc.setWidgetContents($assets);
+    if (! $assets.isEmpty())
+    {
+        $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+        if (!empty($rootclass))
+            $rootclass = $rootclass + " ";
+        $startDateTimeFormat = $perc.widget.item.properties.get('startDateTimeFormat');
+        $endDateTimeFormat = $perc.widget.item.properties.get('endDateTimeFormat');
+
+        $assetItem = $assets.get(0);
+        $eventTitle = $rx.pageutils.html($assetItem,'displaytitle');
+        $eventDescription = $rx.pageutils.html($assetItem, 'body');
+        $eventSummary = $rx.pageutils.html($assetItem,'callout');
+        $eventLocation = $rx.pageutils.html($assetItem,'location');
+
+        $tmp = $assetItem.Node.getProperty('start_time').Date;
+        $ISODateFormat="yyyy-MM-dd hh:mm a";
+        if (empty($tmp))
+        {
+            $eventStart = "";
+            $eventStartISO = "";
+        }
+        else
+        {
+            $eventStart = $tools.date.format($startDateTimeFormat,$tmp.Time);
+            $eventStartISO = $tools.date.format($ISODateFormat,$tmp.Time);
+        }
+
+        $tmp = $assetItem.Node.getProperty('end_time').Date;
+        if (empty($tmp))
+        {
+            $eventEnd = "";
+            $eventEndISO = "";
+        }
+        else
+        {
+            $eventEnd = $tools.date.format($endDateTimeFormat,$tmp.Time);
+            $eventEndISO = $tools.date.format($ISODateFormat,$tmp.Time);
+        }
+
+        $perc_hidefield_displaytitle = $perc.widget.item.properties.get('perc_hidefield_displaytitle');
+        $perc_hidefield_callout = $perc.widget.item.properties.get('perc_hidefield_callout');
+        $perc_hidefield_body = $perc.widget.item.properties.get('perc_hidefield_body');
+        $perc_hidefield_location = $perc.widget.item.properties.get('perc_hidefield_location');
+        $perc_hidefield_start_time = $perc.widget.item.properties.get('perc_hidefield_start_time');
+        $perc_hidefield_end_time = $perc.widget.item.properties.get('perc_hidefield_end_time');
+        $renderEmptyFields = $perc.widget.item.properties.get('renderEmptyFields');
+
+        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+        if ($dsUrl.indexOf("http://localhost") != -1 )
+			$dsUrl = "";
+        $dynamicListData = $tools.esc.html("{ deliveryurl : '" + $dsUrl + "'}");
+    }
+    ]]>
+	</Code>
+	<Content type="velocity">
+        <![CDATA[
+
+#if ($assetItem)
+   <div class="$!{rootclass} perc-event" data="$!{dynamicListData}">
+##  don't need to check for empty on title because it is required
+   #if(! $perc_hidefield_displaytitle)
+      <div class="perc-event-title" >$eventTitle</div>
+   #end
+   #if(!($perc_hidefield_callout || ($eventSummary == "" && ! $renderEmptyFields)))
+      <div class="summary">$eventSummary</div>
+   #end
+   #if(!($perc_hidefield_body || ($eventDescription == "" && ! $renderEmptyFields)))
+      <div class="description">$eventDescription</div>
+   #end
+   #if(!($perc_hidefield_location || ($eventLocation == "" && ! $renderEmptyFields)))
+      <div class="location">$eventLocation</div>
+   #end
+   #if(!($perc_hidefield_start_time || ($eventStart == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtstart" title="$eventStartISO">$eventStart</abbr></div>
+   #end
+   #if(!($perc_hidefield_end_time || ($eventEnd == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtend" title="$eventEndISO">$eventEnd</abbr></div>
+   #end
+   </div>
+#elseif ($perc.isEditMode())  ## if ($assetItem)
+   #createEmptyWidgetContent("event-sample-content", "This event widget is showing sample content.")
+#end
+    ]]>
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/percImageAutoList.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/percImageAutoList.xml
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Widget>
+	<WidgetPrefs title="Image Auto List"
+		contenttype_name="percImageAutoList" category="rich media,search"
+		description="Display an automated list of image assets"
+		author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/imageAutoList/images/widgetIconImageAutoList.png"
+		preferred_editor_width="780" preferred_editor_height="665"
+		is_responsive="true" />
+	<UserPref name="renderingformat"
+		display_name="Rendering format" required="true" default_value="image"
+		datatype="enum">
+		<EnumValue value="image" display_value="Normal image" />
+		<EnumValue value="thumbnail" display_value="Thumbnail" />
+		<EnumValue value="thumbnail_link"
+			display_value="Thumbnail link" />
+	</UserPref>
+	<UserPref name="listTitleFormat"
+		display_name="Format of list title" required="false" datatype="enum"
+		default_value="div">
+		<EnumValue value="h1" display_value="Heading 1" />
+		<EnumValue value="h2" display_value="Heading 2" />
+		<EnumValue value="h3" display_value="Heading 3" />
+		<EnumValue value="h4" display_value="Heading 4" />
+		<EnumValue value="h5" display_value="Heading 5" />
+		<EnumValue value="h6" display_value="Heading 6" />
+		<EnumValue value="p" display_value="Paragraph" />
+		<EnumValue value="div" display_value="Div" />
+	</UserPref>
+	<UserPref name="autoListDivId"
+		display_name="Image Auto List div id" datatype="string" />
+	<UserPref name="listItemFormat"
+		display_name="Format of list items" required="false" datatype="enum"
+		default_value="none">
+		<EnumValue value="h1" display_value="Heading 1" />
+		<EnumValue value="h2" display_value="Heading 2" />
+		<EnumValue value="h3" display_value="Heading 3" />
+		<EnumValue value="h4" display_value="Heading 4" />
+		<EnumValue value="h5" display_value="Heading 5" />
+		<EnumValue value="h6" display_value="Heading 6" />
+		<EnumValue value="p" display_value="Paragraph" />
+		<EnumValue value="div" display_value="Div" />
+		<EnumValue value="none" display_value="None" />
+	</UserPref>
+	<UserPref name="sortby" display_name="Sort by" required="true"
+		default_value="rx:sys_contentpostdate" datatype="enum">
+		<EnumValue value="none" display_value="None" />
+		<EnumValue value="rx:displaytitle" display_value="Title" />
+		<EnumValue value="rx:sys_contentpostdate"
+			display_value="Post date" />
+	</UserPref>
+	<UserPref name="sortDirection" display_name="Sort Order"
+		required="true" default_value="desc" datatype="enum">
+		<EnumValue value="desc" display_value="Descending" />
+		<EnumValue value="asc" display_value="Ascending" />
+	</UserPref>
+	<UserPref name="showPostDate" display_name="Show Post Date"
+		default_value="false" datatype="bool" />
+	<UserPref name="postDateTimeFormat"
+		display_name="Format of image post date"
+		default_value="EEEE MM dd, yyyy" datatype="string" />
+	<UserPref name="locale" display_name="Date Format Locale"
+		required="true" default_value="en-US" datatype="enum">
+		<EnumValue value="sq-AL"
+			display_value="Albanian Albania (AL)" />
+		<EnumValue value="ar-DZ" display_value="Arabic Algeria (DZ)" />
+		<EnumValue value="ar-BH" display_value="Arabic Bahrain (BH)" />
+		<EnumValue value="ar-EG" display_value="Arabic Egypt (EG)" />
+		<EnumValue value="ar-IQ" display_value="Arabic Iraq (IQ)" />
+		<EnumValue value="ar-JO" display_value="Arabic Jordan (JO)" />
+		<EnumValue value="ar-KW" display_value="Arabic Kuwait (KW)" />
+		<EnumValue value="ar-LB" display_value="Arabic Lebanon (LB)" />
+		<EnumValue value="ar-LY" display_value="Arabic Libya (LY)" />
+		<EnumValue value="ar-MA" display_value="Arabic Morocco (MA)" />
+		<EnumValue value="ar-OM" display_value="Arabic Oman (OM)" />
+		<EnumValue value="ar-QA" display_value="Arabic Qatar (QA)" />
+		<EnumValue value="ar-SA"
+			display_value="Arabic Saudi Arabia (SA)" />
+		<EnumValue value="ar-SD" display_value="Arabic Sudan (SD)" />
+		<EnumValue value="ar-SY" display_value="Arabic Syria (SY)" />
+		<EnumValue value="ar-TN" display_value="Arabic Tunisia (TN)" />
+		<EnumValue value="ar-AE"
+			display_value="Arabic United Arab Emirates (AE)" />
+		<EnumValue value="ar-YE" display_value="Arabic Yemen (YE)" />
+		<EnumValue value="be-BY"
+			display_value="Belarusian Belarus (BY)" />
+		<EnumValue value="bg-BG"
+			display_value="Bulgarian Bulgaria (BG)" />
+		<EnumValue value="ca-ES" display_value="Catalan Spain (ES)" />
+		<EnumValue value="zh-CN" display_value="Chinese China (CN)" />
+		<EnumValue value="zh-SG"
+			display_value="Chinese Singapore (SG)" />
+		<EnumValue value="zh-HK"
+			display_value="Chinese Hong Kong (HK)" />
+		<EnumValue value="zh-TW" display_value="Chinese Taiwan (TW)" />
+		<EnumValue value="hr-HR"
+			display_value="Croatian Croatia (HR)" />
+		<EnumValue value="cs-CZ"
+			display_value="Czech Czech Republic (CZ)" />
+		<EnumValue value="da-DK" display_value="Danish Denmark (DK)" />
+		<EnumValue value="nl-BE" display_value="Dutch Belgium (BE)" />
+		<EnumValue value="nl-NL"
+			display_value="Dutch Netherlands (NL)" />
+		<EnumValue value="en-AU"
+			display_value="English Australia (AU)" />
+		<EnumValue value="en-CA" display_value="English Canada (CA)" />
+		<EnumValue value="en-IN" display_value="English India (IN)" />
+		<EnumValue value="en-IE"
+			display_value="English Ireland (IE)" />
+		<EnumValue value="en-MT" display_value="English Malta (MT)" />
+		<EnumValue value="en-NZ"
+			display_value="English New Zealand (NZ)" />
+		<EnumValue value="en-PH"
+			display_value="English Philippines (PH)" />
+		<EnumValue value="en-SG"
+			display_value="English Singapore (SG)" />
+		<EnumValue value="en-ZA"
+			display_value="English South Africa (ZA)" />
+		<EnumValue value="en-GB"
+			display_value="English United Kingdom (GB)" />
+		<EnumValue value="en-US"
+			display_value="English United States (US)" />
+		<EnumValue value="et-EE"
+			display_value="Estonian Estonia (EE)" />
+		<EnumValue value="fi-FI"
+			display_value="Finnish Finland (FI)" />
+		<EnumValue value="fr-BE" display_value="French Belgium (BE)" />
+		<EnumValue value="fr-CA" display_value="French Canada (CA)" />
+		<EnumValue value="fr-FR" display_value="French France (FR)" />
+		<EnumValue value="fr-LU"
+			display_value="French Luxembourg (LU)" />
+		<EnumValue value="fr-CH"
+			display_value="French Switzerland (CH)" />
+		<EnumValue value="de-AT" display_value="German Austria (AT)" />
+		<EnumValue value="de-DE" display_value="German Germany (DE)" />
+		<EnumValue value="de-LU"
+			display_value="German Luxembourg (LU)" />
+		<EnumValue value="de-CH"
+			display_value="German Switzerland (CH)" />
+		<EnumValue value="el-CY" display_value="Greek Cyprus (CY)" />
+		<EnumValue value="el-GR" display_value="Greek Greece (GR)" />
+		<EnumValue value="iw-IL" display_value="Hebrew Israel (IL)" />
+		<EnumValue value="hi-IN" display_value="Hindi India (IN)" />
+		<EnumValue value="hu-HU"
+			display_value="Hungarian Hungary (HU)" />
+		<EnumValue value="is-IS"
+			display_value="Icelandic Iceland (IS)" />
+		<EnumValue value="in-ID"
+			display_value="Indonesian Indonesia (ID)" />
+		<EnumValue value="ga-IE" display_value="Irish Ireland (IE)" />
+		<EnumValue value="it-IT" display_value="Italian Italy (IT)" />
+		<EnumValue value="it-CH"
+			display_value="Italian Switzerland (CH)" />
+		<EnumValue value="ja-JP" display_value="Japanese Japan (JP)" />
+		<EnumValue value="ko-KR"
+			display_value="Korean South Korea (KR)" />
+		<EnumValue value="lv-LV" display_value="Latvian Latvia (LV)" />
+		<EnumValue value="lt-LT"
+			display_value="Lithuanian Lithuania (LT)" />
+		<EnumValue value="mk-MK"
+			display_value="Macedonian Macedonia (MK)" />
+		<EnumValue value="ms-MY" display_value="Malay Malaysia (MY)" />
+		<EnumValue value="mt-MT"
+			display_value="Maltese (mt)    Malta (MT)" />
+		<EnumValue value="no-NO"
+			display_value="Norwegian Norway (NO)" />
+		<EnumValue value="nb-NO"
+			display_value="Norwegian Bokmal Norway (NO)" />
+		<EnumValue value="nn-NO"
+			display_value="Norwegian Nynorsk Norway (NO)" />
+		<EnumValue value="pl-PL" display_value="Polish Poland (PL)" />
+		<EnumValue value="pt-BR"
+			display_value="Portuguese Brazil (BR)" />
+		<EnumValue value="pt-PT"
+			display_value="Portuguese Portugal (PT)" />
+		<EnumValue value="ro-RO"
+			display_value="Romanian Romania (RO)" />
+		<EnumValue value="ru-RU" display_value="Russian Russia (RU)" />
+		<EnumValue value="sr-BA"
+			display_value="Serbian Bosnia and Herzegovina (BA)" />
+		<EnumValue value="sr-ME"
+			display_value="Serbian Montenegro (ME)" />
+		<EnumValue value="sr-RS" display_value="Serbian Serbia (RS)" />
+		<EnumValue value="sk-SK"
+			display_value="Slovak Slovakia (SK)" />
+		<EnumValue value="sl-SI"
+			display_value="Slovenian Slovenia (SI)" />
+		<EnumValue value="es-AR"
+			display_value="Spanish Argentina (AR)" />
+		<EnumValue value="es-BO"
+			display_value="Spanish Bolivia (BO)" />
+		<EnumValue value="es-CL" display_value="Spanish Chile (CL)" />
+		<EnumValue value="es-CO"
+			display_value="Spanish Colombia (CO)" />
+		<EnumValue value="es-CR"
+			display_value="Spanish Costa Rica (CR)" />
+		<EnumValue value="es-DO"
+			display_value="Spanish Dominican Republic (DO)" />
+		<EnumValue value="es-EC"
+			display_value="Spanish Ecuador (EC)" />
+		<EnumValue value="es-SV"
+			display_value="Spanish El Salvador (SV)" />
+		<EnumValue value="es-GT"
+			display_value="Spanish Guatemala (GT)" />
+		<EnumValue value="es-HN"
+			display_value="Spanish Honduras (HN)" />
+		<EnumValue value="es-MX" display_value="Spanish Mexico (MX)" />
+		<EnumValue value="es-NI"
+			display_value="Spanish Nicaragua (NL)" />
+		<EnumValue value="es-PA" display_value="Spanish Panama (PA)" />
+		<EnumValue value="es-PY"
+			display_value="Spanish Paraguay (PY)" />
+		<EnumValue value="es-PE" display_value="Spanish Peru (PE)" />
+		<EnumValue value="es-PR"
+			display_value="Spanish Puerto Rico (PR)" />
+		<EnumValue value="es-ES" display_value="Spanish Spain (ES)" />
+		<EnumValue value="es-US"
+			display_value="Spanish United States (US)" />
+		<EnumValue value="es-UY"
+			display_value="Spanish Uruguay (UY)" />
+		<EnumValue value="es-VE"
+			display_value="Spanish Venezuela (VE)" />
+		<EnumValue value="sv-SE" display_value="Swedish Sweden (SE)" />
+		<EnumValue value="th-TH" display_value="Thai Thailand (TH)" />
+		<EnumValue value="tr-TR" display_value="Turkish Turkey (TR)" />
+		<EnumValue value="uk-UA"
+			display_value="Ukrainian Ukraine (UA)" />
+		<EnumValue value="vi-VN"
+			display_value="Vietnamese Vietnam (VN)" />
+	</UserPref>
+	<UserPref name="maxlength" display_name="Max list length"
+		datatype="number" />
+	<UserPref name="caption" display_name="Show caption"
+		default_value="false" datatype="bool" />
+	<UserPref name="listAriaLabel"
+		display_name="Image Auto List aria-label" datatype="string" />
+	<UserPref name="listAriaRole"
+		display_name="Image Auto List aria-role" datatype="string" />
+	<UserPref name="perc_hide_when_empty"
+		display_name="Hide auto list when empty" default_value="false"
+		datatype="bool" />
+	<UserPref name="layout" display_name="Layout" required="true"
+		default_value="perc-list-vertical" datatype="enum">
+		<EnumValue value="perc-list-horizontal"
+			display_value="Horizontal" />
+		<EnumValue value="perc-list-vertical"
+			display_value="Vertical" />
+	</UserPref>
+	<UserPref name="target" display_name="Link target"
+		required="true" default_value="_self" datatype="enum">
+		<EnumValue value="_self" display_value="Current window" />
+		<EnumValue value="_blank" display_value="New window" />
+	</UserPref>
+	<CssPref name="rootclass" display_name="CSS root class"
+		datatype="string" />
+	<CssPref name="listclass" display_name="CSS image list class"
+		datatype="string" />
+	<CssPref name="thumblinkclass"
+		display_name="CSS thumbnail link class" datatype="string" />
+	<CssPref name="captionclass" display_name="CSS caption class"
+		datatype="string" />
+	<Code type="jexl">
+        <![CDATA[
+   $linkContext = $perc.linkContext;
+   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);
+   $listTitleFormat = $perc.widget.item.properties.get('listTitleFormat');
+   $listItemFormat = $perc.widget.item.properties.get('listItemFormat');
+   $listAriaLabel = $perc.widget.item.properties.get('listAriaLabel');
+   $listAriaRole = $perc.widget.item.properties.get('listAriaRole');
+   $autoListDivId = $perc.widget.item.properties.get('autoListDivId');
+   $showPostDate = $perc.widget.item.properties.get('showPostDate');
+   $postDateTimeFormat = $perc.widget.item.properties.get('postDateTimeFormat');
+   $perc_hide_when_empty = $perc.widget.item.properties.get('perc_hide_when_empty');
+   $perc.setWidgetContents($assetItems);
+   $target = $perc.widget.item.properties.get('target');
+   $layout = $perc.widget.item.properties.get('layout');
+   $rootclass = $perc.widget.item.cssProperties.get('rootclass');
+   if (!empty($rootclass)) {
+      $rootclass = $rootclass;
+   }
+   $listclass = $perc.widget.item.cssProperties.get('listclass');
+   if (!empty($listclass)) {
+      $listclass = $listclass.trim();
+   }
+   if ($listAriaRole == '' || $listAriaRole == null) {
+      $listAriaRole = '';
+   }
+   else {
+       $listAriaRole = 'role="' + $listAriaRole + '"';
+   }
+   if($autoListDivId == '' || $autoListDivId == null) {
+      $autoListDivId = $perc.widget.item.id + "_list";
+   }
+   $headerId = $autoListDivId + '_header';
+   $thumblinkclass = $perc.widget.item.cssProperties.get('thumblinkclass');
+   if (!empty($thumblinkclass)) {
+      $thumblinkclass = $thumblinkclass.trim();
+   }
+   else {
+      $thumblinkclass = "";
+   }
+   if (!empty($thumblinkclass)) {
+      $thumblinkclass = 'class="' + $thumblinkclass + '"';
+   }
+   $caption = $perc.widget.item.properties.get('caption');
+   $captionclass = $perc.widget.item.cssProperties.get('captionclass');
+   if (!empty($captionclass)) {
+      $captionclass = $captionclass.trim();
+   }
+   $maxlength = $perc.widget.item.properties.get('maxlength');
+   if (empty($maxlength)) {
+      $maxlength = 500;
+   }
+   $sortby = $perc.widget.item.properties.get('sortby');
+
+   $sortDirection = $perc.widget.item.properties.get('sortDirection');
+   if($sortDirection == null){
+       $sortDirection = "desc";
+   }
+   $renderingformat = $perc.widget.item.properties.get('renderingformat');
+   $target = $perc.widget.item.properties.get('target');
+
+   if ( ! $assetItems.isEmpty() ) {
+      $assetItem = $assetItems.get(0);
+      $params = $rx.string.stringToMap(null);
+      $query = $assetItem.getNode().getProperty('query').String;
+	  if ($sortby != "none"  && $sortby != null) {
+        $query = $query + " order by " + $sortby + " " + $sortDirection;
+      }
+
+      $params.put('query', $query);
+      $params.put('max_results', $maxlength);
+      $finderName =  "Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder";
+      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);
+      $title = $rx.pageutils.html($assetItem, 'displaytitle');
+      $rowtag = $tools.alternator.auto('perc-list-odd', 'perc-list-even');
+
+      if ($listTitleFormat != 'none') {
+         $titleFormatStartTag = '<' + $listTitleFormat + ' id="' + $headerId + '"' + ' class="perc-list-title" aria-label="Image List Title" title="' + $title + '"' + '>';
+         $titleFormatEndTag = '</' + $listTitleFormat + '>';
+      }
+      else {
+         $titleFormatStartTag = "";
+         $titleFormatEndTag = "";
+      }
+      if ($listItemFormat != 'none') {
+         $itemFormatStartTag = '<' + $listItemFormat + '>';
+         $itemFormatEndTag = '</' + $listItemFormat + '>';
+      }
+      if ($listAriaLabel == '' || $listAriaLabel == null) {
+         if ($title != null && $title != '') {
+             $listAriaLabel = 'aria-label="' + $title + ' image list"';
+         } else {
+             $listAriaLabel = 'aria-label="Image list"';
+         }
+      } else {
+          $listAriaLabel = 'aria-label="' + $listAriaLabel + '"';
+      }
+   }
+   else {
+      ;
+   }
+
+   $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);
+   if ($dsUrl.indexOf("http://localhost") != -1 )
+      $dsUrl = "";
+   $dynamicListData = $tools.esc.html("{ deliveryurl : '" + $dsUrl + "'}");
+
+    ]]>
+	</Code>
+	<Content type="velocity">
+        <![CDATA[
+#define($ariaLabelString)##
+#if($title && $title.length() > 0)##
+aria-labelledby="$!{headerId}"##
+#else##
+$!{listAriaLabel}##
+#end##
+#end##
+##Setup Date Formatting
+#set($formatterOut = $rx.pageutils.getDateFormatFromLocale("$!{postDateTimeFormat}",$locale))##
+#set($postDateObject="")##
+#set($postDate="")##
+<div id="$!{autoListDivId}" class="$!{rootclass} $!{layout} perc-image-auto-list" #if($perc_hide_when_empty && $relresults.size() <= 0)hidden #end $!{ariaLabelString} $!{listAriaRole} data-query="$!{dynamicListData}">
+#if( ! $perc.widgetContents.isEmpty() )
+#if($title && $title.length() > 0)##
+$!{titleFormatStartTag}$title$!{titleFormatEndTag}
+#end
+#if($relresults && $relresults.size() > 0)
+#if($rendering == "ordered")##
+<ol class="$!{listclass} perc-list-main">##
+#else##
+<ul class="$!{listclass} perc-list-main">##
+#end##
+#foreach($result in $relresults)
+#set($postDateObject = $result.node.getProperty('rx:sys_contentpostdate'))##
+#set($postDateObjectString = $result.node.getProperty('rx:sys_contentpostdate').String)##
+#if("$!{postDateObjectString}" == "")##
+#set($postDateObject = $tools.date.getDate())##
+#else##
+#set($postDateObject = $result.node.getProperty('rx:sys_contentpostdate').getDate())##
+#end##
+#if("$!{postDateObject}" != "")##
+#set($postDate = $formatterOut.format($postDateObject.getTime()))##
+#end##
+#if($velocityCount == 1)##
+#set($firstrow = 'perc-list-first')##
+#else##
+#set($firstrow = ' ')##
+#end##
+#if($velocityCount == $relresults.size())##
+#set($lastrow = 'perc-list-last')##
+#else
+#set($lastrow = ' ')##
+#end
+#set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+#set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+#set($link = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result, "percSystem.imageMainBinary")))##
+#set($img_alt = $rx.pageutils.html($result,'alttext'))##
+#if(!$perc.isEditMode())##
+#set($img_title=$rx.pageutils.html($result,'displaytitle'))##
+#else##
+#set($img_title="")##
+#end
+#if($perc.isEditMode() && $img_title == "")##
+#set($img_title_attr = "")##
+#else##
+#set($img_title_attr = 'title="' + $img_title + '"')##
+#end
+$!{itemFormatStartTag}<li class="$rowtag $!{firstrow} $!{lastrow} perc-list-element">
+#if($renderingformat == 'image')
+#set($img_height=$result.node.getProperty('rx:img_height').getString())##
+#set($img_width=$result.node.getProperty('rx:img_width').getString())##
+#if($img_height.length() > 0 && $img_width.length() > 0)
+<img src="$link" $img_title_attr alt="$img_alt" aria-label="$!{img_title}" height="$img_height" width="$img_width" />
+#else##
+<img src="$link" $img_title_attr />
+#end
+#if($showPostDate)##
+#if("$!{postDate}" != "")##
+<span class="perc-image-auto-list-date">$!{postDate}</span>
+#end##
+#end##
+#else##
+#set($img_height=$result.node.getProperty('rx:img2_height').getString())##
+#set($img_width=$result.node.getProperty('rx:img2_width').getString())##
+#set($thumblink=$tools.esc.html($rx.pageutils.itemLink($linkContext, $result, "percSystem.imageThumbBinary")))##
+#if($renderingformat == 'thumbnail')##
+#if($img_height.length() > 0 && $img_width.length() > 0)
+<img src="$thumblink" $img_title_attr alt="$img_alt" height="$img_height" width="$img_width" />
+#else##
+<img src="$thumblink" $img_title_attr />
+#end
+#end
+#if($renderingformat == 'thumbnail_link')
+<a ${thumblinkclass} href="$link" $img_title_attr target="$target">
+<img src="$thumblink"  alt="$img_alt" height="$img_height" width="$img_width"/>
+</a>
+#end
+#end
+#if ($caption)
+#set($caption_text=$result.node.getProperty('rx:resource_link_title').getString())##
+<div class="$!{captionclass} perc-caption">
+${caption_text}
+</div>
+#end
+</li>$!{itemFormatEndTag}
+#end##
+#if($rendering == "ordered")##
+</ol>##
+#else##
+</ul>##
+#end##
+#end##
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("imagelist-sample-content", "This image auto list widget is showing sample content.")
+#end
+</div>
+]]>
+	</Content>
+</Widget>


### PR DESCRIPTION
## Summary

Slice of parent **#2630** (grandparent #2626): remaining product Widget XML residual batch after #2789 / PR #2803.

Extends the Widget XML → Component Package Manifest compiler coverage to **all remaining product packages** (except `perc.Test`):

- **Auto-lists:** `perc.ImageAutoListWidget`, `perc.PageAutoListWidget`, `perc.widget.fileAutoList`
- **Blog/list companions:** archive/category/tag lists, blog index, most-read posts
- **Social/comments/cards:** comments, liked, comment form, openGraph, twitter summary cards
- **Other:** event, imageSlider, cookieConsent, jquery/jqueryUI, registration/secureLogin, Result, Redirect, defaultLanguage (2 widgets)

Dual-run: product `rxconfig/Widgets/*.xml` **kept** (no dual-run exit / XML deletion).

### Code
- `PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS` + `compileRemainingProductPackages`
- Package compile validation for **24 widgets / 23 packages**
- Golden parity: **percImageAutoList**, **percComments**, **percEvent**
- Inventory/docs updated (product compile coverage complete except `perc.Test`)

### Out of scope
- Product Widget XML deletion
- Page/Gadget conversion
- Runtime shim
- `perc.Test`

## Test plan
1. `cd modules/perc-packages && ../../mvnw clean install`
2. Confirm `PSWidgetXmlCompilerTest` green (remaining batch + goldens)
3. No product package source XML removed

## Build evidence (C3)
- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: **76**, Failures: 0, Errors: 0
- **downstream_checked:** none (no public API sealed/final or signature changes affecting reverse deps; package-private batch list + tests only within perc-packages)

## Parent / refs
Parent tracker: #2630 · Grandparent: #2626 · Prior: #2789 #2772 #2751

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2802

> Co-Authored by Grok Build using grok-4.5 with agent main.
