### PR TITLE
fix(perc-system): residual data rawtypes batch 4g (#2760)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2760-data-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2760-data-rawtypes-erlang.md
@@ -1,0 +1,38 @@
+# Erlang pre-commit review — issue #2760 (data rawtypes 4g)
+
+**Date:** 2026-08-10  
+**Reviewer persona:** Erlang (independent of implementer)  
+**Scope:** residual `-Xlint` rawtypes/unchecked in `com.percussion.data` after #2693 / PR #2762
+
+## Change class
+
+Pure tech-debt generics modernization in the data pipeline (stylesheets, SQL builders/optimizers, JDBC type maps, statement extractors, extension runner boundary). No product behavior change intended.
+
+## Companions
+
+| Companion | Status |
+|-----------|--------|
+| Production generics fixes in data package | Done |
+| Unit tests for typed helpers | Done (`*TypedTest`) |
+| Product-docs | N/A — no operator/user-facing change |
+| Playwright | N/A |
+| Downstream modules | API signatures mostly package/private or return-type only; `runSearchResultProcessor` narrowed to `IPSSearchResultRow` matching caller |
+
+## Findings
+
+### Bugs
+- None remaining after self-fix of `PSTableUpdateHandlerBase` (preserved original loop control; did **not** set `added=true` which would change multi-table listener registration).
+
+### Tests
+- Added behavioral unit tests for stylesheet filter rules, SQL builder context blocks, optimizer empty-col path, update/insert extractors, JDBC type-map signatures.
+
+### Cross-platform paths
+- No path I/O changes beyond existing filter singleton; tests use in-memory XML / reflection.
+
+### Hard gates
+- Prefer real generics; boundary suppress only where third-party (jericho) or SPI (`List<Object>` search rows) forces it.
+- Stay out of security/server/HTTPClient.
+
+## Verdict
+
+**PASS** — ready for `system` standalone `mvnw clean install` gate.

--- a/system/src/main/java/com/percussion/data/PSExtensionRunner.java
+++ b/system/src/main/java/com/percussion/data/PSExtensionRunner.java
@@ -344,8 +344,14 @@ public class PSExtensionRunner {
    * @throws PSExtensionProcessingException if thrown by the extension implementation.
    * @see IPSSearchResultsProcessor#processRows(Object[], List, IPSRequestContext)
    */
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  public List runSearchResultProcessor(PSExecutionData data, List searchResultRows)
+  /**
+   * Runs the search-results processor. Parameter/return typing uses {@link
+   * com.percussion.search.IPSSearchResultRow} to match callers; the processor SPI still takes {@code
+   * List&lt;Object&gt;} so a boundary cast is applied.
+   */
+  @SuppressWarnings("unchecked")
+  public List<com.percussion.search.IPSSearchResultRow> runSearchResultProcessor(
+      PSExecutionData data, List<? extends com.percussion.search.IPSSearchResultRow> searchResultRows)
       throws PSDataExtractionException, PSExtensionProcessingException {
     if (data == null) throw new IllegalArgumentException("data must not be null");
 
@@ -356,7 +362,9 @@ public class PSExtensionRunner {
 
     PSRequestContext request = new PSRequestContext(data.getRequest());
 
-    List rows = m_searchResultsProcessor.processRows(args, searchResultRows, request);
+    List<Object> asObjectRows = (List<Object>) (List<?>) searchResultRows;
+    List<Object> processed =
+        m_searchResultsProcessor.processRows(args, asObjectRows, request);
 
     // Trace processing message
     PSLogHandler lh = data.getLogHandler();
@@ -369,7 +377,7 @@ public class PSExtensionRunner {
         dh.printTrace(PSTraceMessageFactory.EXIT_PROC_FLAG, traceArgs);
       }
     }
-    return rows;
+    return (List<com.percussion.search.IPSSearchResultRow>) (List<?>) processed;
   }
 
   /**

--- a/system/src/main/java/com/percussion/data/PSOptimizer.java
+++ b/system/src/main/java/com/percussion/data/PSOptimizer.java
@@ -87,7 +87,8 @@ public abstract class PSOptimizer {
    * @param colList the column list to check
    * @param meta the database meta data to use for the check
    */
-  public static boolean isQueryIndexAvailable(java.util.ArrayList colList, PSTableMetaData meta)
+  public static boolean isQueryIndexAvailable(
+      java.util.List<? extends PSBackEndColumn> colList, PSTableMetaData meta)
       throws java.sql.SQLException {
     if ((colList == null) || (colList.size() == 0))
       return true; // no index required if no queryable columns exist
@@ -96,9 +97,9 @@ public abstract class PSOptimizer {
     if (indexStats == null || indexStats.length == 0) return false;
 
     // add the columns to a hash map for faster/simplified lookup
-    java.util.HashMap colNameMap = new java.util.HashMap();
+    java.util.HashMap<String, PSBackEndColumn> colNameMap = new java.util.HashMap<>();
     for (int i = 0; i < colList.size(); i++) {
-      PSBackEndColumn col = (PSBackEndColumn) colList.get(i);
+      PSBackEndColumn col = colList.get(i);
       colNameMap.put(col.getColumn().toLowerCase(), col);
     }
 

--- a/system/src/main/java/com/percussion/data/PSOracleUpdateInsertBuilder.java
+++ b/system/src/main/java/com/percussion/data/PSOracleUpdateInsertBuilder.java
@@ -17,6 +17,7 @@
 
 package com.percussion.data;
 
+import com.percussion.design.objectstore.PSBackEndColumn;
 import com.percussion.design.objectstore.PSBackEndTable;
 import com.percussion.error.PSIllegalArgumentException;
 import java.util.ArrayList;
@@ -68,7 +69,7 @@ public class PSOracleUpdateInsertBuilder extends PSOracleUpdateBuilder {
 
     // for the INSERT statement, we need all key and update columns
     // in the column list
-    ArrayList columnList = new ArrayList();
+    ArrayList<PSBackEndColumn> columnList = new ArrayList<>();
     columnList.addAll(m_Keys);
     columnList.addAll(m_Columns);
 

--- a/system/src/main/java/com/percussion/data/PSOracleUpdateInsertStatement.java
+++ b/system/src/main/java/com/percussion/data/PSOracleUpdateInsertStatement.java
@@ -87,8 +87,8 @@ public class PSOracleUpdateInsertStatement extends PSOracleUpdateStatement {
    *
    * @return the list of replacement values
    */
-  public List getReplacementValueExtractors() {
-    ArrayList retList = new ArrayList();
+  public List<IPSDataExtractor> getReplacementValueExtractors() {
+    ArrayList<IPSDataExtractor> retList = new ArrayList<>();
 
     retList.addAll(super.getReplacementValueExtractors());
     retList.addAll(m_insertStatement.getReplacementValueExtractors());

--- a/system/src/main/java/com/percussion/data/PSPagedRequestLinkGenerator.java
+++ b/system/src/main/java/com/percussion/data/PSPagedRequestLinkGenerator.java
@@ -134,12 +134,11 @@ public class PSPagedRequestLinkGenerator {
         buf.append(nextParamMarker);
         nextParamMarker = '&';
 
-        Object rawVal = params.get(key);
-        String val = rawVal == null ? null : rawVal.toString();
-        buf.append(
-            PSURLEncoder.encodeQuery(key)
-                + "="
-                + ((val == null) ? "" : PSURLEncoder.encodeQuery(val)));
+        // Historical Map values are Strings; cast preserves ClassCastException for
+        // non-String entries (pre-rawtypes cleanup). Null values intentionally
+        // encode as empty (key=) via the ternary — never encodeQuery(null).
+        String val = (String) params.get(key);
+        appendEncodedQueryParam(buf, key, val);
       }
     }
 
@@ -148,6 +147,27 @@ public class PSPagedRequestLinkGenerator {
     buf.append(PSResultSetXmlConverter.FIRST_QUERY_INDEX_PARAMETER_NAME + "=" + startAt);
 
     return buf.toString();
+  }
+
+  /**
+   * Append {@code key=value} with URL encoding. Null {@code val} yields an empty
+   * value (legacy pagination link behavior); non-null values are query-encoded.
+   *
+   * <p>Package-visible for unit tests documenting the null→empty contract after
+   * rawtypes cleanup (#2760 / PR review).
+   *
+   * @param buf destination buffer (not null)
+   * @param key parameter name (not null)
+   * @param val parameter value, or {@code null} for empty value
+   */
+  static void appendEncodedQueryParam(StringBuilder buf, String key, String val) {
+    buf.append(PSURLEncoder.encodeQuery(key));
+    buf.append('=');
+    if (val == null) {
+      // empty value — same as pre-generics ternary ((val == null) ? "" : encode)
+      return;
+    }
+    buf.append(PSURLEncoder.encodeQuery(val));
   }
 
   int m_type;

--- a/system/src/main/java/com/percussion/data/PSPagedRequestLinkGenerator.java
+++ b/system/src/main/java/com/percussion/data/PSPagedRequestLinkGenerator.java
@@ -23,7 +23,6 @@ import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
 import com.percussion.util.PSURLEncoder;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -127,9 +126,7 @@ public class PSPagedRequestLinkGenerator {
 
     // Add all html parameters here then the psfirst link...
     if (params != null) {
-      Iterator i = params.keySet().iterator();
-      while (i.hasNext()) {
-        String key = (String) i.next();
+      for (String key : params.keySet()) {
         if (key.equalsIgnoreCase(PSResultSetXmlConverter.FIRST_QUERY_INDEX_PARAMETER_NAME))
           continue; // ignore this, we'll do it later
         else if (key.equalsIgnoreCase("psrequrl")) continue; // we've already set this (first step)
@@ -137,7 +134,8 @@ public class PSPagedRequestLinkGenerator {
         buf.append(nextParamMarker);
         nextParamMarker = '&';
 
-        String val = (String) params.get(key);
+        Object rawVal = params.get(key);
+        String val = rawVal == null ? null : rawVal.toString();
         buf.append(
             PSURLEncoder.encodeQuery(key)
                 + "="

--- a/system/src/main/java/com/percussion/data/PSSetStyleSheetEvaluator.java
+++ b/system/src/main/java/com/percussion/data/PSSetStyleSheetEvaluator.java
@@ -83,7 +83,7 @@ public class PSSetStyleSheetEvaluator extends PSConditionalEvaluator {
    *     extensions (from the requestor)
    */
   public boolean hasExplicitExtensionList() {
-    Collection c = m_resultPage.getExtensions();
+    Collection<?> c = m_resultPage.getExtensions();
 
     return ((c != null) && (!c.isEmpty()));
   }

--- a/system/src/main/java/com/percussion/data/PSSqlBuilderContext.java
+++ b/system/src/main/java/com/percussion/data/PSSqlBuilderContext.java
@@ -30,7 +30,7 @@ class PSSqlBuilderContext {
     super();
     m_curGroup = null;
     m_curBlock = new PSStatementBlock(true);
-    m_blocks = new ArrayList();
+    m_blocks = new ArrayList<>();
     m_buf = new ByteArrayOutputStream();
     m_text = new PrintWriter(m_buf);
 
@@ -269,7 +269,7 @@ class PSSqlBuilderContext {
 
   private PSStatementGroup m_curGroup;
   private IPSStatementBlock m_curBlock;
-  private ArrayList m_blocks;
+  private final ArrayList<IPSStatementBlock> m_blocks;
   private ByteArrayOutputStream m_buf;
   private PrintWriter m_text;
 

--- a/system/src/main/java/com/percussion/data/PSStatementColumn.java
+++ b/system/src/main/java/com/percussion/data/PSStatementColumn.java
@@ -137,7 +137,7 @@ public class PSStatementColumn {
     if (m_dataType == Types.ARRAY) {
       value = m_dataExtractor.extract(data);
       if (value == null) {
-        value = new ArrayList();
+        value = new ArrayList<>();
       } else if (!(value instanceof Collection)) {
         Collection<Object> coll = new ArrayList<>();
         coll.add(value);
@@ -214,7 +214,7 @@ public class PSStatementColumn {
       {
         PSSqlHelper.setDataFromNumber(stmt, bindStart, (Number) value, dt);
       } else if ((value instanceof Collection) && (m_dataType == Types.ARRAY)) {
-        OracleTools.setDataFromCollection(stmt, bindStart, (Collection) value, dt);
+        OracleTools.setDataFromCollection(stmt, bindStart, (Collection<?>) value, dt);
       } else // hope JDBC can figure it out
       stmt.setObject(bindStart, value, dt);
     }

--- a/system/src/main/java/com/percussion/data/PSStyleSheetMerger.java
+++ b/system/src/main/java/com/percussion/data/PSStyleSheetMerger.java
@@ -53,7 +53,7 @@ public abstract class PSStyleSheetMerger {
     if (pos == -1) return null;
 
     urlExt = "text/" + urlExt.substring(pos + 1);
-    return (PSStyleSheetMerger) ms_StyleSheetMergers.get(urlExt);
+    return ms_StyleSheetMergers.get(urlExt);
   }
 
   /** Convienience method for {@link #merge(PSRequest,Document,OutputStream, String)} */
@@ -112,7 +112,7 @@ public abstract class PSStyleSheetMerger {
       }
     }
 
-    PSStyleSheetMerger merger = (PSStyleSheetMerger) ms_StyleSheetMergers.get(styleSheet.getType());
+    PSStyleSheetMerger merger = ms_StyleSheetMergers.get(styleSheet.getType());
     if (merger != null) {
       merger.merge(req, doc, out, styleURL, encoding);
 
@@ -176,7 +176,7 @@ public abstract class PSStyleSheetMerger {
    * This is a hash of our style sheet merging engines. The key is the style sheet MIME type (eg,
    * text/css) and the value is an instance of the appropriate PSStyleSheetMerger subclass.
    */
-  private static HashMap ms_StyleSheetMergers = new HashMap<>();
+  private static final HashMap<String, PSStyleSheetMerger> ms_StyleSheetMergers = new HashMap<>();
 
   /**
    * Initializes the static merger map so that the appropriate mergers can be found for each MIME

--- a/system/src/main/java/com/percussion/data/PSStylesheetCleanupFilter.java
+++ b/system/src/main/java/com/percussion/data/PSStylesheetCleanupFilter.java
@@ -233,7 +233,10 @@ public class PSStylesheetCleanupFilter {
   private void addNamespace(String ns, String namespaceUri) {
     if (!StringUtils.isEmpty(namespaceUri)) m_uris.put(ns, namespaceUri);
     if (!m_allowedNS.containsKey(ns)) {
-      List[] lists = {new ArrayList(), new ArrayList(), new ArrayList()};
+      @SuppressWarnings("unchecked")
+      List<String>[] lists =
+          (List<String>[])
+              new List<?>[] {new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>()};
       m_allowedNS.put(ns, lists);
     }
   }
@@ -290,14 +293,12 @@ public class PSStylesheetCleanupFilter {
     if (StringUtils.isBlank(ns)) ns = "";
     if (val == null) val = "";
     if (!m_allowedNS.containsKey(ns)) return false;
-    List list = getList(ns, listIndex);
+    List<String> list = getList(ns, listIndex);
     // First try to find a "*" wildcard entry, if we find this
     // we can just return true and save some time by not iterating
     // the list
     if (list.contains("*")) return true;
-    Iterator it = list.iterator();
-    while (it.hasNext()) {
-      String pattern = (String) it.next();
+    for (String pattern : list) {
       try {
         if (isMatch(val, pattern)) return true;
       } catch (MalformedPatternException e) {
@@ -384,10 +385,10 @@ public class PSStylesheetCleanupFilter {
    * namespace declaration values) Namespace devlaration values really doesn't need to be a list as
    * it is only a single value.
    */
-  private Map<String, List<String>[]> m_allowedNS = new HashMap<String, List<String>[]>();
+  private final Map<String, List<String>[]> m_allowedNS = new HashMap<>();
 
   /** A map that associates namespace prefixes with their corresponding uris. */
-  private Map<String, String> m_uris = new HashMap<String, String>();
+  private final Map<String, String> m_uris = new HashMap<>();
 
   /**
    * The singleton instance of this class, initialized in {@link #getInstance()}, never <code>null

--- a/system/src/main/java/com/percussion/data/PSStylesheetCleanupUtils.java
+++ b/system/src/main/java/com/percussion/data/PSStylesheetCleanupUtils.java
@@ -25,6 +25,7 @@ import au.id.jericho.lib.html.StartTag;
 import au.id.jericho.lib.html.StringOutputSegment;
 import au.id.jericho.lib.html.Tag;
 import java.util.Iterator;
+import java.util.List;
 import java.util.StringTokenizer;
 
 /** A Utility class that contains useful cleanup methods for pre and post processing a stylesheet */
@@ -55,10 +56,12 @@ public class PSStylesheetCleanupUtils {
     StartTag sTag = null;
     Attributes attributes = null;
     boolean replaceTag = false;
-    // Loop through every start tag
-    for (Iterator it = source.findAllStartTags().iterator(); it.hasNext(); ) {
+    // Loop through every start tag (jericho returns raw List/Iterator)
+    @SuppressWarnings("unchecked")
+    List<StartTag> startTags = source.findAllStartTags();
+    for (StartTag tag : startTags) {
       replaceTag = false;
-      sTag = (StartTag) it.next();
+      sTag = tag;
       if (!isNormalMarkupTag(sTag)) continue; // Skip if this is not a normal markup tag
 
       // Remove elements that use namespaces leaving the normal
@@ -74,15 +77,16 @@ public class PSStylesheetCleanupUtils {
       }
 
       attributes = sTag.getAttributes();
-      Iterator attrs = attributes.iterator();
       sb.setLength(0);
       sb.append("<");
       sb.append(getTagNameAsIs(sTag));
 
       // Remove namespace declarations or attribute that use a
       // namespace.
+      @SuppressWarnings("unchecked")
+      Iterator<Attribute> attrs = attributes.iterator();
       while (attrs.hasNext()) {
-        Attribute attr = (Attribute) attrs.next();
+        Attribute attr = attrs.next();
         String attrName = attr.getName().toLowerCase();
         qname = parseQName(attrName);
         // Handle namespace declarations

--- a/system/src/main/java/com/percussion/data/PSTableStatistics.java
+++ b/system/src/main/java/com/percussion/data/PSTableStatistics.java
@@ -58,7 +58,7 @@ class PSTableStatistics {
     m_login = login;
 
     m_indexStatistics = new PSIndexStatistics[0];
-    m_uniqueCounts = new HashMap(m_indexStatistics.length);
+    m_uniqueCounts = new HashMap<>(m_indexStatistics.length);
     m_isEstimated = true;
   }
 
@@ -85,7 +85,7 @@ class PSTableStatistics {
     m_indexStatistics = PSIndexStatistics.getStatistics(table, dmd);
     if (m_indexStatistics == null) m_indexStatistics = new PSIndexStatistics[0];
 
-    m_uniqueCounts = new java.util.HashMap(m_indexStatistics.length);
+    m_uniqueCounts = new java.util.HashMap<>(m_indexStatistics.length);
 
     for (int i = 0; i < m_indexStatistics.length; i++) {
       PSIndexStatistics curIdxStat = m_indexStatistics[i];
@@ -245,7 +245,7 @@ class PSTableStatistics {
     if (m_isEstimated) return m_cardinality;
 
     String columnList = getColumnListString(cols);
-    Integer cardinality = (Integer) m_uniqueCounts.get(columnList);
+    Integer cardinality = m_uniqueCounts.get(columnList);
     if (cardinality == null || cardinality.intValue() < 0) {
       // issue a select count distinct against the cols
       Connection conn = null;
@@ -315,7 +315,7 @@ class PSTableStatistics {
 
   // map from a sorted list of column names used to distinguish to a
   // cardinality of unique tuples given those column names
-  private Map m_uniqueCounts;
+  private Map<String, Integer> m_uniqueCounts;
 
   /**
    * Determines whether this is an estimated object, <code>true</code> if it is an estimated object.

--- a/system/src/main/java/com/percussion/data/PSUpdateInsertStatement.java
+++ b/system/src/main/java/com/percussion/data/PSUpdateInsertStatement.java
@@ -66,8 +66,8 @@ public class PSUpdateInsertStatement extends PSUpdateStatement {
    *
    * @return the list of replacement values
    */
-  public java.util.List getReplacementValueExtractors() {
-    java.util.ArrayList retList = new java.util.ArrayList();
+  public java.util.List<IPSDataExtractor> getReplacementValueExtractors() {
+    java.util.ArrayList<IPSDataExtractor> retList = new java.util.ArrayList<>();
 
     retList.addAll(super.getReplacementValueExtractors());
     retList.addAll(m_insertStatement.getReplacementValueExtractors());

--- a/system/src/main/java/com/percussion/data/PSXslStyleSheetMerger.java
+++ b/system/src/main/java/com/percussion/data/PSXslStyleSheetMerger.java
@@ -97,7 +97,7 @@ public class PSXslStyleSheetMerger extends PSStyleSheetMerger {
       Document doc,
       OutputStream out,
       URL styleFile,
-      Iterator params,
+      Iterator<? extends Map.Entry<?, ?>> params,
       String encoding)
       throws PSConversionException {
     if (doc == null)
@@ -233,7 +233,7 @@ public class PSXslStyleSheetMerger extends PSStyleSheetMerger {
       // add any params supplied
       if (hasParams) {
         while (params.hasNext()) {
-          Map.Entry param = (Map.Entry) params.next();
+          Map.Entry<?, ?> param = params.next();
           transformer.setParameter(param.getKey().toString(), param.getValue().toString());
         }
       }
@@ -363,12 +363,13 @@ public class PSXslStyleSheetMerger extends PSStyleSheetMerger {
    * @return error message, never <code>null</code>, may be empty.
    * @throws IOException reading source file in which error occurred.
    */
-  private static String getErrorMessages(Iterator errors) throws IOException {
+  private static String getErrorMessages(Iterator<? extends TransformerException> errors)
+      throws IOException {
     if (errors == null) throw new IllegalArgumentException("errors may not be null");
 
     StringBuilder errorMsg = new StringBuilder();
     while (errors.hasNext()) {
-      TransformerException e = (TransformerException) errors.next();
+      TransformerException e = errors.next();
       errorMsg.append(e.getMessageAndLocation());
       errorMsg.append(" ");
       errorMsg.append(getExceptionContextData(e));

--- a/system/src/main/java/com/percussion/data/jdbc/PSXmlConnection.java
+++ b/system/src/main/java/com/percussion/data/jdbc/PSXmlConnection.java
@@ -284,7 +284,7 @@ public class PSXmlConnection extends PSFileSystemConnection {
    *
    * @return the java.util.Map object associated with this Connection object
    */
-  public java.util.Map getTypeMap() throws SQLException {
+  public java.util.Map<String, Class<?>> getTypeMap() throws SQLException {
     checkClosed();
     return null;
   }
@@ -296,7 +296,7 @@ public class PSXmlConnection extends PSFileSystemConnection {
    * @param map the java.util.Map object to install as the replacement for this Connection object's
    *     default type map
    */
-  public void setTypeMap(java.util.Map map) throws SQLException {
+  public void setTypeMap(java.util.Map<String, Class<?>> map) throws SQLException {
     checkClosed();
   }
 

--- a/system/src/main/java/com/percussion/data/utils/PSHibernateEvictionTableUpdateHandler.java
+++ b/system/src/main/java/com/percussion/data/utils/PSHibernateEvictionTableUpdateHandler.java
@@ -73,7 +73,7 @@ public class PSHibernateEvictionTableUpdateHandler extends PSTableUpdateHandlerB
     m_classes = persistenceClasses;
   }
 
-  public Iterator getColumns(String tableName, int actionType) {
+  public Iterator<String> getColumns(String tableName, int actionType) {
     int i = m_tables.indexOf(tableName.toLowerCase());
 
     if (i < 0) return null;

--- a/system/src/main/java/com/percussion/data/utils/PSTableUpdateHandlerBase.java
+++ b/system/src/main/java/com/percussion/data/utils/PSTableUpdateHandlerBase.java
@@ -69,9 +69,10 @@ public abstract class PSTableUpdateHandlerBase
       PSCollection tableCol = upPipe.getBackEndDataTank().getTables();
 
       boolean added = false;
-      Iterator tables = tableCol.iterator();
+      @SuppressWarnings("unchecked")
+      Iterator<PSBackEndTable> tables = tableCol.iterator();
       while (tables.hasNext() && !added) {
-        PSBackEndTable table = (PSBackEndTable) tables.next();
+        PSBackEndTable table = tables.next();
         if (m_tables.contains(table.getTable().toLowerCase())) {
           uh.addTableChangeListener(this);
         }

--- a/system/src/test/java/com/percussion/data/PSOptimizerTypedTest.java
+++ b/system/src/test/java/com/percussion/data/PSOptimizerTypedTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSBackEndColumn;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed {@link PSOptimizer#isQueryIndexAvailable} after rawtypes cleanup.
+ */
+@Tag("UnitTest")
+class PSOptimizerTypedTest {
+
+  @Test
+  void emptyColumnListDoesNotRequireIndex() throws Exception {
+    List<PSBackEndColumn> empty = Collections.emptyList();
+    assertTrue(PSOptimizer.isQueryIndexAvailable(empty, null));
+  }
+
+  @Test
+  void nullColumnListDoesNotRequireIndex() throws Exception {
+    assertTrue(PSOptimizer.isQueryIndexAvailable(null, null));
+  }
+
+  @Test
+  void emptyArrayListColumnListDoesNotRequireIndex() throws Exception {
+    assertTrue(PSOptimizer.isQueryIndexAvailable(new ArrayList<>(), null));
+  }
+}

--- a/system/src/test/java/com/percussion/data/PSPagedRequestLinkGeneratorTypedTest.java
+++ b/system/src/test/java/com/percussion/data/PSPagedRequestLinkGeneratorTypedTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Documents pagination query-param encoding after rawtypes cleanup (#2760).
+ *
+ * <p>Null values intentionally encode as empty ({@code key=}), matching the
+ * pre-generics ternary — not {@code encodeQuery(null)} which would throw.
+ */
+@Tag("UnitTest")
+class PSPagedRequestLinkGeneratorTypedTest {
+
+  @Test
+  void nullValueEncodesAsEmptyNotThrow() {
+    StringBuilder buf = new StringBuilder();
+    PSPagedRequestLinkGenerator.appendEncodedQueryParam(buf, "folderid", null);
+    assertEquals("folderid=", buf.toString());
+  }
+
+  @Test
+  void nonNullValueIsQueryEncoded() {
+    StringBuilder buf = new StringBuilder();
+    PSPagedRequestLinkGenerator.appendEncodedQueryParam(buf, "q", "a b");
+    // Space is percent-encoded by PSURLEncoder.encodeQuery
+    assertEquals("q=a+b", buf.toString());
+  }
+
+  @Test
+  void nonStringParameterValueStillClassCastsLikeLegacyCast() {
+    // Mimic historical (String) params.get(key) on a non-String entry.
+    Object raw = Integer.valueOf(42);
+    assertThrows(ClassCastException.class, () -> {
+      @SuppressWarnings("unused")
+      String val = (String) raw;
+    });
+  }
+}

--- a/system/src/test/java/com/percussion/data/PSSqlBuilderContextTypedTest.java
+++ b/system/src/test/java/com/percussion/data/PSSqlBuilderContextTypedTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed {@link PSSqlBuilderContext} block lists after rawtypes cleanup.
+ */
+@Tag("UnitTest")
+class PSSqlBuilderContextTypedTest {
+
+  @Test
+  void initialContextHasSingleStaticStatementBlock() {
+    PSSqlBuilderContext ctx = new PSSqlBuilderContext();
+    ctx.addText("SELECT 1", true);
+
+    IPSStatementBlock[] blocks = ctx.getBlocks();
+    assertNotNull(blocks);
+    assertEquals(1, blocks.length);
+    assertTrue(blocks[0] instanceof PSStatementBlock);
+    assertTrue(blocks[0].isStaticBlock());
+  }
+
+  @Test
+  void newBlockAddsTypedStatementBlockToContext() {
+    PSSqlBuilderContext ctx = new PSSqlBuilderContext();
+    ctx.addText("UPDATE t SET a=1", true);
+    ctx.newBlock(true);
+    ctx.addText(" WHERE b=2", true);
+
+    IPSStatementBlock[] blocks = ctx.getBlocks();
+    assertEquals(2, blocks.length);
+    for (IPSStatementBlock block : blocks) {
+      assertNotNull(block);
+      assertTrue(block instanceof PSStatementBlock || block instanceof PSFunctionBlock);
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/data/PSStylesheetCleanupFilterTypedTest.java
+++ b/system/src/test/java/com/percussion/data/PSStylesheetCleanupFilterTypedTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Behavioral tests for typed namespace rule lists in {@link PSStylesheetCleanupFilter} after
+ * rawtypes cleanup.
+ */
+@Tag("UnitTest")
+class PSStylesheetCleanupFilterTypedTest {
+
+  private PSStylesheetCleanupFilter filter;
+
+  @BeforeEach
+  void loadFilter() throws Exception {
+    // Use a fresh instance via protected fromXml path on the singleton by reloading
+    // the default document content (getInstance may already exist; reconfigure via fromXml).
+    filter = PSStylesheetCleanupFilter.getInstance();
+    try (ByteArrayInputStream bis =
+        new ByteArrayInputStream(FILTER_XML.getBytes(StandardCharsets.UTF_8))) {
+      Document doc = PSXmlDocumentBuilder.createXmlDocument(bis, false);
+      filter.fromXml(doc.getDocumentElement());
+    }
+  }
+
+  @Test
+  void defaultNamespaceAllowsWildcardElementsAndAttributes() {
+    assertTrue(filter.isNSElementAllowed("", "div"));
+    assertTrue(filter.isNSAttributeAllowed("", "id"));
+    assertTrue(filter.isNSDeclarationAllowed("", "http://www.w3.org/1999/xhtml"));
+  }
+
+  @Test
+  void xmlNamespaceAllowsOnlyConfiguredAttributes() {
+    assertTrue(filter.isNSAttributeAllowed("xml", "lang"));
+    assertTrue(filter.isNSAttributeAllowed("xml", "space"));
+    assertFalse(filter.isNSAttributeAllowed("xml", "base"));
+    assertFalse(filter.isNSElementAllowed("xml", "anything"));
+  }
+
+  @Test
+  void unknownNamespaceIsRejectedAndPrefixesAreIterable() {
+    assertFalse(filter.isNSElementAllowed("x", "foo"));
+    Iterator<String> prefixes = filter.getPrefixes();
+    assertTrue(prefixes.hasNext());
+  }
+
+  private static final String FILTER_XML =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
+          + "<stylesheetCleanupFilter>"
+          + "<allowedNamespace name=\"\" declAllowed=\"true \" declValue=\"*xhtml*\">"
+          + "<allowedElement name=\"*\"/>"
+          + "<allowedAttribute name=\"*\"/>"
+          + "</allowedNamespace>"
+          + "<allowedNamespace name=\"xml\" uri=\"http://www.w3.org\" declAllowed=\"false \">"
+          + "<allowedAttribute name=\"lang\"/>"
+          + "<allowedAttribute name=\"space\"/>"
+          + "</allowedNamespace>"
+          + "</stylesheetCleanupFilter>";
+}

--- a/system/src/test/java/com/percussion/data/PSUpdateInsertStatementTypedTest.java
+++ b/system/src/test/java/com/percussion/data/PSUpdateInsertStatementTypedTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSTextLiteral;
+import java.sql.Types;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed {@link PSUpdateInsertStatement#getReplacementValueExtractors()} after
+ * rawtypes cleanup.
+ */
+@Tag("UnitTest")
+class PSUpdateInsertStatementTypedTest {
+
+  @Test
+  void mergeExtractorsFromUpdateAndInsertBlocks() throws Exception {
+    PSStatementBlock upd = new PSStatementBlock(false);
+    upd.addText("UPDATE t SET c=");
+    upd.addReplacementField(new PSTextLiteral("u"), Types.VARCHAR, null);
+
+    PSStatementBlock ins = new PSStatementBlock(false);
+    ins.addText("INSERT INTO t VALUES (");
+    ins.addReplacementField(new PSTextLiteral("i"), Types.VARCHAR, null);
+    ins.addText(")");
+
+    PSUpdateInsertStatement stmt =
+        new PSUpdateInsertStatement(
+            0, new IPSStatementBlock[] {upd}, new IPSStatementBlock[] {ins});
+
+    List<IPSDataExtractor> extractors = stmt.getReplacementValueExtractors();
+    assertNotNull(extractors);
+    assertEquals(2, extractors.size());
+    for (IPSDataExtractor extractor : extractors) {
+      assertNotNull(extractor);
+    }
+  }
+
+  @Test
+  void emptyBlocksYieldEmptyExtractorList() throws Exception {
+    PSStatementBlock upd = new PSStatementBlock(true);
+    upd.addText("UPDATE t SET c=1");
+    PSStatementBlock ins = new PSStatementBlock(true);
+    ins.addText("INSERT INTO t VALUES (1)");
+
+    PSUpdateInsertStatement stmt =
+        new PSUpdateInsertStatement(
+            0, new IPSStatementBlock[] {upd}, new IPSStatementBlock[] {ins});
+
+    List<IPSDataExtractor> extractors = stmt.getReplacementValueExtractors();
+    assertTrue(extractors.isEmpty());
+  }
+}

--- a/system/src/test/java/com/percussion/data/jdbc/PSXmlConnectionTypedTest.java
+++ b/system/src/test/java/com/percussion/data/jdbc/PSXmlConnectionTypedTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Signature/type tests for {@link PSXmlConnection} JDBC type-map methods after rawtypes cleanup.
+ */
+@Tag("UnitTest")
+class PSXmlConnectionTypedTest {
+
+  @Test
+  void getTypeMapReturnsTypedMapSignature() throws Exception {
+    Method m = PSXmlConnection.class.getMethod("getTypeMap");
+    assertEquals(Map.class, m.getReturnType());
+    // Generic return type must be Map<String, Class<?>>
+    String generic = m.getGenericReturnType().getTypeName();
+    assertEquals("java.util.Map<java.lang.String, java.lang.Class<?>>", generic);
+  }
+
+  @Test
+  void setTypeMapAcceptsTypedMapSignature() throws Exception {
+    Method m = PSXmlConnection.class.getMethod("setTypeMap", Map.class);
+    String param = m.getGenericParameterTypes()[0].getTypeName();
+    assertEquals("java.util.Map<java.lang.String, java.lang.Class<?>>", param);
+  }
+
+  @Test
+  void fileSystemConnectionTypeMapSharesTypedSignature() throws Exception {
+    Method get = PSFileSystemConnection.class.getMethod("getTypeMap");
+    assertEquals(
+        "java.util.Map<java.lang.String, java.lang.Class<?>>",
+        get.getGenericReturnType().getTypeName());
+  }
+}


### PR DESCRIPTION
## Summary
Fixes **#2760** (parent **#2022**, grandparent **#2200**): residual `-Xlint` rawtypes/unchecked batch **4g** in `com.percussion.data` after #2693 / PR #2762.

### Changes
- **Stylesheets:** `PSStylesheetCleanupFilter` / `PSStylesheetCleanupUtils` typed namespace rule lists; jericho boundary suppress; `PSXslStyleSheetMerger` / `PSStyleSheetMerger` typed param iterators and merger map
- **SQL builders:** `PSSqlBuilderContext`, `PSOracleUpdateInsertBuilder`/`Statement`, `PSUpdateInsertStatement` typed block/extractor lists; `PSOptimizer.isQueryIndexAvailable` typed column list
- **JDBC / stats / utils:** `PSXmlConnection` `Map<String,Class<?>>` type maps; `PSTableStatistics` uniqueness map; `PSStatementColumn` collection binds; table-update handler iterators; `PSPagedRequestLinkGenerator` / `PSSetStyleSheetEvaluator`
- **Extension boundary:** `PSExtensionRunner.runSearchResultProcessor` typed to `IPSSearchResultRow` with SPI cast to `List<Object>`
- Unit tests: 5 new `*TypedTest` classes (13 methods) + existing stylesheet utils regression
- Erlang report: `docs/ai-generated/code-reviews/issue-2760-data-rawtypes-erlang.md`

### Residual
Hand-written package inventory effectively zeroed; only generated `jdbc/sqlparser/SQLParser.java` raw Vector remains (JavaCC output — leave alone). No residual issue filed.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] Focused: `PSStylesheetCleanupFilterTypedTest`, `PSSqlBuilderContextTypedTest`, `PSOptimizerTypedTest`, `PSUpdateInsertStatementTypedTest`, `PSXmlConnectionTypedTest`, `PSStylesheetCleanupUtilsTest` (14 tests, green)
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: **1685**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] No product behavior change; pure generics tech-debt

## Product documentation
- [x] N/A — pure tech-debt generics modernization; no operator/admin/user-facing behavior change

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system; ..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1685, Failures: 0, Errors: 0, Skipped: 240
- **downstream_checked:** none (same-module callers only; no `final`/sealed; public signature tightenings stay compatible with in-module `PSSearchHandler` and JDBC `Connection`; no reverse-dep modules compile against changed package-private builders)

Fixes #2760

> Co-Authored by Grok Build using grok-4.5 with agent main.
