### PR TITLE
feat(perc-packages): dual-ship Widget XML exit batch A modern roots (#2831)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -46,7 +46,7 @@ Hard order for a package root or definition id:
 | Surface | Path / class | Role today | Dual-run note |
 |---------|--------------|------------|---------------|
 | Widget definitions (install) | `${rxdeploydir}/rxconfig/Widgets/*.xml` via `PSWidgetDao` (`projects/sitemanage/.../dao/impl/PSWidgetDao`) | Loads legacy Widget XML by file id | Prefer modern package when present; XML remains fallback for unconverted customer defs |
-| Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; product source of truth moves off XML (ADR-004) |
+| Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; batch A dual-ships modern `widgets/<stem>/` (#2831) while install XML remains; product source of truth moves off XML (ADR-004) |
 | Package staging Widgets | `sys__UserDependency--rxconfig/Widgets/` or `rxconfig/Widgets/` under a package root | Upgrade-input / deploy layout | Shim package-root API resolves either layout |
 | Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Modern: `gadget-catalog.json` + per-gadget packages (#2771); dual-load residual for WebUI |
 | Page meta / definition XML | Site/page storage dialects | Composition authoring legacy | Product layout packages (`perc.baseTemplates`, `perc.responsiveTemplates`) author modern `pages/` (#2786); native package install stages archive `TemplateDef-N/` without dual-ship roots (#2806). Shim recognizes `rxconfig/Pages` if present for customer defs |
@@ -89,7 +89,7 @@ Deep rewiring of `PSWidgetDao` to call the shim for every load is **incremental*
 The dual-run window ends when **all** of the following hold:
 
 - [x] Product **page layout** packages `perc.baseTemplates` / `perc.responsiveTemplates` are **not** authored as `*.templateDef` (#2786; native install mode #2806 — dual-ship roots off).
-- [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates, widgets, etc. still residual.
+- [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates done; **widget dual-ship batch A** modern roots landed (#2831, 8 widgets); remaining ~40 product widgets still dual-ship XML as install authoring until further batches + native install.
 - [ ] Customer upgrade path documented and used for remaining XML.
 - [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived.
 - [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help.

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
@@ -1,0 +1,82 @@
+# Dual-ship Widget XML exit checklist
+
+| Field | Value |
+|-------|--------|
+| **Status** | Active — batch A modern authoring roots landed (#2831) |
+| **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Related** | Compiler #2751 / #2772 / #2789 / #2802 · Shim #2752 · Phase 5 #2632 · Page dual-ship #2786 / native #2806 |
+| **Code** | `PSWidgetXmlDualShip`, `PSWidgetXmlCompiler`, `PSLegacyDefinitionXmlShim` |
+
+## Purpose
+
+Product widget packages still ship legacy `sys__UserDependency--rxconfig/Widgets/*.xml` so deployer / `PSWidgetDao` install is unchanged. Batch A **authors** modern `widgets/<stem>/component-package.json` + template sources (ADR-004) so dual-run selection prefers the Component Package Manifest when both exist.
+
+This document is the **operator / engineering checklist** for exiting dual-ship Widget XML package-by-package. **Do not** mass-delete remaining product Widget XML until a native install path exists (or a dual-ship install emitter regenerates install XML from modern).
+
+## Authoring vs install
+
+| Layer | Batch A (after #2831) | Other product widgets |
+|-------|----------------------|------------------------|
+| **Authoring truth** | `widgets/<stem>/component-package.json` + `templates/*.vm` | Still Widget XML (compile path validated; modern roots residual) |
+| **Install wire format** | Still `sys__UserDependency--rxconfig/Widgets/*.xml` dual-ship | Same |
+| **Selection** | `PSLegacyDefinitionXmlShim` prefers modern `widgets/` (or root) over legacy XML | Legacy Widget XML until modern roots land |
+
+### Configuration / APIs
+
+| Knob / API | Notes |
+|------------|--------|
+| `PSWidgetXmlDualShip.materializeModernWidgetSources(packageDir)` | Widget XML → `widgets/` (migration / refresh) |
+| `PSWidgetXmlDualShip.materializeModernBatchA(packagesRoot)` | Batch A packages only |
+| `PSWidgetXmlDualShip.hasModernWidgetSources` / `compileModernWidgets` | Product parity tests |
+| CLI | `PSWidgetXmlDualShip materialize-modern\|materialize-modern-batch-a <path>` |
+
+Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `component-package.json` **or** `widgets/<stem>/component-package.json`).
+
+## Packages on modern dual-ship authoring (batch A)
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.baseWidgets` | percSimpleText, percRichText, percRawHtml | Core content widgets; goldens exist |
+| `perc.defaultLanguage` | percDefaultLang, percLocalLang | Multi-widget language package |
+| `perc.eventWidget` | percEvent | Content CT; golden |
+| `perc.openGraphWidget` | percOpenGraph | Social meta |
+| `perc.twitterSummaryCards` | percTwitterSummaryCards | Social meta |
+
+**Batch A total:** 5 packages · **8** widgets with modern roots. Product inventory remains **48** Widget XML files (including `perc.Test`); modern dual-ship does **not** delete install XML.
+
+## Retirement checklist (per package)
+
+1. **Confirm compiler goldens / package compile** — `PSWidgetXmlPackageCompiler.compilePackage` green for the package.
+2. **Materialize modern** — `widgets/<stem>/component-package.json` + templates committed (or refresh via `materializeModernWidgetSources`).
+3. **Parity test** — modern manifest/template equals compile-from-XML (`PSWidgetXmlDualShipTest` pattern).
+4. **Shim** — `selectForPackageRoot` / `selectDefinition` prefer modern when XML co-located.
+5. **Keep install XML** until native widget install (or reverse emitter) exists.
+6. **Later residual** — optional native install mode (page peer: `PSPageXmlNativeInstall` / #2806); then remove dual-ship XML for converted packages only.
+
+## Residual after batch A
+
+| Residual | Scope | Guidance |
+|----------|-------|----------|
+| High-traffic dual-ship roots | title, lists, nav, file, image (7) | Next coherent batch |
+| Long-tail dual-ship roots | blog/calendar/directory/social/forms… | After high-traffic |
+| Remaining product dual-ship roots | auto-lists, companions, login variants… | After long-tail |
+| Native widget install | Package build stages install Widget XML (or new wire format) from modern | Peer of #2806; required before mass XML delete |
+| Global shim removal | #2632 | Metrics + zero required legacy loads |
+
+Approximate residual Widget XML still dual-shipped as **install** source of truth for authoring: **~40** product widgets without modern `widgets/` roots (48 − 8 batch A; still 48 XML files on disk until native exit).
+
+## Dual-run / dual-ship relationship
+
+| Concept | Layer | Status |
+|---------|-------|--------|
+| Dual-run **definition XML shim** | Runtime selection modern vs Widget XML | Time-boxed; Phase 5 #2632 |
+| Dual-ship **widget modern roots** | Package **authoring** under `widgets/` | Batch A (#2831); more batches residual |
+| Dual-ship **page templateDef** | Package-build install bridge | Optional; native preferred for base/responsive (#2806) |
+| Native **widget install** | Package-build stages install artifacts from modern | **Not landed** — do not delete product Widget XML |
+
+## See also
+
+- [widget-xml-inventory.md](./widget-xml-inventory.md)
+- [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md)
+- [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md)
+- [adr/004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md)

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -15,9 +15,10 @@
 | Golden parity (remaining #2802) | **percImageAutoList**, **percComments**, **percEvent** | Plus package compile of auto-lists, blog companions, social/comments/cards, event/slider/cookie/jquery, login variants, Result/Redirect, defaultLanguage (**24** widgets / 23 packages) |
 | Golden parity (perc.Test #2830) | **PSWidget_TestProperties** | Final product residual; package compile via `TEST_PRODUCT_PACKAGE_DIRS` / `compileTestProductPackages` |
 | Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT); residual batches needed no new shapes |
-| **Product packages still ship Widget XML** | Yes (dual-run) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
-| Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Dual-run exit / product XML deletion remains Phase 5 (#2632 / parent #2630) |
-| Runtime legacy XML shim | Landed (cluster #2766) | #2752 |
+| **Product packages still ship Widget XML** | Yes (dual-run install) | Compiler produces modern artifacts; install still uses `sys__UserDependency--rxconfig/Widgets/*.xml`; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
+| **Dual-ship modern authoring roots (batch A #2831)** | **Landed for 8 widgets / 5 packages** | `widgets/<stem>/component-package.json` under baseWidgets, defaultLanguage, event, openGraph, twitter; see [dual-ship-widget-xml-exit.md](./dual-ship-widget-xml-exit.md) |
+| Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Dual-ship modern roots for remaining widgets + native install + XML delete remain residual / Phase 5 (#2632 / parent #2630) |
+| Runtime legacy XML shim | Landed (cluster #2766); prefers `widgets/` modern (#2831) | #2752 |
 
 ### High-traffic batch covered by #2772
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
@@ -170,7 +170,7 @@ public final class PSPageXmlNativeInstall {
     String stem = resolveStem(manifest, pageDir);
     // Mapping loaders key stems lower-case (Windows/macOS case-insensitive product history;
     // dual-ship uses the same policy). Preserve original stem for on-disk templateDef names.
-    String stemKey = stem.toLowerCase(Locale.ROOT);
+    String stemKey = stem != null ? stem.toLowerCase(Locale.ROOT) : "";
     String guid = guidsByStem.get(stemKey);
     String archiveFolder = foldersByStem.get(stemKey);
     if (guid == null || guid.isBlank() || archiveFolder == null || archiveFolder.isBlank()) {
@@ -214,6 +214,7 @@ public final class PSPageXmlNativeInstall {
       if (!km.matches()) {
         continue;
       }
+      // Match loadGuidsFromMapping: lowercase stem keys for mixed-case product ids.
       String stem = km.group(1).toLowerCase(Locale.ROOT);
       String value = props.getProperty(key);
       if (value == null) {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -336,7 +337,8 @@ public final class PSLegacyDefinitionXmlShim {
               b.getParent() != null && b.getParent().getFileName() != null
                   ? b.getParent().getFileName().toString()
                   : b.toString();
-          return an.compareToIgnoreCase(bn);
+          // Locale.ROOT for stable order with PSWidgetXmlDualShip.listModernWidgetDirs
+          return an.toLowerCase(Locale.ROOT).compareTo(bn.toLowerCase(Locale.ROOT));
         });
     return manifests.isEmpty() ? Optional.empty() : Optional.of(manifests.get(0));
   }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
@@ -118,9 +118,10 @@ public final class PSLegacyDefinitionXmlShim {
   /**
    * Select source for a single product / customer <strong>package root</strong> directory.
    *
-   * <p>Modern wins if {@link #MODERN_MANIFEST_FILE_NAME} exists under the root. Otherwise legacy
-   * Widget XML under package staging or install-relative Widgets is preferred over page/gadget
-   * markers when both exist in the same tree (widgets are the primary dual-run surface).
+   * <p>Modern wins if {@link #MODERN_MANIFEST_FILE_NAME} exists under the root <em>or</em> under a
+   * dual-ship {@code widgets/&lt;stem&gt;/} child package (batch A / #2831). Otherwise legacy Widget
+   * XML under package staging or install-relative Widgets is preferred over page/gadget markers when
+   * both exist in the same tree (widgets are the primary dual-run surface).
    *
    * @param packageRoot package source or install package directory (must not be null)
    * @return selection with primary path set to the manifest or first legacy XML found
@@ -138,6 +139,13 @@ public final class PSLegacyDefinitionXmlShim {
     if (Files.isRegularFile(modernManifest)) {
       return new PSDefinitionSourceSelection(
           PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, packageName, modernManifest);
+    }
+
+    // Dual-ship multi-widget authoring: widgets/<stem>/component-package.json (#2831)
+    Optional<Path> modernWidget = findFirstModernWidgetManifest(root);
+    if (modernWidget.isPresent()) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, packageName, modernWidget.get());
     }
 
     Optional<Path> widgetXml = findFirstXml(resolvePackageWidgetsDir(root));
@@ -219,6 +227,13 @@ public final class PSLegacyDefinitionXmlShim {
         return new PSDefinitionSourceSelection(
             PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, definitionId, manifest);
       }
+      // Dual-ship multi-widget package root: widgets/<definitionId>/component-package.json (#2831)
+      Path nested =
+          normalized.resolve("widgets").resolve(definitionId).resolve(MODERN_MANIFEST_FILE_NAME);
+      if (Files.isRegularFile(nested)) {
+        return new PSDefinitionSourceSelection(
+            PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, definitionId, nested);
+      }
     }
 
     Path widgetXml = resolveLegacyXmlFile(legacyWidgetsDir, definitionId);
@@ -288,6 +303,42 @@ public final class PSLegacyDefinitionXmlShim {
       return staging;
     }
     return packageRoot.resolve("rxconfig").resolve("Widgets");
+  }
+
+  /**
+   * First modern dual-ship widget manifest under {@code packageRoot/widgets/&lt;stem&gt;/component-package.json}
+   * (stable order by folder name). Empty when no modern widget authoring tree is present.
+   */
+  static Optional<Path> findFirstModernWidgetManifest(Path packageRoot) throws IOException {
+    Path widgets = packageRoot.resolve("widgets");
+    if (!Files.isDirectory(widgets)) {
+      return Optional.empty();
+    }
+    List<Path> manifests = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(widgets)) {
+      for (Path child : stream) {
+        if (!Files.isDirectory(child)) {
+          continue;
+        }
+        Path manifest = child.resolve(MODERN_MANIFEST_FILE_NAME);
+        if (Files.isRegularFile(manifest)) {
+          manifests.add(manifest);
+        }
+      }
+    }
+    manifests.sort(
+        (a, b) -> {
+          String an =
+              a.getParent() != null && a.getParent().getFileName() != null
+                  ? a.getParent().getFileName().toString()
+                  : a.toString();
+          String bn =
+              b.getParent() != null && b.getParent().getFileName() != null
+                  ? b.getParent().getFileName().toString()
+                  : b.toString();
+          return an.compareToIgnoreCase(bn);
+        });
+    return manifests.isEmpty() ? Optional.empty() : Optional.of(manifests.get(0));
   }
 
   private static Path resolveLegacyXmlFile(Path dir, String definitionId) {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -493,17 +493,26 @@ public final class PSWidgetXmlCompiler {
   }
 
   /**
-   * Resolve a package-relative path (URL-style {@code /}) under {@code base} using portable {@link
-   * Path#resolve(String)} per segment — never string-concatenate OS separators.
+   * Resolve a package-relative path under {@code base} using portable {@link Path#resolve(String)}
+   * per segment — never string-concatenate OS separators. Accepts URL-style {@code /} and Windows
+   * {@code \} in the relative string; strips a leading slash; rejects {@code ..} escapes.
    */
   static Path resolvePackageRelative(Path base, String packageRelative) {
+    if (packageRelative == null || packageRelative.isBlank()) {
+      throw new IllegalArgumentException("relative path must be non-blank");
+    }
+    String normalized = packageRelative.replace('\\', '/');
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
     Path p = base;
-    for (String segment : packageRelative.split("/")) {
+    for (String segment : normalized.split("/")) {
       if (segment.isEmpty() || ".".equals(segment)) {
         continue;
       }
       if ("..".equals(segment)) {
-        throw new IllegalArgumentException("Package-relative path must not contain '..': " + packageRelative);
+        throw new IllegalArgumentException(
+            "Package-relative path must not contain '..': " + packageRelative);
       }
       p = p.resolve(segment);
     }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Dual-ship bridge for product Widget packages (ADR-004 / issue #2831 batch A, parent #2630).
+ *
+ * <p><strong>Authoring truth (modern):</strong> {@code widgets/&lt;widgetStem&gt;/component-package.json}
+ * plus template sources under the product package tree (e.g. {@code perc.baseWidgets}).
+ *
+ * <p><strong>Install path (dual-run):</strong> product packages still ship legacy {@code
+ * sys__UserDependency--rxconfig/Widgets/*.xml} so deployer / {@code PSWidgetDao} install is
+ * unchanged. Modern roots are committed so selection prefers Component Package Manifest when both
+ * exist ({@code PSLegacyDefinitionXmlShim}). Do not mass-delete remaining Widget XML until a native
+ * install path exists (Phase 5 / #2632).
+ *
+ * <p>Batch A (#2831): {@code perc.baseWidgets}, {@code perc.defaultLanguage}, {@code
+ * perc.eventWidget}, {@code perc.openGraphWidget}, {@code perc.twitterSummaryCards} (8 widgets).
+ *
+ * @see PSWidgetXmlCompiler
+ * @see PSWidgetXmlPackageCompiler
+ */
+public final class PSWidgetXmlDualShip {
+
+  /** Package-relative directory holding per-widget modern component packages. */
+  public static final String WIDGETS_DIR_NAME = "widgets";
+
+  /**
+   * Batch A dual-ship exit package directory names under {@code Packages/} (issue #2831). Coherent
+   * base/core set: baseWidgets (3) + defaultLanguage (2) + event + openGraph + twitter cards.
+   */
+  public static final List<String> BATCH_A_PACKAGE_DIRS =
+      List.of(
+          "perc.baseWidgets",
+          "perc.defaultLanguage",
+          "perc.eventWidget",
+          "perc.openGraphWidget",
+          "perc.twitterSummaryCards");
+
+  /** Expected modern widget stems for batch A (stable for tests / residual counting). */
+  public static final List<String> BATCH_A_WIDGET_STEMS =
+      List.of(
+          "percSimpleText",
+          "percRichText",
+          "percRawHtml",
+          "percDefaultLang",
+          "percLocalLang",
+          "percEvent",
+          "percOpenGraph",
+          "percTwitterSummaryCards");
+
+  private PSWidgetXmlDualShip() {
+    // utility
+  }
+
+  /**
+   * CLI for one-time migration / dual-ship ops.
+   *
+   * <p>Usage:
+   *
+   * <ul>
+   *   <li>{@code materialize-modern &lt;packageDir&gt;} — Widget XML → {@code widgets/}
+   *   <li>{@code materialize-modern-batch-a &lt;packagesRoot&gt;} — batch A packages only
+   * </ul>
+   */
+  public static void main(String[] args) throws Exception {
+    if (args.length < 2) {
+      System.err.println(
+          "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a <path>");
+      System.exit(1);
+    }
+    String cmd = args[0].trim().toLowerCase(Locale.ROOT);
+    Path path = Path.of(args[1]).toAbsolutePath().normalize();
+    int n =
+        switch (cmd) {
+          case "materialize-modern" -> materializeModernWidgetSources(path);
+          case "materialize-modern-batch-a" -> materializeModernBatchA(path);
+          default -> throw new IllegalArgumentException("Unknown command: " + args[0]);
+        };
+    System.out.println(cmd + " wrote " + n + " modern widget package(s) under " + path);
+  }
+
+  /**
+   * Whether the package root contains modern widget authoring sources under {@value
+   * #WIDGETS_DIR_NAME}.
+   */
+  public static boolean hasModernWidgetSources(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    return !listModernWidgetDirs(packageDir).isEmpty();
+  }
+
+  /**
+   * Materialize modern {@code widgets/&lt;stem&gt;/} sources from package Widget XML (dual-ship
+   * authoring path). Overwrites existing modern trees for the same stem.
+   *
+   * @param packageDir product package source (e.g. {@code …/Packages/perc.baseWidgets})
+   * @return number of modern widget packages written
+   * @throws PSWidgetXmlException on parse/compile failure
+   * @throws IOException on I/O failure
+   */
+  public static int materializeModernWidgetSources(Path packageDir)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (!Files.isDirectory(packageDir)) {
+      throw new PSWidgetXmlException("Package directory does not exist: " + packageDir);
+    }
+    Path widgetsXmlDir = PSWidgetXmlPackageCompiler.resolveWidgetsDir(packageDir);
+    if (!Files.isDirectory(widgetsXmlDir)) {
+      return 0;
+    }
+    List<PSWidgetXmlCompileResult> compiled = PSWidgetXmlPackageCompiler.compilePackage(packageDir);
+    Path widgets = packageDir.resolve(WIDGETS_DIR_NAME);
+    Files.createDirectories(widgets);
+    int written = 0;
+    for (PSWidgetXmlCompileResult result : compiled) {
+      String stem = result.getSource().widgetStem();
+      if (stem == null || stem.isBlank()) {
+        stem = result.getManifest().getId();
+      }
+      Path out = widgets.resolve(stem);
+      PSWidgetXmlCompiler.writeArtifacts(result, out);
+      written++;
+    }
+    return written;
+  }
+
+  /**
+   * Materialize modern widget sources for every batch A package under {@code packagesRoot}. Missing
+   * package directories are soft-skipped.
+   *
+   * @param packagesRoot {@code Packages/} directory
+   * @return total modern widget packages written across batch A
+   */
+  public static int materializeModernBatchA(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packagesRoot, "packagesRoot");
+    if (!Files.isDirectory(packagesRoot)) {
+      throw new PSWidgetXmlException("Packages root does not exist: " + packagesRoot);
+    }
+    int total = 0;
+    for (String dirName : BATCH_A_PACKAGE_DIRS) {
+      Path packageDir = packagesRoot.resolve(dirName);
+      if (!Files.isDirectory(packageDir)) {
+        continue;
+      }
+      total += materializeModernWidgetSources(packageDir);
+    }
+    return total;
+  }
+
+  /**
+   * Compile (load + validate) all modern widget packages under {@code widgets/}.
+   *
+   * @param packageDir product package source
+   * @return validated results sorted by widget id
+   */
+  public static List<PSWidgetXmlCompileResult> compileModernWidgets(Path packageDir)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    List<Path> widgetDirs = listModernWidgetDirs(packageDir);
+    if (widgetDirs.isEmpty()) {
+      throw new PSWidgetXmlException(
+          "No modern widget packages under: " + packageDir.resolve(WIDGETS_DIR_NAME));
+    }
+    List<PSWidgetXmlCompileResult> results = new ArrayList<>();
+    for (Path widgetDir : widgetDirs) {
+      results.add(loadModernAsCompileResult(widgetDir));
+    }
+    results.sort(
+        Comparator.comparing(
+            r -> r.getManifest().getId() != null ? r.getManifest().getId() : "",
+            String.CASE_INSENSITIVE_ORDER));
+    return results;
+  }
+
+  /**
+   * Load a modern widget package directory into a {@link PSWidgetXmlCompileResult} for parity tests
+   * and dual-ship selection.
+   */
+  public static PSWidgetXmlCompileResult loadModernAsCompileResult(Path widgetDir)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(widgetDir, "widgetDir");
+    Path manifestPath = widgetDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    if (!Files.isRegularFile(manifestPath)) {
+      throw new PSWidgetXmlException("Missing component-package.json under " + widgetDir);
+    }
+    PSComponentPackageManifest manifest;
+    try {
+      manifest = PSComponentPackageManifestIo.read(manifestPath);
+      PSComponentPackageManifestValidator.validate(manifest);
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSWidgetXmlException(
+          "Invalid modern widget package at " + widgetDir + ": " + e.getMessage(), e);
+    }
+
+    Map<String, String> artifacts = new LinkedHashMap<>();
+    if (manifest.getTemplates() != null) {
+      for (PSComponentPackageManifest.TemplateRef t : manifest.getTemplates()) {
+        if (t == null || t.getSourceRef() == null || t.getSourceRef().isBlank()) {
+          continue;
+        }
+        artifacts.put(t.getSourceRef(), readTemplateSourceByRef(widgetDir, t.getSourceRef()));
+      }
+    }
+
+    // Synthetic model for dual-ship tests (stem + title from modern id/name).
+    PSWidgetXmlModel model = new PSWidgetXmlModel();
+    model.setTitle(manifest.getName());
+    model.setDescription(manifest.getDescription());
+    String stem = manifest.getId();
+    if (stem == null || stem.isBlank()) {
+      stem = widgetDir.getFileName() != null ? widgetDir.getFileName().toString() : "widget";
+    }
+    model.setSourceFileName(stem + ".xml");
+    if (manifest.getContentTypes() != null && !manifest.getContentTypes().isEmpty()) {
+      model.setContentTypeName(manifest.getContentTypes().get(0).getName());
+    }
+    if (manifest.getCatalog() != null) {
+      model.setCategory(manifest.getCatalog().getCategory());
+      model.setAuthor(manifest.getCatalog().getAuthor());
+    }
+    if (manifest.getTemplates() != null && !manifest.getTemplates().isEmpty()) {
+      model.setContentType("velocity");
+      model.setCodeType("jexl");
+      String body = artifacts.values().stream().findFirst().orElse("");
+      model.setContentBody(body);
+    }
+
+    return new PSWidgetXmlCompileResult(model, manifest, artifacts);
+  }
+
+  /**
+   * List modern widget package directories under {@code packageDir/widgets} that contain a
+   * {@code component-package.json}. Portable {@link Path} resolve only.
+   */
+  public static List<Path> listModernWidgetDirs(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    Path widgets = packageDir.resolve(WIDGETS_DIR_NAME);
+    if (!Files.isDirectory(widgets)) {
+      return List.of();
+    }
+    List<Path> dirs = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(widgets)) {
+      for (Path child : stream) {
+        if (!Files.isDirectory(child)) {
+          continue;
+        }
+        Path manifest = child.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+        if (Files.isRegularFile(manifest)) {
+          dirs.add(child);
+        }
+      }
+    }
+    dirs.sort(
+        Comparator.comparing(
+            p -> p.getFileName().toString().toLowerCase(Locale.ROOT)));
+    return dirs;
+  }
+
+  /**
+   * Collect modern widget package roots for dual-run selection ({@code
+   * PSLegacyDefinitionXmlShim#selectDefinition}).
+   *
+   * @param packageDir product package source that may contain {@code widgets/}
+   * @return list of modern widget package directories (may be empty)
+   */
+  public static List<Path> modernWidgetPackageRoots(Path packageDir) throws IOException {
+    return listModernWidgetDirs(packageDir);
+  }
+
+  private static String readTemplateSourceByRef(Path widgetDir, String sourceRef)
+      throws PSWidgetXmlException, IOException {
+    Path resolved = resolvePackageRelative(widgetDir, sourceRef);
+    if (!Files.isRegularFile(resolved)) {
+      throw new PSWidgetXmlException(
+          "Template source missing for modern widget at " + widgetDir + ": " + sourceRef);
+    }
+    return Files.readString(resolved);
+  }
+
+  /**
+   * Resolve a package-relative path under {@code root} without accepting absolute or {@code ..}
+   * escapes (portable; uses {@link Path} segments).
+   */
+  static Path resolvePackageRelative(Path root, String relative) {
+    Objects.requireNonNull(root, "root");
+    if (relative == null || relative.isBlank()) {
+      throw new IllegalArgumentException("relative path must be non-blank");
+    }
+    String normalized = relative.replace('\\', '/');
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    Path p = root;
+    for (String segment : normalized.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment)) {
+        continue;
+      }
+      if ("..".equals(segment)) {
+        throw new IllegalArgumentException("relative path must not contain '..': " + relative);
+      }
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
@@ -95,19 +95,25 @@ public final class PSWidgetXmlDualShip {
    * </ul>
    */
   public static void main(String[] args) throws Exception {
+    final String usage =
+        "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a <path>";
     if (args.length < 2) {
-      System.err.println(
-          "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a <path>");
+      System.err.println(usage);
       System.exit(1);
     }
     String cmd = args[0].trim().toLowerCase(Locale.ROOT);
     Path path = Path.of(args[1]).toAbsolutePath().normalize();
-    int n =
-        switch (cmd) {
-          case "materialize-modern" -> materializeModernWidgetSources(path);
-          case "materialize-modern-batch-a" -> materializeModernBatchA(path);
-          default -> throw new IllegalArgumentException("Unknown command: " + args[0]);
-        };
+    int n;
+    switch (cmd) {
+      case "materialize-modern" -> n = materializeModernWidgetSources(path);
+      case "materialize-modern-batch-a" -> n = materializeModernBatchA(path);
+      default -> {
+        System.err.println("Unknown command: " + args[0]);
+        System.err.println(usage);
+        System.exit(1);
+        return;
+      }
+    }
     System.out.println(cmd + " wrote " + n + " modern widget package(s) under " + path);
   }
 
@@ -311,27 +317,11 @@ public final class PSWidgetXmlDualShip {
 
   /**
    * Resolve a package-relative path under {@code root} without accepting absolute or {@code ..}
-   * escapes (portable; uses {@link Path} segments).
+   * escapes. Delegates to {@link PSWidgetXmlCompiler#resolvePackageRelative(Path, String)} so widget
+   * dual-ship and the Widget XML compiler share one implementation.
    */
   static Path resolvePackageRelative(Path root, String relative) {
     Objects.requireNonNull(root, "root");
-    if (relative == null || relative.isBlank()) {
-      throw new IllegalArgumentException("relative path must be non-blank");
-    }
-    String normalized = relative.replace('\\', '/');
-    while (normalized.startsWith("/")) {
-      normalized = normalized.substring(1);
-    }
-    Path p = root;
-    for (String segment : normalized.split("/")) {
-      if (segment.isEmpty() || ".".equals(segment)) {
-        continue;
-      }
-      if ("..".equals(segment)) {
-        throw new IllegalArgumentException("relative path must not contain '..': " + relative);
-      }
-      p = p.resolve(segment);
-    }
-    return p;
+    return PSWidgetXmlCompiler.resolvePackageRelative(root, relative);
   }
 }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -34,13 +34,21 @@ import java.util.Objects;
  * by {@code modules/perc-packages}). Covers baseWidgets, high-traffic product packages (#2772), the
  * residual long-tail batch (#2789), the remaining product residual batch (#2802), and the final
  * {@code perc.Test} residual (#2830). Product Widget XML remains dual-run until install consumes
- * modern packages (Phase 5 exit).
+ * modern packages (Phase 5 exit). Dual-ship modern authoring roots for batch A live under {@code
+ * widgets/&lt;stem&gt;/} ({@link PSWidgetXmlDualShip}, issue #2831).
  */
 public final class PSWidgetXmlPackageCompiler {
 
   /** Legacy staging folder name for user-dependency config inside a package source tree. */
   public static final String WIDGETS_RELATIVE =
       "sys__UserDependency--rxconfig/Widgets";
+
+  /**
+   * Dual-ship Widget XML exit batch A package dirs (issue #2831). See {@link
+   * PSWidgetXmlDualShip#BATCH_A_PACKAGE_DIRS}.
+   */
+  public static final List<String> DUAL_SHIP_BATCH_A_PACKAGE_DIRS =
+      PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS;
 
   /**
    * Named high-traffic product package directory names under {@code Packages/} covered by the

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/component-package.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percRawHtml",
+  "name": "HTML",
+  "version": "1.1.9",
+  "description": "Widget to accept and render raw html code.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "HTML",
+    "category": "integration",
+    "description": "Widget to accept and render raw html code.",
+    "thumbnail": "resources/widgetIconHtm.png",
+    "icon": "resources/widgetIconHtm.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 785,
+    "preferredEditorHeight": 405,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percRawHtmlAsset",
+      "ref": "contentTypes/percRawHtmlAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percRawHtmlSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percRawHtmlSnippet.vm",
+      "contentType": "percRawHtmlAsset",
+      "bindings": []
+    }
+  ],
+  "slots": [
+    {
+      "name": "percRawHtmlContent",
+      "allowedContentTypes": [
+        "percRawHtmlAsset"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconHtm.png",
+      "target": "rx_resources/widgets/PSWidget_RawHtml/images/widgetIconHtm.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/templates/percRawHtmlSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/templates/percRawHtmlSnippet.vm
@@ -1,0 +1,11 @@
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set( $node = $perc.widgetContents.get(0).node )##
+#set ( $widgetHtml = $node.getProperty('rx:html').getString() )##
+#set ( $widgetHtml = $rx.pageutils.updateManagedLinks($perc.linkContext, $widgetHtml,  $sys.assemblyItem.PubServerId,$node.getProperty('sys_contentid').String ) )##
+#set ( $widgetHtml = $widgetHtml.replace("<PRESERVE>", "" ) )##
+#set ( $widgetHtml = $widgetHtml.replace("</PRESERVE>", "" ) )##
+$!{widgetHtml}
+#elseif ( $perc.isEditMode() )##
+#createEmptyWidgetContent( "html-sample-content", "This HTML widget is showing sample content." )##
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/component-package.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percRichText",
+  "name": "Rich Text",
+  "version": "1.1.9",
+  "description": "Widget to enter text using a WYSIWYG editor",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Rich Text",
+    "category": "content",
+    "description": "Widget to enter text using a WYSIWYG editor",
+    "thumbnail": "resources/widgetIconText.png",
+    "icon": "resources/widgetIconText.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 750,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percRichTextAsset",
+      "ref": "contentTypes/percRichTextAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percRichTextSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percRichTextSnippet.vm",
+      "contentType": "percRichTextAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percRichTextContent",
+      "allowedContentTypes": [
+        "percRichTextAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconText.png",
+      "target": "rx_resources/widgets/PSWidget_RichText/images/widgetIconText.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/templates/percRichTextSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/templates/percRichTextSnippet.vm
@@ -1,0 +1,9 @@
+<div$!{classAttribute}>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+$node.getProperty('rx:text').getString()##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("text-sample-content", "This rich text widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/component-package.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percSimpleText",
+  "name": "Simple Text",
+  "version": "1.1.9",
+  "description": "Widget used for entering plain text",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Simple Text",
+    "category": "content",
+    "description": "Widget used for entering plain text",
+    "thumbnail": "resources/widgetIconSimpleText.png",
+    "icon": "resources/widgetIconSimpleText.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 640,
+    "preferredEditorHeight": 500,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSimpleTextAsset",
+      "ref": "contentTypes/percSimpleTextAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percSimpleTextSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percSimpleTextSnippet.vm",
+      "contentType": "percSimpleTextAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percSimpleTextContent",
+      "allowedContentTypes": [
+        "percSimpleTextAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconSimpleText.png",
+      "target": "rx_resources/widgets/PSWidget_SimpleText/images/widgetIconSimpleText.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/templates/percSimpleTextSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/templates/percSimpleTextSnippet.vm
@@ -1,0 +1,9 @@
+<div$!{classAttribute}>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+$rx.pageutils.html($node,'rx:text')##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("simple-text-sample-content", "This simple text widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/component-package.json
@@ -1,0 +1,219 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percDefaultLang",
+  "name": "Default Language",
+  "version": "2.5.2",
+  "description": "For SEO with International sites. When added to a Page or a Template adds the necessary href-lang markup for Google.",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Default Language",
+    "description": "For SEO with International sites. When added to a Page or a Template adds the necessary href-lang markup for Google.",
+    "thumbnail": "resources/percDefaultLangIcon.png",
+    "icon": "resources/percDefaultLangIcon.png",
+    "author": "Nate Chadwick",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percDefaultLanguage",
+      "ref": "contentTypes/percDefaultLanguage"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percDefaultLangSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percDefaultLangSnippet.vm",
+      "contentType": "percDefaultLanguage",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "pagelink",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "data",
+          "expression": "$assetItem.Node.getProperty('rx:defaultLangData').getString()"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($data)"
+        },
+        {
+          "variable": "jsonArray",
+          "expression": "$json.getJSONArray(\"config\")"
+        },
+        {
+          "variable": "headContent",
+          "expression": "\"\""
+        },
+        {
+          "variable": "configured",
+          "expression": "\"\""
+        },
+        {
+          "variable": "sites",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "headLinks",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "percPageID",
+          "expression": "$perc.getPage().getId()"
+        },
+        {
+          "variable": "protocol",
+          "expression": "$j.getString(\"protocol\")"
+        },
+        {
+          "variable": "protocol",
+          "expression": "\"\""
+        },
+        {
+          "variable": "sitename",
+          "expression": "$j.getString(\"sitename\")"
+        },
+        {
+          "variable": "lang",
+          "expression": "$j.getString(\"lang\")"
+        },
+        {
+          "variable": "country",
+          "expression": "$j.getString(\"country\")"
+        },
+        {
+          "variable": "default",
+          "expression": "$j.getString(\"defLang\")"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang + \"-\" + $country"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang"
+        },
+        {
+          "variable": "default",
+          "expression": "false"
+        },
+        {
+          "variable": "pageName",
+          "expression": "$perc.page.name"
+        },
+        {
+          "variable": "folderName",
+          "expression": "$perc.page.folderPaths.get(0)"
+        },
+        {
+          "variable": "temp",
+          "expression": "$folderName.replace(\"//Sites/\",\"\")"
+        },
+        {
+          "variable": "iPos",
+          "expression": "$temp.indexOf(\"/\")"
+        },
+        {
+          "variable": "temp",
+          "expression": "$sitename + \"/\" + $perc.page.name"
+        },
+        {
+          "variable": "path",
+          "expression": "$sitename"
+        },
+        {
+          "variable": "path",
+          "expression": "$sitename + $temp.substring($iPos)"
+        },
+        {
+          "variable": "temp",
+          "expression": "$sitename + $temp.substring($iPos) + \"/\" + $perc.page.name"
+        },
+        {
+          "variable": "livePagePath",
+          "expression": "$temp"
+        },
+        {
+          "variable": "query",
+          "expression": "\"select rx:sys_contentid, rx:sys_folderid from rx:percPage where jcr:path like '//Sites/\" + $path + \"' and rx:sys_title='\" + $pageName + \"'\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "relalt",
+          "expression": "\"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\""
+        },
+        {
+          "variable": "xdefault",
+          "expression": "\"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\""
+        },
+        {
+          "variable": "xdefault",
+          "expression": "\"\""
+        },
+        {
+          "variable": "configured",
+          "expression": "$configured + \" \" + $site + \" \""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    $pagelink=\"\";\n    if ( ! $assets.isEmpty())\n    {\n        $assetItem = $assets.get(0);\n        $data = $assetItem.Node.getProperty('rx:defaultLangData').getString();\n        $json = $rx.pageutils.createJsonObject($data);\n        $jsonArray = $json.getJSONArray(\"config\");\n        $headContent = \"\";\n\n        $configured = \"\";\n        $sites = $rx.string.stringToMap(null);\n        $headLinks = $rx.string.stringToMap(null);\n\n        $percPageID = $perc.getPage().getId();\n\n        if( $percPageID != null && $percPageID != \"\" ){\n            for($j : $jsonArray){\n               if ($j.has(\"protocol\")) {\n                    $protocol = $j.getString(\"protocol\");\n                } else {\n                    $protocol = \"\";\n                }\n                $sitename = $j.getString(\"sitename\");\n                $lang = $j.getString(\"lang\");\n                $country = $j.getString(\"country\");\n                $default = $j.getString(\"defLang\");\n\n\n                if($country != null && $country != \"\"){\n                    $countryLang = $lang + \"-\" + $country;\n                } else {\n                    $countryLang = $lang;\n                }\n\n                if($default == null){\n                    $default = false;\n                }\n\n                $pageName = $perc.page.name;\n                $folderName = $perc.page.folderPaths.get(0);\n                $temp = $folderName.replace(\"//Sites/\",\"\");\n                if($temp.startsWith(\"/\")){$temp = $temp.substring(1);}\n                $iPos = $temp.indexOf(\"/\");\n\n                if($temp.indexOf(\"/\") == -1){\n                    $temp = $sitename + \"/\" + $perc.page.name;\n                    $path = $sitename;\n                } else {\n                    $path = $sitename + $temp.substring($iPos);\n                    $temp = $sitename + $temp.substring($iPos) + \"/\" + $perc.page.name;\n                }\n                $livePagePath =  $temp;\n\n                $query = \"select rx:sys_contentid, rx:sys_folderid from rx:percPage where jcr:path like '//Sites/\" + $path + \"' and rx:sys_title='\" + $pageName + \"'\";\n                $params = $rx.string.stringToMap(null);\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $finderName  = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n                $relresults = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                if($relresults != null && $relresults.size()>0){\n                        $relalt= \"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\";\n                        $headLinks.put($relalt,$relalt);\n                        if($default){\n                                $xdefault = \"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\";\n                                $headLinks.put($xdefault,$xdefault);\n                        } else {\n                            $xdefault = \"\";\n                        }\n                    $sites.put($sitename,$sitename);\n                }\n            }\n\n            for($site : $sites.values()){\n                $configured = $configured + \" \" + $site + \" \";\n            }\n        }\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percDefaultLangContent",
+      "allowedContentTypes": [
+        "percDefaultLanguage"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percDefaultLangIcon.png",
+      "target": "rx_resources/widgets/percDefaultLang/images/percDefaultLangIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/templates/percDefaultLangSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/templates/percDefaultLangSnippet.vm
@@ -1,0 +1,13 @@
+#if($perc.isEditMode())##
+<div style="height: 32px;background: transparent url(/Rhythmyx/rx_resources/widgets/percDefaultLang/images/percDefaultLangPlaceholder.png) no-repeat scroll center center;filter: alpha(opacity=50);opacity: .50;" title="Default Language Widget">
+#if( "$!configured}" != "" && "$!{percPageID}" != "" )##
+<b>Configured International Sites:</b> ($!{configured})
+#end##
+</div>
+#end##
+#set( $newline="
+")##
+#foreach($l in $headLinks)##
+#set($addlHead = $perc.page.getAdditionalHeadContent())##
+$perc.page.setAdditionalHeadContent("$!{addlHead}$!{newline}$!{l}")##
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/component-package.json
@@ -1,0 +1,215 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percLocalLang",
+  "name": "Local Language",
+  "version": "2.5.2",
+  "description": "For SEO with International sites. Allows manual selection of alternate language pages to add necessary href-lang markup for Google.",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Local Language",
+    "description": "For SEO with International sites. Allows manual selection of alternate language pages to add necessary href-lang markup for Google.",
+    "thumbnail": "resources/percLocalLangIcon.png",
+    "icon": "resources/percLocalLangIcon.png",
+    "author": "Piotr Butkiewicz",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percLocalLanguage",
+      "ref": "contentTypes/percLocalLanguage"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percLocalLangSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percLocalLangSnippet.vm",
+      "contentType": "percLocalLanguage",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "pagelink",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "data",
+          "expression": "$assetItem.Node.getProperty('rx:localLangData').getString()"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($data)"
+        },
+        {
+          "variable": "jsonArray",
+          "expression": "$json.getJSONArray(\"config\")"
+        },
+        {
+          "variable": "headContent",
+          "expression": "\"\""
+        },
+        {
+          "variable": "previewLinks",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "headLinks",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "testing",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "resultList",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "protocol",
+          "expression": "$j.getString(\"protocol\")"
+        },
+        {
+          "variable": "protocol",
+          "expression": "\"\""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$j.getString(\"pagepath\")"
+        },
+        {
+          "variable": "pagepath",
+          "expression": "$temppath.replace(\"//Sites\", \"\")"
+        },
+        {
+          "variable": "pagename",
+          "expression": "$j.getString(\"pagename\")"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$temppath.replace($pagename,\"\")"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$j.getString(\"pageId\")"
+        },
+        {
+          "variable": "default",
+          "expression": "$j.getString(\"defLang\")"
+        },
+        {
+          "variable": "default",
+          "expression": "false"
+        },
+        {
+          "variable": "lang",
+          "expression": "$j.getString(\"lang\")"
+        },
+        {
+          "variable": "country",
+          "expression": "$j.getString(\"country\")"
+        },
+        {
+          "variable": "contentId",
+          "expression": "$rx.pageutils.parseGuid($pageId).getUUID()"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang + \"-\" + $country"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang"
+        },
+        {
+          "variable": "query",
+          "expression": "\"select rx:sys_contentid, rx:sys_folderid from rx:percPage where rx:sys_contentid = :contentId\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$result.id"
+        },
+        {
+          "variable": "tempPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "escPath",
+          "expression": "$tools.esc.html($tempPath)"
+        },
+        {
+          "variable": "pageLink",
+          "expression": "$escPath.replace(\"/Sites/\", \"\").toLowerCase()"
+        },
+        {
+          "variable": "xdefault",
+          "expression": "\"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $pageLink + \"'/>\""
+        },
+        {
+          "variable": "relalt",
+          "expression": "\"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"'/>\""
+        },
+        {
+          "variable": "relaltString",
+          "expression": "\"&lt;link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"' /&gt;\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    $pagelink=\"\";\n    if ( ! $assets.isEmpty())\n    {\n        $assetItem = $assets.get(0);\n        $data = $assetItem.Node.getProperty('rx:localLangData').getString();\n        $json = $rx.pageutils.createJsonObject($data);\n        $jsonArray = $json.getJSONArray(\"config\");\n        $headContent = \"\";\n        ##\n        $previewLinks = $rx.string.stringToMap(null);\n        $headLinks = $rx.string.stringToMap(null);\n        $testing = $rx.string.stringToMap(null);\n        $resultList = $rx.string.stringToMap(null);\n        ##\n        for ($j : $jsonArray) {\n             if ($j.has(\"protocol\")) {\n                $protocol = $j.getString(\"protocol\");\n            } else {\n                $protocol = \"\";\n            }\n            $temppath = $j.getString(\"pagepath\");\n            $pagepath = $temppath.replace(\"//Sites\", \"\");\n            $pagename = $j.getString(\"pagename\");\n            $folderpath = $temppath.replace($pagename,\"\");\n            ##\n            $pageId = $j.getString(\"pageId\");\n            $default = $j.getString(\"defLang\");\n            if ($default == null) {\n                $default = false;\n            }\n            $lang = $j.getString(\"lang\");\n            $country = $j.getString(\"country\");\n            ##\n            if ($pageId != null && $pageId != \"\") {\n                $contentId = $rx.pageutils.parseGuid($pageId).getUUID();\n            }\n            ##\n            if ($country != null && $country != \"\") {\n                $countryLang = $lang + \"-\" + $country;\n            } else {\n                $countryLang = $lang;\n            }\n            ##\n            if ($folderpath != null && $pagename != null && $contentId != null) {\n                ##\n                $query = \"select rx:sys_contentid, rx:sys_folderid from rx:percPage where rx:sys_contentid = :contentId\";\n                $params = $rx.string.stringToMap(null);\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $params.put('contentId', $contentId);\n                $finderName  = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n                $relresults = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                if ($relresults != null && $relresults.size()>0) {\n                    for ($result : $relresults) {\n                        $resultList.put($result,$result);\n                        ##\n                        $pageId = $result.id;\n                        if ($pageId != null) {\n                            ##\n                            $tempPath = $rx.pageutils.getItemPath($pageId);\n                            $escPath = $tools.esc.html($tempPath);\n                            $pageLink = $escPath.replace(\"/Sites/\", \"\").toLowerCase();\n                            ##\n                            if($default){\n                                $xdefault = \"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $pageLink + \"'/>\";\n                                $headLinks.put($xdefault,$xdefault);\n                                $previewLinks.put($xdefault,$xdefault);\n                            }\n                            $relalt = \"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"'/>\";\n                            $headLinks.put($relalt, $relalt);\n                            ##\n                            $relaltString = \"&lt;link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"' /&gt;\";\n                            $previewLinks.put($relaltString,$relaltString);\n                        }\n                    }\n                }\n            }\n        } ## End Foreach loop\n        ##\n      } ## end  ! $assets.isEmpty()"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percLocalLangContent",
+      "allowedContentTypes": [
+        "percLocalLanguage"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percLocalLangIcon.png",
+      "target": "rx_resources/widgets/percLocalLang/images/percLocalLangIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/templates/percLocalLangSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/templates/percLocalLangSnippet.vm
@@ -1,0 +1,24 @@
+#if($perc.isEditMode())##
+<div style="background: transparent url(/Rhythmyx/rx_resources/widgets/percLocalLang/images/percLocalLangPlaceholder.png) no-repeat scroll center center;filter: alpha(opacity=50);opacity: .50;" title="Default Language Widget">
+##
+#if("$!previewLinks}" != "")##
+<b>Local Language alternate pages:</b><br/>
+<br />
+#foreach($link in $previewLinks)##
+<div>$link</div>
+#end##
+#else##
+<b>Local Language alternate pages:</b><br/>
+<div>No pages selected</div>
+#end##
+</div>
+#end## End if perc.isEditMode()
+##
+#set( $newline="
+")##
+#if("$!headLinks}" != "")##
+#foreach($l in $headLinks)##
+#set($addlHead = $perc.page.getAdditionalHeadContent())##
+$perc.page.setAdditionalHeadContent("$!{addlHead}$!{newline}$!{l}")##
+#end##
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/component-package.json
@@ -1,0 +1,280 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percEvent",
+  "name": "Event",
+  "version": "1.1.7",
+  "description": "Display information about an event",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Event",
+    "category": "content",
+    "description": "Display information about an event",
+    "thumbnail": "resources/widgetIconEvent.png",
+    "icon": "resources/widgetIconEvent.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 710,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percEventAsset",
+      "ref": "contentTypes/percEventAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percEventSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percEventSnippet.vm",
+      "contentType": "percEventAsset",
+      "bindings": [
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "startDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('startDateTimeFormat')"
+        },
+        {
+          "variable": "endDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('endDateTimeFormat')"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "eventTitle",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "eventDescription",
+          "expression": "$rx.pageutils.html($assetItem, 'body')"
+        },
+        {
+          "variable": "eventSummary",
+          "expression": "$rx.pageutils.html($assetItem,'callout')"
+        },
+        {
+          "variable": "eventLocation",
+          "expression": "$rx.pageutils.html($assetItem,'location')"
+        },
+        {
+          "variable": "tmp",
+          "expression": "$assetItem.Node.getProperty('start_time').Date"
+        },
+        {
+          "variable": "ISODateFormat",
+          "expression": "\"yyyy-MM-dd hh:mm a\""
+        },
+        {
+          "variable": "eventStart",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventStartISO",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventStart",
+          "expression": "$tools.date.format($startDateTimeFormat,$tmp.Time)"
+        },
+        {
+          "variable": "eventStartISO",
+          "expression": "$tools.date.format($ISODateFormat,$tmp.Time)"
+        },
+        {
+          "variable": "tmp",
+          "expression": "$assetItem.Node.getProperty('end_time').Date"
+        },
+        {
+          "variable": "eventEnd",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventEndISO",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventEnd",
+          "expression": "$tools.date.format($endDateTimeFormat,$tmp.Time)"
+        },
+        {
+          "variable": "eventEndISO",
+          "expression": "$tools.date.format($ISODateFormat,$tmp.Time)"
+        },
+        {
+          "variable": "perc_hidefield_displaytitle",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_displaytitle')"
+        },
+        {
+          "variable": "perc_hidefield_callout",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_callout')"
+        },
+        {
+          "variable": "perc_hidefield_body",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_body')"
+        },
+        {
+          "variable": "perc_hidefield_location",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_location')"
+        },
+        {
+          "variable": "perc_hidefield_start_time",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_start_time')"
+        },
+        {
+          "variable": "perc_hidefield_end_time",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_end_time')"
+        },
+        {
+          "variable": "renderEmptyFields",
+          "expression": "$perc.widget.item.properties.get('renderEmptyFields')"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    if (! $assets.isEmpty())\n    {\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if (!empty($rootclass))\n            $rootclass = $rootclass + \" \";\n        $startDateTimeFormat = $perc.widget.item.properties.get('startDateTimeFormat');\n        $endDateTimeFormat = $perc.widget.item.properties.get('endDateTimeFormat');\n\n        $assetItem = $assets.get(0);\n        $eventTitle = $rx.pageutils.html($assetItem,'displaytitle');\n        $eventDescription = $rx.pageutils.html($assetItem, 'body');\n        $eventSummary = $rx.pageutils.html($assetItem,'callout');\n        $eventLocation = $rx.pageutils.html($assetItem,'location');\n\n        $tmp = $assetItem.Node.getProperty('start_time').Date;\n        $ISODateFormat=\"yyyy-MM-dd hh:mm a\";\n        if (empty($tmp))\n        {\n            $eventStart = \"\";\n            $eventStartISO = \"\";\n        }\n        else\n        {\n            $eventStart = $tools.date.format($startDateTimeFormat,$tmp.Time);\n            $eventStartISO = $tools.date.format($ISODateFormat,$tmp.Time);\n        }\n\n        $tmp = $assetItem.Node.getProperty('end_time').Date;\n        if (empty($tmp))\n        {\n            $eventEnd = \"\";\n            $eventEndISO = \"\";\n        }\n        else\n        {\n            $eventEnd = $tools.date.format($endDateTimeFormat,$tmp.Time);\n            $eventEndISO = $tools.date.format($ISODateFormat,$tmp.Time);\n        }\n\n        $perc_hidefield_displaytitle = $perc.widget.item.properties.get('perc_hidefield_displaytitle');\n        $perc_hidefield_callout = $perc.widget.item.properties.get('perc_hidefield_callout');\n        $perc_hidefield_body = $perc.widget.item.properties.get('perc_hidefield_body');\n        $perc_hidefield_location = $perc.widget.item.properties.get('perc_hidefield_location');\n        $perc_hidefield_start_time = $perc.widget.item.properties.get('perc_hidefield_start_time');\n        $perc_hidefield_end_time = $perc.widget.item.properties.get('perc_hidefield_end_time');\n        $renderEmptyFields = $perc.widget.item.properties.get('renderEmptyFields');\n\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t$dsUrl = \"\";\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percEventContent",
+      "allowedContentTypes": [
+        "percEventAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconEvent.png",
+      "target": "rx_resources/widgets/event/images/widgetIconEvent.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/event/css/style.css",
+      "type": "css",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_hidefield_displaytitle",
+      "displayName": "Hide title field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_callout",
+      "displayName": "Hide summary field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_body",
+      "displayName": "Hide description field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_location",
+      "displayName": "Hide location field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_start_time",
+      "displayName": "Hide start date field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_end_time",
+      "displayName": "Hide end date field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "renderEmptyFields",
+      "displayName": "Render empty fields",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "startDateTimeFormat",
+      "displayName": "Format of start date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "M/d/yyyy hh:mm a",
+      "enumValues": []
+    },
+    {
+      "name": "endDateTimeFormat",
+      "displayName": "Format of end date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "M/d/yyyy hh:mm a",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/templates/percEventSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/templates/percEventSnippet.vm
@@ -1,0 +1,25 @@
+#if ($assetItem)
+   <div class="$!{rootclass} perc-event" data="$!{dynamicListData}">
+##  don't need to check for empty on title because it is required
+   #if(! $perc_hidefield_displaytitle)
+      <div class="perc-event-title" >$eventTitle</div>
+   #end
+   #if(!($perc_hidefield_callout || ($eventSummary == "" && ! $renderEmptyFields)))
+      <div class="summary">$eventSummary</div>
+   #end
+   #if(!($perc_hidefield_body || ($eventDescription == "" && ! $renderEmptyFields)))
+      <div class="description">$eventDescription</div>
+   #end
+   #if(!($perc_hidefield_location || ($eventLocation == "" && ! $renderEmptyFields)))
+      <div class="location">$eventLocation</div>
+   #end
+   #if(!($perc_hidefield_start_time || ($eventStart == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtstart" title="$eventStartISO">$eventStart</abbr></div>
+   #end
+   #if(!($perc_hidefield_end_time || ($eventEnd == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtend" title="$eventEndISO">$eventEnd</abbr></div>
+   #end
+   </div>
+#elseif ($perc.isEditMode())  ## if ($assetItem)
+   #createEmptyWidgetContent("event-sample-content", "This event widget is showing sample content.")
+#end

--- a/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/component-package.json
@@ -1,0 +1,1032 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percOpenGraph",
+  "name": "Facebook Open Graph",
+  "version": "1.1.6",
+  "description": "Adds Facebook Open Graph tags to a Page or Template.",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.2.5",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Facebook Open Graph",
+    "category": "social",
+    "description": "Adds Facebook Open Graph tags to a Page or Template.",
+    "thumbnail": "resources/open-graph-icon.png",
+    "icon": "resources/open-graph-icon.png",
+    "author": "Percussion Software, Inc.",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percOpenGraph",
+      "ref": "contentTypes/percOpenGraph"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percOpenGraphSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percOpenGraphSnippet.vm",
+      "contentType": "percOpenGraph",
+      "bindings": [
+        {
+          "variable": "percPageID",
+          "expression": "$perc.getPage().getId()"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "og_site_name",
+          "expression": "$perc.widget.item.properties.get('og_site_name')"
+        },
+        {
+          "variable": "og_type",
+          "expression": "$perc.widget.item.properties.get('og_type')"
+        },
+        {
+          "variable": "og_image",
+          "expression": "$perc.widget.item.properties.get('og_image')"
+        },
+        {
+          "variable": "og_image_width",
+          "expression": "$perc.widget.item.properties.get('og_image_width')"
+        },
+        {
+          "variable": "og_image_height",
+          "expression": "$perc.widget.item.properties.get('og_image_height')"
+        },
+        {
+          "variable": "og_locale",
+          "expression": "$perc.widget.item.properties.get('og_locale')"
+        },
+        {
+          "variable": "fb_app_id",
+          "expression": "$perc.widget.item.properties.get('fb_app_id')"
+        },
+        {
+          "variable": "summary",
+          "expression": "$sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String"
+        },
+        {
+          "variable": "summary",
+          "expression": "\"\""
+        },
+        {
+          "variable": "description",
+          "expression": "$perc.page.description"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "site_name_override",
+          "expression": "$assetItem.getNode().getProperty('site_name_override').String"
+        },
+        {
+          "variable": "title_override",
+          "expression": "$assetItem.getNode().getProperty('title_override').String"
+        },
+        {
+          "variable": "description_override",
+          "expression": "$assetItem.getNode().getProperty('description_override').String"
+        },
+        {
+          "variable": "image_override",
+          "expression": "$assetItem.getNode().getProperty('image_override').String"
+        },
+        {
+          "variable": "image_override_linkId",
+          "expression": "$assetItem.getNode().getProperty('image_override_linkId').String"
+        },
+        {
+          "variable": "image_width_override",
+          "expression": "$assetItem.getNode().getProperty('image_width_override').String"
+        },
+        {
+          "variable": "image_height_override",
+          "expression": "$assetItem.getNode().getProperty('image_height_override').String"
+        },
+        {
+          "variable": "url_override",
+          "expression": "$assetItem.getNode().getProperty('url_override').String"
+        },
+        {
+          "variable": "type_override",
+          "expression": "$assetItem.getNode().getProperty('type_override').String"
+        },
+        {
+          "variable": "locale_override",
+          "expression": "$assetItem.getNode().getProperty('locale_override').String"
+        },
+        {
+          "variable": "fb_app_id_override",
+          "expression": "$assetItem.getNode().getProperty('fb_app_id_override').String"
+        },
+        {
+          "variable": "use_site_name",
+          "expression": "$tools.esc.html($site_name_override)"
+        },
+        {
+          "variable": "use_site_name",
+          "expression": "$tools.esc.html($og_site_name)"
+        },
+        {
+          "variable": "meta_sitename",
+          "expression": "'<meta property=\"og:site_name\" content=\"' + $use_site_name + '\" />'"
+        },
+        {
+          "variable": "use_fb_app_id",
+          "expression": "$tools.esc.html($fb_app_id_override)"
+        },
+        {
+          "variable": "use_fb_app_id",
+          "expression": "$tools.esc.html($fb_app_id)"
+        },
+        {
+          "variable": "meta_fb_app_id",
+          "expression": "'<meta property=\"og:fb_app_id\" content=\"' + $use_fb_app_id + '\" />'"
+        },
+        {
+          "variable": "use_locale",
+          "expression": "$tools.esc.html($locale_override)"
+        },
+        {
+          "variable": "use_locale",
+          "expression": "$tools.esc.html($og_locale)"
+        },
+        {
+          "variable": "meta_locale",
+          "expression": "'<meta property=\"og:locale\" content=\"' + $use_locale + '\" />'"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($title_override)"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($perc.page.title)"
+        },
+        {
+          "variable": "meta_title",
+          "expression": "'<meta property=\"og:title\" content=\"' + $use_title + '\" />'"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($type_override)"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($og_type)"
+        },
+        {
+          "variable": "meta_type",
+          "expression": "'<meta property=\"og:type\" content=\"' + $use_type + '\" />'"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$tools.esc.html($url_override)"
+        },
+        {
+          "variable": "pagelink",
+          "expression": "$tools.esc.html($rx.pageutils.itemLink($perc.linkContext, $perc.page))"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$pagelink"
+        },
+        {
+          "variable": "doc",
+          "expression": "$sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary)"
+        },
+        {
+          "variable": "body",
+          "expression": "$doc.body()"
+        },
+        {
+          "variable": "summary_images",
+          "expression": "$body.getElementsByTag(\"img\")"
+        },
+        {
+          "variable": "summary_image",
+          "expression": "$summary_images.first()"
+        },
+        {
+          "variable": "image_summary",
+          "expression": "$summary_image.attr(\"src\")"
+        },
+        {
+          "variable": "image_alt",
+          "expression": "$summary_image.attr(\"alt\")"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "$doc.text()"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description_override)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$summary_text"
+        },
+        {
+          "variable": "use_description",
+          "expression": "\"\""
+        },
+        {
+          "variable": "meta_description",
+          "expression": "'<meta property=\"og:description\" content=\"' + $use_description + '\" />'"
+        },
+        {
+          "variable": "image_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $image_override_linkId)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$tools.esc.html($image_path)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$image_summary"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$og_image"
+        },
+        {
+          "variable": "use_image_height",
+          "expression": "$tools.esc.html($image_height_override)"
+        },
+        {
+          "variable": "use_image_height",
+          "expression": "$tools.esc.html($og_image_height)"
+        },
+        {
+          "variable": "meta_image_height",
+          "expression": "'<meta property=\"og:image:height\" content=\"' + $use_image_height + '\" />'"
+        },
+        {
+          "variable": "use_image_width",
+          "expression": "$tools.esc.html($image_width_override)"
+        },
+        {
+          "variable": "use_image_width",
+          "expression": "$tools.esc.html($og_image_width)"
+        },
+        {
+          "variable": "meta_image_width",
+          "expression": "'<meta property=\"og:image:width\" content=\"' + $use_image_width + '\" />'"
+        },
+        {
+          "variable": "baseURL",
+          "expression": "$perc.linkContext.getSite().getSiteProtocol() + \"://\""
+        },
+        {
+          "variable": "pubSiteName",
+          "expression": "$perc.linkContext.getSite().getName()"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$use_url.replace(\"/Sites/\",\"\")"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$use_url.substring(1)"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$baseURL + $pubSiteName + \"/\" + $use_url"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$baseURL + $use_url"
+        },
+        {
+          "variable": "meta_url",
+          "expression": "'<meta property=\"og:url\" content=\"' + $use_url + '\" />'"
+        },
+        {
+          "variable": "use_image",
+          "expression": "\"/\" + $use_image"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$baseURL + $pubSiteName + $use_image"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "'<meta property=\"og:image\" content=\"' + $use_image + '\" />'"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "nl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$percPageID = $perc.getPage().getId();\n\t   $pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n          if (empty($rootclass)) {\n            $rootclass = \"\";\n       }\n\t$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\t$perc.setWidgetContents($assetItems);\n\n   $og_site_name = $perc.widget.item.properties.get('og_site_name');\n   $og_type = $perc.widget.item.properties.get('og_type');\n   $og_image = $perc.widget.item.properties.get('og_image');\n   $og_image_width = $perc.widget.item.properties.get('og_image_width');\n   $og_image_height = $perc.widget.item.properties.get('og_image_height');\n   $og_locale = $perc.widget.item.properties.get('og_locale');\n   $fb_app_id = $perc.widget.item.properties.get('fb_app_id');\n\n    if($sys.assemblyItem.getNode().hasProperty(\"rx:page_summary\")){\n   \t\t$summary = $sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String;\n   \t}else{\n   \t\t$summary = \"\";\n   \t}\n   $description = $perc.page.description;\n   $summary_text = \"\";\n\n\t  if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n\t\tif(!empty($assetItem)){\n\t\t\t$site_name_override = $assetItem.getNode().getProperty('site_name_override').String;\n\t\t\t$title_override = $assetItem.getNode().getProperty('title_override').String;\n\t\t\t$description_override = $assetItem.getNode().getProperty('description_override').String;\n\t\t\t$image_override = $assetItem.getNode().getProperty('image_override').String;\n\t\t\t$image_override_linkId = $assetItem.getNode().getProperty('image_override_linkId').String;\n\t\t\t$image_width_override = $assetItem.getNode().getProperty('image_width_override').String;\n\t\t\t$image_height_override = $assetItem.getNode().getProperty('image_height_override').String;\n\t\t\t$url_override = $assetItem.getNode().getProperty('url_override').String;\n\t\t\t$type_override = $assetItem.getNode().getProperty('type_override').String;\n\t\t\t$locale_override = $assetItem.getNode().getProperty('locale_override').String;\n\t\t\t$fb_app_id_override = $assetItem.getNode().getProperty('fb_app_id_override').String;\n\n\t\t}\n\t}\n\n\tif(! empty($site_name_override)){\n\t\t$use_site_name = $tools.esc.html($site_name_override);\n\t}else{\n\t\t$use_site_name= $tools.esc.html($og_site_name);\n\t}\n    $meta_sitename='<meta property=\"og:site_name\" content=\"' + $use_site_name + '\" />';\n\n    if(! empty($fb_app_id_override)){\n\t\t$use_fb_app_id = $tools.esc.html($fb_app_id_override);\n\t}else{\n\t\t$use_fb_app_id = $tools.esc.html($fb_app_id);\n\t}\n\t$meta_fb_app_id='<meta property=\"og:fb_app_id\" content=\"' + $use_fb_app_id + '\" />';\n\n\tif(! empty($locale_override)){\n\t\t$use_locale = $tools.esc.html($locale_override);\n\t}else{\n\t\t$use_locale = $tools.esc.html($og_locale);\n\t}\n\t$meta_locale='<meta property=\"og:locale\" content=\"' + $use_locale + '\" />';\n\n\tif(! empty($title_override)){\n\t\t$use_title = $tools.esc.html($title_override);\n\t}else{\n\t\t$use_title = $tools.esc.html($perc.page.title);\n\t}\n\t$meta_title='<meta property=\"og:title\" content=\"' + $use_title + '\" />';\n\n\tif(! empty($type_override) && $type_override != 'none'){\n\t\t$use_type = $tools.esc.html($type_override);\n\t}else{\n\t\t$use_type = $tools.esc.html($og_type);\n\t}\n\n\t$meta_type='<meta property=\"og:type\" content=\"' + $use_type + '\" />';\n\n\tif(! empty($url_override)){\n\t\t$use_url = $tools.esc.html($url_override);\n\t}else{\n\t\t$pagelink = $tools.esc.html($rx.pageutils.itemLink($perc.linkContext, $perc.page));\n\t\t$use_url = $pagelink;\n\t}\n\n\tif(! empty($summary)){\n\n\t\t$doc = $sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary);\n\t\t$body = $doc.body();\n\t\t$summary_images = $body.getElementsByTag(\"img\");\n\t\tif($summary_images.size() > 0){\n\t\t\t$summary_image = $summary_images.first();\n\t\t$image_summary = $summary_image.attr(\"src\");\n\t\t$image_alt = $summary_image.attr(\"alt\");\n\t\t}\n\t\t$summary_text  = $doc.text();\n\t}\n\n\tif(! empty($description_override)){\n\t\t$use_description = $tools.esc.html($description_override);\n\t}else{\n\t    if(! empty($description)){\n\t\t\t$use_description = $tools.esc.html($description);\n\t\t}\n\t\telse{\n\t\t\tif(!empty($summary_text)){\n\t\t\t\t$use_description = $summary_text;\n\t\t\t}\n\t\t\telse{\n\t\t\t\t$use_description = \"\";\n\t\t\t}\n\t\t}\n\t}\n\t$meta_description='<meta property=\"og:description\" content=\"' + $use_description + '\" />';\n\tif(! empty($image_override) && ! empty($image_override_linkId )){\n\n   \t\t    $image_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $image_override_linkId);\n\t\t\t$use_image = $tools.esc.html($image_path);\n\t}else{\n\t\tif(! empty($image_summary)){\n\t\t\t$use_image = $image_summary;\n\t\t}else{\n\t\t\tif(! empty($og_image)){\n\t\t\t\t$use_image = $og_image;\n\t\t\t}\n\t\t}\n\t}\n\n\n\tif(! empty($image_height_override)){\n\t\t$use_image_height = $tools.esc.html($image_height_override);\n\t}else{\n\t    if(! empty($og_image_height)){\n\t\t\t$use_image_height = $tools.esc.html($og_image_height);\n\t\t}\n\t}\n\n\t$meta_image_height='<meta property=\"og:image:height\" content=\"' + $use_image_height + '\" />';\n\n\n\tif(! empty($image_width_override)){\n\t\t$use_image_width = $tools.esc.html($image_width_override);\n\t}else{\n\t    if(! empty($og_image_width)){\n\t\t\t$use_image_width = $tools.esc.html($og_image_width);\n\t\t}\n\n\t}\n\n\t$meta_image_width='<meta property=\"og:image:width\" content=\"' + $use_image_width + '\" />';\n\n\n\t$baseURL = $perc.linkContext.getSite().getSiteProtocol() + \"://\";\n\t$pubSiteName = $perc.linkContext.getSite().getName();\n\n\tif(! empty($use_url)){\n\t\tif(! $use_url.startsWith(\"http\")){\n\n\t\t\tif($use_url.startsWith(\"/Sites/\"))\n\t\t\t\t$use_url = $use_url.replace(\"/Sites/\",\"\");\n\n\t\t\tif($use_url.startsWith(\"/\"))\n\t\t\t\t$use_url = $use_url.substring(1);\n\n\t\t\tif(! $use_url.startsWith($pubSiteName)){\n\t\t\t\t$use_url = $baseURL + $pubSiteName + \"/\" + $use_url;\n\t\t\t}else{\n\t\t\t\t$use_url = $baseURL + $use_url;\n\t\t\t}\n\n\t\t}\n\t}\n\t$meta_url='<meta property=\"og:url\" content=\"' + $use_url + '\" />';\n\n\tif(! empty($use_image)){\n\t\tif(! $use_image.startsWith(\"http\")){\n\n\t\t\tif(! $use_image.startsWith(\"/\")){\n\t\t\t\t$use_image = \"/\" + $use_image;\n\t\t\t}\n\n\t\t\t$use_image = $baseURL + $pubSiteName + $use_image;\n\t\t}\n\t}\n\n\tif(!empty($use_image)){\n\t    $meta_image='<meta property=\"og:image\" content=\"' + $use_image + '\" />';\n\t}else{\n\t\t$meta_image=\"\";\n\t}\n\n\n\tif( empty($perc.page.getAdditionalHeadContent())){\n\t\t$perc.page.setAdditionalHeadContent(\"\");\n\t\t$addlHead = \"\";\n\t}else{\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t}\n\t$nl=\"\";\n\tif(!empty($use_site_name)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:site_name\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($addlHead + $meta_sitename);\n\t\t}\n\t}\n\n\tif(!empty($use_title)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:title\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_title));\n\t\t}\n\t}\n\n\tif(!empty($use_description)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:description\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_description));\n\t\t}\n\t}\n\tif(!empty($use_url)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:url\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_url));\n\t\t}\n\t}\n\n\tif(!empty($use_type)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:type\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_type));\n\t\t}\n\t}\n\n\tif(!empty($use_image)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:image\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image));\n\t\t}\n\t\tif(!empty($use_image_width)){\n\t\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t\tif (! $addlHead.contains(\"property=\\\"og:image:width\\\"\")) {\n\t\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image_width));\n\t\t\t}\n\t\t}\n\t\tif(!empty($use_image_height)){\n\t\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t\tif (! $addlHead.contains(\"property=\\\"og:image:height\\\"\")) {\n\t\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image_height));\n\t\t\t}\n\t\t}\n\t}\n\n\tif(!empty($use_locale)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:locale\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead, $meta_locale));\n\t\t}\n\t}\n\n\tif(!empty($use_fb_app_id)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:fb_app_id\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_fb_app_id));\n\t\t}\n\t}"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percOpenGraphContent",
+      "allowedContentTypes": [
+        "percOpenGraph"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/open-graph-icon.png",
+      "target": "rx_resources/widgets/percOpenGraph/images/open-graph-icon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "og_site_name",
+      "displayName": "Site Name",
+      "datatype": "string",
+      "required": true,
+      "enumValues": []
+    },
+    {
+      "name": "og_type",
+      "displayName": "Type",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "website",
+      "enumValues": [
+        {
+          "value": "article",
+          "displayValue": "Article"
+        },
+        {
+          "value": "books.author",
+          "displayValue": "Book Author"
+        },
+        {
+          "value": "books.book",
+          "displayValue": "Book"
+        },
+        {
+          "value": "books.genre",
+          "displayValue": "Book Genre"
+        },
+        {
+          "value": "business.business",
+          "displayValue": "Business"
+        },
+        {
+          "value": "fitness.course",
+          "displayValue": "Fitness Course"
+        },
+        {
+          "value": "game.achievement",
+          "displayValue": "Game Achievement"
+        },
+        {
+          "value": "music.album",
+          "displayValue": "Music Album"
+        },
+        {
+          "value": "music.playlist",
+          "displayValue": "Music Playlist"
+        },
+        {
+          "value": "music.radio_station",
+          "displayValue": "Music Radio Station"
+        },
+        {
+          "value": "music.song",
+          "displayValue": "Music Song"
+        },
+        {
+          "value": "place",
+          "displayValue": "Place"
+        },
+        {
+          "value": "product",
+          "displayValue": "Product"
+        },
+        {
+          "value": "product.group",
+          "displayValue": "Product Group"
+        },
+        {
+          "value": "product.item",
+          "displayValue": "Product Item"
+        },
+        {
+          "value": "profile",
+          "displayValue": "Profile"
+        },
+        {
+          "value": "restaurant.menu",
+          "displayValue": "Restaurant Menu"
+        },
+        {
+          "value": "restaurant.menu_item",
+          "displayValue": "Restaurant Menu Item"
+        },
+        {
+          "value": "restaurant.menu_section",
+          "displayValue": "Restaurant Menu Section"
+        },
+        {
+          "value": "restaurant.restaurant",
+          "displayValue": "Restaurant"
+        },
+        {
+          "value": "video.episode",
+          "displayValue": "Video - Television Show Episode"
+        },
+        {
+          "value": "video.movie",
+          "displayValue": "Video - Movie"
+        },
+        {
+          "value": "video.other",
+          "displayValue": "Video - General"
+        },
+        {
+          "value": "video.tv_show",
+          "displayValue": "Video - Television Show"
+        },
+        {
+          "value": "website",
+          "displayValue": "Website"
+        }
+      ]
+    },
+    {
+      "name": "og_image",
+      "displayName": "Image Asset (Path)",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "og_image_width",
+      "displayName": "Image Asset Width",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1200",
+      "enumValues": []
+    },
+    {
+      "name": "og_image_height",
+      "displayName": "Image Asset Height",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "630",
+      "enumValues": []
+    },
+    {
+      "name": "og_locale",
+      "displayName": "Locale",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "en_US",
+      "enumValues": [
+        {
+          "value": "sq_AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar_DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar_BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar_EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar_IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar_JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar_KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar_LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar_LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar_MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar_OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar_QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar_SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar_SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar_SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar_TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar_AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar_YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be_BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg_BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca_ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh_CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh_SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh_HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh_TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr_HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs_CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da_DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl_BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl_NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en_AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en_CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en_IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en_IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en_MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en_NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en_PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en_SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en_ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en_GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en_US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et_EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi_FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr_BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr_CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr_FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr_LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr_CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de_AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de_DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de_LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de_CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el_CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el_GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw_IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi_IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu_HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is_IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in_ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga_IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it_IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it_CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja_JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko_KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv_LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt_LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk_MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms_MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt_MT",
+          "displayValue": "Maltese (mt) Malta (MT)"
+        },
+        {
+          "value": "no_NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb_NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn_NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl_PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt_BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt_PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro_RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru_RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr_BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr_ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr_RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk_SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl_SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es_AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es_BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es_CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es_CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es_CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es_DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es_EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es_SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es_GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es_HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es_MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es_NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es_PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es_PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es_PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es_PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es_ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es_US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es_UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es_VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv_SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th_TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr_TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk_UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi_VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "fb_app_id",
+      "displayName": "Facebook App Id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/templates/percOpenGraphSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/templates/percOpenGraphSnippet.vm
@@ -1,0 +1,3 @@
+#if($perc.isEditMode())##
+<img src="/Rhythmyx/rx_resources/widgets/percOpenGraph/images/open-graph-placeholder-small.png" alt="Facebook Open Graph Tags" title="Facebook Open Graph Tags" />
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/component-package.json
@@ -1,0 +1,375 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percTwitterSummaryCards",
+  "name": "Twitter Summary Cards",
+  "version": "1.1.4",
+  "description": "Adds support for Twitter cards to the Page or Template.",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.2.5",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Twitter Summary Cards",
+    "category": "social",
+    "description": "Adds support for Twitter cards to the Page or Template.",
+    "thumbnail": "resources/twitter-card-icon.png",
+    "icon": "resources/twitter-card-icon.png",
+    "author": "Nate Chadwick",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTwitterCards",
+      "ref": "contentTypes/percTwitterCards"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTwitterSummaryCardsSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTwitterSummaryCardsSnippet.vm",
+      "contentType": "percTwitterCards",
+      "bindings": [
+        {
+          "variable": "percPageID",
+          "expression": "$perc.getPage().getId()"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "twittercard_type",
+          "expression": "$perc.widget.item.properties.get('twittercard_type')"
+        },
+        {
+          "variable": "twitter_site",
+          "expression": "$perc.widget.item.properties.get('twitter_site')"
+        },
+        {
+          "variable": "twitter_image",
+          "expression": "$perc.widget.item.properties.get('twitter_image')"
+        },
+        {
+          "variable": "twitter_image_alt",
+          "expression": "$perc.widget.item.properties.get('twitter_image_alt')"
+        },
+        {
+          "variable": "summary",
+          "expression": "$sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String"
+        },
+        {
+          "variable": "summary",
+          "expression": "\"\""
+        },
+        {
+          "variable": "description",
+          "expression": "$perc.page.description"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "twitter_site_override",
+          "expression": "$assetItem.getNode().getProperty('twitter_site_override').String"
+        },
+        {
+          "variable": "title_override",
+          "expression": "$assetItem.getNode().getProperty('title_override').String"
+        },
+        {
+          "variable": "description_override",
+          "expression": "$assetItem.getNode().getProperty('description_override').String"
+        },
+        {
+          "variable": "image_override",
+          "expression": "$assetItem.getNode().getProperty('image_override').String"
+        },
+        {
+          "variable": "image_override_linkId",
+          "expression": "$assetItem.getNode().getProperty('image_override_linkId').String"
+        },
+        {
+          "variable": "twitter_image_alt_override",
+          "expression": "$assetItem.getNode().getProperty('image_alt_override').String"
+        },
+        {
+          "variable": "use_twitter_site",
+          "expression": "$tools.esc.html($twitter_site_override)"
+        },
+        {
+          "variable": "use_twitter_site",
+          "expression": "$tools.esc.html($twitter_site)"
+        },
+        {
+          "variable": "meta_sitename",
+          "expression": "'<meta property=\"twitter:site\" content=\"' + $use_twitter_site + '\" />'"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($title_override)"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($perc.page.title)"
+        },
+        {
+          "variable": "meta_title",
+          "expression": "'<meta property=\"twitter:title\" content=\"' + $use_title + '\" />'"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($type_override)"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($twittercard_type)"
+        },
+        {
+          "variable": "doc",
+          "expression": "$sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary)"
+        },
+        {
+          "variable": "body",
+          "expression": "$doc.body()"
+        },
+        {
+          "variable": "summary_images",
+          "expression": "$body.getElementsByTag(\"img\")"
+        },
+        {
+          "variable": "summary_image",
+          "expression": "$summary_images.first()"
+        },
+        {
+          "variable": "twitter_image_summary",
+          "expression": "$summary_image.attr(\"src\")"
+        },
+        {
+          "variable": "twitter_image_alt",
+          "expression": "$summary_image.attr(\"alt\")"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "$doc.text()"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description_override)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$summary_text"
+        },
+        {
+          "variable": "use_description",
+          "expression": "\"\""
+        },
+        {
+          "variable": "meta_description",
+          "expression": "'<meta property=\"twitter:description\" content=\"' + $use_description + '\" />'"
+        },
+        {
+          "variable": "image_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext,$image_override_linkId)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$tools.esc.html($image_path)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$twitter_image_summary"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$twitter_image"
+        },
+        {
+          "variable": "use_type",
+          "expression": "\"summary\""
+        },
+        {
+          "variable": "meta_type",
+          "expression": "'<meta property=\"twitter:card\" content=\"' + $use_type + '\" />'"
+        },
+        {
+          "variable": "baseURL",
+          "expression": "$perc.linkContext.getSite().getSiteProtocol() + \"://\""
+        },
+        {
+          "variable": "pubSiteName",
+          "expression": "$perc.linkContext.getSite().getName()"
+        },
+        {
+          "variable": "use_image",
+          "expression": "\"/\" + $use_image"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$baseURL + $pubSiteName + $use_image"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "'<meta property=\"twitter:image\" content=\"' + $use_image + '\" />'"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "\"\""
+        },
+        {
+          "variable": "use_twitter_image_alt",
+          "expression": "\"\""
+        },
+        {
+          "variable": "use_twitter_image_alt",
+          "expression": "$tools.esc.html($twitter_image_alt_override)"
+        },
+        {
+          "variable": "use_twitter_image_alt",
+          "expression": "$tools.esc.html($twitter_image_alt)"
+        },
+        {
+          "variable": "meta_imagealt",
+          "expression": "'<meta property=\"twitter:image:alt\" content=\"' + $use_twitter_image_alt + '\" />'"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "nl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$percPageID = $perc.getPage().getId();\n\t   $pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n          if (empty($rootclass)) {\n            $rootclass = \"\";\n       }\n\t$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\t$perc.setWidgetContents($assetItems);\n\n\n   $twittercard_type = $perc.widget.item.properties.get('twittercard_type');\n   $twitter_site = $perc.widget.item.properties.get('twitter_site');\n   $twitter_image = $perc.widget.item.properties.get('twitter_image');\n   $twitter_image_alt = $perc.widget.item.properties.get('twitter_image_alt');\n   if($sys.assemblyItem.getNode().hasProperty(\"rx:page_summary\")){\n   \t\t$summary = $sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String;\n\t}else{\n\t\t$summary = \"\";\n\t}\n\n   $description = $perc.page.description;\n   $summary_text = \"\";\n\n\t  if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n\t\tif(!empty($assetItem)){\n\t\t\t$twitter_site_override = $assetItem.getNode().getProperty('twitter_site_override').String;\n\t\t\t$title_override = $assetItem.getNode().getProperty('title_override').String;\n\t\t\t$description_override = $assetItem.getNode().getProperty('description_override').String;\n\t\t\t$image_override = $assetItem.getNode().getProperty('image_override').String;\n\t\t\t$image_override_linkId = $assetItem.getNode().getProperty('image_override_linkId').String;\n\t\t\t$twitter_image_alt_override = $assetItem.getNode().getProperty('image_alt_override').String;\n\n\t\t}\n\t}\n\n\tif(! empty($twitter_site_override)){\n\t\t\t$use_twitter_site = $tools.esc.html($twitter_site_override);\n\t}else{\n\t\t$use_twitter_site= $tools.esc.html($twitter_site);\n\t}\n    $meta_sitename='<meta property=\"twitter:site\" content=\"' + $use_twitter_site + '\" />';\n\n\tif(! empty($title_override)){\n\t\t$use_title = $tools.esc.html($title_override);\n\t}else{\n\t\t$use_title = $tools.esc.html($perc.page.title);\n\t}\n\t$meta_title = '<meta property=\"twitter:title\" content=\"' + $use_title + '\" />';\n\n\tif(! empty($type_override)){\n\t\t$use_type = $tools.esc.html($type_override);\n\t}else{\n\t\t$use_type = $tools.esc.html($twittercard_type);\n\t}\n\n\tif(! empty($summary)){\n\t\t\t$doc = $sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary);\n\t\t\t$body = $doc.body();\n\t\t\t$summary_images = $body.getElementsByTag(\"img\");\n\t\t\tif($summary_images.size() > 0){\n\t\t\t\t$summary_image = $summary_images.first();\n\t\t\t$twitter_image_summary = $summary_image.attr(\"src\");\n\t\t\t$twitter_image_alt = $summary_image.attr(\"alt\");\n\t\t\t}\n\t\t\t$summary_text  = $doc.text();\n\t}\n\n\tif(! empty($description_override)){\n\t\t$use_description = $tools.esc.html($description_override);\n\t}else{\n\t\tif(! empty($description))\n\t\t\t$use_description = $tools.esc.html($description);\n\t\telse{\n\t\t\tif(!empty($summary_text)){\n\t\t\t\t$use_description = $summary_text;\n\t\t\t}\n\t\t\telse{\n\t\t\t\t$use_description = \"\";\n\t\t\t}\n\t\t}\n\t}\n\t$meta_description='<meta property=\"twitter:description\" content=\"' + $use_description + '\" />';\n\n\tif(! empty($image_override) && ! empty($image_override_linkId )){\n\n   \t\t    $image_path = $rx.pageutils.renderManagedItemPath($perc.linkContext,$image_override_linkId);\n\t\t\t$use_image = $tools.esc.html($image_path);\n\t}else{\n\t\tif(! empty($twitter_image_summary)){\n\t\t\t$use_image = $twitter_image_summary;\n\t\t}else{\n\t\t\t$use_image = $twitter_image;\n\t\t}\n\t}\n\n\tif(empty($use_image))\n\t\t$use_type=\"summary\";\n\n\t$meta_type='<meta property=\"twitter:card\" content=\"' + $use_type + '\" />';\n\n\t$baseURL = $perc.linkContext.getSite().getSiteProtocol() + \"://\";\n\t$pubSiteName = $perc.linkContext.getSite().getName();\n\n\tif(! empty($use_image)){\n\t\tif(! $use_image.startsWith(\"http\")){\n\n\t\t\tif( ! $use_image.startsWith(\"/\") )\n\t\t\t\t$use_image = \"/\" + $use_image;\n\n\t\t\tif( ! $use_image.startsWith(\"/Rhythmyx/\") ){\n\t\t\t\t$use_image = $baseURL + $pubSiteName + $use_image;\n\t\t\t}\n\t\t}\n\t}\n\tif(!empty($use_image)){\n\t$meta_image='<meta property=\"twitter:image\" content=\"' + $use_image + '\" />';\n\t}else{\n\t\t$meta_image=\"\";\n\t}\n\n\tif(empty($use_image)){\n\t\t$use_twitter_image_alt=\"\";\n\t}else{\n\t\tif(! empty($twitter_image_alt_override)){\n\t\t\t$use_twitter_image_alt = $tools.esc.html($twitter_image_alt_override);\n\t\t}else{\n\t\t\t$use_twitter_image_alt = $tools.esc.html($twitter_image_alt);\n\t\t}\n\t}\n    $meta_imagealt='<meta property=\"twitter:image:alt\" content=\"' + $use_twitter_image_alt + '\" />';\n\n\n\tif( empty($perc.page.getAdditionalHeadContent())){\n\t\t$perc.page.setAdditionalHeadContent(\"\");\n\t\t$addlHead = \"\";\n\t}else{\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t}\n\t$nl=\"\";\n\tif(!empty($use_type)){\n\t\t$perc.page.setAdditionalHeadContent($addlHead + $meta_type);\n\t}\n\n\tif(!empty($use_title)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_title));\n\t}\n\n\tif(!empty($use_description)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_description));\n\t}\n\n\tif(!empty($use_image)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image));\n\t}\n\tif(!empty($use_twitter_image_alt)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead, $meta_imagealt));\n\t}\n\t// Single twitter:site emission (v8.1.7 #838 removed a duplicate block; development was missing both).\n\tif(!empty($use_twitter_site)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead, $meta_sitename));\n\t}"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percTwitterSummaryCardsContent",
+      "allowedContentTypes": [
+        "percTwitterCards"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/twitter-card-icon.png",
+      "target": "rx_resources/widgets/percTwitterSummaryCards/images/twitter-card-icon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "twittercard_type",
+      "displayName": "Summary Card Type",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "summary_large_image",
+      "enumValues": [
+        {
+          "value": "summary_large_image",
+          "displayValue": "Summary Card Large Image"
+        },
+        {
+          "value": "summary",
+          "displayValue": "Summary Card"
+        }
+      ]
+    },
+    {
+      "name": "twitter_site",
+      "displayName": "@username",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "twitter_image",
+      "displayName": "Default Image Asset (Path)",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "twitter_image_alt",
+      "displayName": "Default Image Alt Text",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/templates/percTwitterSummaryCardsSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/templates/percTwitterSummaryCardsSnippet.vm
@@ -1,0 +1,3 @@
+#if($perc.isEditMode())##
+<img src="/Rhythmyx/rx_resources/widgets/percTwitterSummaryCards/images/twitter-card-placeholder-small.png" alt="Twitter Summary Cards Widget Placeholder" title="Twitter Summary Cards Widget" />
+#end##

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
@@ -229,6 +229,7 @@ class PSPageXmlNativeInstallTest {
 
     // GUID map keys are lower-cased (same as dual-ship); on-disk templateDef keeps product case.
     Map<String, String> guids = PSPageXmlDualShip.loadGuidsFromMapping(staging);
+    // GUID map keys are Locale.ROOT lowercase (mixed-case product ids).
     assertEquals("0-4-597", guids.get("perc.resp.banded"));
     assertEquals("0-4-599", guids.get("perc.resp.basic"));
     assertEquals("0-4-627", guids.get("perc.resp.plain"));

--- a/modules/perc-packages/src/test/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShimTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShimTest.java
@@ -115,6 +115,27 @@ class PSLegacyDefinitionXmlShimTest {
   }
 
   @Test
+  void selectForPackageRoot_prefersDualShipWidgetsDirOverLegacyXml() throws Exception {
+    Path pkg = tempDir.resolve("perc.baseWidgets");
+    Path modernWidget = pkg.resolve("widgets").resolve("percSimpleText");
+    Files.createDirectories(modernWidget);
+    Path manifest = modernWidget.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME);
+    Files.writeString(
+        manifest,
+        "{\"schemaVersion\":\"1.0\",\"id\":\"percSimpleText\",\"name\":\"Simple Text\",\"version\":\"1.0.0\"}",
+        StandardCharsets.UTF_8);
+
+    Path widgets = pkg.resolve("sys__UserDependency--rxconfig").resolve("Widgets");
+    Files.createDirectories(widgets);
+    Files.writeString(widgets.resolve("percSimpleText.xml"), "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s = PSLegacyDefinitionXmlShim.selectForPackageRoot(pkg);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, s.getKind());
+    assertEquals(manifest, s.getPrimaryPath().orElseThrow());
+    assertFalse(PSLegacyDefinitionXmlShim.wouldUseLegacyShim(pkg));
+  }
+
+  @Test
   void selectForPackageRoot_installRelativeWidgetsPath() throws Exception {
     Path pkg = tempDir.resolve("installStyle");
     Path widgets = pkg.resolve("rxconfig").resolve("Widgets");

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import com.percussion.packages.shim.PSDefinitionSourceKind;
+import com.percussion.packages.shim.PSDefinitionSourceSelection;
+import com.percussion.packages.shim.PSLegacyDefinitionXmlShim;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Dual-ship modern widget authoring tests (issue #2831 batch A / parent #2630).
+ *
+ * <p>Product packages keep install Widget XML under {@code
+ * sys__UserDependency--rxconfig/Widgets} while committing modern {@code widgets/&lt;stem&gt;/}
+ * roots. Selection prefers modern when both exist.
+ */
+class PSWidgetXmlDualShipTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void materializeModern_fromWidgetXml_writesComponentPackageAndTemplate() throws Exception {
+    Path packageDir = tempDir.resolve("demoPkg");
+    Path widgetsXml =
+        packageDir
+            .resolve("sys__UserDependency--rxconfig")
+            .resolve("Widgets");
+    Files.createDirectories(widgetsXml);
+
+    // Minimal valid-shaped simple text fixture if product package unavailable.
+    Path product = locatePackage("perc.baseWidgets");
+    if (product != null) {
+      Path src =
+          product
+              .resolve("sys__UserDependency--rxconfig")
+              .resolve("Widgets")
+              .resolve("percSimpleText.xml");
+      Files.copy(src, widgetsXml.resolve("percSimpleText.xml"), StandardCopyOption.REPLACE_EXISTING);
+      // Copy package props so context version matches product
+      Path props = product.resolve("psx_archiveInfo.xml");
+      if (Files.isRegularFile(props)) {
+        Files.copy(props, packageDir.resolve("psx_archiveInfo.xml"), StandardCopyOption.REPLACE_EXISTING);
+      }
+    } else {
+      Files.writeString(
+          widgetsXml.resolve("percSimpleText.xml"),
+          """
+          <Widget>
+            <Title>Simple Text</Title>
+            <Content type="velocity"><![CDATA[#loadRelatedWidgetContents()]]></Content>
+            <Code type="jexl"><![CDATA[$x = 1;]]></Code>
+            <contenttype_name>percSimpleTextAsset</contenttype_name>
+            <Category>content</Category>
+          </Widget>
+          """,
+          StandardCharsets.UTF_8);
+    }
+
+    int written = PSWidgetXmlDualShip.materializeModernWidgetSources(packageDir);
+    assertEquals(1, written);
+    assertTrue(PSWidgetXmlDualShip.hasModernWidgetSources(packageDir));
+
+    Path modernRoot =
+        packageDir.resolve(PSWidgetXmlDualShip.WIDGETS_DIR_NAME).resolve("percSimpleText");
+    assertTrue(
+        Files.isRegularFile(
+            modernRoot.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+
+    PSWidgetXmlCompileResult loaded = PSWidgetXmlDualShip.loadModernAsCompileResult(modernRoot);
+    PSComponentPackageManifestValidator.validate(loaded.getManifest());
+    assertEquals("percSimpleText", loaded.getManifest().getId());
+    assertFalse(loaded.getTextArtifacts().isEmpty());
+  }
+
+  @Test
+  void productBatchA_modernAuthoringRoots_presentAndParityWithXmlCompile() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping product batch A dual-ship test");
+      return;
+    }
+
+    Set<String> foundStems = new HashSet<>();
+    int packagesWithModern = 0;
+
+    for (String pkgName : PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS) {
+      Path product = packagesRoot.resolve(pkgName);
+      if (!Files.isDirectory(product)) {
+        System.err.println("WARN: missing package " + pkgName + "; soft-skip");
+        continue;
+      }
+
+      assertTrue(
+          PSWidgetXmlDualShip.hasModernWidgetSources(product),
+          pkgName + " must author modern widgets/ sources (#2831 batch A)");
+
+      // Dual-run: install Widget XML remains until native install path (do not mass-delete).
+      Path xmlDir = PSWidgetXmlPackageCompiler.resolveWidgetsDir(product);
+      assertTrue(Files.isDirectory(xmlDir), pkgName + " still dual-ships Widget XML for install");
+
+      List<PSWidgetXmlCompileResult> fromXml = PSWidgetXmlPackageCompiler.compilePackage(product);
+      List<PSWidgetXmlCompileResult> fromModern = PSWidgetXmlDualShip.compileModernWidgets(product);
+      assertEquals(
+          fromXml.size(),
+          fromModern.size(),
+          pkgName + " modern widget count must match Widget XML count");
+
+      Map<String, PSWidgetXmlCompileResult> xmlById =
+          fromXml.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+      Map<String, PSWidgetXmlCompileResult> modernById =
+          fromModern.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+      for (Map.Entry<String, PSWidgetXmlCompileResult> e : xmlById.entrySet()) {
+        String id = e.getKey();
+        assertTrue(modernById.containsKey(id), pkgName + " missing modern widget " + id);
+        PSComponentPackageManifest expected = e.getValue().getManifest();
+        PSComponentPackageManifest actual = modernById.get(id).getManifest();
+        // Reparse both so map/list equality is stable.
+        PSComponentPackageManifest expectedRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(expected));
+        PSComponentPackageManifest actualRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(actual));
+        assertEquals(expectedRound, actualRound, "modern manifest parity for " + id);
+
+        String templateKey =
+            expected.getTemplates().isEmpty()
+                ? null
+                : expected.getTemplates().get(0).getSourceRef();
+        if (templateKey != null) {
+          assertEquals(
+              normalizeNewlines(e.getValue().getTextArtifacts().get(templateKey)),
+              normalizeNewlines(modernById.get(id).getTextArtifacts().get(templateKey)),
+              "template parity for " + id);
+        }
+        foundStems.add(id);
+      }
+
+      // Shim: package root with modern widgets/ prefers modern over legacy XML.
+      PSDefinitionSourceSelection sel = PSLegacyDefinitionXmlShim.selectForPackageRoot(product);
+      assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, sel.getKind(), pkgName);
+      assertFalse(
+          PSLegacyDefinitionXmlShim.wouldUseLegacyShim(product),
+          pkgName + " dual-ship modern roots should win selection");
+
+      packagesWithModern++;
+    }
+
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS.size(),
+        packagesWithModern,
+        "all batch A packages should be present with modern roots");
+    assertEquals(
+        new HashSet<>(PSWidgetXmlDualShip.BATCH_A_WIDGET_STEMS),
+        foundStems,
+        "batch A must cover the 8 named widget stems");
+  }
+
+  @Test
+  void selectDefinition_prefersNestedWidgetsManifest() throws Exception {
+    Path pkg = tempDir.resolve("perc.baseWidgets");
+    Path modern =
+        pkg.resolve("widgets").resolve("percSimpleText");
+    Files.createDirectories(modern);
+    Path manifest = modern.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME);
+    Files.writeString(
+        manifest,
+        "{\"schemaVersion\":\"1.0\",\"id\":\"percSimpleText\",\"name\":\"Simple Text\",\"version\":\"1.0.0\"}",
+        StandardCharsets.UTF_8);
+
+    Path widgetsXml = pkg.resolve("sys__UserDependency--rxconfig").resolve("Widgets");
+    Files.createDirectories(widgetsXml);
+    Files.writeString(widgetsXml.resolve("percSimpleText.xml"), "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s =
+        PSLegacyDefinitionXmlShim.selectDefinition(
+            "percSimpleText",
+            List.of(pkg),
+            widgetsXml,
+            null,
+            null);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, s.getKind());
+    assertEquals(manifest, s.getPrimaryPath().orElseThrow());
+  }
+
+  @Test
+  void batchA_packageDirs_disjointFromTestAndSized() {
+    assertFalse(PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS.contains("perc.Test"));
+    assertEquals(5, PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS.size());
+    assertEquals(8, PSWidgetXmlDualShip.BATCH_A_WIDGET_STEMS.size());
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS,
+        PSWidgetXmlPackageCompiler.DUAL_SHIP_BATCH_A_PACKAGE_DIRS);
+  }
+
+  @Test
+  void resolvePackageRelative_rejectsDotDot() {
+    Path root = tempDir.resolve("root");
+    try {
+      PSWidgetXmlDualShip.resolvePackageRelative(root, "../escape");
+      throw new AssertionError("expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains(".."));
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  private static Path locatePackage(String packageDirName) {
+    Path packages = locatePackagesRoot();
+    if (packages == null) {
+      return null;
+    }
+    Path candidate = packages.resolve(packageDirName);
+    return Files.isDirectory(candidate) ? candidate : null;
+  }
+
+  private static Path locatePackagesRoot() {
+    Path candidate = Path.of("src", "main", "resources", "Packages");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src").resolve("main").resolve("resources").resolve("Packages");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}


### PR DESCRIPTION
## Summary
Dual-ship Widget XML **exit batch A** (#2831 / parent #2630): product packages for **baseWidgets + defaultLanguage + event/openGraph/twitter** now author modern `widgets/<stem>/component-package.json` + template sources (8 widgets / 5 packages). Install still dual-ships legacy `sys__UserDependency--rxconfig/Widgets/*.xml` (no mass-delete; shim/native widget install still residual).

- New `PSWidgetXmlDualShip` (materialize modern, batch A constants, load/compile modern)
- `PSLegacyDefinitionXmlShim` prefers `widgets/<stem>/component-package.json` over legacy XML
- Product modern roots committed for batch A
- Checklist: `docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md`
- Bonus suite fix: native page install mixed-case mapping lookup (`PSPageXmlNativeInstall`) so module clean install stays green

**Residual Widget XML count:** still **48** definition XMLs on disk (install path). Modern dual-ship authoring roots: **8**. Remaining product widgets without modern roots: **~40** (excl. counting nuance of perc.Test).

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2630 · Grandparent: #2626

Fixes #2831

## Test plan
1. `cd modules/perc-packages && ../../mvnw.cmd clean install` (standalone)
2. Confirm `PSWidgetXmlDualShipTest` product batch A parity + shim modern preference
3. Confirm package build still emits `.ppkg` for batch A packages (install XML retained)

## Build evidence (C3)
- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **104**, Failures: 0, Errors: 0
- **downstream_checked:** none (no public API final/signature blast; leaf package dual-ship + shim selection only)

## Product documentation
- [x] N/A — engineering dual-ship packaging / compiler path; no operator product-docs surface change (install wire format unchanged). Engineering checklist updated under `docs/ai-generated/tasks/template-assembler-normalization/`.

> Co-Authored by Grok Build using grok-4.5 with agent main.
