### PR TITLE
feat(perc-packages): native install of modern page packages; dual-ship opt-out (#2806)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -78,6 +78,8 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Component package manifest | `modules/perc-packages/.../manifest/PSComponentPackageManifest*.java` |
 | Widget XML compiler | `modules/perc-packages/.../widgetxml/PSWidgetXmlCompiler.java` (#2751 baseWidgets, #2772 high-traffic) |
 | Page templateDef compiler | `modules/perc-packages/.../pagexml/PSPageXmlCompiler.java` (#2770) |
+| Page dual-ship / native install | `…/pagexml/PSPageXmlDualShip.java`, `PSPageXmlNativeInstall.java`, `PSPageXmlInstallPolicy.java` (#2786 / #2806) |
+| Dual-ship retirement checklist | [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md) |
 | Gadget registry compiler | `modules/perc-packages/.../gadgetxml/PSGadgetRegistryCompiler.java` (#2771) |
 | Modern gadget catalog (ship) | `modules/perc-packages/src/main/resources/catalogs/gadgets/gadget-catalog.json` |
 | Dual-run definition source shim | `modules/perc-packages/.../shim/PSLegacyDefinitionXmlShim.java` |

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -71,7 +71,9 @@ Compiler for upgrade-input Page / assembly `*.templateDef` → Component Package
 | Golden parity (`perc.base.plain`) | `modules/perc-packages/src/test/resources/pagexml/golden/` |
 | Inventory + dual-run note | [../page-definition-inventory.md](../page-definition-inventory.md) |
 
-**#2786 (landed):** `perc.baseTemplates` and `perc.responsiveTemplates` **author** modern `pages/<id>/component-package.json` + sources. Package build dual-ships install `*.templateDef` via `PSPageXmlDualShip` / `PSPackageBuilder` so deployer `TemplateDef` install parity is preserved. Baseline system templates and native modern install remain residual under #2630.
+**#2786 (landed):** `perc.baseTemplates` and `perc.responsiveTemplates` **author** modern `pages/<id>/component-package.json` + sources.
+
+**#2806 (landed):** native package install — those packages set `page.installMode=native` so dual-ship root `*.templateDef` generation is off; `PSPageXmlNativeInstall` stages archive `TemplateDef-N/` from modern pages. Dual-ship remains default for packages that have not opted in. Retirement checklist: [../dual-ship-page-template-retirement.md](../dual-ship-page-template-retirement.md). Baseline system templates remain residual under #2630.
 
 ## Gadget registry compiler (slice #2771)
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -49,7 +49,7 @@ Hard order for a package root or definition id:
 | Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; product source of truth moves off XML (ADR-004) |
 | Package staging Widgets | `sys__UserDependency--rxconfig/Widgets/` or `rxconfig/Widgets/` under a package root | Upgrade-input / deploy layout | Shim package-root API resolves either layout |
 | Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Modern: `gadget-catalog.json` + per-gadget packages (#2771); dual-load residual for WebUI |
-| Page meta / definition XML | Site/page storage dialects | Composition authoring legacy | Product layout packages (`perc.baseTemplates`, `perc.responsiveTemplates`) author modern `pages/` (#2786); dual-ship still emits install `*.templateDef` into `.ppkg`. Shim recognizes `rxconfig/Pages` if present for customer defs |
+| Page meta / definition XML | Site/page storage dialects | Composition authoring legacy | Product layout packages (`perc.baseTemplates`, `perc.responsiveTemplates`) author modern `pages/` (#2786); native package install stages archive `TemplateDef-N/` without dual-ship roots (#2806). Shim recognizes `rxconfig/Pages` if present for customer defs |
 
 **Selection API (no Spring wiring required for unit use):**
 
@@ -88,7 +88,7 @@ Deep rewiring of `PSWidgetDao` to call the shim for every load is **incremental*
 
 The dual-run window ends when **all** of the following hold:
 
-- [x] Product **page layout** packages `perc.baseTemplates` / `perc.responsiveTemplates` are **not** authored as `*.templateDef` (#2786; dual-ship for install only).
+- [x] Product **page layout** packages `perc.baseTemplates` / `perc.responsiveTemplates` are **not** authored as `*.templateDef` (#2786; native install mode #2806 — dual-ship roots off).
 - [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates, widgets, etc. still residual.
 - [ ] Customer upgrade path documented and used for remaining XML.
 - [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived.

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
@@ -1,0 +1,78 @@
+# Dual-ship page templateDef retirement checklist
+
+| Field | Value |
+|-------|--------|
+| **Status** | Active (#2806 native install path landed; dual-ship optional) |
+| **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Related** | #2786 dual-ship modern authoring · #2806 native package install · Phase 5 shim #2632 |
+| **Code** | `PSPageXmlInstallPolicy`, `PSPageXmlNativeInstall`, `PSPageXmlDualShip`, `PSPackageBuilder` |
+
+## Purpose
+
+Product page layout packages author modern `pages/<id>/component-package.json` + template sources (ADR-004). Until #2806, package build **dual-shipped** root `*.templateDef` so deployer `TemplateDef` install was unchanged. Native install stages the same assembly-template XML **directly into** archive `TemplateDef-N/` folders without dual-ship root materialization.
+
+This document is the **operator / engineering checklist** for turning dual-ship off package-by-package and eventually removing the dual-ship code path.
+
+## Install modes
+
+| Mode | When | Package-build behavior |
+|------|------|------------------------|
+| **dual-ship** (default) | No package-local opt-in; system prop unset | Materialize root `*.templateDef` → reorganize maps to `TemplateDef-N/` |
+| **native** | `package-install.properties` `page.installMode=native`, or sys props below | Skip root dual-ship; after reorganize, `PSPageXmlNativeInstall.stageArchiveTemplateDefs` writes `TemplateDef-N/<stem>.templateDef` |
+
+### Configuration knobs
+
+| Knob | Values | Notes |
+|------|--------|-------|
+| Package-local `package-install.properties` → `page.installMode` | `native` \| `dual-ship` | Preferred for converted product packages |
+| System property `perc.packages.page.installMode` | `native` \| `dual-ship` | Overrides package-local (CI / one-off builds) |
+| System property `perc.packages.dualShip.pageTemplateDefs` | `false` / `0` / `off` | Forces native (dual-ship generation off) |
+
+Policy code: `com.percussion.packages.pagexml.PSPageXmlInstallPolicy` (aligns with modern-preferred selection in `PSLegacyDefinitionXmlShim`).
+
+## Packages already on native install
+
+| Package | Mode file | Notes |
+|---------|-----------|-------|
+| `perc.baseTemplates` | `package-install.properties` → `native` | 20 page layouts |
+| `perc.responsiveTemplates` | `package-install.properties` → `native` | Banded / Basic / plain |
+
+## Retirement checklist (per package)
+
+1. **Author modern** — `pages/<id>/component-package.json` + `templates/*.vm` present; no product-authored root `*.templateDef`.
+2. **Mapping intact** — `*.mapping.properties` still lists `stem.templateDef=TemplateDef-N` (and ACL side-cars as needed).
+3. **Opt into native** — add package-root `package-install.properties` with `page.installMode=native`.
+4. **Parity test** — unit test or golden: native archive XML GUID / name / assembler / body match dual-ship emit (`PSPageXmlNativeInstallTest` pattern).
+5. **Package build** — `PSPackageBuilder` log line `native-install page TemplateDefs for <pkg>: N written`.
+6. **Install smoke** — deployer installs package; templates load with stable GUIDs (human QA when host install available).
+7. **Remove dual-ship dependency** — package no longer needs root materialization; keep mapping + ACLs.
+
+## Global dual-ship exit criteria
+
+Dual-ship **code path** can be deleted when **all** hold:
+
+- [x] Native install API + policy exist (`PSPageXmlNativeInstall` / `PSPageXmlInstallPolicy`) — #2806
+- [x] `perc.baseTemplates` / `perc.responsiveTemplates` use native mode — #2806
+- [ ] Remaining page layout packages on native (e.g. `perc.Baseline` system templates after #2805)
+- [ ] Widget packages that still dual-ship any page-like templateDefs inventoried and converted or explicitly dual-ship-retained
+- [ ] CI / product package build has zero `dual-ship page templateDefs` log lines (or only waived packages)
+- [ ] Docs (this file + page inventory + ADR-004) mark dual-ship retired
+- [ ] Follow-up removes `PSPageXmlDualShip.materializeInstallTemplateDefs` call sites when unused
+
+## Deployer note
+
+Runtime install still uses `PSTemplateDefDependencyHandler` and assembly-template XML **inside** the `.ppkg`. Native install does **not** require deployer to parse `component-package.json` at runtime yet; it makes package **build** the consumer of modern packages (shim policy: modern preferred). A future residual may teach deployer to load modern manifests directly from archive user-deps; until then, archive `TemplateDef-N/` XML remains the wire format.
+
+## Dual-run / dual-ship relationship
+
+| Concept | Layer | Status |
+|---------|-------|--------|
+| Dual-run **definition XML shim** | Runtime selection modern vs Widget/Page/Gadget XML | Time-boxed; Phase 5 #2632 |
+| Dual-ship **page templateDef** | Package-build install bridge for page layouts | Optional; native preferred for converted packages |
+| Native **page install** | Package-build stages TemplateDef archive from modern pages | Landed #2806 for base/responsive |
+
+## See also
+
+- [page-definition-inventory.md](./page-definition-inventory.md)
+- [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md)
+- [adr/004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md)

--- a/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/page-definition-inventory.md
@@ -27,8 +27,8 @@ CM1 **page item** region trees / widget instances live in site storage (sitemana
 
 | Package | Modern `pages/` count | Assembler (typical) | Output format | Notes |
 |---------|----------------------:|---------------------|---------------|-------|
-| `perc.baseTemplates` | 20 | `pageAssembler` | Page | **Modern authoring (#2786)**; dual-ship generates install `*.templateDef` at package build |
-| `perc.responsiveTemplates` | 3 | `pageAssembler` | Page | **Modern authoring (#2786)**; Banded / Basic / plain |
+| `perc.baseTemplates` | 20 | `pageAssembler` | Page | **Modern authoring (#2786)**; **native install** (#2806) — dual-ship roots off |
+| `perc.responsiveTemplates` | 3 | `pageAssembler` | Page | **Modern authoring (#2786)**; **native install** (#2806); Banded / Basic / plain |
 | `perc.Baseline` | (still `*.templateDef`) | mix (`pageAssembler`, `velocityAssembler`, …) | Page / Global | System templates residual — convert carefully |
 
 Snippet-style `*.templateDef` files also appear inside **widget** packages (e.g. file/image binary templates). Those are **not** page layout packages; leave them to widget conversion residuals unless inventory shows Page `output-format`.
@@ -37,6 +37,7 @@ Snippet-style `*.templateDef` files also appear inside **widget** packages (e.g.
 
 ```text
 Packages/perc.baseTemplates/
+  package-install.properties    ← page.installMode=native (#2806)
   pages/<templateId>/component-package.json
   pages/<templateId>/templates/<templateId>.vm
   *.templateDef.aclDef          ← ACL side-cars (unchanged)
@@ -45,7 +46,7 @@ Packages/perc.baseTemplates/
   sys__UserDependency--rx_resources/…
 ```
 
-Install dual-ship (package build): root `*.templateDef` regenerated into staging from `pages/` with GUIDs from mapping (`TemplateDef-N` → `0-4-N`). Product source trees **do not** author root `*.templateDef`.
+Native install (package build, #2806): archive `TemplateDef-N/<stem>.templateDef` staged from `pages/` with GUIDs from mapping (`TemplateDef-N` → `0-4-N`). Dual-ship root materialization is off for this package. Product source trees **do not** author root `*.templateDef`.
 
 | Template name | Label (sample) | Regions (`#region`) |
 |---------------|----------------|---------------------|
@@ -80,7 +81,7 @@ Install dual-ship (package build): root `*.templateDef` regenerated into staging
 | Matching `id="…" class="perc-region perc-vertical …"` | `slots[].layout.orientation`, `slots[].styles.rootclass` (+ span hints) |
 | `catalog.kind` | always `page` for this compiler |
 
-**Dual-ship (install parity, #2786):** product **authors** modern `pages/` only for `perc.baseTemplates` and `perc.responsiveTemplates`. `PSPackageBuilder` calls `PSPageXmlDualShip.materializeInstallTemplateDefs` so `.ppkg` still contains root `*.templateDef` for deployer `TemplateDef` handlers. Semantic parity (name, assembler, body, GUID, slots) is unit-tested in `PSPageXmlDualShipTest`. Native deployer install of `component-package.json` remains a follow-on.
+**Install packaging (#2786 dual-ship + #2806 native):** product **authors** modern `pages/` only for `perc.baseTemplates` and `perc.responsiveTemplates`. Package-local `package-install.properties` sets `page.installMode=native` so dual-ship root `*.templateDef` generation is **off**; `PSPageXmlNativeInstall` stages archive `TemplateDef-N/<stem>.templateDef` from modern pages (same XML/GUID semantics as dual-ship). Default for other packages remains dual-ship until they opt in. Policy: `PSPageXmlInstallPolicy`. Retirement checklist: [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md).
 
 ## Golden fixtures
 
@@ -91,14 +92,17 @@ Install dual-ship (package build): root `*.templateDef` regenerated into staging
 | Template golden | `…/pagexml/golden/perc.base.plain.vm` |
 | Compiler tests | `com.percussion.packages.pagexml.PSPageXmlCompilerTest` |
 | Dual-ship tests | `com.percussion.packages.pagexml.PSPageXmlDualShipTest` |
+| Native install tests | `com.percussion.packages.pagexml.PSPageXmlNativeInstallTest` |
 | Product modern sources | `…/Packages/perc.baseTemplates/pages/`, `…/Packages/perc.responsiveTemplates/pages/` |
+| Native opt-in | `…/Packages/perc.baseTemplates/package-install.properties` (and responsive) |
 
 ## Residuals (not this PR)
 
-1. **Native deployer install** of modern page `component-package.json` (then dual-ship generator can retire).
+1. **Runtime deployer** reading `component-package.json` from archive (today native path is package-build staging into TemplateDef wire format).
 2. **Thumbnails / resources** wiring for template images into `resources[]`.
-3. **Baseline system templates** conversion matrix (Global / Xml / Database / Dispatcher).
+3. **Baseline system templates** conversion matrix (Global / Xml / Database / Dispatcher) + native opt-in when ready.
 4. **Page item composition** (site storage region trees) → slot composition IR — depends on Phase 2 storage / REST (#2690 family).
+5. **Delete dual-ship code path** when all page packages use native (see retirement checklist).
 
 ## Related
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
@@ -19,6 +19,9 @@ package com.percussion.packages;
 
 import com.percussion.packages.pagexml.PSPageXmlDualShip;
 import com.percussion.packages.pagexml.PSPageXmlException;
+import com.percussion.packages.pagexml.PSPageXmlInstallMode;
+import com.percussion.packages.pagexml.PSPageXmlInstallPolicy;
+import com.percussion.packages.pagexml.PSPageXmlNativeInstall;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -38,8 +41,15 @@ import java.util.zip.ZipOutputStream;
  * haven't changed).
  *
  * <p>Page layout packages that author modern {@code pages/&lt;id&gt;/component-package.json} (ADR-004
- * / #2786) dual-ship install {@code *.templateDef} into the staging copy before zip so deployer
- * {@code TemplateDef} install parity is preserved.
+ * / #2786 / #2806) are staged for deployer {@code TemplateDef} install:
+ *
+ * <ul>
+ *   <li><strong>Dual-ship</strong> (default): materialize root {@code *.templateDef} before reorganize
+ *   <li><strong>Native</strong> (package-local or system property): stage {@code TemplateDef-N/}
+ *       archive folders from modern pages without dual-ship root files — see {@link
+ *       com.percussion.packages.pagexml.PSPageXmlInstallPolicy} / {@link
+ *       com.percussion.packages.pagexml.PSPageXmlNativeInstall}
+ * </ul>
  *
  * <p>Usage: {@code PSPackageBuilder <packagesDir> <outputDir> <tempDir>}
  */
@@ -140,8 +150,8 @@ public final class PSPackageBuilder {
       // Step 1: Copy source files to temp1
       copyDirectory(packageDir, temp1);
 
-      // Step 1b: Dual-ship modern page packages → install *.templateDef (ADR-004 / #2786)
-      dualShipPageTemplateDefs(temp1, dirName);
+      // Step 1b: Modern page packages → deployer TemplateDef install (#2786 / #2806)
+      stageModernPageInstallArtifacts(temp1, temp2, dirName, true);
 
       // Step 2: Read mapping properties
       var propsFile = packageDir.resolve(dirName + MAPPING_EXT);
@@ -155,6 +165,9 @@ public final class PSPackageBuilder {
       // Step 3: Reorganize files from temp1 into temp2 using mapping
       reorganizeFiles(dirName, temp1, temp1.toFile(), temp2, props);
 
+      // Step 3b: Native mode stages TemplateDef-N after reorganize (no dual-ship roots)
+      stageModernPageInstallArtifacts(temp1, temp2, dirName, false);
+
       // Step 4: Zip temp2 into .ppkg
       zipDirectory(temp2, outputFile);
     } finally {
@@ -166,21 +179,44 @@ public final class PSPackageBuilder {
   }
 
   /**
-   * When a package authors modern {@code pages/} component packages, materialize root-level {@code
-   * *.templateDef} for deployer install parity. Fail the package build if dual-ship cannot run.
+   * Stage modern page packages for deployer TemplateDef install.
+   *
+   * @param preReorganize when {@code true}, run dual-ship root materialization only; when {@code
+   *     false}, run native archive staging only
    */
-  private static void dualShipPageTemplateDefs(Path stagingPackageDir, String packageName)
+  private static void stageModernPageInstallArtifacts(
+      Path stagingPackageDir, Path archiveRoot, String packageName, boolean preReorganize)
       throws IOException {
     try {
       if (!PSPageXmlDualShip.hasModernPageSources(stagingPackageDir)) {
         return;
       }
-      int n = PSPageXmlDualShip.materializeInstallTemplateDefs(stagingPackageDir);
+      PSPageXmlInstallMode mode = PSPageXmlInstallPolicy.resolve(stagingPackageDir);
+      if (preReorganize) {
+        if (mode != PSPageXmlInstallMode.DUAL_SHIP) {
+          return;
+        }
+        int n = PSPageXmlDualShip.materializeInstallTemplateDefs(stagingPackageDir);
+        System.out.println(
+            "  dual-ship page templateDefs for " + packageName + ": " + n + " written");
+        return;
+      }
+      // post-reorganize: native archive staging
+      if (mode != PSPageXmlInstallMode.NATIVE) {
+        return;
+      }
+      int n = PSPageXmlNativeInstall.stageArchiveTemplateDefs(stagingPackageDir, archiveRoot);
       System.out.println(
-          "  dual-ship page templateDefs for " + packageName + ": " + n + " written");
+          "  native-install page TemplateDefs for " + packageName + ": " + n + " written");
     } catch (PSPageXmlException e) {
       throw new IOException(
-          "Page dual-ship failed for package " + packageName + ": " + e.getMessage(), e);
+          "Page install staging failed for package "
+              + packageName
+              + " ("
+              + (preReorganize ? "dual-ship" : "native")
+              + "): "
+              + e.getMessage(),
+          e);
     }
   }
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlDualShip.java
@@ -39,17 +39,19 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Dual-ship bridge for product page layout packages (ADR-004 / issue #2786).
+ * Dual-ship bridge for product page layout packages (ADR-004 / issues #2786 + #2806).
  *
  * <p><strong>Authoring truth:</strong> {@code pages/&lt;templateId&gt;/component-package.json} plus
  * template sources under the product package tree (e.g. {@code perc.baseTemplates}, {@code
  * perc.responsiveTemplates}).
  *
- * <p><strong>Install path:</strong> package build materializes root-level {@code *.templateDef}
- * files (legacy {@code TemplateDef} dependency) so {@code .ppkg} install parity is preserved until
- * deployer consumes modern manifests natively.
+ * <p><strong>Install path (dual-ship mode):</strong> package build materializes root-level {@code
+ * *.templateDef} files (legacy {@code TemplateDef} dependency) so reorganize + {@code .ppkg}
+ * install parity is preserved. Prefer {@link PSPageXmlNativeInstall} / {@link
+ * PSPageXmlInstallMode#NATIVE} (package-local or system property) to stage archive {@code
+ * TemplateDef-N/} folders without dual-ship root files — see {@link PSPageXmlInstallPolicy}.
  *
- * <p>GUIDs for dual-ship templateDefs are derived from {@code &lt;package&gt;.mapping.properties}
+ * <p>GUIDs for install templateDefs are derived from {@code &lt;package&gt;.mapping.properties}
  * entries ({@code TemplateDef-N} → {@code 0-4-N}).
  */
 public final class PSPageXmlDualShip {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallArtifact.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallArtifact.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.util.Objects;
+
+/**
+ * One install-path TemplateDef payload derived from a modern page component package.
+ *
+ * @param stem template id / file stem (e.g. {@code perc.base.plain})
+ * @param guid assembly GUID string (e.g. {@code 0-4-591})
+ * @param archiveFolder mapping value (e.g. {@code TemplateDef-591})
+ * @param templateDefXml legacy {@code <assembly-template>} document text for deployer install
+ */
+public record PSPageXmlInstallArtifact(
+    String stem, String guid, String archiveFolder, String templateDefXml) {
+
+  public PSPageXmlInstallArtifact {
+    Objects.requireNonNull(stem, "stem");
+    Objects.requireNonNull(guid, "guid");
+    Objects.requireNonNull(archiveFolder, "archiveFolder");
+    Objects.requireNonNull(templateDefXml, "templateDefXml");
+    if (stem.isBlank()) {
+      throw new IllegalArgumentException("stem must not be blank");
+    }
+    if (guid.isBlank()) {
+      throw new IllegalArgumentException("guid must not be blank");
+    }
+    if (archiveFolder.isBlank()) {
+      throw new IllegalArgumentException("archiveFolder must not be blank");
+    }
+  }
+
+  /** Root dual-ship file name: {@code &lt;stem&gt;.templateDef}. */
+  public String rootFileName() {
+    return stem + ".templateDef";
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallMode.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallMode.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+/**
+ * How package build stages modern page {@code component-package.json} sources into deployer {@code
+ * TemplateDef} archive entries (issue #2806 / parent #2630).
+ *
+ * <ul>
+ *   <li>{@link #DUAL_SHIP} — materialize root {@code *.templateDef} before reorganize (legacy dual-ship
+ *       bridge from #2786)
+ *   <li>{@link #NATIVE} — convert modern pages directly into archive {@code TemplateDef-N/} folders
+ *       without dual-ship root files (preferred for converted packages)
+ * </ul>
+ */
+public enum PSPageXmlInstallMode {
+  /** Dual-ship: write root {@code *.templateDef} so existing reorganize mapping picks them up. */
+  DUAL_SHIP,
+  /**
+   * Native: stage {@code TemplateDef-N/&lt;stem&gt;.templateDef} from modern {@code pages/} after
+   * reorganize; no root dual-ship materialization.
+   */
+  NATIVE
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallPolicy.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallPolicy.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Resolves page-template install mode for a package root (ADR-004 / issues #2786 + #2806).
+ *
+ * <p>Precedence (highest first):
+ *
+ * <ol>
+ *   <li>System property {@value #SYS_PROP_INSTALL_MODE} — {@code native} or {@code dual-ship}
+ *   <li>System property {@value #SYS_PROP_DUAL_SHIP} — {@code false}/{@code 0}/{@code off} forces
+ *       native when modern pages exist (dual-ship generation off)
+ *   <li>Package-local {@value #PACKAGE_INSTALL_PROPS} key {@value #PROP_PAGE_INSTALL_MODE}
+ *   <li>Default: {@link PSPageXmlInstallMode#DUAL_SHIP} (safe for packages not yet opted into native)
+ * </ol>
+ *
+ * <p>Aligns with {@link com.percussion.packages.shim.PSLegacyDefinitionXmlShim} policy: modern
+ * authoring is preferred; dual-ship is a time-boxed install bridge, not permanent product
+ * authoring.
+ */
+public final class PSPageXmlInstallPolicy {
+
+  /**
+   * System property forcing install mode: {@code native} or {@code dual-ship} (case-insensitive).
+   */
+  public static final String SYS_PROP_INSTALL_MODE = "perc.packages.page.installMode";
+
+  /**
+   * System property: when {@code false}/{@code 0}/{@code off}, dual-ship root templateDef generation
+   * is disabled (native archive staging used when modern pages are present).
+   */
+  public static final String SYS_PROP_DUAL_SHIP = "perc.packages.dualShip.pageTemplateDefs";
+
+  /** Package-local properties file at package root. */
+  public static final String PACKAGE_INSTALL_PROPS = "package-install.properties";
+
+  /** Property key: {@code native} or {@code dual-ship}. */
+  public static final String PROP_PAGE_INSTALL_MODE = "page.installMode";
+
+  private PSPageXmlInstallPolicy() {
+    // utility
+  }
+
+  /**
+   * Resolve install mode for a package directory (or staging copy). Does not require modern pages
+   * to be present — callers decide whether to act on modern sources.
+   *
+   * @param packageDir package source or staging root; may be null → default dual-ship
+   * @return non-null mode
+   */
+  public static PSPageXmlInstallMode resolve(Path packageDir) {
+    String sysMode = System.getProperty(SYS_PROP_INSTALL_MODE);
+    if (sysMode != null && !sysMode.isBlank()) {
+      return parseMode(sysMode.trim());
+    }
+
+    String dualShipProp = System.getProperty(SYS_PROP_DUAL_SHIP);
+    if (dualShipProp != null && isFalsey(dualShipProp)) {
+      return PSPageXmlInstallMode.NATIVE;
+    }
+
+    if (packageDir != null) {
+      try {
+        Properties props = loadPackageInstallProps(packageDir);
+        if (props != null) {
+          String mode = props.getProperty(PROP_PAGE_INSTALL_MODE);
+          if (mode != null && !mode.isBlank()) {
+            return parseMode(mode.trim());
+          }
+        }
+      } catch (IOException e) {
+        throw new IllegalStateException(
+            "Failed reading " + PACKAGE_INSTALL_PROPS + " under " + packageDir + ": " + e.getMessage(),
+            e);
+      }
+    }
+
+    return PSPageXmlInstallMode.DUAL_SHIP;
+  }
+
+  /** Whether dual-ship root {@code *.templateDef} materialization should run for this package. */
+  public static boolean isDualShipEnabled(Path packageDir) {
+    return resolve(packageDir) == PSPageXmlInstallMode.DUAL_SHIP;
+  }
+
+  /** Whether native archive staging (no dual-ship root files) is selected. */
+  public static boolean isNativeInstallEnabled(Path packageDir) {
+    return resolve(packageDir) == PSPageXmlInstallMode.NATIVE;
+  }
+
+  static Properties loadPackageInstallProps(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    Path propsFile = packageDir.resolve(PACKAGE_INSTALL_PROPS);
+    if (!Files.isRegularFile(propsFile)) {
+      return null;
+    }
+    Properties props = new Properties();
+    try (InputStream in = Files.newInputStream(propsFile)) {
+      props.load(in);
+    }
+    return props;
+  }
+
+  static PSPageXmlInstallMode parseMode(String raw) {
+    String v = raw.toLowerCase(Locale.ROOT).replace('_', '-').trim();
+    return switch (v) {
+      case "native", "native-install", "archive" -> PSPageXmlInstallMode.NATIVE;
+      case "dual-ship", "dualship", "dual" -> PSPageXmlInstallMode.DUAL_SHIP;
+      default -> throw new IllegalArgumentException(
+          "Unknown page install mode '"
+              + raw
+              + "'. Expected 'native' or 'dual-ship' ("
+              + SYS_PROP_INSTALL_MODE
+              + " / "
+              + PROP_PAGE_INSTALL_MODE
+              + ").");
+    };
+  }
+
+  private static boolean isFalsey(String raw) {
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    return "false".equals(v) || "0".equals(v) || "off".equals(v) || "no".equals(v);
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Native package-install path for modern page component packages (issue #2806 / parent #2630).
+ *
+ * <p>Converts {@code pages/&lt;id&gt;/component-package.json} + template sources into deployer {@code
+ * TemplateDef} archive entries ({@code TemplateDef-N/&lt;stem&gt;.templateDef}) without dual-ship
+ * root-level {@code *.templateDef} materialization.
+ *
+ * <p>Aligns with {@link com.percussion.packages.shim.PSLegacyDefinitionXmlShim}: modern packages are
+ * preferred; dual-ship is optional and package-local / feature-flag controlled via {@link
+ * PSPageXmlInstallPolicy}.
+ *
+ * <p>Deployer runtime still consumes legacy assembly-template XML inside the {@code .ppkg}
+ * (PSTemplateDefDependencyHandler). This class is the package-build / staging bridge that makes that
+ * install path work from modern authoring alone.
+ */
+public final class PSPageXmlNativeInstall {
+
+  private static final Pattern TEMPLATE_DEF_KEY =
+      Pattern.compile("^(.+)\\.templateDef$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern TEMPLATE_DEF_VALUE =
+      Pattern.compile("^TemplateDef-(\\d+)$", Pattern.CASE_INSENSITIVE);
+
+  private PSPageXmlNativeInstall() {
+    // utility
+  }
+
+  /**
+   * Build install artifacts for every modern page under {@code pages/}.
+   *
+   * @param packageDir product package source or staging copy
+   * @return ordered list (by stem); empty when no modern pages
+   */
+  public static List<PSPageXmlInstallArtifact> listInstallArtifacts(Path packageDir)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (!PSPageXmlDualShip.hasModernPageSources(packageDir)) {
+      return List.of();
+    }
+
+    Map<String, String> guidsByStem = PSPageXmlDualShip.loadGuidsFromMapping(packageDir);
+    Map<String, String> foldersByStem = loadArchiveFoldersFromMapping(packageDir);
+    Path pages = packageDir.resolve(PSPageXmlDualShip.PAGES_DIR_NAME);
+    List<Path> pageDirs = PSPageXmlDualShip.listModernPageDirs(pages);
+
+    List<PSPageXmlInstallArtifact> artifacts = new ArrayList<>(pageDirs.size());
+    for (Path pageDir : pageDirs) {
+      artifacts.add(toInstallArtifact(pageDir, guidsByStem, foldersByStem, packageDir));
+    }
+    return artifacts;
+  }
+
+  /**
+   * Stage deployer archive folders under {@code archiveRoot}: {@code
+   * TemplateDef-N/&lt;stem&gt;.templateDef}.
+   *
+   * @param packageDir modern sources + mapping (staging copy is fine)
+   * @param archiveRoot package-build temp2 / archive layout root
+   * @return number of templateDefs written
+   */
+  public static int stageArchiveTemplateDefs(Path packageDir, Path archiveRoot)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    Objects.requireNonNull(archiveRoot, "archiveRoot");
+    List<PSPageXmlInstallArtifact> artifacts = listInstallArtifacts(packageDir);
+    int written = 0;
+    for (PSPageXmlInstallArtifact a : artifacts) {
+      Path outDir = archiveRoot.resolve(a.archiveFolder());
+      Files.createDirectories(outDir);
+      Path out = outDir.resolve(a.rootFileName());
+      Files.writeString(out, a.templateDefXml(), StandardCharsets.UTF_8);
+      written++;
+    }
+    return written;
+  }
+
+  /**
+   * Convenience: emit root-level dual-ship style files using the native conversion pipeline
+   * (semantic parity with {@link PSPageXmlDualShip#materializeInstallTemplateDefs}). Prefer {@link
+   * #stageArchiveTemplateDefs} when dual-ship is off.
+   */
+  public static int materializeRootTemplateDefs(Path packageDir)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    List<PSPageXmlInstallArtifact> artifacts = listInstallArtifacts(packageDir);
+    int written = 0;
+    for (PSPageXmlInstallArtifact a : artifacts) {
+      Path out = packageDir.resolve(a.rootFileName());
+      Files.writeString(out, a.templateDefXml(), StandardCharsets.UTF_8);
+      written++;
+    }
+    return written;
+  }
+
+  /**
+   * Convert a single modern page directory to install XML for a known GUID.
+   *
+   * @param pageDir directory containing {@code component-package.json}
+   * @param guid assembly GUID (e.g. {@code 0-4-591}); required non-blank
+   * @return install artifact (archive folder inferred as {@code TemplateDef-&lt;uuid&gt;} from guid
+   *     when form {@code 0-4-N})
+   */
+  public static PSPageXmlInstallArtifact fromModernPageDir(Path pageDir, String guid)
+      throws PSPageXmlException, IOException {
+    Objects.requireNonNull(pageDir, "pageDir");
+    if (guid == null || guid.isBlank()) {
+      throw new PSPageXmlException("GUID is required for native page install: " + pageDir);
+    }
+    String archiveFolder = archiveFolderFromGuid(guid.trim());
+    Map<String, String> guids = Map.of();
+    Map<String, String> folders = Map.of();
+    // Load with explicit guid override path
+    Path manifestPath = pageDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    PSComponentPackageManifest manifest = readManifest(manifestPath, pageDir);
+    String stem = resolveStem(manifest, pageDir);
+    String templateSource = readPrimaryTemplateSource(pageDir, manifest);
+    String xml = PSPageXmlTemplateDefEmitter.emit(manifest, templateSource, guid.trim());
+    if (archiveFolder == null) {
+      archiveFolder = "TemplateDef-" + stem;
+    }
+    // Prefer caller guid; folder from 0-4-N when possible
+    return new PSPageXmlInstallArtifact(stem, guid.trim(), archiveFolder, xml);
+  }
+
+  private static PSPageXmlInstallArtifact toInstallArtifact(
+      Path pageDir,
+      Map<String, String> guidsByStem,
+      Map<String, String> foldersByStem,
+      Path packageDir)
+      throws PSPageXmlException, IOException {
+    Path manifestPath = pageDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    PSComponentPackageManifest manifest = readManifest(manifestPath, pageDir);
+    String stem = resolveStem(manifest, pageDir);
+    String guid = guidsByStem.get(stem);
+    String archiveFolder = foldersByStem.get(stem);
+    if (guid == null || guid.isBlank() || archiveFolder == null || archiveFolder.isBlank()) {
+      Path mapping = PSPageXmlDualShip.findMappingProperties(packageDir);
+      String mappingHint =
+          mapping != null ? mapping.toString() : "(no *.mapping.properties under package root)";
+      throw new PSPageXmlException(
+          "Missing stable install mapping for modern page stem '"
+              + stem
+              + "'. Expected key '"
+              + stem
+              + ".templateDef=TemplateDef-N' in mapping file: "
+              + mappingHint);
+    }
+    String templateSource = readPrimaryTemplateSource(pageDir, manifest);
+    String xml = PSPageXmlTemplateDefEmitter.emit(manifest, templateSource, guid);
+    return new PSPageXmlInstallArtifact(stem, guid, archiveFolder, xml);
+  }
+
+  /**
+   * Mapping value {@code TemplateDef-N} by stem (for archive folder names). Same keys as GUID
+   * loader.
+   */
+  public static Map<String, String> loadArchiveFoldersFromMapping(Path packageDir)
+      throws IOException {
+    Map<String, String> folders = new LinkedHashMap<>();
+    Path propsFile = PSPageXmlDualShip.findMappingProperties(packageDir);
+    if (propsFile == null) {
+      return folders;
+    }
+    Properties props = new Properties();
+    try (InputStream in = Files.newInputStream(propsFile)) {
+      props.load(in);
+    }
+    for (String key : props.stringPropertyNames()) {
+      String lower = key.toLowerCase(Locale.ROOT);
+      if (!lower.endsWith(".templatedef") || lower.endsWith(".templatedef.acldef")) {
+        continue;
+      }
+      Matcher km = TEMPLATE_DEF_KEY.matcher(key);
+      if (!km.matches()) {
+        continue;
+      }
+      String stem = km.group(1);
+      String value = props.getProperty(key);
+      if (value == null) {
+        continue;
+      }
+      String trimmed = value.trim();
+      Matcher vm = TEMPLATE_DEF_VALUE.matcher(trimmed);
+      if (vm.matches()) {
+        folders.put(stem, trimmed);
+      }
+    }
+    return folders;
+  }
+
+  static String archiveFolderFromGuid(String guid) {
+    // product GUIDs are 0-4-N for TemplateDef-N
+    if (guid == null) {
+      return null;
+    }
+    String g = guid.trim();
+    if (g.startsWith("0-4-")) {
+      return "TemplateDef-" + g.substring("0-4-".length());
+    }
+    return null;
+  }
+
+  private static PSComponentPackageManifest readManifest(Path manifestPath, Path pageDir)
+      throws PSPageXmlException, IOException {
+    try {
+      PSComponentPackageManifest manifest = PSComponentPackageManifestIo.read(manifestPath);
+      PSComponentPackageManifestValidator.validate(manifest);
+      return manifest;
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSPageXmlException(
+          "Invalid modern page package at " + pageDir + ": " + e.getMessage(), e);
+    }
+  }
+
+  private static String resolveStem(PSComponentPackageManifest manifest, Path pageDir) {
+    if (manifest.getId() != null && !manifest.getId().isBlank()) {
+      return manifest.getId();
+    }
+    return pageDir.getFileName().toString();
+  }
+
+  private static String readPrimaryTemplateSource(Path pageDir, PSComponentPackageManifest manifest)
+      throws PSPageXmlException, IOException {
+    String sourceRef = null;
+    if (manifest.getTemplates() != null && !manifest.getTemplates().isEmpty()) {
+      sourceRef = manifest.getTemplates().get(0).getSourceRef();
+    }
+    if (sourceRef == null || sourceRef.isBlank()) {
+      throw new PSPageXmlException(
+          "Modern page package missing templates[0].sourceRef: " + pageDir);
+    }
+    Path templatePath = PSPageXmlCompiler.resolvePackageRelative(pageDir, sourceRef);
+    if (!Files.isRegularFile(templatePath)) {
+      throw new PSPageXmlException("Missing template source " + sourceRef + " under " + pageDir);
+    }
+    return Files.readString(templatePath, StandardCharsets.UTF_8);
+  }
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseTemplates/package-install.properties
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseTemplates/package-install.properties
@@ -1,0 +1,4 @@
+# Native deployer install for modern page component packages (#2806 / #2630).
+# Dual-ship root *.templateDef generation is OFF for this package; package build
+# stages TemplateDef-N/ archive folders from pages/<id>/component-package.json.
+page.installMode=native

--- a/modules/perc-packages/src/main/resources/Packages/perc.responsiveTemplates/package-install.properties
+++ b/modules/perc-packages/src/main/resources/Packages/perc.responsiveTemplates/package-install.properties
@@ -1,0 +1,4 @@
+# Native deployer install for modern page component packages (#2806 / #2630).
+# Dual-ship root *.templateDef generation is OFF for this package; package build
+# stages TemplateDef-N/ archive folders from pages/<id>/component-package.json.
+page.installMode=native

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.pagexml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Native page install packaging parity (issue #2806 / parent #2630).
+ *
+ * <p>When dual-ship is off, modern {@code pages/} sources stage directly into {@code
+ * TemplateDef-N/} archive folders with the same XML/GUID semantics as dual-ship root materialization.
+ */
+class PSPageXmlNativeInstallTest {
+
+  private static final String FIXTURE_PLAIN = "/pagexml/perc.base.plain.templateDef";
+
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void clearSysProps() {
+    System.clearProperty(PSPageXmlInstallPolicy.SYS_PROP_INSTALL_MODE);
+    System.clearProperty(PSPageXmlInstallPolicy.SYS_PROP_DUAL_SHIP);
+  }
+
+  @Test
+  void policy_defaultIsDualShip() {
+    assertEquals(PSPageXmlInstallMode.DUAL_SHIP, PSPageXmlInstallPolicy.resolve(null));
+    assertTrue(PSPageXmlInstallPolicy.isDualShipEnabled(null));
+    assertFalse(PSPageXmlInstallPolicy.isNativeInstallEnabled(null));
+  }
+
+  @Test
+  void policy_packageLocalNativeWinsWhenNoSysProp() throws Exception {
+    Path pkg = tempDir.resolve("pkg-native");
+    Files.createDirectories(pkg);
+    Files.writeString(
+        pkg.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS),
+        PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE + "=native\n",
+        StandardCharsets.UTF_8);
+    assertEquals(PSPageXmlInstallMode.NATIVE, PSPageXmlInstallPolicy.resolve(pkg));
+    assertTrue(PSPageXmlInstallPolicy.isNativeInstallEnabled(pkg));
+    assertFalse(PSPageXmlInstallPolicy.isDualShipEnabled(pkg));
+  }
+
+  @Test
+  void policy_sysPropInstallModeOverridesPackageLocal() throws Exception {
+    Path pkg = tempDir.resolve("pkg-override");
+    Files.createDirectories(pkg);
+    Files.writeString(
+        pkg.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS),
+        PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE + "=native\n",
+        StandardCharsets.UTF_8);
+    System.setProperty(PSPageXmlInstallPolicy.SYS_PROP_INSTALL_MODE, "dual-ship");
+    assertEquals(PSPageXmlInstallMode.DUAL_SHIP, PSPageXmlInstallPolicy.resolve(pkg));
+  }
+
+  @Test
+  void policy_dualShipFalseSysPropForcesNative() {
+    System.setProperty(PSPageXmlInstallPolicy.SYS_PROP_DUAL_SHIP, "false");
+    assertEquals(PSPageXmlInstallMode.NATIVE, PSPageXmlInstallPolicy.resolve(null));
+  }
+
+  @Test
+  void stageArchive_fromModernPages_writesTemplateDefFolders() throws Exception {
+    Path packageDir = tempDir.resolve("perc.baseTemplates");
+    Files.createDirectories(packageDir);
+    Files.writeString(
+        packageDir.resolve("perc.baseTemplates.mapping.properties"),
+        "perc.base.plain.templateDef=TemplateDef-591\n",
+        StandardCharsets.UTF_8);
+
+    Path pageDir = packageDir.resolve(PSPageXmlDualShip.PAGES_DIR_NAME).resolve("perc.base.plain");
+    Files.createDirectories(pageDir);
+    PSPageXmlModel model = PSPageXmlParser.parse(readClasspath(FIXTURE_PLAIN));
+    model.setSourceFileName("perc.base.plain.templateDef");
+    PSPageXmlCompileResult compiled =
+        PSPageXmlCompiler.compile(model, baseTemplatesLikeContext());
+    PSPageXmlCompiler.writeArtifacts(compiled, pageDir);
+
+    Path archiveRoot = tempDir.resolve("archive");
+    Files.createDirectories(archiveRoot);
+
+    int n = PSPageXmlNativeInstall.stageArchiveTemplateDefs(packageDir, archiveRoot);
+    assertEquals(1, n);
+
+    // Native mode must NOT require dual-ship roots
+    assertFalse(Files.isRegularFile(packageDir.resolve("perc.base.plain.templateDef")));
+
+    Path staged =
+        archiveRoot.resolve("TemplateDef-591").resolve("perc.base.plain.templateDef");
+    assertTrue(Files.isRegularFile(staged), "archive TemplateDef folder layout");
+
+    PSPageXmlModel install = PSPageXmlParser.parse(staged);
+    assertEquals("0-4-591", install.getGuid());
+    assertEquals("perc.base.plain", install.getName());
+    assertEquals(
+        normalizeNewlines(model.getTemplateBody()),
+        normalizeNewlines(install.getTemplateBody()));
+  }
+
+  @Test
+  void nativeAndDualShip_emitIdenticalInstallXml() throws Exception {
+    Path packageDir = tempDir.resolve("parity");
+    Files.createDirectories(packageDir);
+    Files.writeString(
+        packageDir.resolve("parity.mapping.properties"),
+        "perc.base.plain.templateDef=TemplateDef-591\n",
+        StandardCharsets.UTF_8);
+
+    Path pageDir = packageDir.resolve(PSPageXmlDualShip.PAGES_DIR_NAME).resolve("perc.base.plain");
+    Files.createDirectories(pageDir);
+    PSPageXmlModel model = PSPageXmlParser.parse(readClasspath(FIXTURE_PLAIN));
+    model.setSourceFileName("perc.base.plain.templateDef");
+    PSPageXmlCompileResult compiled =
+        PSPageXmlCompiler.compile(model, baseTemplatesLikeContext());
+    PSPageXmlCompiler.writeArtifacts(compiled, pageDir);
+
+    Path dualStaging = tempDir.resolve("dual-copy");
+    copyTree(packageDir, dualStaging);
+    PSPageXmlDualShip.materializeInstallTemplateDefs(dualStaging);
+    String dualXml =
+        Files.readString(
+            dualStaging.resolve("perc.base.plain.templateDef"), StandardCharsets.UTF_8);
+
+    List<PSPageXmlInstallArtifact> artifacts =
+        PSPageXmlNativeInstall.listInstallArtifacts(packageDir);
+    assertEquals(1, artifacts.size());
+    assertEquals("TemplateDef-591", artifacts.get(0).archiveFolder());
+    assertEquals(
+        normalizeNewlines(dualXml),
+        normalizeNewlines(artifacts.get(0).templateDefXml()),
+        "native conversion must match dual-ship root emit");
+  }
+
+  @Test
+  void productBaseTemplates_nativeInstallMode_archiveParityWithoutDualShipRoots() throws Exception {
+    Path product = locatePackage("perc.baseTemplates");
+    if (product == null) {
+      System.err.println("WARN: perc.baseTemplates not found; skipping native product test");
+      return;
+    }
+
+    assertEquals(
+        PSPageXmlInstallMode.NATIVE,
+        PSPageXmlInstallPolicy.resolve(product),
+        "baseTemplates must opt into native install (#2806)");
+    assertFalse(PSPageXmlInstallPolicy.isDualShipEnabled(product));
+    assertTrue(PSPageXmlDualShip.hasModernPageSources(product));
+    assertTrue(
+        PSPageXmlPackageCompiler.listTemplateDefs(product).isEmpty(),
+        "must not author root *.templateDef");
+
+    Path staging = tempDir.resolve("base-native-src");
+    Path archive = tempDir.resolve("base-native-archive");
+    copyTree(product, staging);
+    Files.createDirectories(archive);
+
+    // Simulate dual-ship OFF: do not materialize roots
+    assertFalse(Files.isRegularFile(staging.resolve("perc.base.plain.templateDef")));
+
+    int written = PSPageXmlNativeInstall.stageArchiveTemplateDefs(staging, archive);
+    assertTrue(written >= 20, "expected ≥20 base layout templates, got " + written);
+
+    Map<String, String> guids = PSPageXmlDualShip.loadGuidsFromMapping(staging);
+    assertEquals("0-4-591", guids.get("perc.base.plain"));
+
+    Path plain =
+        archive.resolve("TemplateDef-591").resolve("perc.base.plain.templateDef");
+    assertTrue(Files.isRegularFile(plain));
+    PSPageXmlModel install = PSPageXmlParser.parse(plain);
+    assertEquals("perc.base.plain", install.getName());
+    assertEquals("0-4-591", install.getGuid());
+    assertEquals("Java/global/percussion/assembly/pageAssembler", install.getAssembler());
+    assertEquals("Page", install.getOutputFormat());
+
+    // Still no dual-ship roots on staging
+    assertFalse(Files.isRegularFile(staging.resolve("perc.base.plain.templateDef")));
+  }
+
+  @Test
+  void productResponsiveTemplates_nativeInstallMode() throws Exception {
+    Path product = locatePackage("perc.responsiveTemplates");
+    if (product == null) {
+      System.err.println(
+          "WARN: perc.responsiveTemplates not found; skipping native product test");
+      return;
+    }
+
+    assertEquals(PSPageXmlInstallMode.NATIVE, PSPageXmlInstallPolicy.resolve(product));
+
+    Path staging = tempDir.resolve("resp-native-src");
+    Path archive = tempDir.resolve("resp-native-archive");
+    copyTree(product, staging);
+    Files.createDirectories(archive);
+
+    int written = PSPageXmlNativeInstall.stageArchiveTemplateDefs(staging, archive);
+    assertEquals(3, written);
+
+    Map<String, String> guids = PSPageXmlDualShip.loadGuidsFromMapping(staging);
+    assertEquals("0-4-597", guids.get("perc.resp.Banded"));
+    assertTrue(
+        Files.isRegularFile(
+            archive.resolve("TemplateDef-597").resolve("perc.resp.Banded.templateDef")));
+    assertTrue(
+        Files.isRegularFile(
+            archive.resolve("TemplateDef-599").resolve("perc.resp.Basic.templateDef")));
+    assertTrue(
+        Files.isRegularFile(
+            archive.resolve("TemplateDef-627").resolve("perc.resp.plain.templateDef")));
+  }
+
+  @Test
+  void missingMapping_failsFast() throws Exception {
+    Path packageDir = tempDir.resolve("missing-map");
+    Files.createDirectories(packageDir);
+    Files.writeString(
+        packageDir.resolve("missing-map.mapping.properties"),
+        "other.templateDef=TemplateDef-1\n",
+        StandardCharsets.UTF_8);
+
+    Path pageDir = packageDir.resolve(PSPageXmlDualShip.PAGES_DIR_NAME).resolve("perc.base.plain");
+    Files.createDirectories(pageDir);
+    PSPageXmlModel model = PSPageXmlParser.parse(readClasspath(FIXTURE_PLAIN));
+    model.setSourceFileName("perc.base.plain.templateDef");
+    PSPageXmlCompileResult compiled =
+        PSPageXmlCompiler.compile(model, baseTemplatesLikeContext());
+    PSPageXmlCompiler.writeArtifacts(compiled, pageDir);
+
+    Path archive = tempDir.resolve("missing-map-archive");
+    Files.createDirectories(archive);
+    PSPageXmlException ex =
+        assertThrows(
+            PSPageXmlException.class,
+            () -> PSPageXmlNativeInstall.stageArchiveTemplateDefs(packageDir, archive));
+    assertTrue(ex.getMessage().contains("Missing stable install mapping"));
+    assertTrue(ex.getMessage().contains("perc.base.plain"));
+  }
+
+  @Test
+  void packageInstallProps_isCopiedAsRootFileInProductTree() throws Exception {
+    Path product = locatePackage("perc.baseTemplates");
+    if (product == null) {
+      return;
+    }
+    Path props = product.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS);
+    assertTrue(Files.isRegularFile(props));
+    Properties p = new Properties();
+    try (var in = Files.newInputStream(props)) {
+      p.load(in);
+    }
+    assertEquals("native", p.getProperty(PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE));
+  }
+
+  private static PSPageXmlPackageContext baseTemplatesLikeContext() {
+    PSPageXmlPackageContext ctx = new PSPageXmlPackageContext();
+    ctx.setPackageId("perc.baseTemplates");
+    ctx.setPackageName("perc.baseTemplates");
+    ctx.setVersion("1.1.5");
+    ctx.setDescription("Percussion base layout templates.");
+    ctx.setPublisherName("Percussion Software Inc.");
+    ctx.setPublisherUrl("http://www.percussion.com");
+    ctx.setCmsMin("1.0.0");
+    ctx.setCmsMax("9.0.0");
+    return ctx;
+  }
+
+  private static String readClasspath(String resource) throws Exception {
+    try (var in = PSPageXmlNativeInstallTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  private static Path locatePackage(String packageName) {
+    Path candidate = Path.of("src", "main", "resources", "Packages", packageName);
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src")
+            .resolve("main")
+            .resolve("resources")
+            .resolve("Packages")
+            .resolve(packageName);
+    return Files.isDirectory(alt) ? alt : null;
+  }
+
+  private static void copyTree(Path source, Path target) throws Exception {
+    Files.walk(source)
+        .forEach(
+            src -> {
+              try {
+                Path rel = source.relativize(src);
+                Path dst = target.resolve(rel);
+                if (Files.isDirectory(src)) {
+                  Files.createDirectories(dst);
+                } else {
+                  Files.createDirectories(dst.getParent());
+                  Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
+                }
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+}


### PR DESCRIPTION
## Summary

Parent **#2630** residual after **#2786** / PR **#2804** (grandparent **#2626**): wire package-build / install packaging to consume modern page `component-package.json` **natively** so dual-ship root `*.templateDef` generation can be package-local or feature-flagged off.

### What changed
- **`PSPageXmlInstallPolicy`** — install mode `native` | `dual-ship` via:
  - package-local `package-install.properties` → `page.installMode`
  - sys props `perc.packages.page.installMode` / `perc.packages.dualShip.pageTemplateDefs=false`
- **`PSPageXmlNativeInstall`** — converts modern `pages/<id>/` → archive `TemplateDef-N/<stem>.templateDef` (same XML/GUID semantics as dual-ship)
- **`PSPackageBuilder`** — dual-ship pre-reorganize **or** native post-reorganize staging
- **Product opt-in:** `perc.baseTemplates` + `perc.responsiveTemplates` set `page.installMode=native` (dual-ship roots **off**)
- **Tests:** `PSPageXmlNativeInstallTest` (policy + parity + product base/responsive)
- **Docs:** dual-ship retirement checklist + inventory/ADR/shim updates

### Stacking
**Depends on open PR #2804** (`fix/issue-2786-baseTemplates-modern-packages`). This PR is based on that branch so only the #2806 delta is reviewed. After #2804 merges, retarget/rebase onto `main`.

### Out of scope / residual
- Runtime deployer parsing `component-package.json` from archive (still TemplateDef wire format inside `.ppkg`)
- Baseline system templates native opt-in (#2805)
- Deleting dual-ship code path after all packages opt in

## Test plan
1. `cd modules/perc-packages && ../../mvnw.cmd clean install` (JDK 21)
2. Confirm package-build log: `native-install page TemplateDefs for perc.baseTemplates: 20 written` and responsive `3 written`
3. Confirm **no** `dual-ship page templateDefs` lines for base/responsive
4. Confirm `PSPageXmlNativeInstallTest` green

## Build gates evidence
- **modules_built:** `modules/perc-packages`
- **Command:** `cd modules/perc-packages; $env:JAVA_HOME='C:\Program Files\Microsoft\jdk-21.0.12.8-hotspot'; ..\..\mvnw.cmd clean install`
- **Result:** BUILD SUCCESS
- **Tests:** Tests run: 78, Failures: 0 (includes 10 `PSPageXmlNativeInstallTest`)
- **downstream_checked:** none (package-local install types; no public type final/signature change for reverse deps; deployer not modified)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2806
Refs #2630 #2786 #2626

> Co-Authored by Grok Build using grok-4.5 with agent main.
