### PR TITLE
fix(perc-packages): perc.Test modern widget compile residual (#2830)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -4,18 +4,19 @@
 **Source:** `modules/perc-packages/src/main/resources/Packages/**/rxconfig/Widgets/*.xml`  
 **Machine-readable:** [widget-xml-inventory.csv](./widget-xml-inventory.csv)
 
-## Compiler status (#2751 / #2772 / #2789 / #2802 / parent #2630)
+## Compiler status (#2751 / #2772 / #2789 / #2802 / #2830 / parent #2630)
 
 | Area | Status | Notes |
 |------|--------|-------|
-| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic + residual #2789 + remaining #2802** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
+| **Widget XML → Component Package Manifest compiler** | Landed for **baseWidgets + high-traffic + residual #2789 + remaining #2802 + perc.Test #2830** | `com.percussion.packages.widgetxml.PSWidgetXmlCompiler` (+ package scanner) in `modules/perc-packages` |
 | Golden parity (baseWidgets) | **percSimpleText** (+ package compile of all 3 baseWidgets) | Fixtures under `modules/perc-packages/src/test/resources/widgetxml/` |
 | Golden parity (high-traffic #2772) | **percTitle**, **simplePageAutoList**, **percNavBreadcrumb** | Plus package compile of title, lists×2, nav×2, file, image (7 widgets) |
 | Golden parity (residual #2789) | **percForm**, **percPoll**, **percIframe** | Plus package compile of blog/calendar×2/directory×4/social/form/poll/login/rss/iframe (**13** widgets) |
 | Golden parity (remaining #2802) | **percImageAutoList**, **percComments**, **percEvent** | Plus package compile of auto-lists, blog companions, social/comments/cards, event/slider/cookie/jquery, login variants, Result/Redirect, defaultLanguage (**24** widgets / 23 packages) |
+| Golden parity (perc.Test #2830) | **PSWidget_TestProperties** | Final product residual; package compile via `TEST_PRODUCT_PACKAGE_DIRS` / `compileTestProductPackages` |
 | Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT); residual batches needed no new shapes |
 | **Product packages still ship Widget XML** | Yes (dual-run) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
-| Residual product packages (after #2802) | **None** (product inventory complete except `perc.Test`) | Dual-run exit / product XML deletion remains Phase 5 (#2632 / parent #2630) |
+| Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Dual-run exit / product XML deletion remains Phase 5 (#2632 / parent #2630) |
 | Runtime legacy XML shim | Landed (cluster #2766) | #2752 |
 
 ### High-traffic batch covered by #2772
@@ -75,6 +76,14 @@ Measurable reduction (#2789): **+13** product widget definition XMLs on the vali
 | `perc.defaultLanguage` | percDefaultLang, percLocalLang | Multi-widget language package |
 
 Measurable reduction (#2802): **+24** product widget definition XMLs on the validated modern compile path (cumulative product widgets with package compile coverage: **3 + 7 + 13 + 24 = 47**, excluding `perc.Test`; full product inventory of 48 − test = 47).
+
+### Final product residual covered by #2830
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.Test` | PSWidget_TestProperties | Test-harness widget; 4 UserPrefs (bool/enum); golden |
+
+Measurable reduction (#2830): **+1** product widget definition XML on the validated modern compile path (cumulative **3 + 7 + 13 + 24 + 1 = 48** — full product inventory). Dual-run XML remains until Phase 5 (#2632).
 
 Ship format: [component-package-manifest.md](./component-package-manifest.md). ADR: [004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md).
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
@@ -168,8 +168,11 @@ public final class PSPageXmlNativeInstall {
     Path manifestPath = pageDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
     PSComponentPackageManifest manifest = readManifest(manifestPath, pageDir);
     String stem = resolveStem(manifest, pageDir);
-    String guid = guidsByStem.get(stem);
-    String archiveFolder = foldersByStem.get(stem);
+    // Mapping loaders key stems lower-case (Windows/macOS case-insensitive product history;
+    // dual-ship uses the same policy). Preserve original stem for on-disk templateDef names.
+    String stemKey = stem.toLowerCase(Locale.ROOT);
+    String guid = guidsByStem.get(stemKey);
+    String archiveFolder = foldersByStem.get(stemKey);
     if (guid == null || guid.isBlank() || archiveFolder == null || archiveFolder.isBlank()) {
       Path mapping = PSPageXmlDualShip.findMappingProperties(packageDir);
       String mappingHint =
@@ -189,7 +192,7 @@ public final class PSPageXmlNativeInstall {
 
   /**
    * Mapping value {@code TemplateDef-N} by stem (for archive folder names). Same keys as GUID
-   * loader.
+   * loader — stem keys are lower-cased for case-insensitive match against manifest ids.
    */
   public static Map<String, String> loadArchiveFoldersFromMapping(Path packageDir)
       throws IOException {
@@ -211,7 +214,7 @@ public final class PSPageXmlNativeInstall {
       if (!km.matches()) {
         continue;
       }
-      String stem = km.group(1);
+      String stem = km.group(1).toLowerCase(Locale.ROOT);
       String value = props.getProperty(key);
       if (value == null) {
         continue;

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -36,15 +36,16 @@ import java.util.regex.Pattern;
 
 /**
  * Compiles legacy Widget definition XML into a modern {@link PSComponentPackageManifest} plus
- * template source artifacts (Phase 3 / ADR-004 / issues #2751, #2772, #2789, #2802).
+ * template source artifacts (Phase 3 / ADR-004 / issues #2751, #2772, #2789, #2802, #2830).
  *
  * <p><strong>Scope:</strong> baseWidgets-shaped widgets, high-traffic product packages (title,
  * lists, nav chrome, file, image — #2772), residual long-tail product packages (blog, calendar,
- * directory, social, forms, poll, login, rss, iframe — #2789), and remaining product packages
+ * directory, social, forms, poll, login, rss, iframe — #2789), remaining product packages
  * (auto-lists, blog/list companions, comments/liked/cards, event/slider/cookie/jquery, login
- * variants, Result/Redirect, defaultLanguage — #2802): JEXL code + Velocity content + optional
- * asset content type + UserPref/CssPref + {@code <Resource>} CSS/JS refs. Product Widget XML
- * remains dual-run until Phase 5 exit; inventory:
+ * variants, Result/Redirect, defaultLanguage — #2802), and the final {@code perc.Test} residual
+ * ({@code PSWidget_TestProperties} — #2830): JEXL code + Velocity content + optional asset content
+ * type + UserPref/CssPref + {@code <Resource>} CSS/JS refs. Product Widget XML remains dual-run
+ * until Phase 5 exit; inventory:
  * {@code docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md}.
  *
  * <p>Assembler mapping: {@code Content type="velocity"} → {@code velocityAssembler}; {@code html}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -32,8 +32,9 @@ import java.util.Objects;
  *
  * <p>Looks under {@code sys__UserDependency--rxconfig/Widgets/*.xml} (product packaging layout used
  * by {@code modules/perc-packages}). Covers baseWidgets, high-traffic product packages (#2772), the
- * residual long-tail batch (#2789), and the remaining product residual batch (#2802). Product Widget
- * XML remains dual-run until install consumes modern packages (Phase 5 exit).
+ * residual long-tail batch (#2789), the remaining product residual batch (#2802), and the final
+ * {@code perc.Test} residual (#2830). Product Widget XML remains dual-run until install consumes
+ * modern packages (Phase 5 exit).
  */
 public final class PSWidgetXmlPackageCompiler {
 
@@ -75,8 +76,9 @@ public final class PSWidgetXmlPackageCompiler {
    * Remaining product package directory names under {@code Packages/} covered by issue #2802
    * (auto-lists, blog/list companions, social/comments cards, event/slider/cookie/jquery, login
    * variants, Result/Redirect, defaultLanguage). Beyond {@link #RESIDUAL_PRODUCT_PACKAGE_DIRS},
-   * {@link #HIGH_TRAFFIC_PACKAGE_DIRS}, and {@code perc.baseWidgets}. Excludes {@code perc.Test}.
-   * Dual-run: product Widget XML remains until install consumes modern packages.
+   * {@link #HIGH_TRAFFIC_PACKAGE_DIRS}, and {@code perc.baseWidgets}. Excludes {@code perc.Test}
+   * (covered by {@link #TEST_PRODUCT_PACKAGE_DIRS} / #2830). Dual-run: product Widget XML remains
+   * until install consumes modern packages.
    */
   public static final List<String> REMAINING_PRODUCT_PACKAGE_DIRS =
       List.of(
@@ -107,6 +109,13 @@ public final class PSWidgetXmlPackageCompiler {
           "perc.widget.Result",
           "perc.widgets.Redirect",
           "perc.defaultLanguage");
+
+  /**
+   * Final product package residual under {@code Packages/} covered by issue #2830 ({@code
+   * perc.Test} / {@code PSWidget_TestProperties}). Beyond {@link #REMAINING_PRODUCT_PACKAGE_DIRS}.
+   * Dual-run: product Widget XML remains until install consumes modern packages (Phase 5 exit).
+   */
+  public static final List<String> TEST_PRODUCT_PACKAGE_DIRS = List.of("perc.Test");
 
   private PSWidgetXmlPackageCompiler() {
     // utility
@@ -202,6 +211,21 @@ public final class PSWidgetXmlPackageCompiler {
   public static List<PSWidgetXmlCompileResult> compileRemainingProductPackages(Path packagesRoot)
       throws PSWidgetXmlException, IOException {
     return compileNamedPackages(packagesRoot, REMAINING_PRODUCT_PACKAGE_DIRS);
+  }
+
+  /**
+   * Compile the final {@code perc.Test} product package residual under a {@code Packages/} root
+   * directory (issue #2830 — residual after #2802). Missing package directories are soft-skipped
+   * (same policy as prior batches).
+   *
+   * @param packagesRoot non-null directory containing package folders
+   * @return compile results sorted by package then widget stem (may be empty if none present)
+   * @throws PSWidgetXmlException on parse/compile failure of a present package
+   * @throws IOException on I/O failure
+   */
+  public static List<PSWidgetXmlCompileResult> compileTestProductPackages(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    return compileNamedPackages(packagesRoot, TEST_PRODUCT_PACKAGE_DIRS);
   }
 
   /**

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
@@ -20,6 +20,7 @@ package com.percussion.packages.pagexml;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -226,8 +227,11 @@ class PSPageXmlNativeInstallTest {
     int written = PSPageXmlNativeInstall.stageArchiveTemplateDefs(staging, archive);
     assertEquals(3, written);
 
+    // GUID map keys are lower-cased (same as dual-ship); on-disk templateDef keeps product case.
     Map<String, String> guids = PSPageXmlDualShip.loadGuidsFromMapping(staging);
-    assertEquals("0-4-597", guids.get("perc.resp.Banded"));
+    assertEquals("0-4-597", guids.get("perc.resp.banded"));
+    assertEquals("0-4-599", guids.get("perc.resp.basic"));
+    assertEquals("0-4-627", guids.get("perc.resp.plain"));
     assertTrue(
         Files.isRegularFile(
             archive.resolve("TemplateDef-597").resolve("perc.resp.Banded.templateDef")));
@@ -264,6 +268,45 @@ class PSPageXmlNativeInstallTest {
             () -> PSPageXmlNativeInstall.stageArchiveTemplateDefs(packageDir, archive));
     assertTrue(ex.getMessage().contains("Missing stable install mapping"));
     assertTrue(ex.getMessage().contains("perc.base.plain"));
+  }
+
+  /**
+   * Product packages use mixed-case stems (e.g. {@code perc.base.Box}). Mapping loaders must match
+   * dual-ship lower-case stem keys so native install does not fail GUID/folder lookup.
+   */
+  @Test
+  void mixedCaseStem_mappingLookupIsCaseInsensitive() throws Exception {
+    Path packageDir = tempDir.resolve("mixed-case-pkg");
+    Files.createDirectories(packageDir);
+    Files.writeString(
+        packageDir.resolve("mixed-case-pkg.mapping.properties"),
+        "perc.base.Box.templateDef=TemplateDef-557\n",
+        StandardCharsets.UTF_8);
+
+    Path pageDir = packageDir.resolve(PSPageXmlDualShip.PAGES_DIR_NAME).resolve("perc.base.Box");
+    Files.createDirectories(pageDir);
+    PSPageXmlModel model = PSPageXmlParser.parse(readClasspath(FIXTURE_PLAIN));
+    model.setSourceFileName("perc.base.Box.templateDef");
+    model.setName("perc.base.Box");
+    PSPageXmlCompileResult compiled =
+        PSPageXmlCompiler.compile(model, baseTemplatesLikeContext());
+    // Force manifest id to mixed case (product Box template).
+    compiled.getManifest().setId("perc.base.Box");
+    PSPageXmlCompiler.writeArtifacts(compiled, pageDir);
+
+    Map<String, String> folders =
+        PSPageXmlNativeInstall.loadArchiveFoldersFromMapping(packageDir);
+    assertEquals("TemplateDef-557", folders.get("perc.base.box"));
+    assertNull(folders.get("perc.base.Box"), "folders map keys are lower-cased");
+
+    Path archive = tempDir.resolve("mixed-case-archive");
+    Files.createDirectories(archive);
+    int written = PSPageXmlNativeInstall.stageArchiveTemplateDefs(packageDir, archive);
+    assertEquals(1, written);
+    assertTrue(
+        Files.isRegularFile(
+            archive.resolve("TemplateDef-557").resolve("perc.base.Box.templateDef")),
+        "archive file keeps original mixed-case stem");
   }
 
   @Test

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlCompilerTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Unit + golden parity tests for Widget XML → Component Package Manifest compiler (#2751
  * baseWidgets, #2772 high-traffic residual batch, #2789 residual product batch, #2802 remaining
- * product residual batch).
+ * product residual batch, #2830 perc.Test residual).
  */
 class PSWidgetXmlCompilerTest {
 
@@ -97,6 +97,13 @@ class PSWidgetXmlCompilerTest {
   private static final String GOLDEN_EVENT_MANIFEST =
       "/widgetxml/golden/percEvent.component-package.json";
   private static final String GOLDEN_EVENT_TEMPLATE = "/widgetxml/golden/percEventSnippet.vm";
+
+  // #2830 perc.Test residual
+  private static final String FIXTURE_TEST_PROPERTIES = "/widgetxml/PSWidget_TestProperties.xml";
+  private static final String GOLDEN_TEST_PROPERTIES_MANIFEST =
+      "/widgetxml/golden/PSWidget_TestProperties.component-package.json";
+  private static final String GOLDEN_TEST_PROPERTIES_TEMPLATE =
+      "/widgetxml/golden/PSWidget_TestPropertiesSnippet.vm";
 
   @TempDir Path tempDir;
 
@@ -833,6 +840,113 @@ class PSWidgetXmlCompilerTest {
           "remaining must not re-list #2789 residual package: " + residual);
     }
     assertEquals(23, PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS.size());
+  }
+
+  @Test
+  void parseTestProperties_userPrefsEnumAndVelocityContent() throws Exception {
+    PSWidgetXmlModel model =
+        parseClasspath(FIXTURE_TEST_PROPERTIES, "PSWidget_TestProperties.xml");
+    assertEquals("Test Properties", model.getTitle());
+    assertEquals("PSWidget_TestProperties", model.getContentTypeName());
+    assertEquals("Widget for testing", model.getDescription());
+    assertEquals("velocity", model.getContentType());
+    assertNotNull(model.getContentBody());
+    assertTrue(model.getContentBody().contains("$perc.widget.item.name"));
+    assertTrue(model.getContentBody().contains("day_of_week"));
+    assertEquals(4, model.getUserPrefs().size());
+    assertEquals("show_date", model.getUserPrefs().get(0).getName());
+    assertEquals("bool", model.getUserPrefs().get(0).getDatatype());
+    assertEquals("day_of_week", model.getUserPrefs().get(3).getName());
+    assertEquals("enum", model.getUserPrefs().get(3).getDatatype());
+    assertEquals(5, model.getUserPrefs().get(3).getEnumValues().size());
+    assertEquals("PSWidget_TestProperties", model.widgetStem());
+  }
+
+  @Test
+  void compileTestProperties_matchesGoldenManifestAndTemplate() throws Exception {
+    PSWidgetXmlCompileResult result =
+        assertGoldenParity(
+            FIXTURE_TEST_PROPERTIES,
+            "PSWidget_TestProperties.xml",
+            "perc.Test",
+            GOLDEN_TEST_PROPERTIES_MANIFEST,
+            GOLDEN_TEST_PROPERTIES_TEMPLATE,
+            "templates/PSWidget_TestPropertiesSnippet.vm");
+    assertEquals(
+        "PSWidget_TestProperties",
+        result.getManifest().getContentTypes().get(0).getName());
+    assertEquals(
+        "PSWidget_TestPropertiesContent", result.getManifest().getSlots().get(0).getName());
+    assertEquals(4, result.getManifest().getUserPreferences().size());
+    assertTrue(
+        result.getManifest().getUserPreferences().stream()
+            .anyMatch(
+                p ->
+                    "day_of_week".equals(p.getName())
+                        && p.getEnumValues() != null
+                        && p.getEnumValues().size() == 5));
+    assertEquals("1.0.3", result.getManifest().getVersion());
+    assertEquals("velocityAssembler", result.getManifest().getTemplates().get(0).getAssembler());
+  }
+
+  @Test
+  void compileTestProductPackages_allValidate() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping perc.Test product package test");
+      return;
+    }
+
+    List<PSWidgetXmlCompileResult> results =
+        PSWidgetXmlPackageCompiler.compileTestProductPackages(packagesRoot);
+    assertEquals(
+        1,
+        results.size(),
+        "perc.Test residual #2830 should compile PSWidget_TestProperties only");
+
+    PSWidgetXmlCompileResult testProps = results.get(0);
+    assertEquals("PSWidget_TestProperties", testProps.getManifest().getId());
+    PSComponentPackageManifestValidator.validate(testProps.getManifest());
+    assertFalse(testProps.getTextArtifacts().isEmpty());
+    assertEquals(
+        "velocityAssembler", testProps.getManifest().getTemplates().get(0).getAssembler());
+    assertEquals(
+        "PSWidget_TestProperties",
+        testProps.getManifest().getContentTypes().get(0).getName());
+    assertEquals(4, testProps.getManifest().getUserPreferences().size());
+    assertEquals("1.0.3", testProps.getManifest().getVersion());
+
+    Path outRoot = tempDir.resolve("test-product-out");
+    PSWidgetXmlPackageCompiler.writeAll(results, outRoot);
+    assertTrue(
+        Files.isRegularFile(
+            outRoot
+                .resolve("PSWidget_TestProperties")
+                .resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)),
+        "writeAll missing perc.Test manifest for PSWidget_TestProperties");
+  }
+
+  @Test
+  void testProductPackageDirs_disjointFromPriorBatches() {
+    assertEquals(1, PSWidgetXmlPackageCompiler.TEST_PRODUCT_PACKAGE_DIRS.size());
+    assertTrue(PSWidgetXmlPackageCompiler.TEST_PRODUCT_PACKAGE_DIRS.contains("perc.Test"));
+    assertFalse(
+        PSWidgetXmlPackageCompiler.TEST_PRODUCT_PACKAGE_DIRS.contains("perc.baseWidgets"));
+    for (String high : PSWidgetXmlPackageCompiler.HIGH_TRAFFIC_PACKAGE_DIRS) {
+      assertFalse(
+          PSWidgetXmlPackageCompiler.TEST_PRODUCT_PACKAGE_DIRS.contains(high),
+          "test residual must not re-list high-traffic package: " + high);
+    }
+    for (String residual : PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS) {
+      assertFalse(
+          PSWidgetXmlPackageCompiler.TEST_PRODUCT_PACKAGE_DIRS.contains(residual),
+          "test residual must not re-list #2789 residual package: " + residual);
+    }
+    for (String remaining : PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS) {
+      assertFalse(
+          PSWidgetXmlPackageCompiler.TEST_PRODUCT_PACKAGE_DIRS.contains(remaining),
+          "test residual must not re-list #2802 remaining package: " + remaining);
+    }
   }
 
   private static PSWidgetXmlCompileResult assertGoldenParity(

--- a/modules/perc-packages/src/test/resources/widgetxml/PSWidget_TestProperties.xml
+++ b/modules/perc-packages/src/test/resources/widgetxml/PSWidget_TestProperties.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Widget>
+	<WidgetPrefs title="Test Properties"
+		contenttype_name="PSWidget_TestProperties"
+		description="Widget for testing" author="Percussion Software Inc"
+		thumbnail="/rx_resources/widgets/PSWidget_TestProperties/images/widgetIconTestProperties.png" />
+	<UserPref name="show_date" display_name="Show Dates?"
+		datatype="bool" default_value="true" />
+	<UserPref name="show_summ" display_name="Show Summaries?"
+		datatype="bool" default_value="true" />
+	<UserPref name="num_entries" display_name="Number of Entries:"
+		default_value="5" />
+	<UserPref name="day_of_week" display_name="Day of Week:"
+		default_value="monday" datatype="enum">
+		<EnumValue display_value="Monday" value="monday" />
+		<EnumValue display_value="Tuesday" value="tuesday" />
+		<EnumValue display_value="Wednesday" value="wednesday" />
+		<EnumValue display_value="Thursday" value="thursday" />
+		<EnumValue display_value="Friday" value="friday" />
+	</UserPref>
+	<!-- <UserPref name="primes" display_name="Primes:" default_value="['1','2','3','5','7']"
+		datatype="list" /> -->
+	<Content type="velocity">
+		$perc.widget.item.name
+		$perc.widget.item.properties.get('day_of_week')
+	</Content>
+</Widget>

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/PSWidget_TestProperties.component-package.json
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/PSWidget_TestProperties.component-package.json
@@ -1,0 +1,113 @@
+{
+  "schemaVersion": "1.0",
+  "id": "PSWidget_TestProperties",
+  "name": "Test Properties",
+  "version": "1.0.3",
+  "description": "Widget for testing",
+  "publisher": {
+    "name": "Percussion",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "5.3.14"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Test Properties",
+    "description": "Widget for testing",
+    "thumbnail": "resources/widgetIconTestProperties.png",
+    "icon": "resources/widgetIconTestProperties.png",
+    "author": "Percussion Software Inc",
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "PSWidget_TestProperties",
+      "ref": "contentTypes/PSWidget_TestProperties"
+    }
+  ],
+  "templates": [
+    {
+      "name": "PSWidget_TestPropertiesSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/PSWidget_TestPropertiesSnippet.vm",
+      "contentType": "PSWidget_TestProperties",
+      "bindings": []
+    }
+  ],
+  "slots": [
+    {
+      "name": "PSWidget_TestPropertiesContent",
+      "allowedContentTypes": [
+        "PSWidget_TestProperties"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconTestProperties.png",
+      "target": "rx_resources/widgets/PSWidget_TestProperties/images/widgetIconTestProperties.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "show_date",
+      "displayName": "Show Dates?",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "show_summ",
+      "displayName": "Show Summaries?",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "num_entries",
+      "displayName": "Number of Entries:",
+      "required": false,
+      "defaultValue": "5",
+      "enumValues": []
+    },
+    {
+      "name": "day_of_week",
+      "displayName": "Day of Week:",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "monday",
+      "enumValues": [
+        {
+          "value": "monday",
+          "displayValue": "Monday"
+        },
+        {
+          "value": "tuesday",
+          "displayValue": "Tuesday"
+        },
+        {
+          "value": "wednesday",
+          "displayValue": "Wednesday"
+        },
+        {
+          "value": "thursday",
+          "displayValue": "Thursday"
+        },
+        {
+          "value": "friday",
+          "displayValue": "Friday"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/test/resources/widgetxml/golden/PSWidget_TestPropertiesSnippet.vm
+++ b/modules/perc-packages/src/test/resources/widgetxml/golden/PSWidget_TestPropertiesSnippet.vm
@@ -1,0 +1,2 @@
+$perc.widget.item.name
+		$perc.widget.item.properties.get('day_of_week')


### PR DESCRIPTION
## Summary
- Completes modern Widget XML → component package **compile coverage** for product residual `perc.Test` / `PSWidget_TestProperties` (parent #2630 / grandparent #2626; residual after #2802 / PR #2811).
- Adds `TEST_PRODUCT_PACKAGE_DIRS` + `compileTestProductPackages`, golden parity (manifest + Velocity snippet), parse/compile assertions, and package `writeAll` validation.
- Dual-run product Widget XML **kept** (Phase 3 policy; Phase 5 / #2632 removes XML).
- **Bugfix (same module, build gate):** native page install now lower-cases mapping stem keys like dual-ship, fixing product `perc.base.Box` / responsive mixed-case native install tests from #2806.

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2630

Fixes #2830

## Test plan
- [x] `cd modules/perc-packages && ../../mvnw clean install`
- [x] `PSWidgetXmlCompilerTest` — 36 tests (includes perc.Test residual)
- [x] `PSPageXmlNativeInstallTest` — 11 tests (mixed-case stem + product native)
- [x] Full module suite: **Tests run: 103, Failures: 0**
- [x] Package build includes `perc.Test.ppkg`

## C3 build evidence
- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **103**, Failures: 0, Errors: 0; package build 45 built
- **downstream_checked:** none (no public API final/signature/package-visible API change requiring reverse-dep testCompile; C2 N/A)

## Notes
- No human QA issue: pure packaging/compiler residual; agent-proven unit + module clean install; no UI/install UX change beyond dual-run XML still shipping (unchanged product layout).

> Co-Authored by Grok Build using grok-4.5 with agent main.