### PR TITLE
feat(WebUI): Explorer action toolbar + context menu enablement (#2849)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -19,9 +19,10 @@
  *
  * <p>Composes DCE-style top menu bar (Content / View / Help), tree, detail
  * list, reduced actions, server-driven action toolbar (with nested MENU
- * dropdowns), context menu, search panel, IA relationships panel, dependency
- * viewer, and display-format selector so the SPA route approaches Desktop
- * Content Explorer parity (#2400 / #2731 / #2768 / #2769).</p>
+ * dropdowns and enablement filtering from {@code rest/actions}), item/folder
+ * context menu, search panel, IA relationships panel, dependency viewer, and
+ * display-format selector so the SPA route approaches Desktop Content Explorer
+ * parity (#2400 / #2407 / #2731 / #2768 / #2769 / #2849).</p>
  */
 
 import React, {
@@ -55,6 +56,10 @@ import type {
 } from "../api/contentExplorer/types";
 import { useSpaBootstrap } from "../app/bootstrap/BootstrapContext";
 import { message } from "../i18n/message";
+import {
+  filterContextMenuActions,
+  filterToolbarActions,
+} from "./actionEnablement";
 import { ActionToolbar } from "./ActionToolbar";
 import { ClipboardPanel } from "./clipboard/ClipboardPanel";
 import { EMPTY_CLIPBOARD, setClipboard as buildClipboard } from "./clipboard/model";
@@ -216,6 +221,18 @@ function isWorkflowEligibleItem(item: PSPathItem | null | undefined): boolean {
   return id.length > 0;
 }
 
+/**
+ * Load the server action catalog for the current selection (#2849).
+ *
+ * <p>When a content item is selected, prefer per-content-type menus from
+ * {@code POST /actions/find/types}. Otherwise load the full cascading tree
+ * from {@code GET /actions/find} (no {@code item=true} filter) so toolbar
+ * dropdown parents ({@code MENU}) remain available — {@code item=true}
+ * would keep only flat {@code MENUITEM} roots and drop nested chrome.</p>
+ *
+ * <p>Desktop-only / surface enablement is applied by the shell after load
+ * via {@link filterToolbarActions} / {@link filterContextMenuActions}.</p>
+ */
 async function defaultLoadMenuActions(
   item: PSPathItem | null,
 ): Promise<MenuAction[]> {
@@ -226,7 +243,7 @@ async function defaultLoadMenuActions(
       return mapActionMenusToMenuActions(menus);
     }
   }
-  const menus = await findActions({ item: true });
+  const menus = await findActions({});
   return mapActionMenusToMenuActions(menus);
 }
 
@@ -408,7 +425,9 @@ export function ContentExplorerShell({
           workflow = null;
         }
         if (cancelled) return;
-        setMenuActions(mergeWorkflowMenuActions(base ?? [], workflow));
+        // Toolbar surface: drop desktop-only URLs and CONTEXTMENU roots (#2849).
+        const merged = mergeWorkflowMenuActions(base ?? [], workflow);
+        setMenuActions(filterToolbarActions(merged));
       } catch {
         if (!cancelled) setMenuActions([]);
       }
@@ -530,8 +549,10 @@ export function ContentExplorerShell({
             workflow = null;
           }
           if (requestId !== contextMenuRequestIdRef.current) return;
+          // Context-menu surface: keep CONTEXTMENU roots; drop desktop-only (#2849).
+          const merged = mergeWorkflowMenuActions(base ?? [], workflow);
           setContextMenu({
-            actions: mergeWorkflowMenuActions(base ?? [], workflow),
+            actions: filterContextMenuActions(merged),
             x: clientX,
             y: clientY,
           });

--- a/WebUI/src/main/ts/contentExplorer/actionEnablement.ts
+++ b/WebUI/src/main/ts/contentExplorer/actionEnablement.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Server-action enablement / visibility helpers for product Explorer
+ * (#2849 / parent #2407 / grandparent #2400).
+ *
+ * <p>The REST {@code /actions/*} catalog includes Desktop Content Explorer
+ * (DCE) menu entries that are not web-executable (custom app protocols,
+ * {@code file:}, {@code javascript:}, empty client markers that only the
+ * desktop CX understands). The product SPA must not surface those as
+ * toolbar / context-menu affordances. These pure helpers filter
+ * {@link MenuAction} trees after mapping from wire {@code ActionMenu}
+ * DTOs — they do not invent new action types and do not execute actions.</p>
+ *
+ * <p>Rules (FR-011: hide unauthorized / non-applicable):</p>
+ * <ul>
+ *   <li>Client-handled leaves (no URL, or URL sentinel {@code CLIENT}) stay —
+ *       the shell routes them through {@code onInvoke}.</li>
+ *   <li>Leaves with a URL must pass {@link classifyUrl} (same-origin /
+ *       relative / http(s) whitelist) or they are treated as desktop-only
+ *       and dropped for the SPA surface.</li>
+ *   <li>{@code CONTEXTMENU} roots are context-menu only (not toolbar
+ *       chrome), matching DCE menu-type semantics.</li>
+ *   <li>Empty cascading {@code MENU} parents after filtering are dropped.</li>
+ * </ul>
+ */
+
+import type { MenuAction } from "../api/contentExplorer/types";
+import { classifyUrl } from "../util/safeNavigate";
+
+/** Where the filtered menu will be rendered. */
+export type ActionSurface = "toolbar" | "contextmenu";
+
+/**
+ * Optional selection context for enablement. Multi-select / clipboard is
+ * intentionally out of scope for #2849 (see #2408).
+ */
+export interface ActionEnablementContext {
+  surface: ActionSurface;
+  /**
+   * Currently selected detail-list item, or {@code null} when only a folder
+   * is active. Reserved for future access-level gating; filters today are
+   * URL/surface based so folder-level catalog menus still show.
+   */
+  selectionItem?: { type?: string; accessLevel?: string } | null;
+  /**
+   * Synthetic base URL for {@link classifyUrl} (tests pass an absolute
+   * origin; production callers may omit and use {@code window.location}).
+   */
+  baseHref?: string;
+}
+
+/**
+ * DCE / legacy CX marks pure client actions with the literal URL token
+ * {@code CLIENT} (see ContentExplorerMenu.xml). That is not a navigable
+ * href — the SPA treats it as "client-handled" like a missing URL.
+ */
+const CLIENT_URL_SENTINELS: ReadonlySet<string> = new Set([
+  "client",
+  "clientaction",
+  "client-action",
+]);
+
+/**
+ * True when the action has no navigable URL and should be delegated to
+ * the shell {@code onInvoke} path (or is a pure cascade parent).
+ */
+export function isClientHandledAction(action: MenuAction): boolean {
+  const raw = action.url;
+  if (raw == null) return true;
+  const trimmed = String(raw).trim();
+  if (trimmed.length === 0) return true;
+  return CLIENT_URL_SENTINELS.has(trimmed.toLowerCase());
+}
+
+/**
+ * True when the action URL cannot run in the product SPA (desktop-only
+ * protocol, different origin, or known-dangerous scheme). Client-handled
+ * actions are never desktop-only.
+ */
+export function isDesktopOnlyActionUrl(
+  url: string | undefined | null,
+  baseHref?: string,
+): boolean {
+  if (url == null) return false;
+  const trimmed = String(url).trim();
+  if (trimmed.length === 0) return false;
+  if (CLIENT_URL_SENTINELS.has(trimmed.toLowerCase())) return false;
+  const result = classifyUrl(trimmed, baseHref);
+  return !result.ok;
+}
+
+/**
+ * True when a leaf action is usable in the SPA: client-handled or a
+ * web-safe URL. Cascade parents with children are evaluated separately.
+ */
+export function isWebExecutableLeaf(
+  action: MenuAction,
+  baseHref?: string,
+): boolean {
+  if (isClientHandledAction(action)) {
+    return true;
+  }
+  return !isDesktopOnlyActionUrl(action.url, baseHref);
+}
+
+/**
+ * Whether this action (as a root or nested entry) may appear on the
+ * given surface before child filtering.
+ *
+ * <p>{@code CONTEXTMENU} menu types are DCE context-popup roots; they are
+ * kept for the context-menu surface and hidden from the horizontal
+ * toolbar so product chrome does not dump the entire popup tree as
+ * buttons.</p>
+ */
+export function isActionAllowedOnSurface(
+  action: MenuAction,
+  surface: ActionSurface,
+): boolean {
+  const type = (action.menuType ?? "MENUITEM").toUpperCase();
+  if (surface === "toolbar" && type === "CONTEXTMENU") {
+    return false;
+  }
+  return true;
+}
+
+function hasChildren(action: MenuAction): boolean {
+  return (action.children?.length ?? 0) > 0;
+}
+
+/**
+ * Recursively filter a {@link MenuAction} tree for product Explorer
+ * surfaces. Pure: does not mutate the input array or child arrays.
+ *
+ * @param actions Root actions from {@code mapActionMenusToMenuActions}
+ * @param ctx Surface + optional base URL for URL classification
+ * @returns New array of enabled actions (may be empty)
+ */
+export function filterEnabledMenuActions(
+  actions: MenuAction[] | null | undefined,
+  ctx: ActionEnablementContext,
+): MenuAction[] {
+  if (actions == null || actions.length === 0) {
+    return [];
+  }
+  const baseHref = ctx.baseHref;
+  const out: MenuAction[] = [];
+  for (const action of actions) {
+    if (!action || !action.name) {
+      continue;
+    }
+    if (!isActionAllowedOnSurface(action, ctx.surface)) {
+      continue;
+    }
+
+    if (hasChildren(action)) {
+      const filteredChildren = filterEnabledMenuActions(action.children, ctx);
+      if (filteredChildren.length === 0) {
+        // Cascade parent with no web-usable children: drop entirely.
+        continue;
+      }
+      out.push({
+        ...action,
+        children: filteredChildren,
+      });
+      continue;
+    }
+
+    // Leaf
+    if (!isWebExecutableLeaf(action, baseHref)) {
+      continue;
+    }
+    out.push(action);
+  }
+  return out;
+}
+
+/**
+ * Convenience: filter for the horizontal server action toolbar.
+ */
+export function filterToolbarActions(
+  actions: MenuAction[] | null | undefined,
+  baseHref?: string,
+): MenuAction[] {
+  return filterEnabledMenuActions(actions, { surface: "toolbar", baseHref });
+}
+
+/**
+ * Convenience: filter for the item/folder context menu popup.
+ */
+export function filterContextMenuActions(
+  actions: MenuAction[] | null | undefined,
+  baseHref?: string,
+): MenuAction[] {
+  return filterEnabledMenuActions(actions, {
+    surface: "contextmenu",
+    baseHref,
+  });
+}

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -269,6 +269,101 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     expect(screen.queryByTestId("context-menu-item-open-slow")).toBeNull();
   });
 
+  it("filters desktop-only actions from toolbar and mounts context menu for items (#2849)", async () => {
+    const loadMenuActions = vi.fn(async () => [
+      {
+        name: "open",
+        label: "Open",
+        sortRank: 1,
+        menuType: "MENUITEM" as const,
+      },
+      {
+        name: "desktop-cx",
+        label: "Desktop only",
+        sortRank: 2,
+        menuType: "MENUITEM" as const,
+        url: "rxapp://launch-cx",
+      },
+      {
+        name: "cx-popup",
+        label: "CX popup",
+        sortRank: 3,
+        menuType: "CONTEXTMENU" as const,
+        children: [
+          {
+            name: "cx-edit",
+            label: "Edit in CX",
+            sortRank: 1,
+            menuType: "MENUITEM" as const,
+          },
+        ],
+      },
+    ]);
+
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("paginatedFolder") || url.includes("/folder/")) {
+        return new Response(
+          JSON.stringify({
+            PagedItemList: {
+              childrenInPage: [
+                {
+                  id: "501",
+                  name: "page-five",
+                  path: "/Sites/page-five",
+                  type: "page",
+                  accessLevel: "WRITE",
+                },
+              ],
+              childrenCount: 1,
+              startIndex: 1,
+            },
+            PathItem: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        initialPath="/Sites"
+        loadDisplayFormats={async () => []}
+        loadMenuActions={loadMenuActions}
+        loadWorkflowMenuActions={async () => null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
+      expect(screen.getByTestId("action-toolbar-item-open")).toBeInTheDocument();
+    });
+    // Desktop-only URL and CONTEXTMENU roots must not appear on the toolbar.
+    expect(screen.queryByTestId("action-toolbar-item-desktop-cx")).toBeNull();
+    expect(screen.queryByTestId("action-toolbar-item-cx-popup")).toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-row-501")).toBeInTheDocument();
+    });
+    fireEvent.contextMenu(screen.getByTestId("detail-row-501"), {
+      clientX: 12,
+      clientY: 24,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("context-menu")).toBeInTheDocument();
+      expect(screen.getByTestId("context-menu-item-open")).toBeInTheDocument();
+      // CONTEXTMENU roots are allowed on the context-menu surface.
+      expect(screen.getByTestId("context-menu-item-cx-popup")).toBeInTheDocument();
+    });
+    // Desktop-only URL still filtered from context menu.
+    expect(screen.queryByTestId("context-menu-item-desktop-cx")).toBeNull();
+  });
+
   it("merges workflow transition group into toolbar and invokes transition (#2732)", async () => {
     const runWorkflowTransition = vi.fn(async () => undefined);
     const loadWorkflowMenuActions = vi.fn(async (item) => {

--- a/WebUI/src/test/ts/contentExplorer/actionEnablement.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionEnablement.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { MenuAction } from "../../../main/ts/api/contentExplorer/types";
+import {
+  filterContextMenuActions,
+  filterEnabledMenuActions,
+  filterToolbarActions,
+  isActionAllowedOnSurface,
+  isClientHandledAction,
+  isDesktopOnlyActionUrl,
+  isWebExecutableLeaf,
+} from "../../../main/ts/contentExplorer/actionEnablement";
+
+const BASE = "http://localhost:9992/Rhythmyx/cm/app/spa.jsp?entry=explorer";
+
+function leaf(
+  partial: Partial<MenuAction> & Pick<MenuAction, "name">,
+): MenuAction {
+  return {
+    label: partial.label ?? partial.name,
+    sortRank: partial.sortRank ?? 1,
+    menuType: partial.menuType ?? "MENUITEM",
+    ...partial,
+  };
+}
+
+describe("isClientHandledAction", () => {
+  it("treats missing / blank / CLIENT sentinel URLs as client-handled", () => {
+    expect(isClientHandledAction(leaf({ name: "open" }))).toBe(true);
+    expect(isClientHandledAction(leaf({ name: "open", url: "" }))).toBe(true);
+    expect(isClientHandledAction(leaf({ name: "open", url: "  " }))).toBe(true);
+    expect(isClientHandledAction(leaf({ name: "open", url: "CLIENT" }))).toBe(
+      true,
+    );
+    expect(isClientHandledAction(leaf({ name: "open", url: "client" }))).toBe(
+      true,
+    );
+  });
+
+  it("treats real URLs as not client-handled", () => {
+    expect(
+      isClientHandledAction(
+        leaf({ name: "edit", url: "/Rhythmyx/cm/app/editAsset.jsp?id=1" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isDesktopOnlyActionUrl / isWebExecutableLeaf", () => {
+  it("flags javascript:, file:, and custom app protocols as desktop-only", () => {
+    expect(isDesktopOnlyActionUrl("javascript:alert(1)", BASE)).toBe(true);
+    expect(isDesktopOnlyActionUrl("file:///C:/secret", BASE)).toBe(true);
+    expect(isDesktopOnlyActionUrl("rxapp://launch-cx", BASE)).toBe(true);
+    expect(isDesktopOnlyActionUrl("applet:foo", BASE)).toBe(true);
+  });
+
+  it("allows relative CMS paths and same-origin http(s)", () => {
+    expect(isDesktopOnlyActionUrl("/Rhythmyx/sys_ActionPage/panel.html", BASE)).toBe(
+      false,
+    );
+    expect(
+      isDesktopOnlyActionUrl(
+        "http://localhost:9992/Rhythmyx/cm/app/editAsset.jsp",
+        BASE,
+      ),
+    ).toBe(false);
+    expect(isDesktopOnlyActionUrl("CLIENT", BASE)).toBe(false);
+    expect(isDesktopOnlyActionUrl(undefined, BASE)).toBe(false);
+  });
+
+  it("marks leaves with desktop-only URLs as non-executable", () => {
+    expect(
+      isWebExecutableLeaf(
+        leaf({ name: "bad", url: "javascript:void(0)" }),
+        BASE,
+      ),
+    ).toBe(false);
+    expect(
+      isWebExecutableLeaf(
+        leaf({ name: "ok", url: "/Rhythmyx/cm/app/editAsset.jsp" }),
+        BASE,
+      ),
+    ).toBe(true);
+    expect(isWebExecutableLeaf(leaf({ name: "client-only" }), BASE)).toBe(true);
+  });
+});
+
+describe("isActionAllowedOnSurface", () => {
+  it("hides CONTEXTMENU roots on the toolbar but keeps them for context menu", () => {
+    const ctxRoot = leaf({
+      name: "cx-popup",
+      menuType: "CONTEXTMENU",
+    });
+    expect(isActionAllowedOnSurface(ctxRoot, "toolbar")).toBe(false);
+    expect(isActionAllowedOnSurface(ctxRoot, "contextmenu")).toBe(true);
+  });
+
+  it("allows MENUITEM and MENU on both surfaces", () => {
+    expect(
+      isActionAllowedOnSurface(leaf({ name: "open", menuType: "MENUITEM" }), "toolbar"),
+    ).toBe(true);
+    expect(
+      isActionAllowedOnSurface(
+        leaf({ name: "file", menuType: "MENU", children: [] }),
+        "contextmenu",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("filterEnabledMenuActions", () => {
+  it("drops desktop-only leaves and empty cascade parents", () => {
+    const actions: MenuAction[] = [
+      leaf({ name: "open", sortRank: 1 }),
+      leaf({ name: "evil", url: "javascript:alert(1)", sortRank: 2 }),
+      {
+        name: "file",
+        label: "File",
+        sortRank: 3,
+        menuType: "MENU",
+        children: [
+          leaf({ name: "desktop-only", url: "rxapp://cx" }),
+          leaf({ name: "nested-ok", url: "/Rhythmyx/ok" }),
+        ],
+      },
+      {
+        name: "empty-after-filter",
+        label: "Empty",
+        sortRank: 4,
+        menuType: "MENU",
+        children: [leaf({ name: "gone", url: "file:///tmp/x" })],
+      },
+    ];
+
+    const filtered = filterToolbarActions(actions, BASE);
+    expect(filtered.map((a) => a.name)).toEqual(["open", "file"]);
+    const file = filtered.find((a) => a.name === "file");
+    expect(file?.children?.map((c) => c.name)).toEqual(["nested-ok"]);
+  });
+
+  it("keeps CONTEXTMENU roots only on the context-menu surface", () => {
+    const actions: MenuAction[] = [
+      leaf({ name: "open", menuType: "MENUITEM" }),
+      {
+        name: "cx-root",
+        label: "CX",
+        sortRank: 2,
+        menuType: "CONTEXTMENU",
+        children: [leaf({ name: "cx-child" })],
+      },
+    ];
+
+    expect(filterToolbarActions(actions, BASE).map((a) => a.name)).toEqual([
+      "open",
+    ]);
+    expect(filterContextMenuActions(actions, BASE).map((a) => a.name)).toEqual([
+      "open",
+      "cx-root",
+    ]);
+  });
+
+  it("returns empty for null/empty input without throwing", () => {
+    expect(filterEnabledMenuActions(null, { surface: "toolbar", baseHref: BASE })).toEqual(
+      [],
+    );
+    expect(filterEnabledMenuActions([], { surface: "toolbar", baseHref: BASE })).toEqual(
+      [],
+    );
+  });
+
+  it("does not mutate the input tree", () => {
+    const child = leaf({ name: "child", url: "javascript:x" });
+    const parent: MenuAction = {
+      name: "parent",
+      label: "Parent",
+      sortRank: 1,
+      menuType: "MENU",
+      children: [child, leaf({ name: "keep" })],
+    };
+    const input = [parent];
+    const filtered = filterToolbarActions(input, BASE);
+    expect(input[0].children?.length).toBe(2);
+    expect(filtered[0].children?.map((c) => c.name)).toEqual(["keep"]);
+    expect(filtered[0]).not.toBe(input[0]);
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/index.ts
+++ b/WebUI/src/test/ts/contentExplorer/index.ts
@@ -24,7 +24,7 @@
  * <p>Add the following per-US test files (implementer):</p>
  * <ul>
  *   <li>US1: {@code pathApi.test.ts}, {@code ExplorerTree.test.tsx}, {@code DetailList.test.tsx}, {@code reducedActions.test.tsx}, {@code sc005-perf-regression.test.tsx}</li>
- *   <li>US3: {@code actionMenuMapper.test.ts}, {@code ContextMenu.test.tsx}, {@code ContextMenu.a11y.test.tsx}</li>
+ *   <li>US3: {@code actionMenuApi.test.ts}, {@code actionEnablement.test.ts}, {@code ContextMenu.test.tsx}, {@code ActionToolbar.test.tsx}</li>
  *   <li>US4: {@code aclLockout.test.ts}, {@code FolderSecurityPanel.test.tsx}, {@code currentUserIdentities.test.ts}</li>
  *   <li>US5: {@code searchApi.test.ts}, {@code SearchPanel.test.tsx}</li>
  *   <li>US7: {@code clipboard.test.ts}, {@code wizards/}, {@code views/}</li>

--- a/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
@@ -96,6 +96,35 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible();
   });
 
+  test("server action toolbar mounts; detail list supports context menu (#2849)", async ({
+    page,
+  }) => {
+    // Product Explorer route: ActionToolbar is always present; right-click
+    // on a detail row opens the ContextMenu anchor (actions may be empty on
+    // a minimal Derby catalog — empty state is still a mounted menu).
+    await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+    await expect(
+      page.locator('[data-testid="content-explorer-shell"]'),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible();
+    await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+
+    const row = page.locator('[data-testid^="detail-row-"]').first();
+    if ((await row.count()) === 0) {
+      // Empty folder: still assert chrome; context menu needs a row.
+      test.info().annotations.push({
+        type: "note",
+        description:
+          "No detail rows on this CMS folder; skipped context-menu click path",
+      });
+      return;
+    }
+    await row.click({ button: "right" });
+    await expect(page.locator('[data-testid="context-menu"]')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
   test("Explorer shell opens search panel from View menu (#2400 / #2731)", async ({
     page,
   }) => {

--- a/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us1-core-explorer.spec.js
@@ -102,12 +102,65 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     // Product Explorer route: ActionToolbar is always present; right-click
     // on a detail row opens the ContextMenu anchor (actions may be empty on
     // a minimal Derby catalog — empty state is still a mounted menu).
+    //
+    // Enablement (#2849): inject a desktop-only action into the live
+    // /actions/find* responses so the E2E path exercises
+    // filterToolbarActions / filterContextMenuActions (absence of the
+    // known desktop-only item). Vitest covers the pure helpers exhaustively.
+    const DESKTOP_ONLY_NAME = "night-desktop-only-cx";
+    const desktopOnlyWire = {
+      id: 9_000_001,
+      name: DESKTOP_ONLY_NAME,
+      label: "Desktop CX only (night probe)",
+      sortRank: 9999,
+      menuType: "MENUITEM",
+      url: "rxapp://launch-cx",
+    };
+
+    await page.route("**/Rhythmyx/rest/actions/find**", async (route) => {
+      const response = await route.fetch();
+      const contentType = response.headers()["content-type"] || "";
+      if (!contentType.includes("application/json")) {
+        return route.fulfill({ response });
+      }
+      let body;
+      try {
+        body = await response.json();
+      } catch {
+        return route.fulfill({ response });
+      }
+      if (Array.isArray(body?.ActionMenu)) {
+        body = {
+          ...body,
+          ActionMenu: [...body.ActionMenu, desktopOnlyWire],
+        };
+      } else if (Array.isArray(body?.ActionMenuList)) {
+        body = {
+          ...body,
+          ActionMenuList: [...body.ActionMenuList, desktopOnlyWire],
+        };
+      }
+      return route.fulfill({
+        status: response.status(),
+        headers: {
+          ...response.headers(),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+    });
+
     await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
     await expect(
       page.locator('[data-testid="content-explorer-shell"]'),
     ).toBeVisible({ timeout: 15_000 });
     await expect(page.locator('[data-testid="action-toolbar"]')).toBeVisible();
     await expect(page.locator('[data-testid="detail-list"]')).toBeVisible();
+
+    // Desktop-only probe must never appear on the toolbar (filtered).
+    await expect(
+      page.locator(`[data-testid="action-toolbar-item-${DESKTOP_ONLY_NAME}"]`),
+    ).toHaveCount(0);
 
     const row = page.locator('[data-testid^="detail-row-"]').first();
     if ((await row.count()) === 0) {
@@ -123,6 +176,10 @@ test.describe("modern React Content Explorer (US1) — feature 992", () => {
     await expect(page.locator('[data-testid="context-menu"]')).toBeVisible({
       timeout: 10_000,
     });
+    // Filtered out on context-menu surface as well.
+    await expect(
+      page.locator(`[data-testid="context-menu-item-${DESKTOP_ONLY_NAME}"]`),
+    ).toHaveCount(0);
   });
 
   test("Explorer shell opens search panel from View menu (#2400 / #2731)", async ({

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -1,0 +1,60 @@
+---
+id: admin-content-explorer
+title: Content Explorer
+description: Product Content Explorer shell — browse, server actions, and context menus
+version: "8.2"
+order: 42
+tags: [admin, content explorer, ui]
+---
+
+# Content Explorer
+
+The **Content Explorer** is the product web shell for browsing Sites, folders, pages, and
+assets without launching Desktop Content Explorer (DCE). Open it from the SPA at
+`/cm/app/spa.jsp?entry=explorer` (or the Explorer entry in the product navigation).
+
+## What you see
+
+| Chrome | Purpose |
+|--------|---------|
+| **Menu bar** (Content / View / Help) | Product commands: search, clipboard, site/subfolder copy, view tools |
+| **Reduced actions** | Always-available open / preview / create folder / rename / move / copy / delete |
+| **Server action toolbar** | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection |
+| **Tree + detail list** | Folder navigation and list of children; optional display-format columns |
+| **Context menu** | Right-click an item or folder row for the same catalog filtered for the popup surface |
+
+## Server actions and context menu
+
+Menus and toolbar buttons come from the server action catalog used by Content Explorer:
+
+- When you select a content item, the shell loads allowed menus for that content type.
+- When only a folder is active, the shell loads the cascading action tree for the Explorer UI.
+- **Desktop-only** actions (for example custom application protocols that only DCE can run) are
+  **hidden** in the web shell so operators are not offered controls that cannot succeed in the
+  browser.
+- Actions of type **context menu** appear on right-click, not as permanent toolbar buttons.
+- Workflow transition triggers (when available for the selected item) appear as a labeled group
+  on the toolbar and in the context menu.
+
+Selecting a server action either navigates to a product-safe same-origin URL or refreshes the
+list after a client-handled command (for example a workflow transition).
+
+## Display format
+
+Use the **display format** selector in the menu bar to choose list columns for the current folder
+(`validForFolder` formats). Changing the format reloads the detail list with the selected columns.
+
+## Search, security, and advanced tools
+
+From the **View** menu you can toggle:
+
+- **Search** — extended search panel (criteria for the current folder path)
+- **Folder security** — ACL / properties for the selected folder
+- **Translations**, **Relationships**, and **Dependencies** — advanced item tools when a suitable
+  item is selected
+
+## Related
+
+- [Sites & content structure](id:admin-sites)
+- [Users, roles & security](id:admin-users-roles)
+- [Publishing](id:admin-publishing)

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -15,6 +15,7 @@ day-two server operations.
 ## Topics
 
 - [Sites & content structure](id:admin-sites)
+- [Content Explorer](id:admin-content-explorer)
 - [Users, roles & security](id:admin-users-roles)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -51,5 +51,6 @@ See [Virtual Sites (developer)](id:developer-virtual-sites) and
 
 ## Related
 
+- [Content Explorer](id:admin-content-explorer) — product shell for browsing Sites/folders and running server actions
 - [Publishing](id:admin-publishing)
 - [Users, roles & security](id:admin-users-roles)


### PR DESCRIPTION
## Summary

Implements **#2849** (slice 2 of **#2407** / grandparent **#2400**): product Explorer server action toolbar + item/folder context menu composition from existing `rest/actions`, with client-side **enablement helpers** that hide desktop-only / non-web-executable actions and route `CONTEXTMENU` roots to the popup only.

### Changes
- **`actionEnablement.ts`**: pure helpers (`filterToolbarActions` / `filterContextMenuActions`, desktop URL detection, CLIENT sentinel handling, surface rules).
- **`ContentExplorerShell`**: apply enablement after catalog + workflow merge; load full cascading tree for folder context (drop `item=true` which only kept flat MENUITEM roots).
- **Vitest**: `actionEnablement.test.ts` (11) + shell test for toolbar filter + context-menu mount.
- **Playwright**: `us1-core-explorer` asserts toolbar + right-click context menu when rows exist.
- **product-docs**: new [Content Explorer](product-docs/8.2/admin/content-explorer.md) admin page + index/sites links.

### Out of scope (unchanged)
- New action types, clipboard multi-select (#2408), search panel (#2850).

## Parent / slices
| Issue | Role |
|-------|------|
| #2400 | Grandparent DCE parity epic |
| #2407 | Parent shell composition |
| #2849 | This PR (slice 2) |
| #2848 | Slice 1 display formats (done) |
| #2850 | Slice 3 search + Playwright chrome |

## Test plan
- [x] `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Vitest full suite: **1783 passed** (incl. 11 enablement + shell #2849)
- [x] Java Surefire: 37 tests, Failures: 0
- [ ] Playwright `us1-core-explorer` against QA H2 when available (assertions added)

## Product documentation
- [x] Updated pages under `product-docs/` (`8.2/admin/content-explorer.md`, admin index, sites related link)

## Build evidence (C3)
- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI; ..\mvnw.cmd clean install` → BUILD SUCCESS; Vitest Tests 1783 passed; Surefire Failures: 0
- **downstream_checked:** none (no public Java API / final / signature change; WebUI TS + product-docs + Playwright only)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2849

> Co-Authored by Grok Build using grok-4.5 with agent main.
