### PR TITLE
fix(WebUI): land consolidated Admin on working Admin tools (#2784)

### DIFF
--- a/WebUI/src/main/ts/admin/AdminShell.tsx
+++ b/WebUI/src/main/ts/admin/AdminShell.tsx
@@ -73,7 +73,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
       <header className={styles.header}>
         <div className={styles.headerRow}>
           <h1>{message(ADMIN_MSG.ADMIN_TITLE)}</h1>
-          {/* Top nav consolidates Admin (#2702); keep Workflow admin reachable here. */}
+          {/* Top nav lands on Admin tools (#2784); keep Workflow admin reachable. */}
           <Link
             to="/workflow"
             className={styles.siblingLink}

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -22,7 +22,11 @@ import { i18nKeyAttr } from "../../i18n/i18nDom";
 import { message, MSG } from "../../i18n/message";
 import { UserMenu } from "./UserMenu";
 import styles from "./AppLayout.module.css";
-import { isAdminNavPath, topNavItemIds } from "./topNavConfig";
+import {
+  ADMIN_NAV_LANDING,
+  isAdminNavPath,
+  topNavItemIds,
+} from "./topNavConfig";
 
 /**
  * Product top navigation for the SPA shell.
@@ -135,19 +139,19 @@ export function TopNav(): React.ReactElement {
                 </li>
               );
             case "admin":
-              // Consolidated Administration + Admin tools entry (#2702).
-              // Landing: workflow admin hub; /admin remains deep-linked.
+              // Consolidated Administration + Admin tools entry (#2702 / #2784).
+              // Landing: working Admin tools shell; /workflow remains deep-linked.
               return (
                 <li key={id}>
                   <NavLink
-                    to="/workflow"
+                    to={ADMIN_NAV_LANDING}
                     className={() =>
                       adminActive
                         ? `${styles.navLink} ${styles.navLinkActive}`
                         : styles.navLink
                     }
                     data-testid="nav-admin"
-                    // NavLink only marks active for /workflow*; force for /admin* too
+                    // NavLink only marks active for /admin*; force for /workflow* too
                     data-nav-active={adminActive ? "true" : "false"}
                     aria-current={adminActive ? "page" : undefined}
                     {...i18nKeyAttr(MSG.NAV_ADMIN)}

--- a/WebUI/src/main/ts/app/layout/topNavConfig.ts
+++ b/WebUI/src/main/ts/app/layout/topNavConfig.ts
@@ -16,12 +16,15 @@
  */
 
 /**
- * Primary product top-nav order and role gates (issue #2702).
+ * Primary product top-nav order and role gates (issue #2702 / #2784).
  *
  * Dashboard is intentionally omitted from top chrome (gadgets remain on Home
  * via deep link {@code /home/gadgets}). Administration + Admin tools collapse
- * to a single {@code admin} item whose landing is the workflow admin hub;
- * {@code /admin} remains a deep-linked route for Admin tools.
+ * to a single {@code admin} item.
+ *
+ * <p>Landing is the working <strong>Admin tools</strong> shell at {@code /admin}
+ * (#2784). Workflow administration remains at {@code /workflow} via deep link
+ * and the Admin tools sibling cross-link.</p>
  */
 
 export type TopNavItemId =
@@ -39,6 +42,12 @@ export interface TopNavGates {
   isDesigner?: boolean;
   isWidgetBuilderActive?: boolean;
 }
+
+/**
+ * Client path for the consolidated Admin top-nav NavLink (#2784).
+ * Prefer Admin tools over Workflow administration as the primary landing.
+ */
+export const ADMIN_NAV_LANDING = "/admin";
 
 /**
  * Ordered top-nav item ids for the given role / feature gates.
@@ -66,7 +75,7 @@ export function topNavItemIds(gates: TopNavGates = {}): TopNavItemId[] {
 
 /**
  * Whether a client pathname should mark the consolidated Admin top-nav active.
- * Covers both workflow administration and admin-tools SPA routes.
+ * Covers both admin-tools and workflow administration SPA routes.
  */
 export function isAdminNavPath(pathname: string): boolean {
   const p = pathname || "";

--- a/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
@@ -73,7 +73,7 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
       <header className={styles.header}>
         <div className={styles.headerRow}>
           <h1>{message(WF_ADMIN_MSG.TITLE)}</h1>
-          {/* Top nav consolidates Admin (#2702); keep Admin tools reachable here. */}
+          {/* Admin tools is top-nav landing (#2784); keep cross-link when deep-linked here. */}
           <Link
             to="/admin"
             className={styles.siblingLink}

--- a/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
+++ b/WebUI/src/main/ts/workflowAdmin/user/landingOptions.ts
@@ -60,7 +60,7 @@ export const ALL_LANDING_OPTIONS: readonly LandingOption[] = [
   },
   {
     value: HOMEPAGE_TYPES.WORKFLOW,
-    // Product consolidated "Admin" top-nav (#2702) → Workflow SPA entry
+    // Workflow admin SPA (still a valid homepage); top-nav Admin lands on tools (#2784)
     labelKey: "perc.ui.navMenu.admin@Administration",
   },
 ] as const;

--- a/WebUI/src/main/webapp/cm/app/includes/mainnav.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/mainnav.jsp
@@ -132,8 +132,8 @@
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DESIGN"><i18n:message key="perc.ui.navMenu.design@Design"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_PUBLISH"><i18n:message key="perc.ui.navMenu.publish@Publish"/></li>
         <% } %><% if (isAdmin) { %>
-        <%-- Single Admin entry (en-us label already "Admin"); classic Administration surfaces --%>
-        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WORKFLOW"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
+        <%-- Single Admin entry (#2702/#2784): SPA Admin tools landing; workflow via sibling in SPA --%>
+        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_ADMIN" data-spa-href="/cm/app/spa.jsp?entry=admin"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
         <% } %>
         <% if (isWdgActive && (isAdmin || isDesigner)) { %>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WIDGET_BUILDER"><i18n:message key="perc.ui.navMenu.admin@Widget Builder"/></li>

--- a/WebUI/src/main/webapp/cm/app/includes/minuetCommonTemplates/navigationTemplates.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/minuetCommonTemplates/navigationTemplates.jsp
@@ -58,7 +58,8 @@
             </div>
             <% } %><% if (isAdmin) { %>
             <div class="col-6 col-md-4 col-lg-3">
-                <div role="button" title='<i18n:message key="perc.ui.navMenu.admin@Administration"/>' tabindex="0" data-navmgr="VIEW_WORKFLOW" class="perc-nav-item perc-actions-menu-item text-center">
+                <%-- #2784: Admin tools SPA landing (peer of Explorer spa-href exit) --%>
+                <div role="button" title='<i18n:message key="perc.ui.navMenu.admin@Administration"/>' tabindex="0" data-navmgr="VIEW_ADMIN" data-spa-href="/cm/app/spa.jsp?entry=admin" class="perc-nav-item perc-actions-menu-item text-center">
                     <i aria-hidden class="perc-nav-icon fas fa-users-cog fa-5x fa-fw"></i>
                     <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.admin@Administration"/></span>
                 </div>

--- a/WebUI/src/main/webapp/cm/pages/app/includes/mainnav.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/mainnav.jsp
@@ -123,8 +123,8 @@
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DESIGN"><i18n:message key="perc.ui.navMenu.design@Design"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_PUBLISH"><i18n:message key="perc.ui.navMenu.publish@Publish"/></li>
         <% } %><% if (isAdmin) { %>
-        <%-- Single Admin entry (en-us label already "Admin"); classic Administration surfaces --%>
-        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WORKFLOW"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
+        <%-- Single Admin entry (#2702/#2784): SPA Admin tools landing; workflow via sibling in SPA --%>
+        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_ADMIN" data-spa-href="/cm/app/spa.jsp?entry=admin"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
         <% } %>
         <% if (isWdgActive && (isAdmin || isDesigner)) { %>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WIDGET_BUILDER"><i18n:message key="perc.ui.navMenu.admin@Widget Builder"/></li>

--- a/WebUI/src/main/webapp/cm/pages/app/includes/minuetCommonTemplates/navigationTemplates.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/minuetCommonTemplates/navigationTemplates.jsp
@@ -58,7 +58,8 @@
             </div>
             <% } %><% if (isAdmin) { %>
             <div class="col-6 col-md-4 col-lg-3">
-                <div role="button" title='<i18n:message key="perc.ui.navMenu.admin@Administration"/>' tabindex="0" data-navmgr="VIEW_WORKFLOW" class="perc-nav-item perc-actions-menu-item text-center">
+                <%-- #2784: Admin tools SPA landing (peer of Explorer spa-href exit) --%>
+                <div role="button" title='<i18n:message key="perc.ui.navMenu.admin@Administration"/>' tabindex="0" data-navmgr="VIEW_ADMIN" data-spa-href="/cm/app/spa.jsp?entry=admin" class="perc-nav-item perc-actions-menu-item text-center">
                     <i aria-hidden class="perc-nav-icon fas fa-users-cog fa-5x fa-fw"></i>
                     <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.admin@Administration"/></span>
                 </div>

--- a/WebUI/src/test/ts/app/layout/TopNav.test.tsx
+++ b/WebUI/src/test/ts/app/layout/TopNav.test.tsx
@@ -77,6 +77,14 @@ describe("TopNav (#2702)", () => {
     expect(screen.getByTestId("nav-admin").textContent).toMatch(/Admin/i);
   });
 
+  it("lands consolidated Admin on Admin tools shell path (#2784)", () => {
+    renderNav();
+    const admin = screen.getByTestId("nav-admin");
+    // React Router NavLink href is basename-relative under MemoryRouter
+    const href = admin.getAttribute("href") || "";
+    expect(href === "/admin" || href.endsWith("/admin")).toBe(true);
+  });
+
   it("hides Admin for non-admin", () => {
     bootstrapState.isAdmin = false;
     bootstrapState.isDesigner = false;
@@ -86,13 +94,13 @@ describe("TopNav (#2702)", () => {
     expect(screen.getByTestId("nav-explorer")).toBeTruthy();
   });
 
-  it("marks Admin active on workflow and admin-tools routes", () => {
-    const { unmount } = renderNav("/cm/app/workflow/roles");
+  it("marks Admin active on admin-tools and workflow routes", () => {
+    const { unmount } = renderNav("/cm/app/admin/tools");
     expect(screen.getByTestId("nav-admin").getAttribute("data-nav-active")).toBe(
       "true",
     );
     unmount();
-    renderNav("/cm/app/admin/tools");
+    renderNav("/cm/app/workflow/roles");
     expect(screen.getByTestId("nav-admin").getAttribute("data-nav-active")).toBe(
       "true",
     );

--- a/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
+++ b/WebUI/src/test/ts/app/layout/topNavConfig.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  ADMIN_NAV_LANDING,
   isAdminNavPath,
   topNavItemIds,
 } from "../../../../main/ts/app/layout/topNavConfig";
@@ -78,12 +79,19 @@ describe("topNavItemIds (#2702)", () => {
   });
 });
 
+describe("ADMIN_NAV_LANDING (#2784)", () => {
+  it("points consolidated Admin top-nav at Admin tools shell", () => {
+    expect(ADMIN_NAV_LANDING).toBe("/admin");
+    expect(isAdminNavPath(ADMIN_NAV_LANDING)).toBe(true);
+  });
+});
+
 describe("isAdminNavPath", () => {
-  it("marks workflow and admin-tools SPA paths as Admin-active", () => {
-    expect(isAdminNavPath("/workflow")).toBe(true);
-    expect(isAdminNavPath("/workflow/roles")).toBe(true);
+  it("marks admin-tools and workflow SPA paths as Admin-active", () => {
     expect(isAdminNavPath("/admin")).toBe(true);
     expect(isAdminNavPath("/admin/tools")).toBe(true);
+    expect(isAdminNavPath("/workflow")).toBe(true);
+    expect(isAdminNavPath("/workflow/roles")).toBe(true);
     expect(isAdminNavPath("/home")).toBe(false);
     expect(isAdminNavPath("/explorer")).toBe(false);
   });

--- a/WebUI/war/app/includes/mainnav.jsp
+++ b/WebUI/war/app/includes/mainnav.jsp
@@ -123,8 +123,8 @@
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_DESIGN"><i18n:message key="perc.ui.navMenu.design@Design"/></li>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_PUBLISH"><i18n:message key="perc.ui.navMenu.publish@Publish"/></li>
         <% } %><% if (isAdmin) { %>
-        <%-- Single Admin entry (en-us label already "Admin"); classic Administration surfaces --%>
-        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WORKFLOW"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
+        <%-- Single Admin entry (#2702/#2784): SPA Admin tools landing; workflow via sibling in SPA --%>
+        <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_ADMIN" data-spa-href="/cm/app/spa.jsp?entry=admin"><i18n:message key="perc.ui.navMenu.admin@Administration"/></li>
         <% } %>
         <% if (isWdgActive && (isAdmin || isDesigner)) { %>
         <li role="menuitem" class="perc-actions-menu-item" data-navmgr="VIEW_WIDGET_BUILDER"><i18n:message key="perc.ui.navMenu.admin@Widget Builder"/></li>

--- a/WebUI/war/app/includes/minuetCommonTemplates/navigationTemplates.jsp
+++ b/WebUI/war/app/includes/minuetCommonTemplates/navigationTemplates.jsp
@@ -58,7 +58,8 @@
             </div>
             <% } %><% if (isAdmin) { %>
             <div class="col-6 col-md-4 col-lg-3">
-                <div role="button" title='<i18n:message key="perc.ui.navMenu.admin@Administration"/>' tabindex="0" data-navmgr="VIEW_WORKFLOW" class="perc-nav-item perc-actions-menu-item text-center">
+                <%-- #2784: Admin tools SPA landing (peer of Explorer spa-href exit) --%>
+                <div role="button" title='<i18n:message key="perc.ui.navMenu.admin@Administration"/>' tabindex="0" data-navmgr="VIEW_ADMIN" data-spa-href="/cm/app/spa.jsp?entry=admin" class="perc-nav-item perc-actions-menu-item text-center">
                     <i aria-hidden class="perc-nav-icon fas fa-users-cog fa-5x fa-fw"></i>
                     <span class="perc-nav-description"><i18n:message key="perc.ui.navMenu.admin@Administration"/></span>
                 </div>

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -16,10 +16,11 @@
  */
 
 /**
- * Top navigation restructure (#2702):
+ * Top navigation restructure (#2702 / #2784):
  * - Dashboard removed from SPA top chrome
  * - Explorer immediately after Home
  * - Single consolidated Admin (no separate Administration + Admin tools)
+ * - Admin lands on working Admin tools shell (/admin); Workflow via sibling
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/top-nav-restructure.spec.js
@@ -75,16 +76,16 @@ test.describe("Top nav restructure (#2702)", () => {
     });
     expect(adjacency).toBe(true);
 
-    // Consolidated Admin lands on workflow hub
+    // Consolidated Admin lands on working Admin tools shell (#2784)
     await admin.click();
-    await expect(page.getByTestId("perc-workflow-admin-shell")).toBeVisible({
+    await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
       timeout: 30_000,
     });
-    // Admin tools still reachable from workflow hub sibling link
-    const toolsLink = page.getByTestId("admin-sibling-tools-link");
-    await expect(toolsLink).toBeVisible();
-    await toolsLink.click();
-    await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
+    // Workflow administration still reachable from Admin tools sibling link
+    const workflowLink = page.getByTestId("admin-sibling-workflow-link");
+    await expect(workflowLink).toBeVisible();
+    await workflowLink.click();
+    await expect(page.getByTestId("perc-workflow-admin-shell")).toBeVisible({
       timeout: 30_000,
     });
   });


### PR DESCRIPTION
## Summary

Fixes **#2784** regression from the Administration + Admin Tools top-nav merge (**#2702** / PR #2713).

After consolidation, the single **Admin** top-nav item landed on `/workflow` (Administration / WorkflowAdminShell). The previously working **Admin tools** shell at `/admin` was removed from top chrome and only reachable via deep link or sibling link—while the retained Administration landing was the non-working path reported by QA.

### Fix

- SPA **Admin** `NavLink` now lands on **`/admin`** (working Admin tools / `AdminShell`) via shared `ADMIN_NAV_LANDING`.
- **`/workflow`** remains a first-class SPA route; top-nav still marks Admin active on both `/admin*` and `/workflow*`.
- Sibling cross-links remain: Admin tools → Administration, and vice versa.
- Classic dual-ship residual nav (mainnav + Minuet templates) uses `data-spa-href="/cm/app/spa.jsp?entry=admin"` (same pattern as Explorer).
- Vitest: landing path + active-state coverage.
- Playwright surface `top-nav-restructure.spec.js`: Admin click expects `perc-admin-shell`, then sibling to workflow hub.

Fixes #2784

## Test plan

- [x] Vitest TopNav + topNavConfig (#2784 landing assertions)
- [x] `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests: 1742 passed)
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [ ] Human QA: Admin top-nav → Admin tools shell; sibling → Workflow administration; no dual Admin entries

## Gates evidence (C3)

| Gate | Result |
|------|--------|
| modules_built | `WebUI`, `modules/perc-qa-automation` |
| build_evidence | `cd WebUI` → `..\mvnw.cmd clean install` **BUILD SUCCESS**, Vitest **Tests 1742 passed**; `cd modules/perc-qa-automation` → `..\..\mvnw.cmd clean install` **BUILD SUCCESS** |
| downstream_checked | none (no final/public Java API shape change; SPA + residual JSP nav only) |
| Change class | WebUI product top-nav landing + dual-ship classic residual + Playwright companion |
| Erlang self-review | Landing swap only; URL paths use `/` (correct for SPA/HTTP); dual-ship mirrors aligned |
| Cross-platform | No OS filesystem path construction |

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.