### PR TITLE
docs(#2835): definition-XML shim removal criteria + inventory

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/README.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/README.md
@@ -60,6 +60,7 @@ All **48** product widget definitions use `Code type=jexl` and `Content type=vel
 | [page-definition-inventory.md](./page-definition-inventory.md) | Product page `*.templateDef` inventory + compiler (#2770) |
 | [gadget-definition-inventory.md](./gadget-definition-inventory.md) | Gadget XML / SPA survey |
 | [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) | Phase 3 dual-run operator policy + runtime shim selection (#2752) |
+| [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) | Phase 5 shim removal metrics, gates, time-box + inventory (#2835 / #2632) |
 | [adr/](./adr/) | Architecture decision records |
 | [parity-notes.md](./parity-notes.md) | Region vs slot, pageAssembler vs velocity, etc. |
 | [region-slot-mapping.md](./region-slot-mapping.md) | Phase 2 residual: region↔slot composition + CssPref upgrade (#2690) |

--- a/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/adr/004-no-definition-xml-packaging.md
@@ -35,7 +35,7 @@ Content types + Templates (assembler + JEXL bindings + source)
 - Compiler/upgrade tooling is mandatory before deleting package XML.
 - Widget Builder / Design tools write modern format only.
 - Package install/export paths must understand the new manifest shape (prefer extending existing package system).
-- **Dual-run runtime shim (time-boxed):** selection prefers modern `component-package.json`, falls back to legacy Widget/Page/Gadget definition XML when modern is absent, and fails clearly when neither exists. Implementation: `com.percussion.packages.shim.PSLegacyDefinitionXmlShim` (#2752). Operator policy, entry points, and exit criteria: [dual-run-legacy-definition-xml-shim.md](../dual-run-legacy-definition-xml-shim.md). Product packages must not depend on the shim long-term; Phase 5 (#2632) removes it when metrics allow.
+- **Dual-run runtime shim (time-boxed):** selection prefers modern `component-package.json`, falls back to legacy Widget/Page/Gadget definition XML when modern is absent, and fails clearly when neither exists. Implementation: `com.percussion.packages.shim.PSLegacyDefinitionXmlShim` (#2752). Operator policy / entry points: [dual-run-legacy-definition-xml-shim.md](../dual-run-legacy-definition-xml-shim.md). **Removal metrics, test gates, time-box, inventory:** [definition-xml-shim-removal-criteria.md](../definition-xml-shim-removal-criteria.md) (#2835 / Phase 5 #2632). Product packages must not depend on the shim long-term; remove only when those criteria are met with evidence — no unattended mass-delete.
 
 ## Component Package Manifest (schema v1.0)
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
@@ -1,0 +1,201 @@
+# Definition-XML shim removal criteria (Phase 5)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Criteria **not met** (snapshot 2026-08-10) — shim **must remain** |
+| **Issue** | [#2835](https://github.com/intersoftdatalabs-in/percussioncms/issues/2835) (slice 3 of [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632)) |
+| **Parent** | [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) Phase 5 · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Depends on** | Phase 3 [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) product off definition XML; dual-run policy [#2752](https://github.com/intersoftdatalabs-in/percussioncms/issues/2752) |
+| **Policy / selection** | [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) |
+| **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
+| **Code (selection API)** | `com.percussion.packages.shim.PSLegacyDefinitionXmlShim` (`modules/perc-packages`) |
+
+## Purpose
+
+This document is the **hard gate** for deleting or hard-disabling the legacy definition-XML dual-run path. It expands the high-level exit checklist in the dual-run operator doc into:
+
+1. **Metrics** (what to measure and pass thresholds)
+2. **Test / CI gates** (what must be green before code deletion)
+3. **Time-box** (when removal work is allowed to start)
+4. **Inventory** (grep snapshot of dual-run surfaces as of this slice)
+
+**Hard ban:** unattended mass deletion of the customer-facing shim without evidence that every criterion below is met. Thin removal is allowed **only** for paths proven dead with tests (none found in this snapshot).
+
+## Decision (this slice)
+
+| Question | Answer (2026-08-10) |
+|----------|---------------------|
+| Are removal criteria met? | **No** |
+| May agents delete `PSLegacyDefinitionXmlShim` / related dual-run loaders now? | **No** — leave shim |
+| Thin proven-dead removal in this PR? | **None** — no dead production path safe to drop |
+| Residual? | File residual for **shim removal when metrics allow** (see Residual work) |
+
+---
+
+## 1. Metrics (must all pass)
+
+### M1 — Zero product package definition-XML as ship format
+
+| Metric | Pass condition | How to measure |
+|--------|----------------|----------------|
+| Product Widget definition XML in repo | **0** files under `modules/perc-packages/src/main/resources/Packages/**/sys__UserDependency--rxconfig/Widgets/*.xml` (except explicitly waived test packages such as `perc.Test`) | `Get-ChildItem -Recurse` / CI inventory job against Packages tree |
+| Product Page meta definition XML | **0** product-authored `rxconfig/Pages/*.xml` (or package staging equivalent) as package source of truth | Same inventory; see [page-definition-inventory.md](./page-definition-inventory.md) |
+| Product Gadget definition XML | **0** product per-gadget OpenSocial-style definition XML required at runtime | [gadget-definition-inventory.md](./gadget-definition-inventory.md) |
+| ADR-004 ship bar | Product packages author **only** modern `component-package.json` (+ CT / template / slot / catalog artifacts) | Package tree review + package-compile CI |
+
+**Snapshot 2026-08-10:** **FAIL M1** — **48** Widget definition XML files still under `Packages/**/sys__UserDependency--rxconfig/Widgets/` across **39** product package trees; modern `component-package.json` present primarily under page layout packages (`perc.baseTemplates`, `perc.responsiveTemplates`, `perc.Baseline` pages) — **30** manifests total, not a full widget replacement set.
+
+### M2 — Zero (or waived) runtime legacy definition-XML loads
+
+| Metric | Pass condition | How to measure |
+|--------|----------------|----------------|
+| Legacy selection rate | `wouldUseLegacyShim(packageRoot) == false` for all product package roots in install/staging | Unit / integration probe using `PSLegacyDefinitionXmlShim.wouldUseLegacyShim` |
+| Runtime selection kind | No production log/metric for `LEGACY_WIDGET_XML` / `LEGACY_PAGE_XML` / `LEGACY_GADGET_XML` over agreed window (see time-box), **or** remaining hits are **explicitly waived** with owner + sunset date | Log field or counter on selection kind when DAO wiring is complete |
+| Widget DAO path | Production widget load no longer depends solely on `${rxdeploydir}/rxconfig/Widgets/*.xml` for product widgets | Code + install smoke |
+| Gadget registry dual-load | WebUI `GadgetRegistry` last load source is modern catalog in product installs (legacy XML only for waived customer cases) | `GadgetRegistry.getLastLoadSource()` / tests |
+
+**Snapshot 2026-08-10:** **FAIL M2** — selection API exists and is unit-tested, but **no production caller** outside `modules/perc-packages` shim package + javadoc cross-refs wires `PSLegacyDefinitionXmlShim` into live load paths. `PSWidgetDao` still binds `@Value("${rxdeploydir}/rxconfig/Widgets")`. `GadgetRegistry` dual-load (modern catalog preferred, legacy `GadgetRegistry.xml` fallback) is still active.
+
+### M3 — Customer upgrade window closed (or accepted residual)
+
+| Metric | Pass condition | How to measure |
+|--------|----------------|----------------|
+| Conversion tooling | Widget / Page / Gadget compilers documented and available for customer XML → modern package | [widget-xml-inventory.md](./widget-xml-inventory.md), [component-package-manifest.md](./component-package-manifest.md) |
+| Support inventory | Support / field inventory shows no **required** customer dependence on definition XML, **or** residual customers are listed with waiver + migration plan | Support ticket sample or customer list (operator process; not committed secrets) |
+| Upgrade docs | Operators have a documented convert → deploy modern → remove XML path | Dual-run checklist in [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) + product-docs when operator-facing steps freeze |
+
+**Snapshot 2026-08-10:** **FAIL M3** — compilers and dual-run operator checklist exist; customer upgrade window is **still open** by design for 8.2 dual-run. No production metric stream yet to prove “zero loads.”
+
+---
+
+## 2. Test / CI gates (must all pass before deletion PR)
+
+| Gate | Requirement |
+|------|-------------|
+| **G1** | `modules/perc-packages` standalone `mvnw clean install` green after removal (or modern-only replacement) |
+| **G2** | Behavioral tests prove modern-only selection: modern present → modern; **neither** → clear `PSDefinitionSourceNotFoundException` (no silent invent) |
+| **G3** | No remaining production references to deleted APIs (`PSLegacyDefinitionXmlShim` legacy kinds, dual-load fallbacks) except upgrade-input **compilers** (XML as input only is OK) |
+| **G4** | Product package inventory job (or scripted assertion) fails CI if new definition XML reappears under Packages Widgets/Pages/Gadgets ship paths |
+| **G5** | Reverse-dep / known runtime consumers still green: at minimum `projects/sitemanage` widget load tests and WebUI `GadgetRegistry` tests if those surfaces change |
+| **G6** | Cross-platform: no Unix-only path assumptions in any replacement load path (`Path` / `Files` only) |
+
+**Snapshot 2026-08-10:** G2 partially satisfied for the **selection API** (`PSLegacyDefinitionXmlShimTest`). G1/G3–G6 for **deletion** are N/A until M1–M3 pass.
+
+---
+
+## 3. Time-box
+
+| Phase | Window | Allowed work |
+|-------|--------|--------------|
+| **Dual-run (now)** | Through Phase 3 product conversion + customer upgrade window | Ship modern preferred; keep legacy fallback; **no** mass shim delete |
+| **Criteria lock** | This doc (#2835) | Metrics + inventory + residual filed; re-evaluate when M1–M3 evidence exists |
+| **Removal PR** | Only after M1–M3 + G1–G6 | Thin, reviewed deletion of proven-dead dual-run code + tests; update help |
+| **Post-removal** | Next minor after removal merges | Treat reintroduction of product definition XML as regression (G4) |
+
+**Rules for agents / humans:**
+
+1. Do **not** open a “delete all shim” PR because Phase 5 is open.
+2. Do **not** remove customer-facing fallback until M2 has evidence (logs/metrics or waived residual list).
+3. Compilers may keep reading definition XML as **upgrade input** forever if useful — that is **not** the runtime dual-run shim.
+4. Page **dual-ship** (`PSPageXmlDualShip`) is a related but separate package-build bridge — see [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md). Do not conflate dual-ship retirement with runtime shim removal.
+
+---
+
+## 4. Inventory snapshot (grep / tree) — 2026-08-10
+
+### 4.1 Selection API package (`modules/perc-packages`)
+
+| Type / file | Role | Dual-run? |
+|-------------|------|-----------|
+| `…/shim/PSLegacyDefinitionXmlShim.java` | Modern-preferred selection (`selectByPresence`, `selectForPackageRoot`, `selectDefinition`, `wouldUseLegacyShim`) | **Yes** — canonical policy |
+| `…/shim/PSDefinitionSourceKind.java` | `MODERN_COMPONENT_PACKAGE`, `LEGACY_WIDGET_XML`, `LEGACY_PAGE_XML`, `LEGACY_GADGET_XML` | Yes |
+| `…/shim/PSDefinitionSourceSelection.java` | Selection result + `isLegacyXml()` | Yes |
+| `…/shim/PSDefinitionSourceNotFoundException.java` | Neither modern nor legacy | Yes |
+| `…/shim/PSLegacyDefinitionXmlShimTest.java` | Unit coverage for selection | Test only |
+
+**Production callers of `PSLegacyDefinitionXmlShim` (excluding self + tests):** **none**.  
+Javadoc-only alignment references:
+
+- `com.percussion.packages.pagexml.PSPageXmlInstallPolicy`
+- `com.percussion.packages.pagexml.PSPageXmlNativeInstall`
+
+### 4.2 Related dual-run / dual-ship surfaces (not all deletable with the shim)
+
+| Surface | Path / class | Status in snapshot | Removal coupled to shim? |
+|---------|--------------|--------------------|---------------------------|
+| Widget install load | `projects/sitemanage/.../dao/impl/PSWidgetDao` → `${rxdeploydir}/rxconfig/Widgets` | **Live** legacy XML directory load | **Yes** for product modern-only; must rewire before shim delete |
+| Product Widget package XML | `modules/perc-packages/.../Packages/**/sys__UserDependency--rxconfig/Widgets/*.xml` | **48** files / **39** package trees still present | Product XML deletion is Phase 3 residual / Phase 5 M1 — **not** this criteria-only PR |
+| Widget XML compilers | `…/widgetxml/PSWidgetXml*` | Upgrade-input compilers; keep after runtime shim exit | **No** (upgrade input OK) |
+| Page dual-ship / native | `…/pagexml/PSPageXmlDualShip`, `PSPageXmlNativeInstall`, `PSPageXmlInstallPolicy` | Native for base/responsive; dual-ship default elsewhere | Separate checklist ([dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md)) |
+| Gadget catalog ship | `modules/perc-packages/.../catalogs/gadgets/gadget-catalog.json` | Modern catalog present | Preferred path |
+| Gadget WebUI dual-load | `WebUI/.../GadgetRegistry.java` (modern catalog → legacy `GadgetRegistry.xml`) | **Live** dual-load | Related dual-run; own residual or same removal epic when M2 covers gadgets |
+| Gadget registry compiler | `…/gadgetxml/PSGadgetRegistry*` | Upgrade-input / build | Keep as compiler |
+| Component package manifest | `…/manifest/PSComponentPackageManifest*` | Modern ship format | Keep |
+
+### 4.3 Grep recipes (re-run before any removal PR)
+
+From repo root (PowerShell-friendly; adjust path tools as needed):
+
+```text
+# Selection API + kinds
+rg -n "PSLegacyDefinitionXmlShim|PSDefinitionSourceKind|wouldUseLegacyShim|LEGACY_WIDGET_XML|LEGACY_PAGE_XML|LEGACY_GADGET_XML" --glob "*.java"
+
+# Widget XML install surface
+rg -n "rxconfig/Widgets|rxconfig\\\\Widgets" --glob "*.java"
+
+# Gadget dual-load
+rg -n "LEGACY_REGISTRY_XML|gadget-catalog.json|GadgetRegistry.xml" --glob "*.{java,ts,tsx}"
+
+# Product package Widget XML residual count
+# (PowerShell) Get-ChildItem modules\perc-packages\src\main\resources\Packages -Recurse -Filter *.xml |
+#   Where-Object FullName -match 'sys__UserDependency--rxconfig\\Widgets'
+```
+
+### 4.4 Proven-dead thin removal?
+
+| Candidate | Dead? | Action this slice |
+|-----------|-------|-------------------|
+| Entire `PSLegacyDefinitionXmlShim` package | **No** — policy + tests; future wiring target | Keep |
+| `PSWidgetDao` Widgets path | **No** — production load path | Keep |
+| `GadgetRegistry` legacy fallback | **No** — dual-load still required until product dual-load residual closes | Keep |
+| Page dual-ship default for non-native packages | **No** — still default for non-opted packages | Keep (separate doc) |
+
+**Conclusion:** no thin proven-dead removal in #2835.
+
+---
+
+## 5. Checklist for a future removal PR
+
+Copy into the residual issue / PR when M1–M3 evidence exists:
+
+- [ ] M1 product definition XML count = 0 (or waived list attached)
+- [ ] M2 runtime legacy load metrics / support inventory = zero or waived
+- [ ] M3 customer upgrade window closed or residual customers documented
+- [ ] G1–G6 test/CI gates green with evidence in PR body
+- [ ] Dual-run operator doc marked **retired**; this criteria doc status → **Met**
+- [ ] Help / product-docs updated only if operator-facing behavior changes
+- [ ] **No** mass-delete of upgrade-input compilers without a separate decision
+- [ ] Parent #2632 / epic #2626 Agent progress updated
+
+---
+
+## 6. Residual work
+
+| Work | Form | Notes |
+|------|------|-------|
+| Runtime dual-run shim deletion + consumer rewiring when criteria met | Residual GitHub issue (p2, unassigned) | Modules: `modules/perc-packages`, likely `projects/sitemanage` (widget DAO), possibly `WebUI` gadget dual-load |
+| Product Widget XML deletion from Packages after modern ship | Owned under Phase 3 [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) residuals — **do not** invent mega-delete here | Prerequisite for M1 |
+| Page dual-ship code retirement | [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md) | Parallel, not identical |
+
+Residual issue for this slice is filed from the night-issue-prs run of #2835 (link in issue/PR comments and parent Agent progress).
+
+---
+
+## See also
+
+- [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md) — operator dual-run policy
+- [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md) — package-build dual-ship
+- [widget-xml-inventory.md](./widget-xml-inventory.md) / [page-definition-inventory.md](./page-definition-inventory.md) / [gadget-definition-inventory.md](./gadget-definition-inventory.md)
+- [component-package-manifest.md](./component-package-manifest.md) / [adr/004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md)
+- [plan.md](./plan.md) § Phase 5
+- Epic [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) · Phase 5 [#2632](https://github.com/intersoftdatalabs-in/percussioncms/issues/2632) · Phase 3 [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630)

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -2,9 +2,10 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | Accepted for Phase 3 slice 3 (#2752) |
+| **Status** | Accepted for Phase 3 slice 3 (#2752); **shim still required** (criteria not met — see Phase 5 criteria) |
 | **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) (Phase 3) |
 | **Epic** | [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Phase 5 criteria** | [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) (#2835 / #2632) |
 | **ADR** | [ADR-004](./adr/004-no-definition-xml-packaging.md) |
 | **Code** | `com.percussion.packages.shim.PSLegacyDefinitionXmlShim` (`modules/perc-packages`) |
 | **Related slices** | Manifest model #2750 / PR #2754; Widget XML compiler #2751 / PR #2755 |
@@ -86,13 +87,15 @@ Deep rewiring of `PSWidgetDao` to call the shim for every load is **incremental*
 
 ## Exit criteria (shim retirement)
 
-The dual-run window ends when **all** of the following hold:
+The dual-run window ends when **all** of the following hold. **Authoritative metrics, test gates, time-box, and 2026-08-10 inventory:** [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) (#2835).
 
 - [x] Product **page layout** packages `perc.baseTemplates` / `perc.responsiveTemplates` are **not** authored as `*.templateDef` (#2786; native install mode #2806 — dual-ship roots off).
-- [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates done; **widget dual-ship batch A** modern roots landed (#2831, 8 widgets); remaining ~40 product widgets still dual-ship XML as install authoring until further batches + native install.
-- [ ] Customer upgrade path documented and used for remaining XML.
-- [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived.
-- [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help.
+- [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates done; **widget dual-ship batch A** modern roots landed (#2831, 8 widgets); remaining ~40 product widgets still dual-ship XML as install authoring until further batches + native install. **Inventory detail:** product Widget definition XMLs under Packages (`sys__UserDependency--rxconfig/Widgets`) — see [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md).
+- [ ] Customer upgrade path documented and used for remaining XML (window still open for 8.2 dual-run).
+- [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived. **Snapshot:** selection API un-wired into `PSWidgetDao`; no M2 metrics yet.
+- [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help — **blocked** until criteria doc M1–M3 + G1–G6 pass; residual tracks the deletion PR.
+
+**Do not** mass-delete the customer-facing shim while any box above is open.
 
 ## Non-goals
 
@@ -102,7 +105,9 @@ The dual-run window ends when **all** of the following hold:
 
 ## See also
 
+- [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) — Phase 5 metrics, gates, time-box, inventory (#2835)
 - [ADR-004](./adr/004-no-definition-xml-packaging.md) — no definition XML for product packaging
 - [component-package-manifest.md](./component-package-manifest.md) — modern ship format (when present on branch)
-- [plan.md](./plan.md) — Phase 3 goals
+- [plan.md](./plan.md) — Phase 3 / Phase 5 goals
 - [widget-xml-inventory.md](./widget-xml-inventory.md) — product widget matrix
+- [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md) — package-build dual-ship (related, not identical)

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
@@ -67,7 +67,7 @@ Runtime install still uses `PSTemplateDefDependencyHandler` and assembly-templat
 
 | Concept | Layer | Status |
 |---------|-------|--------|
-| Dual-run **definition XML shim** | Runtime selection modern vs Widget/Page/Gadget XML | Time-boxed; Phase 5 #2632 |
+| Dual-run **definition XML shim** | Runtime selection modern vs Widget/Page/Gadget XML | Time-boxed; Phase 5 #2632 — criteria: [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) |
 | Dual-ship **page templateDef** | Package-build install bridge for page layouts | Optional; native preferred for converted packages |
 | Native **page install** | Package-build stages TemplateDef archive from modern pages | Landed #2806 for base/responsive |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/plan.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/plan.md
@@ -384,7 +384,7 @@ Align with `design-templates-item-types` phases D0–D4:
 ### Phase 5 — Deprecation & cleanup (post-8.2 acceptable if product XML is already gone)
 
 1. Docs: single “Assemblers & Templates” guide; archive dual-model tutorials; Velocity as advanced track; HTML-first/Markdown for simple cases. *(#2833 implementer guide when present.)*
-2. Remove product shims when metrics show zero XML definition loads.
+2. Remove product shims when metrics show zero XML definition loads — **hard gate:** [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md) (metrics M1–M3, test gates G1–G6, time-box; inventory snapshot #2835). Do **not** mass-delete while criteria are unmet.
 3. XSL: support statement only; migration cookbook to Velocity/HTML/Markdown. **Done (docs / #2834):** [xsl-migration-cookbook.md](./xsl-migration-cookbook.md) + [rhino-js-extension-note.md](./rhino-js-extension-note.md). No XSL runtime removal in 8.2.
 4. Optional later (not this plan): revisit Rhino JS extension handler health independently of assembly. (Short posture note: [rhino-js-extension-note.md](./rhino-js-extension-note.md).)
 


### PR DESCRIPTION
## Summary

Phase 5 slice 3 of **#2632** (epic **#2626**): document **hard gates** for removing the legacy definition-XML dual-run runtime shim, plus a **2026-08-10 inventory** of dual-run call sites.

**Decision:** criteria are **not met** — leave `PSLegacyDefinitionXmlShim` and related dual-run loaders in place. Residual **#2852** tracks the actual deletion PR when M1–M3 + G1–G6 have evidence.

### Delivered
- New: `docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md`
  - Metrics M1–M3 (product XML, runtime loads, customer upgrade window)
  - Test/CI gates G1–G6
  - Time-box rules (no mass-delete)
  - Grep/tree inventory (shim package, PSWidgetDao, GadgetRegistry dual-load, 48 product Widget XMLs / 39 package trees)
- Cross-links from dual-run policy, ADR-004, plan Phase 5, README, dual-ship doc

### Explicit non-goals in this PR
- No code deletion of customer-facing shim
- No product Widget XML mass-delete (Phase 3 / M1)

## Test plan
- [x] Docs-only review: criteria readable; inventory matches tree snapshot on branch
- [x] N/A Maven — no production/test source or `pom.xml` changes

## Product documentation
- [x] N/A — engineering criteria under `docs/ai-generated/tasks/`; no operator-facing product behavior change in this PR. Operator dual-run checklist remains in dual-run doc (still required).

## Build evidence (C3)
- **modules_built:** none (docs-only)
- **build_evidence:** No Maven modules changed; standalone clean install not required
- **downstream_checked:** none (no API/type changes)

## Residual
- #2852 — Phase 5 residual: remove definition-XML dual-run shim when criteria met

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2632 · Epic: #2626

Fixes #2835
Partial: residual #2852 for code deletion when criteria met

> Co-Authored by Grok Build using grok-4.5 with agent main.
