### PR TITLE
docs(#2834): XSL migration cookbook + Rhino JS extension note

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -23,6 +23,8 @@ One **Template** object model (page / snippet / global / binary / resource) + or
 | JavaScript extensions / UDFs | Rhino + `PSJavaScriptExtensionHandler` | Legacy extension handler `handler="JavaScript"` — leave alone this track |
 | WebUI / gadgets host | Browser JS | Client only |
 
+Short note (Phase 5): [rhino-js-extension-note.md](./rhino-js-extension-note.md). **Not** an assembler — do not use Rhino for XSL migration targets ([xsl-migration-cookbook.md](./xsl-migration-cookbook.md)).
+
 All **48** product widget definitions use `Code type=jexl` and `Content type=velocity` (see [widget-xml-inventory.md](./widget-xml-inventory.md)).
 
 ## Decision summary (approved)
@@ -49,6 +51,9 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | Doc | Purpose |
 |-----|---------|
 | [plan.md](./plan.md) | Full strategic plan (canonical) |
+| [implementer-guide.md](./implementer-guide.md) | Phase 5 single Assemblers & Templates implementer guide (#2833; when present) |
+| [xsl-migration-cookbook.md](./xsl-migration-cookbook.md) | Phase 5 XSL / `legacyAssembler` support statement + migration cookbook (#2834) |
+| [rhino-js-extension-note.md](./rhino-js-extension-note.md) | Phase 5 optional Rhino JS **extension** note — non-assembly (#2834) |
 | [component-package-manifest.md](./component-package-manifest.md) | Phase 3 ship-format manifest schema v1.0 + Java model |
 | [widget-xml-inventory.md](./widget-xml-inventory.md) | Product widget matrix (48 defs) |
 | [widget-xml-inventory.csv](./widget-xml-inventory.csv) | Machine-readable inventory |

--- a/docs/ai-generated/tasks/template-assembler-normalization/binding-modules.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/binding-modules.md
@@ -67,7 +67,7 @@ Normalization direction: keep `$perc` as a **documented context module**, not a 
 | Markdown content | `Java/global/percussion/assembly/markdownAssembler` |
 | Macros, loops, `#parse`, AA macros | `Java/global/percussion/assembly/velocityAssembler` |
 | CM1 page with regions | `pageAssembler` (today Velocity + `$perc`; thin context provider) |
-| XSL / XML app | `legacyAssembler` (support only) |
+| XSL / XML app | `legacyAssembler` (support only) — migrate via [xsl-migration-cookbook.md](./xsl-migration-cookbook.md) |
 
 ## Design SPA assembler picker (#2810)
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/parity-notes.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/parity-notes.md
@@ -63,4 +63,6 @@ CM1 templates carry `htmlHeader`, `cssRegion`, `additionalHeadContent`, protecte
 
 ## 7. Legacy XSL variants
 
-`legacyAssembler` proxies XML app + stylesheet. No JEXL bindings. Support-only; no new design investment. Migration cookbook later (outside forced 8.2 cut).
+`legacyAssembler` proxies XML app + stylesheet. No JEXL bindings. Support-only; no new design investment. **Not removed in 8.2.**
+
+**Cookbook (Phase 5 / #2834):** [xsl-migration-cookbook.md](./xsl-migration-cookbook.md) — 8.2 support statement, inventory surfaces, and incremental migration steps toward HTML-first / Velocity / Markdown. Optional non-assembly note: [rhino-js-extension-note.md](./rhino-js-extension-note.md).

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -383,10 +383,10 @@ Align with `design-templates-item-types` phases D0–D4:
 
 ### Phase 5 — Deprecation & cleanup (post-8.2 acceptable if product XML is already gone)
 
-1. Docs: single “Assemblers & Templates” guide; archive dual-model tutorials; Velocity as advanced track; HTML-first/Markdown for simple cases.
+1. Docs: single “Assemblers & Templates” guide; archive dual-model tutorials; Velocity as advanced track; HTML-first/Markdown for simple cases. *(#2833 implementer guide when present.)*
 2. Remove product shims when metrics show zero XML definition loads.
-3. XSL: support statement only; migration cookbook to Velocity/HTML/Markdown.
-4. Optional later (not this plan): revisit Rhino JS extension handler health independently of assembly.
+3. XSL: support statement only; migration cookbook to Velocity/HTML/Markdown. **Done (docs / #2834):** [xsl-migration-cookbook.md](./xsl-migration-cookbook.md) + [rhino-js-extension-note.md](./rhino-js-extension-note.md). No XSL runtime removal in 8.2.
+4. Optional later (not this plan): revisit Rhino JS extension handler health independently of assembly. (Short posture note: [rhino-js-extension-note.md](./rhino-js-extension-note.md).)
 
 ---
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/rhino-js-extension-note.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/rhino-js-extension-note.md
@@ -1,0 +1,57 @@
+# Rhino JavaScript extensions (non-assembly) — short note
+
+| Field | Value |
+|-------|--------|
+| **Status** | Informational — Phase 5 optional note (#2834) |
+| **Parent** | [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) · epic [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Audience** | Implementers who see Rhino on the classpath and wonder if templates should use JS |
+| **Related** | [ADR-001](./adr/001-jexl-bindings-stay.md), [README.md](./README.md) “Why Rhino is on the classpath”, [xsl-migration-cookbook.md](./xsl-migration-cookbook.md), [plan.md](./plan.md) §2.5 / §3.5 |
+
+## One-sentence rule
+
+**Rhino powers legacy JavaScript *extensions* / UDFs — it is not a template assembler and not a replacement for JEXL bindings or for XSL migration.**
+
+## Surfaces (do not conflate)
+
+| Surface | Mechanism | Assembly role? |
+|---------|-----------|----------------|
+| Template **bindings** | Commons JEXL 3 (`PSScript`, `PSTemplateBinding`) | **Yes** — assembly variables; **stay JEXL** (ADR-001) |
+| Text **assemblers** | Velocity / HTML-first / Markdown / `legacyAssembler` / specialized | **Yes** — render body |
+| **JavaScript extensions / UDFs** | Rhino + `PSJavaScriptExtensionHandler` (`handler="JavaScript"`) | **No** — classic extension exits, Workbench “JavaScript” category |
+| WebUI / gadgets host | Browser JS | **No** — client only |
+
+Code anchors:
+
+- `system/src/main/java/com/percussion/extension/PSJavaScriptExtensionHandler.java` — handler name `"JavaScript"`
+- Root / system POMs: `org.mozilla:rhino` dependency (classpath presence is **not** evidence that template bindings are JS)
+
+## 8.2 posture
+
+| Do | Do not |
+|----|--------|
+| Leave existing JavaScript extension exits alone if they still work | Use Rhino/JS as a **new assembler** language |
+| Prefer **JEXL** + `@IPSJexlMethod` / `$rx.*` tools for new assembly-side logic | Plan XSL → Rhino “because both are old scripting” |
+| Treat Rhino extension **health** (engine version, security, rewrites) as a **separate** workstream | Block template/assembler normalization on a Rhino rewrite |
+
+Plan text (unchanged intent): optional later revisit of Rhino JS extension handler health is **independent of assembly**; this track does **not** expand or replace Rhino for bindings.
+
+## When you are migrating off XSL
+
+Use the [XSL migration cookbook](./xsl-migration-cookbook.md):
+
+1. Target **HTML-first**, **Markdown**, or **Velocity** (+ JEXL bindings).
+2. Do **not** invent a “JavaScript assembler” on Rhino for product templates.
+3. If an old XSL path called a **JavaScript UDF exit**, that exit can remain as an extension while the **template body** moves to a modern assembler — migrate the UDF later only if the extension itself is unhealthy.
+
+## Out of scope for this note
+
+- Removing Rhino from the product classpath
+- Porting JavaScript extensions to GraalJS or pure Java
+- Changing the Design SPA assembler picker to include JavaScript
+- Any runtime code change
+
+## See also
+
+- [xsl-migration-cookbook.md](./xsl-migration-cookbook.md) — XSL / `legacyAssembler` support statement + migration steps
+- [implementer-guide.md](./implementer-guide.md) — Phase 5 Assemblers & Templates guide (when present)
+- [adr/001-jexl-bindings-stay.md](./adr/001-jexl-bindings-stay.md) — bindings stay JEXL

--- a/docs/ai-generated/tasks/template-assembler-normalization/xsl-migration-cookbook.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/xsl-migration-cookbook.md
@@ -1,0 +1,189 @@
+# XSL / legacyAssembler migration cookbook (8.2)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Active — Phase 5 docs (#2834) |
+| **Parent** | [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) Phase 5 · epic [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Audience** | Implementers / integrators leaving legacy XSL assembly |
+| **Related** | [ADR-002](./adr/002-assembler-set.md), [plan.md](./plan.md) §3.4 / §5 Phase 5, [parity-notes.md](./parity-notes.md) §7, [binding-modules.md](./binding-modules.md), [implementer-guide.md](./implementer-guide.md) (when present — #2833 / PR #2845) |
+
+## Purpose
+
+This cookbook helps sites that still assemble content through **`legacyAssembler`** (XML application + stylesheet / XSL path) move toward the **supported modern text assemblers** without waiting for a forced runtime removal.
+
+It does **not**:
+
+- Remove XSL / `legacyAssembler` from the product in this track
+- Provide mass automated content conversion
+- Replace template **bindings** with JavaScript (bindings stay **JEXL** — [ADR-001](./adr/001-jexl-bindings-stay.md))
+
+For Rhino **JavaScript extensions** (non-assembly UDFs), see the short companion note: [rhino-js-extension-note.md](./rhino-js-extension-note.md).
+
+---
+
+## 8.2 support statement
+
+| Posture | What it means in 8.2 |
+|---------|----------------------|
+| **Supported & recommended (new design)** | **Velocity** (power), **HTML-first** (`htmlAssembler`), **Markdown** (`markdownAssembler`), with ordered **JEXL** bindings |
+| **Supported legacy (existing installs)** | `legacyAssembler` + classic XML apps / stylesheets that already work; classic Workbench Active Assembly; pre-upgrade definition XML still loadable via dual-run shims until converted |
+| **No new investment** | New product packages, new Design SPA defaults, new help examples, or feature work that *requires* XSL / `legacyAssembler` |
+| **Not removed in 8.2** | `PSLegacyAssembler`, installer data paths that still register legacy variants, customer XSL that continues to assemble |
+
+**Product messaging (honest):**
+
+1. Existing XSL / `legacyAssembler` content **continues to run** in 8.2.
+2. **New** templates and product packaging should **not** choose XSL.
+3. There is **no hard “must convert XSL on upgrade” cliff** in 8.2; conversion is operator-driven and incremental.
+4. Long-term direction (ADR-002 / plan): XSL is **compatibility only**. Prefer HTML-first / Markdown for simple bodies; Velocity when macros, loops, or existing AA patterns are required.
+
+Specialized non-text assemblers (**Binary**, **Dispatch**, **Database**, **Resource**) are unchanged by this cookbook — they are purpose assemblers, not XSL languages.
+
+---
+
+## How legacy XSL assembly works (inventory surfaces)
+
+### Runtime seam
+
+| Piece | Role |
+|-------|------|
+| Extension / assembler id | `legacyAssembler` |
+| Implementation | `system/.../impl/plugin/PSLegacyAssembler.java` |
+| Behavior | Proxies an **internal request** to the template’s **assembly URL** (XML application resource path). Acts as a **marker** so the assembly service **skips JEXL binding processing** for that item. |
+| Template fields that matter | Assembler name = `legacyAssembler`; **assembly URL** points at the XML app resource; variant/template id forced into request params (`sys_variantid`, etc.) |
+
+Key implication for migration: **legacy assembly does not run ordered template bindings**. Any “logic” lives in the XML app / XSL / request parameters, not in modern `PSTemplateBinding` rows.
+
+### Surfaces to inventory on a site
+
+Use this checklist to find remaining XSL / legacy usage before planning cutover.
+
+| Surface | What to look for | Where / how |
+|---------|------------------|-------------|
+| **Assembly templates** | Assembler = `legacyAssembler` (or historic XSL variant names mapped to it) | Design SPA template list / Workbench template editor; REST `GET` templates; DB assembly template rows |
+| **Assembly URL** | Paths into classic XML applications (`…/sys_…`, app-specific resources) | Template property `assemblyUrl` / equivalent |
+| **XML applications** | Stylesheet resources, query/result pipes feeding XSL | `rxconfig` / installed app trees under the CMS install; Workbench Application Explorer |
+| **Publish / site variants** | Publish templates still on legacy assembler | Site publish templates, content type default variants |
+| **Slots / related content** | Snippets assembled via legacy variants inside AA slots | Slot allowed templates; preview assembly |
+| **Custom packages** | Customer or partner packages shipping XSL bodies | Deployed packages under `Packages` / custom install |
+| **Product baseline** | Prefer **not** to add new XSL; inventory is for **customer/custom** debt | Product widgets are already JEXL + Velocity (see [widget-xml-inventory.md](./widget-xml-inventory.md)) |
+
+### What product packages already look like
+
+All **48** product widget definitions use `Code type=jexl` and `Content type=velocity` ([widget-xml-inventory.md](./widget-xml-inventory.md)). Product page templates use `pageAssembler` → Velocity (`PSPageAssembler` extends `PSVelocityAssembler`). So **product out-of-box** is not an XSL migration problem; **customer and historic custom** templates are.
+
+---
+
+## Target assemblers (where to land)
+
+Pick a **text assembler** per template. Bindings remain **JEXL** in all cases except pure static HTML-first with zero dynamics.
+
+| Target | When to choose | Assembler id | Body model |
+|--------|----------------|--------------|------------|
+| **HTML-first** | Mostly static HTML; few dynamic values; no Velocity macros | `htmlAssembler` | HTML + `${dotted.path}` placeholders ([ADR-002](./adr/002-assembler-set.md)) |
+| **Markdown** | Content-oriented prose → HTML | `markdownAssembler` | CommonMark after JEXL bindings |
+| **Velocity** | Macros, loops, AA slot macros, existing Velocity snippets | `velocityAssembler` | Velocity 2.x + JEXL-bound `$vars` |
+| **Page context** | CM1 page/template with `$perc` / regions | `pageAssembler` today (thin context + Velocity; long-term “context + text assembler”) | Same as Velocity body with page bindings |
+
+**Do not** migrate XSL assembly into Rhino / `handler="JavaScript"` extensions. That path is **not** an assembler (see [rhino-js-extension-note.md](./rhino-js-extension-note.md)).
+
+Picker / module cheat sheet: [binding-modules.md](./binding-modules.md).
+
+---
+
+## Migration steps (per template or small batch)
+
+Work **one template (or one content type’s variants)** at a time. Golden HTML diffs beat big-bang cutovers.
+
+### 1. Inventory and freeze
+
+1. List templates with assembler `legacyAssembler` (or XSL-era variants).
+2. Record for each: content types using it, sites/publish contexts, assembly URL, MIME type, AA type, dependencies on request params.
+3. Capture **golden outputs**: preview + publish HTML (or binary) for representative items (draft + public if filters differ).
+4. Note any XML app resources **shared** by multiple templates (shared stylesheets complicate per-template cutover).
+
+### 2. Classify complexity
+
+| Class | Symptoms | Recommended target |
+|-------|----------|--------------------|
+| **A — Static shell** | XSL mostly emits fixed markup + a few field values | HTML-first + JEXL bindings + `${path}` |
+| **B — Light transform** | Field maps, simple conditionals, string formatting | HTML-first or Markdown; put conditionals in **JEXL bindings** |
+| **C — Structural / iterative** | Loops over nodes, complex grouping, slot-like expansion in XSL | Velocity (or restructure as modern slots + snippet templates) |
+| **D — Full XML app pipeline** | Multi-resource apps, queries, non-HTML mime, deep request param contracts | Keep on `legacyAssembler` until the **pipeline** is redesigned; do not “paste XSL into Velocity” |
+
+### 3. Rebuild the modern template
+
+1. Create a **new** assembly template (keep the legacy template until parity is signed off).
+2. Set assembler to `htmlAssembler`, `markdownAssembler`, `velocityAssembler`, or `pageAssembler` as classified.
+3. **Port data access to JEXL bindings** (ordered list), not XSL `select`/`value-of` only:
+   - Item fields, `$sys.*`, `$rx.*` tools, related content helpers as documented in [binding-modules.md](./binding-modules.md).
+   - Remember: modern path **runs** bindings; legacy path **skipped** them.
+4. Port markup:
+   - Class A/B → HTML-first body with `${bindingKey}` / `${sys…}` only (no bare `$title`, no Mustache, no Velocity directives in HTML-first).
+   - Class C → Velocity body; prefer small macros over one giant stylesheet.
+5. Wire the same (or intentional) MIME / charset / AA type / sites as the legacy template.
+
+### 4. Dual-run parity
+
+1. Point a **non-production** content type variant or site publish template at the new template first.
+2. Diff golden HTML (normalize whitespace / line endings).
+3. Exercise: edit mode vs publish, filters/auth types, empty fields, multi-valued fields, related content in slots.
+4. Only then switch default variants / publish templates in production.
+
+### 5. Retire the legacy path (local site policy)
+
+1. Unlink content types / publish configs from the legacy template.
+2. Archive or document the old assembly URL + stylesheet for rollback.
+3. Leave `legacyAssembler` registered on the server — **site-level** retirement does not require product runtime removal.
+4. Optionally track “zero remaining legacy templates on this install” as an operator metric; product-wide XSL removal remains a later residual (not this doc).
+
+### 6. Packaging (when applicable)
+
+If the template ships in a package, follow the modern **component package** model ([component-package-manifest.md](./component-package-manifest.md), ADR-004): content type + template(s) + slots + catalog — **not** new Page/Widget/Gadget definition XML, and **not** new XSL app packaging for greenfield work.
+
+---
+
+## Mapping cheat sheet (XSL ideas → modern)
+
+| Legacy XSL / app idea | Modern approach |
+|----------------------|-----------------|
+| Stylesheet field copy `value-of` | JEXL binding → `${field}` (HTML-first) or `$field` (Velocity) |
+| `xsl:if` / choose | JEXL binding computing a flag or preformatted fragment; or Velocity `#if` |
+| `xsl:for-each` over children | Velocity `#foreach`; or model as **slot** + related items + snippet templates |
+| Call another XML resource | Snippet template include / slot expansion / internal link helpers — not a second XSL app when avoidable |
+| Request parameters as control surface | Prefer bindings + template config; document any remaining HTML params |
+| “No bindings” mental model | **Invert**: move pure presentation to body; move data shaping to **ordered JEXL** |
+| Binary or non-HTML pipeline | Specialized assembler or keep legacy until redesigned |
+
+---
+
+## Explicit non-goals (this cookbook)
+
+- Deleting `PSLegacyAssembler` or unregistering `legacyAssembler`
+- Mass-conversion scripts or overnight bulk rewrites of customer XSL
+- Migrating **JEXL bindings** to GraalJS / Rhino / dual language columns
+- Forcing conversion during 8.2 upgrade
+- Treating gadgets as assembly templates (gadgets are not XSL assembly — see [gadget-definition-inventory.md](./gadget-definition-inventory.md))
+
+---
+
+## Related Phase 5 docs
+
+| Doc | Role |
+|-----|------|
+| [implementer-guide.md](./implementer-guide.md) | Single Assemblers & Templates implementer guide (#2833) — link when landed |
+| [rhino-js-extension-note.md](./rhino-js-extension-note.md) | Optional Rhino JS **extension** note (not an assembler) |
+| [plan.md](./plan.md) | Strategic plan; Phase 5 item “XSL support statement + cookbook” |
+| [parity-notes.md](./parity-notes.md) §7 | One-line legacy XSL parity note |
+| [adr/002-assembler-set.md](./adr/002-assembler-set.md) | Assembler set decision |
+
+---
+
+## Acceptance (issue #2834)
+
+- [x] Cookbook committed under this task folder
+- [x] Explicit 8.2 support statement
+- [x] Migration steps toward HTML-first / Velocity / Markdown per ADR-002
+- [x] Cross-linked from task [README.md](./README.md); reciprocal link to Phase 5 implementer guide path
+- [x] Companion Rhino note (non-assembly)
+- [x] Docs-only — no XSL runtime removal


### PR DESCRIPTION
## Summary

Phase 5 slice 2 of **#2632** (epic **#2626**): ship the **XSL / legacyAssembler migration cookbook** plus a short optional **Rhino JavaScript extension** note (non-assembly).

- New: `docs/ai-generated/tasks/template-assembler-normalization/xsl-migration-cookbook.md`
  - Explicit **8.2 support statement** (supported legacy; no new investment; not removed)
  - Inventory surfaces for site-level XSL usage
  - Complexity classification (A–D) and targets (HTML-first / Markdown / Velocity / pageAssembler)
  - Incremental dual-run migration steps + XSL→modern mapping cheat sheet
  - Explicit non-goals (no runtime removal, no mass conversion, bindings stay JEXL)
- New: `docs/ai-generated/tasks/template-assembler-normalization/rhino-js-extension-note.md`
  - Rhino is for `handler="JavaScript"` extensions/UDFs only — **not** a template assembler
- Cross-links: task `README.md`, `plan.md` Phase 5, `parity-notes.md` §7, `binding-modules.md`
- Sibling to implementer guide **#2833** / PR **#2845** (relative link to `implementer-guide.md` when present)
- Docs-only; **no** XSL runtime removal

**Operator:** Grok: night-issue-prs (model grok-4.5)

**Parent tracker:** #2632 · Grandparent: #2626 · Sibling: #2833

## Test plan

- [x] Relative links from cookbook/Rhino note resolve within the task folder (ADRs, plan, parity, bindings, inventories)
- [x] Task README lists cookbook + Rhino note
- [x] plan Phase 5 item 3 points at cookbook
- [x] No Maven modules changed (docs-only under `docs/ai-generated/`)
- [ ] Optional human skim for accuracy vs ADR-002 / plan §3.4

## Build evidence (C3)

| Field | Value |
|-------|--------|
| **modules_built** | none (docs-only under `docs/ai-generated/`) |
| **build_evidence** | N/A — no `pom.xml` / sources / tests changed; Pre-PR Maven clean install not required for docs-only |
| **downstream_checked** | none (C2 N/A — no API/type shape changes) |

## Product documentation

- [x] **N/A** — engineering cookbook under `docs/ai-generated/`; not a customer-facing product-docs surface. Product help rewrite remains a later Phase 5 item when product help maps are rewritten.

## Fixes

Fixes #2834  
Refs #2632 #2626 #2833

> Co-Authored by Grok Build using grok-4.5 with agent main.
