### PR TITLE
feat(WebUI): Design SPA template library list shell (#2808)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -57,6 +57,7 @@ public class PSWebUiSpaFallbackFilter implements Filter {
           "admin",
           "widget-builder",
           "developer",
+          "design",
           "explorer",
           "profile",
           "unavailable");
@@ -217,7 +218,10 @@ public class PSWebUiSpaFallbackFilter implements Filter {
 
     if (segments.length >= 2) {
       String second = segments[1];
-      if ("home".equals(entry) || "publish".equals(entry) || "developer".equals(entry)) {
+      if ("home".equals(entry)
+          || "publish".equals(entry)
+          || "developer".equals(entry)
+          || "design".equals(entry)) {
         forward.append("&section=").append(urlEncode(second));
       } else if ("workflow".equals(entry) || "admin".equals(entry)) {
         forward.append("&tab=").append(urlEncode(second));

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -23,6 +23,7 @@ export const SPA_ENTRIES = [
   "admin",
   "widget-builder",
   "developer",
+  "design",
   "explorer",
   "profile",
   "unavailable",
@@ -109,6 +110,18 @@ export const DEVELOPER_SECTIONS = [
 ] as const;
 
 export type DeveloperSection = (typeof DEVELOPER_SECTIONS)[number];
+
+/** Design SPA sections (lockstep with DesignShell) — #2808 template library. */
+export const DESIGN_SECTIONS = ["templates"] as const;
+
+export type DesignSection = (typeof DESIGN_SECTIONS)[number];
+
+const DESIGN_SECTION_ALIASES: Record<string, DesignSection> = {
+  template: "templates",
+  tpl: "templates",
+  library: "templates",
+  "template-library": "templates",
+};
 
 const DEVELOPER_SECTION_ALIASES: Record<string, DeveloperSection> = {
   contenttypes: "content-types",
@@ -228,6 +241,17 @@ export function normalizeDeveloperSection(
     return n as DeveloperSection;
   }
   return DEVELOPER_SECTION_ALIASES[n];
+}
+
+export function normalizeDesignSection(
+  raw: string | null | undefined,
+): DesignSection | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const n = raw.trim().toLowerCase().replace(/_/g, "-");
+  if ((DESIGN_SECTIONS as readonly string[]).includes(n)) {
+    return n as DesignSection;
+  }
+  return DESIGN_SECTION_ALIASES[n];
 }
 
 export function normalizeId(raw: string | null | undefined): string | undefined {

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -18,6 +18,7 @@
 import {
   isSpaEntry,
   normalizeAdminTab,
+  normalizeDesignSection,
   normalizeDeveloperSection,
   normalizeExplorerPath,
   normalizeHomeSection,
@@ -108,6 +109,14 @@ export function parseEntryQuery(
         entry,
         section,
         clientPath: section ? `/developer/${section}` : "/developer",
+      };
+    }
+    case "design": {
+      const section = normalizeDesignSection(sectionParam ?? tabParam);
+      return {
+        entry,
+        section,
+        clientPath: section ? `/design/${section}` : "/design",
       };
     }
     case "explorer": {
@@ -212,6 +221,14 @@ export function parseClientPath(
     }
     case "widget-builder":
       return { entry, clientPath: "/widget-builder" };
+    case "design": {
+      const section = normalizeDesignSection(second);
+      return {
+        entry,
+        section,
+        clientPath: section ? `/design/${section}` : "/design",
+      };
+    }
     case "developer": {
       const section = normalizeDeveloperSection(second);
       return {

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -107,6 +107,20 @@ export function TopNav(): React.ReactElement {
                   </a>
                 </li>
               );
+            case "design":
+              return (
+                <li key={id}>
+                  <NavLink
+                    to="/design"
+                    className={linkClass}
+                    data-testid="nav-design"
+                    title={message(MSG.NAV_DESIGN_TITLE)}
+                    {...i18nKeyAttr(MSG.NAV_DESIGN)}
+                  >
+                    {message(MSG.NAV_DESIGN)}
+                  </NavLink>
+                </li>
+              );
             case "developer":
               return (
                 <li key={id}>

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -29,6 +29,7 @@ export type TopNavItemId =
   | "explorer"
   | "editor"
   | "architecture"
+  | "design"
   | "developer"
   | "publish"
   | "admin"
@@ -53,7 +54,7 @@ export function topNavItemIds(gates: TopNavGates = {}): TopNavItemId[] {
 
   const items: TopNavItemId[] = ["home", "explorer", "editor"];
   if (canPublish) {
-    items.push("architecture", "developer", "publish");
+    items.push("architecture", "design", "developer", "publish");
   }
   if (isAdmin) {
     items.push("admin");

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -20,6 +20,7 @@ import { Navigate, Route, Routes } from "react-router";
 import { FeaturePlaceholder } from "./FeaturePlaceholder";
 import { AppLayout } from "./layout/AppLayout";
 import { AdminRoute } from "./routes/AdminRoute";
+import { DesignRoute } from "./routes/DesignRoute";
 import { DeveloperRoute } from "./routes/DeveloperRoute";
 import { ExplorerRoute } from "./routes/ExplorerRoute";
 import { HomeRoute } from "./routes/HomeRoute";
@@ -49,6 +50,8 @@ export function AppRoutes(): React.ReactElement {
         <Route path="widget-builder" element={<WidgetBuilderRoute />} />
         <Route path="developer" element={<DeveloperRoute />} />
         <Route path="developer/:section" element={<DeveloperRoute />} />
+        <Route path="design" element={<DesignRoute />} />
+        <Route path="design/:section" element={<DesignRoute />} />
         <Route path="explorer" element={<ExplorerRoute />} />
         <Route path="profile" element={<ProfileRoute />} />
         <Route

--- a/WebUI/src/main/ts/app/routes/DesignRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/DesignRoute.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { lazy } from "react";
+import { useParams } from "react-router";
+import { loadComponent } from "../../registry";
+import { DESIGN_MSG } from "../../design/messages";
+import { LazyRouteFrame } from "./RouteErrorBoundary";
+import { RequireRole } from "./RequireRole";
+
+const DesignShellLazy = lazy(() =>
+  loadComponent("DesignShell").then((C) => ({ default: C })),
+);
+
+/**
+ * SPA Design module — Admin or Designer.
+ * Slice 1 (#2808): template library list shell + read-only detail drawer.
+ */
+export function DesignRoute(): React.ReactElement {
+  const { section } = useParams();
+
+  return (
+    <RequireRole gate="adminOrDesigner">
+      <LazyRouteFrame
+        label={DESIGN_MSG.TITLE}
+        fallback={
+          <div data-testid="route-design-loading" style={{ padding: "1.5rem" }}>
+            {DESIGN_MSG.SHELL_LOADING}
+          </div>
+        }
+      >
+        <DesignShellLazy embedded initialSection={section} />
+      </LazyRouteFrame>
+    </RequireRole>
+  );
+}

--- a/WebUI/src/main/ts/design/DesignShell.tsx
+++ b/WebUI/src/main/ts/design/DesignShell.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from "react";
+import {
+  DESIGN_SECTIONS,
+  normalizeDesignSection as normalizeFromAllowlist,
+  type DesignSection,
+} from "../app/deepLinks/allowlists";
+import { catalogColors } from "../developer/catalogStyles";
+import { DESIGN_MSG } from "./messages";
+import { TemplateLibraryPanel } from "./TemplateLibraryPanel";
+
+export type { DesignSection };
+
+const SECTION_LABEL: Record<DesignSection, string> = {
+  templates: DESIGN_MSG.TAB_TEMPLATES,
+};
+
+/** Shell default when raw section is missing/unknown. */
+export function normalizeDesignSection(
+  raw: string | null | undefined,
+): DesignSection {
+  return normalizeFromAllowlist(raw) ?? "templates";
+}
+
+export interface DesignShellProps {
+  initialSection?: DesignSection | string;
+  /**
+   * When true (SPA AppLayout), shell is under product chrome — tighter padding.
+   */
+  embedded?: boolean;
+}
+
+const tabStyle = (active: boolean): React.CSSProperties => ({
+  padding: "10px 16px",
+  border: "none",
+  borderBottom: active
+    ? `3px solid ${catalogColors.accent}`
+    : "3px solid transparent",
+  fontWeight: active ? 600 : 400,
+  background: "transparent",
+  cursor: "pointer",
+  color: active ? catalogColors.accent : catalogColors.text,
+});
+
+/**
+ * Design SPA shell — Phase 4 template library list entry (#2808 / parent #2631).
+ * Later slices add source editor and assembler/slots under this surface.
+ */
+export const DesignShell: React.FC<DesignShellProps> = ({
+  initialSection = "templates",
+  embedded = false,
+}) => {
+  const [active, setActive] = useState<DesignSection>(() =>
+    normalizeDesignSection(initialSection),
+  );
+
+  return (
+    <div
+      className="perc-design-shell"
+      data-testid="perc-design-shell"
+      data-embedded={embedded ? "true" : "false"}
+      style={{
+        fontFamily: "var(--perc-font-family, sans-serif)",
+        padding: embedded ? "8px 12px 20px" : "20px",
+        maxWidth: "1200px",
+        margin: "0 auto",
+      }}
+    >
+      <header style={{ marginBottom: "12px" }}>
+        <h1 style={{ marginBottom: "8px" }} data-testid="design-shell-title">
+          {DESIGN_MSG.TITLE}
+        </h1>
+        <p
+          style={{ margin: 0, color: catalogColors.muted, maxWidth: "48rem" }}
+          data-testid="design-shell-intro"
+        >
+          {DESIGN_MSG.INTRO}
+        </p>
+      </header>
+
+      <nav
+        className="perc-tab-nav"
+        role="tablist"
+        aria-label="Design sections"
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          borderBottom: `1px solid ${catalogColors.headerBorder}`,
+          marginBottom: "20px",
+          gap: "4px",
+        }}
+      >
+        {DESIGN_SECTIONS.map((section) => (
+          <button
+            key={section}
+            type="button"
+            role="tab"
+            id={`tab-design-${section}`}
+            aria-selected={active === section}
+            aria-controls={`panel-design-${section}`}
+            onClick={() => setActive(section)}
+            style={tabStyle(active === section)}
+            data-testid={`tab-design-${section}`}
+          >
+            {SECTION_LABEL[section]}
+          </button>
+        ))}
+      </nav>
+
+      <div
+        role="tabpanel"
+        id={`panel-design-${active}`}
+        aria-labelledby={`tab-design-${active}`}
+        data-testid={`panel-design-${active}`}
+      >
+        {active === "templates" ? <TemplateLibraryPanel /> : null}
+      </div>
+    </div>
+  );
+};

--- a/WebUI/src/main/ts/design/TemplateDetailDrawer.tsx
+++ b/WebUI/src/main/ts/design/TemplateDetailDrawer.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useId, useState } from "react";
+import { getTemplateDetail } from "../api/developer/assemblyApi";
+import type { TemplateDetail } from "../api/developer/types";
+import {
+  extractRestErrorMessage,
+  isApiError,
+  isSessionRedirectError,
+} from "../api/client";
+import { catalogColors } from "../developer/catalogStyles";
+import { DESIGN_MSG } from "./messages";
+
+function drawerErrMsg(err: unknown, fallback: string): string {
+  if (isSessionRedirectError(err)) return DESIGN_MSG.SESSION_REDIRECT;
+  if (isApiError(err)) {
+    const fromBody = extractRestErrorMessage(err.body);
+    if (fromBody) return `${fallback} ${fromBody}`;
+    return `${fallback} (${err.status})`;
+  }
+  if (err instanceof Error && err.message) return `${fallback} ${err.message}`;
+  return fallback;
+}
+
+const drawerShell: React.CSSProperties = {
+  position: "fixed",
+  top: 0,
+  right: 0,
+  width: "min(420px, 100vw)",
+  height: "100vh",
+  background: "#fff",
+  borderLeft: `1px solid ${catalogColors.headerBorder}`,
+  boxShadow: "-4px 0 16px rgba(0,0,0,0.08)",
+  zIndex: 1200,
+  display: "flex",
+  flexDirection: "column",
+  fontFamily: "var(--perc-font-family, sans-serif)",
+};
+
+const backdrop: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.25)",
+  zIndex: 1190,
+};
+
+const metaGrid: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "auto 1fr",
+  gap: "6px 14px",
+  marginTop: "12px",
+  fontSize: "0.9rem",
+};
+
+const mono: React.CSSProperties = {
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+  fontSize: "0.85rem",
+};
+
+function dash(value: string | number | null | undefined): string {
+  if (value == null) return DESIGN_MSG.NONE;
+  const s = String(value).trim();
+  return s.length > 0 ? s : DESIGN_MSG.NONE;
+}
+
+/**
+ * Read-only template summary drawer for Design template library (#2808).
+ * Edit surfaces (source, bindings, slots) remain out of scope for this slice.
+ */
+export function TemplateDetailDrawer({
+  idOrName,
+  onClose,
+}: {
+  idOrName: string;
+  onClose: () => void;
+}): React.ReactElement {
+  const titleId = useId();
+  const [detail, setDetail] = useState<TemplateDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setDetail(null);
+    getTemplateDetail(idOrName)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(drawerErrMsg(e, DESIGN_MSG.DRAWER_ERROR));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [idOrName]);
+
+  useEffect(() => {
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") {
+        ev.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const bindingCount = detail?.bindings?.length ?? 0;
+  const slotCount = detail?.slots?.length ?? 0;
+  const gaps = (detail?.designGaps || []).filter((g) => g && String(g).trim());
+
+  return (
+    <>
+      <div
+        data-testid="design-tpl-drawer-backdrop"
+        style={backdrop}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <aside
+        data-testid="design-tpl-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        style={drawerShell}
+      >
+        <header
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "8px",
+            padding: "14px 16px",
+            borderBottom: `1px solid ${catalogColors.headerBorder}`,
+          }}
+        >
+          <div>
+            <h2
+              id={titleId}
+              style={{ margin: 0, fontSize: "1.1rem" }}
+              data-testid="design-tpl-drawer-title"
+            >
+              {DESIGN_MSG.DRAWER_TITLE}
+            </h2>
+            <p
+              style={{
+                margin: "4px 0 0",
+                fontSize: "0.8rem",
+                color: catalogColors.muted,
+              }}
+            >
+              {DESIGN_MSG.DRAWER_READONLY}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="design-tpl-drawer-close"
+            aria-label={DESIGN_MSG.DRAWER_CLOSE_ARIA}
+            onClick={onClose}
+            style={{
+              background: "transparent",
+              border: `1px solid ${catalogColors.softBorder}`,
+              borderRadius: "4px",
+              padding: "6px 12px",
+              cursor: "pointer",
+              font: "inherit",
+            }}
+          >
+            {DESIGN_MSG.DRAWER_CLOSE}
+          </button>
+        </header>
+
+        <div style={{ padding: "16px", overflowY: "auto", flex: 1 }}>
+          {loading && (
+            <div data-testid="design-tpl-drawer-loading">
+              {DESIGN_MSG.DRAWER_LOADING}
+            </div>
+          )}
+          {!loading && error && (
+            <div data-testid="design-tpl-drawer-error" role="alert" style={{ color: catalogColors.error }}>
+              {error}
+            </div>
+          )}
+          {!loading && !error && detail && (
+            <div data-testid="design-tpl-drawer-body">
+              <div style={metaGrid}>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_LABEL}</span>
+                <span data-testid="design-tpl-drawer-label">
+                  {dash(detail.label || detail.name)}
+                </span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_NAME}</span>
+                <span data-testid="design-tpl-drawer-name" style={mono}>
+                  {dash(detail.name)}
+                </span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_ID}</span>
+                <span data-testid="design-tpl-drawer-id" style={mono}>
+                  {detail.templateId != null
+                    ? String(detail.templateId)
+                    : dash(detail.guid?.stringValue)}
+                </span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_DESCRIPTION}</span>
+                <span data-testid="design-tpl-drawer-description">
+                  {dash(detail.description)}
+                </span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_ASSEMBLER}</span>
+                <span data-testid="design-tpl-drawer-assembler" style={mono}>
+                  {dash(detail.assembler)}
+                </span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_MIME}</span>
+                <span data-testid="design-tpl-drawer-mime" style={mono}>
+                  {dash(detail.mimeType)}
+                </span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_TYPE}</span>
+                <span data-testid="design-tpl-drawer-type" style={mono}>
+                  {dash(detail.templateType)}
+                </span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_BINDINGS}</span>
+                <span data-testid="design-tpl-drawer-bindings">{bindingCount}</span>
+                <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_SLOTS}</span>
+                <span data-testid="design-tpl-drawer-slots">{slotCount}</span>
+                {gaps.length > 0 && (
+                  <>
+                    <span style={{ color: catalogColors.muted }}>{DESIGN_MSG.FIELD_GAPS}</span>
+                    <span data-testid="design-tpl-drawer-gaps">{gaps.join(", ")}</span>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/WebUI/src/main/ts/design/TemplateLibraryPanel.tsx
+++ b/WebUI/src/main/ts/design/TemplateLibraryPanel.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import { listTemplates } from "../api/developer/assemblyApi";
+import type { TemplateSummary } from "../api/developer/types";
+import {
+  extractRestErrorMessage,
+  isApiError,
+  isSessionRedirectError,
+} from "../api/client";
+import {
+  CatalogHint,
+  CatalogStatus,
+  SimpleCatalogTable,
+} from "../developer/CatalogTable";
+import { monoCell, mutedCell, openButtonStyle } from "../developer/catalogStyles";
+import { DESIGN_MSG } from "./messages";
+import { TemplateDetailDrawer } from "./TemplateDetailDrawer";
+
+/** Open-key for detail drawer; null when the row is not selectable. */
+export function templateSelectionKey(t: TemplateSummary): string | null {
+  if (t.templateName) return t.templateName;
+  if (t.templateId != null) return String(t.templateId);
+  return null;
+}
+
+function listErrMsg(err: unknown, fallback: string): string {
+  if (isSessionRedirectError(err)) return DESIGN_MSG.SESSION_REDIRECT;
+  if (isApiError(err)) {
+    const fromBody = extractRestErrorMessage(err.body);
+    if (fromBody) return `${fallback} ${fromBody}`;
+    return `${fallback} (${err.status})`;
+  }
+  if (err instanceof Error && err.message) return `${fallback} ${err.message}`;
+  return fallback;
+}
+
+/**
+ * Design template library list (#2808): browse catalog, empty/error states,
+ * read-only detail drawer. Reuses public REST {@code GET /services/templates}.
+ */
+export function TemplateLibraryPanel(): React.ReactElement {
+  const [items, setItems] = useState<TemplateSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listTemplates()
+      .then((list) => {
+        if (!cancelled) setItems(list);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(listErrMsg(e, DESIGN_MSG.TPL_ERROR));
+        setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sorted = useMemo(() => {
+    if (!items) return [];
+    return [...items].sort((a, b) =>
+      (a.templateLabel || a.templateName || "").localeCompare(
+        b.templateLabel || b.templateName || "",
+        undefined,
+        { sensitivity: "base" },
+      ),
+    );
+  }, [items]);
+
+  if (error) {
+    return (
+      <CatalogStatus testId="design-tpl-error" error>
+        {error}
+      </CatalogStatus>
+    );
+  }
+  if (items == null) {
+    return (
+      <CatalogStatus testId="design-tpl-loading">{DESIGN_MSG.TPL_LOADING}</CatalogStatus>
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <CatalogStatus testId="design-tpl-empty">{DESIGN_MSG.TPL_EMPTY}</CatalogStatus>
+    );
+  }
+
+  return (
+    <div data-testid="design-tpl-panel">
+      <CatalogHint>{DESIGN_MSG.TPL_HINT}</CatalogHint>
+      <SimpleCatalogTable
+        tableTestId="design-tpl-table"
+        rowTestId="design-tpl-row"
+        columns={[
+          DESIGN_MSG.TPL_COL_LABEL,
+          DESIGN_MSG.TPL_COL_NAME,
+          DESIGN_MSG.TPL_COL_ID,
+          DESIGN_MSG.TPL_COL_DESCRIPTION,
+        ]}
+        rows={sorted.map((t, index) => {
+          const openKey = templateSelectionKey(t);
+          const label = t.templateLabel || t.templateName || openKey || "—";
+          return {
+            key: String(t.templateId ?? t.templateName ?? `tpl-${index}`),
+            cells: [
+              openKey ? (
+                <button
+                  key="open"
+                  type="button"
+                  style={openButtonStyle}
+                  aria-label={DESIGN_MSG.TPL_OPEN_ARIA.replace("{0}", label)}
+                  data-testid={`design-tpl-open-${index}`}
+                  onClick={() => setSelected(openKey)}
+                >
+                  {t.templateLabel || "—"}
+                </button>
+              ) : (
+                t.templateLabel || "—"
+              ),
+              <span key="n" style={monoCell}>
+                {t.templateName || "—"}
+              </span>,
+              <span key="i" style={monoCell}>
+                {t.templateId != null ? String(t.templateId) : "—"}
+              </span>,
+              <span key="d" style={mutedCell}>
+                {t.templateDescription || ""}
+              </span>,
+            ],
+          };
+        })}
+      />
+      {selected && (
+        <TemplateDetailDrawer
+          idOrName={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/design/index.ts
+++ b/WebUI/src/main/ts/design/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DesignShell, normalizeDesignSection } from "./DesignShell";
+export type { DesignShellProps, DesignSection } from "./DesignShell";
+export { TemplateLibraryPanel, templateSelectionKey } from "./TemplateLibraryPanel";
+export { TemplateDetailDrawer } from "./TemplateDetailDrawer";
+export { DESIGN_MSG, DESIGN_MSG_KEYS } from "./messages";

--- a/WebUI/src/main/ts/design/messages.ts
+++ b/WebUI/src/main/ts/design/messages.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { message } from "../i18n/message";
+
+/**
+ * Design SPA chrome keys (#2808 / parent #2631).
+ * English after {@code @} is the source fallback when TMX is not loaded.
+ * Small key set only — no multi-locale mass TMX backfill in this slice.
+ */
+const KEYS = {
+  TITLE: "perc.ui.design.modern@Design",
+  INTRO:
+    "perc.ui.design.modern@Browse modern templates from the design catalog. Open a row for a read-only summary.",
+  SHELL_LOADING: "perc.ui.design.modern@Loading Design…",
+  TAB_TEMPLATES: "perc.ui.design.modern@Templates",
+  TPL_HINT:
+    "perc.ui.design.modern@Assembly templates available in this CMS. Source editing and slot layout land in later Design slices.",
+  TPL_LOADING: "perc.ui.design.modern@Loading templates…",
+  TPL_EMPTY: "perc.ui.design.modern@No templates found.",
+  TPL_ERROR: "perc.ui.design.modern@Could not load templates.",
+  TPL_COL_LABEL: "perc.ui.design.modern@Label",
+  TPL_COL_NAME: "perc.ui.design.modern@Name",
+  TPL_COL_ID: "perc.ui.design.modern@Id",
+  TPL_COL_DESCRIPTION: "perc.ui.design.modern@Description",
+  TPL_OPEN_ARIA: "perc.ui.design.modern@Open template details for {0}",
+  DRAWER_TITLE: "perc.ui.design.modern@Template details",
+  DRAWER_CLOSE: "perc.ui.design.modern@Close",
+  DRAWER_CLOSE_ARIA: "perc.ui.design.modern@Close template details",
+  DRAWER_LOADING: "perc.ui.design.modern@Loading template…",
+  DRAWER_ERROR: "perc.ui.design.modern@Could not load template details.",
+  DRAWER_READONLY: "perc.ui.design.modern@Read-only summary",
+  FIELD_LABEL: "perc.ui.design.modern@Label",
+  FIELD_NAME: "perc.ui.design.modern@Name",
+  FIELD_ID: "perc.ui.design.modern@Id",
+  FIELD_DESCRIPTION: "perc.ui.design.modern@Description",
+  FIELD_ASSEMBLER: "perc.ui.design.modern@Assembler",
+  FIELD_MIME: "perc.ui.design.modern@MIME type",
+  FIELD_TYPE: "perc.ui.design.modern@Template type",
+  FIELD_BINDINGS: "perc.ui.design.modern@Bindings",
+  FIELD_SLOTS: "perc.ui.design.modern@Slots",
+  FIELD_GAPS: "perc.ui.design.modern@Design gaps",
+  SESSION_REDIRECT: "perc.ui.design.modern@Session expired — sign in again.",
+  NONE: "perc.ui.design.modern@—",
+} as const;
+
+export type DesignMsgKey = keyof typeof KEYS;
+
+/** Resolved Design SPA strings (TMX when loaded, English fallback after @). */
+export const DESIGN_MSG: { [K in DesignMsgKey]: string } = new Proxy(
+  {} as { [K in DesignMsgKey]: string },
+  {
+    get(_t, prop: string) {
+      const key = KEYS[prop as DesignMsgKey];
+      if (!key) return prop;
+      return message(key);
+    },
+  },
+);
+
+/** Catalog keys for tests that assert raw TMX key strings. */
+export const DESIGN_MSG_KEYS = KEYS;

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -207,6 +207,10 @@ export const MSG = {
   NAV_DASHBOARD: "perc.ui.navMenu.dashboard@Dashboard",
   NAV_EDITOR: "perc.ui.navMenu.webmgt@Editor",
   NAV_ARCHITECTURE: "perc.ui.navMenu.architecture@Architecture",
+  /** Design SPA top-nav (#2808) — classic key already en-us "Design". */
+  NAV_DESIGN: "perc.ui.navMenu.design@Design",
+  NAV_DESIGN_TITLE:
+    "perc.ui.design.modern@Template library and design tools",
   NAV_DEVELOPER: "perc.ui.dashboard.modern@Developer",
   NAV_PUBLISH: "perc.ui.navMenu.publish@Publish",
   /**

--- a/WebUI/src/main/ts/registry.ts
+++ b/WebUI/src/main/ts/registry.ts
@@ -105,6 +105,8 @@ const loaders: Record<string, Loader> = {
     import("./admin/AdminShell").then((m) => ({ default: m.AdminShell })),
   DeveloperShell: () =>
     import("./developer").then((m) => ({ default: m.DeveloperShell })),
+  DesignShell: () =>
+    import("./design").then((m) => ({ default: m.DesignShell })),
 };
 
 const cache = new Map<string, Promise<ComponentType<any>>>();

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -85,6 +85,16 @@ public class PSWebUiSpaFallbackFilterTest {
   }
 
   @Test
+  public void forwardsDesignWithSection() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=design",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/design", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=design&section=templates",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/design/templates", null));
+  }
+
+  @Test
   public void dualTreePagesAppSupported() {
     assertEquals(
         "/cm/pages/app/spa.jsp?entry=home&section=recent",

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -66,6 +66,19 @@ describe("parseEntryQuery", () => {
     expect(parseClientPath("/developer/pipelines").section).toBe("pipelines");
   });
 
+  it("maps design entry and section aliases (#2808)", () => {
+    expect(parseEntryQuery("?entry=design").entry).toBe("design");
+    expect(parseEntryQuery("?entry=design").clientPath).toBe("/design");
+    expect(
+      parseEntryQuery("?entry=design&section=templates").clientPath,
+    ).toBe("/design/templates");
+    expect(parseEntryQuery("?entry=design&section=library").section).toBe(
+      "templates",
+    );
+    expect(parseClientPath("/design/templates").entry).toBe("design");
+    expect(parseClientPath("/design/templates").section).toBe("templates");
+  });
+
   it("unknown entry falls back to home", () => {
     expect(parseEntryQuery("?entry=nope").entry).toBe("home");
   });

--- a/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
+++ b/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
@@ -57,6 +57,7 @@ describe("topNavItemIds (#2702)", () => {
       "explorer",
       "editor",
       "architecture",
+      "design",
       "developer",
       "publish",
       "admin",
@@ -72,6 +73,7 @@ describe("topNavItemIds (#2702)", () => {
       "explorer",
       "editor",
       "architecture",
+      "design",
       "developer",
       "publish",
     ]);

--- a/WebUI/src/test/ts/design/DesignShell.test.tsx
+++ b/WebUI/src/test/ts/design/DesignShell.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import {
+  DesignShell,
+  normalizeDesignSection,
+} from "../../../main/ts/design/DesignShell";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  listTemplates: vi.fn(),
+  getTemplateDetail: vi.fn(),
+}));
+
+const listTemplates = assemblyApi.listTemplates as ReturnType<typeof vi.fn>;
+
+describe("normalizeDesignSection", () => {
+  it("defaults unknown to templates", () => {
+    expect(normalizeDesignSection(undefined)).toBe("templates");
+    expect(normalizeDesignSection("nope")).toBe("templates");
+    expect(normalizeDesignSection("library")).toBe("templates");
+    expect(normalizeDesignSection("templates")).toBe("templates");
+  });
+});
+
+describe("DesignShell (#2808)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listTemplates.mockReset();
+    listTemplates.mockResolvedValue([]);
+  });
+
+  it("renders shell chrome and templates panel", async () => {
+    render(<DesignShell embedded />);
+    expect(screen.getByTestId("perc-design-shell")).toBeTruthy();
+    expect(screen.getByTestId("perc-design-shell").getAttribute("data-embedded")).toBe(
+      "true",
+    );
+    expect(screen.getByTestId("design-shell-title")).toBeTruthy();
+    expect(screen.getByTestId("tab-design-templates")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-empty")).toBeTruthy();
+    });
+  });
+});

--- a/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
+++ b/WebUI/src/test/ts/design/TemplateLibraryPanel.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import {
+  TemplateLibraryPanel,
+  templateSelectionKey,
+} from "../../../main/ts/design/TemplateLibraryPanel";
+import { DESIGN_MSG } from "../../../main/ts/design/messages";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  listTemplates: vi.fn(),
+  getTemplateDetail: vi.fn(),
+}));
+
+const listTemplates = assemblyApi.listTemplates as ReturnType<typeof vi.fn>;
+const getTemplateDetail = assemblyApi.getTemplateDetail as ReturnType<
+  typeof vi.fn
+>;
+
+describe("templateSelectionKey", () => {
+  it("prefers name then id", () => {
+    expect(
+      templateSelectionKey({ templateName: "a", templateId: 1 }),
+    ).toBe("a");
+    expect(templateSelectionKey({ templateId: 9 })).toBe("9");
+    expect(templateSelectionKey({})).toBeNull();
+  });
+});
+
+describe("TemplateLibraryPanel (#2808)", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listTemplates.mockReset();
+    getTemplateDetail.mockReset();
+  });
+
+  it("lists templates on success", async () => {
+    listTemplates.mockResolvedValue([
+      {
+        templateId: 42,
+        templateName: "perc.page",
+        templateLabel: "Page",
+        templateDescription: "Page template",
+      },
+    ]);
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("design-tpl-table").textContent).toContain("Page");
+    expect(screen.getByTestId("design-tpl-table").textContent).toContain(
+      "perc.page",
+    );
+  });
+
+  it("shows empty state when API returns no templates", async () => {
+    listTemplates.mockResolvedValue([]);
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message on SessionRedirectError", async () => {
+    listTemplates.mockRejectedValue(new SessionRedirectError());
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("design-tpl-error").textContent).toBe(
+      DESIGN_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("design-tpl-empty")).toBeNull();
+  });
+
+  it("shows ApiError status", async () => {
+    listTemplates.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("design-tpl-error").textContent).toBe(
+      `${DESIGN_MSG.TPL_ERROR} (500)`,
+    );
+  });
+
+  it("opens read-only detail drawer when a row is opened", async () => {
+    listTemplates.mockResolvedValue([
+      {
+        templateId: 7,
+        templateName: "site.base",
+        templateLabel: "Base",
+        templateDescription: "Base template",
+      },
+    ]);
+    getTemplateDetail.mockResolvedValue({
+      templateId: 7,
+      name: "site.base",
+      label: "Base",
+      description: "Base template",
+      assembler: "velocityAssembler",
+      mimeType: "text/html",
+      templateType: "page",
+      bindings: [{ variable: "x", expression: "1" }],
+      slots: [{ name: "main" }],
+    });
+    render(<TemplateLibraryPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-open-0")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-tpl-open-0"));
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-drawer")).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("design-tpl-drawer-body")).toBeTruthy();
+    });
+    expect(screen.getByTestId("design-tpl-drawer-name").textContent).toContain(
+      "site.base",
+    );
+    expect(screen.getByTestId("design-tpl-drawer-assembler").textContent).toContain(
+      "velocityAssembler",
+    );
+    expect(screen.getByTestId("design-tpl-drawer-bindings").textContent).toBe(
+      "1",
+    );
+    expect(screen.getByTestId("design-tpl-drawer-slots").textContent).toBe("1");
+    fireEvent.click(screen.getByTestId("design-tpl-drawer-close"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("design-tpl-drawer")).toBeNull();
+    });
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/design-template-library.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/design-template-library.spec.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Design SPA template library list shell (#2808 / parent #2631).
+ *
+ * Surface-filtered only:
+ *   npm run test:surface -- --path tests/design-template-library.spec.js
+ *
+ * QA mode: perc-devctl qa-up → TEST_CMS_URL + ADMIN_* → test:surface → qa-down.
+ *
+ * Entry: spa.jsp?entry=design&section=templates
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  catalogRowSelector,
+} = require("./helpers/developer-catalog-selectors");
+
+function designTemplatesUrl() {
+  const q = new URLSearchParams({
+    entry: "design",
+    section: "templates",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Design template library list shell (#2808)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("route shell, list or empty/error, optional read-only drawer @smoke @ui", async ({
+    page,
+  }) => {
+    await page.goto(designTemplatesUrl(), { waitUntil: "networkidle" });
+
+    await expect(page.locator('[data-testid="nav-design"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="perc-design-shell"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="tab-design-templates"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const error = page.locator('[data-testid="design-tpl-error"]');
+    const panel = page.locator('[data-testid="design-tpl-panel"]');
+    const empty = page.locator('[data-testid="design-tpl-empty"]');
+
+    await expect(panel.or(empty).or(error).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await error.isVisible()) {
+      const msg = (await error.innerText()).trim();
+      throw new Error(`Design templates catalog error: ${msg}`);
+    }
+
+    if (await empty.isVisible()) {
+      // Empty catalog is a valid shell state on bare CMS images.
+      await expect(empty).toBeVisible();
+      return;
+    }
+
+    const firstRow = page.locator(catalogRowSelector("design-tpl-row", 0));
+    await expect(firstRow).toBeVisible({ timeout: 15_000 });
+    const openBtn = page.locator('[data-testid="design-tpl-open-0"]');
+    await expect(openBtn).toBeVisible({ timeout: 5_000 });
+    await openBtn.click();
+
+    await expect(page.locator('[data-testid="design-tpl-drawer"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="design-tpl-drawer-body"]'),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.locator('[data-testid="design-tpl-drawer-name"]'),
+    ).toBeVisible();
+
+    await page.locator('[data-testid="design-tpl-drawer-close"]').click();
+    await expect(page.locator('[data-testid="design-tpl-drawer"]')).toHaveCount(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Design SPA **template library list shell** for Phase 4 slice 1 of template/assembler normalization.

**Parent:** #2631 (Phase 4 Design SPA consolidation) · **Grandparent:** #2626

### Delivered
- SPA route `/design` (+ `/design/templates`) with Admin/Designer gate
- Top-nav **Design** entry (designer/admin) replacing classic-only design access for this surface
- Template library list from existing REST `GET /services/templates` (no new rest/sitemanage adaptor)
- Empty / loading / error states
- **Read-only** detail drawer (label, name, id, description, assembler, MIME, type, binding/slot counts)
- Deep link `spa.jsp?entry=design&section=templates` + path fallback filter
- Small `perc.ui.design.modern@…` i18n key set (en fallback after `@`; no multi-locale TMX mass backfill)

### Out of scope (remaining slices)
- Source / JEXL editor → #2809
- Assembler picker + visual slots → #2810
- Classic Design retirement

## Test plan
1. As Admin/Designer: open top-nav **Design** → template list loads (or empty state)
2. Open a row → read-only drawer with metadata; Close / Escape dismisses
3. Deep link: `/Rhythmyx/cm/app/spa.jsp?entry=design&section=templates`
4. Vitest: Design shell + list + drawer
5. Playwright surface (after deploy to QA H2):
   `npm run test:surface -- --path tests/design-template-library.spec.js`

## Build evidence (C3)
- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest **Tests 1733 passed** (Surefire + frontend)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
  - `npm run test:unit` (perc-qa-automation frontend) → **214 passed**
  - `npm run test:surface:list -- --path tests/design-template-library.spec.js` → 1 test listed
  - Live surface Playwright not run this session: matrix CMS H2 on :9993 returned **503** (unhealthy); no host install with this SPA build
- **downstream_checked:** none (WebUI SPA entry allowlist + filter only; no public Java type final/signature change affecting reverse-deps)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2808
Partial for #2631

> Co-Authored by Grok Build using grok-4.5 with agent main.
