### PR TITLE
fix(deployer): Xlint residual — handlers + hierarchy this-escape (#2847)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
@@ -93,7 +93,8 @@ public abstract class PSDependency
     if (displayName == null || displayName.trim().length() == 0)
       throw new IllegalArgumentException("displayName may not be null or empty");
 
-    setDependencyType(dependencyType);
+    // private helper avoids overridable setDependencyType this-escape
+    applyDependencyType(dependencyType);
     m_dependencyId = dependencyId;
     m_displayName = displayName;
     m_objectType = objectType;
@@ -115,7 +116,8 @@ public abstract class PSDependency
   public PSDependency(Element src) throws PSUnknownNodeTypeException {
     if (src == null) throw new IllegalArgumentException("src may not be null");
 
-    fromXml(src);
+    // private helper avoids overridable fromXml this-escape
+    readFromXml(src);
   }
 
   /** Parameterless ctor for use by derived classes only. */
@@ -445,6 +447,16 @@ public abstract class PSDependency
    * @param type One of the <code>TYPE_XXX</code> types.
    */
   public void setDependencyType(int type) {
+    applyDependencyType(type);
+  }
+
+  /**
+   * Applies the dependency type and inclusion side-effects. Private so constructors can call it
+   * without a this-escape via the overridable {@link #setDependencyType(int)}.
+   *
+   * @param type One of the <code>TYPE_XXX</code> types.
+   */
+  private void applyDependencyType(int type) {
     if (!validateType(type)) throw new IllegalArgumentException("invalid type");
 
     m_dependencyType = type;
@@ -1135,6 +1147,29 @@ public abstract class PSDependency
    *     by the class.
    */
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+    readFromXml(sourceNode);
+  }
+
+  /**
+   * Restores base dependency state from XML. Final so subclass Element constructors can load the
+   * nested {@code PSXDependency} element without a this-escape through overridable {@link
+   * #fromXml(Element)}.
+   *
+   * @param sourceNode the PSXDependency element, not <code>null</code>.
+   * @throws PSUnknownNodeTypeException if the XML is malformed.
+   */
+  final void restoreDependencyFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+    readFromXml(sourceNode);
+  }
+
+  /**
+   * Restores state from XML. Private so constructors can call it without a this-escape via the
+   * overridable {@link #fromXml(Element)}.
+   *
+   * @param sourceNode the XML element node to populate from, not <code>null</code>.
+   * @throws PSUnknownNodeTypeException if the XML is malformed.
+   */
+  private void readFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
@@ -1142,7 +1177,9 @@ public abstract class PSDependency
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
     }
 
-    String sTemp = getRequiredAttribute(sourceNode, XML_ATT_DEPENDENCY_TYPE);
+    // static helper — avoid overridable getRequiredAttribute this-escape from Element ctor
+    String sTemp =
+        PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATT_DEPENDENCY_TYPE);
     m_dependencyType = -1;
     for (int i = 0; i < TYPE_ENUM.length && m_dependencyType == -1; i++) {
       if (TYPE_ENUM[i].equals(sTemp)) m_dependencyType = i;
@@ -1152,10 +1189,14 @@ public abstract class PSDependency
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
     }
 
-    m_dependencyId = getRequiredAttribute(sourceNode, XML_ATT_DEPENDENCY_ID);
-    m_displayName = getRequiredAttribute(sourceNode, XML_ATT_DISPLAY_NAME);
-    m_objectType = getRequiredAttribute(sourceNode, XML_ATT_OBJECT_TYPE);
-    m_objectTypeName = getRequiredAttribute(sourceNode, XML_ATT_OBJECT_TYPE_NAME);
+    m_dependencyId =
+        PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATT_DEPENDENCY_ID);
+    m_displayName =
+        PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATT_DISPLAY_NAME);
+    m_objectType =
+        PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATT_OBJECT_TYPE);
+    m_objectTypeName =
+        PSDeployComponentUtils.getRequiredAttribute(sourceNode, XML_ATT_OBJECT_TYPE_NAME);
     m_supportsIdTypes = XML_ATT_VAL_TRUE.equals(sourceNode.getAttribute(XML_ATT_SUPPORTS_ID_TYPES));
     m_supportsIdMapping =
         XML_ATT_VAL_TRUE.equals(sourceNode.getAttribute(XML_ATT_SUPPORTS_ID_MAPPING));

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyData.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependencyData.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** A container class to encapsulate a schema and a table data for a dependency object. */
-public class PSDependencyData implements IPSDeployComponent {
+public final class PSDependencyData implements IPSDeployComponent {
 
   /**
    * Constructing the object with the given parameters.
@@ -68,7 +68,8 @@ public class PSDependencyData implements IPSDeployComponent {
     if (source == null) throw new IllegalArgumentException("source may not be null");
     if (typeMap == null) throw new IllegalArgumentException("typeMap may not be null");
 
-    fromXml(source, typeMap);
+    // final class + private load helper for Element-ctor this-escape
+    readFromXml(source, typeMap);
   }
 
   /**
@@ -129,6 +130,15 @@ public class PSDependencyData implements IPSDeployComponent {
    * @throws PSUnknownNodeTypeException if the XML is malformed.
    */
   public void fromXml(Element sourceNode, PSJdbcDataTypeMap typeMap)
+      throws PSUnknownNodeTypeException {
+    readFromXml(sourceNode, typeMap);
+  }
+
+  /**
+   * Restores schema and table data from XML. Private so the Element constructor can call it without
+   * a this-escape via the public {@link #fromXml(Element, PSJdbcDataTypeMap)}.
+   */
+  private void readFromXml(Element sourceNode, PSJdbcDataTypeMap typeMap)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null || typeMap == null) {
       throw new IllegalArgumentException("sourceNode and typeMap may not be null");

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableElement.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableElement.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Dependency class that represents a top-level cms element that may be deployed stand-alone. */
-public class PSDeployableElement extends PSDependency {
+public final class PSDeployableElement extends PSDependency {
 
   /**
    * Convenience ctor that calls <code>this(dependencyType, dependencyId,
@@ -118,7 +118,8 @@ public class PSDeployableElement extends PSDependency {
   public PSDeployableElement(Element src) throws PSUnknownNodeTypeException {
     if (src == null) throw new IllegalArgumentException("src may not be null");
 
-    fromXml(src);
+    // final class + direct load; keep private helper for clarity with peer hierarchy
+    readFromXml(src);
   }
 
   /**
@@ -176,6 +177,14 @@ public class PSDeployableElement extends PSDependency {
    */
   @Override
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+    readFromXml(sourceNode);
+  }
+
+  /**
+   * Restores state from XML. Private so the Element constructor can call it without a this-escape
+   * via the overridable {@link #fromXml(Element)}.
+   */
+  private void readFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new IllegalArgumentException("sourceNode may not be null");
     }
@@ -191,7 +200,8 @@ public class PSDeployableElement extends PSDependency {
       throw new PSUnknownNodeTypeException(
           IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
     }
-    super.fromXml(dep);
+    // final helper — avoid overridable super.fromXml this-escape from Element ctor
+    restoreDependencyFromXml(dep);
     m_description =
         Optional.ofNullable(tree.getElementData(XML_EL_DESC))
             .orElseThrow(

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableObject.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDeployableObject.java
@@ -114,15 +114,23 @@ public class PSDeployableObject extends PSDependency {
   /**
    * Constructs this object from its XML representation.
    *
+   * <p>Uses a private load helper (not overridable {@link #fromXml(Element)}). Remaining {@code
+   * this-escape} is from nested child linking inside {@link #restoreDependencyFromXml(Element)}
+   * ({@code setParentDependency(this)}), which is intentional for the dependency tree and cannot be
+   * deferred without behavior change. Class is not {@code final} because {@link PSUserDependency}
+   * extends it.
+   *
    * @param src The source element. Format expected is defined by {@link #toXml(Document)}.
    * @throws IllegalArgumentException if <code>sourceNode</code> is <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node does not represent a type supported
    *     by the class.
    */
+  @SuppressWarnings("this-escape")
   public PSDeployableObject(Element src) throws PSUnknownNodeTypeException {
     if (src == null) throw new IllegalArgumentException("src may not be null");
 
-    fromXml(src);
+    // private helper avoids overridable fromXml this-escape
+    readFromXml(src);
   }
 
   /** Parameterless ctor for use by derived classes only. */
@@ -166,6 +174,14 @@ public class PSDeployableObject extends PSDependency {
    *     by the class.
    */
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+    readFromXml(sourceNode);
+  }
+
+  /**
+   * Restores state from XML. Private so the Element constructor can call it without a this-escape
+   * via the overridable {@link #fromXml(Element)}.
+   */
+  private void readFromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new IllegalArgumentException("sourceNode may not be null");
     }
@@ -181,7 +197,8 @@ public class PSDeployableObject extends PSDependency {
       throw new PSUnknownNodeTypeException(
           IPSObjectStoreErrors.XML_ELEMENT_NULL, PSDependency.XML_NODE_NAME);
     }
-    super.fromXml(dep);
+    // final helper — avoid overridable super.fromXml this-escape from Element ctor
+    restoreDependencyFromXml(dep);
     m_classNames.clear();
     // RequiredClasses is a sibling of PSXDependency under the root element.
     tree.setCurrent(sourceNode);

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDescriptor.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDescriptor.java
@@ -63,7 +63,8 @@ public abstract class PSDescriptor implements IPSDeployComponent {
   protected PSDescriptor(Element src) throws PSUnknownNodeTypeException, PSDeployException {
     if (src == null) throw new IllegalArgumentException("src may not be null");
 
-    fromXml(src);
+    // private helper avoids overridable fromXml this-escape
+    readFromXml(src);
   }
 
   /** Parameterless ctor for use by derived classes only. */
@@ -186,6 +187,14 @@ public abstract class PSDescriptor implements IPSDeployComponent {
    * signature.
    */
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException, PSDeployException {
+    readFromXml(sourceNode);
+  }
+
+  /**
+   * Restores descriptor fields from XML. Private so constructors can call it without a this-escape
+   * via the overridable {@link #fromXml(Element)}.
+   */
+  private void readFromXml(Element sourceNode) throws PSUnknownNodeTypeException, PSDeployException {
     if (sourceNode == null) {
       throw new IllegalArgumentException("sourceNode may not be null");
     }

--- a/deployer/src/main/java/com/percussion/deployer/server/PSIdTypeManager.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSIdTypeManager.java
@@ -361,9 +361,9 @@ public class PSIdTypeManager {
       if (typeList == null) {
         // not cached, look it up
         typeList = new ArrayList<>();
-        Iterator types = depMgr.getPossibleIdTypes(tok, id);
+        Iterator<PSDependencyDef> types = depMgr.getPossibleIdTypes(tok, id);
         while (types.hasNext()) {
-          PSDependencyDef def = (PSDependencyDef) types.next();
+          PSDependencyDef def = types.next();
           typeList.add(def.getObjectType());
         }
 
@@ -392,11 +392,11 @@ public class PSIdTypeManager {
       PSApplicationIDTypes idTypes, Map<String, IPSExtensionDef> extensionCache) {
     Iterator<PSApplicationIDTypeMapping> mappings = idTypes.getAllMappings(false);
     while (mappings.hasNext()) {
-      PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
+      PSApplicationIDTypeMapping mapping = mappings.next();
 
       Iterator<PSApplicationIdContext> contexts = mapping.getContext().getAllContexts();
       while (contexts.hasNext()) {
-        PSApplicationIdContext ctx = (PSApplicationIdContext) contexts.next();
+        PSApplicationIdContext ctx = contexts.next();
         if (!(ctx instanceof PSAppExtensionParamIdContext)) continue;
 
         PSAppExtensionParamIdContext extParamCtx = (PSAppExtensionParamIdContext) ctx;
@@ -424,7 +424,7 @@ public class PSIdTypeManager {
           }
 
           // get the name and set on the ctx
-          Iterator paramNames = def.getRuntimeParameterNames();
+          Iterator<?> paramNames = def.getRuntimeParameterNames();
           int i = 0;
           while (paramNames.hasNext() && i <= index) {
             String name = paramNames.next().toString();
@@ -470,7 +470,7 @@ public class PSIdTypeManager {
     if (usedMappings == null) throw new IllegalArgumentException("usedMappings may not be null");
 
     while (mappings.hasNext()) {
-      PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
+      PSApplicationIDTypeMapping mapping = mappings.next();
       PSApplicationIdContext ctx = mapping.getContext();
       PSApplicationIDTypeMapping cur = idTypes.getMapping(resourceName, elementName, ctx);
 
@@ -510,7 +510,7 @@ public class PSIdTypeManager {
         Iterator<PSApplicationIDTypeMapping> mappings =
             idTypes.getIdTypeMappings(resource, element, false);
         while (mappings.hasNext()) {
-          PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
+          PSApplicationIDTypeMapping mapping = mappings.next();
           if (usedMappings.getMapping(resource, element, mapping.getContext()) == null) {
             idTypes.removeMapping(resource, element, mapping.getContext());
           }

--- a/deployer/src/main/java/com/percussion/deployer/server/PSTransformsHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSTransformsHandler.java
@@ -226,10 +226,10 @@ public class PSTransformsHandler {
     }
 
     PSDependency parent = null;
-    Iterator childDeps = root.getDependencies();
+    Iterator<PSDependency> childDeps = root.getDependencies();
     if (childDeps != null) {
       while (childDeps.hasNext() && parent != null) {
-        parent = getParentDependency(dep, parentType, (PSDependency) childDeps.next());
+        parent = getParentDependency(dep, parentType, childDeps.next());
       }
     }
 
@@ -248,10 +248,10 @@ public class PSTransformsHandler {
   private void getSupportedIdMapDependencies(
       PSDependency dependency, List<PSDependency> idMapDeps) {
     if (dependency.supportsIDMapping()) idMapDeps.add(dependency);
-    Iterator childDeps = dependency.getDependencies();
+    Iterator<PSDependency> childDeps = dependency.getDependencies();
     if (childDeps != null) {
       while (childDeps.hasNext()) {
-        getSupportedIdMapDependencies((PSDependency) childDeps.next(), idMapDeps);
+        getSupportedIdMapDependencies(childDeps.next(), idMapDeps);
       }
     }
   }
@@ -452,9 +452,9 @@ public class PSTransformsHandler {
     }
 
     Set<String> usedElements = new HashSet<>();
-    Iterator mappings = m_idMap.getMappings();
+    Iterator<PSIdMapping> mappings = m_idMap.getMappings();
     while (mappings.hasNext()) {
-      PSIdMapping mapping = (PSIdMapping) mappings.next();
+      PSIdMapping mapping = mappings.next();
       if (mapping.getObjectType().equals(objectType) && mapping.getTargetId() != null) {
         usedElements.add(
             mapping.getTargetId()
@@ -492,10 +492,11 @@ public class PSTransformsHandler {
       throws PSDeployException, PSNotFoundException {
     Set<PSMappingElement> mapElems = new HashSet<>();
 
-    Iterator iter = PSDependencyManager.getInstance().getDependencies(m_tok, type);
+    Iterator<PSDependency> iter =
+        PSDependencyManager.getInstance().getDependencies(m_tok, type);
 
     while (iter.hasNext()) {
-      PSDependency dep = (PSDependency) iter.next();
+      PSDependency dep = iter.next();
       PSMappingElement element =
           new PSMappingElement(dep.getObjectType(), dep.getDependencyId(), dep.getDisplayName());
       mapElems.add(element);
@@ -542,10 +543,10 @@ public class PSTransformsHandler {
         Iterator<PSMappingElement> parentIter = getElementsByType(parentType);
         while (parentIter.hasNext()) {
           PSMappingElement parentElement = parentIter.next();
-          Iterator childElements =
+          Iterator<PSDependency> childElements =
               PSDependencyManager.getInstance().getDependencies(m_tok, type, parentElement.getId());
           while (childElements.hasNext()) {
-            PSDependency element = (PSDependency) childElements.next();
+            PSDependency element = childElements.next();
             PSMappingElement childElement =
                 new PSMappingElement(
                     element.getObjectType(), element.getDependencyId(), element.getDisplayName());
@@ -572,7 +573,7 @@ public class PSTransformsHandler {
    * @return See {@link PSDependencyManager#getParentTypes()}.
    * @throws PSDeployException
    */
-  private Map getParentTypes() throws PSDeployException {
+  private Map<String, String> getParentTypes() throws PSDeployException {
     return PSDependencyManager.getInstance().getParentTypes();
   }
 
@@ -597,8 +598,8 @@ public class PSTransformsHandler {
    * @throws PSDeployException if an error happens getting parent types.
    */
   private String getParentType(String type) throws PSDeployException {
-    Map parentTypes = getParentTypes();
-    return (String) parentTypes.get(type);
+    Map<String, String> parentTypes = getParentTypes();
+    return parentTypes.get(type);
   }
 
   /**
@@ -611,9 +612,9 @@ public class PSTransformsHandler {
     if (m_idTypes == null) {
       m_idTypes = new HashSet<>();
       PSDependencyManager mgr = PSDependencyManager.getInstance();
-      Iterator idTypes = mgr.getObjectTypes();
+      Iterator<PSDependencyDef> idTypes = mgr.getObjectTypes();
       while (idTypes.hasNext()) {
-        PSDependencyDef def = (PSDependencyDef) idTypes.next();
+        PSDependencyDef def = idTypes.next();
         if (def.supportsIdMapping()) {
           m_idTypes.add(def);
         }
@@ -632,9 +633,9 @@ public class PSTransformsHandler {
    */
   private PSIdMap getValidMappings(PSIdMap idMap) {
     PSIdMap copy = new PSIdMap(idMap.getSourceServer());
-    Iterator mappings = idMap.getMappings();
+    Iterator<PSIdMapping> mappings = idMap.getMappings();
     while (mappings.hasNext()) {
-      PSIdMapping mapping = (PSIdMapping) mappings.next();
+      PSIdMapping mapping = mappings.next();
       if (mapping.isMapped()) copy.addMapping(mapping);
     }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAppObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAppObjectDependencyHandler.java
@@ -115,7 +115,8 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
    * @param srcNode The element to search, may not be <code>null</code>.
    * @throws PSDeployException if there are any errors creating the dependencies.
    */
-  protected void addApplicationDependencies(PSSecurityToken tok, Set childDeps, Element srcNode)
+  protected void addApplicationDependencies(
+      PSSecurityToken tok, Set<PSDependency> childDeps, Element srcNode)
       throws PSDeployException, com.percussion.services.error.PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -243,13 +244,13 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
    * @throws IllegalArgumentException if any param is invalid.
    * @throws PSDeployException if there are any errors.
    */
-  protected List getLiteralPathDependencies(PSSecurityToken tok, Element srcNode)
+  protected List<PSDependency> getLiteralPathDependencies(PSSecurityToken tok, Element srcNode)
       throws PSDeployException, com.percussion.services.error.PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
     if (srcNode == null) throw new IllegalArgumentException("srcNode may not be null");
 
-    List childDeps = new ArrayList();
+    List<PSDependency> childDeps = new ArrayList<>();
 
     NodeList lits = srcNode.getElementsByTagName(PSTextLiteral.ms_NodeType);
     for (int i = 0; i < lits.getLength(); i++) {
@@ -429,9 +430,9 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
       int fileStart = path.indexOf(appName) + appName.length() + 1;
       if (fileStart < path.length()) {
         String filePath = path.substring(fileStart);
-        Iterator appFiles = getAppFiles(tok, appName);
+        Iterator<File> appFiles = getAppFiles(tok, appName);
         while (appFiles.hasNext() && appFile == null) {
-          File test = (File) appFiles.next();
+          File test = appFiles.next();
           if (compareFiles(test.getPath(), filePath)) appFile = test;
         }
       }
@@ -542,18 +543,19 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
    * @throws IllegalArgumentException if any param is invalid.
    * @throws PSDeployException if any errors occur.
    */
-  protected Iterator getAppFiles(PSSecurityToken tok, String appName) throws PSDeployException {
+  protected Iterator<File> getAppFiles(PSSecurityToken tok, String appName)
+      throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
     if (appName == null || appName.trim().length() == 0)
       throw new IllegalArgumentException("appName may not be null or empty");
 
     try {
-      List appFiles = new ArrayList();
+      List<File> appFiles = new ArrayList<>();
       PSServerXmlObjectStore os = PSServerXmlObjectStore.getInstance();
-      Iterator files = os.getApplicationFiles(appName);
+      Iterator<File> files = os.getApplicationFiles(appName);
       while (files.hasNext()) {
-        File file = (File) files.next();
+        File file = files.next();
 
         // ignore files in AA temp dirs
         if (isValidAppFile(file, appName)) appFiles.add(file);
@@ -633,8 +635,8 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
    * @return An iterator over zero or more filepaths as <code>String</code> objects, never <code>
    *     null</code>.
    */
-  private Iterator getVarPaths(Document doc, Map varMap) {
-    Set pathSet = new HashSet();
+  private Iterator<String> getVarPaths(Document doc, Map<String, String> varMap) {
+    Set<String> pathSet = new HashSet<>();
 
     if (!varMap.isEmpty()) {
       // walk all nodes and check for var use
@@ -656,7 +658,7 @@ public abstract class PSAppObjectDependencyHandler extends PSIdTypeDependencyHan
         String var = path.substring(path.indexOf(CONCAT_START) + CONCAT_START.length(), iSep);
 
         // see if its in the map
-        String replVal = (String) varMap.get(var);
+        String replVal = varMap.get(var);
         if (replVal == null) continue;
 
         // get the file

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSApplicationDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSApplicationDependencyHandler.java
@@ -125,9 +125,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
       if (pipe == null) continue;
       var tank = pipe.getBackEndDataTank();
       if (tank == null) continue;
-      Iterator dsTableIter = tank.getTables().iterator();
-      while (dsTableIter.hasNext()) {
-        var table = (PSBackEndTable) dsTableIter.next();
+      for (Object rawTable : tank.getTables()) {
+        var table = (PSBackEndTable) rawTable;
         var schemaDep =
             getDependencyHandler(PSSchemaDependencyHandler.DEPENDENCY_TYPE)
                 .getDependency(tok, table.getTable());
@@ -170,9 +169,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
     boolean gotCE = false;
     PSCollection dataSetColl = app.getDataSets();
     if (dataSetColl != null) {
-      Iterator datasets = dataSetColl.iterator();
-      while (datasets.hasNext()) {
-        PSDataSet ds = (PSDataSet) datasets.next();
+      for (Object rawDsObj : dataSetColl) {
+        PSDataSet ds = (PSDataSet) rawDsObj;
         // get tables from tank
         PSPipe pipe = ds.getPipe();
         if (pipe == null) continue;
@@ -180,9 +178,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
         PSBackEndDataTank tank = pipe.getBackEndDataTank();
         if (tank == null) continue;
 
-        Iterator tables = tank.getTables().iterator();
-        while (tables.hasNext()) {
-          PSBackEndTable table = (PSBackEndTable) tables.next();
+        for (Object rawTable : tank.getTables()) {
+          PSBackEndTable table = (PSBackEndTable) rawTable;
           PSDependency schemaDep = schemaHandler.getDependency(tok, table.getTable());
           if (schemaDep != null) {
             if (schemaDep.getDependencyType() == PSDependency.TYPE_SHARED) {
@@ -198,7 +195,7 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
         // check for function defs and child resource cache dependencies
         if (pipe instanceof PSQueryPipe) {
           PSQueryPipe qPipe = (PSQueryPipe) pipe;
-          Iterator childResources = qPipe.getCacheSettings().getDependencies();
+          Iterator<?> childResources = qPipe.getCacheSettings().getDependencies();
           while (childResources.hasNext()) {
             String child = (String) childResources.next();
             PSDependency appDep = getDepFromPath(tok, child);
@@ -209,9 +206,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
           if (selector != null) {
             PSCollection whereColl = selector.getWhereClauses();
             if (whereColl != null) {
-              Iterator wheres = whereColl.iterator();
-              while (wheres.hasNext()) {
-                PSWhereClause where = (PSWhereClause) wheres.next();
+              for (Object rawWhere : whereColl) {
+                PSWhereClause where = (PSWhereClause) rawWhere;
                 IPSReplacementValue[] vars = {where.getValue(), where.getVariable()};
 
                 PSDependencyHandler funcHandler =
@@ -248,9 +244,9 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
       var doc = os.getApplicationDoc(dep.getDependencyId(), tok);
       files.add(new PSDependencyFile(PSDependencyFile.TYPE_APPLICATION_XML, createXmlFile(doc)));
 
-      Iterator appFilesIter = getAppFiles(tok, dep.getDependencyId());
+      Iterator<File> appFilesIter = getAppFiles(tok, dep.getDependencyId());
       while (appFilesIter.hasNext()) {
-        File appFile = (File) appFilesIter.next();
+        File appFile = appFilesIter.next();
         File tmpFile = getFileFromApp(tok, dep.getDependencyId(), appFile);
         files.add(new PSDependencyFile(PSDependencyFile.TYPE_APPLICATION_FILE, tmpFile, appFile));
       }
@@ -281,9 +277,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
       PSCollection dataSetColl = app.getDataSets();
       if (dataSetColl == null) return infoList;
 
-      Iterator datasets = dataSetColl.iterator();
-      while (datasets.hasNext()) {
-        PSDataSet ds = (PSDataSet) datasets.next();
+      for (Object rawDs : dataSetColl) {
+        PSDataSet ds = (PSDataSet) rawDs;
 
         PSPipe pipe = ds.getPipe();
         if (pipe == null) continue;
@@ -291,9 +286,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
         PSBackEndDataTank tank = pipe.getBackEndDataTank();
         if (tank == null) continue;
 
-        Iterator tables = tank.getTables().iterator();
-        while (tables.hasNext()) {
-          PSBackEndTable table = (PSBackEndTable) tables.next();
+        for (Object rawTable : tank.getTables()) {
+          PSBackEndTable table = (PSBackEndTable) rawTable;
           String dataSrc = table.getDataSource();
 
           // see if datasource is not blank
@@ -327,10 +321,10 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
 
     String appName = dep.getDependencyId();
     Document appDoc = null;
-    List appFileList = new ArrayList();
-    Iterator files = archive.getFiles(dep);
+    List<PSDependencyFile> appFileList = new ArrayList<>();
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
     while (files.hasNext()) {
-      PSDependencyFile file = (PSDependencyFile) files.next();
+      PSDependencyFile file = files.next();
       if (file.getType() == PSDependencyFile.TYPE_APPLICATION_XML) {
         String archivePath =
             file.getArchiveLocation() != null ? file.getArchiveLocation().getPath() : null;
@@ -390,18 +384,16 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
 
       // if app exists, get current app files to determine if adding or
       // overwriting files
-      List curFileList = new ArrayList();
+      List<File> curFileList = new ArrayList<>();
       if (exists) {
-        Iterator curFiles = getAppFiles(tok, app.getName());
+        Iterator<File> curFiles = getAppFiles(tok, app.getName());
         while (curFiles.hasNext()) curFileList.add(curFiles.next());
       }
 
       // save the application files
-      Iterator appFiles = appFileList.iterator();
-      while (appFiles.hasNext()) {
+      for (PSDependencyFile appFile : appFileList) {
         int transAction = PSTransactionSummary.ACTION_CREATED;
 
-        PSDependencyFile appFile = (PSDependencyFile) appFiles.next();
         File origFile = normalizePathSep(appFile.getOriginalFile());
         PSXmlObjectStoreLockerId filelockId = null;
         try {
@@ -428,10 +420,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
       }
 
       // remaining files have to be deleted and logged
-      Iterator it = curFileList.iterator();
       File appDir = new File(PSServer.getRxDir(), appName);
-      while (it.hasNext()) {
-        File f = (File) it.next();
+      for (File f : curFileList) {
         File appFile = new File(appDir, f.getPath());
 
         if (os.removeApplicationFile(app, appFile, lockId, tok))
@@ -490,11 +480,12 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
   }
 
   // see base class
-  public Iterator getDependencies(PSSecurityToken tok) throws PSDeployException {
+  @Override
+  public Iterator<PSDependency> getDependencies(PSSecurityToken tok) throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
     // get all applications
-    List deps = new ArrayList();
+    List<PSDependency> deps = new ArrayList<>();
     PSApplicationSummary[] sums =
         PSServerXmlObjectStore.getInstance().getApplicationSummaryObjects(tok, false);
     for (int i = 0; i < sums.length; i++) {
@@ -553,7 +544,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
    * @return An iterator over zero or more types as <code>String</code> objects, never <code>null
    *     </code>, does not contain <code>null</code> or empty entries.
    */
-  public Iterator getChildTypes() {
+  @Override
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
@@ -599,10 +591,9 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
       PSCollection dataSetColl = app.getDataSets();
       if (dataSetColl == null) return idTypes;
 
-      Iterator datasets = dataSetColl.iterator();
-      while (datasets.hasNext()) {
-        List mappings = new ArrayList();
-        PSDataSet ds = (PSDataSet) datasets.next();
+      for (Object rawDs : dataSetColl) {
+        List<PSApplicationIDTypeMapping> mappings = new ArrayList<>();
+        PSDataSet ds = (PSDataSet) rawDs;
         String reqName = getResourceName(ds);
 
         // check page selection/validation properties
@@ -633,9 +624,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
             PSCollection pageColl = pageSet.getResultPages();
             if (pageColl != null) {
               mappings.clear();
-              Iterator pages = pageColl.iterator();
-              while (pages.hasNext()) {
-                PSAppTransformer.checkResultPage(mappings, (PSResultPage) pages.next(), null);
+              for (Object rawPage : pageColl) {
+                PSAppTransformer.checkResultPage(mappings, (PSResultPage) rawPage, null);
               }
 
               idTypes.addMappings(
@@ -693,18 +683,19 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
     PSApplication app = (PSApplication) object;
 
     // walk id types and perform any transforms
-    Iterator resources = idTypes.getResourceList(false);
+    Iterator<String> resources = idTypes.getResourceList(false);
     while (resources.hasNext()) {
-      String resource = (String) resources.next();
+      String resource = resources.next();
       PSDataSet ds = getResource(app, resource);
       if (ds == null) continue;
 
-      Iterator elements = idTypes.getElementList(resource, false);
+      Iterator<String> elements = idTypes.getElementList(resource, false);
       while (elements.hasNext()) {
-        String element = (String) elements.next();
-        Iterator mappings = idTypes.getIdTypeMappings(resource, element, false);
+        String element = elements.next();
+        Iterator<PSApplicationIDTypeMapping> mappings =
+            idTypes.getIdTypeMappings(resource, element, false);
         while (mappings.hasNext()) {
-          PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
+          PSApplicationIDTypeMapping mapping = mappings.next();
 
           if (mapping.getType().equals(PSApplicationIDTypeMapping.TYPE_NONE)) {
             continue;
@@ -734,10 +725,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
                 if (pageSet != null) {
                   PSCollection pageColl = pageSet.getResultPages();
                   if (pageColl != null) {
-                    Iterator pages = pageColl.iterator();
-                    while (pages.hasNext()) {
-                      PSAppTransformer.transformResultPage(
-                          (PSResultPage) pages.next(), mapping, idMap);
+                    for (Object rawPage : pageColl) {
+                      PSAppTransformer.transformResultPage((PSResultPage) rawPage, mapping, idMap);
                     }
                   }
                 }
@@ -840,22 +829,20 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
     PSCollection dataSetColl = app.getDataSets();
     if (dataSetColl == null) return;
 
-    Iterator datasets = dataSetColl.iterator();
-    while (datasets.hasNext()) {
-      PSDataSet ds = (PSDataSet) datasets.next();
+    for (Object rawDs : dataSetColl) {
+      PSDataSet ds = (PSDataSet) rawDs;
       PSPipe pipe = ds.getPipe();
       if (pipe == null) continue;
 
       PSBackEndDataTank tank = pipe.getBackEndDataTank();
       if (tank == null) continue;
 
-      Iterator tables = tank.getTables().iterator();
-      while (tables.hasNext()) {
-        PSBackEndTable table = (PSBackEndTable) tables.next();
+      for (Object rawTable : tank.getTables()) {
+        PSBackEndTable table = (PSBackEndTable) rawTable;
         if (srcRep != null && dbmsMap != null && StringUtils.isNotEmpty(table.getDataSource())) {
-          Iterator mappings = dbmsMap.getMappings();
+          Iterator<PSDbmsMapping> mappings = dbmsMap.getMappings();
           while (mappings.hasNext()) {
-            PSDbmsMapping mapping = (PSDbmsMapping) mappings.next();
+            PSDbmsMapping mapping = mappings.next();
             String srcInfo = mapping.getSourceInfo();
             String tgtInfo = mapping.getTargetInfo();
             if (tgtInfo == null) continue;
@@ -958,9 +945,9 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
 
     PSCollection dataSetColl = app.getDataSets();
     if (dataSetColl != null) {
-      Iterator datasets = dataSetColl.iterator();
-      while (datasets.hasNext() && ds == null) {
-        PSDataSet test = (PSDataSet) datasets.next();
+      for (Object rawDs : dataSetColl) {
+        if (ds != null) break;
+        PSDataSet test = (PSDataSet) rawDs;
         if (getResourceName(test).equals(resourceName)) ds = test;
       }
     }
@@ -982,9 +969,8 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
     IPSBackEndRoleMgr beRoleMgr = PSRoleMgrLocator.getBackEndRoleManager();
     PSAcl acl = app.getAcl();
     PSCollection coll = acl.getEntries();
-    Iterator<PSAclEntry> iter = coll.iterator();
-    while (iter.hasNext()) {
-      PSAclEntry aclEntry = iter.next();
+    for (Object rawEntry : coll) {
+      PSAclEntry aclEntry = (PSAclEntry) rawEntry;
       if (aclEntry.isRole()) {
         String name = aclEntry.getName();
         beRoleMgr.createRole(name);
@@ -999,13 +985,7 @@ public class PSApplicationDependencyHandler extends PSContentEditorObjectDepende
   private static final String SYS_PREFIX = "sys_";
 
   /** List of child types supported by this handler, never <code>null</code> or empty. */
-  private static List<String> ms_childTypes = new ArrayList<>();
-
-  /**
-   * Set of all child types supported by this handler, including any type supporting idType mapping,
-   * never <code>null</code> or empty.
-   */
-  private Set m_childTypes = new HashSet();
+  private static final List<String> ms_childTypes = new ArrayList<>();
 
   static {
     ms_childTypes.add(DEPENDENCY_TYPE);

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDependencyHandler.java
@@ -56,11 +56,17 @@ public abstract class PSDependencyHandler implements IPSDependencyHandler {
   /**
    * Construct a dependency handler.
    *
+   * <p>Calls abstract {@link #getType()} to validate {@code def}. That is intentional for handler
+   * registration (subclasses return a constant type string). javac {@code this-escape} cannot be
+   * cleared via a private helper here without changing the abstract type API of every handler
+   * subclass; suppress is scoped to this constructor only.
+   *
    * @param def The def for the type supported by this handler. May not be <code>null</code> and
    *     must be of the type supported by this class. See {@link #getType()} for more info.
    * @param dependencyMap The full dependency map. May not be <code>null</code>.
    * @throws IllegalArgumentException if any param is invalid.
    */
+  @SuppressWarnings("this-escape")
   public PSDependencyHandler(PSDependencyDef def, PSDependencyMap dependencyMap) {
     if (def == null) throw new IllegalArgumentException("def may not be null");
 

--- a/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyHierarchyXlintTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/objectstore/PSDependencyHierarchyXlintTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.lang.reflect.Modifier;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Smoke coverage for hierarchy this-escape mitigation and leaf {@code final} (issue #2847 Xlint
+ * residual after batch 5).
+ */
+public class PSDependencyHierarchyXlintTest {
+
+  @Test
+  public void deployableElementAndDependencyDataAreFinal() {
+    assertTrue(Modifier.isFinal(PSDeployableElement.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSDependencyData.class.getModifiers()));
+    // Not final: PSUserDependency extends PSDeployableObject
+    assertFalse(Modifier.isFinal(PSDeployableObject.class.getModifiers()));
+  }
+
+  @Test
+  public void deployableElementXmlRoundTripViaElementCtor() throws Exception {
+    PSDeployableElement original =
+        new PSDeployableElement(
+            PSDependency.TYPE_SHARED,
+            "app1",
+            "Application",
+            "Application",
+            "App One",
+            true,
+            true,
+            false);
+    original.setDescription("desc");
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+    PSDeployableElement restored = new PSDeployableElement(xml);
+
+    assertEquals(original.getDependencyId(), restored.getDependencyId());
+    assertEquals(original.getDisplayName(), restored.getDisplayName());
+    assertEquals(original.getObjectType(), restored.getObjectType());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getDependencyType(), restored.getDependencyType());
+  }
+
+  @Test
+  public void deployableObjectXmlRoundTripViaElementCtor() throws Exception {
+    PSDeployableObject original =
+        new PSDeployableObject(
+            PSDependency.TYPE_SHARED,
+            "obj1",
+            "Schema",
+            "Schema",
+            "Table One",
+            false,
+            false,
+            false);
+    // TYPE_SHARED may toggle inclusion; TYPE_LOCAL always includes and rejects setIsIncluded
+    original.setIsIncluded(true);
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+    PSDeployableObject restored = new PSDeployableObject(xml);
+
+    assertEquals(original.getDependencyId(), restored.getDependencyId());
+    assertEquals(original.getDisplayName(), restored.getDisplayName());
+    assertEquals(original.getObjectType(), restored.getObjectType());
+    assertEquals(original.getDependencyType(), restored.getDependencyType());
+    assertTrue(restored.isIncluded());
+  }
+
+  @Test
+  public void setDependencyTypeSideEffectsUnchanged() {
+    PSDeployableObject local =
+        new PSDeployableObject(
+            PSDependency.TYPE_SHARED,
+            "x",
+            "T",
+            "T",
+            "x",
+            false,
+            false,
+            false);
+    local.setDependencyType(PSDependency.TYPE_LOCAL);
+    assertEquals(PSDependency.TYPE_LOCAL, local.getDependencyType());
+    assertTrue(local.isIncluded());
+
+    local.setDependencyType(PSDependency.TYPE_SYSTEM);
+    assertEquals(PSDependency.TYPE_SYSTEM, local.getDependencyType());
+    assertFalse(local.isIncluded());
+  }
+
+  @Test
+  public void deployableElementChildIteratorIsTyped() {
+    PSDeployableElement el =
+        new PSDeployableElement(
+            PSDependency.TYPE_SHARED,
+            "root",
+            "Application",
+            "Application",
+            "Root",
+            true,
+            false,
+            false);
+    Iterator<PSDependency> children = el.getDependencies();
+    assertFalse(children.hasNext());
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSApplicationDependencyHandlerTypedTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSApplicationDependencyHandlerTypedTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.server.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.deployer.objectstore.PSDependency;
+import com.percussion.security.PSSecurityToken;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Signature smoke for typed Application / AppObject dependency handler surfaces (issue #2847 Xlint
+ * residual after batch 5). Runtime paths require a live CMS; these tests lock compile-time API
+ * shapes that cleared rawtypes diagnostics.
+ */
+public class PSApplicationDependencyHandlerTypedTest {
+
+  @Test
+  public void getDependenciesAndChildTypesReturnTypedIterators() throws Exception {
+    Method getDeps =
+        PSApplicationDependencyHandler.class.getMethod("getDependencies", PSSecurityToken.class);
+    assertEquals(Iterator.class, getDeps.getReturnType());
+    Type generic = getDeps.getGenericReturnType();
+    assertTrue(generic instanceof ParameterizedType);
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(PSDependency.class, args[0]);
+
+    Method getChildTypes = PSApplicationDependencyHandler.class.getMethod("getChildTypes");
+    assertEquals(Iterator.class, getChildTypes.getReturnType());
+    Type childGeneric = getChildTypes.getGenericReturnType();
+    assertTrue(childGeneric instanceof ParameterizedType);
+    Type[] childArgs = ((ParameterizedType) childGeneric).getActualTypeArguments();
+    assertEquals(1, childArgs.length);
+    assertEquals(String.class, childArgs[0]);
+  }
+
+  @Test
+  public void getAppFilesReturnsTypedFileIterator() throws Exception {
+    Method getAppFiles =
+        PSAppObjectDependencyHandler.class.getDeclaredMethod(
+            "getAppFiles", PSSecurityToken.class, String.class);
+    assertEquals(Iterator.class, getAppFiles.getReturnType());
+    Type generic = getAppFiles.getGenericReturnType();
+    assertTrue(generic instanceof ParameterizedType);
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(File.class, args[0]);
+  }
+
+  @Test
+  public void dependencyTypeConstantStable() {
+    assertEquals("Application", PSApplicationDependencyHandler.DEPENDENCY_TYPE);
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-2847-deployer-xlint-residual-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2847-deployer-xlint-residual-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — issue #2847 perc-deployer Xlint residual (handlers + hierarchy)
+
+**Status:** PASS  
+**Reviewer persona:** Erlang (pre-commit)  
+**Scope:** deployer module Xlint residual after batch 5 (#2825 / PR #2846)
+
+## Change class
+
+Compile-time generics typing + hierarchy this-escape mitigation. No product behavior change.
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / logic regressions | PASS — private helpers delegate to same bodies; Element XML round-trips covered by tests |
+| Behavioral unit tests | PASS — `PSDependencyHierarchyXlintTest`, `PSApplicationDependencyHandlerTypedTest` |
+| Cross-platform paths | PASS — no new path I/O |
+| Change-class companions | PASS — tests + module suite; product-docs N/A (tech-debt only) |
+| C2 final types | PASS — grepped monorepo for `extends PSDeployableElement` / `PSDependencyData` — none; `PSDeployableObject` remains non-final (`PSUserDependency`) |
+| Module clean install | PASS — `cd deployer && ../mvnw.cmd clean install` |
+
+## Findings
+
+None blocking. Scoped `@SuppressWarnings("this-escape")` on `PSDependencyHandler` ctor (abstract `getType()`) and `PSDeployableObject` Element ctor (`setParentDependency(this)` child linking) are documented; private/final helpers used where possible.
+
+## Residual (next batch)
+
+Maven still caps Xlint report at 100. Post-batch composition dominated by other dependency handlers (`PSDataObjectDependencyHandler`, `PSCmsObjectDependencyHandler`, `PSAuthTypeDependencyHandler`, community/component handlers) — file residual child under #2028/#2200.


### PR DESCRIPTION
## Summary
Partial Xlint cleanup for **perc-deployer** (issue #2847, slice of #2028, parent tracker #2200). Residual after batch 5 (#2825 / PR #2846).

### Main changes
- **PSApplicationDependencyHandler / PSAppObjectDependencyHandler**: real generics on `List`/`Set`/`Iterator`/`File` surfaces; typed `getDependencies` / `getChildTypes` / `getAppFiles` / literal-path helpers
- **PSTransformsHandler / PSIdTypeManager**: typed iterators/maps; drop redundant casts after typed APIs
- **Hierarchy this-escape**: private/final XML restore helpers (`readFromXml` / `restoreDependencyFromXml` / `applyDependencyType`); leaf `final` on `PSDeployableElement` + `PSDependencyData`; scoped `@SuppressWarnings("this-escape")` only for abstract `getType()` validation and intentional `setParentDependency(this)` child linking on non-final `PSDeployableObject`

### Tests
- `PSDependencyHierarchyXlintTest` (final smoke, XML Element-ctor round-trip, setDependencyType side-effects)
- `PSApplicationDependencyHandlerTypedTest` (generic return signatures for Application/AppObject surfaces)

## Residual
Maven still reports 100 (cap). Post-batch composition is dominated by other dependency handlers (`PSDataObjectDependencyHandler`, `PSCmsObjectDependencyHandler`, `PSAuthTypeDependencyHandler`, community/component handlers). Residual child filed under #2028/#2200.

## Test plan
- [x] `cd deployer && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **220**, Failures: **0**, Errors: **0**, Skipped: **19**
- [x] Target-file rawtypes for Application/AppObject/Transforms/IdTypeManager cleared from report; hierarchy this-escape mitigated
- [x] C2: grepped monorepo for `extends PSDeployableElement` / `extends PSDependencyData` / anonymous subclasses — none
- [x] No monorepo-wide reformat

## Gates
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2847-deployer-xlint-residual-erlang.md` — PASS
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

### Product documentation
- [x] N/A — pure compile-time tech-debt / Xlint cleanup; no operator-, admin-, or end-user-facing behavior change

### C3 build evidence
- **modules_built:** deployer
- **build_evidence:** `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 220, Failures: 0, Errors: 0, Skipped: 19
- **downstream_checked:** C2 grep monorepo for extends/anonymous of newly-final `PSDeployableElement` and `PSDependencyData` — none; no reverse-dep compile required (deployer leaf types; handler typing is module-local)

Fixes #2847  
Partial for #2028  
Refs #2200 #2825 #2846

> Co-Authored by Grok Build using grok-4.5 with agent main.
