### PR TITLE
cluster: absorb Widget XML exit batches A/B/C (#2841 #2843 #2854)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -46,7 +46,7 @@ Hard order for a package root or definition id:
 | Surface | Path / class | Role today | Dual-run note |
 |---------|--------------|------------|---------------|
 | Widget definitions (install) | `${rxdeploydir}/rxconfig/Widgets/*.xml` via `PSWidgetDao` (`projects/sitemanage/.../dao/impl/PSWidgetDao`) | Loads legacy Widget XML by file id | Prefer modern package when present; XML remains fallback for unconverted customer defs |
-| Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; product source of truth moves off XML (ADR-004) |
+| Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; batch A dual-ships modern `widgets/<stem>/` (#2831) while install XML remains; product source of truth moves off XML (ADR-004) |
 | Package staging Widgets | `sys__UserDependency--rxconfig/Widgets/` or `rxconfig/Widgets/` under a package root | Upgrade-input / deploy layout | Shim package-root API resolves either layout |
 | Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Modern: `gadget-catalog.json` + per-gadget packages (#2771); dual-load residual for WebUI |
 | Page meta / definition XML | Site/page storage dialects | Composition authoring legacy | Product layout packages (`perc.baseTemplates`, `perc.responsiveTemplates`) author modern `pages/` (#2786); native package install stages archive `TemplateDef-N/` without dual-ship roots (#2806). Shim recognizes `rxconfig/Pages` if present for customer defs |
@@ -89,7 +89,7 @@ Deep rewiring of `PSWidgetDao` to call the shim for every load is **incremental*
 The dual-run window ends when **all** of the following hold:
 
 - [x] Product **page layout** packages `perc.baseTemplates` / `perc.responsiveTemplates` are **not** authored as `*.templateDef` (#2786; native install mode #2806 — dual-ship roots off).
-- [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates, widgets, etc. still residual.
+- [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates done; **widget dual-ship batch A** modern roots landed (#2831, 8 widgets); remaining ~40 product widgets still dual-ship XML as install authoring until further batches + native install.
 - [ ] Customer upgrade path documented and used for remaining XML.
 - [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived.
 - [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help.

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
@@ -2,21 +2,21 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | Active — batch A modern authoring roots landed (#2831) |
+| **Status** | Active — batch A + batch B modern authoring roots landed (#2831 / #2832) |
 | **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
 | **Related** | Compiler #2751 / #2772 / #2789 / #2802 · Shim #2752 · Phase 5 #2632 · Page dual-ship #2786 / native #2806 |
 | **Code** | `PSWidgetXmlDualShip`, `PSWidgetXmlCompiler`, `PSLegacyDefinitionXmlShim` |
 
 ## Purpose
 
-Product widget packages still ship legacy `sys__UserDependency--rxconfig/Widgets/*.xml` so deployer / `PSWidgetDao` install is unchanged. Batch A **authors** modern `widgets/<stem>/component-package.json` + template sources (ADR-004) so dual-run selection prefers the Component Package Manifest when both exist.
+Product widget packages still ship legacy `sys__UserDependency--rxconfig/Widgets/*.xml` so deployer / `PSWidgetDao` install is unchanged. Batches A/B **author** modern `widgets/<stem>/component-package.json` + template sources (ADR-004) so dual-run selection prefers the Component Package Manifest when both exist.
 
 This document is the **operator / engineering checklist** for exiting dual-ship Widget XML package-by-package. **Do not** mass-delete remaining product Widget XML until a native install path exists (or a dual-ship install emitter regenerates install XML from modern).
 
 ## Authoring vs install
 
-| Layer | Batch A (after #2831) | Other product widgets |
-|-------|----------------------|------------------------|
+| Layer | Batch A + B (after #2831 / #2832) | Other product widgets |
+|-------|----------------------------------|------------------------|
 | **Authoring truth** | `widgets/<stem>/component-package.json` + `templates/*.vm` | Still Widget XML (compile path validated; modern roots residual) |
 | **Install wire format** | Still `sys__UserDependency--rxconfig/Widgets/*.xml` dual-ship | Same |
 | **Selection** | `PSLegacyDefinitionXmlShim` prefers modern `widgets/` (or root) over legacy XML | Legacy Widget XML until modern roots land |
@@ -27,8 +27,9 @@ This document is the **operator / engineering checklist** for exiting dual-ship 
 |------------|--------|
 | `PSWidgetXmlDualShip.materializeModernWidgetSources(packageDir)` | Widget XML → `widgets/` (migration / refresh) |
 | `PSWidgetXmlDualShip.materializeModernBatchA(packagesRoot)` | Batch A packages only |
+| `PSWidgetXmlDualShip.materializeModernBatchB(packagesRoot)` | Batch B packages only |
 | `PSWidgetXmlDualShip.hasModernWidgetSources` / `compileModernWidgets` | Product parity tests |
-| CLI | `PSWidgetXmlDualShip materialize-modern\|materialize-modern-batch-a <path>` |
+| CLI | `PSWidgetXmlDualShip materialize-modern\|materialize-modern-batch-a\|materialize-modern-batch-b <path>` |
 
 Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `component-package.json` **or** `widgets/<stem>/component-package.json`).
 
@@ -42,7 +43,30 @@ Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `compone
 | `perc.openGraphWidget` | percOpenGraph | Social meta |
 | `perc.twitterSummaryCards` | percTwitterSummaryCards | Social meta |
 
-**Batch A total:** 5 packages · **8** widgets with modern roots. Product inventory remains **48** Widget XML files (including `perc.Test`); modern dual-ship does **not** delete install XML.
+**Batch A total:** 5 packages · **8** widgets with modern roots.
+
+## Packages on modern dual-ship authoring (batch B)
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.widget.title` | percTitle | High-traffic (#2772) |
+| `perc.widgets.lists` | simplePageAutoList, simpleTextAutoList | High-traffic |
+| `perc.widgets.nav` | percNavBar, percNavBreadcrumb | High-traffic chrome |
+| `perc.FileAssetWidget` | percFile | High-traffic |
+| `perc.widgets.image` | percImage | High-traffic |
+| `perc.widgets.blog` | percBlogPost | Residual long-tail (#2789) |
+| `perc.widget.calendar` | percCalendar, percCalendarTwo | Residual |
+| `perc.widget.directory` | percDepartment, percDirectory, percOrganization, percPerson | Residual multi-widget |
+| `perc.widget.socialButtons` | percSocialButtons | Residual |
+| `perc.widget.form` | percForm | Residual; golden |
+| `perc.widget.poll` | percPoll | Residual; golden |
+| `perc.widget.login` | percLogin | Residual |
+| `perc.widget.rss` | percRss | Residual |
+| `perc.widget.iframe` | percIframe | Residual; golden |
+
+**Batch B total:** 14 packages · **20** widgets with modern roots.
+
+**Cumulative modern dual-ship authoring roots:** **28** widgets / **19** packages (batch A + B). Product inventory remains **48** Widget XML files (including `perc.Test`); modern dual-ship does **not** delete install XML.
 
 ## Retirement checklist (per package)
 
@@ -53,24 +77,23 @@ Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `compone
 5. **Keep install XML** until native widget install (or reverse emitter) exists.
 6. **Later residual** — optional native install mode (page peer: `PSPageXmlNativeInstall` / #2806); then remove dual-ship XML for converted packages only.
 
-## Residual after batch A
+## Residual after batch B
 
 | Residual | Scope | Guidance |
 |----------|-------|----------|
-| High-traffic dual-ship roots | title, lists, nav, file, image (7) | Next coherent batch |
-| Long-tail dual-ship roots | blog/calendar/directory/social/forms… | After high-traffic |
-| Remaining product dual-ship roots | auto-lists, companions, login variants… | After long-tail |
+| Remaining product dual-ship roots | auto-lists, blog companions, comments/liked/commentForm, imageSlider, cookieConsent, jquery/jqueryUI, registration/secureLogin, Result/Redirect (~20 widgets / ~18 packages, excl. batch A already done) | Next dual-ship exit batch C |
+| `perc.Test` | Test package modern roots | #2830 / compile residual |
 | Native widget install | Package build stages install Widget XML (or new wire format) from modern | Peer of #2806; required before mass XML delete |
 | Global shim removal | #2632 | Metrics + zero required legacy loads |
 
-Approximate residual Widget XML still dual-shipped as **install** source of truth for authoring: **~40** product widgets without modern `widgets/` roots (48 − 8 batch A; still 48 XML files on disk until native exit).
+Approximate residual Widget XML still dual-shipped as **install** source of truth for authoring without modern `widgets/` roots: **~20** product widgets (48 − 8 batch A − 20 batch B; still 48 XML files on disk until native exit; `perc.Test` may add compile residual).
 
 ## Dual-run / dual-ship relationship
 
 | Concept | Layer | Status |
 |---------|-------|--------|
 | Dual-run **definition XML shim** | Runtime selection modern vs Widget XML | Time-boxed; Phase 5 #2632 |
-| Dual-ship **widget modern roots** | Package **authoring** under `widgets/` | Batch A (#2831); more batches residual |
+| Dual-ship **widget modern roots** | Package **authoring** under `widgets/` | Batch A (#2831) + batch B (#2832); more batches residual |
 | Dual-ship **page templateDef** | Package-build install bridge | Optional; native preferred for base/responsive (#2806) |
 | Native **widget install** | Package-build stages install artifacts from modern | **Not landed** — do not delete product Widget XML |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
@@ -2,22 +2,22 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | Active — batch A + batch B modern authoring roots landed (#2831 / #2832) |
+| **Status** | Active — batch A + B + C modern authoring roots landed (#2831 / #2832 / #2844) |
 | **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
 | **Related** | Compiler #2751 / #2772 / #2789 / #2802 · Shim #2752 · Phase 5 #2632 · Page dual-ship #2786 / native #2806 |
 | **Code** | `PSWidgetXmlDualShip`, `PSWidgetXmlCompiler`, `PSLegacyDefinitionXmlShim` |
 
 ## Purpose
 
-Product widget packages still ship legacy `sys__UserDependency--rxconfig/Widgets/*.xml` so deployer / `PSWidgetDao` install is unchanged. Batches A/B **author** modern `widgets/<stem>/component-package.json` + template sources (ADR-004) so dual-run selection prefers the Component Package Manifest when both exist.
+Product widget packages still ship legacy `sys__UserDependency--rxconfig/Widgets/*.xml` so deployer / `PSWidgetDao` install is unchanged. Batches A/B/C **author** modern `widgets/<stem>/component-package.json` + template sources (ADR-004) so dual-run selection prefers the Component Package Manifest when both exist.
 
 This document is the **operator / engineering checklist** for exiting dual-ship Widget XML package-by-package. **Do not** mass-delete remaining product Widget XML until a native install path exists (or a dual-ship install emitter regenerates install XML from modern).
 
 ## Authoring vs install
 
-| Layer | Batch A + B (after #2831 / #2832) | Other product widgets |
-|-------|----------------------------------|------------------------|
-| **Authoring truth** | `widgets/<stem>/component-package.json` + `templates/*.vm` | Still Widget XML (compile path validated; modern roots residual) |
+| Layer | Batch A + B + C (after #2831 / #2832 / #2844) | Other product widgets |
+|-------|-----------------------------------------------|------------------------|
+| **Authoring truth** | `widgets/<stem>/component-package.json` + `templates/*.vm` | `perc.Test` residual (#2830) |
 | **Install wire format** | Still `sys__UserDependency--rxconfig/Widgets/*.xml` dual-ship | Same |
 | **Selection** | `PSLegacyDefinitionXmlShim` prefers modern `widgets/` (or root) over legacy XML | Legacy Widget XML until modern roots land |
 
@@ -28,8 +28,9 @@ This document is the **operator / engineering checklist** for exiting dual-ship 
 | `PSWidgetXmlDualShip.materializeModernWidgetSources(packageDir)` | Widget XML → `widgets/` (migration / refresh) |
 | `PSWidgetXmlDualShip.materializeModernBatchA(packagesRoot)` | Batch A packages only |
 | `PSWidgetXmlDualShip.materializeModernBatchB(packagesRoot)` | Batch B packages only |
+| `PSWidgetXmlDualShip.materializeModernBatchC(packagesRoot)` | Batch C packages only |
 | `PSWidgetXmlDualShip.hasModernWidgetSources` / `compileModernWidgets` | Product parity tests |
-| CLI | `PSWidgetXmlDualShip materialize-modern\|materialize-modern-batch-a\|materialize-modern-batch-b <path>` |
+| CLI | `PSWidgetXmlDualShip materialize-modern\|materialize-modern-batch-a\|materialize-modern-batch-b\|materialize-modern-batch-c <path>` |
 
 Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `component-package.json` **or** `widgets/<stem>/component-package.json`).
 
@@ -66,7 +67,33 @@ Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `compone
 
 **Batch B total:** 14 packages · **20** widgets with modern roots.
 
-**Cumulative modern dual-ship authoring roots:** **28** widgets / **19** packages (batch A + B). Product inventory remains **48** Widget XML files (including `perc.Test`); modern dual-ship does **not** delete install XML.
+## Packages on modern dual-ship authoring (batch C)
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.ImageAutoListWidget` | percImageAutoList | Remaining product residual (#2802 / #2844) |
+| `perc.PageAutoListWidget` | percPageAutoList | Auto-list |
+| `perc.widget.fileAutoList` | percFileAutoList | Auto-list |
+| `perc.widget.blogIndexPage` | percBlogIndexPage | Blog companion |
+| `perc.widget.archiveList` | percArchiveList | Blog companion |
+| `perc.widget.categoryList` | percCategoryList | Blog companion |
+| `perc.widget.taglist` | percTagList | Blog companion |
+| `perc.widget.MostReadBlogPosts` | percMostReadBlogPosts | Blog companion |
+| `perc.widgets.comments` | percComments | Social / comments |
+| `perc.widgets.liked` | percLiked | Social / comments |
+| `perc.widget.commentForm` | percCommentsForm | Social / comments |
+| `perc.widget.imageSlider` | percImageSlider | Residual product |
+| `perc.widget.cookieConsent` | percCookieConsent | Residual product |
+| `perc.widget.jquery` | percJQueryWidget | Residual product |
+| `perc.widget.jqueryUI` | percJQueryUIWidget | Residual product |
+| `perc.widget.registration` | percRegistration | Login variant |
+| `perc.widget.secureLogin` | percSecureLogin | Login variant |
+| `perc.widget.Result` | percResult | Residual product |
+| `perc.widgets.Redirect` | percRedirect | Residual product |
+
+**Batch C total:** 19 packages · **19** widgets with modern roots.
+
+**Cumulative modern dual-ship authoring roots:** **47** widgets / **38** packages (batch A + B + C). Product inventory remains **48** Widget XML files (including `perc.Test`); modern dual-ship does **not** delete install XML. Product modern-root gap excl. Test is **0**.
 
 ## Retirement checklist (per package)
 
@@ -77,23 +104,23 @@ Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `compone
 5. **Keep install XML** until native widget install (or reverse emitter) exists.
 6. **Later residual** — optional native install mode (page peer: `PSPageXmlNativeInstall` / #2806); then remove dual-ship XML for converted packages only.
 
-## Residual after batch B
+## Residual after batch C
 
 | Residual | Scope | Guidance |
 |----------|-------|----------|
-| Remaining product dual-ship roots | auto-lists, blog companions, comments/liked/commentForm, imageSlider, cookieConsent, jquery/jqueryUI, registration/secureLogin, Result/Redirect (~20 widgets / ~18 packages, excl. batch A already done) | Next dual-ship exit batch C |
-| `perc.Test` | Test package modern roots | #2830 / compile residual |
+| Product modern-root gap | **0** (excl. `perc.Test`) | Batch A+B+C complete product dual-ship authoring |
+| `perc.Test` | Test package modern roots | #2830 / PR #2840 compile residual |
 | Native widget install | Package build stages install Widget XML (or new wire format) from modern | Peer of #2806; required before mass XML delete |
 | Global shim removal | #2632 | Metrics + zero required legacy loads |
 
-Approximate residual Widget XML still dual-shipped as **install** source of truth for authoring without modern `widgets/` roots: **~20** product widgets (48 − 8 batch A − 20 batch B; still 48 XML files on disk until native exit; `perc.Test` may add compile residual).
+Approximate residual Widget XML still dual-shipped as **install** source of truth (not authoring): **all 48** product + test XML files remain on disk until native widget install. Authoring without modern `widgets/` roots: **`perc.Test` only** among product/test packages in inventory.
 
 ## Dual-run / dual-ship relationship
 
 | Concept | Layer | Status |
 |---------|-------|--------|
 | Dual-run **definition XML shim** | Runtime selection modern vs Widget XML | Time-boxed; Phase 5 #2632 |
-| Dual-ship **widget modern roots** | Package **authoring** under `widgets/` | Batch A (#2831) + batch B (#2832); more batches residual |
+| Dual-ship **widget modern roots** | Package **authoring** under `widgets/` | Batch A (#2831) + B (#2832) + C (#2844); product complete excl. Test |
 | Dual-ship **page templateDef** | Package-build install bridge | Optional; native preferred for base/responsive (#2806) |
 | Native **widget install** | Package-build stages install artifacts from modern | **Not landed** — do not delete product Widget XML |
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md
@@ -1,0 +1,82 @@
+# Dual-ship Widget XML exit checklist
+
+| Field | Value |
+|-------|--------|
+| **Status** | Active — batch A modern authoring roots landed (#2831) |
+| **Parent** | [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630) · Grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626) |
+| **Related** | Compiler #2751 / #2772 / #2789 / #2802 · Shim #2752 · Phase 5 #2632 · Page dual-ship #2786 / native #2806 |
+| **Code** | `PSWidgetXmlDualShip`, `PSWidgetXmlCompiler`, `PSLegacyDefinitionXmlShim` |
+
+## Purpose
+
+Product widget packages still ship legacy `sys__UserDependency--rxconfig/Widgets/*.xml` so deployer / `PSWidgetDao` install is unchanged. Batch A **authors** modern `widgets/<stem>/component-package.json` + template sources (ADR-004) so dual-run selection prefers the Component Package Manifest when both exist.
+
+This document is the **operator / engineering checklist** for exiting dual-ship Widget XML package-by-package. **Do not** mass-delete remaining product Widget XML until a native install path exists (or a dual-ship install emitter regenerates install XML from modern).
+
+## Authoring vs install
+
+| Layer | Batch A (after #2831) | Other product widgets |
+|-------|----------------------|------------------------|
+| **Authoring truth** | `widgets/<stem>/component-package.json` + `templates/*.vm` | Still Widget XML (compile path validated; modern roots residual) |
+| **Install wire format** | Still `sys__UserDependency--rxconfig/Widgets/*.xml` dual-ship | Same |
+| **Selection** | `PSLegacyDefinitionXmlShim` prefers modern `widgets/` (or root) over legacy XML | Legacy Widget XML until modern roots land |
+
+### Configuration / APIs
+
+| Knob / API | Notes |
+|------------|--------|
+| `PSWidgetXmlDualShip.materializeModernWidgetSources(packageDir)` | Widget XML → `widgets/` (migration / refresh) |
+| `PSWidgetXmlDualShip.materializeModernBatchA(packagesRoot)` | Batch A packages only |
+| `PSWidgetXmlDualShip.hasModernWidgetSources` / `compileModernWidgets` | Product parity tests |
+| CLI | `PSWidgetXmlDualShip materialize-modern\|materialize-modern-batch-a <path>` |
+
+Policy alignment: modern preferred in `PSLegacyDefinitionXmlShim` (root `component-package.json` **or** `widgets/<stem>/component-package.json`).
+
+## Packages on modern dual-ship authoring (batch A)
+
+| Package | Widgets | Notes |
+|---------|---------|-------|
+| `perc.baseWidgets` | percSimpleText, percRichText, percRawHtml | Core content widgets; goldens exist |
+| `perc.defaultLanguage` | percDefaultLang, percLocalLang | Multi-widget language package |
+| `perc.eventWidget` | percEvent | Content CT; golden |
+| `perc.openGraphWidget` | percOpenGraph | Social meta |
+| `perc.twitterSummaryCards` | percTwitterSummaryCards | Social meta |
+
+**Batch A total:** 5 packages · **8** widgets with modern roots. Product inventory remains **48** Widget XML files (including `perc.Test`); modern dual-ship does **not** delete install XML.
+
+## Retirement checklist (per package)
+
+1. **Confirm compiler goldens / package compile** — `PSWidgetXmlPackageCompiler.compilePackage` green for the package.
+2. **Materialize modern** — `widgets/<stem>/component-package.json` + templates committed (or refresh via `materializeModernWidgetSources`).
+3. **Parity test** — modern manifest/template equals compile-from-XML (`PSWidgetXmlDualShipTest` pattern).
+4. **Shim** — `selectForPackageRoot` / `selectDefinition` prefer modern when XML co-located.
+5. **Keep install XML** until native widget install (or reverse emitter) exists.
+6. **Later residual** — optional native install mode (page peer: `PSPageXmlNativeInstall` / #2806); then remove dual-ship XML for converted packages only.
+
+## Residual after batch A
+
+| Residual | Scope | Guidance |
+|----------|-------|----------|
+| High-traffic dual-ship roots | title, lists, nav, file, image (7) | Next coherent batch |
+| Long-tail dual-ship roots | blog/calendar/directory/social/forms… | After high-traffic |
+| Remaining product dual-ship roots | auto-lists, companions, login variants… | After long-tail |
+| Native widget install | Package build stages install Widget XML (or new wire format) from modern | Peer of #2806; required before mass XML delete |
+| Global shim removal | #2632 | Metrics + zero required legacy loads |
+
+Approximate residual Widget XML still dual-shipped as **install** source of truth for authoring: **~40** product widgets without modern `widgets/` roots (48 − 8 batch A; still 48 XML files on disk until native exit).
+
+## Dual-run / dual-ship relationship
+
+| Concept | Layer | Status |
+|---------|-------|--------|
+| Dual-run **definition XML shim** | Runtime selection modern vs Widget XML | Time-boxed; Phase 5 #2632 |
+| Dual-ship **widget modern roots** | Package **authoring** under `widgets/` | Batch A (#2831); more batches residual |
+| Dual-ship **page templateDef** | Package-build install bridge | Optional; native preferred for base/responsive (#2806) |
+| Native **widget install** | Package-build stages install artifacts from modern | **Not landed** — do not delete product Widget XML |
+
+## See also
+
+- [widget-xml-inventory.md](./widget-xml-inventory.md)
+- [dual-run-legacy-definition-xml-shim.md](./dual-run-legacy-definition-xml-shim.md)
+- [dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md)
+- [adr/004-no-definition-xml-packaging.md](./adr/004-no-definition-xml-packaging.md)

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -18,8 +18,9 @@
 | **Product packages still ship Widget XML** | Yes (dual-run install) | Compiler produces modern artifacts; install still uses `sys__UserDependency--rxconfig/Widgets/*.xml`; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
 | **Dual-ship modern authoring roots (batch A #2831)** | **Landed for 8 widgets / 5 packages** | `widgets/<stem>/component-package.json` under baseWidgets, defaultLanguage, event, openGraph, twitter; see [dual-ship-widget-xml-exit.md](./dual-ship-widget-xml-exit.md) |
 | **Dual-ship modern authoring roots (batch B #2832)** | **Landed for 20 widgets / 14 packages** | high-traffic (#2772) + residual long-tail (#2789): title/lists/nav/file/image + blog/calendar/directory/social/form/poll/login/rss/iframe |
-| Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Dual-ship modern roots for remaining widgets + native install + XML delete remain residual / Phase 5 (#2632 / parent #2630) |
-| Runtime legacy XML shim | Landed (cluster #2766); prefers `widgets/` modern (#2831 / #2832) | #2752 |
+| **Dual-ship modern authoring roots (batch C #2844)** | **Landed for 19 widgets / 19 packages** | remaining product residual after A/B: auto-lists, blog companions, comments/liked/commentForm, imageSlider, cookieConsent, jquery*, registration/secureLogin, Result/Redirect |
+| Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Product modern dual-ship roots complete excl. Test (47 widgets). Native install + XML delete remain residual / Phase 5 (#2632 / parent #2630) |
+| Runtime legacy XML shim | Landed (cluster #2766); prefers `widgets/` modern (#2831 / #2832 / #2844) | #2752 |
 
 ### High-traffic batch covered by #2772
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -17,8 +17,9 @@
 | Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT); residual batches needed no new shapes |
 | **Product packages still ship Widget XML** | Yes (dual-run install) | Compiler produces modern artifacts; install still uses `sys__UserDependency--rxconfig/Widgets/*.xml`; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
 | **Dual-ship modern authoring roots (batch A #2831)** | **Landed for 8 widgets / 5 packages** | `widgets/<stem>/component-package.json` under baseWidgets, defaultLanguage, event, openGraph, twitter; see [dual-ship-widget-xml-exit.md](./dual-ship-widget-xml-exit.md) |
+| **Dual-ship modern authoring roots (batch B #2832)** | **Landed for 20 widgets / 14 packages** | high-traffic (#2772) + residual long-tail (#2789): title/lists/nav/file/image + blog/calendar/directory/social/form/poll/login/rss/iframe |
 | Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Dual-ship modern roots for remaining widgets + native install + XML delete remain residual / Phase 5 (#2632 / parent #2630) |
-| Runtime legacy XML shim | Landed (cluster #2766); prefers `widgets/` modern (#2831) | #2752 |
+| Runtime legacy XML shim | Landed (cluster #2766); prefers `widgets/` modern (#2831 / #2832) | #2752 |
 
 ### High-traffic batch covered by #2772
 

--- a/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md
@@ -15,9 +15,10 @@
 | Golden parity (remaining #2802) | **percImageAutoList**, **percComments**, **percEvent** | Plus package compile of auto-lists, blog companions, social/comments/cards, event/slider/cookie/jquery, login variants, Result/Redirect, defaultLanguage (**24** widgets / 23 packages) |
 | Golden parity (perc.Test #2830) | **PSWidget_TestProperties** | Final product residual; package compile via `TEST_PRODUCT_PACKAGE_DIRS` / `compileTestProductPackages` |
 | Compiler extensions (#2772) | `<Resource href/type/placement>`, chrome slots without CT, layout UserPref → slot.layout | CSS/JS resources + nav chrome (no asset CT); residual batches needed no new shapes |
-| **Product packages still ship Widget XML** | Yes (dual-run) | Compiler produces modern artifacts; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
-| Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Dual-run exit / product XML deletion remains Phase 5 (#2632 / parent #2630) |
-| Runtime legacy XML shim | Landed (cluster #2766) | #2752 |
+| **Product packages still ship Widget XML** | Yes (dual-run install) | Compiler produces modern artifacts; install still uses `sys__UserDependency--rxconfig/Widgets/*.xml`; does **not** yet remove product `rxconfig/Widgets/*.xml` from source trees |
+| **Dual-ship modern authoring roots (batch A #2831)** | **Landed for 8 widgets / 5 packages** | `widgets/<stem>/component-package.json` under baseWidgets, defaultLanguage, event, openGraph, twitter; see [dual-ship-widget-xml-exit.md](./dual-ship-widget-xml-exit.md) |
+| Residual product packages (after #2830) | **None** (full product inventory on modern compile path) | Dual-ship modern roots for remaining widgets + native install + XML delete remain residual / Phase 5 (#2632 / parent #2630) |
+| Runtime legacy XML shim | Landed (cluster #2766); prefers `widgets/` modern (#2831) | #2752 |
 
 ### High-traffic batch covered by #2772
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
@@ -170,7 +170,7 @@ public final class PSPageXmlNativeInstall {
     String stem = resolveStem(manifest, pageDir);
     // Mapping loaders key stems lower-case (Windows/macOS case-insensitive product history;
     // dual-ship uses the same policy). Preserve original stem for on-disk templateDef names.
-    String stemKey = stem.toLowerCase(Locale.ROOT);
+    String stemKey = stem != null ? stem.toLowerCase(Locale.ROOT) : "";
     String guid = guidsByStem.get(stemKey);
     String archiveFolder = foldersByStem.get(stemKey);
     if (guid == null || guid.isBlank() || archiveFolder == null || archiveFolder.isBlank()) {
@@ -214,6 +214,7 @@ public final class PSPageXmlNativeInstall {
       if (!km.matches()) {
         continue;
       }
+      // Match loadGuidsFromMapping: lowercase stem keys for mixed-case product ids.
       String stem = km.group(1).toLowerCase(Locale.ROOT);
       String value = props.getProperty(key);
       if (value == null) {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
@@ -17,6 +17,7 @@
 
 package com.percussion.packages.shim;
 
+import com.percussion.packages.widgetxml.PSWidgetXmlDualShip;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -230,7 +231,10 @@ public final class PSLegacyDefinitionXmlShim {
       }
       // Dual-ship multi-widget package root: widgets/<definitionId>/component-package.json (#2831)
       Path nested =
-          normalized.resolve("widgets").resolve(definitionId).resolve(MODERN_MANIFEST_FILE_NAME);
+          normalized
+              .resolve(PSWidgetXmlDualShip.WIDGETS_DIR_NAME)
+              .resolve(definitionId)
+              .resolve(MODERN_MANIFEST_FILE_NAME);
       if (Files.isRegularFile(nested)) {
         return new PSDefinitionSourceSelection(
             PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, definitionId, nested);
@@ -311,7 +315,7 @@ public final class PSLegacyDefinitionXmlShim {
    * (stable order by folder name). Empty when no modern widget authoring tree is present.
    */
   static Optional<Path> findFirstModernWidgetManifest(Path packageRoot) throws IOException {
-    Path widgets = packageRoot.resolve("widgets");
+    Path widgets = packageRoot.resolve(PSWidgetXmlDualShip.WIDGETS_DIR_NAME);
     if (!Files.isDirectory(widgets)) {
       return Optional.empty();
     }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -336,7 +337,8 @@ public final class PSLegacyDefinitionXmlShim {
               b.getParent() != null && b.getParent().getFileName() != null
                   ? b.getParent().getFileName().toString()
                   : b.toString();
-          return an.compareToIgnoreCase(bn);
+          // Locale.ROOT for stable order with PSWidgetXmlDualShip.listModernWidgetDirs
+          return an.toLowerCase(Locale.ROOT).compareTo(bn.toLowerCase(Locale.ROOT));
         });
     return manifests.isEmpty() ? Optional.empty() : Optional.of(manifests.get(0));
   }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
@@ -118,9 +118,10 @@ public final class PSLegacyDefinitionXmlShim {
   /**
    * Select source for a single product / customer <strong>package root</strong> directory.
    *
-   * <p>Modern wins if {@link #MODERN_MANIFEST_FILE_NAME} exists under the root. Otherwise legacy
-   * Widget XML under package staging or install-relative Widgets is preferred over page/gadget
-   * markers when both exist in the same tree (widgets are the primary dual-run surface).
+   * <p>Modern wins if {@link #MODERN_MANIFEST_FILE_NAME} exists under the root <em>or</em> under a
+   * dual-ship {@code widgets/&lt;stem&gt;/} child package (batch A / #2831). Otherwise legacy Widget
+   * XML under package staging or install-relative Widgets is preferred over page/gadget markers when
+   * both exist in the same tree (widgets are the primary dual-run surface).
    *
    * @param packageRoot package source or install package directory (must not be null)
    * @return selection with primary path set to the manifest or first legacy XML found
@@ -138,6 +139,13 @@ public final class PSLegacyDefinitionXmlShim {
     if (Files.isRegularFile(modernManifest)) {
       return new PSDefinitionSourceSelection(
           PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, packageName, modernManifest);
+    }
+
+    // Dual-ship multi-widget authoring: widgets/<stem>/component-package.json (#2831)
+    Optional<Path> modernWidget = findFirstModernWidgetManifest(root);
+    if (modernWidget.isPresent()) {
+      return new PSDefinitionSourceSelection(
+          PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, packageName, modernWidget.get());
     }
 
     Optional<Path> widgetXml = findFirstXml(resolvePackageWidgetsDir(root));
@@ -219,6 +227,13 @@ public final class PSLegacyDefinitionXmlShim {
         return new PSDefinitionSourceSelection(
             PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, definitionId, manifest);
       }
+      // Dual-ship multi-widget package root: widgets/<definitionId>/component-package.json (#2831)
+      Path nested =
+          normalized.resolve("widgets").resolve(definitionId).resolve(MODERN_MANIFEST_FILE_NAME);
+      if (Files.isRegularFile(nested)) {
+        return new PSDefinitionSourceSelection(
+            PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, definitionId, nested);
+      }
     }
 
     Path widgetXml = resolveLegacyXmlFile(legacyWidgetsDir, definitionId);
@@ -288,6 +303,42 @@ public final class PSLegacyDefinitionXmlShim {
       return staging;
     }
     return packageRoot.resolve("rxconfig").resolve("Widgets");
+  }
+
+  /**
+   * First modern dual-ship widget manifest under {@code packageRoot/widgets/&lt;stem&gt;/component-package.json}
+   * (stable order by folder name). Empty when no modern widget authoring tree is present.
+   */
+  static Optional<Path> findFirstModernWidgetManifest(Path packageRoot) throws IOException {
+    Path widgets = packageRoot.resolve("widgets");
+    if (!Files.isDirectory(widgets)) {
+      return Optional.empty();
+    }
+    List<Path> manifests = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(widgets)) {
+      for (Path child : stream) {
+        if (!Files.isDirectory(child)) {
+          continue;
+        }
+        Path manifest = child.resolve(MODERN_MANIFEST_FILE_NAME);
+        if (Files.isRegularFile(manifest)) {
+          manifests.add(manifest);
+        }
+      }
+    }
+    manifests.sort(
+        (a, b) -> {
+          String an =
+              a.getParent() != null && a.getParent().getFileName() != null
+                  ? a.getParent().getFileName().toString()
+                  : a.toString();
+          String bn =
+              b.getParent() != null && b.getParent().getFileName() != null
+                  ? b.getParent().getFileName().toString()
+                  : b.toString();
+          return an.compareToIgnoreCase(bn);
+        });
+    return manifests.isEmpty() ? Optional.empty() : Optional.of(manifests.get(0));
   }
 
   private static Path resolveLegacyXmlFile(Path dir, String definitionId) {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlCompiler.java
@@ -493,17 +493,26 @@ public final class PSWidgetXmlCompiler {
   }
 
   /**
-   * Resolve a package-relative path (URL-style {@code /}) under {@code base} using portable {@link
-   * Path#resolve(String)} per segment — never string-concatenate OS separators.
+   * Resolve a package-relative path under {@code base} using portable {@link Path#resolve(String)}
+   * per segment — never string-concatenate OS separators. Accepts URL-style {@code /} and Windows
+   * {@code \} in the relative string; strips a leading slash; rejects {@code ..} escapes.
    */
   static Path resolvePackageRelative(Path base, String packageRelative) {
+    if (packageRelative == null || packageRelative.isBlank()) {
+      throw new IllegalArgumentException("relative path must be non-blank");
+    }
+    String normalized = packageRelative.replace('\\', '/');
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
     Path p = base;
-    for (String segment : packageRelative.split("/")) {
+    for (String segment : normalized.split("/")) {
       if (segment.isEmpty() || ".".equals(segment)) {
         continue;
       }
       if ("..".equals(segment)) {
-        throw new IllegalArgumentException("Package-relative path must not contain '..': " + packageRelative);
+        throw new IllegalArgumentException(
+            "Package-relative path must not contain '..': " + packageRelative);
       }
       p = p.resolve(segment);
     }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestException;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Dual-ship bridge for product Widget packages (ADR-004 / issue #2831 batch A, parent #2630).
+ *
+ * <p><strong>Authoring truth (modern):</strong> {@code widgets/&lt;widgetStem&gt;/component-package.json}
+ * plus template sources under the product package tree (e.g. {@code perc.baseWidgets}).
+ *
+ * <p><strong>Install path (dual-run):</strong> product packages still ship legacy {@code
+ * sys__UserDependency--rxconfig/Widgets/*.xml} so deployer / {@code PSWidgetDao} install is
+ * unchanged. Modern roots are committed so selection prefers Component Package Manifest when both
+ * exist ({@code PSLegacyDefinitionXmlShim}). Do not mass-delete remaining Widget XML until a native
+ * install path exists (Phase 5 / #2632).
+ *
+ * <p>Batch A (#2831): {@code perc.baseWidgets}, {@code perc.defaultLanguage}, {@code
+ * perc.eventWidget}, {@code perc.openGraphWidget}, {@code perc.twitterSummaryCards} (8 widgets).
+ *
+ * @see PSWidgetXmlCompiler
+ * @see PSWidgetXmlPackageCompiler
+ */
+public final class PSWidgetXmlDualShip {
+
+  /** Package-relative directory holding per-widget modern component packages. */
+  public static final String WIDGETS_DIR_NAME = "widgets";
+
+  /**
+   * Batch A dual-ship exit package directory names under {@code Packages/} (issue #2831). Coherent
+   * base/core set: baseWidgets (3) + defaultLanguage (2) + event + openGraph + twitter cards.
+   */
+  public static final List<String> BATCH_A_PACKAGE_DIRS =
+      List.of(
+          "perc.baseWidgets",
+          "perc.defaultLanguage",
+          "perc.eventWidget",
+          "perc.openGraphWidget",
+          "perc.twitterSummaryCards");
+
+  /** Expected modern widget stems for batch A (stable for tests / residual counting). */
+  public static final List<String> BATCH_A_WIDGET_STEMS =
+      List.of(
+          "percSimpleText",
+          "percRichText",
+          "percRawHtml",
+          "percDefaultLang",
+          "percLocalLang",
+          "percEvent",
+          "percOpenGraph",
+          "percTwitterSummaryCards");
+
+  private PSWidgetXmlDualShip() {
+    // utility
+  }
+
+  /**
+   * CLI for one-time migration / dual-ship ops.
+   *
+   * <p>Usage:
+   *
+   * <ul>
+   *   <li>{@code materialize-modern &lt;packageDir&gt;} — Widget XML → {@code widgets/}
+   *   <li>{@code materialize-modern-batch-a &lt;packagesRoot&gt;} — batch A packages only
+   * </ul>
+   */
+  public static void main(String[] args) throws Exception {
+    if (args.length < 2) {
+      System.err.println(
+          "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a <path>");
+      System.exit(1);
+    }
+    String cmd = args[0].trim().toLowerCase(Locale.ROOT);
+    Path path = Path.of(args[1]).toAbsolutePath().normalize();
+    int n =
+        switch (cmd) {
+          case "materialize-modern" -> materializeModernWidgetSources(path);
+          case "materialize-modern-batch-a" -> materializeModernBatchA(path);
+          default -> throw new IllegalArgumentException("Unknown command: " + args[0]);
+        };
+    System.out.println(cmd + " wrote " + n + " modern widget package(s) under " + path);
+  }
+
+  /**
+   * Whether the package root contains modern widget authoring sources under {@value
+   * #WIDGETS_DIR_NAME}.
+   */
+  public static boolean hasModernWidgetSources(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    return !listModernWidgetDirs(packageDir).isEmpty();
+  }
+
+  /**
+   * Materialize modern {@code widgets/&lt;stem&gt;/} sources from package Widget XML (dual-ship
+   * authoring path). Overwrites existing modern trees for the same stem.
+   *
+   * @param packageDir product package source (e.g. {@code …/Packages/perc.baseWidgets})
+   * @return number of modern widget packages written
+   * @throws PSWidgetXmlException on parse/compile failure
+   * @throws IOException on I/O failure
+   */
+  public static int materializeModernWidgetSources(Path packageDir)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    if (!Files.isDirectory(packageDir)) {
+      throw new PSWidgetXmlException("Package directory does not exist: " + packageDir);
+    }
+    Path widgetsXmlDir = PSWidgetXmlPackageCompiler.resolveWidgetsDir(packageDir);
+    if (!Files.isDirectory(widgetsXmlDir)) {
+      return 0;
+    }
+    List<PSWidgetXmlCompileResult> compiled = PSWidgetXmlPackageCompiler.compilePackage(packageDir);
+    Path widgets = packageDir.resolve(WIDGETS_DIR_NAME);
+    Files.createDirectories(widgets);
+    int written = 0;
+    for (PSWidgetXmlCompileResult result : compiled) {
+      String stem = result.getSource().widgetStem();
+      if (stem == null || stem.isBlank()) {
+        stem = result.getManifest().getId();
+      }
+      Path out = widgets.resolve(stem);
+      PSWidgetXmlCompiler.writeArtifacts(result, out);
+      written++;
+    }
+    return written;
+  }
+
+  /**
+   * Materialize modern widget sources for every batch A package under {@code packagesRoot}. Missing
+   * package directories are soft-skipped.
+   *
+   * @param packagesRoot {@code Packages/} directory
+   * @return total modern widget packages written across batch A
+   */
+  public static int materializeModernBatchA(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packagesRoot, "packagesRoot");
+    if (!Files.isDirectory(packagesRoot)) {
+      throw new PSWidgetXmlException("Packages root does not exist: " + packagesRoot);
+    }
+    int total = 0;
+    for (String dirName : BATCH_A_PACKAGE_DIRS) {
+      Path packageDir = packagesRoot.resolve(dirName);
+      if (!Files.isDirectory(packageDir)) {
+        continue;
+      }
+      total += materializeModernWidgetSources(packageDir);
+    }
+    return total;
+  }
+
+  /**
+   * Compile (load + validate) all modern widget packages under {@code widgets/}.
+   *
+   * @param packageDir product package source
+   * @return validated results sorted by widget id
+   */
+  public static List<PSWidgetXmlCompileResult> compileModernWidgets(Path packageDir)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    List<Path> widgetDirs = listModernWidgetDirs(packageDir);
+    if (widgetDirs.isEmpty()) {
+      throw new PSWidgetXmlException(
+          "No modern widget packages under: " + packageDir.resolve(WIDGETS_DIR_NAME));
+    }
+    List<PSWidgetXmlCompileResult> results = new ArrayList<>();
+    for (Path widgetDir : widgetDirs) {
+      results.add(loadModernAsCompileResult(widgetDir));
+    }
+    results.sort(
+        Comparator.comparing(
+            r -> r.getManifest().getId() != null ? r.getManifest().getId() : "",
+            String.CASE_INSENSITIVE_ORDER));
+    return results;
+  }
+
+  /**
+   * Load a modern widget package directory into a {@link PSWidgetXmlCompileResult} for parity tests
+   * and dual-ship selection.
+   */
+  public static PSWidgetXmlCompileResult loadModernAsCompileResult(Path widgetDir)
+      throws PSWidgetXmlException, IOException {
+    Objects.requireNonNull(widgetDir, "widgetDir");
+    Path manifestPath = widgetDir.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+    if (!Files.isRegularFile(manifestPath)) {
+      throw new PSWidgetXmlException("Missing component-package.json under " + widgetDir);
+    }
+    PSComponentPackageManifest manifest;
+    try {
+      manifest = PSComponentPackageManifestIo.read(manifestPath);
+      PSComponentPackageManifestValidator.validate(manifest);
+    } catch (PSComponentPackageManifestException e) {
+      throw new PSWidgetXmlException(
+          "Invalid modern widget package at " + widgetDir + ": " + e.getMessage(), e);
+    }
+
+    Map<String, String> artifacts = new LinkedHashMap<>();
+    if (manifest.getTemplates() != null) {
+      for (PSComponentPackageManifest.TemplateRef t : manifest.getTemplates()) {
+        if (t == null || t.getSourceRef() == null || t.getSourceRef().isBlank()) {
+          continue;
+        }
+        artifacts.put(t.getSourceRef(), readTemplateSourceByRef(widgetDir, t.getSourceRef()));
+      }
+    }
+
+    // Synthetic model for dual-ship tests (stem + title from modern id/name).
+    PSWidgetXmlModel model = new PSWidgetXmlModel();
+    model.setTitle(manifest.getName());
+    model.setDescription(manifest.getDescription());
+    String stem = manifest.getId();
+    if (stem == null || stem.isBlank()) {
+      stem = widgetDir.getFileName() != null ? widgetDir.getFileName().toString() : "widget";
+    }
+    model.setSourceFileName(stem + ".xml");
+    if (manifest.getContentTypes() != null && !manifest.getContentTypes().isEmpty()) {
+      model.setContentTypeName(manifest.getContentTypes().get(0).getName());
+    }
+    if (manifest.getCatalog() != null) {
+      model.setCategory(manifest.getCatalog().getCategory());
+      model.setAuthor(manifest.getCatalog().getAuthor());
+    }
+    if (manifest.getTemplates() != null && !manifest.getTemplates().isEmpty()) {
+      model.setContentType("velocity");
+      model.setCodeType("jexl");
+      String body = artifacts.values().stream().findFirst().orElse("");
+      model.setContentBody(body);
+    }
+
+    return new PSWidgetXmlCompileResult(model, manifest, artifacts);
+  }
+
+  /**
+   * List modern widget package directories under {@code packageDir/widgets} that contain a
+   * {@code component-package.json}. Portable {@link Path} resolve only.
+   */
+  public static List<Path> listModernWidgetDirs(Path packageDir) throws IOException {
+    Objects.requireNonNull(packageDir, "packageDir");
+    Path widgets = packageDir.resolve(WIDGETS_DIR_NAME);
+    if (!Files.isDirectory(widgets)) {
+      return List.of();
+    }
+    List<Path> dirs = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(widgets)) {
+      for (Path child : stream) {
+        if (!Files.isDirectory(child)) {
+          continue;
+        }
+        Path manifest = child.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME);
+        if (Files.isRegularFile(manifest)) {
+          dirs.add(child);
+        }
+      }
+    }
+    dirs.sort(
+        Comparator.comparing(
+            p -> p.getFileName().toString().toLowerCase(Locale.ROOT)));
+    return dirs;
+  }
+
+  /**
+   * Collect modern widget package roots for dual-run selection ({@code
+   * PSLegacyDefinitionXmlShim#selectDefinition}).
+   *
+   * @param packageDir product package source that may contain {@code widgets/}
+   * @return list of modern widget package directories (may be empty)
+   */
+  public static List<Path> modernWidgetPackageRoots(Path packageDir) throws IOException {
+    return listModernWidgetDirs(packageDir);
+  }
+
+  private static String readTemplateSourceByRef(Path widgetDir, String sourceRef)
+      throws PSWidgetXmlException, IOException {
+    Path resolved = resolvePackageRelative(widgetDir, sourceRef);
+    if (!Files.isRegularFile(resolved)) {
+      throw new PSWidgetXmlException(
+          "Template source missing for modern widget at " + widgetDir + ": " + sourceRef);
+    }
+    return Files.readString(resolved);
+  }
+
+  /**
+   * Resolve a package-relative path under {@code root} without accepting absolute or {@code ..}
+   * escapes (portable; uses {@link Path} segments).
+   */
+  static Path resolvePackageRelative(Path root, String relative) {
+    Objects.requireNonNull(root, "root");
+    if (relative == null || relative.isBlank()) {
+      throw new IllegalArgumentException("relative path must be non-blank");
+    }
+    String normalized = relative.replace('\\', '/');
+    while (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    Path p = root;
+    for (String segment : normalized.split("/")) {
+      if (segment.isEmpty() || ".".equals(segment)) {
+        continue;
+      }
+      if ("..".equals(segment)) {
+        throw new IllegalArgumentException("relative path must not contain '..': " + relative);
+      }
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+}

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
@@ -34,7 +34,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Dual-ship bridge for product Widget packages (ADR-004 / issue #2831 batch A, parent #2630).
+ * Dual-ship bridge for product Widget packages (ADR-004 / issues #2831 batch A, #2832 batch B,
+ * parent #2630).
  *
  * <p><strong>Authoring truth (modern):</strong> {@code widgets/&lt;widgetStem&gt;/component-package.json}
  * plus template sources under the product package tree (e.g. {@code perc.baseWidgets}).
@@ -47,6 +48,10 @@ import java.util.Objects;
  *
  * <p>Batch A (#2831): {@code perc.baseWidgets}, {@code perc.defaultLanguage}, {@code
  * perc.eventWidget}, {@code perc.openGraphWidget}, {@code perc.twitterSummaryCards} (8 widgets).
+ *
+ * <p>Batch B (#2832): high-traffic (#2772) + residual long-tail (#2789) product packages —
+ * title/lists/nav/file/image + blog/calendar/directory/social/form/poll/login/rss/iframe (20
+ * widgets / 14 packages).
  *
  * @see PSWidgetXmlCompiler
  * @see PSWidgetXmlPackageCompiler
@@ -80,6 +85,56 @@ public final class PSWidgetXmlDualShip {
           "percOpenGraph",
           "percTwitterSummaryCards");
 
+  /**
+   * Batch B dual-ship exit package directory names under {@code Packages/} (issue #2832). High-traffic
+   * product packages (#2772) plus residual long-tail (#2789): auto-list companions live in a later
+   * residual after this batch.
+   */
+  public static final List<String> BATCH_B_PACKAGE_DIRS =
+      List.of(
+          // high-traffic (#2772)
+          "perc.widget.title",
+          "perc.widgets.lists",
+          "perc.widgets.nav",
+          "perc.FileAssetWidget",
+          "perc.widgets.image",
+          // residual long-tail (#2789)
+          "perc.widgets.blog",
+          "perc.widget.calendar",
+          "perc.widget.directory",
+          "perc.widget.socialButtons",
+          "perc.widget.form",
+          "perc.widget.poll",
+          "perc.widget.login",
+          "perc.widget.rss",
+          "perc.widget.iframe");
+
+  /** Expected modern widget stems for batch B (stable for tests / residual counting). */
+  public static final List<String> BATCH_B_WIDGET_STEMS =
+      List.of(
+          // high-traffic
+          "percTitle",
+          "simplePageAutoList",
+          "simpleTextAutoList",
+          "percNavBar",
+          "percNavBreadcrumb",
+          "percFile",
+          "percImage",
+          // residual long-tail
+          "percBlogPost",
+          "percCalendar",
+          "percCalendarTwo",
+          "percDepartment",
+          "percDirectory",
+          "percOrganization",
+          "percPerson",
+          "percSocialButtons",
+          "percForm",
+          "percPoll",
+          "percLogin",
+          "percRss",
+          "percIframe");
+
   private PSWidgetXmlDualShip() {
     // utility
   }
@@ -92,11 +147,12 @@ public final class PSWidgetXmlDualShip {
    * <ul>
    *   <li>{@code materialize-modern &lt;packageDir&gt;} — Widget XML → {@code widgets/}
    *   <li>{@code materialize-modern-batch-a &lt;packagesRoot&gt;} — batch A packages only
+   *   <li>{@code materialize-modern-batch-b &lt;packagesRoot&gt;} — batch B packages only
    * </ul>
    */
   public static void main(String[] args) throws Exception {
     final String usage =
-        "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a <path>";
+        "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a|materialize-modern-batch-b <path>";
     if (args.length < 2) {
       System.err.println(usage);
       System.exit(1);
@@ -107,6 +163,7 @@ public final class PSWidgetXmlDualShip {
     switch (cmd) {
       case "materialize-modern" -> n = materializeModernWidgetSources(path);
       case "materialize-modern-batch-a" -> n = materializeModernBatchA(path);
+      case "materialize-modern-batch-b" -> n = materializeModernBatchB(path);
       default -> {
         System.err.println("Unknown command: " + args[0]);
         System.err.println(usage);
@@ -170,12 +227,39 @@ public final class PSWidgetXmlDualShip {
    */
   public static int materializeModernBatchA(Path packagesRoot)
       throws PSWidgetXmlException, IOException {
+    return materializeModernNamedPackages(packagesRoot, BATCH_A_PACKAGE_DIRS);
+  }
+
+  /**
+   * Materialize modern widget sources for every batch B package under {@code packagesRoot}. Missing
+   * package directories are soft-skipped.
+   *
+   * @param packagesRoot {@code Packages/} directory
+   * @return total modern widget packages written across batch B
+   */
+  public static int materializeModernBatchB(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    return materializeModernNamedPackages(packagesRoot, BATCH_B_PACKAGE_DIRS);
+  }
+
+  /**
+   * Materialize modern widget sources for each named package under {@code packagesRoot}. Missing
+   * package directories are soft-skipped.
+   *
+   * @param packagesRoot {@code Packages/} directory
+   * @param packageDirNames ordered package directory names
+   * @return total modern widget packages written
+   */
+  public static int materializeModernNamedPackages(
+      Path packagesRoot, List<String> packageDirNames)
+      throws PSWidgetXmlException, IOException {
     Objects.requireNonNull(packagesRoot, "packagesRoot");
+    Objects.requireNonNull(packageDirNames, "packageDirNames");
     if (!Files.isDirectory(packagesRoot)) {
       throw new PSWidgetXmlException("Packages root does not exist: " + packagesRoot);
     }
     int total = 0;
-    for (String dirName : BATCH_A_PACKAGE_DIRS) {
+    for (String dirName : packageDirNames) {
       Path packageDir = packagesRoot.resolve(dirName);
       if (!Files.isDirectory(packageDir)) {
         continue;

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 
 /**
  * Dual-ship bridge for product Widget packages (ADR-004 / issues #2831 batch A, #2832 batch B,
- * parent #2630).
+ * #2844 batch C, parent #2630).
  *
  * <p><strong>Authoring truth (modern):</strong> {@code widgets/&lt;widgetStem&gt;/component-package.json}
  * plus template sources under the product package tree (e.g. {@code perc.baseWidgets}).
@@ -52,6 +52,10 @@ import java.util.Objects;
  * <p>Batch B (#2832): high-traffic (#2772) + residual long-tail (#2789) product packages —
  * title/lists/nav/file/image + blog/calendar/directory/social/form/poll/login/rss/iframe (20
  * widgets / 14 packages).
+ *
+ * <p>Batch C (#2844): remaining product residual (#2802) after A/B — auto-lists, blog companions,
+ * comments/liked/commentForm, imageSlider, cookieConsent, jquery/jqueryUI, registration/secureLogin,
+ * Result/Redirect (19 widgets / 19 packages). Excludes {@code perc.Test} (#2830).
  *
  * @see PSWidgetXmlCompiler
  * @see PSWidgetXmlPackageCompiler
@@ -135,6 +139,66 @@ public final class PSWidgetXmlDualShip {
           "percRss",
           "percIframe");
 
+  /**
+   * Batch C dual-ship exit package directory names under {@code Packages/} (issue #2844). Remaining
+   * product residual after batches A/B (#2802 subset not already dual-shipped in A): auto-lists,
+   * blog companions, comments/liked/commentForm, imageSlider, cookieConsent, jquery*, login
+   * variants, Result/Redirect. Excludes packages already in batch A (openGraph, twitter, event,
+   * defaultLanguage) and {@code perc.Test}.
+   */
+  public static final List<String> BATCH_C_PACKAGE_DIRS =
+      List.of(
+          // auto-lists
+          "perc.ImageAutoListWidget",
+          "perc.PageAutoListWidget",
+          "perc.widget.fileAutoList",
+          // blog / list companions
+          "perc.widget.blogIndexPage",
+          "perc.widget.archiveList",
+          "perc.widget.categoryList",
+          "perc.widget.taglist",
+          "perc.widget.MostReadBlogPosts",
+          // social / comments
+          "perc.widgets.comments",
+          "perc.widgets.liked",
+          "perc.widget.commentForm",
+          // other residual product widgets
+          "perc.widget.imageSlider",
+          "perc.widget.cookieConsent",
+          "perc.widget.jquery",
+          "perc.widget.jqueryUI",
+          "perc.widget.registration",
+          "perc.widget.secureLogin",
+          "perc.widget.Result",
+          "perc.widgets.Redirect");
+
+  /** Expected modern widget stems for batch C (stable for tests / residual counting). */
+  public static final List<String> BATCH_C_WIDGET_STEMS =
+      List.of(
+          // auto-lists
+          "percImageAutoList",
+          "percPageAutoList",
+          "percFileAutoList",
+          // blog / list companions
+          "percBlogIndexPage",
+          "percArchiveList",
+          "percCategoryList",
+          "percTagList",
+          "percMostReadBlogPosts",
+          // social / comments
+          "percComments",
+          "percLiked",
+          "percCommentsForm",
+          // other residual
+          "percImageSlider",
+          "percCookieConsent",
+          "percJQueryWidget",
+          "percJQueryUIWidget",
+          "percRegistration",
+          "percSecureLogin",
+          "percResult",
+          "percRedirect");
+
   private PSWidgetXmlDualShip() {
     // utility
   }
@@ -148,11 +212,12 @@ public final class PSWidgetXmlDualShip {
    *   <li>{@code materialize-modern &lt;packageDir&gt;} — Widget XML → {@code widgets/}
    *   <li>{@code materialize-modern-batch-a &lt;packagesRoot&gt;} — batch A packages only
    *   <li>{@code materialize-modern-batch-b &lt;packagesRoot&gt;} — batch B packages only
+   *   <li>{@code materialize-modern-batch-c &lt;packagesRoot&gt;} — batch C packages only
    * </ul>
    */
   public static void main(String[] args) throws Exception {
     final String usage =
-        "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a|materialize-modern-batch-b <path>";
+        "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a|materialize-modern-batch-b|materialize-modern-batch-c <path>";
     if (args.length < 2) {
       System.err.println(usage);
       System.exit(1);
@@ -164,6 +229,7 @@ public final class PSWidgetXmlDualShip {
       case "materialize-modern" -> n = materializeModernWidgetSources(path);
       case "materialize-modern-batch-a" -> n = materializeModernBatchA(path);
       case "materialize-modern-batch-b" -> n = materializeModernBatchB(path);
+      case "materialize-modern-batch-c" -> n = materializeModernBatchC(path);
       default -> {
         System.err.println("Unknown command: " + args[0]);
         System.err.println(usage);
@@ -240,6 +306,18 @@ public final class PSWidgetXmlDualShip {
   public static int materializeModernBatchB(Path packagesRoot)
       throws PSWidgetXmlException, IOException {
     return materializeModernNamedPackages(packagesRoot, BATCH_B_PACKAGE_DIRS);
+  }
+
+  /**
+   * Materialize modern widget sources for every batch C package under {@code packagesRoot}. Missing
+   * package directories are soft-skipped.
+   *
+   * @param packagesRoot {@code Packages/} directory
+   * @return total modern widget packages written across batch C
+   */
+  public static int materializeModernBatchC(Path packagesRoot)
+      throws PSWidgetXmlException, IOException {
+    return materializeModernNamedPackages(packagesRoot, BATCH_C_PACKAGE_DIRS);
   }
 
   /**

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java
@@ -95,19 +95,25 @@ public final class PSWidgetXmlDualShip {
    * </ul>
    */
   public static void main(String[] args) throws Exception {
+    final String usage =
+        "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a <path>";
     if (args.length < 2) {
-      System.err.println(
-          "Usage: PSWidgetXmlDualShip materialize-modern|materialize-modern-batch-a <path>");
+      System.err.println(usage);
       System.exit(1);
     }
     String cmd = args[0].trim().toLowerCase(Locale.ROOT);
     Path path = Path.of(args[1]).toAbsolutePath().normalize();
-    int n =
-        switch (cmd) {
-          case "materialize-modern" -> materializeModernWidgetSources(path);
-          case "materialize-modern-batch-a" -> materializeModernBatchA(path);
-          default -> throw new IllegalArgumentException("Unknown command: " + args[0]);
-        };
+    int n;
+    switch (cmd) {
+      case "materialize-modern" -> n = materializeModernWidgetSources(path);
+      case "materialize-modern-batch-a" -> n = materializeModernBatchA(path);
+      default -> {
+        System.err.println("Unknown command: " + args[0]);
+        System.err.println(usage);
+        System.exit(1);
+        return;
+      }
+    }
     System.out.println(cmd + " wrote " + n + " modern widget package(s) under " + path);
   }
 
@@ -311,27 +317,11 @@ public final class PSWidgetXmlDualShip {
 
   /**
    * Resolve a package-relative path under {@code root} without accepting absolute or {@code ..}
-   * escapes (portable; uses {@link Path} segments).
+   * escapes. Delegates to {@link PSWidgetXmlCompiler#resolvePackageRelative(Path, String)} so widget
+   * dual-ship and the Widget XML compiler share one implementation.
    */
   static Path resolvePackageRelative(Path root, String relative) {
     Objects.requireNonNull(root, "root");
-    if (relative == null || relative.isBlank()) {
-      throw new IllegalArgumentException("relative path must be non-blank");
-    }
-    String normalized = relative.replace('\\', '/');
-    while (normalized.startsWith("/")) {
-      normalized = normalized.substring(1);
-    }
-    Path p = root;
-    for (String segment : normalized.split("/")) {
-      if (segment.isEmpty() || ".".equals(segment)) {
-        continue;
-      }
-      if ("..".equals(segment)) {
-        throw new IllegalArgumentException("relative path must not contain '..': " + relative);
-      }
-      p = p.resolve(segment);
-    }
-    return p;
+    return PSWidgetXmlCompiler.resolvePackageRelative(root, relative);
   }
 }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -34,13 +34,21 @@ import java.util.Objects;
  * by {@code modules/perc-packages}). Covers baseWidgets, high-traffic product packages (#2772), the
  * residual long-tail batch (#2789), the remaining product residual batch (#2802), and the final
  * {@code perc.Test} residual (#2830). Product Widget XML remains dual-run until install consumes
- * modern packages (Phase 5 exit).
+ * modern packages (Phase 5 exit). Dual-ship modern authoring roots for batch A live under {@code
+ * widgets/&lt;stem&gt;/} ({@link PSWidgetXmlDualShip}, issue #2831).
  */
 public final class PSWidgetXmlPackageCompiler {
 
   /** Legacy staging folder name for user-dependency config inside a package source tree. */
   public static final String WIDGETS_RELATIVE =
       "sys__UserDependency--rxconfig/Widgets";
+
+  /**
+   * Dual-ship Widget XML exit batch A package dirs (issue #2831). See {@link
+   * PSWidgetXmlDualShip#BATCH_A_PACKAGE_DIRS}.
+   */
+  public static final List<String> DUAL_SHIP_BATCH_A_PACKAGE_DIRS =
+      PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS;
 
   /**
    * Named high-traffic product package directory names under {@code Packages/} covered by the

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -51,6 +51,13 @@ public final class PSWidgetXmlPackageCompiler {
       PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS;
 
   /**
+   * Dual-ship Widget XML exit batch B package dirs (issue #2832). See {@link
+   * PSWidgetXmlDualShip#BATCH_B_PACKAGE_DIRS}.
+   */
+  public static final List<String> DUAL_SHIP_BATCH_B_PACKAGE_DIRS =
+      PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS;
+
+  /**
    * Named high-traffic product package directory names under {@code Packages/} covered by the
    * residual batch in issue #2772 (beyond {@code perc.baseWidgets}).
    */

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java
@@ -58,6 +58,13 @@ public final class PSWidgetXmlPackageCompiler {
       PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS;
 
   /**
+   * Dual-ship Widget XML exit batch C package dirs (issue #2844). See {@link
+   * PSWidgetXmlDualShip#BATCH_C_PACKAGE_DIRS}.
+   */
+  public static final List<String> DUAL_SHIP_BATCH_C_PACKAGE_DIRS =
+      PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS;
+
+  /**
    * Named high-traffic product package directory names under {@code Packages/} covered by the
    * residual batch in issue #2772 (beyond {@code perc.baseWidgets}).
    */

--- a/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/widgets/percFile/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/widgets/percFile/component-package.json
@@ -1,0 +1,192 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percFile",
+  "name": "File",
+  "version": "1.1.6",
+  "description": "Upload a file and display a link to it",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.3",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "File",
+    "category": "content,rich media",
+    "description": "Upload a file and display a link to it",
+    "thumbnail": "resources/widgetIconFile.png",
+    "icon": "resources/widgetIconFile.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 340,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percFileAsset",
+      "ref": "contentTypes/percFileAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percFileSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percFileSnippet.vm",
+      "contentType": "percFileAsset",
+      "bindings": [
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "referalPolicy",
+          "expression": "$props.get(\"referalPolicy\")"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "linkNewWindow",
+          "expression": "$perc.widget.item.properties.get('linkNewWindow')"
+        },
+        {
+          "variable": "target",
+          "expression": "\"_blank\""
+        },
+        {
+          "variable": "target",
+          "expression": "\"_self\""
+        },
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "link",
+          "expression": "$rx.pageutils.itemLink($linkContext, $assetItem, \"percSystem.fileBinary\")"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "link",
+          "expression": "$tools.esc.html($link)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$props = $perc.widget.item.properties;\n        $referalPolicy = $props.get(\"referalPolicy\");\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if(!empty($rootclass)) {\n            $rootclass = $rootclass + \" \";\n        }\n\n        $linkNewWindow = $perc.widget.item.properties.get('linkNewWindow');\n\n\n        if ($linkNewWindow == true) {\n            $target=\"_blank\";\n        }\n        else {\n            $target=\"_self\";\n        }\n        $linkContext = $perc.linkContext;\n        $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n        $perc.setWidgetContents($assetItems);\n        if ( ! $assetItems.isEmpty() ) {\n            $assetItem = $assetItems.get(0);\n            $link = $rx.pageutils.itemLink($linkContext, $assetItem, \"percSystem.fileBinary\");\n            $title = $rx.pageutils.html($assetItem,'displaytitle');\n            $link = $tools.esc.html($link);\n        }\n\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percFileContent",
+      "allowedContentTypes": [
+        "percFileAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconFile.png",
+      "target": "rx_resources/widgets/file/images/widgetIconFile.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "linkNewWindow",
+      "displayName": "Open link in new window",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "referalPolicy",
+      "displayName": "Referrer-Policy",
+      "datatype": "enum",
+      "required": false,
+      "enumValues": [
+        {
+          "value": "no-referrer",
+          "displayValue": "no-referrer"
+        },
+        {
+          "value": "no-referrer-when-downgrade",
+          "displayValue": "no-referrer-when-downgrade"
+        },
+        {
+          "value": "origin",
+          "displayValue": "origin"
+        },
+        {
+          "value": "origin-when-cross-origin",
+          "displayValue": "origin-when-cross-origin"
+        },
+        {
+          "value": "same-origin",
+          "displayValue": "same-origin"
+        },
+        {
+          "value": "strict-origin",
+          "displayValue": "strict-origin"
+        },
+        {
+          "value": "strict-origin-when-cross-origin",
+          "displayValue": "strict-origin-when-cross-origin"
+        },
+        {
+          "value": "unsafe-url",
+          "displayValue": "unsafe-url"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/widgets/percFile/templates/percFileSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.FileAssetWidget/widgets/percFile/templates/percFileSnippet.vm
@@ -1,0 +1,9 @@
+<div class="$!{rootclass} perc-file" data="$!{dynamicListData}">
+        #if( ! $perc.widgetContents.isEmpty() )##
+            <span property="perc:asset-link" aria-hidden="true" style="display: none;">$!{link}</span>
+            <span property="perc:asset-title" aria-hidden="true" style="display: none;">$!{title}</span>
+            <a href="$!{link}" referrerpolicy="$!{referalPolicy}"  title="$!{title}"target="$!{target}">$!{title}</a>
+        #elseif ($perc.isEditMode())##
+            #createEmptyWidgetContent("file-sample-content", "This file widget is showing sample content.")##
+        #end##
+    </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/widgets/percImageAutoList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/widgets/percImageAutoList/component-package.json
@@ -1,0 +1,991 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percImageAutoList",
+  "name": "Image Auto List",
+  "version": "1.1.12",
+  "description": "Display an automated list of image assets",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Image Auto List",
+    "category": "rich media,search",
+    "description": "Display an automated list of image assets",
+    "thumbnail": "resources/widgetIconImageAutoList.png",
+    "icon": "resources/widgetIconImageAutoList.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 665,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percImageAutoList",
+      "ref": "contentTypes/percImageAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percImageAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percImageAutoListSnippet.vm",
+      "contentType": "percImageAutoList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "listTitleFormat",
+          "expression": "$perc.widget.item.properties.get('listTitleFormat')"
+        },
+        {
+          "variable": "listItemFormat",
+          "expression": "$perc.widget.item.properties.get('listItemFormat')"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "$perc.widget.item.properties.get('listAriaLabel')"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "$perc.widget.item.properties.get('listAriaRole')"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.properties.get('autoListDivId')"
+        },
+        {
+          "variable": "showPostDate",
+          "expression": "$perc.widget.item.properties.get('showPostDate')"
+        },
+        {
+          "variable": "postDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('postDateTimeFormat')"
+        },
+        {
+          "variable": "perc_hide_when_empty",
+          "expression": "$perc.widget.item.properties.get('perc_hide_when_empty')"
+        },
+        {
+          "variable": "target",
+          "expression": "$perc.widget.item.properties.get('target')"
+        },
+        {
+          "variable": "layout",
+          "expression": "$perc.widget.item.properties.get('layout')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "listclass",
+          "expression": "$perc.widget.item.cssProperties.get('listclass')"
+        },
+        {
+          "variable": "listclass",
+          "expression": "$listclass.trim()"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "''"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "'role=\"' + $listAriaRole + '\"'"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.id + \"_list\""
+        },
+        {
+          "variable": "headerId",
+          "expression": "$autoListDivId + '_header'"
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "$perc.widget.item.cssProperties.get('thumblinkclass')"
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "$thumblinkclass.trim()"
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "thumblinkclass",
+          "expression": "'class=\"' + $thumblinkclass + '\"'"
+        },
+        {
+          "variable": "caption",
+          "expression": "$perc.widget.item.properties.get('caption')"
+        },
+        {
+          "variable": "captionclass",
+          "expression": "$perc.widget.item.cssProperties.get('captionclass')"
+        },
+        {
+          "variable": "captionclass",
+          "expression": "$captionclass.trim()"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "$perc.widget.item.properties.get('maxlength')"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "500"
+        },
+        {
+          "variable": "sortby",
+          "expression": "$perc.widget.item.properties.get('sortby')"
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "$perc.widget.item.properties.get('sortDirection')"
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "\"desc\""
+        },
+        {
+          "variable": "renderingformat",
+          "expression": "$perc.widget.item.properties.get('renderingformat')"
+        },
+        {
+          "variable": "target",
+          "expression": "$perc.widget.item.properties.get('target')"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "$assetItem.getNode().getProperty('query').String"
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortby + \" \" + $sortDirection"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem, 'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('perc-list-odd', 'perc-list-even')"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "'<' + $listTitleFormat + ' id=\"' + $headerId + '\"' + ' class=\"perc-list-title\" aria-label=\"Image List Title\" title=\"' + $title + '\"' + '>'"
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "'</' + $listTitleFormat + '>'"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "\"\""
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "\"\""
+        },
+        {
+          "variable": "itemFormatStartTag",
+          "expression": "'<' + $listItemFormat + '>'"
+        },
+        {
+          "variable": "itemFormatEndTag",
+          "expression": "'</' + $listItemFormat + '>'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $title + ' image list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"Image list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $listAriaLabel + '\"'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $listTitleFormat = $perc.widget.item.properties.get('listTitleFormat');\n   $listItemFormat = $perc.widget.item.properties.get('listItemFormat');\n   $listAriaLabel = $perc.widget.item.properties.get('listAriaLabel');\n   $listAriaRole = $perc.widget.item.properties.get('listAriaRole');\n   $autoListDivId = $perc.widget.item.properties.get('autoListDivId');\n   $showPostDate = $perc.widget.item.properties.get('showPostDate');\n   $postDateTimeFormat = $perc.widget.item.properties.get('postDateTimeFormat');\n   $perc_hide_when_empty = $perc.widget.item.properties.get('perc_hide_when_empty');\n   $perc.setWidgetContents($assetItems);\n   $target = $perc.widget.item.properties.get('target');\n   $layout = $perc.widget.item.properties.get('layout');\n   $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n   if (!empty($rootclass)) {\n      $rootclass = $rootclass;\n   }\n   $listclass = $perc.widget.item.cssProperties.get('listclass');\n   if (!empty($listclass)) {\n      $listclass = $listclass.trim();\n   }\n   if ($listAriaRole == '' || $listAriaRole == null) {\n      $listAriaRole = '';\n   }\n   else {\n       $listAriaRole = 'role=\"' + $listAriaRole + '\"';\n   }\n   if($autoListDivId == '' || $autoListDivId == null) {\n      $autoListDivId = $perc.widget.item.id + \"_list\";\n   }\n   $headerId = $autoListDivId + '_header';\n   $thumblinkclass = $perc.widget.item.cssProperties.get('thumblinkclass');\n   if (!empty($thumblinkclass)) {\n      $thumblinkclass = $thumblinkclass.trim();\n   }\n   else {\n      $thumblinkclass = \"\";\n   }\n   if (!empty($thumblinkclass)) {\n      $thumblinkclass = 'class=\"' + $thumblinkclass + '\"';\n   }\n   $caption = $perc.widget.item.properties.get('caption');\n   $captionclass = $perc.widget.item.cssProperties.get('captionclass');\n   if (!empty($captionclass)) {\n      $captionclass = $captionclass.trim();\n   }\n   $maxlength = $perc.widget.item.properties.get('maxlength');\n   if (empty($maxlength)) {\n      $maxlength = 500;\n   }\n   $sortby = $perc.widget.item.properties.get('sortby');\n\n   $sortDirection = $perc.widget.item.properties.get('sortDirection');\n   if($sortDirection == null){\n       $sortDirection = \"desc\";\n   }\n   $renderingformat = $perc.widget.item.properties.get('renderingformat');\n   $target = $perc.widget.item.properties.get('target');\n\n   if ( ! $assetItems.isEmpty() ) {\n      $assetItem = $assetItems.get(0);\n      $params = $rx.string.stringToMap(null);\n      $query = $assetItem.getNode().getProperty('query').String;\n\t  if ($sortby != \"none\"  && $sortby != null) {\n        $query = $query + \" order by \" + $sortby + \" \" + $sortDirection;\n      }\n\n      $params.put('query', $query);\n      $params.put('max_results', $maxlength);\n      $finderName =  \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n      $title = $rx.pageutils.html($assetItem, 'displaytitle');\n      $rowtag = $tools.alternator.auto('perc-list-odd', 'perc-list-even');\n\n      if ($listTitleFormat != 'none') {\n         $titleFormatStartTag = '<' + $listTitleFormat + ' id=\"' + $headerId + '\"' + ' class=\"perc-list-title\" aria-label=\"Image List Title\" title=\"' + $title + '\"' + '>';\n         $titleFormatEndTag = '</' + $listTitleFormat + '>';\n      }\n      else {\n         $titleFormatStartTag = \"\";\n         $titleFormatEndTag = \"\";\n      }\n      if ($listItemFormat != 'none') {\n         $itemFormatStartTag = '<' + $listItemFormat + '>';\n         $itemFormatEndTag = '</' + $listItemFormat + '>';\n      }\n      if ($listAriaLabel == '' || $listAriaLabel == null) {\n         if ($title != null && $title != '') {\n             $listAriaLabel = 'aria-label=\"' + $title + ' image list\"';\n         } else {\n             $listAriaLabel = 'aria-label=\"Image list\"';\n         }\n      } else {\n          $listAriaLabel = 'aria-label=\"' + $listAriaLabel + '\"';\n      }\n   }\n   else {\n      ;\n   }\n\n   $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n   if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n      $dsUrl = \"\";\n   $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percImageAutoListContent",
+      "allowedContentTypes": [
+        "percImageAutoList"
+      ],
+      "layout": {
+        "maxlength": "",
+        "layout": "perc-list-vertical"
+      },
+      "styles": {
+        "rootclass": "",
+        "listclass": "",
+        "thumblinkclass": "",
+        "captionclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconImageAutoList.png",
+      "target": "rx_resources/widgets/imageAutoList/images/widgetIconImageAutoList.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "renderingformat",
+      "displayName": "Rendering format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "image",
+      "enumValues": [
+        {
+          "value": "image",
+          "displayValue": "Normal image"
+        },
+        {
+          "value": "thumbnail",
+          "displayValue": "Thumbnail"
+        },
+        {
+          "value": "thumbnail_link",
+          "displayValue": "Thumbnail link"
+        }
+      ]
+    },
+    {
+      "name": "listTitleFormat",
+      "displayName": "Format of list title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    },
+    {
+      "name": "autoListDivId",
+      "displayName": "Image Auto List div id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listItemFormat",
+      "displayName": "Format of list items",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "none",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "none",
+          "displayValue": "None"
+        }
+      ]
+    },
+    {
+      "name": "sortby",
+      "displayName": "Sort by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "rx:sys_contentpostdate",
+      "enumValues": [
+        {
+          "value": "none",
+          "displayValue": "None"
+        },
+        {
+          "value": "rx:displaytitle",
+          "displayValue": "Title"
+        },
+        {
+          "value": "rx:sys_contentpostdate",
+          "displayValue": "Post date"
+        }
+      ]
+    },
+    {
+      "name": "sortDirection",
+      "displayName": "Sort Order",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "desc",
+      "enumValues": [
+        {
+          "value": "desc",
+          "displayValue": "Descending"
+        },
+        {
+          "value": "asc",
+          "displayValue": "Ascending"
+        }
+      ]
+    },
+    {
+      "name": "showPostDate",
+      "displayName": "Show Post Date",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "postDateTimeFormat",
+      "displayName": "Format of image post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEEE MM dd, yyyy",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt)    Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "maxlength",
+      "displayName": "Max list length",
+      "datatype": "number",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "caption",
+      "displayName": "Show caption",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "listAriaLabel",
+      "displayName": "Image Auto List aria-label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listAriaRole",
+      "displayName": "Image Auto List aria-role",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "perc_hide_when_empty",
+      "displayName": "Hide auto list when empty",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "perc-list-vertical",
+      "enumValues": [
+        {
+          "value": "perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    },
+    {
+      "name": "target",
+      "displayName": "Link target",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "_self",
+      "enumValues": [
+        {
+          "value": "_self",
+          "displayValue": "Current window"
+        },
+        {
+          "value": "_blank",
+          "displayValue": "New window"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "listclass",
+      "displayName": "CSS image list class",
+      "datatype": "string"
+    },
+    {
+      "name": "thumblinkclass",
+      "displayName": "CSS thumbnail link class",
+      "datatype": "string"
+    },
+    {
+      "name": "captionclass",
+      "displayName": "CSS caption class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/widgets/percImageAutoList/templates/percImageAutoListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.ImageAutoListWidget/widgets/percImageAutoList/templates/percImageAutoListSnippet.vm
@@ -1,0 +1,106 @@
+#define($ariaLabelString)##
+#if($title && $title.length() > 0)##
+aria-labelledby="$!{headerId}"##
+#else##
+$!{listAriaLabel}##
+#end##
+#end##
+##Setup Date Formatting
+#set($formatterOut = $rx.pageutils.getDateFormatFromLocale("$!{postDateTimeFormat}",$locale))##
+#set($postDateObject="")##
+#set($postDate="")##
+<div id="$!{autoListDivId}" class="$!{rootclass} $!{layout} perc-image-auto-list" #if($perc_hide_when_empty && $relresults.size() <= 0)hidden #end $!{ariaLabelString} $!{listAriaRole} data-query="$!{dynamicListData}">
+#if( ! $perc.widgetContents.isEmpty() )
+#if($title && $title.length() > 0)##
+$!{titleFormatStartTag}$title$!{titleFormatEndTag}
+#end
+#if($relresults && $relresults.size() > 0)
+#if($rendering == "ordered")##
+<ol class="$!{listclass} perc-list-main">##
+#else##
+<ul class="$!{listclass} perc-list-main">##
+#end##
+#foreach($result in $relresults)
+#set($postDateObject = $result.node.getProperty('rx:sys_contentpostdate'))##
+#set($postDateObjectString = $result.node.getProperty('rx:sys_contentpostdate').String)##
+#if("$!{postDateObjectString}" == "")##
+#set($postDateObject = $tools.date.getDate())##
+#else##
+#set($postDateObject = $result.node.getProperty('rx:sys_contentpostdate').getDate())##
+#end##
+#if("$!{postDateObject}" != "")##
+#set($postDate = $formatterOut.format($postDateObject.getTime()))##
+#end##
+#if($velocityCount == 1)##
+#set($firstrow = 'perc-list-first')##
+#else##
+#set($firstrow = ' ')##
+#end##
+#if($velocityCount == $relresults.size())##
+#set($lastrow = 'perc-list-last')##
+#else
+#set($lastrow = ' ')##
+#end
+#set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+#set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+#set($link = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result, "percSystem.imageMainBinary")))##
+#set($img_alt = $rx.pageutils.html($result,'alttext'))##
+#if(!$perc.isEditMode())##
+#set($img_title=$rx.pageutils.html($result,'displaytitle'))##
+#else##
+#set($img_title="")##
+#end
+#if($perc.isEditMode() && $img_title == "")##
+#set($img_title_attr = "")##
+#else##
+#set($img_title_attr = 'title="' + $img_title + '"')##
+#end
+$!{itemFormatStartTag}<li class="$rowtag $!{firstrow} $!{lastrow} perc-list-element">
+#if($renderingformat == 'image')
+#set($img_height=$result.node.getProperty('rx:img_height').getString())##
+#set($img_width=$result.node.getProperty('rx:img_width').getString())##
+#if($img_height.length() > 0 && $img_width.length() > 0)
+<img src="$link" $img_title_attr alt="$img_alt" aria-label="$!{img_title}" height="$img_height" width="$img_width" />
+#else##
+<img src="$link" $img_title_attr />
+#end
+#if($showPostDate)##
+#if("$!{postDate}" != "")##
+<span class="perc-image-auto-list-date">$!{postDate}</span>
+#end##
+#end##
+#else##
+#set($img_height=$result.node.getProperty('rx:img2_height').getString())##
+#set($img_width=$result.node.getProperty('rx:img2_width').getString())##
+#set($thumblink=$tools.esc.html($rx.pageutils.itemLink($linkContext, $result, "percSystem.imageThumbBinary")))##
+#if($renderingformat == 'thumbnail')##
+#if($img_height.length() > 0 && $img_width.length() > 0)
+<img src="$thumblink" $img_title_attr alt="$img_alt" height="$img_height" width="$img_width" />
+#else##
+<img src="$thumblink" $img_title_attr />
+#end
+#end
+#if($renderingformat == 'thumbnail_link')
+<a ${thumblinkclass} href="$link" $img_title_attr target="$target">
+<img src="$thumblink"  alt="$img_alt" height="$img_height" width="$img_width"/>
+</a>
+#end
+#end
+#if ($caption)
+#set($caption_text=$result.node.getProperty('rx:resource_link_title').getString())##
+<div class="$!{captionclass} perc-caption">
+${caption_text}
+</div>
+#end
+</li>$!{itemFormatEndTag}
+#end##
+#if($rendering == "ordered")##
+</ol>##
+#else##
+</ul>##
+#end##
+#end##
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("imagelist-sample-content", "This image auto list widget is showing sample content.")
+#end
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/widgets/percPageAutoList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/widgets/percPageAutoList/component-package.json
@@ -1,0 +1,1381 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percPageAutoList",
+  "name": "Page Auto List",
+  "version": "1.7.1",
+  "description": "Display a dynamic list of page links",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Page Auto List",
+    "category": "content,search",
+    "description": "Display a dynamic list of page links",
+    "thumbnail": "resources/widgetIconLinkAutoList.png",
+    "icon": "resources/widgetIconLinkAutoList.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percPageAutoList",
+      "ref": "contentTypes/percPageAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percPageAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percPageAutoListSnippet.vm",
+      "contentType": "percPageAutoList",
+      "bindings": [
+        {
+          "variable": "isEditMode",
+          "expression": "$perc.isEditMode() || $perc.isPreviewMode()"
+        },
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "pagingPagesText",
+          "expression": "$perc.widget.item.properties.get('pagingPagesText')"
+        },
+        {
+          "variable": "itemTitleFormat",
+          "expression": "$perc.widget.item.properties.get('itemTitleFormat')"
+        },
+        {
+          "variable": "rendering",
+          "expression": "$perc.widget.item.properties.get('listType')"
+        },
+        {
+          "variable": "listTitleFormat",
+          "expression": "$perc.widget.item.properties.get('listTitleFormat')"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.properties.get('autoListDivId')"
+        },
+        {
+          "variable": "perc_hidefield_title",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_title')"
+        },
+        {
+          "variable": "summary",
+          "expression": "$perc.widget.item.properties.get('summary')"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "$perc.widget.item.properties.get('listAriaLabel')"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "$perc.widget.item.properties.get('listAriaRole')"
+        },
+        {
+          "variable": "perc_hide_when_empty",
+          "expression": "$perc.widget.item.properties.get('perc_hide_when_empty')"
+        },
+        {
+          "variable": "enableRssIcon",
+          "expression": "$perc.widget.item.properties.get('enable_rss_icon')"
+        },
+        {
+          "variable": "rssIconPosition",
+          "expression": "$perc.widget.item.properties.get('rssIconPosition')"
+        },
+        {
+          "variable": "summaryclass",
+          "expression": "$perc.widget.item.cssProperties.get('summaryclass')"
+        },
+        {
+          "variable": "showPostDate",
+          "expression": "$perc.widget.item.properties.get('showPostDate')"
+        },
+        {
+          "variable": "rssLinkText",
+          "expression": "$perc.widget.item.properties.get('rssLinkText')"
+        },
+        {
+          "variable": "postDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('postDateTimeFormat')"
+        },
+        {
+          "variable": "enableCalenderIcon",
+          "expression": "$perc.widget.item.properties.get('enableCalenderIcon')"
+        },
+        {
+          "variable": "listItemFormatStartTag",
+          "expression": "'<' + $itemTitleFormat + '>'"
+        },
+        {
+          "variable": "listItemFormatEndTag",
+          "expression": "'</' + $itemTitleFormat + '>'"
+        },
+        {
+          "variable": "postDateTimeFormat",
+          "expression": "\"EEEE MM dd, yyyy\""
+        },
+        {
+          "variable": "locale",
+          "expression": "$perc.widget.item.properties.get('locale')"
+        },
+        {
+          "variable": "locale",
+          "expression": "\"en-US\""
+        },
+        {
+          "variable": "summaryclass",
+          "expression": "$summaryclass.trim()"
+        },
+        {
+          "variable": "summaryclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "'role=\"region\"'"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "'role=\"' + $listAriaRole + '\"'"
+        },
+        {
+          "variable": "target",
+          "expression": "$perc.widget.item.properties.get('target')"
+        },
+        {
+          "variable": "layout",
+          "expression": "$perc.widget.item.properties.get('layout')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "totalMaxResults",
+          "expression": "$perc.widget.item.properties.get('totalMaxResults')"
+        },
+        {
+          "variable": "totalMaxResults",
+          "expression": "500"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "$perc.widget.item.properties.get('maxlength')"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "$totalMaxResults"
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "$perc.widget.item.properties.get('sortDirection')"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.id + \"_list\""
+        },
+        {
+          "variable": "headerId",
+          "expression": "$autoListDivId + '_header'"
+        },
+        {
+          "variable": "sortbyVal",
+          "expression": "$perc.widget.item.properties.get('sortby')"
+        },
+        {
+          "variable": "sortbyVal",
+          "expression": "\"rx:resource_link_title\""
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "\"asc\""
+        },
+        {
+          "variable": "enableRssField",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "enableRssField",
+          "expression": "$assetItem.getNode().getProperty('enable_rss_feed').String"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "$assetItem.getNode().getProperty('query').String"
+        },
+        {
+          "variable": "currentDate",
+          "expression": "$tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $tools.date.getDate())"
+        },
+        {
+          "variable": "hidePastResults",
+          "expression": "$assetItem.getNode().getProperty('hide_past_results').String"
+        },
+        {
+          "variable": "hidePastResultsFilterType",
+          "expression": "$assetItem.getNode().getProperty('hide_past_results_filter').String"
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" and \" +  $hidePastResultsFilterType + \" > '\" + $currentDate + \"'\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" where \" +  $hidePastResultsFilterType + \" > '\" + $currentDate + \"'\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortbyVal + \" desc\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortbyVal + \" \" + $sortDirection"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "sitePath",
+          "expression": "$assetItem.getNode().getProperty('site_path').String"
+        },
+        {
+          "variable": "feedname",
+          "expression": "$assetItem.getNode().getProperty('feed_name').String"
+        },
+        {
+          "variable": "baseUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "siteName",
+          "expression": "$pathParts[2]"
+        },
+        {
+          "variable": "sUrl",
+          "expression": "$baseUrl + \"/feeds/rss/\" + $siteName + \"/\" + $feedname +\"/\""
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "$totalMaxResults"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem, 'displaytitle')"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "'<' + $listTitleFormat + ' id=\"' + $headerId +'\" class=\"perc-list-title\" aria-label=\"' + $title + '\" title=\"' + $title + '\"' + '>'"
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "'</' + $listTitleFormat + '>'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $title + ' page list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"Page list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $listAriaLabel + '\"'"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('perc-list-odd', 'perc-list-even')"
+        },
+        {
+          "variable": "titleContains",
+          "expression": "$assetItem.getNode().getProperty('title_contains').String"
+        },
+        {
+          "variable": "starDate",
+          "expression": "$assetItem.getNode().getProperty('start_date').String"
+        },
+        {
+          "variable": "endDate",
+          "expression": "$assetItem.getNode().getProperty('end_date').String"
+        },
+        {
+          "variable": "hidePastResultsFilterType",
+          "expression": "\"dcterms:created\""
+        },
+        {
+          "variable": "hidePastResultsFilterType",
+          "expression": "\"perc:end_date\""
+        },
+        {
+          "variable": "templatesList",
+          "expression": "$assetItem.getNode().getProperty('page_templates_list').String"
+        },
+        {
+          "variable": "categoryList",
+          "expression": "$assetItem.getNode().getProperty('page_category_list').String"
+        },
+        {
+          "variable": "tagsList",
+          "expression": "$assetItem.getNode().getProperty('page_tags_list').String"
+        },
+        {
+          "variable": "criteria",
+          "expression": "\"[\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"&quot;type = 'page'&quot;\""
+        },
+        {
+          "variable": "criteriaSep",
+          "expression": "\", \""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + $criteriaSep + \"&quot;linktext LIKE '%\" + $titleContains +\"%'&quot;\""
+        },
+        {
+          "variable": "sd",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$starDate)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\""
+        },
+        {
+          "variable": "ed",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$endDate)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$sitePath.replace(\"//Sites/\", \"\")"
+        },
+        {
+          "variable": "temppaths",
+          "expression": "$temppath.split(\"/\")"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\""
+        },
+        {
+          "variable": "folderpath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "counter",
+          "expression": "1"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$folderpath + \"/\" + $temppaths[$counter]"
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\""
+        },
+        {
+          "variable": "categoryPathList",
+          "expression": "$categoryList.split(\",\")"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;perc:category = '\" + $rx.pageutils.getCategoryLabel($categoryPathList[0]) + \"'&quot;\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "\"(\""
+        },
+        {
+          "variable": "counter",
+          "expression": "0"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \"'\" + $rx.pageutils.getCategoryLabel($categoryPathList[$counter]) + \"'\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \", \""
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \")\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;perc:category IN \" + $inCl + \"&quot;\""
+        },
+        {
+          "variable": "templateNameList",
+          "expression": "$rx.pageutils.templateNames($templatesList)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "\"(\""
+        },
+        {
+          "variable": "counter",
+          "expression": "0"
+        },
+        {
+          "variable": "templNameArray",
+          "expression": "$templateNameList.toArray()"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \"'\" + $templNameArray[$counter] + \"'\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \", \""
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \")\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"]\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"linktext_lower \" + $sortDirection"
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:title asc, linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:title \" + $sortDirection +\", linktext_lower \" + $sortDirection"
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"name asc, linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"name \" + $sortDirection +\", linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:date desc, linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:date \" + $sortDirection + \", linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created desc , linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created \" + $sortDirection + \", linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created desc , linktext_lower asc\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{\" + \"&quot;criteria&quot;:\" + $criteria"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;maxResults&quot;:\" + $maxlength"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;pagingPagesText&quot;:\" + \"&quot;\" + $pagingPagesText + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;totalMaxResults&quot;:\" + $totalMaxResults"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $baseUrl + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\""
+        },
+        {
+          "variable": "feedDynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$isEditMode = $perc.isEditMode() || $perc.isPreviewMode();\n    $linkContext = $perc.linkContext;\n    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assetItems);\n    $pagingPagesText = $perc.widget.item.properties.get('pagingPagesText');\n    $itemTitleFormat = $perc.widget.item.properties.get('itemTitleFormat');\n    $rendering = $perc.widget.item.properties.get('listType');\n    $listTitleFormat = $perc.widget.item.properties.get('listTitleFormat');\n    $autoListDivId = $perc.widget.item.properties.get('autoListDivId');\n    $perc_hidefield_title = $perc.widget.item.properties.get('perc_hidefield_title');\n    $summary = $perc.widget.item.properties.get('summary');\n    $listAriaLabel = $perc.widget.item.properties.get('listAriaLabel');\n    $listAriaRole = $perc.widget.item.properties.get('listAriaRole');\n    $perc_hide_when_empty = $perc.widget.item.properties.get('perc_hide_when_empty');\n    $enableRssIcon = $perc.widget.item.properties.get('enable_rss_icon');\n    $rssIconPosition = $perc.widget.item.properties.get('rssIconPosition');\n    $summaryclass = $perc.widget.item.cssProperties.get('summaryclass');\n    $showPostDate = $perc.widget.item.properties.get('showPostDate');\n    $rssLinkText = $perc.widget.item.properties.get('rssLinkText');\n    $postDateTimeFormat = $perc.widget.item.properties.get('postDateTimeFormat');\n    $enableCalenderIcon = $perc.widget.item.properties.get('enableCalenderIcon');\n\n    if ($itemTitleFormat != 'none') {\n        $listItemFormatStartTag = '<' + $itemTitleFormat + '>';\n        $listItemFormatEndTag = '</' + $itemTitleFormat + '>';\n    }\n\n    if($postDateTimeFormat == null){\n        $postDateTimeFormat = \"EEEE MM dd, yyyy\";\n    }\n\n    $locale = $perc.widget.item.properties.get('locale');\n\n    if($locale == null) {\n        $locale = \"en-US\";\n    }\n\n    if (!empty($summaryclass)) {\n        $summaryclass = $summaryclass.trim();\n    }\n    else {\n        $summaryclass = \"\";\n    }\n\n    if ($listAriaRole == '' || $listAriaRole == null) {\n        $listAriaRole = 'role=\"region\"';\n    }\n    else {\n        $listAriaRole = 'role=\"' + $listAriaRole + '\"';\n    }\n\n    $target = $perc.widget.item.properties.get('target');\n    $layout = $perc.widget.item.properties.get('layout');\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n\n    if (!empty($rootclass)) {\n        $rootclass = $rootclass + \" \";\n    }\n\n\t$totalMaxResults = $perc.widget.item.properties.get('totalMaxResults');\n\n\tif (empty($totalMaxResults)) {\n        $totalMaxResults = 500;\n    }\n\n    $maxlength = $perc.widget.item.properties.get('maxlength');\n\n    if (empty($maxlength)) {\n        $maxlength = $totalMaxResults;\n    }\n\n    $sortDirection = $perc.widget.item.properties.get('sortDirection');\n\n    if($autoListDivId == '' || $autoListDivId == null) {\n        $autoListDivId = $perc.widget.item.id + \"_list\";\n    }\n\n    $headerId = $autoListDivId + '_header';\n    $sortbyVal = $perc.widget.item.properties.get('sortby');\n\n    if($sortbyVal == null || $sortbyVal == \"none\"){\n        $sortbyVal = \"rx:resource_link_title\";\n        $sortDirection = \"asc\";\n    }\n\n    $enableRssField = \"\";\n\n    if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n        $enableRssField = $assetItem.getNode().getProperty('enable_rss_feed').String;\n        $params = $rx.string.stringToMap(null);\n        $query = $assetItem.getNode().getProperty('query').String;\n        $currentDate =  $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $tools.date.getDate());\n        $hidePastResults = $assetItem.getNode().getProperty('hide_past_results').String;\n        $hidePastResultsFilterType = $assetItem.getNode().getProperty('hide_past_results_filter').String;\n\n        if ($hidePastResults == 'true')\n        {\n            if ($query.contains('where'))\n            {\n                $query = $query + \" and \" +  $hidePastResultsFilterType + \" > '\" + $currentDate + \"'\";\n            }\n            else\n            {\n                $query = $query + \" where \" +  $hidePastResultsFilterType + \" > '\" + $currentDate + \"'\";\n            }\n        }\n\n        if($sortDirection == null){\n            $query = $query + \" order by \" + $sortbyVal + \" desc\";\n        }else{\n           $query = $query + \" order by \" + $sortbyVal + \" \" + $sortDirection;\n        }\n\n\n\n        $params.put('query', $query);\n        $params.put('max_results', $totalMaxResults);\n        $pageId = $perc.page.id;\n        $sitePath = $assetItem.getNode().getProperty('site_path').String;\n        $feedname = $assetItem.getNode().getProperty('feed_name').String;\n        $baseUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n        if(!empty($pageId))\n        {\n            $finderPath = $rx.pageutils.getItemPath($pageId);\n            $pathParts = $finderPath.split(\"\\/\");\n            $siteName = $pathParts[2];\n            $sUrl = $baseUrl + \"/feeds/rss/\" + $siteName + \"/\" + $feedname +\"/\";\n        }\n        $finderName=\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n        $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n\n        if ($maxlength == -1) {\n            $maxlength = $totalMaxResults;\n        }\n\n        $title = $rx.pageutils.html($assetItem, 'displaytitle');\n\n        if ($listTitleFormat != 'none') {\n           $titleFormatStartTag = '<' + $listTitleFormat + ' id=\"' + $headerId +'\" class=\"perc-list-title\" aria-label=\"' + $title + '\" title=\"' + $title + '\"' + '>';\n           $titleFormatEndTag = '</' + $listTitleFormat + '>';\n        }\n\n        if ($listAriaLabel == '' || $listAriaLabel == null)\n        {\n            if ($title != null && $title != '')\n            {\n                $listAriaLabel = 'aria-label=\"' + $title + ' page list\"';\n            }\n            else\n            {\n                $listAriaLabel = 'aria-label=\"Page list\"';\n            }\n        }\n        else\n        {\n            $listAriaLabel = 'aria-label=\"' + $listAriaLabel + '\"';\n        }\n\n        $rowtag = $tools.alternator.auto('perc-list-odd', 'perc-list-even');\n\n        ##Page auto list query starts\n        ##Gets the individual field values\n        $titleContains = $assetItem.getNode().getProperty('title_contains').String;\n        $starDate = $assetItem.getNode().getProperty('start_date').String;\n        $endDate = $assetItem.getNode().getProperty('end_date').String;\n\n        ##\n        ## update the Past Results Filter Type to use the correct type for the dynamic DTS call\n        ##\n        if ($hidePastResultsFilterType == \"rx:sys_contentpostdate\")\n        {\n            $hidePastResultsFilterType = \"dcterms:created\";\n        }\n        if ($hidePastResultsFilterType == \"rx:page_end_date\")\n        {\n            $hidePastResultsFilterType = \"perc:end_date\";\n        }\n\n        $templatesList = $assetItem.getNode().getProperty('page_templates_list').String;\n        ## Tags and Categories\n        if($assetItem.getNode().hasProperty('page_category_list'))\n            $categoryList = $assetItem.getNode().getProperty('page_category_list').String;\n        if($assetItem.getNode().hasProperty('page_tags_list'))\n            $tagsList = $assetItem.getNode().getProperty('page_tags_list').String;\n\n        ##Builds the criteria\n        $criteria = \"[\";\n        $criteria = $criteria + \"&quot;type = 'page'&quot;\";\n        $criteriaSep = \", \";\n        if ($titleContains != null && $titleContains != \"\")\n        {\n             $criteria = $criteria + $criteriaSep + \"&quot;linktext LIKE '%\" + $titleContains +\"%'&quot;\";\n        }\n        if ($starDate != null && $starDate != \"\"){\n             $sd = $tools.date.toDate(\"MM/dd/yyyy\",$starDate);\n             $criteria = $criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\";\n        }\n        if ($endDate != null && $endDate != \"\"){\n             $ed = $tools.date.toDate(\"MM/dd/yyyy\",$endDate);\n             $criteria = $criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\";\n        }\n        if ($sitePath != null && $sitePath != \"\" && $sitePath != \"//Sites\")\n        {\n            $temppath = $sitePath.replace(\"//Sites/\", \"\");\n            if($temppath.indexOf(\"/\") > 0)\n            {\n                $temppaths = $temppath.split(\"/\");\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\";\n                $folderpath = \"\";\n                $counter = 1;\n                while($counter < $temppaths.size())\n                {\n                    $folderpath = $folderpath + \"/\" + $temppaths[$counter];\n                    $counter = $counter + 1;\n                }\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\";\n            }\n            else\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\";\n            }\n        }\n\n        if(!empty($categoryList) && $categoryList != \"\") {\n            $categoryPathList = $categoryList.split(\",\");\n            if($categoryPathList.size()== 1){\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;perc:category = '\" + $rx.pageutils.getCategoryLabel($categoryPathList[0]) + \"'&quot;\";\n            }\n            else if($categoryPathList.size() > 1)\n            {\n                $inCl = \"(\";\n                $counter = 0;\n\n                while($counter < $categoryPathList.size())\n                {\n                    $inCl = $inCl + \"'\" + $rx.pageutils.getCategoryLabel($categoryPathList[$counter]) + \"'\";\n                    if($counter != $categoryPathList.size()-1)\n                        $inCl = $inCl + \", \";\n                    $counter = $counter + 1;\n                }\n                $inCl = $inCl + \")\";\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;perc:category IN \" + $inCl + \"&quot;\";\n            }\n        }\n\n        if($templatesList != null && $templatesList != \"\")\n        {\n            $templateNameList = $rx.pageutils.templateNames($templatesList);\n            if($templateNameList.size() == 1)\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\";\n            }\n            else if($templateNameList.size() > 1)\n            {\n                $inCl = \"(\";\n                $counter = 0;\n                $templNameArray = $templateNameList.toArray();\n\n                while($counter < $templNameArray.size())\n                {\n                    $inCl = $inCl + \"'\" + $templNameArray[$counter] + \"'\";\n                    if($counter != $templNameArray.size()-1)\n                        $inCl = $inCl + \", \";\n                    $counter = $counter + 1;\n                }\n                $inCl = $inCl + \")\";\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\";\n            }\n        }\n\n        $criteria = $criteria + \"]\";\n\n        ##builds the order by clause\n        $orderby = \"\";\n        if($sortbyVal == \"none\" || $sortbyVal == \"rx:resource_link_title\")\n        {\n             if($sortDirection == null){\n                $orderby = \"linktext_lower asc\";\n            }else{\n               $orderby = \"linktext_lower \" + $sortDirection;\n            }\n\n        }\n        else if ( $sortbyVal == \"rx:page_title\")\n        {\n           if($sortDirection == null){\n                $orderby = \"dcterms:title asc, linktext_lower asc\";\n            }else{\n               $orderby = \"dcterms:title \" + $sortDirection +\", linktext_lower \" + $sortDirection;\n            }\n\n        }\n        else if( $sortbyVal == \"rx:sys_title\" )  {\n            if($sortDirection == null){\n               $orderby = \"name asc, linktext_lower asc\";\n            }else{\n               $orderby = \"name \" + $sortDirection +\", linktext_lower asc\";\n            }\n\n\n        }\n        else if($sortbyVal == \"rx:sys_contentcreateddate\")\n        {\n           if($sortDirection == null){\n               $orderby = \"dcterms:date desc, linktext_lower asc\";\n            }else{\n               $orderby = \"dcterms:date \" + $sortDirection + \", linktext_lower asc\";\n            }\n\n        }\n        else if($sortbyVal == \"rx:sys_contentpostdate\")\n        {\n\n          if($sortDirection == null){\n               $orderby = \"dcterms:created desc , linktext_lower asc\";\n            }else{\n               $orderby = \"dcterms:created \" + $sortDirection + \", linktext_lower asc\";\n            }\n\n        }\n        else if($sortbyVal == null)\n        {\n            $orderby = \"dcterms:created desc , linktext_lower asc\";\n        }\n\n        ##Build the query string for the delivery side auto list\n        $dynamicListData = \"{\" + \"&quot;criteria&quot;:\" + $criteria;\n\n        if ($maxlength != null && $maxlength != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;maxResults&quot;:\" + $maxlength ;\n        }\n        if ($pagingPagesText != null && $pagingPagesText != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;pagingPagesText&quot;:\" + \"&quot;\" + $pagingPagesText + \"&quot;\" ;\n        }\n        if($orderby != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\";\n        }\n        if($totalMaxResults != \"\")\n        {\n        \t$dynamicListData = $dynamicListData + \", &quot;totalMaxResults&quot;:\" + $totalMaxResults;\n        }\n\n        $dynamicListData = $dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $baseUrl + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\";\n\n        $feedDynamicListData = $dynamicListData + \"}\";\n        $dynamicListData = $dynamicListData + \"}\";\n        ##Page auto list query ends\n   }\n   else {\n      ;\n   }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percPageAutoListContent",
+      "allowedContentTypes": [
+        "percPageAutoList"
+      ],
+      "layout": {
+        "layout": "perc-list-vertical",
+        "maxlength": "10"
+      },
+      "styles": {
+        "rootclass": "",
+        "summaryclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLinkAutoList.png",
+      "target": "rx_resources/widgets/pageAutoList/images/widgetIconLinkAutoList.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/perc_common_ui.js",
+      "target": "perc-common-ui/js/perc_common_ui.js",
+      "type": "javascript",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "listType",
+      "displayName": "List Type",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "unordered",
+      "enumValues": [
+        {
+          "value": "unordered",
+          "displayValue": "Unordered List"
+        },
+        {
+          "value": "ordered",
+          "displayValue": "Ordered List"
+        }
+      ]
+    },
+    {
+      "name": "listTitleFormat",
+      "displayName": "Format of list title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    },
+    {
+      "name": "autoListDivId",
+      "displayName": "Page Auto List div id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "itemTitleFormat",
+      "displayName": "Format of list items",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "none",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "none",
+          "displayValue": "None"
+        }
+      ]
+    },
+    {
+      "name": "sortby",
+      "displayName": "Sort by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "rx:sys_contentpostdate",
+      "enumValues": [
+        {
+          "value": "none",
+          "displayValue": "None"
+        },
+        {
+          "value": "rx:resource_link_title",
+          "displayValue": "Link text"
+        },
+        {
+          "value": "rx:page_title",
+          "displayValue": "Title"
+        },
+        {
+          "value": "rx:sys_title",
+          "displayValue": "File Name"
+        },
+        {
+          "value": "rx:sys_contentcreateddate",
+          "displayValue": "Created date"
+        },
+        {
+          "value": "rx:sys_contentpostdate",
+          "displayValue": "Post date"
+        }
+      ]
+    },
+    {
+      "name": "sortDirection",
+      "displayName": "Sort Order",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "desc",
+      "enumValues": [
+        {
+          "value": "desc",
+          "displayValue": "Descending"
+        },
+        {
+          "value": "asc",
+          "displayValue": "Ascending"
+        }
+      ]
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "perc-list-vertical",
+      "enumValues": [
+        {
+          "value": "perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    },
+    {
+      "name": "totalMaxResults",
+      "displayName": "Maximum number of total results",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "500",
+      "enumValues": []
+    },
+    {
+      "name": "maxlength",
+      "displayName": "Number of posts per page",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "10",
+      "enumValues": []
+    },
+    {
+      "name": "pagingPagesText",
+      "displayName": "Text to use for <em>pages</em> (X of Y <strong>pages</strong>)",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "pages",
+      "enumValues": []
+    },
+    {
+      "name": "summary",
+      "displayName": "Show page summary",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "listAriaLabel",
+      "displayName": "Page Auto List aria-label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listAriaRole",
+      "displayName": "Page Auto List aria-role",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "perc_hide_when_empty",
+      "displayName": "Hide auto list when empty",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "target",
+      "displayName": "Link target",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "enable_rss_icon",
+      "displayName": "Include rss icon",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "rssIconPosition",
+      "displayName": "RSS icon position",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "perc-list-top",
+      "enumValues": [
+        {
+          "value": "perc-list-top",
+          "displayValue": "Top of list"
+        },
+        {
+          "value": "perc-list-bottom",
+          "displayValue": "Bottom of list"
+        }
+      ]
+    },
+    {
+      "name": "rssLinkText",
+      "displayName": "Text to use for \"RSS Link\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "RSS Link",
+      "enumValues": []
+    },
+    {
+      "name": "showPostDate",
+      "displayName": "Show Post Date",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "postDateTimeFormat",
+      "displayName": "Format of page post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEEE MM dd, yyyy",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt)    Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "enableCalenderIcon",
+      "displayName": "Enable Calendar Icon",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "summaryclass",
+      "displayName": "CSS page summary class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/widgets/percPageAutoList/templates/percPageAutoListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.PageAutoListWidget/widgets/percPageAutoList/templates/percPageAutoListSnippet.vm
@@ -1,0 +1,197 @@
+#define($ariaLabelString)##
+#if($title && $title.length() > 0)##
+aria-labelledby="$!{headerId}"##
+#else##
+$!{listAriaLabel}##
+#end##
+#end##
+#if($feedname)##
+<div style="display:none" hidden data-name="feedQuery_$feedname" data-hide-past-results="$!{hidePastResults}" data-hide-past-results-filter-type="$!{hidePastResultsFilterType}" data-query="$!{feedDynamicListData}"></div>
+#end##
+<div id="$!{autoListDivId}" $ariaLabelString class="#cleanClass("$!{rootclass} ${layout} perc-page-auto-list")" #if($perc_hide_when_empty && $relresults.size() <= 0)hidden #end data-hide-past-results="$!{hidePastResults}" data-hide-past-results-filter-type="$!{hidePastResultsFilterType}" data-query="$!{dynamicListData}" $!{listAriaRole} aria-live="polite" aria-relevant="additions" aria-atomic="true" aria-busy="true" data-locale="$!{locale}" data-datefmt="$!{postDateTimeFormat}">
+##This is a hidden div that holds the structure of the list when the page auto list
+##output structure changes this hidden div and delivery side view
+##should be modified to match the new structure.
+<div style="display:none" hidden class="perc-page-auto-list-structure">
+#if($rendering == "ordered")##
+<ol class="perc-list-main">##
+#else##
+<ul class="perc-list-main">##
+#end##
+<li class="perc-list-element">$!{listItemFormatStartTag}
+#if("$target" != "")##
+#set($setTarget = 'target=' + '"' + $!{target} + '"')##
+<a href="" $!{setTarget}></a>
+#else##
+<a href="#" title="placeholder">Placeholder</a>
+#end##
+$!{listItemFormatEndTag}
+#if($showPostDate)##
+<span class="perc-page-auto-list-date"></span>
+#end##
+#if($enableCalenderIcon)##
+<div class="perc-page-auto-list-calicon">
+<div class="perc-page-auto-list-calicon-month"></div>
+<div class="perc-page-auto-list-calicon-day"></div>
+</div>
+#end##
+#if ($summary)##
+<div class="#cleanClass("perc-page-auto-list-summary-container $!{summaryclass}")"></div>
+#end##
+</li>
+#if($rendering == "ordered")##
+</ol>##
+#else##
+</ul>##
+#end##
+</div>
+#if( ! $perc.widgetContents.isEmpty() )##
+#if($title && $title.length() > 0)##
+$!{titleFormatStartTag}$!{title}$!{titleFormatEndTag}
+#end##
+#if($enableRssIcon && $enableRssField == "Enable Rss feed" && $rssIconPosition == "perc-list-top")##
+##Keep link class name perc-rss-icon in sync with delivery tier.
+<span class ="perc-rss-icon-top"><a class="perc-rss-icon" aria-label="$!{rssLinkText}" title="$!{rssLinkText}" href="$!{sUrl}">RSS link</a></span>
+#end##
+#set($filteredList = $rx.string.getArrayList())##
+#if(0  < $relresults.size() )##
+#if($rendering == "ordered")##
+<div class = "perc-list-main-wrapper"><ol class="perc-list-main">##
+#else##
+<div class = "perc-list-main-wrapper"><ul class="perc-list-main">##
+#end##
+#if("$!{categoryList}" != "")##
+#foreach($result in $relresults)##
+#set($catMap = $rx.string.stringToMap(null))##
+#set($catClass = "")##
+#set($filterIn = true)##
+#set($cid = $result.getNode().getProperty("sys_contentid").getString())##
+#set($rid = $result.getNode().getProperty("revision").getString())##
+#set($sys_rid = $result.getNode().getProperty("sys_revision").getString())##
+#set($catFilters = $categoryList.split(","))##
+#set($catLike = "")##
+#foreach($cat in $catFilters)##
+#if($catLike != "")##
+#set($catLike = "$catLike OR")##
+#end## --($catLike != "")--
+#if($linkContext.getMode()=="PREVIEW")##
+#set($catLike = "$catLike (SELECT COUNT(CONTENTID) FROM CT_PAGE_PAGE_CATEGORIES_SET WHERE CONTENTID=$!{cid} AND (REVISIONID >= $!{rid}) AND  PAGE_CATEGORIES_TREE = '$!{cat}')>=1 ")##
+#else##
+#set($catLike = "$catLike (SELECT COUNT(CONTENTID) FROM CT_PAGE_PAGE_CATEGORIES_SET WHERE CONTENTID=$!{cid} AND (REVISIONID = $!{rid}) AND  PAGE_CATEGORIES_TREE = '$!{cat}')>=1 ")##
+#end##
+#end##
+#if($linkContext.getMode()=="PREVIEW")##
+#set($catSQL = "SELECT DISTINCT CONTENTID FROM CT_PAGE_PAGE_CATEGORIES_SET WHERE CONTENTID=$!{cid} AND REVISIONID >= $!{rid} AND $!{catLike}")## In preview display current or whatever the latest revision is.
+#else##
+#set($catSQL = "SELECT DISTINCT CONTENTID FROM CT_PAGE_PAGE_CATEGORIES_SET WHERE CONTENTID=$!{cid} AND REVISIONID=$!{rid} AND $!{catLike}")##
+#end##
+##$catSQL
+#set($categoryFilter = $rx.db.get("RhythmyxData", $catSQL))##
+#if(($categoryFilter.size() > 0))##
+#set($dummy = $filteredList.add($result))##
+#end##
+#end##
+#else##
+#set($filteredList=$relresults)##
+#end##
+#if($filteredList.size()>0)##
+#foreach($result in $filteredList)##
+#if($velocityCount <= $maxlength)
+#if($velocityCount == 1)##
+#set($firstrow = 'perc-list-first')##
+#else##
+#set($firstrow = ' ')##
+#end##
+#if($velocityCount == $relresults.size())##
+#set($lastrow = 'perc-list-last')##
+#else##
+#set($lastrow = ' ')##
+#end##
+#set($pagelink=$tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+#set($linkTitle=$rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+#if($result.node.hasProperty('rx:page_categories_tree'))##
+#set($postCategories=$result.node.getProperty('rx:page_categories_tree').getValues())##
+#foreach($category in $postCategories)##
+#foreach($node in $rx.pageutils.getCategoryLabel( $category.getString()).split("/"))##
+#if("$!{node}" !="" && "$!{node}" != "Categories")##
+#set($leaf = $node.replaceAll("[^a-zA-Z0-9]+","").trim().toLowerCase())##
+#set($dummy = $catMap.put($leaf,$leaf))##
+#end##
+#end##
+#end##
+#foreach($c in $catMap.entrySet())##
+#if(""=="$!{catClass}")##
+#set($catClass = " perc-autolist-category-$!{c.key}")##
+#else##
+#set($catClass = "$!{catClass} perc-autolistlist-category-$!{c.key}")##
+#end##if
+#end##for
+#end##if
+<li class="#cleanClass("$rowtag $firstrow $lastrow perc-list-element $!{catClass}")">$!{listItemFormatStartTag}
+#if("$target" != "")
+#set($setTarget = 'target=' + '"' + $!{target} + '"')##
+#end##
+<a href="$!{pagelink}" aria-label="$!{linkTitle}" title="$!{linkTitle}" $!{setTarget}>$!{linkTitle}</a>$!{listItemFormatEndTag}
+##Setup Date Formatting
+#set($formatterOut = $rx.pageutils.getDateFormatFromLocale("$!{postDateTimeFormat}",$locale))##
+#set($postDateObject="")##
+#set($postDate="")##
+#set($postDateObject=$result.node.getProperty('rx:sys_contentpostdate'))##
+#set($postDateObjectString=$result.node.getProperty('rx:sys_contentpostdate').String)##
+#if("$!{postDateObjectString}" == "")##
+#set($postDateObject=$tools.date.getDate())##
+#else##
+#set($postDateObject=$result.node.getProperty('rx:sys_contentpostdate').getDate())##
+#end##
+#if("$!{postDateObject}" != "")##
+#set($postDate = $formatterOut.format($postDateObject.getTime()))##
+#end##
+#if($showPostDate)##
+#set( $postDateTz = $result.node.getProperty('rx:sys_contentpostdatetz').String  )##
+#if($postDateTz == "Default")##
+#set( $postDateTz = "" )##
+#end##
+#if("$!{postDate}" != "")##
+<span class="perc-page-auto-list-date">$!{postDate} $postDateTz</span>
+#end##
+#end##
+#if($enableCalenderIcon)##
+<div class="perc-page-auto-list-calicon">
+<div class="perc-page-auto-list-calicon-month">
+#set($formatterOut2 = $rx.pageutils.getDateFormatFromLocale("MMM",$locale))##
+#set($postDate = $formatterOut2.format($postDateObject.getTime()))##
+$postDate##
+</div>
+<div class="perc-page-auto-list-calicon-day">
+#set($formatterOut3 = $rx.pageutils.getDateFormatFromLocale("dd",$locale))##
+#set($postDate = $formatterOut3.format($postDateObject.getTime()))##
+$postDate##
+</div>
+</div>
+#end##
+#if ($summary)##
+#set($summary_text=$result.node.getProperty('rx:page_summary').getString().replace('<span class="perc-blog-more-link"></span>', "<a href='$!{pagelink}' aria-label='Read more about  $!{linkTitle}' title='$!{linkTitle}'>...more</a>"))##
+#if("$!{summary_text}" != "")##
+<div class="#cleanClass("perc-page-auto-list-summary-container $!{summaryclass}")">
+$!{summary_text}
+</div>
+#end##
+#end##
+</li>
+#end##
+#end##
+#end##
+#if($rendering == "ordered")##
+</ol></div>##
+#else##
+</ul></div>##
+#end##
+#if($enableRssIcon && $enableRssField == "Enable Rss feed" && $rssIconPosition == "perc-list-bottom")##
+##Keep link class name perc-rss-icon in sync with delivery tier.
+<span class="perc-rss-icon-bottom"><a class="perc-rss-icon" aria-label="$!{rssLinkText}" title="$!{rssLinkText}" href="$!{sUrl}">RSS link</a></span>
+#end##
+#end##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("pagelist-sample-content", "This page auto list widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/component-package.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percRawHtml",
+  "name": "HTML",
+  "version": "1.1.9",
+  "description": "Widget to accept and render raw html code.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "HTML",
+    "category": "integration",
+    "description": "Widget to accept and render raw html code.",
+    "thumbnail": "resources/widgetIconHtm.png",
+    "icon": "resources/widgetIconHtm.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 785,
+    "preferredEditorHeight": 405,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percRawHtmlAsset",
+      "ref": "contentTypes/percRawHtmlAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percRawHtmlSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percRawHtmlSnippet.vm",
+      "contentType": "percRawHtmlAsset",
+      "bindings": []
+    }
+  ],
+  "slots": [
+    {
+      "name": "percRawHtmlContent",
+      "allowedContentTypes": [
+        "percRawHtmlAsset"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconHtm.png",
+      "target": "rx_resources/widgets/PSWidget_RawHtml/images/widgetIconHtm.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/templates/percRawHtmlSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRawHtml/templates/percRawHtmlSnippet.vm
@@ -1,0 +1,11 @@
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set( $node = $perc.widgetContents.get(0).node )##
+#set ( $widgetHtml = $node.getProperty('rx:html').getString() )##
+#set ( $widgetHtml = $rx.pageutils.updateManagedLinks($perc.linkContext, $widgetHtml,  $sys.assemblyItem.PubServerId,$node.getProperty('sys_contentid').String ) )##
+#set ( $widgetHtml = $widgetHtml.replace("<PRESERVE>", "" ) )##
+#set ( $widgetHtml = $widgetHtml.replace("</PRESERVE>", "" ) )##
+$!{widgetHtml}
+#elseif ( $perc.isEditMode() )##
+#createEmptyWidgetContent( "html-sample-content", "This HTML widget is showing sample content." )##
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/component-package.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percRichText",
+  "name": "Rich Text",
+  "version": "1.1.9",
+  "description": "Widget to enter text using a WYSIWYG editor",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Rich Text",
+    "category": "content",
+    "description": "Widget to enter text using a WYSIWYG editor",
+    "thumbnail": "resources/widgetIconText.png",
+    "icon": "resources/widgetIconText.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 750,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percRichTextAsset",
+      "ref": "contentTypes/percRichTextAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percRichTextSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percRichTextSnippet.vm",
+      "contentType": "percRichTextAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percRichTextContent",
+      "allowedContentTypes": [
+        "percRichTextAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconText.png",
+      "target": "rx_resources/widgets/PSWidget_RichText/images/widgetIconText.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/templates/percRichTextSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percRichText/templates/percRichTextSnippet.vm
@@ -1,0 +1,9 @@
+<div$!{classAttribute}>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+$node.getProperty('rx:text').getString()##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("text-sample-content", "This rich text widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/component-package.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percSimpleText",
+  "name": "Simple Text",
+  "version": "1.1.9",
+  "description": "Widget used for entering plain text",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Simple Text",
+    "category": "content",
+    "description": "Widget used for entering plain text",
+    "thumbnail": "resources/widgetIconSimpleText.png",
+    "icon": "resources/widgetIconSimpleText.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 640,
+    "preferredEditorHeight": 500,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSimpleTextAsset",
+      "ref": "contentTypes/percSimpleTextAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percSimpleTextSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percSimpleTextSnippet.vm",
+      "contentType": "percSimpleTextAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percSimpleTextContent",
+      "allowedContentTypes": [
+        "percSimpleTextAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconSimpleText.png",
+      "target": "rx_resources/widgets/PSWidget_SimpleText/images/widgetIconSimpleText.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/templates/percSimpleTextSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.baseWidgets/widgets/percSimpleText/templates/percSimpleTextSnippet.vm
@@ -1,0 +1,9 @@
+<div$!{classAttribute}>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+$rx.pageutils.html($node,'rx:text')##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("simple-text-sample-content", "This simple text widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/component-package.json
@@ -1,0 +1,219 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percDefaultLang",
+  "name": "Default Language",
+  "version": "2.5.2",
+  "description": "For SEO with International sites. When added to a Page or a Template adds the necessary href-lang markup for Google.",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Default Language",
+    "description": "For SEO with International sites. When added to a Page or a Template adds the necessary href-lang markup for Google.",
+    "thumbnail": "resources/percDefaultLangIcon.png",
+    "icon": "resources/percDefaultLangIcon.png",
+    "author": "Nate Chadwick",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percDefaultLanguage",
+      "ref": "contentTypes/percDefaultLanguage"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percDefaultLangSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percDefaultLangSnippet.vm",
+      "contentType": "percDefaultLanguage",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "pagelink",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "data",
+          "expression": "$assetItem.Node.getProperty('rx:defaultLangData').getString()"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($data)"
+        },
+        {
+          "variable": "jsonArray",
+          "expression": "$json.getJSONArray(\"config\")"
+        },
+        {
+          "variable": "headContent",
+          "expression": "\"\""
+        },
+        {
+          "variable": "configured",
+          "expression": "\"\""
+        },
+        {
+          "variable": "sites",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "headLinks",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "percPageID",
+          "expression": "$perc.getPage().getId()"
+        },
+        {
+          "variable": "protocol",
+          "expression": "$j.getString(\"protocol\")"
+        },
+        {
+          "variable": "protocol",
+          "expression": "\"\""
+        },
+        {
+          "variable": "sitename",
+          "expression": "$j.getString(\"sitename\")"
+        },
+        {
+          "variable": "lang",
+          "expression": "$j.getString(\"lang\")"
+        },
+        {
+          "variable": "country",
+          "expression": "$j.getString(\"country\")"
+        },
+        {
+          "variable": "default",
+          "expression": "$j.getString(\"defLang\")"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang + \"-\" + $country"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang"
+        },
+        {
+          "variable": "default",
+          "expression": "false"
+        },
+        {
+          "variable": "pageName",
+          "expression": "$perc.page.name"
+        },
+        {
+          "variable": "folderName",
+          "expression": "$perc.page.folderPaths.get(0)"
+        },
+        {
+          "variable": "temp",
+          "expression": "$folderName.replace(\"//Sites/\",\"\")"
+        },
+        {
+          "variable": "iPos",
+          "expression": "$temp.indexOf(\"/\")"
+        },
+        {
+          "variable": "temp",
+          "expression": "$sitename + \"/\" + $perc.page.name"
+        },
+        {
+          "variable": "path",
+          "expression": "$sitename"
+        },
+        {
+          "variable": "path",
+          "expression": "$sitename + $temp.substring($iPos)"
+        },
+        {
+          "variable": "temp",
+          "expression": "$sitename + $temp.substring($iPos) + \"/\" + $perc.page.name"
+        },
+        {
+          "variable": "livePagePath",
+          "expression": "$temp"
+        },
+        {
+          "variable": "query",
+          "expression": "\"select rx:sys_contentid, rx:sys_folderid from rx:percPage where jcr:path like '//Sites/\" + $path + \"' and rx:sys_title='\" + $pageName + \"'\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "relalt",
+          "expression": "\"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\""
+        },
+        {
+          "variable": "xdefault",
+          "expression": "\"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\""
+        },
+        {
+          "variable": "xdefault",
+          "expression": "\"\""
+        },
+        {
+          "variable": "configured",
+          "expression": "$configured + \" \" + $site + \" \""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    $pagelink=\"\";\n    if ( ! $assets.isEmpty())\n    {\n        $assetItem = $assets.get(0);\n        $data = $assetItem.Node.getProperty('rx:defaultLangData').getString();\n        $json = $rx.pageutils.createJsonObject($data);\n        $jsonArray = $json.getJSONArray(\"config\");\n        $headContent = \"\";\n\n        $configured = \"\";\n        $sites = $rx.string.stringToMap(null);\n        $headLinks = $rx.string.stringToMap(null);\n\n        $percPageID = $perc.getPage().getId();\n\n        if( $percPageID != null && $percPageID != \"\" ){\n            for($j : $jsonArray){\n               if ($j.has(\"protocol\")) {\n                    $protocol = $j.getString(\"protocol\");\n                } else {\n                    $protocol = \"\";\n                }\n                $sitename = $j.getString(\"sitename\");\n                $lang = $j.getString(\"lang\");\n                $country = $j.getString(\"country\");\n                $default = $j.getString(\"defLang\");\n\n\n                if($country != null && $country != \"\"){\n                    $countryLang = $lang + \"-\" + $country;\n                } else {\n                    $countryLang = $lang;\n                }\n\n                if($default == null){\n                    $default = false;\n                }\n\n                $pageName = $perc.page.name;\n                $folderName = $perc.page.folderPaths.get(0);\n                $temp = $folderName.replace(\"//Sites/\",\"\");\n                if($temp.startsWith(\"/\")){$temp = $temp.substring(1);}\n                $iPos = $temp.indexOf(\"/\");\n\n                if($temp.indexOf(\"/\") == -1){\n                    $temp = $sitename + \"/\" + $perc.page.name;\n                    $path = $sitename;\n                } else {\n                    $path = $sitename + $temp.substring($iPos);\n                    $temp = $sitename + $temp.substring($iPos) + \"/\" + $perc.page.name;\n                }\n                $livePagePath =  $temp;\n\n                $query = \"select rx:sys_contentid, rx:sys_folderid from rx:percPage where jcr:path like '//Sites/\" + $path + \"' and rx:sys_title='\" + $pageName + \"'\";\n                $params = $rx.string.stringToMap(null);\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $finderName  = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n                $relresults = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                if($relresults != null && $relresults.size()>0){\n                        $relalt= \"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\";\n                        $headLinks.put($relalt,$relalt);\n                        if($default){\n                                $xdefault = \"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $livePagePath.toLowerCase() + \"'/>\";\n                                $headLinks.put($xdefault,$xdefault);\n                        } else {\n                            $xdefault = \"\";\n                        }\n                    $sites.put($sitename,$sitename);\n                }\n            }\n\n            for($site : $sites.values()){\n                $configured = $configured + \" \" + $site + \" \";\n            }\n        }\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percDefaultLangContent",
+      "allowedContentTypes": [
+        "percDefaultLanguage"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percDefaultLangIcon.png",
+      "target": "rx_resources/widgets/percDefaultLang/images/percDefaultLangIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/templates/percDefaultLangSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percDefaultLang/templates/percDefaultLangSnippet.vm
@@ -1,0 +1,13 @@
+#if($perc.isEditMode())##
+<div style="height: 32px;background: transparent url(/Rhythmyx/rx_resources/widgets/percDefaultLang/images/percDefaultLangPlaceholder.png) no-repeat scroll center center;filter: alpha(opacity=50);opacity: .50;" title="Default Language Widget">
+#if( "$!configured}" != "" && "$!{percPageID}" != "" )##
+<b>Configured International Sites:</b> ($!{configured})
+#end##
+</div>
+#end##
+#set( $newline="
+")##
+#foreach($l in $headLinks)##
+#set($addlHead = $perc.page.getAdditionalHeadContent())##
+$perc.page.setAdditionalHeadContent("$!{addlHead}$!{newline}$!{l}")##
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/component-package.json
@@ -1,0 +1,215 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percLocalLang",
+  "name": "Local Language",
+  "version": "2.5.2",
+  "description": "For SEO with International sites. Allows manual selection of alternate language pages to add necessary href-lang markup for Google.",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Local Language",
+    "description": "For SEO with International sites. Allows manual selection of alternate language pages to add necessary href-lang markup for Google.",
+    "thumbnail": "resources/percLocalLangIcon.png",
+    "icon": "resources/percLocalLangIcon.png",
+    "author": "Piotr Butkiewicz",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percLocalLanguage",
+      "ref": "contentTypes/percLocalLanguage"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percLocalLangSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percLocalLangSnippet.vm",
+      "contentType": "percLocalLanguage",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "pagelink",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "data",
+          "expression": "$assetItem.Node.getProperty('rx:localLangData').getString()"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($data)"
+        },
+        {
+          "variable": "jsonArray",
+          "expression": "$json.getJSONArray(\"config\")"
+        },
+        {
+          "variable": "headContent",
+          "expression": "\"\""
+        },
+        {
+          "variable": "previewLinks",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "headLinks",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "testing",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "resultList",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "protocol",
+          "expression": "$j.getString(\"protocol\")"
+        },
+        {
+          "variable": "protocol",
+          "expression": "\"\""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$j.getString(\"pagepath\")"
+        },
+        {
+          "variable": "pagepath",
+          "expression": "$temppath.replace(\"//Sites\", \"\")"
+        },
+        {
+          "variable": "pagename",
+          "expression": "$j.getString(\"pagename\")"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$temppath.replace($pagename,\"\")"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$j.getString(\"pageId\")"
+        },
+        {
+          "variable": "default",
+          "expression": "$j.getString(\"defLang\")"
+        },
+        {
+          "variable": "default",
+          "expression": "false"
+        },
+        {
+          "variable": "lang",
+          "expression": "$j.getString(\"lang\")"
+        },
+        {
+          "variable": "country",
+          "expression": "$j.getString(\"country\")"
+        },
+        {
+          "variable": "contentId",
+          "expression": "$rx.pageutils.parseGuid($pageId).getUUID()"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang + \"-\" + $country"
+        },
+        {
+          "variable": "countryLang",
+          "expression": "$lang"
+        },
+        {
+          "variable": "query",
+          "expression": "\"select rx:sys_contentid, rx:sys_folderid from rx:percPage where rx:sys_contentid = :contentId\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$result.id"
+        },
+        {
+          "variable": "tempPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "escPath",
+          "expression": "$tools.esc.html($tempPath)"
+        },
+        {
+          "variable": "pageLink",
+          "expression": "$escPath.replace(\"/Sites/\", \"\").toLowerCase()"
+        },
+        {
+          "variable": "xdefault",
+          "expression": "\"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $pageLink + \"'/>\""
+        },
+        {
+          "variable": "relalt",
+          "expression": "\"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"'/>\""
+        },
+        {
+          "variable": "relaltString",
+          "expression": "\"&lt;link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"' /&gt;\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    $pagelink=\"\";\n    if ( ! $assets.isEmpty())\n    {\n        $assetItem = $assets.get(0);\n        $data = $assetItem.Node.getProperty('rx:localLangData').getString();\n        $json = $rx.pageutils.createJsonObject($data);\n        $jsonArray = $json.getJSONArray(\"config\");\n        $headContent = \"\";\n        ##\n        $previewLinks = $rx.string.stringToMap(null);\n        $headLinks = $rx.string.stringToMap(null);\n        $testing = $rx.string.stringToMap(null);\n        $resultList = $rx.string.stringToMap(null);\n        ##\n        for ($j : $jsonArray) {\n             if ($j.has(\"protocol\")) {\n                $protocol = $j.getString(\"protocol\");\n            } else {\n                $protocol = \"\";\n            }\n            $temppath = $j.getString(\"pagepath\");\n            $pagepath = $temppath.replace(\"//Sites\", \"\");\n            $pagename = $j.getString(\"pagename\");\n            $folderpath = $temppath.replace($pagename,\"\");\n            ##\n            $pageId = $j.getString(\"pageId\");\n            $default = $j.getString(\"defLang\");\n            if ($default == null) {\n                $default = false;\n            }\n            $lang = $j.getString(\"lang\");\n            $country = $j.getString(\"country\");\n            ##\n            if ($pageId != null && $pageId != \"\") {\n                $contentId = $rx.pageutils.parseGuid($pageId).getUUID();\n            }\n            ##\n            if ($country != null && $country != \"\") {\n                $countryLang = $lang + \"-\" + $country;\n            } else {\n                $countryLang = $lang;\n            }\n            ##\n            if ($folderpath != null && $pagename != null && $contentId != null) {\n                ##\n                $query = \"select rx:sys_contentid, rx:sys_folderid from rx:percPage where rx:sys_contentid = :contentId\";\n                $params = $rx.string.stringToMap(null);\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $params.put('contentId', $contentId);\n                $finderName  = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n                $relresults = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                if ($relresults != null && $relresults.size()>0) {\n                    for ($result : $relresults) {\n                        $resultList.put($result,$result);\n                        ##\n                        $pageId = $result.id;\n                        if ($pageId != null) {\n                            ##\n                            $tempPath = $rx.pageutils.getItemPath($pageId);\n                            $escPath = $tools.esc.html($tempPath);\n                            $pageLink = $escPath.replace(\"/Sites/\", \"\").toLowerCase();\n                            ##\n                            if($default){\n                                $xdefault = \"<link rel='alternate' hreflang='x-default' href='\" + $protocol + \"://\" + $pageLink + \"'/>\";\n                                $headLinks.put($xdefault,$xdefault);\n                                $previewLinks.put($xdefault,$xdefault);\n                            }\n                            $relalt = \"<link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"'/>\";\n                            $headLinks.put($relalt, $relalt);\n                            ##\n                            $relaltString = \"&lt;link rel='alternate' hreflang='\" + $countryLang + \"' href='\" + $protocol + \"://\" + $pageLink + \"' /&gt;\";\n                            $previewLinks.put($relaltString,$relaltString);\n                        }\n                    }\n                }\n            }\n        } ## End Foreach loop\n        ##\n      } ## end  ! $assets.isEmpty()"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percLocalLangContent",
+      "allowedContentTypes": [
+        "percLocalLanguage"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percLocalLangIcon.png",
+      "target": "rx_resources/widgets/percLocalLang/images/percLocalLangIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/templates/percLocalLangSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.defaultLanguage/widgets/percLocalLang/templates/percLocalLangSnippet.vm
@@ -1,0 +1,24 @@
+#if($perc.isEditMode())##
+<div style="background: transparent url(/Rhythmyx/rx_resources/widgets/percLocalLang/images/percLocalLangPlaceholder.png) no-repeat scroll center center;filter: alpha(opacity=50);opacity: .50;" title="Default Language Widget">
+##
+#if("$!previewLinks}" != "")##
+<b>Local Language alternate pages:</b><br/>
+<br />
+#foreach($link in $previewLinks)##
+<div>$link</div>
+#end##
+#else##
+<b>Local Language alternate pages:</b><br/>
+<div>No pages selected</div>
+#end##
+</div>
+#end## End if perc.isEditMode()
+##
+#set( $newline="
+")##
+#if("$!headLinks}" != "")##
+#foreach($l in $headLinks)##
+#set($addlHead = $perc.page.getAdditionalHeadContent())##
+$perc.page.setAdditionalHeadContent("$!{addlHead}$!{newline}$!{l}")##
+#end##
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/component-package.json
@@ -1,0 +1,280 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percEvent",
+  "name": "Event",
+  "version": "1.1.7",
+  "description": "Display information about an event",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Event",
+    "category": "content",
+    "description": "Display information about an event",
+    "thumbnail": "resources/widgetIconEvent.png",
+    "icon": "resources/widgetIconEvent.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 710,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percEventAsset",
+      "ref": "contentTypes/percEventAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percEventSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percEventSnippet.vm",
+      "contentType": "percEventAsset",
+      "bindings": [
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "startDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('startDateTimeFormat')"
+        },
+        {
+          "variable": "endDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('endDateTimeFormat')"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "eventTitle",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "eventDescription",
+          "expression": "$rx.pageutils.html($assetItem, 'body')"
+        },
+        {
+          "variable": "eventSummary",
+          "expression": "$rx.pageutils.html($assetItem,'callout')"
+        },
+        {
+          "variable": "eventLocation",
+          "expression": "$rx.pageutils.html($assetItem,'location')"
+        },
+        {
+          "variable": "tmp",
+          "expression": "$assetItem.Node.getProperty('start_time').Date"
+        },
+        {
+          "variable": "ISODateFormat",
+          "expression": "\"yyyy-MM-dd hh:mm a\""
+        },
+        {
+          "variable": "eventStart",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventStartISO",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventStart",
+          "expression": "$tools.date.format($startDateTimeFormat,$tmp.Time)"
+        },
+        {
+          "variable": "eventStartISO",
+          "expression": "$tools.date.format($ISODateFormat,$tmp.Time)"
+        },
+        {
+          "variable": "tmp",
+          "expression": "$assetItem.Node.getProperty('end_time').Date"
+        },
+        {
+          "variable": "eventEnd",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventEndISO",
+          "expression": "\"\""
+        },
+        {
+          "variable": "eventEnd",
+          "expression": "$tools.date.format($endDateTimeFormat,$tmp.Time)"
+        },
+        {
+          "variable": "eventEndISO",
+          "expression": "$tools.date.format($ISODateFormat,$tmp.Time)"
+        },
+        {
+          "variable": "perc_hidefield_displaytitle",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_displaytitle')"
+        },
+        {
+          "variable": "perc_hidefield_callout",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_callout')"
+        },
+        {
+          "variable": "perc_hidefield_body",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_body')"
+        },
+        {
+          "variable": "perc_hidefield_location",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_location')"
+        },
+        {
+          "variable": "perc_hidefield_start_time",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_start_time')"
+        },
+        {
+          "variable": "perc_hidefield_end_time",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_end_time')"
+        },
+        {
+          "variable": "renderEmptyFields",
+          "expression": "$perc.widget.item.properties.get('renderEmptyFields')"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    if (! $assets.isEmpty())\n    {\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if (!empty($rootclass))\n            $rootclass = $rootclass + \" \";\n        $startDateTimeFormat = $perc.widget.item.properties.get('startDateTimeFormat');\n        $endDateTimeFormat = $perc.widget.item.properties.get('endDateTimeFormat');\n\n        $assetItem = $assets.get(0);\n        $eventTitle = $rx.pageutils.html($assetItem,'displaytitle');\n        $eventDescription = $rx.pageutils.html($assetItem, 'body');\n        $eventSummary = $rx.pageutils.html($assetItem,'callout');\n        $eventLocation = $rx.pageutils.html($assetItem,'location');\n\n        $tmp = $assetItem.Node.getProperty('start_time').Date;\n        $ISODateFormat=\"yyyy-MM-dd hh:mm a\";\n        if (empty($tmp))\n        {\n            $eventStart = \"\";\n            $eventStartISO = \"\";\n        }\n        else\n        {\n            $eventStart = $tools.date.format($startDateTimeFormat,$tmp.Time);\n            $eventStartISO = $tools.date.format($ISODateFormat,$tmp.Time);\n        }\n\n        $tmp = $assetItem.Node.getProperty('end_time').Date;\n        if (empty($tmp))\n        {\n            $eventEnd = \"\";\n            $eventEndISO = \"\";\n        }\n        else\n        {\n            $eventEnd = $tools.date.format($endDateTimeFormat,$tmp.Time);\n            $eventEndISO = $tools.date.format($ISODateFormat,$tmp.Time);\n        }\n\n        $perc_hidefield_displaytitle = $perc.widget.item.properties.get('perc_hidefield_displaytitle');\n        $perc_hidefield_callout = $perc.widget.item.properties.get('perc_hidefield_callout');\n        $perc_hidefield_body = $perc.widget.item.properties.get('perc_hidefield_body');\n        $perc_hidefield_location = $perc.widget.item.properties.get('perc_hidefield_location');\n        $perc_hidefield_start_time = $perc.widget.item.properties.get('perc_hidefield_start_time');\n        $perc_hidefield_end_time = $perc.widget.item.properties.get('perc_hidefield_end_time');\n        $renderEmptyFields = $perc.widget.item.properties.get('renderEmptyFields');\n\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t$dsUrl = \"\";\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percEventContent",
+      "allowedContentTypes": [
+        "percEventAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconEvent.png",
+      "target": "rx_resources/widgets/event/images/widgetIconEvent.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/event/css/style.css",
+      "type": "css",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_hidefield_displaytitle",
+      "displayName": "Hide title field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_callout",
+      "displayName": "Hide summary field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_body",
+      "displayName": "Hide description field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_location",
+      "displayName": "Hide location field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_start_time",
+      "displayName": "Hide start date field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_end_time",
+      "displayName": "Hide end date field",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "renderEmptyFields",
+      "displayName": "Render empty fields",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "startDateTimeFormat",
+      "displayName": "Format of start date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "M/d/yyyy hh:mm a",
+      "enumValues": []
+    },
+    {
+      "name": "endDateTimeFormat",
+      "displayName": "Format of end date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "M/d/yyyy hh:mm a",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/templates/percEventSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.eventWidget/widgets/percEvent/templates/percEventSnippet.vm
@@ -1,0 +1,25 @@
+#if ($assetItem)
+   <div class="$!{rootclass} perc-event" data="$!{dynamicListData}">
+##  don't need to check for empty on title because it is required
+   #if(! $perc_hidefield_displaytitle)
+      <div class="perc-event-title" >$eventTitle</div>
+   #end
+   #if(!($perc_hidefield_callout || ($eventSummary == "" && ! $renderEmptyFields)))
+      <div class="summary">$eventSummary</div>
+   #end
+   #if(!($perc_hidefield_body || ($eventDescription == "" && ! $renderEmptyFields)))
+      <div class="description">$eventDescription</div>
+   #end
+   #if(!($perc_hidefield_location || ($eventLocation == "" && ! $renderEmptyFields)))
+      <div class="location">$eventLocation</div>
+   #end
+   #if(!($perc_hidefield_start_time || ($eventStart == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtstart" title="$eventStartISO">$eventStart</abbr></div>
+   #end
+   #if(!($perc_hidefield_end_time || ($eventEnd == "" && ! $renderEmptyFields)))
+      <div class="perc-event-date"><abbr class="dtend" title="$eventEndISO">$eventEnd</abbr></div>
+   #end
+   </div>
+#elseif ($perc.isEditMode())  ## if ($assetItem)
+   #createEmptyWidgetContent("event-sample-content", "This event widget is showing sample content.")
+#end

--- a/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/component-package.json
@@ -1,0 +1,1032 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percOpenGraph",
+  "name": "Facebook Open Graph",
+  "version": "1.1.6",
+  "description": "Adds Facebook Open Graph tags to a Page or Template.",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.2.5",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Facebook Open Graph",
+    "category": "social",
+    "description": "Adds Facebook Open Graph tags to a Page or Template.",
+    "thumbnail": "resources/open-graph-icon.png",
+    "icon": "resources/open-graph-icon.png",
+    "author": "Percussion Software, Inc.",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percOpenGraph",
+      "ref": "contentTypes/percOpenGraph"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percOpenGraphSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percOpenGraphSnippet.vm",
+      "contentType": "percOpenGraph",
+      "bindings": [
+        {
+          "variable": "percPageID",
+          "expression": "$perc.getPage().getId()"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "og_site_name",
+          "expression": "$perc.widget.item.properties.get('og_site_name')"
+        },
+        {
+          "variable": "og_type",
+          "expression": "$perc.widget.item.properties.get('og_type')"
+        },
+        {
+          "variable": "og_image",
+          "expression": "$perc.widget.item.properties.get('og_image')"
+        },
+        {
+          "variable": "og_image_width",
+          "expression": "$perc.widget.item.properties.get('og_image_width')"
+        },
+        {
+          "variable": "og_image_height",
+          "expression": "$perc.widget.item.properties.get('og_image_height')"
+        },
+        {
+          "variable": "og_locale",
+          "expression": "$perc.widget.item.properties.get('og_locale')"
+        },
+        {
+          "variable": "fb_app_id",
+          "expression": "$perc.widget.item.properties.get('fb_app_id')"
+        },
+        {
+          "variable": "summary",
+          "expression": "$sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String"
+        },
+        {
+          "variable": "summary",
+          "expression": "\"\""
+        },
+        {
+          "variable": "description",
+          "expression": "$perc.page.description"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "site_name_override",
+          "expression": "$assetItem.getNode().getProperty('site_name_override').String"
+        },
+        {
+          "variable": "title_override",
+          "expression": "$assetItem.getNode().getProperty('title_override').String"
+        },
+        {
+          "variable": "description_override",
+          "expression": "$assetItem.getNode().getProperty('description_override').String"
+        },
+        {
+          "variable": "image_override",
+          "expression": "$assetItem.getNode().getProperty('image_override').String"
+        },
+        {
+          "variable": "image_override_linkId",
+          "expression": "$assetItem.getNode().getProperty('image_override_linkId').String"
+        },
+        {
+          "variable": "image_width_override",
+          "expression": "$assetItem.getNode().getProperty('image_width_override').String"
+        },
+        {
+          "variable": "image_height_override",
+          "expression": "$assetItem.getNode().getProperty('image_height_override').String"
+        },
+        {
+          "variable": "url_override",
+          "expression": "$assetItem.getNode().getProperty('url_override').String"
+        },
+        {
+          "variable": "type_override",
+          "expression": "$assetItem.getNode().getProperty('type_override').String"
+        },
+        {
+          "variable": "locale_override",
+          "expression": "$assetItem.getNode().getProperty('locale_override').String"
+        },
+        {
+          "variable": "fb_app_id_override",
+          "expression": "$assetItem.getNode().getProperty('fb_app_id_override').String"
+        },
+        {
+          "variable": "use_site_name",
+          "expression": "$tools.esc.html($site_name_override)"
+        },
+        {
+          "variable": "use_site_name",
+          "expression": "$tools.esc.html($og_site_name)"
+        },
+        {
+          "variable": "meta_sitename",
+          "expression": "'<meta property=\"og:site_name\" content=\"' + $use_site_name + '\" />'"
+        },
+        {
+          "variable": "use_fb_app_id",
+          "expression": "$tools.esc.html($fb_app_id_override)"
+        },
+        {
+          "variable": "use_fb_app_id",
+          "expression": "$tools.esc.html($fb_app_id)"
+        },
+        {
+          "variable": "meta_fb_app_id",
+          "expression": "'<meta property=\"og:fb_app_id\" content=\"' + $use_fb_app_id + '\" />'"
+        },
+        {
+          "variable": "use_locale",
+          "expression": "$tools.esc.html($locale_override)"
+        },
+        {
+          "variable": "use_locale",
+          "expression": "$tools.esc.html($og_locale)"
+        },
+        {
+          "variable": "meta_locale",
+          "expression": "'<meta property=\"og:locale\" content=\"' + $use_locale + '\" />'"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($title_override)"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($perc.page.title)"
+        },
+        {
+          "variable": "meta_title",
+          "expression": "'<meta property=\"og:title\" content=\"' + $use_title + '\" />'"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($type_override)"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($og_type)"
+        },
+        {
+          "variable": "meta_type",
+          "expression": "'<meta property=\"og:type\" content=\"' + $use_type + '\" />'"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$tools.esc.html($url_override)"
+        },
+        {
+          "variable": "pagelink",
+          "expression": "$tools.esc.html($rx.pageutils.itemLink($perc.linkContext, $perc.page))"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$pagelink"
+        },
+        {
+          "variable": "doc",
+          "expression": "$sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary)"
+        },
+        {
+          "variable": "body",
+          "expression": "$doc.body()"
+        },
+        {
+          "variable": "summary_images",
+          "expression": "$body.getElementsByTag(\"img\")"
+        },
+        {
+          "variable": "summary_image",
+          "expression": "$summary_images.first()"
+        },
+        {
+          "variable": "image_summary",
+          "expression": "$summary_image.attr(\"src\")"
+        },
+        {
+          "variable": "image_alt",
+          "expression": "$summary_image.attr(\"alt\")"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "$doc.text()"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description_override)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$summary_text"
+        },
+        {
+          "variable": "use_description",
+          "expression": "\"\""
+        },
+        {
+          "variable": "meta_description",
+          "expression": "'<meta property=\"og:description\" content=\"' + $use_description + '\" />'"
+        },
+        {
+          "variable": "image_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $image_override_linkId)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$tools.esc.html($image_path)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$image_summary"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$og_image"
+        },
+        {
+          "variable": "use_image_height",
+          "expression": "$tools.esc.html($image_height_override)"
+        },
+        {
+          "variable": "use_image_height",
+          "expression": "$tools.esc.html($og_image_height)"
+        },
+        {
+          "variable": "meta_image_height",
+          "expression": "'<meta property=\"og:image:height\" content=\"' + $use_image_height + '\" />'"
+        },
+        {
+          "variable": "use_image_width",
+          "expression": "$tools.esc.html($image_width_override)"
+        },
+        {
+          "variable": "use_image_width",
+          "expression": "$tools.esc.html($og_image_width)"
+        },
+        {
+          "variable": "meta_image_width",
+          "expression": "'<meta property=\"og:image:width\" content=\"' + $use_image_width + '\" />'"
+        },
+        {
+          "variable": "baseURL",
+          "expression": "$perc.linkContext.getSite().getSiteProtocol() + \"://\""
+        },
+        {
+          "variable": "pubSiteName",
+          "expression": "$perc.linkContext.getSite().getName()"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$use_url.replace(\"/Sites/\",\"\")"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$use_url.substring(1)"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$baseURL + $pubSiteName + \"/\" + $use_url"
+        },
+        {
+          "variable": "use_url",
+          "expression": "$baseURL + $use_url"
+        },
+        {
+          "variable": "meta_url",
+          "expression": "'<meta property=\"og:url\" content=\"' + $use_url + '\" />'"
+        },
+        {
+          "variable": "use_image",
+          "expression": "\"/\" + $use_image"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$baseURL + $pubSiteName + $use_image"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "'<meta property=\"og:image\" content=\"' + $use_image + '\" />'"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "nl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$percPageID = $perc.getPage().getId();\n\t   $pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n          if (empty($rootclass)) {\n            $rootclass = \"\";\n       }\n\t$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\t$perc.setWidgetContents($assetItems);\n\n   $og_site_name = $perc.widget.item.properties.get('og_site_name');\n   $og_type = $perc.widget.item.properties.get('og_type');\n   $og_image = $perc.widget.item.properties.get('og_image');\n   $og_image_width = $perc.widget.item.properties.get('og_image_width');\n   $og_image_height = $perc.widget.item.properties.get('og_image_height');\n   $og_locale = $perc.widget.item.properties.get('og_locale');\n   $fb_app_id = $perc.widget.item.properties.get('fb_app_id');\n\n    if($sys.assemblyItem.getNode().hasProperty(\"rx:page_summary\")){\n   \t\t$summary = $sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String;\n   \t}else{\n   \t\t$summary = \"\";\n   \t}\n   $description = $perc.page.description;\n   $summary_text = \"\";\n\n\t  if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n\t\tif(!empty($assetItem)){\n\t\t\t$site_name_override = $assetItem.getNode().getProperty('site_name_override').String;\n\t\t\t$title_override = $assetItem.getNode().getProperty('title_override').String;\n\t\t\t$description_override = $assetItem.getNode().getProperty('description_override').String;\n\t\t\t$image_override = $assetItem.getNode().getProperty('image_override').String;\n\t\t\t$image_override_linkId = $assetItem.getNode().getProperty('image_override_linkId').String;\n\t\t\t$image_width_override = $assetItem.getNode().getProperty('image_width_override').String;\n\t\t\t$image_height_override = $assetItem.getNode().getProperty('image_height_override').String;\n\t\t\t$url_override = $assetItem.getNode().getProperty('url_override').String;\n\t\t\t$type_override = $assetItem.getNode().getProperty('type_override').String;\n\t\t\t$locale_override = $assetItem.getNode().getProperty('locale_override').String;\n\t\t\t$fb_app_id_override = $assetItem.getNode().getProperty('fb_app_id_override').String;\n\n\t\t}\n\t}\n\n\tif(! empty($site_name_override)){\n\t\t$use_site_name = $tools.esc.html($site_name_override);\n\t}else{\n\t\t$use_site_name= $tools.esc.html($og_site_name);\n\t}\n    $meta_sitename='<meta property=\"og:site_name\" content=\"' + $use_site_name + '\" />';\n\n    if(! empty($fb_app_id_override)){\n\t\t$use_fb_app_id = $tools.esc.html($fb_app_id_override);\n\t}else{\n\t\t$use_fb_app_id = $tools.esc.html($fb_app_id);\n\t}\n\t$meta_fb_app_id='<meta property=\"og:fb_app_id\" content=\"' + $use_fb_app_id + '\" />';\n\n\tif(! empty($locale_override)){\n\t\t$use_locale = $tools.esc.html($locale_override);\n\t}else{\n\t\t$use_locale = $tools.esc.html($og_locale);\n\t}\n\t$meta_locale='<meta property=\"og:locale\" content=\"' + $use_locale + '\" />';\n\n\tif(! empty($title_override)){\n\t\t$use_title = $tools.esc.html($title_override);\n\t}else{\n\t\t$use_title = $tools.esc.html($perc.page.title);\n\t}\n\t$meta_title='<meta property=\"og:title\" content=\"' + $use_title + '\" />';\n\n\tif(! empty($type_override) && $type_override != 'none'){\n\t\t$use_type = $tools.esc.html($type_override);\n\t}else{\n\t\t$use_type = $tools.esc.html($og_type);\n\t}\n\n\t$meta_type='<meta property=\"og:type\" content=\"' + $use_type + '\" />';\n\n\tif(! empty($url_override)){\n\t\t$use_url = $tools.esc.html($url_override);\n\t}else{\n\t\t$pagelink = $tools.esc.html($rx.pageutils.itemLink($perc.linkContext, $perc.page));\n\t\t$use_url = $pagelink;\n\t}\n\n\tif(! empty($summary)){\n\n\t\t$doc = $sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary);\n\t\t$body = $doc.body();\n\t\t$summary_images = $body.getElementsByTag(\"img\");\n\t\tif($summary_images.size() > 0){\n\t\t\t$summary_image = $summary_images.first();\n\t\t$image_summary = $summary_image.attr(\"src\");\n\t\t$image_alt = $summary_image.attr(\"alt\");\n\t\t}\n\t\t$summary_text  = $doc.text();\n\t}\n\n\tif(! empty($description_override)){\n\t\t$use_description = $tools.esc.html($description_override);\n\t}else{\n\t    if(! empty($description)){\n\t\t\t$use_description = $tools.esc.html($description);\n\t\t}\n\t\telse{\n\t\t\tif(!empty($summary_text)){\n\t\t\t\t$use_description = $summary_text;\n\t\t\t}\n\t\t\telse{\n\t\t\t\t$use_description = \"\";\n\t\t\t}\n\t\t}\n\t}\n\t$meta_description='<meta property=\"og:description\" content=\"' + $use_description + '\" />';\n\tif(! empty($image_override) && ! empty($image_override_linkId )){\n\n   \t\t    $image_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $image_override_linkId);\n\t\t\t$use_image = $tools.esc.html($image_path);\n\t}else{\n\t\tif(! empty($image_summary)){\n\t\t\t$use_image = $image_summary;\n\t\t}else{\n\t\t\tif(! empty($og_image)){\n\t\t\t\t$use_image = $og_image;\n\t\t\t}\n\t\t}\n\t}\n\n\n\tif(! empty($image_height_override)){\n\t\t$use_image_height = $tools.esc.html($image_height_override);\n\t}else{\n\t    if(! empty($og_image_height)){\n\t\t\t$use_image_height = $tools.esc.html($og_image_height);\n\t\t}\n\t}\n\n\t$meta_image_height='<meta property=\"og:image:height\" content=\"' + $use_image_height + '\" />';\n\n\n\tif(! empty($image_width_override)){\n\t\t$use_image_width = $tools.esc.html($image_width_override);\n\t}else{\n\t    if(! empty($og_image_width)){\n\t\t\t$use_image_width = $tools.esc.html($og_image_width);\n\t\t}\n\n\t}\n\n\t$meta_image_width='<meta property=\"og:image:width\" content=\"' + $use_image_width + '\" />';\n\n\n\t$baseURL = $perc.linkContext.getSite().getSiteProtocol() + \"://\";\n\t$pubSiteName = $perc.linkContext.getSite().getName();\n\n\tif(! empty($use_url)){\n\t\tif(! $use_url.startsWith(\"http\")){\n\n\t\t\tif($use_url.startsWith(\"/Sites/\"))\n\t\t\t\t$use_url = $use_url.replace(\"/Sites/\",\"\");\n\n\t\t\tif($use_url.startsWith(\"/\"))\n\t\t\t\t$use_url = $use_url.substring(1);\n\n\t\t\tif(! $use_url.startsWith($pubSiteName)){\n\t\t\t\t$use_url = $baseURL + $pubSiteName + \"/\" + $use_url;\n\t\t\t}else{\n\t\t\t\t$use_url = $baseURL + $use_url;\n\t\t\t}\n\n\t\t}\n\t}\n\t$meta_url='<meta property=\"og:url\" content=\"' + $use_url + '\" />';\n\n\tif(! empty($use_image)){\n\t\tif(! $use_image.startsWith(\"http\")){\n\n\t\t\tif(! $use_image.startsWith(\"/\")){\n\t\t\t\t$use_image = \"/\" + $use_image;\n\t\t\t}\n\n\t\t\t$use_image = $baseURL + $pubSiteName + $use_image;\n\t\t}\n\t}\n\n\tif(!empty($use_image)){\n\t    $meta_image='<meta property=\"og:image\" content=\"' + $use_image + '\" />';\n\t}else{\n\t\t$meta_image=\"\";\n\t}\n\n\n\tif( empty($perc.page.getAdditionalHeadContent())){\n\t\t$perc.page.setAdditionalHeadContent(\"\");\n\t\t$addlHead = \"\";\n\t}else{\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t}\n\t$nl=\"\";\n\tif(!empty($use_site_name)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:site_name\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($addlHead + $meta_sitename);\n\t\t}\n\t}\n\n\tif(!empty($use_title)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:title\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_title));\n\t\t}\n\t}\n\n\tif(!empty($use_description)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:description\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_description));\n\t\t}\n\t}\n\tif(!empty($use_url)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:url\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_url));\n\t\t}\n\t}\n\n\tif(!empty($use_type)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:type\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_type));\n\t\t}\n\t}\n\n\tif(!empty($use_image)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:image\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image));\n\t\t}\n\t\tif(!empty($use_image_width)){\n\t\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t\tif (! $addlHead.contains(\"property=\\\"og:image:width\\\"\")) {\n\t\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image_width));\n\t\t\t}\n\t\t}\n\t\tif(!empty($use_image_height)){\n\t\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t\tif (! $addlHead.contains(\"property=\\\"og:image:height\\\"\")) {\n\t\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image_height));\n\t\t\t}\n\t\t}\n\t}\n\n\tif(!empty($use_locale)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:locale\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead, $meta_locale));\n\t\t}\n\t}\n\n\tif(!empty($use_fb_app_id)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\tif (! $addlHead.contains(\"property=\\\"og:fb_app_id\\\"\")) {\n\t\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_fb_app_id));\n\t\t}\n\t}"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percOpenGraphContent",
+      "allowedContentTypes": [
+        "percOpenGraph"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/open-graph-icon.png",
+      "target": "rx_resources/widgets/percOpenGraph/images/open-graph-icon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "og_site_name",
+      "displayName": "Site Name",
+      "datatype": "string",
+      "required": true,
+      "enumValues": []
+    },
+    {
+      "name": "og_type",
+      "displayName": "Type",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "website",
+      "enumValues": [
+        {
+          "value": "article",
+          "displayValue": "Article"
+        },
+        {
+          "value": "books.author",
+          "displayValue": "Book Author"
+        },
+        {
+          "value": "books.book",
+          "displayValue": "Book"
+        },
+        {
+          "value": "books.genre",
+          "displayValue": "Book Genre"
+        },
+        {
+          "value": "business.business",
+          "displayValue": "Business"
+        },
+        {
+          "value": "fitness.course",
+          "displayValue": "Fitness Course"
+        },
+        {
+          "value": "game.achievement",
+          "displayValue": "Game Achievement"
+        },
+        {
+          "value": "music.album",
+          "displayValue": "Music Album"
+        },
+        {
+          "value": "music.playlist",
+          "displayValue": "Music Playlist"
+        },
+        {
+          "value": "music.radio_station",
+          "displayValue": "Music Radio Station"
+        },
+        {
+          "value": "music.song",
+          "displayValue": "Music Song"
+        },
+        {
+          "value": "place",
+          "displayValue": "Place"
+        },
+        {
+          "value": "product",
+          "displayValue": "Product"
+        },
+        {
+          "value": "product.group",
+          "displayValue": "Product Group"
+        },
+        {
+          "value": "product.item",
+          "displayValue": "Product Item"
+        },
+        {
+          "value": "profile",
+          "displayValue": "Profile"
+        },
+        {
+          "value": "restaurant.menu",
+          "displayValue": "Restaurant Menu"
+        },
+        {
+          "value": "restaurant.menu_item",
+          "displayValue": "Restaurant Menu Item"
+        },
+        {
+          "value": "restaurant.menu_section",
+          "displayValue": "Restaurant Menu Section"
+        },
+        {
+          "value": "restaurant.restaurant",
+          "displayValue": "Restaurant"
+        },
+        {
+          "value": "video.episode",
+          "displayValue": "Video - Television Show Episode"
+        },
+        {
+          "value": "video.movie",
+          "displayValue": "Video - Movie"
+        },
+        {
+          "value": "video.other",
+          "displayValue": "Video - General"
+        },
+        {
+          "value": "video.tv_show",
+          "displayValue": "Video - Television Show"
+        },
+        {
+          "value": "website",
+          "displayValue": "Website"
+        }
+      ]
+    },
+    {
+      "name": "og_image",
+      "displayName": "Image Asset (Path)",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "og_image_width",
+      "displayName": "Image Asset Width",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1200",
+      "enumValues": []
+    },
+    {
+      "name": "og_image_height",
+      "displayName": "Image Asset Height",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "630",
+      "enumValues": []
+    },
+    {
+      "name": "og_locale",
+      "displayName": "Locale",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "en_US",
+      "enumValues": [
+        {
+          "value": "sq_AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar_DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar_BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar_EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar_IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar_JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar_KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar_LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar_LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar_MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar_OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar_QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar_SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar_SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar_SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar_TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar_AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar_YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be_BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg_BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca_ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh_CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh_SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh_HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh_TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr_HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs_CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da_DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl_BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl_NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en_AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en_CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en_IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en_IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en_MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en_NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en_PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en_SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en_ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en_GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en_US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et_EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi_FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr_BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr_CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr_FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr_LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr_CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de_AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de_DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de_LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de_CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el_CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el_GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw_IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi_IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu_HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is_IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in_ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga_IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it_IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it_CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja_JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko_KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv_LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt_LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk_MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms_MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt_MT",
+          "displayValue": "Maltese (mt) Malta (MT)"
+        },
+        {
+          "value": "no_NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb_NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn_NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl_PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt_BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt_PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro_RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru_RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr_BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr_ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr_RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk_SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl_SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es_AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es_BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es_CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es_CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es_CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es_DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es_EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es_SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es_GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es_HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es_MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es_NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es_PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es_PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es_PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es_PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es_ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es_US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es_UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es_VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv_SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th_TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr_TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk_UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi_VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "fb_app_id",
+      "displayName": "Facebook App Id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/templates/percOpenGraphSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/widgets/percOpenGraph/templates/percOpenGraphSnippet.vm
@@ -1,0 +1,3 @@
+#if($perc.isEditMode())##
+<img src="/Rhythmyx/rx_resources/widgets/percOpenGraph/images/open-graph-placeholder-small.png" alt="Facebook Open Graph Tags" title="Facebook Open Graph Tags" />
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/component-package.json
@@ -1,0 +1,375 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percTwitterSummaryCards",
+  "name": "Twitter Summary Cards",
+  "version": "1.1.4",
+  "description": "Adds support for Twitter cards to the Page or Template.",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.2.5",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Twitter Summary Cards",
+    "category": "social",
+    "description": "Adds support for Twitter cards to the Page or Template.",
+    "thumbnail": "resources/twitter-card-icon.png",
+    "icon": "resources/twitter-card-icon.png",
+    "author": "Nate Chadwick",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTwitterCards",
+      "ref": "contentTypes/percTwitterCards"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTwitterSummaryCardsSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTwitterSummaryCardsSnippet.vm",
+      "contentType": "percTwitterCards",
+      "bindings": [
+        {
+          "variable": "percPageID",
+          "expression": "$perc.getPage().getId()"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "twittercard_type",
+          "expression": "$perc.widget.item.properties.get('twittercard_type')"
+        },
+        {
+          "variable": "twitter_site",
+          "expression": "$perc.widget.item.properties.get('twitter_site')"
+        },
+        {
+          "variable": "twitter_image",
+          "expression": "$perc.widget.item.properties.get('twitter_image')"
+        },
+        {
+          "variable": "twitter_image_alt",
+          "expression": "$perc.widget.item.properties.get('twitter_image_alt')"
+        },
+        {
+          "variable": "summary",
+          "expression": "$sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String"
+        },
+        {
+          "variable": "summary",
+          "expression": "\"\""
+        },
+        {
+          "variable": "description",
+          "expression": "$perc.page.description"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "twitter_site_override",
+          "expression": "$assetItem.getNode().getProperty('twitter_site_override').String"
+        },
+        {
+          "variable": "title_override",
+          "expression": "$assetItem.getNode().getProperty('title_override').String"
+        },
+        {
+          "variable": "description_override",
+          "expression": "$assetItem.getNode().getProperty('description_override').String"
+        },
+        {
+          "variable": "image_override",
+          "expression": "$assetItem.getNode().getProperty('image_override').String"
+        },
+        {
+          "variable": "image_override_linkId",
+          "expression": "$assetItem.getNode().getProperty('image_override_linkId').String"
+        },
+        {
+          "variable": "twitter_image_alt_override",
+          "expression": "$assetItem.getNode().getProperty('image_alt_override').String"
+        },
+        {
+          "variable": "use_twitter_site",
+          "expression": "$tools.esc.html($twitter_site_override)"
+        },
+        {
+          "variable": "use_twitter_site",
+          "expression": "$tools.esc.html($twitter_site)"
+        },
+        {
+          "variable": "meta_sitename",
+          "expression": "'<meta property=\"twitter:site\" content=\"' + $use_twitter_site + '\" />'"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($title_override)"
+        },
+        {
+          "variable": "use_title",
+          "expression": "$tools.esc.html($perc.page.title)"
+        },
+        {
+          "variable": "meta_title",
+          "expression": "'<meta property=\"twitter:title\" content=\"' + $use_title + '\" />'"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($type_override)"
+        },
+        {
+          "variable": "use_type",
+          "expression": "$tools.esc.html($twittercard_type)"
+        },
+        {
+          "variable": "doc",
+          "expression": "$sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary)"
+        },
+        {
+          "variable": "body",
+          "expression": "$doc.body()"
+        },
+        {
+          "variable": "summary_images",
+          "expression": "$body.getElementsByTag(\"img\")"
+        },
+        {
+          "variable": "summary_image",
+          "expression": "$summary_images.first()"
+        },
+        {
+          "variable": "twitter_image_summary",
+          "expression": "$summary_image.attr(\"src\")"
+        },
+        {
+          "variable": "twitter_image_alt",
+          "expression": "$summary_image.attr(\"alt\")"
+        },
+        {
+          "variable": "summary_text",
+          "expression": "$doc.text()"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description_override)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$tools.esc.html($description)"
+        },
+        {
+          "variable": "use_description",
+          "expression": "$summary_text"
+        },
+        {
+          "variable": "use_description",
+          "expression": "\"\""
+        },
+        {
+          "variable": "meta_description",
+          "expression": "'<meta property=\"twitter:description\" content=\"' + $use_description + '\" />'"
+        },
+        {
+          "variable": "image_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext,$image_override_linkId)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$tools.esc.html($image_path)"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$twitter_image_summary"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$twitter_image"
+        },
+        {
+          "variable": "use_type",
+          "expression": "\"summary\""
+        },
+        {
+          "variable": "meta_type",
+          "expression": "'<meta property=\"twitter:card\" content=\"' + $use_type + '\" />'"
+        },
+        {
+          "variable": "baseURL",
+          "expression": "$perc.linkContext.getSite().getSiteProtocol() + \"://\""
+        },
+        {
+          "variable": "pubSiteName",
+          "expression": "$perc.linkContext.getSite().getName()"
+        },
+        {
+          "variable": "use_image",
+          "expression": "\"/\" + $use_image"
+        },
+        {
+          "variable": "use_image",
+          "expression": "$baseURL + $pubSiteName + $use_image"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "'<meta property=\"twitter:image\" content=\"' + $use_image + '\" />'"
+        },
+        {
+          "variable": "meta_image",
+          "expression": "\"\""
+        },
+        {
+          "variable": "use_twitter_image_alt",
+          "expression": "\"\""
+        },
+        {
+          "variable": "use_twitter_image_alt",
+          "expression": "$tools.esc.html($twitter_image_alt_override)"
+        },
+        {
+          "variable": "use_twitter_image_alt",
+          "expression": "$tools.esc.html($twitter_image_alt)"
+        },
+        {
+          "variable": "meta_imagealt",
+          "expression": "'<meta property=\"twitter:image:alt\" content=\"' + $use_twitter_image_alt + '\" />'"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "nl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "addlHead",
+          "expression": "$perc.page.getAdditionalHeadContent()"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$percPageID = $perc.getPage().getId();\n\t   $pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n          if (empty($rootclass)) {\n            $rootclass = \"\";\n       }\n\t$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\t$perc.setWidgetContents($assetItems);\n\n\n   $twittercard_type = $perc.widget.item.properties.get('twittercard_type');\n   $twitter_site = $perc.widget.item.properties.get('twitter_site');\n   $twitter_image = $perc.widget.item.properties.get('twitter_image');\n   $twitter_image_alt = $perc.widget.item.properties.get('twitter_image_alt');\n   if($sys.assemblyItem.getNode().hasProperty(\"rx:page_summary\")){\n   \t\t$summary = $sys.assemblyItem.getNode().getProperty(\"rx:page_summary\").value.String;\n\t}else{\n\t\t$summary = \"\";\n\t}\n\n   $description = $perc.page.description;\n   $summary_text = \"\";\n\n\t  if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n\t\tif(!empty($assetItem)){\n\t\t\t$twitter_site_override = $assetItem.getNode().getProperty('twitter_site_override').String;\n\t\t\t$title_override = $assetItem.getNode().getProperty('title_override').String;\n\t\t\t$description_override = $assetItem.getNode().getProperty('description_override').String;\n\t\t\t$image_override = $assetItem.getNode().getProperty('image_override').String;\n\t\t\t$image_override_linkId = $assetItem.getNode().getProperty('image_override_linkId').String;\n\t\t\t$twitter_image_alt_override = $assetItem.getNode().getProperty('image_alt_override').String;\n\n\t\t}\n\t}\n\n\tif(! empty($twitter_site_override)){\n\t\t\t$use_twitter_site = $tools.esc.html($twitter_site_override);\n\t}else{\n\t\t$use_twitter_site= $tools.esc.html($twitter_site);\n\t}\n    $meta_sitename='<meta property=\"twitter:site\" content=\"' + $use_twitter_site + '\" />';\n\n\tif(! empty($title_override)){\n\t\t$use_title = $tools.esc.html($title_override);\n\t}else{\n\t\t$use_title = $tools.esc.html($perc.page.title);\n\t}\n\t$meta_title = '<meta property=\"twitter:title\" content=\"' + $use_title + '\" />';\n\n\tif(! empty($type_override)){\n\t\t$use_type = $tools.esc.html($type_override);\n\t}else{\n\t\t$use_type = $tools.esc.html($twittercard_type);\n\t}\n\n\tif(! empty($summary)){\n\t\t\t$doc = $sys.getClass().forName('org.jsoup.Jsoup').parseBodyFragment($summary);\n\t\t\t$body = $doc.body();\n\t\t\t$summary_images = $body.getElementsByTag(\"img\");\n\t\t\tif($summary_images.size() > 0){\n\t\t\t\t$summary_image = $summary_images.first();\n\t\t\t$twitter_image_summary = $summary_image.attr(\"src\");\n\t\t\t$twitter_image_alt = $summary_image.attr(\"alt\");\n\t\t\t}\n\t\t\t$summary_text  = $doc.text();\n\t}\n\n\tif(! empty($description_override)){\n\t\t$use_description = $tools.esc.html($description_override);\n\t}else{\n\t\tif(! empty($description))\n\t\t\t$use_description = $tools.esc.html($description);\n\t\telse{\n\t\t\tif(!empty($summary_text)){\n\t\t\t\t$use_description = $summary_text;\n\t\t\t}\n\t\t\telse{\n\t\t\t\t$use_description = \"\";\n\t\t\t}\n\t\t}\n\t}\n\t$meta_description='<meta property=\"twitter:description\" content=\"' + $use_description + '\" />';\n\n\tif(! empty($image_override) && ! empty($image_override_linkId )){\n\n   \t\t    $image_path = $rx.pageutils.renderManagedItemPath($perc.linkContext,$image_override_linkId);\n\t\t\t$use_image = $tools.esc.html($image_path);\n\t}else{\n\t\tif(! empty($twitter_image_summary)){\n\t\t\t$use_image = $twitter_image_summary;\n\t\t}else{\n\t\t\t$use_image = $twitter_image;\n\t\t}\n\t}\n\n\tif(empty($use_image))\n\t\t$use_type=\"summary\";\n\n\t$meta_type='<meta property=\"twitter:card\" content=\"' + $use_type + '\" />';\n\n\t$baseURL = $perc.linkContext.getSite().getSiteProtocol() + \"://\";\n\t$pubSiteName = $perc.linkContext.getSite().getName();\n\n\tif(! empty($use_image)){\n\t\tif(! $use_image.startsWith(\"http\")){\n\n\t\t\tif( ! $use_image.startsWith(\"/\") )\n\t\t\t\t$use_image = \"/\" + $use_image;\n\n\t\t\tif( ! $use_image.startsWith(\"/Rhythmyx/\") ){\n\t\t\t\t$use_image = $baseURL + $pubSiteName + $use_image;\n\t\t\t}\n\t\t}\n\t}\n\tif(!empty($use_image)){\n\t$meta_image='<meta property=\"twitter:image\" content=\"' + $use_image + '\" />';\n\t}else{\n\t\t$meta_image=\"\";\n\t}\n\n\tif(empty($use_image)){\n\t\t$use_twitter_image_alt=\"\";\n\t}else{\n\t\tif(! empty($twitter_image_alt_override)){\n\t\t\t$use_twitter_image_alt = $tools.esc.html($twitter_image_alt_override);\n\t\t}else{\n\t\t\t$use_twitter_image_alt = $tools.esc.html($twitter_image_alt);\n\t\t}\n\t}\n    $meta_imagealt='<meta property=\"twitter:image:alt\" content=\"' + $use_twitter_image_alt + '\" />';\n\n\n\tif( empty($perc.page.getAdditionalHeadContent())){\n\t\t$perc.page.setAdditionalHeadContent(\"\");\n\t\t$addlHead = \"\";\n\t}else{\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t}\n\t$nl=\"\";\n\tif(!empty($use_type)){\n\t\t$perc.page.setAdditionalHeadContent($addlHead + $meta_type);\n\t}\n\n\tif(!empty($use_title)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_title));\n\t}\n\n\tif(!empty($use_description)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_description));\n\t}\n\n\tif(!empty($use_image)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead,$meta_image));\n\t}\n\tif(!empty($use_twitter_image_alt)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead, $meta_imagealt));\n\t}\n\t// Single twitter:site emission (v8.1.7 #838 removed a duplicate block; development was missing both).\n\tif(!empty($use_twitter_site)){\n\t\t$addlHead = $perc.page.getAdditionalHeadContent();\n\t\t$perc.page.setAdditionalHeadContent($nl.format(\"%s%n%s\", $addlHead, $meta_sitename));\n\t}"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percTwitterSummaryCardsContent",
+      "allowedContentTypes": [
+        "percTwitterCards"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/twitter-card-icon.png",
+      "target": "rx_resources/widgets/percTwitterSummaryCards/images/twitter-card-icon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "twittercard_type",
+      "displayName": "Summary Card Type",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "summary_large_image",
+      "enumValues": [
+        {
+          "value": "summary_large_image",
+          "displayValue": "Summary Card Large Image"
+        },
+        {
+          "value": "summary",
+          "displayValue": "Summary Card"
+        }
+      ]
+    },
+    {
+      "name": "twitter_site",
+      "displayName": "@username",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "twitter_image",
+      "displayName": "Default Image Asset (Path)",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "twitter_image_alt",
+      "displayName": "Default Image Alt Text",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/templates/percTwitterSummaryCardsSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards/widgets/percTwitterSummaryCards/templates/percTwitterSummaryCardsSnippet.vm
@@ -1,0 +1,3 @@
+#if($perc.isEditMode())##
+<img src="/Rhythmyx/rx_resources/widgets/percTwitterSummaryCards/images/twitter-card-placeholder-small.png" alt="Twitter Summary Cards Widget Placeholder" title="Twitter Summary Cards Widget" />
+#end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/widgets/percMostReadBlogPosts/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/widgets/percMostReadBlogPosts/component-package.json
@@ -1,0 +1,825 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percMostReadBlogPosts",
+  "name": "Most Read Blog Posts",
+  "version": "1.1.6",
+  "description": "Display most read blog posts",
+  "publisher": {
+    "name": "Percussion",
+    "url": "www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Most Read Blog Posts",
+    "category": "search",
+    "description": "Display most read blog posts",
+    "thumbnail": "resources/percMostReadBlogPostsIcon.png",
+    "icon": "resources/percMostReadBlogPostsIcon.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percMostReadBlogPostsSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percMostReadBlogPostsSnippet.vm",
+      "bindings": [
+        {
+          "variable": "sectionPath",
+          "expression": "$perc.widget.item.properties.get('sectionPath')"
+        },
+        {
+          "variable": "promotedPagePaths",
+          "expression": "$perc.widget.item.properties.get('promotedPagePaths')"
+        },
+        {
+          "variable": "summary",
+          "expression": "$perc.widget.item.properties.get('summary')"
+        },
+        {
+          "variable": "mostReadMoreText",
+          "expression": "$perc.widget.item.properties.get('mostReadMoreText')"
+        },
+        {
+          "variable": "timePeriod",
+          "expression": "$perc.widget.item.properties.get('timePeriod')"
+        },
+        {
+          "variable": "hideDate",
+          "expression": "$perc.widget.item.properties.get('hideDate')"
+        },
+        {
+          "variable": "headingStyle",
+          "expression": "$perc.widget.item.properties.get('headingStyle')"
+        },
+        {
+          "variable": "ariaRole",
+          "expression": "$perc.widget.item.properties.get('ariaRole')"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$perc.widget.item.properties.get('ariaLabel')"
+        },
+        {
+          "variable": "numberOfResults",
+          "expression": "$perc.widget.item.properties.get('numberOfResults')"
+        },
+        {
+          "variable": "sortOrderByHits",
+          "expression": "$perc.widget.item.properties.get('sortOrderByHits')"
+        },
+        {
+          "variable": "listDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('listDateTimeFormat')"
+        },
+        {
+          "variable": "locale",
+          "expression": "$perc.widget.item.properties.get('locale')"
+        },
+        {
+          "variable": "listTitle",
+          "expression": "$perc.widget.item.properties.get('listTitle')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "' aria-label=' + '\"' + $ariaLabel + '\"'"
+        },
+        {
+          "variable": "ariaRole",
+          "expression": "' role=' + '\"' + $ariaRole + '\"'"
+        },
+        {
+          "variable": "data",
+          "expression": "\"{\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \"&quot;sectionPath&quot;:&quot;\" + $sectionPath  + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \",&quot;promotedPagePaths&quot;:&quot;\" + $promotedPagePaths  + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;summary&quot;:\" + $summary"
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;readMoreLink&quot;:\" + \"&quot;\" + $mostReadMoreText + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;dateFormat&quot;:\" + \"&quot;\" + $listDateTimeFormat + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;locale&quot;:\" + \"&quot;\" + $locale + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;timePeriod&quot;:&quot;\" + $timePeriod  + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;headingStyle&quot;:&quot;\" + $headingStyle  + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;hideDate&quot;:&quot;\" + $hideDate  + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;numberOfResults&quot;:&quot;\" + $numberOfResults  + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;sortOrderByHits&quot;:&quot;\" + $sortOrderByHits  + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;listTitle&quot;:&quot;\" + $listTitle  + \"&quot;\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$sectionPath = $perc.widget.item.properties.get('sectionPath');\n    $promotedPagePaths = $perc.widget.item.properties.get('promotedPagePaths');\n    $summary = $perc.widget.item.properties.get('summary');\n    $mostReadMoreText = $perc.widget.item.properties.get('mostReadMoreText');\n    $timePeriod = $perc.widget.item.properties.get('timePeriod');\n    $hideDate = $perc.widget.item.properties.get('hideDate');\n    $headingStyle = $perc.widget.item.properties.get('headingStyle');\n    $ariaRole = $perc.widget.item.properties.get('ariaRole');\n    $ariaLabel = $perc.widget.item.properties.get('ariaLabel');\n    $numberOfResults = $perc.widget.item.properties.get('numberOfResults');\n    $sortOrderByHits = $perc.widget.item.properties.get('sortOrderByHits');\n    $listDateTimeFormat = $perc.widget.item.properties.get('listDateTimeFormat');\n    $locale = $perc.widget.item.properties.get('locale');\n    $listTitle = $perc.widget.item.properties.get('listTitle');\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass)) {\n       $rootclass = $rootclass + \" \";\n    }\n\n    if ($ariaLabel != '' && $ariaLabel != null) {\n        $ariaLabel = ' aria-label=' + '\"' + $ariaLabel + '\"';\n    }\n\n    if ($ariaRole != '' && $ariaRole != null) {\n        $ariaRole = ' role=' + '\"' + $ariaRole + '\"';\n    }\n\n    $data = \"{\";\n\n    $data = $data + \"&quot;sectionPath&quot;:&quot;\" + $sectionPath  + \"&quot;\";\n    $data = $data + \",&quot;promotedPagePaths&quot;:&quot;\" + $promotedPagePaths  + \"&quot;\";\n    $data = $data + \", &quot;summary&quot;:\" + $summary;\n    if ($mostReadMoreText != null && $mostReadMoreText != \"\")\n    {\n        $data = $data + \", &quot;readMoreLink&quot;:\" + \"&quot;\" + $mostReadMoreText + \"&quot;\" ;\n    }\n    if ($listDateTimeFormat != null && $listDateTimeFormat != \"\")\n    {\n        $data = $data + \", &quot;dateFormat&quot;:\" + \"&quot;\" + $listDateTimeFormat + \"&quot;\" ;\n    }\n\n    if ($locale != null && $locale != \"\")\n    {\n        $data = $data + \", &quot;locale&quot;:\" + \"&quot;\" + $locale + \"&quot;\" ;\n    }\n    $data = $data + \", &quot;timePeriod&quot;:&quot;\" + $timePeriod  + \"&quot;\";\n    $data = $data + \", &quot;headingStyle&quot;:&quot;\" + $headingStyle  + \"&quot;\";\n    $data = $data + \", &quot;hideDate&quot;:&quot;\" + $hideDate  + \"&quot;\";\n    $data = $data + \", &quot;numberOfResults&quot;:&quot;\" + $numberOfResults  + \"&quot;\";\n    $data = $data + \", &quot;sortOrderByHits&quot;:&quot;\" + $sortOrderByHits  + \"&quot;\";\n    $data = $data + \", &quot;listTitle&quot;:&quot;\" + $listTitle  + \"&quot;\";\n\n    $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n    $data = $data + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\";\n\n\t$data = $data + \"}\";\n    ##result query ends"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percMostReadBlogPostsChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percMostReadBlogPostsIcon.png",
+      "target": "rx_resources/widgets/percMostReadBlogPosts/images/percMostReadBlogPostsIcon.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/perc_common_ui.js",
+      "target": "perc-common-ui/js/perc_common_ui.js",
+      "type": "javascript",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "sectionPath",
+      "displayName": "Section path",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "promotedPagePaths",
+      "displayName": "Promoted page paths",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "summary",
+      "displayName": "Show page summary",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "hideDate",
+      "displayName": "Hide date and time",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "listDateTimeFormat",
+      "displayName": "Format of blog post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEE MMM d, yyyy hh:mm a",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt) Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "mostReadMoreText",
+      "displayName": "Text to use for \"more link\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "more...",
+      "enumValues": []
+    },
+    {
+      "name": "timePeriod",
+      "displayName": "Time period",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "WEEK",
+      "enumValues": [
+        {
+          "value": "TODAY",
+          "displayValue": "Today"
+        },
+        {
+          "value": "WEEK",
+          "displayValue": "Week"
+        },
+        {
+          "value": "MONTH",
+          "displayValue": "Month"
+        },
+        {
+          "value": "YEAR",
+          "displayValue": "Year"
+        },
+        {
+          "value": "ALLTIME",
+          "displayValue": "All time"
+        }
+      ]
+    },
+    {
+      "name": "headingStyle",
+      "displayName": "Heading style",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "H3",
+      "enumValues": [
+        {
+          "value": "H2",
+          "displayValue": "H2"
+        },
+        {
+          "value": "H3",
+          "displayValue": "H3"
+        },
+        {
+          "value": "H4",
+          "displayValue": "H4"
+        },
+        {
+          "value": "H5",
+          "displayValue": "H5"
+        },
+        {
+          "value": "SPAN",
+          "displayValue": "span"
+        },
+        {
+          "value": "DIV",
+          "displayValue": "div"
+        }
+      ]
+    },
+    {
+      "name": "ariaRole",
+      "displayName": "Aria role",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Aria label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "numberOfResults",
+      "displayName": "Number of results",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "R-5",
+      "enumValues": [
+        {
+          "value": "R-3",
+          "displayValue": "3"
+        },
+        {
+          "value": "R-5",
+          "displayValue": "5"
+        },
+        {
+          "value": "R-10",
+          "displayValue": "10"
+        },
+        {
+          "value": "R-25",
+          "displayValue": "25"
+        },
+        {
+          "value": "R-50",
+          "displayValue": "50"
+        }
+      ]
+    },
+    {
+      "name": "sortOrderByHits",
+      "displayName": "Sort order by hits",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "desc",
+      "enumValues": [
+        {
+          "value": "desc",
+          "displayValue": "Descending"
+        },
+        {
+          "value": "asc",
+          "displayValue": "Asscending"
+        }
+      ]
+    },
+    {
+      "name": "listTitle",
+      "displayName": "List Title",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Most read blog posts",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/widgets/percMostReadBlogPosts/templates/percMostReadBlogPostsSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.MostReadBlogPosts/widgets/percMostReadBlogPosts/templates/percMostReadBlogPostsSnippet.vm
@@ -1,0 +1,5 @@
+#if ($perc.isEditMode())##
+        #createEmptyWidgetContent("most-read-sample-content", "This most read blog post widget is showing sample content.")##
+    #elseif ( ! $perc.isEditMode())##
+        <div class="$!{rootclass} perc-most-read-blog-posts-view" data-query="$!{data}"$!{ariaLabel}$!{ariaRole}></div>
+    #end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/widgets/percResult/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/widgets/percResult/component-package.json
@@ -1,0 +1,778 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percResult",
+  "name": "Result",
+  "version": "1.1.8",
+  "description": "Display the result of a search",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Result",
+    "category": "search",
+    "description": "Display the result of a search",
+    "thumbnail": "resources/widgetIconLinkResult.png",
+    "icon": "resources/widgetIconLinkResult.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percResultSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percResultSnippet.vm",
+      "bindings": [
+        {
+          "variable": "isEditMode",
+          "expression": "\"false\""
+        },
+        {
+          "variable": "summary",
+          "expression": "$perc.widget.item.properties.get('summary')"
+        },
+        {
+          "variable": "sortbyVal",
+          "expression": "$perc.widget.item.properties.get('sortby')"
+        },
+        {
+          "variable": "resultHeaderText",
+          "expression": "$perc.widget.item.properties.get('resultHeaderText')"
+        },
+        {
+          "variable": "resultDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('resultDateTimeFormat')"
+        },
+        {
+          "variable": "resultEntriesTextPlural",
+          "expression": "$perc.widget.item.properties.get('resultEntriesTextPlural')"
+        },
+        {
+          "variable": "resultEntriesTextSingular",
+          "expression": "$perc.widget.item.properties.get('resultEntriesTextSingular')"
+        },
+        {
+          "variable": "readMoreLink",
+          "expression": "$perc.widget.item.properties.get('readMoreLink')"
+        },
+        {
+          "variable": "totalMaxResults",
+          "expression": "$perc.widget.item.properties.get('totalMaxResults')"
+        },
+        {
+          "variable": "perc_max_post_entries",
+          "expression": "$perc.widget.item.properties.get('maxResultsPerPage')"
+        },
+        {
+          "variable": "pagingPagesText",
+          "expression": "$perc.widget.item.properties.get('pagingPagesText')"
+        },
+        {
+          "variable": "pagingOfText",
+          "expression": "$perc.widget.item.properties.get('pagingOfText')"
+        },
+        {
+          "variable": "locale",
+          "expression": "$perc.widget.item.properties.get('locale')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "resultEntriesTextPlural",
+          "expression": "'results'"
+        },
+        {
+          "variable": "resultEntriesTextSingular",
+          "expression": "'result'"
+        },
+        {
+          "variable": "locale",
+          "expression": "\"en-US\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:title asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created desc\""
+        },
+        {
+          "variable": "data",
+          "expression": "\"{\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \" &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;locale&quot;:\" + \"&quot;\" + $locale + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;dateFormat&quot;:\" + \"&quot;\" + $resultDateTimeFormat + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;headerText&quot;:&quot;\" + $resultHeaderText + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;entriesTextPlural&quot;:&quot;\" + $resultEntriesTextPlural + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;entriesTextSingular&quot;:&quot;\" + $resultEntriesTextSingular + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;readMoreLink&quot;:&quot;\" + $readMoreLink + \"&quot;\""
+        },
+        {
+          "variable": "totalMaxResults",
+          "expression": "500"
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;totalMaxResults&quot;:\" + $totalMaxResults"
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;maxResults&quot;:\" + $perc_max_post_entries"
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;pagingPagesText&quot;:\" + \"&quot;\" + $pagingPagesText + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;pagingOfText&quot;:\" + \"&quot;\" + $pagingOfText + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;summary&quot;:&quot;\" + $summary + \"&quot;\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\""
+        },
+        {
+          "variable": "data",
+          "expression": "$data + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$isEditMode=\"false\";\n    $summary = $perc.widget.item.properties.get('summary');\n    $sortbyVal = $perc.widget.item.properties.get('sortby');\n    $resultHeaderText = $perc.widget.item.properties.get('resultHeaderText');\n    $resultDateTimeFormat = $perc.widget.item.properties.get('resultDateTimeFormat');\n    $resultEntriesTextPlural = $perc.widget.item.properties.get('resultEntriesTextPlural');\n    $resultEntriesTextSingular = $perc.widget.item.properties.get('resultEntriesTextSingular');\n    $readMoreLink = $perc.widget.item.properties.get('readMoreLink');\n    $totalMaxResults = $perc.widget.item.properties.get('totalMaxResults');\n    $perc_max_post_entries = $perc.widget.item.properties.get('maxResultsPerPage');\n    $pagingPagesText = $perc.widget.item.properties.get('pagingPagesText');\n    $pagingOfText = $perc.widget.item.properties.get('pagingOfText');\n    $locale = $perc.widget.item.properties.get('locale');\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass)) {\n       $rootclass = $rootclass + \" \";\n    }\n    if ($resultEntriesTextPlural == \"\" || $resultEntriesTextPlural == null)\n    {\n        $resultEntriesTextPlural = 'results';\n    }\n    if ($resultEntriesTextSingular == \"\" || $resultEntriesTextSingular == null)\n    {\n        $resultEntriesTextSingular = 'result';\n    }\n\n    if($locale == null)\n        $locale = \"en-US\";\n\n    ##builds the order by clause\n    $orderby = \"\";\n    if ($sortbyVal == \"rx:page_title\")\n    {\n        $orderby = \"dcterms:title asc\";\n    }\n    else if($sortbyVal == \"rx:sys_contentpostdate\")\n    {\n        $orderby = \"dcterms:created asc\";\n    }\n    else if($sortbyVal == \"rx:sys_contentpostdate desc\")\n    {\n        $orderby = \"dcterms:created desc\";\n    }\n    $data = \"{\";\n\n    if($orderby != \"\")\n    {\n        $data = $data + \" &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\";\n    }\n    if ($locale != null && $locale != \"\")\n    {\n        $data = $data + \", &quot;locale&quot;:\" + \"&quot;\" + $locale + \"&quot;\" ;\n    }\n    if ($resultDateTimeFormat != null && $resultDateTimeFormat != \"\")\n    {\n        $data = $data + \", &quot;dateFormat&quot;:\" + \"&quot;\" + $resultDateTimeFormat + \"&quot;\" ;\n    }\n    $data = $data + \", &quot;headerText&quot;:&quot;\" + $resultHeaderText + \"&quot;\";\n    if ($resultEntriesTextPlural != \"\")\n    {\n        $data = $data + \", &quot;entriesTextPlural&quot;:&quot;\" + $resultEntriesTextPlural + \"&quot;\";\n    }\n    if ($resultEntriesTextSingular != \"\")\n    {\n        $data = $data + \", &quot;entriesTextSingular&quot;:&quot;\" + $resultEntriesTextSingular + \"&quot;\";\n    }\n    $data = $data + \", &quot;readMoreLink&quot;:&quot;\" + $readMoreLink + \"&quot;\";\n\n    if (empty($totalMaxResults)) {\n          $totalMaxResults = 500;\n    }\n\n    $data = $data + \", &quot;totalMaxResults&quot;:\" + $totalMaxResults ;\n\n    if ($perc_max_post_entries != null && $perc_max_post_entries != \"\")\n    {\n        $data = $data + \", &quot;maxResults&quot;:\" + $perc_max_post_entries ;\n    }\n    if ($pagingPagesText != null && $pagingPagesText != \"\")\n    {\n        $data = $data + \", &quot;pagingPagesText&quot;:\" + \"&quot;\" + $pagingPagesText + \"&quot;\" ;\n    }\n    if ($pagingOfText != null && $pagingOfText != \"\")\n    {\n        $data = $data + \", &quot;pagingOfText&quot;:\" + \"&quot;\" + $pagingOfText + \"&quot;\" ;\n    }\n    ##summary option.\n    if($summary)\n    {\n        $data = $data + \", &quot;summary&quot;:&quot;\" + $summary + \"&quot;\";\n    }\n\n    $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n    $data = $data + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\";\n    $data = $data + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\";\n\t$data = $data + \"}\";\n    ##result query ends"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percResultChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLinkResult.png",
+      "target": "rx_resources/widgets/result/images/widgetIconLinkResult.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/perc_common_ui.js",
+      "target": "perc-common-ui/js/perc_common_ui.js",
+      "type": "javascript",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "summary",
+      "displayName": "Show page summary",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "sortby",
+      "displayName": "Sort by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "rx:sys_contentpostdate desc",
+      "enumValues": [
+        {
+          "value": "none",
+          "displayValue": "None"
+        },
+        {
+          "value": "rx:page_title",
+          "displayValue": "Title"
+        },
+        {
+          "value": "rx:sys_contentpostdate desc",
+          "displayValue": "Latest date"
+        },
+        {
+          "value": "rx:sys_contentpostdate",
+          "displayValue": "Earliest date"
+        }
+      ]
+    },
+    {
+      "name": "resultDateTimeFormat",
+      "displayName": "Format of result post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEE MMM d, yyyy hh:mm a",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt) Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "totalMaxResults",
+      "displayName": "Maximum number of total results",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "500",
+      "enumValues": []
+    },
+    {
+      "name": "maxResultsPerPage",
+      "displayName": "Number of items per page",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "10",
+      "enumValues": []
+    },
+    {
+      "name": "pagingOfText",
+      "displayName": "Text to use for <em>of</em> (X <strong>of</strong> Y pages)",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "of",
+      "enumValues": []
+    },
+    {
+      "name": "pagingPagesText",
+      "displayName": "Text to use for <em>pages</em> (X of Y <strong>pages</strong>)",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "pages",
+      "enumValues": []
+    },
+    {
+      "name": "resultHeaderText",
+      "displayName": "Text to use for result header",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Results for",
+      "enumValues": []
+    },
+    {
+      "name": "resultEntriesTextPlural",
+      "displayName": "Text for \"entries\" in results count",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "entries",
+      "enumValues": []
+    },
+    {
+      "name": "resultEntriesTextSingular",
+      "displayName": "Text for \"entry\" when one result is returned",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "entry",
+      "enumValues": []
+    },
+    {
+      "name": "readMoreLink",
+      "displayName": "Text to use for \"more link\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "more...",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/widgets/percResult/templates/percResultSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.Result/widgets/percResult/templates/percResultSnippet.vm
@@ -1,0 +1,5 @@
+#if ($perc.isEditMode())##
+        #createEmptyWidgetContent("result-sample-content", "This result widget is showing sample content.")##
+    #else##
+        <div class="$!{rootclass} perc-result-view" data-query="$!{data}"></div>
+    #end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/widgets/percArchiveList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/widgets/percArchiveList/component-package.json
@@ -1,0 +1,827 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percArchiveList",
+  "name": "Archives",
+  "version": "1.2.4",
+  "description": "Display of summary of pages published grouped by date",
+  "publisher": {
+    "name": "Percussion Software, Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Archives",
+    "category": "blog,search",
+    "description": "Display of summary of pages published grouped by date",
+    "thumbnail": "resources/widgetIconArchive.gif",
+    "icon": "resources/widgetIconArchive.gif",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percArchiveList",
+      "ref": "contentTypes/percArchiveList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percArchiveListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percArchiveListSnippet.vm",
+      "contentType": "percArchiveList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "isEditMode",
+          "expression": "$perc.isEditMode()"
+        },
+        {
+          "variable": "isPreviewMode",
+          "expression": "$perc.isPreviewMode()"
+        },
+        {
+          "variable": "archiveListMax",
+          "expression": "$perc.widget.item.properties.get('list_maxlength')"
+        },
+        {
+          "variable": "archiveListMaxNum",
+          "expression": "10000"
+        },
+        {
+          "variable": "archiveListMaxNum",
+          "expression": "$tools.number.toNumber($archiveListMax)"
+        },
+        {
+          "variable": "archiveLayout",
+          "expression": "$perc.widget.item.properties.get('layout')"
+        },
+        {
+          "variable": "archiveLayout",
+          "expression": "\"perc-list-hierarchical\""
+        },
+        {
+          "variable": "archiveLocale",
+          "expression": "$perc.widget.item.properties.get('locale')"
+        },
+        {
+          "variable": "archiveLocale",
+          "expression": "\"en-US\""
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "currentDate",
+          "expression": "$tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $tools.date.getDate())"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "query",
+          "expression": "$assetItem.getNode().getProperty('query_string').String"
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" and rx:sys_contentpostdate \" + \" <= '\" + $currentDate + \"'\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" where rx:sys_contentpostdate \" + \" <= '\" + $currentDate + \"'\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "blogYears",
+          "expression": "$rx.pageutils.getProcessedBlogs($relresults)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem, 'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('perc-list-odd', 'perc-list-even')"
+        },
+        {
+          "variable": "titleContains",
+          "expression": "$assetItem.getNode().getProperty('query_title_contains').String"
+        },
+        {
+          "variable": "publishedAfter",
+          "expression": "$assetItem.getNode().getProperty('query_published_after').String"
+        },
+        {
+          "variable": "publishedBefore",
+          "expression": "$assetItem.getNode().getProperty('query_published_before').String"
+        },
+        {
+          "variable": "sitePath",
+          "expression": "$assetItem.getNode().getProperty('query_site_path').String"
+        },
+        {
+          "variable": "templatesList",
+          "expression": "$assetItem.getNode().getProperty('query_template_list').String"
+        },
+        {
+          "variable": "archiveResultPage",
+          "expression": "$assetItem.getNode().getProperty('archive_page_result').String"
+        },
+        {
+          "variable": "criteria",
+          "expression": "\"[\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"&quot;type = 'page'&quot;\""
+        },
+        {
+          "variable": "criteriaSep",
+          "expression": "\", \""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + $criteriaSep + \"&quot;dcterms:title LIKE '%\" + $titleContains +\"%'&quot;\""
+        },
+        {
+          "variable": "sd",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$publishedAfter)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\""
+        },
+        {
+          "variable": "ed",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$publishedBefore)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$sitePath.replace(\"//Sites/\", \"\")"
+        },
+        {
+          "variable": "temppaths",
+          "expression": "$temppath.split(\"/\")"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\""
+        },
+        {
+          "variable": "folderpath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "counter",
+          "expression": "1"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$folderpath + \"/\" + $temppaths[$counter]"
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\""
+        },
+        {
+          "variable": "templateNameList",
+          "expression": "$rx.pageutils.templateNames($templatesList)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "\"(\""
+        },
+        {
+          "variable": "counter",
+          "expression": "0"
+        },
+        {
+          "variable": "templNameArray",
+          "expression": "$templateNameList.toArray()"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \"'\" + $templNameArray[$counter] + \"'\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \", \""
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \")\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"]\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{\" + \"&quot;criteria&quot;:\" + $criteria"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;layout&quot;:&quot;\" +$archiveLayout + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;numberEntries&quot;:&quot;\" + $archiveListMax + \"&quot;\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;archive_page_result&quot;:&quot;\" +$archiveResultPage + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isEditMode&quot; : &quot;\" + $isEditMode + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isPreviewMode&quot; : &quot;\" + $isPreviewMode + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assetItems);\n    $isEditMode = $perc.isEditMode();\n\t$isPreviewMode = $perc.isPreviewMode();\n    ##Get widget user prefs\n    $archiveListMax = $perc.widget.item.properties.get('list_maxlength');\n    $archiveListMaxNum = 10000;\n    if($archiveListMax != null && $archiveListMax != \"\")\n    {\n        $archiveListMaxNum = $tools.number.toNumber($archiveListMax);\n    }\n    $archiveLayout = $perc.widget.item.properties.get('layout');\n    if($archiveLayout == null)\n       $archiveLayout = \"perc-list-hierarchical\";\n\n    $archiveLocale = $perc.widget.item.properties.get('locale');\n    if($archiveLocale == null)\n       $archiveLocale = \"en-US\";\n    ##Get widget csas prefs\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n\n    if (!empty($rootclass)) {\n       $rootclass = $rootclass + \" \";\n    }\n\n    $currentDate =  $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $tools.date.getDate());\n\n    if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n        $query = $assetItem.getNode().getProperty('query_string').String;\n        if (! $query.contains('<=')) {\n            if ($query.contains('where'))\n            {\n                $query = $query + \" and rx:sys_contentpostdate \" + \" <= '\" + $currentDate + \"'\";\n            }\n            else\n            {\n                $query = $query + \" where rx:sys_contentpostdate \" + \" <= '\" + $currentDate + \"'\";\n            }\n        }\n        $params = $rx.string.stringToMap(null);\n        $params.put('query', $query);\n        $finderName = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n        $relresults =  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n        $blogYears = $rx.pageutils.getProcessedBlogs($relresults);\n        $title = $rx.pageutils.html($assetItem, 'displaytitle');\n        $rowtag = $tools.alternator.auto('perc-list-odd', 'perc-list-even');\n\n        ##Archive list query starts\n        ##Gets the individual field values\n        $titleContains = $assetItem.getNode().getProperty('query_title_contains').String;\n        $publishedAfter = $assetItem.getNode().getProperty('query_published_after').String;\n        $publishedBefore = $assetItem.getNode().getProperty('query_published_before').String;\n        $sitePath = $assetItem.getNode().getProperty('query_site_path').String;\n        $templatesList = $assetItem.getNode().getProperty('query_template_list').String;\n        $archiveResultPage = $assetItem.getNode().getProperty('archive_page_result').String;\n        ##Builds the criteria\n        $criteria = \"[\";\n        $criteria = $criteria + \"&quot;type = 'page'&quot;\";\n        $criteriaSep = \", \";\n        if ($titleContains != null && $titleContains != \"\")\n        {\n            $criteria = $criteria + $criteriaSep + \"&quot;dcterms:title LIKE '%\" + $titleContains +\"%'&quot;\";\n        }\n\n        if ($publishedAfter != null && $publishedAfter != \"\"){\n            $sd = $tools.date.toDate(\"MM/dd/yyyy\",$publishedAfter);\n            $criteria = $criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\";\n        }\n        if ($publishedBefore != null && $publishedBefore != \"\"){\n            $ed = $tools.date.toDate(\"MM/dd/yyyy\",$publishedBefore);\n            $criteria = $criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\";\n        }\n\n        if ($sitePath != null && $sitePath != \"\" && $sitePath != \"//Sites\")\n        {\n            $temppath = $sitePath.replace(\"//Sites/\", \"\");\n            if($temppath.indexOf(\"/\") > 0)\n            {\n                $temppaths = $temppath.split(\"/\");\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\";\n                $folderpath = \"\";\n                $counter = 1;\n                while($counter < $temppaths.size())\n                {\n                    $folderpath = $folderpath + \"/\" + $temppaths[$counter];\n                    $counter = $counter + 1;\n                }\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\";\n            }\n            else\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\";\n            }\n        }\n        if($templatesList != null && $templatesList != \"\")\n        {\n            $templateNameList = $rx.pageutils.templateNames($templatesList);\n            if($templateNameList.size() == 1)\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\";\n            }\n            else if($templateNameList.size() > 1)\n            {\n                $inCl = \"(\";\n                $counter = 0;\n                $templNameArray = $templateNameList.toArray();\n\n                while($counter < $templNameArray.size())\n                {\n                    $inCl = $inCl + \"'\" + $templNameArray[$counter] + \"'\";\n                    if($counter != $templNameArray.size()-1)\n                    $inCl = $inCl + \", \";\n                    $counter = $counter + 1;\n                }\n                $inCl = $inCl + \")\";\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\";\n            }\n        }\n\n        $criteria = $criteria + \"]\";\n\n        ##Build the query string for the delivery side archive list\n        ##builds the order by clause\n\n        $dynamicListData = \"{\" + \"&quot;criteria&quot;:\" + $criteria;\n        $dynamicListData = $dynamicListData + \", &quot;layout&quot;:&quot;\" +$archiveLayout + \"&quot;\";\n        if($archiveListMax != null)\n        {\n            $dynamicListData = $dynamicListData + \", &quot;numberEntries&quot;:&quot;\" + $archiveListMax + \"&quot;\";\n        }\n\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n        $dynamicListData = $dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\";\n\n        $dynamicListData = $dynamicListData + \", &quot;archive_page_result&quot;:&quot;\" +$archiveResultPage + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isEditMode&quot; : &quot;\" + $isEditMode + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isPreviewMode&quot; : &quot;\" + $isPreviewMode + \"&quot;\";\n\n        $dynamicListData = $dynamicListData + \"}\";\n        ##Archive list query ends\n    }\n    else {\n        ;\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percArchiveListContent",
+      "allowedContentTypes": [
+        "percArchiveList"
+      ],
+      "layout": {
+        "layout": "perc-list-hierarchical"
+      },
+      "styles": {
+        "rootclass": "",
+        "summaryclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconArchive.gif",
+      "target": "rx_resources/widgets/archiveList/images/widgetIconArchive.gif",
+      "type": "image"
+    },
+    {
+      "path": "resources/perc_common_ui.js",
+      "target": "perc-common-ui/js/perc_common_ui.js",
+      "type": "javascript",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "perc-list-hierarchical",
+      "enumValues": [
+        {
+          "value": "perc-list-hierarchical",
+          "displayValue": "Hierarchical by year"
+        },
+        {
+          "value": "perc-list-flat",
+          "displayValue": "List by months"
+        }
+      ]
+    },
+    {
+      "name": "list_maxlength",
+      "displayName": "Number of entries to show",
+      "datatype": "number",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt) Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmål Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "summaryclass",
+      "displayName": "CSS page summary class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/widgets/percArchiveList/templates/percArchiveListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.archiveList/widgets/percArchiveList/templates/percArchiveListSnippet.vm
@@ -1,0 +1,88 @@
+<div class="$!{rootclass} perc-archive-list" data-query="$!{dynamicListData}">
+##This is a hidden div that holds the structure of the list when the category list output structure changes this hidden div and delivery side view
+##should be modified to match the new structure.
+#if ($title && $title.length() > 0)##
+<div class="perc-archive-title">$title</div>
+#end##
+<div style="display:none" class="perc-archive-list-structure">
+</div>
+<div class="perc-archive-list-container">
+#if( ! $perc.widgetContents.isEmpty() )##
+#if($blogYears && $blogYears.size() > 0)##
+## Split archive locale to get language and country
+#if("" == "$!{archiveLocale}")##
+#set($archiveLocale="en-US")##
+#end##
+##
+##Setup Date Formatting
+#set($formatterIn = $rx.pageutils.getDateFormatForString("MMMM d, yyyy"))##
+#set($formatterOut = $rx.pageutils.getDateFormatFromLocale("MMMM",$locale))##
+#if($archiveLayout == "perc-list-hierarchical")##
+<ul class="perc-archive-list-wrapper perc-archive-hierarchical">
+#foreach ($blogYear in $blogYears)##
+#if($blogYear.getYearCount() > 0)##
+#if($velocityCount <= $archiveListMaxNum)##
+#set ($dateValue =  "January 01, "+ $blogYear.getYear())##
+#set($date = $formatterIn.parse($dateValue))##
+#set($dummy = $formatterOut.applyPattern("YYYY"))##
+#set($year = $formatterOut.format($date))##
+<li class="perc-archive-year"><a href="#">$year ($blogYear.getYearCount())</a>
+<ul class="perc-archive-month-wrapper">
+#foreach ($blogMonth in $blogYear.getMonths())##
+#if($blogMonth.getCount() > 0)##
+## Get Date from Blog Month
+#set ($dateValue = $blogMonth.getMonth() + " 01, "+ $blogYear.getYear())##
+## Formate Date
+#set($date = $formatterIn.parse($dateValue))##
+#set($dummy = $formatterOut.applyPattern("MMMMM"))##
+#set($month = $formatterOut.format($date))##
+#if($month.length() >0)##
+#set($letter = $month.substring(0,1).toUpperCase())##
+#set($properMonth = $letter + $month.substring(1))##
+#else##
+#set($properMonth =  $month)##
+#end##
+<li class="perc-archive-month"><a href="#">$properMonth ($blogMonth.getCount())</a></li>
+#end##
+#end##
+</ul>
+</li>
+#end##
+#end##
+#end##
+</ul>
+#end##
+#if($archiveLayout == "perc-list-flat")##
+<ul class="perc-archive-list-container perc-archive-flat">
+#foreach ($blogYear in $blogYears)##
+#foreach ($blogMonth in $blogYear.getMonths())##
+#if($blogMonth.getCount() > 0)##
+#if($velocityCount <= $archiveListMaxNum)##
+## Get Date from Blog Month
+#set ($dateValue = $blogMonth.getMonth() + " 01, "+ $blogYear.getYear())##
+## Formate Date
+#set($date = $formatterIn.parse($dateValue))##
+#set($dummy = $formatterOut.applyPattern("MMMMM"))##
+#set($month = $formatterOut.format($date))##
+#if($month.length()>1)##
+#set($letter = $month.substring(0,1).toUpperCase())##
+#set($properMonth = $letter + $month.substring(1))##
+#else##
+#set($properMonth =  $month)##
+#end##
+##
+#set($dummy = $formatterOut.applyPattern("YYYY"))##
+#set($year = $formatterOut.format($date))##
+<li class="perc-archive-month"><a href="#">$properMonth $year ($blogMonth.getCount())</a></li>
+#end##
+#end##
+#end##
+#end##
+</ul>
+#end##
+#end##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("archivelist-sample-content", "This archive list widget is showing sample content.")##
+#end##
+</div>
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/widgets/percBlogIndexPage/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/widgets/percBlogIndexPage/component-package.json
@@ -1,0 +1,1304 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percBlogIndexPage",
+  "name": "Blog List",
+  "version": "1.3.5",
+  "description": "Blog list page for dispaying all blog post",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.PageAutoListWidget",
+      "version": "1.4.4",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Blog List",
+    "category": "blog",
+    "description": "Blog list page for dispaying all blog post",
+    "thumbnail": "resources/widgetIconBlogIndex.gif",
+    "icon": "resources/widgetIconBlogIndex.gif",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 520,
+    "createSharedAsset": false,
+    "editableOnTemplate": false,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percBlogIndexAsset",
+      "ref": "contentTypes/percBlogIndexAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percBlogIndexPageSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percBlogIndexPageSnippet.vm",
+      "contentType": "percBlogIndexAsset",
+      "bindings": [
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "isEditMode",
+          "expression": "$perc.isEditMode() || $perc.isPreviewMode()"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "titleFormat",
+          "expression": "$perc.widget.item.properties.get('titleFormat')"
+        },
+        {
+          "variable": "blogPostDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('blogPostDateTimeFormat')"
+        },
+        {
+          "variable": "enableCalenderIcon",
+          "expression": "$perc.widget.item.properties.get('enableCalenderIcon')"
+        },
+        {
+          "variable": "blogPostReadMoreText",
+          "expression": "$perc.widget.item.properties.get('blogPostReadMoreText')"
+        },
+        {
+          "variable": "perc_hidefield_title",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_title')"
+        },
+        {
+          "variable": "perc_hidefield_summary",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_summary')"
+        },
+        {
+          "variable": "perc_hidefield_blog_date",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_blog_date')"
+        },
+        {
+          "variable": "perc_hidefield_byline",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_byline')"
+        },
+        {
+          "variable": "perc_hidefield_comments",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_comments')"
+        },
+        {
+          "variable": "resultEntriesTextPlural",
+          "expression": "$perc.widget.item.properties.get('resultEntriesTextPlural')"
+        },
+        {
+          "variable": "resultEntriesTextSingular",
+          "expression": "$perc.widget.item.properties.get('resultEntriesTextSingular')"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.properties.get('autoListDivId')"
+        },
+        {
+          "variable": "blogPostCommentsText",
+          "expression": "$perc.widget.item.properties.get('blogPostCommentsText')"
+        },
+        {
+          "variable": "totalMaxResults",
+          "expression": "$perc.widget.item.properties.get('totalMaxResults')"
+        },
+        {
+          "variable": "perc_max_post_entries",
+          "expression": "$perc.widget.item.properties.get('blogPostMaxResults')"
+        },
+        {
+          "variable": "pagingPagesText",
+          "expression": "$perc.widget.item.properties.get('pagingPagesText')"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "$perc.widget.item.properties.get('listAriaLabel')"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "$perc.widget.item.properties.get('listAriaRole')"
+        },
+        {
+          "variable": "perc_hide_when_empty",
+          "expression": "$perc.widget.item.properties.get('perc_hide_when_empty')"
+        },
+        {
+          "variable": "pagingOfText",
+          "expression": "$perc.widget.item.properties.get('pagingOfText')"
+        },
+        {
+          "variable": "blogPostNoContentText",
+          "expression": "$perc.widget.item.properties.get('blogPostNoContentText')"
+        },
+        {
+          "variable": "rssLinkText",
+          "expression": "$perc.widget.item.properties.get('rssLinkText')"
+        },
+        {
+          "variable": "perc_hidefield_tags",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_tags')"
+        },
+        {
+          "variable": "perc_tag_label",
+          "expression": "$perc.widget.item.properties.get('perc_tag_label')"
+        },
+        {
+          "variable": "perc_hidefield_categories",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_categories')"
+        },
+        {
+          "variable": "perc_category_label",
+          "expression": "$perc.widget.item.properties.get('perc_category_label')"
+        },
+        {
+          "variable": "blogPostBylineText",
+          "expression": "$perc.widget.item.properties.get('blogPostBylineText')"
+        },
+        {
+          "variable": "results_title",
+          "expression": "$perc.widget.item.properties.get('blogListHeaderText')"
+        },
+        {
+          "variable": "sortByVal",
+          "expression": "$perc.widget.item.properties.get('sortby')"
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "$perc.widget.item.properties.get('sortDirection')"
+        },
+        {
+          "variable": "sortByVal",
+          "expression": "\"rx:sys_contentpostdate\""
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "\"desc\""
+        },
+        {
+          "variable": "pageTitle",
+          "expression": "$perc.page.title"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $pageTitle + ' blog list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"Blog list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $listAriaLabel + '\"'"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "'role=\"region\"'"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "'role=\"' + $listAriaRole + '\"'"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.id + \"_list\""
+        },
+        {
+          "variable": "resultEntriesTextPlural",
+          "expression": "'results'"
+        },
+        {
+          "variable": "resultEntriesTextSingular",
+          "expression": "'result'"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "'<' + $titleFormat +' class=\"perc-blog-list-title\">'"
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "'</' + $titleFormat + '>'"
+        },
+        {
+          "variable": "enableRssIcon",
+          "expression": "$perc.widget.item.properties.get('enable_rss_icon')"
+        },
+        {
+          "variable": "rssIconPosition",
+          "expression": "$perc.widget.item.properties.get('rssIconPosition')"
+        },
+        {
+          "variable": "locale",
+          "expression": "$perc.widget.item.properties.get('locale')"
+        },
+        {
+          "variable": "locale",
+          "expression": "\"en-US\""
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "baseUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "enableRssField",
+          "expression": "$assetItem.getNode().getProperty('enable_rss_feed').String"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "feedname",
+          "expression": "$assetItem.getNode().getProperty('feed_name').String"
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "siteName",
+          "expression": "$pathParts[2]"
+        },
+        {
+          "variable": "sUrl",
+          "expression": "$baseUrl + \"/feeds/rss/\" + $siteName + \"/\" + $feedname +\"/\""
+        },
+        {
+          "variable": "navFinder",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "navContainer",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $navFinder, null, true)"
+        },
+        {
+          "variable": "navLoc",
+          "expression": "\"\""
+        },
+        {
+          "variable": "navLoc",
+          "expression": "$navContainer.get(0).getFolderPath()"
+        },
+        {
+          "variable": "blogPostTempId",
+          "expression": "$rx.pageutils.getBlogPostTemplateId($navLoc)"
+        },
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "query",
+          "expression": "\"select rx:sys_contentid, rx:sys_folderid from rx:percPage  where jcr:path like '\" + $navLoc + \"/%'\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" and rx:templateid = '\" + $blogPostTempId + \"'\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortByVal + \"  desc\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortByVal + \" \" + $sortDirection"
+        },
+        {
+          "variable": "perc_max_post_entries",
+          "expression": "10"
+        },
+        {
+          "variable": "totalMaxResults",
+          "expression": "500"
+        },
+        {
+          "variable": "maxResults",
+          "expression": "$perc_max_post_entries"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('ui-perc-list-odd', 'ui-perc-list-even')"
+        },
+        {
+          "variable": "tagValues",
+          "expression": "$post.node.getProperty('rx:page_tags').getValues()"
+        },
+        {
+          "variable": "catValues",
+          "expression": "$post.node.getProperty('rx:page_categories_tree').getValues()"
+        },
+        {
+          "variable": "criteria",
+          "expression": "\"[\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"&quot;type = 'page'&quot;\""
+        },
+        {
+          "variable": "criteriaSep",
+          "expression": "\", \""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$navLoc.replace(\"//Sites/\", \"\")"
+        },
+        {
+          "variable": "temppaths",
+          "expression": "$temppath.split(\"/\")"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\""
+        },
+        {
+          "variable": "folderpath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "counter",
+          "expression": "1"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$folderpath + \"/\" + $temppaths[$counter]"
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\""
+        },
+        {
+          "variable": "templateNameList",
+          "expression": "$rx.pageutils.templateNames($blogPostTempId)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"]\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"linktext_lower \" + $sortDirection"
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:title asc, linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:title  \" + $sortDirection +\", linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created desc, linktext_lower asc\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created asc, linktext_lower asc\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{\" + \"&quot;criteria&quot;:\" + $criteria"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;maxResults&quot;:\" + $perc_max_post_entries"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;pagingPagesText&quot;:\" + \"&quot;\" + $pagingPagesText + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;pagingOfText&quot;:\" + \"&quot;\" + $pagingOfText + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;blogPostReadMoreText&quot;:\" + \"&quot;\" + $blogPostReadMoreText + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;blogPostBylineText&quot;:\" + \"&quot;\" + $blogPostBylineText + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;blogPostCommentsText&quot;:\" + \"&quot;\" + $blogPostCommentsText + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;rssLinkText&quot;:\" + \"&quot;\" + $rssLinkText + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;locale&quot;:\" + \"&quot;\" + $locale + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;dateFormat&quot;:\" + \"&quot;\" + $blogPostDateTimeFormat + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;entriesTextPlural&quot;:&quot;\" + $resultEntriesTextPlural + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;entriesTextSingular&quot;:&quot;\" + $resultEntriesTextSingular + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;totalMaxResults&quot;:\" + $totalMaxResults"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;deliveryurl&quot; : &quot;\" + $baseUrl + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isEditMode&quot; : &quot;\" + $isEditMode + \"&quot;\""
+        },
+        {
+          "variable": "feedDynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "titleResults",
+          "expression": "\"{&quot;resultsTitle&quot; : &quot;\" + $results_title + \"&quot;}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assetItems);\n    ## Initialize Properties\n    $isEditMode = $perc.isEditMode() || $perc.isPreviewMode();\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    $titleFormat = $perc.widget.item.properties.get('titleFormat');\n    $blogPostDateTimeFormat = $perc.widget.item.properties.get('blogPostDateTimeFormat');\n    $enableCalenderIcon = $perc.widget.item.properties.get('enableCalenderIcon');\n    $blogPostReadMoreText = $perc.widget.item.properties.get('blogPostReadMoreText');\n    $perc_hidefield_title = $perc.widget.item.properties.get('perc_hidefield_title');\n    $perc_hidefield_summary = $perc.widget.item.properties.get('perc_hidefield_summary');\n    $perc_hidefield_blog_date = $perc.widget.item.properties.get('perc_hidefield_blog_date');\n    $perc_hidefield_byline = $perc.widget.item.properties.get('perc_hidefield_byline');\n    $perc_hidefield_comments = $perc.widget.item.properties.get('perc_hidefield_comments');\n    $resultEntriesTextPlural = $perc.widget.item.properties.get('resultEntriesTextPlural');\n    $resultEntriesTextSingular = $perc.widget.item.properties.get('resultEntriesTextSingular');\n    $autoListDivId = $perc.widget.item.properties.get('autoListDivId');\n    $blogPostCommentsText = $perc.widget.item.properties.get('blogPostCommentsText');\n    $totalMaxResults = $perc.widget.item.properties.get('totalMaxResults');\n    $perc_max_post_entries = $perc.widget.item.properties.get('blogPostMaxResults');\n    $pagingPagesText = $perc.widget.item.properties.get('pagingPagesText');\n    $listAriaLabel = $perc.widget.item.properties.get('listAriaLabel');\n    $listAriaRole = $perc.widget.item.properties.get('listAriaRole');\n    $perc_hide_when_empty = $perc.widget.item.properties.get('perc_hide_when_empty');\n    $pagingOfText = $perc.widget.item.properties.get('pagingOfText');\n    $blogPostNoContentText = $perc.widget.item.properties.get('blogPostNoContentText');\n    $rssLinkText = $perc.widget.item.properties.get('rssLinkText');\n    $perc_hidefield_tags = $perc.widget.item.properties.get('perc_hidefield_tags');\n    $perc_tag_label = $perc.widget.item.properties.get('perc_tag_label');\n    $perc_hidefield_categories = $perc.widget.item.properties.get('perc_hidefield_categories');\n    $perc_category_label = $perc.widget.item.properties.get('perc_category_label');\n    $blogPostBylineText = $perc.widget.item.properties.get('blogPostBylineText');\n    $results_title = $perc.widget.item.properties.get('blogListHeaderText');\n    $sortByVal = $perc.widget.item.properties.get('sortby');\n    $sortDirection = $perc.widget.item.properties.get('sortDirection');\n    if($sortByVal == null || $sortByVal == \"none\") {\n        $sortByVal = \"rx:sys_contentpostdate\";\n\t\t$sortDirection = \"desc\";\n    }\n\n    $pageTitle = $perc.page.title;\n    if ($listAriaLabel == '' || $listAriaLabel == null) {\n        if ($pageTitle != null && $pageTitle != '') {\n            $listAriaLabel = 'aria-label=\"' + $pageTitle + ' blog list\"';\n        } else {\n            $listAriaLabel = 'aria-label=\"Blog list\"';\n        }\n    } else {\n        $listAriaLabel = 'aria-label=\"' + $listAriaLabel + '\"';\n    }\n    if ($listAriaRole == '' || $listAriaRole == null) {\n        $listAriaRole = 'role=\"region\"';\n    }\n    else {\n        $listAriaRole = 'role=\"' + $listAriaRole + '\"';\n    }\n    if($autoListDivId == '' || $autoListDivId == null) {\n       $autoListDivId = $perc.widget.item.id + \"_list\";\n    }\n    if ($resultEntriesTextPlural == \"\" || $resultEntriesTextPlural == null)\n    {\n        $resultEntriesTextPlural = 'results';\n    }\n    if ($resultEntriesTextSingular == \"\" || $resultEntriesTextSingular == null)\n    {\n        $resultEntriesTextSingular = 'result';\n    }\n    $titleFormatStartTag = '<' + $titleFormat +' class=\"perc-blog-list-title\">';\n    $titleFormatEndTag = '</' + $titleFormat + '>';\n    $enableRssIcon = $perc.widget.item.properties.get('enable_rss_icon');\n    $rssIconPosition = $perc.widget.item.properties.get('rssIconPosition');\n    $locale = $perc.widget.item.properties.get('locale');\n    if($locale == null)\n        $locale = \"en-US\";\n    if (empty($rootclass)) {\n        $rootclass = \"\";\n    }\n    $baseUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n    if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n        $enableRssField = $assetItem.getNode().getProperty('enable_rss_feed').String;\n        $pageId = $perc.page.id;\n        $feedname = $assetItem.getNode().getProperty('feed_name').String;\n        if(!empty($pageId))\n        {\n            $finderPath = $rx.pageutils.getItemPath($pageId);\n            $pathParts = $finderPath.split(\"\\/\");\n            $siteName = $pathParts[2];\n            $sUrl = $baseUrl + \"/feeds/rss/\" + $siteName + \"/\" + $feedname +\"/\";\n        }\n    }\n    ## Get navigation.  If we can't find it, we're probably in a template.\n    $navFinder=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n    $navContainer = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $navFinder, null, true);\n    $navLoc = \"\";\n    if ( ! $navContainer.isEmpty() ) {\n        $navLoc = $navContainer.get(0).getFolderPath();\n        $blogPostTempId = $rx.pageutils.getBlogPostTemplateId($navLoc);\n        ## Building the jcr query to get a list of appropriate pages.\n        $linkContext = $perc.linkContext;\n        $query = \"select rx:sys_contentid, rx:sys_folderid from rx:percPage  where jcr:path like '\" + $navLoc + \"/%'\";\n        ## Filter by the blog post templates only - if we don't find a template - filter by -1 so non blog pages don't get picked up\n        if ($blogPostTempId != null)\n        {\n            $query = $query + \" and rx:templateid = '\" + $blogPostTempId + \"'\";\n        }\n         if($sortDirection == null){\n            $query = $query + \" order by \" + $sortByVal + \"  desc\";\n        }else{\n           $query = $query + \" order by \" + $sortByVal + \" \" + $sortDirection;\n        }\n        if ($perc_max_post_entries == '' || $perc_max_post_entries == null) {\n            $perc_max_post_entries = 10;\n        }\n        if(empty($totalMaxResults)) {\n          $totalMaxResults = 500;\n        }\n        $maxResults = $perc_max_post_entries;\n        $params = $rx.string.stringToMap(null);\n        $params.put('query', $query);\n        $params.put('max_results', $totalMaxResults);\n        $finderName=\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n        $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n        $rowtag = $tools.alternator.auto('ui-perc-list-odd', 'ui-perc-list-even');\n        ##Apply the alpha order to the list of tags and categories\n        for($post : $relresults){\n            if($post.node.hasProperty('rx:page_tags')){\n                $tagValues = $post.node.getProperty('rx:page_tags').getValues();\n                $rx.pageutils.alphaOrderTag($tagValues);\n            }\n            if($post.node.hasProperty('rx:page_tags')){\n                $catValues = $post.node.getProperty('rx:page_categories_tree').getValues();\n                $rx.pageutils.alphaOrderCategory($catValues);\n            }\n        }\n        ## Builds the criteria object for use on the delivery tier\n        $criteria = \"[\";\n        $criteria = $criteria + \"&quot;type = 'page'&quot;\";\n        $criteriaSep = \", \";\n        if ($navLoc != null && $navLoc != \"\" && $navLoc != \"//Sites\")\n        {\n            $temppath = $navLoc.replace(\"//Sites/\", \"\");\n            if($temppath.indexOf(\"/\") > 0)\n            {\n                $temppaths = $temppath.split(\"/\");\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\";\n                $folderpath = \"\";\n                $counter = 1;\n                while($counter < $temppaths.size())\n                {\n                    $folderpath = $folderpath + \"/\" + $temppaths[$counter];\n                    $counter = $counter + 1;\n                }\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\";\n                if ($blogPostTempId != null)\n                {\n                   $templateNameList = $rx.pageutils.templateNames($blogPostTempId);\n                   if($templateNameList.size() > 0)\n                   {\n                       $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\";\n                   }\n                }\n            }\n            else\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\";\n            }\n        }\n        $criteria = $criteria + \"]\";\n        ##builds the order by clause\n        $orderby = \"\";\n        if($sortByVal == \"rx:resource_link_title\")\n        {\n            if($sortDirection == null){\n               $orderby = \"linktext_lower asc\";\n            }else{\n               $orderby = \"linktext_lower \" + $sortDirection;\n            }\n\n        }\n        else if ($sortByVal == \"rx:page_title\")\n      {\n            if($sortDirection == null){\n               $orderby = \"dcterms:title asc, linktext_lower asc\";\n            }else{\n               $orderby = \"dcterms:title  \" + $sortDirection +\", linktext_lower asc\";\n            }\n\n      }\n        else if($sortbyVal == \"rx:sys_contentpostdate\" || $sortbyVal == \"none\" || $sortbyVal == null)\n        {\n             if($sortDirection == null || $sortDirection == \"desc\"){\n                  $orderby = \"dcterms:created desc, linktext_lower asc\";\n                }else{\n                  $orderby = \"dcterms:created asc, linktext_lower asc\";\n              }\n\n        }\n\n\n        ##Build the query string for the delivery side blog list\n        $dynamicListData = \"{\" + \"&quot;criteria&quot;:\" + $criteria;\n        if($orderby != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\";\n        }\n\n        if ($perc_max_post_entries != null && $perc_max_post_entries != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;maxResults&quot;:\" + $perc_max_post_entries;\n        }\n        if ($pagingPagesText != null && $pagingPagesText != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;pagingPagesText&quot;:\" + \"&quot;\" + $pagingPagesText + \"&quot;\" ;\n        }\n        if ($pagingOfText != null && $pagingOfText != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;pagingOfText&quot;:\" + \"&quot;\" + $pagingOfText + \"&quot;\" ;\n        }\n        if ($blogPostReadMoreText != null && $blogPostReadMoreText != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;blogPostReadMoreText&quot;:\" + \"&quot;\" + $blogPostReadMoreText + \"&quot;\" ;\n        }\n        if ($blogPostBylineText != null && $blogPostBylineText != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;blogPostBylineText&quot;:\" + \"&quot;\" + $blogPostBylineText + \"&quot;\" ;\n        }\n        if ($blogPostCommentsText != null && $blogPostCommentsText != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;blogPostCommentsText&quot;:\" + \"&quot;\" + $blogPostCommentsText + \"&quot;\" ;\n        }\n        if ($rssLinkText != null && $rssLinkText != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;rssLinkText&quot;:\" + \"&quot;\" + $rssLinkText + \"&quot;\" ;\n        }\n        if ($locale != null && $locale != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;locale&quot;:\" + \"&quot;\" + $locale + \"&quot;\" ;\n        }\n        if ($blogPostDateTimeFormat != null && $blogPostDateTimeFormat != \"\")\n        {\n            $dynamicListData = $dynamicListData + \", &quot;dateFormat&quot;:\" + \"&quot;\" + $blogPostDateTimeFormat + \"&quot;\" ;\n        }\n        if ($resultEntriesTextPlural != \"\" && $resultEntriesTextPlural != null)\n        {\n            $dynamicListData = $dynamicListData + \", &quot;entriesTextPlural&quot;:&quot;\" + $resultEntriesTextPlural + \"&quot;\";\n        }\n        if ($resultEntriesTextSingular != \"\" && $resultEntriesTextSingular != null)\n        {\n            $dynamicListData = $dynamicListData + \", &quot;entriesTextSingular&quot;:&quot;\" + $resultEntriesTextSingular + \"&quot;\";\n        }\n        if($totalMaxResults != \"\")\n        {\n        \t$dynamicListData = $dynamicListData + \", &quot;totalMaxResults&quot;:\" + $totalMaxResults;\n        }\n        $dynamicListData = $dynamicListData + \", &quot;deliveryurl&quot; : &quot;\" + $baseUrl + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isEditMode&quot; : &quot;\" + $isEditMode + \"&quot;\";\n\n        $feedDynamicListData = $dynamicListData + \"}\";\n        $dynamicListData = $dynamicListData + \"}\";\n\n        ##Blog list query ends\n        $titleResults = \"{&quot;resultsTitle&quot; : &quot;\" + $results_title + \"&quot;}\";\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percBlogIndexPageContent",
+      "allowedContentTypes": [
+        "percBlogIndexAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconBlogIndex.gif",
+      "target": "rx_resources/widgets/blogIndexPage/images/widgetIconBlogIndex.gif",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "titleFormat",
+      "displayName": "Format of blog post title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "h2",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        }
+      ]
+    },
+    {
+      "name": "autoListDivId",
+      "displayName": "Blog list div id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "sortby",
+      "displayName": "Sort by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "rx:sys_contentpostdate",
+      "enumValues": [
+        {
+          "value": "none",
+          "displayValue": "None"
+        },
+        {
+          "value": "rx:resource_link_title",
+          "displayValue": "Link text"
+        },
+        {
+          "value": "rx:page_title",
+          "displayValue": "Title"
+        },
+        {
+          "value": "rx:sys_contentpostdate",
+          "displayValue": "Post Date"
+        }
+      ]
+    },
+    {
+      "name": "sortDirection",
+      "displayName": "Sort Order",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "desc",
+      "enumValues": [
+        {
+          "value": "desc",
+          "displayValue": "Descending"
+        },
+        {
+          "value": "asc",
+          "displayValue": "Ascending"
+        }
+      ]
+    },
+    {
+      "name": "blogPostDateTimeFormat",
+      "displayName": "Format of blog post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEE MMM d, yyyy hh:mm a",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt) Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "perc_hidefield_title",
+      "displayName": "Hide post title",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_summary",
+      "displayName": "Hide post summary",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_blog_date",
+      "displayName": "Hide date and time",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_byline",
+      "displayName": "Hide byline",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_comments",
+      "displayName": "Hide comments",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_tags",
+      "displayName": "Hide tags",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_tag_label",
+      "displayName": "Text to use for \"tags\" label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Tags:",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_categories",
+      "displayName": "Hide categories",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_category_label",
+      "displayName": "Text to use for \"categories\" label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Categories:",
+      "enumValues": []
+    },
+    {
+      "name": "totalMaxResults",
+      "displayName": "Maximum number of total results",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "500",
+      "enumValues": []
+    },
+    {
+      "name": "blogPostMaxResults",
+      "displayName": "Number of posts per page",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "10",
+      "enumValues": []
+    },
+    {
+      "name": "pagingPagesText",
+      "displayName": "Text to use for <em>pages</em> (X of Y <strong>pages</strong>)",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "pages",
+      "enumValues": []
+    },
+    {
+      "name": "resultEntriesTextPlural",
+      "displayName": "Text for \"entries\" in list count",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "entries",
+      "enumValues": []
+    },
+    {
+      "name": "resultEntriesTextSingular",
+      "displayName": "Text for \"entry\" when one list has one item",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "entry",
+      "enumValues": []
+    },
+    {
+      "name": "listAriaLabel",
+      "displayName": "Blog List aria-label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listAriaRole",
+      "displayName": "Blog List aria-role",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "perc_hide_when_empty",
+      "displayName": "Hide blog list when empty",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "blogListHeaderText",
+      "displayName": "Text to use for result header",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Results for",
+      "enumValues": []
+    },
+    {
+      "name": "blogPostReadMoreText",
+      "displayName": "Text to use for \"more link\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "more...",
+      "enumValues": []
+    },
+    {
+      "name": "blogPostCommentsText",
+      "displayName": "Text to use for \"Comments\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Comments",
+      "enumValues": []
+    },
+    {
+      "name": "blogPostBylineText",
+      "displayName": "Text to use for \"Author Byline\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "by",
+      "enumValues": []
+    },
+    {
+      "name": "enable_rss_icon",
+      "displayName": "Include rss icon",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "rssIconPosition",
+      "displayName": "RSS icon position",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "perc-list-top",
+      "enumValues": [
+        {
+          "value": "perc-list-top",
+          "displayValue": "Top of list"
+        },
+        {
+          "value": "perc-list-bottom",
+          "displayValue": "Bottom of list"
+        }
+      ]
+    },
+    {
+      "name": "rssLinkText",
+      "displayName": "Text to use for \"RSS Link\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "RSS Link",
+      "enumValues": []
+    },
+    {
+      "name": "enableCalenderIcon",
+      "displayName": "Enable Calendar Icon",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/widgets/percBlogIndexPage/templates/percBlogIndexPageSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.blogIndexPage/widgets/percBlogIndexPage/templates/percBlogIndexPageSnippet.vm
@@ -1,0 +1,262 @@
+#define($ariaLabelString)##
+#if($title && $title.length() > 0)##
+aria-labelledby="$!{headerId}"##
+#else##
+$!{listAriaLabel}##
+#end##
+#end##
+#if( "" != "$!{relresults}" && 0 < $relresults.size() )##
+#if($feedname)##
+<div style="display:none" hidden data-name="feedQuery_$feedname" data-query="$!{feedDynamicListData}"></div>
+#end##
+<div id="$!{autoListDivId}" $!{ariaLabelString} class="#cleanClass("$!{rootclass} perc-blog-list-container")" #if($perc_hide_when_empty && $relresults.size() <= 0)hidden #end aria-live="polite" $!{listAriaRole} aria-busy="true" aria-relevant="additions" aria-atomic="true" data-query="$!{dynamicListData}" data-title="$!{titleResults}">
+## The large number of #*  *# and ## notations prevent extra spacing from being output by velocity.  This makes the html line up correctly.
+#if("$navLoc" != "")##
+#if(0 < $relresults.size())##
+#if($enableRssIcon && $enableRssField == "Enable Rss feed" && $rssIconPosition == "perc-list-top")##Keep link class name perc-rss-icon in sync with delivery tier.
+<span class='perc-rss-icon-top'><a class='perc-rss-icon' href="$!{sUrl}" aria-label="$!{rssLinkText}" title="$!{rssLinkText}" >$!{rssLinkText}</a></span>
+#end##
+<ol style="visibility:hidden" class="perc-blog-list perc-list-main">
+#foreach($result in $relresults)##
+#set($catMap = $rx.string.stringToMap(null))##
+#set($catClass = "")##
+## Row alternator stuff, providing necessary classes for styling
+#if($velocityCount == 1)##
+#set($firstrow = ' ui-perc-list-first')##
+#else##
+#set($firstrow = ' ')##
+#end##
+#if($velocityCount == $relresults.size())##
+#set($lastrow = ' ui-perc-list-last')##
+#else##
+#set($lastrow = ' ')##
+#end##
+#set($hidden = "")##
+#if($velocityCount > $perc_max_post_entries)##
+#set($hidden = ' style="display:none"')##
+#end##
+## Obtain various properties from the given page.
+#set($pagelink=$tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+#set($linkTitle=$rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+#if($result.node.hasProperty('rx:page_summary'))##
+#set($pageSummary = $result.node.getProperty('rx:page_summary').getString().replace('<span class="perc-blog-more-link"></span>', "<a href='$!{pagelink}' aria-label='Read more about $!{linkTitle}' title='$!{linkTitle}'>$!{blogPostReadMoreText}</a>"))##
+#end##
+#set($formatterOut = $rx.pageutils.getDateFormatFromLocale("$!{blogPostDateTimeFormat}",$locale))##
+#set($postDateObject="")##
+#set($postDate="")##
+#if($result.node.hasProperty('rx:sys_contentpostdate'))##
+#set($postDateObject=$result.node.getProperty('rx:sys_contentpostdate'))##
+#if("$!{postDateObject.Date}" != "")##
+#set($dummy = $formatterOut.applyPattern($!{blogPostDateTimeFormat}))##
+#set($postDate = $formatterOut.format($postDateObject.Date.Time))##
+#end##
+#end##
+#if("$!{postDate}" == "")##
+#set($dummy = $formatterOut.applyPattern($!{blogPostDateTimeFormat}))##
+#set($postDate = $formatterOut.format($tools.date.getDate()))##
+#end##
+#if($result.node.hasProperty('rx:page_authorname'))##
+#set($author=$tools.esc.html($result.node.getProperty('rx:page_authorname').getString().trim()))##
+#end##
+#if($result.node.hasProperty('rx:page_categories_tree'))##
+#set($postCategories=$result.node.getProperty('rx:page_categories_tree').getValues())##
+#foreach($category in $postCategories)##
+#foreach($node in $category.getString().split("/"))##
+#if("$!{node}" !="" && "$!{node}" != "Categories")##
+#set($leaf=$node)##
+#set($leaf = $leaf.replaceAll("[^a-zA-Z0-9]+","").trim().toLowerCase())##
+#set($dummy = $catMap.put($leaf,$leaf))##
+#end##
+#end##
+#end##
+#foreach($c in $catMap.entrySet())##
+#if(""=="$!{catClass}")##
+#set($catClass = " perc-bloglist-category-$!{c.key}")##
+#else##
+#set($catClass = "$!{catClass} perc-bloglist-category-$!{c.key}")##
+#end##if
+#end##for
+#end##if
+<li$!{hidden} class="#cleanClass("$!{rowtag}$!{firstrow}$!{lastrow} ui-perc-list-element$!{catClass}")">##
+##start calendar icon support##
+#if($enableCalenderIcon)##
+#set($calPostDateObject="")##
+#set($calPostDate="")##
+#set($calPostDateObject=$result.node.getProperty('rx:sys_contentpostdate'))##
+#set($calPostDateObjectString=$result.node.getProperty('rx:sys_contentpostdate').String)##
+#if("$!{calPostDateObjectString}" == "")##
+#set($calPostDateObject=$tools.date.getDate())##
+#else##
+#set($calPostDateObject=$result.node.getProperty('rx:sys_contentpostdate').getDate())##
+#end##
+#if("$!{calPostDateObject}" != "")##
+#set($calPostDate = $formatterOut.format($calPostDateObject.getTime()))##
+#end##
+<div class="perc-blog-list-calicon">
+<div class="perc-blog-list-calicon-month">
+#set($formatterOut2 = $rx.pageutils.getDateFormatFromLocale("MMM",$locale))##
+#set($calPostDate = $formatterOut2.format($calPostDateObject.getTime()))##
+$calPostDate##
+</div>
+<div class="perc-blog-list-calicon-day">
+#set($formatterOut3 = $rx.pageutils.getDateFormatFromLocale("dd",$locale))##
+#set($calPostDate = $formatterOut3.format($calPostDateObject.getTime()))##
+$calPostDate##
+</div>
+</div>
+#end##
+##end calendar icon support##
+#if( ! $perc_hidefield_title)##
+#if("$!{linkTitle}" != "")##
+$!{titleFormatStartTag}<a href="$!{pagelink}" aria-label="$!{linkTitle}" title="$!{linkTitle}">$!{linkTitle}</a>$!{titleFormatEndTag}
+#end##
+#end##
+#if(!$perc_hidefield_byline || !$perc_hidefield_blog_date)##
+<div class="perc-blog-list-dateByline-container">
+#end##
+#if(!$perc_hidefield_byline)##
+<div class="perc-blog-list-byline-container">
+#if("$!{author}" != "")##
+$!{blogPostBylineText} $!{author}##
+#end##
+</div>
+#end##
+#if(!$perc_hidefield_blog_date)##
+#set( $postDateTz = $result.node.getProperty('rx:sys_contentpostdatetz').String  )##
+#if($postDateTz == "Default")##
+#set( $postDateTz = "" )##
+#end##
+<div class="perc-blog-list-date-container">
+$!{postDate} $postDateTz
+</div>
+#end##
+#if(!$perc_hidefield_byline || !$perc_hidefield_blog_date)##
+</div>
+#end##
+#if(!$perc_hidefield_summary)##
+<div class="perc-blog-list-summary-container">
+$!{pageSummary}
+</div>
+#end##
+#if(!$perc_hidefield_tags)##
+#if($result.node.hasProperty('rx:page_tags'))##
+#set($postTags=$result.node.getProperty('rx:page_tags').getValues())##
+#if($postTags.size()>0)##
+#set($noValue="")##
+#else##
+#set($noValue="perc-blog-hide-container")##
+#end##
+<div class="perc-blog-list-tag-container $noValue">
+<span>$!{perc_tag_label}</span>
+#set($sep=",")##
+#foreach($tag in $postTags)##
+#if($velocityCount == $postTags.size())##
+#set($sep="")##
+#end##
+<a href="javascript:void(0)" aria-label="Tag: $tools.esc.html($tag.getString())" title="$tools.esc.html($tag.getString())">$tools.esc.html($tag.getString())$sep</a>
+#end##
+</div>
+#else##
+<div class="perc-blog-list-tag-container perc-blog-list-hide-container">
+<span>$tools.esc.html($!{perc_tag_label})</span>
+</div>
+#end##
+#end##
+#if(!$perc_hidefield_categories)##
+#if($result.node.hasProperty('rx:page_categories_tree'))##
+#set($postCategories=$result.node.getProperty('rx:page_categories_tree').getValues())##
+#if($postCategories.size()>0)##
+#set($noValue="")##
+#else##
+#set($noValue="perc-blog-hide-container")##
+#end##
+<div class="#cleanClass("perc-blog-list-category-container $noValue")">
+<span>$!{perc_category_label}</span>
+#set($sep=",")##
+#foreach($category in $postCategories)##
+#if($velocityCount == $postCategories.size())##
+#set($sep="")##
+#end##
+#foreach($node in $category.getString().split("/"))##
+#set($leaf=$node)##
+#end##
+<a href="javascript:void(0)" aria-label="Category: $tools.esc.html($!{leaf})" title="$tools.esc.html($!{leaf})">$tools.esc.html($!{leaf})$!{sep}</a>
+#end##
+</div>
+#else##
+<div class="perc-blog-list-category-container perc-blog-list-hide-container">
+<span>$tools.esc.html($!{perc_category_label})</span>
+</div>
+#end##
+#end##
+#if(!$perc_hidefield_comments)##
+<div class="perc-blog-list-comment-container">
+#set($blogPostCommentsText = $tools.esc.html($blogPostCommentsText))##
+<p><a href="$!{pagelink}" aria-label="Comments for: $!{linkTitle}" title="$!{blogPostCommentsText}">$!{blogPostCommentsText}</a></p>
+</div>
+#end##
+</li>
+#end##
+</ol>
+#if($enableRssIcon && $enableRssField == "Enable Rss feed" && $rssIconPosition == "perc-list-bottom")##Keep link class name perc-rss-icon in sync with delivery tier.
+<span class = 'perc-rss-icon-bottom'><a class = 'perc-rss-icon' href="$!{sUrl}" aria-label="$!{rssLinkText}" title="$!{rssLinkText}">$!{rssLinkText}</a></span>
+#end##
+#else##
+<div class = "perc-no-post">$!{blogPostNoContentText}</div>
+#end##
+## Blog List Structure for useage by delivery tier services. Must be kept in sync with regular structure.
+<div style="display:none" role="presentation" class="perc-blog-list-structure">
+<ol class="perc-blog-list">
+<li class="#cleanClass("$rowtag ui-perc-list-element")">##
+##start calendar icon structure##
+#if($enableCalenderIcon)##
+<div class="perc-blog-list-calicon">
+<div class="perc-blog-list-calicon-month"></div>
+<div class="perc-blog-list-calicon-day"></div>
+</div>
+#end##
+##end calendar icon structure##
+#if( ! $perc_hidefield_title)##
+$!{titleFormatStartTag}<a>Placeholder Text</a>$!{titleFormatEndTag}
+#end##
+#if(!$perc_hidefield_byline || !$perc_hidefield_blog_date)##
+<div class="perc-blog-list-dateByline-container">
+#end##
+#if(!$perc_hidefield_byline)##
+<div class="perc-blog-list-byline-container">
+</div>
+#end##
+#if(!$perc_hidefield_blog_date)##
+<div class="perc-blog-list-date-container">
+</div>
+#end##
+#if(!$perc_hidefield_byline || !$perc_hidefield_blog_date)##
+</div>
+#end##
+#if(!$perc_hidefield_summary)##
+<div class="perc-blog-list-summary-container">
+</div>
+#end##
+#if(!$perc_hidefield_tags)##
+<div class="perc-blog-list-tag-container">
+<span>$!{perc_tag_label}</span>
+</div>
+#end##
+#if(!$perc_hidefield_categories)##
+<div class="perc-blog-list-category-container">
+<span>$!{perc_category_label}</span>
+</div>
+#end##
+#if(!$perc_hidefield_comments)##
+<div class="perc-blog-list-comment-container">
+<p><a class="perc-no-update-link-text" title="$!{blogPostCommentsText}">$!{blogPostCommentsText}</a></p>
+</div>
+#end##
+</li>
+</ol>
+#end##
+</div>
+#else##
+#createEmptyWidgetContent("bloglist-sample-content", "This blog list widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendar/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendar/component-package.json
@@ -1,0 +1,280 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percCalendar",
+  "name": "Calendar",
+  "version": "2.4.8",
+  "description": "Promote date driven events by displaying a calendar",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.5.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Calendar",
+    "category": "Other",
+    "description": "Promote date driven events by displaying a calendar",
+    "thumbnail": "resources/calendarIcon.png",
+    "icon": "resources/calendarIcon.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 425,
+    "responsive": false,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percCalendarAsset",
+      "ref": "contentTypes/percCalendarAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percCalendarSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percCalendarSnippet.vm",
+      "contentType": "percCalendarAsset",
+      "bindings": [
+        {
+          "variable": "widgetProps",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "perc_calendar_view",
+          "expression": "$widgetProps.get(\"perc_calendar_view\")"
+        },
+        {
+          "variable": "perc_calendar_type",
+          "expression": "$widgetProps.get(\"perc_calendar_type\")"
+        },
+        {
+          "variable": "perc_show_page_summary",
+          "expression": "$widgetProps.get(\"perc_show_page_summary\")"
+        },
+        {
+          "variable": "perc_start_day_number",
+          "expression": "$widgetProps.get(\"perc_start_day\").replace(\"Day_\",\"\")"
+        },
+        {
+          "variable": "perc_time_format",
+          "expression": "$widgetProps.get(\"perc_time_format\")"
+        },
+        {
+          "variable": "perc_time_format",
+          "expression": "\"hh:mmt\""
+        },
+        {
+          "variable": "perc_time_format",
+          "expression": "\"HH:mm\""
+        },
+        {
+          "variable": "pagesInCal",
+          "expression": "\"[]\""
+        },
+        {
+          "variable": "calTitle",
+          "expression": "\"\""
+        },
+        {
+          "variable": "calStartDate",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "id",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "id",
+          "expression": "$assetItem.id"
+        },
+        {
+          "variable": "calTitle",
+          "expression": "$assetItem.getNode().getProperty(\"calendar_title\").String"
+        },
+        {
+          "variable": "calName",
+          "expression": "$assetItem.getNode().getProperty(\"sys_title\").String"
+        },
+        {
+          "variable": "fullCalendarPage",
+          "expression": "$assetItem.getNode().getProperty(\"full_calendar_page\").String"
+        },
+        {
+          "variable": "calStartDate",
+          "expression": "$assetItem.getNode().getProperty(\"calendar_start_date\").String"
+        },
+        {
+          "variable": "pagesInCal",
+          "expression": "$rx.pageutils.getPagesForCalendar($calName).toString()"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer()"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "##Widget properties\n        $widgetProps = $perc.widget.item.properties;\n        $perc_calendar_view = $widgetProps.get(\"perc_calendar_view\");\n        $perc_calendar_type = $widgetProps.get(\"perc_calendar_type\");\n        $perc_show_page_summary = $widgetProps.get(\"perc_show_page_summary\");\n        $perc_start_day_number = $widgetProps.get(\"perc_start_day\").replace(\"Day_\",\"\");\n\n        $perc_time_format = $widgetProps.get(\"perc_time_format\");\n        if($perc_time_format == \"ampm\")\n            $perc_time_format = \"hh:mmt\";\n        else\n            $perc_time_format = \"HH:mm\";\n\n        $pagesInCal = \"[]\";\n        $calTitle = \"\";\n        $calStartDate = \"\";\n        $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n        $id = \"\";\n        $perc.setWidgetContents($assetItems);\n        if ( ! $assetItems.isEmpty() ) {\n            $assetItem = $assetItems.get(0);\n            $id = $assetItem.id;\n            $calTitle = $assetItem.getNode().getProperty(\"calendar_title\").String;\n            $calName = $assetItem.getNode().getProperty(\"sys_title\").String;\n            $fullCalendarPage = $assetItem.getNode().getProperty(\"full_calendar_page\").String;\n            $calStartDate = $assetItem.getNode().getProperty(\"calendar_start_date\").String;\n            $pagesInCal = $rx.pageutils.getPagesForCalendar($calName).toString();\n        }\n       $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n       if(empty($rootclass)){\n            $rootclass = \"\";\n       }\n\n\t    $dsUrl = $rx.pageutils.getDeliveryServer();\n\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percCalendarContent",
+      "allowedContentTypes": [
+        "percCalendarAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/calendarIcon.png",
+      "target": "rx_resources/widgets/calendar/images/calendarIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_calendar_view",
+      "displayName": "Choose calendar view",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "full",
+      "enumValues": [
+        {
+          "value": "full",
+          "displayValue": "Full calendar"
+        },
+        {
+          "value": "mini",
+          "displayValue": "Mini calendar"
+        }
+      ]
+    },
+    {
+      "name": "perc_calendar_type",
+      "displayName": "Calendar type",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "month",
+      "enumValues": [
+        {
+          "value": "agendaDay",
+          "displayValue": "Day"
+        },
+        {
+          "value": "agendaWeek",
+          "displayValue": "Week"
+        },
+        {
+          "value": "month",
+          "displayValue": "Month"
+        }
+      ]
+    },
+    {
+      "name": "perc_show_page_summary",
+      "displayName": "Show summary",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_start_day",
+      "displayName": "Start week with",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "Day_0",
+      "enumValues": [
+        {
+          "value": "Day_0",
+          "displayValue": "Sunday"
+        },
+        {
+          "value": "Day_1",
+          "displayValue": "Monday"
+        },
+        {
+          "value": "Day_2",
+          "displayValue": "Tuesday"
+        },
+        {
+          "value": "Day_3",
+          "displayValue": "Wednesday"
+        },
+        {
+          "value": "Day_4",
+          "displayValue": "Thursday"
+        },
+        {
+          "value": "Day_5",
+          "displayValue": "Friday"
+        },
+        {
+          "value": "Day_6",
+          "displayValue": "Saturday"
+        }
+      ]
+    },
+    {
+      "name": "perc_time_format",
+      "displayName": "Time format",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "ampm",
+      "enumValues": [
+        {
+          "value": "ampm",
+          "displayValue": "12 hour"
+        },
+        {
+          "value": "military",
+          "displayValue": "24 hour"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendar/templates/percCalendarSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendar/templates/percCalendarSnippet.vm
@@ -1,0 +1,192 @@
+<div class="$!{rootclass} perc-calendar" data="$!dynamicListData">
+          #if( ! $perc.widgetContents.isEmpty() )
+                #if($perc_calendar_view == "full")##
+                    <div class ="perc-full-calendar" id="perc-full-calendar-$id"></div>
+                    <script>
+                    window.addEventListener('DOMContentLoaded', function() {
+                        var urlParams = jQuery.deparam.querystring();
+                        var calDefView = urlParams.startDate?'agendaDay':'$perc_calendar_type';
+                        jQuery("#perc-full-calendar-$id").fullCalendar({
+                            header: {
+                                left: 'title',
+                                center: 'prev,next today',
+                                right: 'month,agendaWeek,agendaDay'
+                            },
+                            firstDay: $perc_start_day_number,
+                            timeFormat: '$perc_time_format',
+                            defaultView: calDefView,
+                            editable: false,
+                            events: function(start, end, callback)
+                                    {
+                                        #if($perc.isEditMode() || $perc.isPreviewMode())
+                                            callback($pagesInCal);
+                                        #else
+                                            /*
+                                             * get the results from delivery tier service and return
+                                             * below we are looking to restrict the amount of information
+                                             * pulled back from the DTS.  The dates are found and used to
+                                             * restrict to the current selected month in the calendar.
+                                             */
+                                            var startMonth = start.getMonth()+1 < 10 ? '0' + (start.getMonth()+1) : start.getMonth()+1;
+                                            var endMonth = end.getMonth()+1 < 10 ? '0' + (end.getMonth()+1) : end.getMonth()+1;
+                                            var startDay = start.getDate() < 10 ? '0' + start.getDate() : start.getDate();
+                                            var endDay = end.getDate() < 10 ? '0' + end.getDate() : end.getDate();
+                                            var startValue = start.getFullYear() + '-' + startMonth + '-' + startDay;
+                                            var endValue = end.getFullYear() + '-' + endMonth + '-' + endDay;
+                                            var serviceUrl = "/perc-metadata-services/metadata/dated/get";
+                                            var dataObj = {"criteria":["type = 'page'", "perc:calendar = '$calName'", "perc:start_date >= '" + startValue + "'","perc:start_date <= '" + endValue + "'"]}
+                                            // here the last value condition perc:start_Date < is present to prevent duplicate events from populating between first call and second
+                                            var dataObj2 = {"criteria":["type = 'page'", "perc:calendar = '$calName'", "perc:end_date >= '" + startValue + "'", "perc:start_date < '" + startValue + "'"]}
+
+                                            /*
+                                             * Here we make two calls to the metadata service as a workaround as the backend currently doesn't support OR operations.
+                                             * @param endOfCall here the function is called twice, when endOfCall is true the callback populates the page with the calendar events
+                                             * @param firstEvents passes the results from the first metadata call to the second call.
+                                             */
+                                            var makeApiCall = function(dataObj, endOfCall, firstEvents) {
+                                                var deferred = jQuery.Deferred();
+                                                jQuery.PercServiceUtils.makeXdmJsonRequest(null,serviceUrl,jQuery.PercServiceUtils.TYPE_POST,function(status, results)
+                                                {
+                                                    if(status == jQuery.PercServiceUtils.STATUS_SUCCESS) {
+                                                        if(endOfCall){
+                                                            if(typeof(firstEvents) === "undefined"){
+									                            firstEvents = [];
+								                            }
+                                                            callback(firstEvents.concat(jQuery.PercServiceUtils.toJSON(results.data).events));
+                                                        }
+
+                                                        else
+                                                            deferred.resolve(jQuery.PercServiceUtils.toJSON(results.data).events);
+                                                    }
+                                                    else {
+                                                        deferred.resolve([]);
+                                                    }
+                                                }, dataObj);
+                                                return deferred.promise();
+                                            }
+                                            jQuery.when( makeApiCall(dataObj, false, []) ).then(function(events) {
+                                                makeApiCall(dataObj2, true, events);
+                                            });
+                                        #end
+                                    },
+                            dayClick: function(date, allDay, jsEvent, view) {
+                              if(typeof(percCalenderDayClick) === typeof(Function)){
+                                // if you need to bind to the dayClick even, define a function with a definition that
+                                // looks like function percCalenderDayClick(div_id, object,date,allDay,jsEvent,view)
+                                percCalenderDayClick("#perc-full-calendar-$id",$(this),date,allDay,jsEvent,view);
+                              }
+                            },
+                            eventRender: function(event, element) {
+                                #if($perc_show_page_summary)
+                                    event['allDay'] = false;
+                                    if(event.summary !='' && event.summary != null && event.summary != 'undefined') {
+                                        element.qtip({
+                                            content: event.summary,
+                                            style: {
+                                                    name: 'light', // Inherit from preset style,
+                                                    tip: true
+                                                },
+                                            position: {
+                                                    corner: {
+                                                            tooltip: 'bottomMiddle', // Use the corner...
+                                                            target: 'topMiddle' // ...and opposite corner
+                                                    }
+                                            }
+                                        });
+                                    }
+                                #end
+                            }
+                        });
+                        var startDate = new Date();
+                        if(urlParams.startDate)
+                        {
+                            var temp = urlParams.startDate.split(",");
+                            startDate = new Date(parseInt(temp[2], 10),parseInt(temp[0], 10)-1,parseInt(temp[1], 10));
+                        }
+                        else if('$calStartDate' != '')
+                        {
+                            var startDateTemp = '$calStartDate'.replace("00:00:00.0", '').split('-');
+                            startDate = new Date(parseInt(startDateTemp[0], 10), parseInt(startDateTemp[1],10)-1, parseInt(startDateTemp[2], 10))
+                        }
+                        jQuery('.perc-full-calendar').fullCalendar('gotoDate', startDate);
+                        });
+                    </script>
+                #else##
+                    <div class="perc-mini-calendar" id="perc-mini-calendar-$id"></div>
+                    <script>
+                    window.addEventListener('DOMContentLoaded', function() {
+                            tempDateArray = [];
+                            dateWithData = [];
+                            #if($perc.isEditMode() || $perc.isPreviewMode())
+                               tempDateArray = $pagesInCal;
+
+                               // prepare a temp array of dates which has event associated with it
+                               for (var i = 0; i < tempDateArray.length; i++) {
+                                   dateWithData.push(tempDateArray[i].start);
+                               }
+                               $("#perc-mini-calendar-$id").datepicker({
+                                   beforeShowDay: highlightDays,
+                                   onSelect: function(dateText, inst) {
+                                       #if($perc.isEditMode() || $perc.isPreviewMode())
+                                           return;
+                                       #else
+                                           clickedDate = dateText.replace(/\//g, ',');
+                                           var fullCalendarPage = '$fullCalendarPage';
+                                           window.location.href =  fullCalendarPage + "?startDate=" + clickedDate;
+                                       #end
+                                   }
+                               });
+
+                            #else
+                                //get the results from delivery tier service and return
+                                var serviceUrl = "/perc-metadata-services/metadata/dated/get";
+                                var dataObj = {"criteria":["type = 'page'", "perc:calendar = '$calName'"]}
+                                jQuery.PercServiceUtils.makeXdmJsonRequest(null,serviceUrl,jQuery.PercServiceUtils.TYPE_POST,function(status, results)
+                                {
+                                    if(status == jQuery.PercServiceUtils.STATUS_SUCCESS){
+                                        tempDateArray = jQuery.PercServiceUtils.toJSON(results.data).events;
+
+                                     // prepare a temp array of dates which has event associated with it
+                                     for (var i = 0; i < tempDateArray.length; i++) {
+                                         dateWithData.push(tempDateArray[i].start);
+                                     }
+
+                                     $("#perc-mini-calendar-$id").datepicker({
+                                         beforeShowDay: highlightDays,
+                                         onSelect: function(dateText, inst) {
+                                             #if($perc.isEditMode() || $perc.isPreviewMode())
+                                                 return;
+                                             #else
+                                                 clickedDate = dateText.replace(/\//g, ',');
+                                                 var fullCalendarPage = '$fullCalendarPage';
+                                                 window.location.href =  fullCalendarPage + "?startDate=" + clickedDate;
+                                             #end
+                                         }
+                                     });
+                                    }
+                                    else{
+                                        if (typeof(callback) != "undefined"){
+                                                tempDateArray = callback([]);
+                                        }
+                                    }
+                                }, dataObj);
+                            #end
+
+
+                            //Higlight the date in mini-calendar which has event associated with it.
+                            function highlightDays(date) {
+                                for (var i = 0; i < dateWithData.length; i++) {
+                                    if (new Date(dateWithData[i]).toString().substring(0, 15) == date.toString().substring(0, 15)) {
+                                        return [true, 'highlight'];
+                                    }
+                                  }
+                                  return [true, ''];
+                            }
+                        });
+                    </script>
+                #end##
+
+          #elseif ($perc.isEditMode())
+              #createEmptyWidgetContent("calendar-sample-content", "This Calendar widget is showing sample content.")
+          #end
+       </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendarTwo/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendarTwo/component-package.json
@@ -1,0 +1,713 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percCalendarTwo",
+  "name": "Calendar 2.0",
+  "version": "2.4.8",
+  "description": "Enables integration of Google Calendar with Percussion",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.5.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Calendar 2.0",
+    "category": "Other",
+    "description": "Enables integration of Google Calendar with Percussion",
+    "thumbnail": "resources/calendarIcon.png",
+    "icon": "resources/calendarIcon.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 900,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percCalendarAsset",
+      "ref": "contentTypes/percCalendarAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percCalendarTwoSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percCalendarTwoSnippet.vm",
+      "contentType": "percCalendarAsset",
+      "bindings": [
+        {
+          "variable": "widgetProps",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "perc_layout_type",
+          "expression": "$widgetProps.get(\"perc_layout_type\")"
+        },
+        {
+          "variable": "perc_max_results",
+          "expression": "$widgetProps.get(\"perc_max_results\")"
+        },
+        {
+          "variable": "perc_enable_calendar_icon",
+          "expression": "$widgetProps.get(\"enableCalenderIcon\")"
+        },
+        {
+          "variable": "perc_show_event_date",
+          "expression": "$widgetProps.get(\"showEventDate\")"
+        },
+        {
+          "variable": "perc_show_event_time",
+          "expression": "$widgetProps.get(\"showEventTime\")"
+        },
+        {
+          "variable": "perc_calendar_view",
+          "expression": "$widgetProps.get(\"perc_calendar_view\")"
+        },
+        {
+          "variable": "perc_calendar_type",
+          "expression": "$widgetProps.get(\"perc_calendar_type\")"
+        },
+        {
+          "variable": "perc_calendar_detail",
+          "expression": "$widgetProps.get(\"perc_calendar_detail\")"
+        },
+        {
+          "variable": "perc_show_page_summary",
+          "expression": "$widgetProps.get(\"perc_show_page_summary\")"
+        },
+        {
+          "variable": "perc_calendar_display_language",
+          "expression": "$widgetProps.get(\"perc_calendar_display_language\")"
+        },
+        {
+          "variable": "perc_start_day_number",
+          "expression": "$widgetProps.get(\"perc_start_day\").replace(\"Day_\",\"\")"
+        },
+        {
+          "variable": "perc_show_perc_events_button",
+          "expression": "$widgetProps.get(\"perc_show_perc_events_button\")"
+        },
+        {
+          "variable": "perc_event_button_label",
+          "expression": "$widgetProps.get(\"perc_event_button_label\")"
+        },
+        {
+          "variable": "eventDateFormat",
+          "expression": "$widgetProps.get(\"eventDateFormat\")"
+        },
+        {
+          "variable": "eventTimeFormat",
+          "expression": "$widgetProps.get(\"eventTimeFormat\")"
+        },
+        {
+          "variable": "perc_event_title_tag_type",
+          "expression": "$widgetProps.get(\"perc_event_title_tag_type\")"
+        },
+        {
+          "variable": "perc_enable_view_toggle_buttons",
+          "expression": "$widgetProps.get(\"perc_enable_view_toggle_buttons\")"
+        },
+        {
+          "variable": "perc_time_format",
+          "expression": "$widgetProps.get(\"perc_time_format\")"
+        },
+        {
+          "variable": "perc_time_format",
+          "expression": "\"hh:mmt\""
+        },
+        {
+          "variable": "perc_time_format",
+          "expression": "\"HH:mm\""
+        },
+        {
+          "variable": "pagesInCal",
+          "expression": "\"[]\""
+        },
+        {
+          "variable": "calTitle",
+          "expression": "\"\""
+        },
+        {
+          "variable": "calStartDate",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "id",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "id",
+          "expression": "$assetItem.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "calTitle",
+          "expression": "$assetItem.getNode().getProperty(\"calendar_title\").String"
+        },
+        {
+          "variable": "calName",
+          "expression": "$assetItem.getNode().getProperty(\"sys_title\").String"
+        },
+        {
+          "variable": "fullCalendarPage",
+          "expression": "$assetItem.getNode().getProperty(\"full_calendar_page\").String"
+        },
+        {
+          "variable": "calStartDate",
+          "expression": "$assetItem.getNode().getProperty(\"calendar_start_date\").String"
+        },
+        {
+          "variable": "pagesInCal",
+          "expression": "$rx.pageutils.getPagesForCalendar($calName).toString()"
+        },
+        {
+          "variable": "data",
+          "expression": "$assetItem.Node.getProperty('rx:googleSetupData').getString()"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($data)"
+        },
+        {
+          "variable": "googleCalendarArray",
+          "expression": "$json.getJSONArray(\"config\")"
+        },
+        {
+          "variable": "calendarContentId",
+          "expression": "$assetItem.Node.getProperty('rx:sys_contentid').getString()"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer()"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "##Widget properties\n      $widgetProps = $perc.widget.item.properties;\n      $perc_layout_type = $widgetProps.get(\"perc_layout_type\");\n      $perc_max_results = $widgetProps.get(\"perc_max_results\");\n      $perc_enable_calendar_icon = $widgetProps.get(\"enableCalenderIcon\");\n      $perc_show_event_date = $widgetProps.get(\"showEventDate\");\n      $perc_show_event_time = $widgetProps.get(\"showEventTime\");\n      $perc_calendar_view = $widgetProps.get(\"perc_calendar_view\");\n      $perc_calendar_type = $widgetProps.get(\"perc_calendar_type\");\n      $perc_calendar_detail = $widgetProps.get(\"perc_calendar_detail\");\n      $perc_show_page_summary = $widgetProps.get(\"perc_show_page_summary\");\n      $perc_calendar_display_language = $widgetProps.get(\"perc_calendar_display_language\");\n      $perc_start_day_number = $widgetProps.get(\"perc_start_day\").replace(\"Day_\",\"\");\n      $perc_show_perc_events_button = $widgetProps.get(\"perc_show_perc_events_button\");\n      $perc_event_button_label = $widgetProps.get(\"perc_event_button_label\");\n      $eventDateFormat = $widgetProps.get(\"eventDateFormat\");\n      $eventTimeFormat = $widgetProps.get(\"eventTimeFormat\");\n      $perc_event_title_tag_type = $widgetProps.get(\"perc_event_title_tag_type\");\n      $perc_enable_view_toggle_buttons = $widgetProps.get(\"perc_enable_view_toggle_buttons\");\n\n\n      $perc_time_format = $widgetProps.get(\"perc_time_format\");\n      if($perc_time_format == \"ampm\")\n          $perc_time_format = \"hh:mmt\";\n      else\n          $perc_time_format = \"HH:mm\";\n\n      $pagesInCal = \"[]\";\n      $calTitle = \"\";\n      $calStartDate = \"\";\n      $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n      $id = \"\";\n      $perc.setWidgetContents($assetItems);\n      if ( ! $assetItems.isEmpty() ) {\n          $assetItem = $assetItems.get(0);\n          $id = $assetItem.id;\n          $widgetId = $perc.widget.item.id;\n          $calTitle = $assetItem.getNode().getProperty(\"calendar_title\").String;\n          $calName = $assetItem.getNode().getProperty(\"sys_title\").String;\n          $fullCalendarPage = $assetItem.getNode().getProperty(\"full_calendar_page\").String;\n          $calStartDate = $assetItem.getNode().getProperty(\"calendar_start_date\").String;\n          $pagesInCal = $rx.pageutils.getPagesForCalendar($calName).toString();\n          $data = $assetItem.Node.getProperty('rx:googleSetupData').getString();\n          $json = $rx.pageutils.createJsonObject($data);\n          $googleCalendarArray = $json.getJSONArray(\"config\");\n          $calendarContentId = $assetItem.Node.getProperty('rx:sys_contentid').getString();\n      }\n\n      $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n\n      if(empty($rootclass)){\n          $rootclass = \"\";\n      }\n\n      $dsUrl = $rx.pageutils.getDeliveryServer();\n\n      $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percCalendarTwoContent",
+      "allowedContentTypes": [
+        "percCalendarAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/calendarIcon.png",
+      "target": "rx_resources/widgets/percCalendarTwo/images/calendarIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_layout_type",
+      "displayName": "Choose layout type",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "Calendar",
+      "enumValues": [
+        {
+          "value": "calendar",
+          "displayValue": "Calendar"
+        },
+        {
+          "value": "list",
+          "displayValue": "Event List"
+        }
+      ]
+    },
+    {
+      "name": "perc_enable_view_toggle_buttons",
+      "displayName": "Enable view toggle buttons",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_max_results",
+      "displayName": "<span style=\"font-size:125%;\"><br><b>Event List View Options</b></span><br><br>Event List Limit",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "5",
+      "enumValues": []
+    },
+    {
+      "name": "perc_event_title_tag_type",
+      "displayName": "Format for event title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "p",
+      "enumValues": [
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        }
+      ]
+    },
+    {
+      "name": "enableCalenderIcon",
+      "displayName": "Enable calendar icon",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "showEventDate",
+      "displayName": "Show event date",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "eventDateFormat",
+      "displayName": "Format of event date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "dddd, MMMM Do YYYY",
+      "enumValues": []
+    },
+    {
+      "name": "showEventTime",
+      "displayName": "Show event time",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "eventTimeFormat",
+      "displayName": "Format of event time",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "h:mmA",
+      "enumValues": []
+    },
+    {
+      "name": "perc_calendar_view",
+      "displayName": "<span style=\"font-size:125%;\"><br><br><b>Calendar View Options</b></span><br><br>Choose calendar view",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "full",
+      "enumValues": [
+        {
+          "value": "full",
+          "displayValue": "Full calendar"
+        },
+        {
+          "value": "mini",
+          "displayValue": "Mini calendar"
+        }
+      ]
+    },
+    {
+      "name": "perc_calendar_type",
+      "displayName": "Default calendar type",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "month",
+      "enumValues": [
+        {
+          "value": "Day",
+          "displayValue": "Day"
+        },
+        {
+          "value": "Week",
+          "displayValue": "Week"
+        },
+        {
+          "value": "month",
+          "displayValue": "Month"
+        }
+      ]
+    },
+    {
+      "name": "perc_calendar_detail",
+      "displayName": "Detail Level",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "basic",
+      "enumValues": [
+        {
+          "value": "basic",
+          "displayValue": "Basic (times not displayed for week and day views)"
+        },
+        {
+          "value": "agenda",
+          "displayValue": "Agenda"
+        }
+      ]
+    },
+    {
+      "name": "perc_show_page_summary",
+      "displayName": "Show summary",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_start_day",
+      "displayName": "Start week with",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "Day_0",
+      "enumValues": [
+        {
+          "value": "Day_0",
+          "displayValue": "Sunday"
+        },
+        {
+          "value": "Day_1",
+          "displayValue": "Monday"
+        },
+        {
+          "value": "Day_2",
+          "displayValue": "Tuesday"
+        },
+        {
+          "value": "Day_3",
+          "displayValue": "Wednesday"
+        },
+        {
+          "value": "Day_4",
+          "displayValue": "Thursday"
+        },
+        {
+          "value": "Day_5",
+          "displayValue": "Friday"
+        },
+        {
+          "value": "Day_6",
+          "displayValue": "Saturday"
+        }
+      ]
+    },
+    {
+      "name": "perc_time_format",
+      "displayName": "Time format",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "ampm",
+      "enumValues": [
+        {
+          "value": "ampm",
+          "displayValue": "12 hour"
+        },
+        {
+          "value": "military",
+          "displayValue": "24 hour"
+        }
+      ]
+    },
+    {
+      "name": "perc_calendar_display_language",
+      "displayName": "Language",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "en",
+      "enumValues": [
+        {
+          "value": "en",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "ar-ma",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-sa",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-tn",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "bg",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "cs",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "de-at",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "el",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "en-au",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-ca",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-gb",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-ie",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-nz",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "es",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "fi",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-ca",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-ch",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "fr",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "he",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-in",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hr",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "hu",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "id",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "is",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "it",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "ja",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lb",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "lt",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "lv",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "nb",
+          "displayValue": "Norwegian Bokmål Norway (NO)"
+        },
+        {
+          "value": "nl",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "nn",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-br",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sk",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "sr",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sv",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        },
+        {
+          "value": "zh-cn",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-tw",
+          "displayValue": "Chinese Taiwan (TW)"
+        }
+      ]
+    },
+    {
+      "name": "perc_show_perc_events_button",
+      "displayName": "Display show/hide button for Percussion events",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "N",
+      "enumValues": [
+        {
+          "value": "N",
+          "displayValue": "No"
+        },
+        {
+          "value": "Y",
+          "displayValue": "Yes"
+        }
+      ]
+    },
+    {
+      "name": "perc_event_button_label",
+      "displayName": "Percussion event button label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Other",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendarTwo/templates/percCalendarTwoSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/widgets/percCalendarTwo/templates/percCalendarTwoSnippet.vm
@@ -1,0 +1,577 @@
+<div class="$!{rootclass} perc-calendar" data="$!dynamicListData">
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($googleSourceCount = 0)##
+#foreach($googleSource in $googleCalendarArray)##
+#set($googleSourceCount = $googleSourceCount + 1)##
+#end##
+#if( $perc_enable_view_toggle_buttons == "true")##
+  <div id="perc-toggle-button-container" class="perc-toggle-button-container" >
+  <button type="button" id="showCalendarButton-${calendarContentId}-${widgetId}" class="fc-button fc-state-default fc-corner-left fc-corner-right perc-type-toggle" >Calendar View</button>
+  <button type="button" id="showListButton-${calendarContentId}-${widgetId}" class="fc-button fc-state-default fc-corner-left fc-corner-right perc-type-toggle" >List View</button>
+  </div>
+#end##
+##
+#if($perc.isEditMode() || $perc.isPreviewMode())##
+<script src="/Rhythmyx/web_resources/widgets/calendarTwo/js/moment.min.js"></script>
+#set($resourcePrefix = "/Rhythmyx")##
+#else##
+<script src="/web_resources/widgets/calendarTwo/js/moment.min.js"></script>
+#set($resourcePrefix = "")##
+#end##
+##
+      <link rel="stylesheet" href="$resourcePrefix/web_resources/widgets/calendarTwo/css/fullcalendar.print.css" type="text/css" media="print" />
+      <style>
+      @media only screen
+      and (max-width: 480px)
+      {
+        .fc-left {
+          float: left !important;
+          display:block !important;
+          width: 100% !important;
+          margin: 5px !important;
+          text-align: center !important;
+        }
+
+        .fc-right {
+          float: left !important;
+          display:block !important;
+          width: 100% !important;
+          margin: 5px !important;
+          text-align: center !important;
+        }
+
+        .fc-center {
+          float: left !important;
+          display:block !important;
+          width: 100% !important;
+          margin: 5px !important;
+          text-align: center !important;
+        }
+      }
+
+      .perc-full-calendar {
+
+        margin: 0 auto;
+        font-size: 14px;
+      }
+
+      .perc-hide-calendar {
+        display: none;
+      }
+
+      .perc-calendar-button {
+        border: none;
+        border-radius: 4px;
+        color: white;
+        padding: 9px 10px;
+        text-align: center;
+        text-decoration: none;
+        display: inline-block;f
+        font-size: 12px;
+        cursor: pointer;
+        margin: 0px;
+        margin-top: 5px;
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+        -o-user-select: none;
+      }
+
+      .perc-disabled-calendar-button {
+        opacity: 0.6;
+      }
+      .perc-button-container {
+        float: left;
+      }
+
+      .perc-calendar-other {
+        background-color: #3a87ad;
+        color: #ffffff;
+      }
+
+#foreach($googleSource in $googleCalendarArray)##
+        .perc-$googleSource.getString("className") {
+        background-color: $googleSource.getString("backgroundColor") !important;
+        color: $googleSource.getString("textColor") !important;
+        border: $googleSource.getString("backgroundColor") !important;
+      }
+#end##
+      .perc-event-list-template {
+        display:none;
+      }
+
+      .perc-event-list-element {
+        width: 100%;
+        padding-bottom:15px;
+        #if( $perc_enable_calendar_icon == 'true' )##
+        list-style: none;
+        #end##
+      }
+
+      .perc-cal-icon {
+        margin-right: 15px;
+        text-align: center;
+        padding: 3px;
+        text-transform: uppercase;
+        float: left;
+        display: inline-block;
+        background-color: #666;
+        color: #FFF;
+      }
+
+      .perc-month-mmm {
+        padding: 5px 15px;
+      }
+
+      .perc-date-dd {
+        background-color: #FFF;
+        color:#666;
+        width: 100%;
+        display: block;
+        font-size: 25px;
+        padding: 5px 0px;
+      }
+
+      #perc-event-list-${calendarContentId}-${widgetId} ul {
+        margin: 0px;
+        padding: 0px;
+      }
+
+      #perc-button-container-${calendarContentId}-${widgetId} {
+        display:none;
+      }
+
+      .perc-type-toggle {
+        margin-bottom: 15px;
+        padding: 5px;
+      }
+
+      </style>
+
+	  <script>
+      window.addEventListener('DOMContentLoaded', function() {
+		  function hideCalendarSource(calendarClass) {
+			$('#'+calendarClass+'-button').toggleClass("perc-disabled-calendar-button");
+			$('.'+calendarClass).toggleClass("perc-hide-calendar");
+		  };
+      });
+      </script>
+
+      #if($perc_calendar_view == "full")##
+      <div class ="perc-full-calendar" id="calendar-${calendarContentId}-${widgetId}"></div>
+
+      #if( ($googleSourceCount >= 1 || $perc_show_perc_events_button == 'Y'))
+      <form>
+      <div id="perc-button-container-${calendarContentId}-${widgetId}" class="perc-button-container">
+      #foreach($googleSource in $googleCalendarArray)
+      <div id="perc-${googleSource.getString('className')}-button" class="perc-calendar-button perc-$googleSource.getString('className')" onClick="hideCalendarSource('perc-${googleSource.getString('className')}')">$googleSource.getString('calendarName')</div>
+      #end
+
+      #if($perc_show_perc_events_button == 'Y' && $perc_event_button_label != '')
+      <div id="perc-calendar-other-button" class="perc-calendar-button perc-calendar-other" onClick="hideCalendarSource('perc-calendar-other')">$perc_event_button_label</div>
+      #end
+      </div>
+      </form>
+      #end
+
+<div id="perc-event-list-template-${calendarContentId}-${widgetId}" class="perc-event-list-template">
+    <ul class="perc-list-main">
+        <li class="perc-event-list-element perc-list-element">
+            <div class="perc-cal-icon">
+                <div class="perc-month-mmm">MMM</div>
+                <div class="perc-date-dd">DD</div>
+            </div>
+            <div class="perc-event-info">
+                <div class="perc-event-title"><$perc_event_title_tag_type><a class="perc-event-title-link" href="" target="_blank" rel = "noopener noreferrer">Event Title</a></$perc_event_title_tag_type></div>
+        <div class="perc-event-date">mm/dd/yyyy</div>
+                <div class="perc-event-time">Event Time</div>
+                </div>
+        </li>
+    </ul>
+</div>
+<div id='perc-event-list-${calendarContentId}-${widgetId}' class="perc-event-list">
+    <ul></ul>
+</div>
+      <script>
+      window.addEventListener('DOMContentLoaded', function() {
+      /**
+      * Extremely important note:
+      * The fullcalendar.js file has been modified to make the event list available
+      * as a global variable in the Perc namespace by resolving a deferred object. The object is
+      * resolved in the reportEvents function. Also, the stock fullcalendar.js file is hard-coded to
+      * Retrieve 6 weeks of events. This needed to be changed to allow for events in list view
+      * to appear even if they are beyond that 6 week range. The Perc.range property is set below
+      * depending on the layout type. This is used in the computeRange method in the JavaScript file.
+      * Updating the fullcalendar.js with a future version of the stock file will require a manual change
+      * to keep both of these modifications in place.
+      **/
+
+	$(function(){
+
+        $('#perc-event-list-${calendarContentId}-${widgetId}').hide();
+
+        // These variables are for event list functionality
+        if(!window.Perc) {
+            window.Perc = {};
+        }
+        if(!Perc.events) {
+            Perc.events = {};
+        }
+#if($perc_layout_type == 'list')##
+        Perc.range = 52;
+#else##
+        Perc.range = 6;
+#end##
+        Perc.events['calendar-${calendarContentId}-${widgetId}'] = jQuery.Deferred();
+        var maxResults = $perc_max_results;
+        var layoutType = '$perc_layout_type';
+        var percShowCalIcon = '$perc_enable_calendar_icon';
+        var percShowEventDate = '$perc_show_event_date';
+        var percShowEventTime = '$perc_show_event_time';
+
+        initializeCalendar();
+
+        if( layoutType == 'calendar' ) {
+          $('#perc-button-container-${calendarContentId}-${widgetId}').fadeIn();
+        }
+
+        function initializeCalendar() {
+
+        $("#calendar-${calendarContentId}-${widgetId}").fullCalendar({
+
+            timeFormat: '${perc_time_format}',
+            #if($calStartDate != "")
+            defaultDate: '$calStartDate',
+            #end
+            lang: '${perc_calendar_display_language}',
+            firstDay: $perc_start_day_number,
+            defaultView: '#if($perc_calendar_type != 'month')$perc_calendar_detail#end$perc_calendar_type',
+            header: {
+                left: 'title',
+                center: 'prev,next today',
+                right: 'month,${perc_calendar_detail}Week,${perc_calendar_detail}Day'
+            },
+
+            eventSources: [
+            #if($googleSourceCount > 0)
+            #foreach($googleSource in $googleCalendarArray)
+                {
+                    googleCalendarApiKey: '${googleSource.getString("apiKey")}',
+                    googleCalendarId: '${googleSource.getString("calendarId")}',
+                    className: 'perc-${googleSource.getString("className")}'
+                }#if($velocityCount <= $googleSourceCount),#end
+            #end
+            #end
+
+                {
+                    events: function(start, end, timezone, callback)
+          {
+              #if($perc.isEditMode() || $perc.isPreviewMode())
+                  callback($pagesInCal);
+              #else
+                  /*
+                    * get the results from delivery tier service and return
+                    * below we are looking to restrict the amount of information
+                    * pulled back from the DTS.  The dates are found and used to
+                    * restrict to the current selected month in the calendar.
+                    */
+                  var start2 = new Date(start._d);
+                  var end2 = new Date(end._d);
+                  var startMonth = start2.getMonth()+1 < 10 ? '0' + (start2.getMonth()+1) : start2.getMonth()+1;
+                  var endMonth = end2.getMonth()+1 < 10 ? '0' + (end2.getMonth()+1) : end2.getMonth()+1;
+                  var startDay = start2.getDate() < 10 ? '0' + start2.getDate() : start2.getDate();
+                  var endDay = end2.getDate() < 10 ? '0' + end2.getDate() : end2.getDate();
+                  var startValue = start2.getFullYear() + '-' + startMonth + '-' + startDay;
+                  var endValue = end2.getFullYear() + '-' + endMonth + '-' + endDay;
+                  var serviceUrl = "/perc-metadata-services/metadata/dated/get";
+                  var dataObj = {"criteria":["type = 'page'", "perc:calendar = '$calName'", "perc:start_date >= '" + startValue + "'","perc:start_date <= '" + endValue + "'"]}
+                  // here the last value condition perc:start_Date < is present to prevent duplicate events from populating between first call and second
+                  var dataObj2 = {"criteria":["type = 'page'", "perc:calendar = '$calName'", "perc:end_date >= '" + startValue + "'", "perc:start_date < '" + startValue + "'"]}
+                  /*
+                    * Here we make two calls to the metadata service as a workaround as the backend currently doesn't support OR operations.
+                    * @param endOfCall here the function is called twice, when endOfCall is true the callback populates the page with the calendar events
+                    * @param firstEvents passes the results from the first metadata call to the second call.
+                    */
+                  var makeApiCall = function(dataObj, endOfCall, firstEvents) {
+                      var deferred = jQuery.Deferred();
+                      jQuery.PercServiceUtils.makeXdmJsonRequest(null,serviceUrl,jQuery.PercServiceUtils.TYPE_POST,function(status, results)
+                      {
+                          if(status == jQuery.PercServiceUtils.STATUS_SUCCESS) {
+                              if(endOfCall){
+                                if(typeof(firstEvents) === "undefined"){
+								    firstEvents = [];
+								}
+                                callback(firstEvents.concat(jQuery.PercServiceUtils.toJSON(results.data).events));
+                          }
+                              else
+                                  deferred.resolve(jQuery.PercServiceUtils.toJSON(results.data).events);
+                          }
+                          else {
+                              deferred.resolve([]);
+                          }
+                      }, dataObj);
+                      return deferred.promise();
+                  }
+                  jQuery.when( makeApiCall(dataObj, false, []) ).then(function(events) {
+                      makeApiCall(dataObj2, true, events);
+                  });
+              #end
+          },
+        className: 'perc-calendar-other',
+
+        }
+            ],
+            editable: false,
+
+      dayClick: function(date, allDay, jsEvent, view) {
+      if(typeof(percCalenderDayClick) === typeof(Function)){
+      // if you need to bind to the dayClick even, define a function with a definition that
+      // looks like function percCalenderDayClick(div_id, object,date,allDay,jsEvent,view)
+      percCalenderDayClick("#calendar-${calendarContentId}-${widgetId}",$(this),date,allDay,jsEvent,view);
+      }
+      },
+      eventRender: function(event, element) {
+      #if($perc_show_page_summary)
+      event['allDay'] = false;
+      if(event.summary !='' && event.summary != null && event.summary != 'undefined') {
+      element.qtip({
+      content: event.summary,
+      style: {
+      name: 'light', // Inherit from preset style,
+      tip: true
+      },
+      position: {
+      corner: {
+      tooltip: 'bottomMiddle', // Use the corner...
+      target: 'topMiddle' // ...and opposite corner
+      }
+      }
+      });
+      }
+      #end
+      }
+
+      });
+
+      } //end initialize calendar
+
+      if( layoutType == 'list' ) {
+        $('#calendar-${calendarContentId}-${widgetId}').hide();
+        $('.perc-mini-calendar').hide();
+        jQuery.when(Perc.events['calendar-${calendarContentId}-${widgetId}'])
+		 .then(
+			function(resolvedEvents) {
+				console.log('processing event list');
+				percProcessEventList(resolvedEvents, maxResults);
+			},
+			function(err) { console.log('errpr processing event list', err); }
+		  );
+      }
+
+      // This method hides the calendar view, shows the list view, and populates the target with the event list
+        function percProcessEventList(eventObject, maxResults) {
+
+            $('#perc-event-list-${calendarContentId}-${widgetId}').fadeIn();
+
+            //  fullcalendar does not presort the event dates
+            eventObject.sort(function(x, y){
+                return x.start - y.start;
+			});
+
+            percCurrentDate = new Date();
+
+            //  indentifies the target for the event list, and the template to clone
+            var percTargetEventList = $('#perc-event-list-${calendarContentId}-${widgetId}');
+            var percEventStructureListRoot = $('#perc-event-list-template-${calendarContentId}-${widgetId} ul li');
+            var percEventListElem = percEventStructureListRoot.clone();
+            var eventCount = 0;
+            var eventIterator = 0;
+
+            // Count the total number of possible events to show so later on we can determine if we are on the last event
+            jQuery.each(eventObject, function( index, event ){
+                if( !(moment(event.start).isBefore(percCurrentDate, 'day')) ) {
+                    eventCount++;
+                }
+      });
+
+            jQuery.each(eventObject, function( index, event ){
+
+                //  we only want to show the events in list view that are today's date or later, and no more
+                //  events than the designated maxResults
+                if ( !(moment(event.start).isBefore(percCurrentDate, 'day')) && eventIterator < maxResults ) {
+
+                    percNewEventListElem = percEventListElem.clone();
+
+                    if ( eventIterator == 0 ) {
+                        percNewEventListElem.addClass('perc-list-first');
+                    }
+
+                    if ( eventIterator == eventCount || (eventIterator + 1) == maxResults ) {
+                        percNewEventListElem.addClass('perc-list-last');
+                    }
+
+                    // Check if we are an odd or even value, but remember that eventIterator is starting at zero
+                    if( (eventIterator+1) % 2 == 0) {
+                        percNewEventListElem.addClass('perc-list-even');
+                    }
+                    else {
+                        percNewEventListElem.addClass('perc-list-odd');
+                    }
+
+                    if(!(event.url)) {
+                            percNewEventListElem.find('a').removeAttr("href");
+                    }
+                    else {
+                        percNewEventListElem.find('a').attr('href', event.url);
+                    }
+
+                    if( percShowCalIcon == 'false' ) {
+                        percNewEventListElem.find('.perc-cal-icon').remove();
+                    }
+            if( percShowEventDate == 'false' ) {
+                        percNewEventListElem.find('.perc-event-date').remove();
+                    }
+            if( percShowEventTime == 'false' ) {
+              percNewEventListElem.find('.perc-event-time').remove();
+            }
+
+            percNewEventListElem.find('.perc-event-date').text(moment(event.start).format("${eventDateFormat}"));
+                    percNewEventListElem.find('.perc-month-mmm').text(moment(event.start).format("MMM").toUpperCase());
+                    percNewEventListElem.find('.perc-date-dd').text(moment(event.start).format("D"));
+                    percNewEventListElem.find('.perc-event-time').text(moment(event.start).format("${eventTimeFormat}"));
+            if(event.end) {
+              percNewEventListElem.find('.perc-event-time').append(' - ' + moment(event.end).format("${eventTimeFormat}"));
+            }
+                    percNewEventListElem.find('.perc-event-title-link').text(event.title);
+
+                    // Populates the target container with the event item
+                    $('#perc-event-list-${calendarContentId}-${widgetId} ul').append(percNewEventListElem);
+
+                    eventIterator++;
+
+                }   // end if event is before today's date and does not exceed max results
+
+            }); // end each eventObject
+
+        }   // end function percProcessEventList
+
+
+      $('#showCalendarButton-${calendarContentId}-${widgetId}').on("click", function() {
+        $('#perc-event-list-${calendarContentId}-${widgetId}').hide();
+        Perc.range = 6;
+        $('#calendar-${calendarContentId}-${widgetId}').fadeIn().fullCalendar( 'destroy' );
+        initializeCalendar();
+        $('#perc-button-container-${calendarContentId}-${widgetId}').fadeIn();
+      });
+      $('#showListButton-${calendarContentId}-${widgetId}').on("click",function() {
+        $('#perc-button-container-${calendarContentId}-${widgetId}').hide();
+        $('#calendar-${calendarContentId}-${widgetId}').fullCalendar( 'destroy' );
+        Perc.events['calendar-${calendarContentId}-${widgetId}'] = jQuery.Deferred();
+        jQuery.when(Perc.events['calendar-${calendarContentId}-${widgetId}']).then(
+			function( resolvedEvents ){
+              percProcessEventList(resolvedEvents, maxResults);
+			},
+			function(err) { console.log('error processing events', err); }
+		);
+        Perc.range = 52;
+        $('#perc-event-list-${calendarContentId}-${widgetId}').fadeIn();
+        $('#perc-event-list-${calendarContentId}-${widgetId} ul').empty();
+        $('#calendar-${calendarContentId}-${widgetId}').show();
+        initializeCalendar();
+          $('#calendar-${calendarContentId}-${widgetId}').hide();
+        });
+	});
+    });
+      </script>
+
+
+    #else##
+    #set($caljQuery="$")##
+                    <div class="perc-mini-calendar" id="perc-mini-calendar-$id"></div>
+                    <script>
+                    window.addEventListener('DOMContentLoaded', function() {
+						$(function(){
+                            tempDateArray = [];
+                            dateWithData = [];
+                            #if($perc.isEditMode() || $perc.isPreviewMode())
+                               tempDateArray = $pagesInCal;
+
+                               // prepare a temp array of dates which has event associated with it
+                               for (var i = 0; i < tempDateArray.length; i++) {
+                                   dateWithData.push(tempDateArray[i].start);
+                               }
+
+                              ${caljQuery}.datepicker.setDefaults( ${caljQuery}.datepicker.regional['${perc_calendar_display_language}'] );
+
+                               $("#perc-mini-calendar-$id").datepicker({
+                                   beforeShowDay: highlightDays,
+                                   onSelect: function(dateText, inst) {
+                                       #if($perc.isEditMode() || $perc.isPreviewMode())
+                                           return;
+                                       #else
+                                           clickedDate = dateText.replace(/\//g, ',');
+                                           var fullCalendarPage = '$fullCalendarPage';
+                                           window.location.href =  fullCalendarPage + "?startDate=" + clickedDate;
+                                       #end
+                                   }
+                               });
+
+                            #else
+                                //get the results from delivery tier service and return
+                                var serviceUrl = "/perc-metadata-services/metadata/dated/get";
+                                var dataObj = {"criteria":["type = 'page'", "perc:calendar = '$calName'"]}
+                                jQuery.PercServiceUtils.makeXdmJsonRequest(null,serviceUrl,jQuery.PercServiceUtils.TYPE_POST,function(status, results)
+                                {
+                                    if(status == jQuery.PercServiceUtils.STATUS_SUCCESS){
+                                        tempDateArray = jQuery.PercServiceUtils.toJSON(results.data).events;
+
+                                     // prepare a temp array of dates which has event associated with it
+                                     for (var i = 0; i < tempDateArray.length; i++) {
+                                         dateWithData.push(tempDateArray[i].start);
+                                     }
+
+                                     ${caljQuery}.datepicker.setDefaults( ${caljQuery}.datepicker.regional['${perc_calendar_display_language}'] );
+
+                                     $("#perc-mini-calendar-$id").datepicker({
+                                         beforeShowDay: highlightDays,
+                                         onSelect: function(dateText, inst) {
+                                             #if($perc.isEditMode() || $perc.isPreviewMode())
+                                                 return;
+                                             #else
+                                                 clickedDate = dateText.replace(/\//g, ',');
+                                                 var fullCalendarPage = '$fullCalendarPage';
+                                                 window.location.href =  fullCalendarPage + "?startDate=" + clickedDate;
+                                             #end
+                                         }
+                                     });
+                                    }
+                                    else{
+                                        if (typeof(callback) != "undefined"){
+                                            tempDateArray = callback([]);
+                                        }
+                                    }
+                                }, dataObj);
+                            #end
+
+
+                            //hi-light the date in mini-calendar which has event associated with it.
+                            function highlightDays(date) {
+                                for (var i = 0; i < dateWithData.length; i++) {
+                                    if (new Date(dateWithData[i]).toString().substring(0, 15) == date.toString().substring(0, 15)) {
+                                        return [true, 'highlight'];
+                                    }
+                                  }
+                                  return [true, ''];
+                            }
+						});
+                     });
+                    </script>
+
+
+      #end##
+
+      #elseif ($perc.isEditMode())
+      #createEmptyWidgetContent("calendar-sample-content", "This Calendar widget is showing sample content.")
+      #end
+      </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/widgets/percCategoryList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/widgets/percCategoryList/component-package.json
@@ -1,0 +1,363 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percCategoryList",
+  "name": "Categories",
+  "version": "1.2.3",
+  "description": "Display a hierarchical list of categories",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com/"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.widget.calendar",
+      "version": "2.0.3",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Categories",
+    "category": "blog,search",
+    "description": "Display a hierarchical list of categories",
+    "thumbnail": "resources/widgetIconLinkCategoryList.png",
+    "icon": "resources/widgetIconLinkCategoryList.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percCategoryList",
+      "ref": "contentTypes/percCategoryList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percCategoryListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percCategoryListSnippet.vm",
+      "contentType": "percCategoryList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "isEditMode",
+          "expression": "$perc.isEditMode()"
+        },
+        {
+          "variable": "isPreviewMode",
+          "expression": "$perc.isPreviewMode()"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "display",
+          "expression": "$perc.widget.item.properties.get('perc_display_option')"
+        },
+        {
+          "variable": "maxCat",
+          "expression": "$perc.widget.item.properties.get('perc_max_categories').toString().trim()"
+        },
+        {
+          "variable": "maxCat",
+          "expression": "0"
+        },
+        {
+          "variable": "maxCat",
+          "expression": "0 + $perc.widget.item.properties.get('perc_max_categories')"
+        },
+        {
+          "variable": "maxCat",
+          "expression": "0"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "$assetItem.getNode().getProperty('query').String"
+        },
+        {
+          "variable": "query",
+          "expression": "'select rx:sys_contentid, rx:sys_folderid from rx:percPage'"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "processedCategories",
+          "expression": "$rx.pageutils.getProcessedCategories($relresults)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem, 'displaytitle')"
+        },
+        {
+          "variable": "titleContains",
+          "expression": "$assetItem.getNode().getProperty('title_contains').String"
+        },
+        {
+          "variable": "starDate",
+          "expression": "$assetItem.getNode().getProperty('start_date').String"
+        },
+        {
+          "variable": "endDate",
+          "expression": "$assetItem.getNode().getProperty('end_date').String"
+        },
+        {
+          "variable": "sitePath",
+          "expression": "$assetItem.getNode().getProperty('site_path').String"
+        },
+        {
+          "variable": "templatesList",
+          "expression": "$assetItem.getNode().getProperty('page_templates_list').String"
+        },
+        {
+          "variable": "categoryPageResult",
+          "expression": "$assetItem.getNode().getProperty('category_page_result').String"
+        },
+        {
+          "variable": "criteria",
+          "expression": "\"[\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"&quot;type = 'page'&quot;\""
+        },
+        {
+          "variable": "criteriaSep",
+          "expression": "\", \""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + $criteriaSep + \"&quot;dcterms:title LIKE '%\" + $titleContains +\"%'&quot;\""
+        },
+        {
+          "variable": "sd",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$starDate)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\""
+        },
+        {
+          "variable": "ed",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$endDate)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$sitePath.replace(\"//Sites/\", \"\")"
+        },
+        {
+          "variable": "temppaths",
+          "expression": "$temppath.split(\"/\")"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\""
+        },
+        {
+          "variable": "folderpath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "counter",
+          "expression": "1"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$folderpath + \"/\" + $temppaths[$counter]"
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\""
+        },
+        {
+          "variable": "templateNameList",
+          "expression": "$rx.pageutils.templateNames($templatesList)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "\"(\""
+        },
+        {
+          "variable": "counter",
+          "expression": "0"
+        },
+        {
+          "variable": "templNameArray",
+          "expression": "$templateNameList.toArray()"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \"'\" + $templNameArray[$counter] + \"'\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \", \""
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \")\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"]\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{\" + \"&quot;criteria&quot;:\" + $criteria"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;category_page_result&quot;:&quot;\" +$categoryPageResult + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;display_option&quot;:&quot;\" +$display + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;max_categories&quot;:&quot;\" +$maxCat + \"&quot;\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isPreviewMode&quot;:&quot;\" + $isPreviewMode + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n    $isEditMode = $perc.isEditMode();\n    $isPreviewMode =  $perc.isPreviewMode();\n    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assetItems);\n    $display = $perc.widget.item.properties.get('perc_display_option');\n    $maxCat = $perc.widget.item.properties.get('perc_max_categories').toString().trim();\n    if (empty($maxCat)) {\n        $maxCat = 0;\n    }else{\n        ##Use 0 + to force a integer result\n        $maxCat = 0 + $perc.widget.item.properties.get('perc_max_categories');\n        if( $maxCat < 0){\n            $maxCat = 0;\n        }\n    }\n\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass)) {\n        $rootclass = $rootclass + \" \";\n    }\n    if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n        $params = $rx.string.stringToMap(null);\n        if ( $assetItem.getNode().hasProperty('query') ){\n                $query = $assetItem.getNode().getProperty('query').String;\n        }else{\n                $query = 'select rx:sys_contentid, rx:sys_folderid from rx:percPage';\n        }\n        $params.put('query', $query);\n        $params.put('max_results', $maxCat);\n\t\t$finderName = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n        $relresults =  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n        $processedCategories = $rx.pageutils.getProcessedCategories($relresults);\n        $title = $rx.pageutils.html($assetItem, 'displaytitle');\n\n        ##Category list query starts\n        ##Gets the individual field values\n        $titleContains = $assetItem.getNode().getProperty('title_contains').String;\n        $starDate = $assetItem.getNode().getProperty('start_date').String;\n        $endDate = $assetItem.getNode().getProperty('end_date').String;\n        $sitePath = $assetItem.getNode().getProperty('site_path').String;\n        $templatesList = $assetItem.getNode().getProperty('page_templates_list').String;\n\t\t$categoryPageResult = $assetItem.getNode().getProperty('category_page_result').String;\n        ##Builds the criteria\n        $criteria = \"[\";\n        $criteria = $criteria + \"&quot;type = 'page'&quot;\";\n        $criteriaSep = \", \";\n        if ($titleContains != null && $titleContains != \"\")\n        {\n             $criteria = $criteria + $criteriaSep + \"&quot;dcterms:title LIKE '%\" + $titleContains +\"%'&quot;\";\n        }\n        if ($starDate != null && $starDate != \"\"){\n             $sd = $tools.date.toDate(\"MM/dd/yyyy\",$starDate);\n             $criteria = $criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\";\n        }\n        if ($endDate != null && $endDate != \"\"){\n             $ed = $tools.date.toDate(\"MM/dd/yyyy\",$endDate);\n             $criteria = $criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\";\n        }\n        if ($sitePath != null && $sitePath != \"\" && $sitePath != \"//Sites\")\n        {\n            $temppath = $sitePath.replace(\"//Sites/\", \"\");\n            if($temppath.indexOf(\"/\") > 0)\n            {\n                $temppaths = $temppath.split(\"/\");\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\";\n                $folderpath = \"\";\n                $counter = 1;\n                while($counter < $temppaths.size())\n                {\n                    $folderpath = $folderpath + \"/\" + $temppaths[$counter];\n                    $counter = $counter + 1;\n                }\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\";\n            }\n            else\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\";\n            }\n        }\n        if($templatesList != null && $templatesList != \"\")\n        {\n            $templateNameList = $rx.pageutils.templateNames($templatesList);\n            if($templateNameList.size() == 1)\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\";\n            }\n            else if($templateNameList.size() > 1)\n            {\n                $inCl = \"(\";\n                $counter = 0;\n                $templNameArray = $templateNameList.toArray();\n\n                while($counter < $templNameArray.size())\n                {\n                    $inCl = $inCl + \"'\" + $templNameArray[$counter] + \"'\";\n                    if($counter != $templNameArray.size()-1)\n                        $inCl = $inCl + \", \";\n                    $counter = $counter + 1;\n                }\n                $inCl = $inCl + \")\";\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\";\n            }\n        }\n\n        $criteria = $criteria + \"]\";\n\n        ##Build the query string for the delivery side category list\n\t\t##builds the order by clause\n\n        $dynamicListData = \"{\" + \"&quot;criteria&quot;:\" + $criteria;\n\n\t\t$dynamicListData = $dynamicListData + \", &quot;category_page_result&quot;:&quot;\" +$categoryPageResult + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;display_option&quot;:&quot;\" +$display + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;max_categories&quot;:&quot;\" +$maxCat + \"&quot;\";\n\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n        $dynamicListData = $dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isPreviewMode&quot;:&quot;\" + $isPreviewMode + \"&quot;\";\n        $dynamicListData = $dynamicListData + \"}\";\n        ##Category list query ends\n    }\n    else {\n        ;\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percCategoryListContent",
+      "allowedContentTypes": [
+        "percCategoryList"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLinkCategoryList.png",
+      "target": "rx_resources/widgets/categoryList/images/widgetIconLinkCategoryList.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/perc_common_ui.js",
+      "target": "perc-common-ui/js/perc_common_ui.js",
+      "type": "javascript",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_display_option",
+      "displayName": "Display",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "expanded",
+      "enumValues": [
+        {
+          "value": "expanded",
+          "displayValue": "Expanded hierarchy"
+        },
+        {
+          "value": "collapsible",
+          "displayValue": "Collapsible"
+        }
+      ]
+    },
+    {
+      "name": "perc_max_categories",
+      "displayName": "Maximum number of categories to show",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "10",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/widgets/percCategoryList/templates/percCategoryListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.categoryList/widgets/percCategoryList/templates/percCategoryListSnippet.vm
@@ -1,0 +1,25 @@
+<div class="$!{rootclass} perc-category-list" data-query="$!{dynamicListData}">
+##This is a hidden div that holds the structure of the list when the category list output structure changes this hidden div and delivery side view
+##should be modified to match the new structure.
+#if ($title && $title.length() > 0)##
+    <div class="perc-category-title">$title</div>
+#end##
+#if($display == "expanded")##
+<div class="perc-category-list-expanded">
+#else##
+<div class="perc-category-list-collapsible" maxCat="$!{maxCat}">
+#end##
+#if( ! $perc.widgetContents.isEmpty() )##
+#if($processedCategories)##
+#if($display == "expanded")##
+#perc_processCategoryNodeExpanded($processedCategories, $maxCat, 0, 0)##
+#else##
+#set($nRow = 0)##
+#perc_processCategoryNodeCollapsible($processedCategories, $maxCat, -1)##
+#end##
+#end##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("categorylist-sample-content", "This category list widget is showing sample content.")##
+#end###
+</div>
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/widgets/percCommentsForm/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/widgets/percCommentsForm/component-package.json
@@ -1,0 +1,175 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percCommentsForm",
+  "name": "Comments Form",
+  "version": "1.2.3",
+  "description": "Build a form for submitting comments",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Comments Form",
+    "category": "blog,social",
+    "description": "Build a form for submitting comments",
+    "thumbnail": "resources/WidgetIconComntForm.png",
+    "icon": "resources/WidgetIconComntForm.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 680,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percCommentsFormAsset",
+      "ref": "contentTypes/percCommentsFormAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percCommentsFormSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percCommentsFormSnippet.vm",
+      "contentType": "percCommentsFormAsset",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"perc-label-location-top\""
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"perc-label-location-left\""
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "sUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId) +  \"/perc-comments-services/comment\""
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "siteName",
+          "expression": "$pathParts[2]"
+        },
+        {
+          "variable": "pagePath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "counter",
+          "expression": "0"
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "pagePath",
+          "expression": "$pagePath + \"/\" + $part"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n        $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n        $perc.setWidgetContents($assetItems);\n        if ( ! $assetItems.isEmpty() ) {\n            $assetItem = $assetItems.get(0);\n        }\n\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if(!empty($rootclass)) {\n            $rootclass = $rootclass;\n        }\n        $props = $perc.widget.item.properties;\n        $labelalignclass = \"perc-label-location-top\";\n        if($props.get(\"labelalign\") != null && $props.get(\"labelalign\").equals(\"left\"))\n            $labelalignclass = \"perc-label-location-left\";\n        $pageId = $perc.page.id;\n        $widgetId = $perc.widget.item.id;\n        $sUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId) +  \"/perc-comments-services/comment\";\n        if(!empty($pageId))\n        {\n            $finderPath = $rx.pageutils.getItemPath($pageId);\n            $pathParts = $finderPath.split(\"\\/\");\n            $siteName = $pathParts[2];\n            $pagePath = \"\";\n            $counter = 0;\n            for($part : $pathParts)\n            {\n                $counter = $counter + 1;\n                if($counter > 3)\n                $pagePath = $pagePath + \"/\" + $part;\n            }\n        }\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percCommentsFormContent",
+      "allowedContentTypes": [
+        "percCommentsFormAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/WidgetIconComntForm.png",
+      "target": "rx_resources/widgets/commentsForm/images/WidgetIconComntForm.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "labelalign",
+      "displayName": "Label align",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "top",
+      "enumValues": [
+        {
+          "value": "top",
+          "displayValue": "Top of the control"
+        },
+        {
+          "value": "left",
+          "displayValue": "Left of the control"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/widgets/percCommentsForm/templates/percCommentsFormSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.commentForm/widgets/percCommentsForm/templates/percCommentsFormSnippet.vm
@@ -1,0 +1,35 @@
+#loadRelatedWidgetContents()
+          <div class = "perc-comments-form $!{rootclass} $!{labelalignclass}" data-query="$!{dynamicListData}">
+              #if( ! $perc.widgetContents.isEmpty() )
+                 #set($node = $perc.widgetContents.get(0).node)
+                 #set($formdata = $node.getProperty('rx:formdata').getString())
+                 #set($renderedForm = $node.getProperty('rx:renderedform').getString())
+                 #set($renderedForm = $renderedForm.replace("${tools.esc.q}PERC_RV_COMMENT_FORM_ACTION${tools.esc.q}","${tools.esc.q}${sUrl}${tools.esc.q}"))
+                 #set($renderedForm = $renderedForm.replace("PERC_RV_COMMENT_FORM_ACTION","${tools.esc.q}${sUrl}${tools.esc.q}"))
+                 #set($renderedForm = $renderedForm.replace("${tools.esc.q}PERC_RV_SITE_NAME${tools.esc.q}","${tools.esc.q}${siteName}${tools.esc.q}"))
+                 #set($renderedForm = $renderedForm.replace("PERC_RV_SITE_NAME","${tools.esc.q}${siteName}${tools.esc.q}"))
+                 #set($renderedForm = $renderedForm.replace("${tools.esc.q}PERC_RV_PAGE_PATH${tools.esc.q}","${tools.esc.q}$tools.esc.html($pagePath)${tools.esc.q}"))
+                 #set($renderedForm = $renderedForm.replace("PERC_RV_PAGE_PATH","${tools.esc.q}$tools.esc.html($pagePath)${tools.esc.q}"))
+                 <div class = "perc-form-name">$renderedForm </div>
+                 #if($formdata.contains('Honeypot'))##
+                     <script >
+                         function validatePercForm() {
+                             if(!document.getElementById("topyenoh").value) {
+                                 return true;
+                             }
+                             return false;
+                         }
+                     </script>
+                 #end##
+              #elseif ($perc.isEditMode())
+                 #createEmptyWidgetContent("commentsform-sample-content", "This Form widget is showing sample content.")
+             #end
+
+             #if($perc.isPreviewMode())
+                <script>
+                    window.addEventListener('DOMContentLoaded', function() {
+                        jQuery("input[type = 'submit']").attr('disabled', 'disabled');
+                    });
+                </script>
+             #end
+        </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/widgets/percCookieConsent/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/widgets/percCookieConsent/component-package.json
@@ -1,0 +1,240 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percCookieConsent",
+  "name": "Cookie Consent",
+  "version": "1.1.8",
+  "description": "This widget is used to display a paginated list of people belonging to a selected organization and enable users to search through the list.",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Cookie Consent",
+    "description": "This widget is used to display a paginated list of people belonging to a selected organization and enable users to search through the list.",
+    "thumbnail": "resources/percCookieConsentIcon.png",
+    "icon": "resources/percCookieConsentIcon.png",
+    "author": "Percussion Software Inc.",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percCookieConsent",
+      "ref": "contentTypes/percCookieConsent"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percCookieConsentSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percCookieConsentSnippet.vm",
+      "contentType": "percCookieConsent",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percCookieConsent'"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "overlayPosition",
+          "expression": "$perc.widget.item.properties.get('overlayPosition')"
+        },
+        {
+          "variable": "privacyPolicyLinkText",
+          "expression": "$perc.widget.item.properties.get('privacyPolicyLinkText')"
+        },
+        {
+          "variable": "cookiePolicyLinkText",
+          "expression": "$perc.widget.item.properties.get('cookiePolicyLinkText')"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$perc.widget.item.properties.get('ariaLabel')"
+        },
+        {
+          "variable": "ariaRole",
+          "expression": "$perc.widget.item.properties.get('ariaRole')"
+        },
+        {
+          "variable": "hideInPreview",
+          "expression": "$perc.widget.item.properties.get('hideInPreview')"
+        },
+        {
+          "variable": "overlayPosClass",
+          "expression": "'perc-consent-bottom'"
+        },
+        {
+          "variable": "overlayPosClass",
+          "expression": "'perc-consent-top'"
+        },
+        {
+          "variable": "privacyPolicyLinkText",
+          "expression": "'Privacy Policy'"
+        },
+        {
+          "variable": "cookiePolicyLinkText",
+          "expression": "'Cookie Policy'"
+        },
+        {
+          "variable": "ariaLabelHtml",
+          "expression": "'aria-label=\"' + $ariaLabel + '\"'"
+        },
+        {
+          "variable": "ariaRoleHtml",
+          "expression": "'role=\"' + $ariaRole + '\"'"
+        },
+        {
+          "variable": "assetContentId",
+          "expression": "$assetItem.getNode().getProperty('sys_contentid').String"
+        },
+        {
+          "variable": "consentText",
+          "expression": "$rx.pageutils.html($assetItem, 'consenttext')"
+        },
+        {
+          "variable": "privacypolicy_linkId",
+          "expression": "$assetItem.getNode().getProperty('privacypolicy_linkId').String"
+        },
+        {
+          "variable": "privacypolicy_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $privacypolicy_linkId)"
+        },
+        {
+          "variable": "cookiepolicy_linkId",
+          "expression": "$assetItem.getNode().getProperty('cookiepolicy_linkId').String"
+        },
+        {
+          "variable": "cookiepolicy_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $cookiepolicy_linkId)"
+        },
+        {
+          "variable": "baseUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "siteName",
+          "expression": "$pathParts[2]"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{\" + \"&quot;siteName&quot;:&quot;\" + $siteName + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $baseUrl + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n        $widgetId = $perc.widget.item.id;\n        $rootclass = 'percCookieConsent';\n\n        ## Get asset item(s)\n        $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n        $perc.setWidgetContents($assets);\n\n        $overlayPosition = $perc.widget.item.properties.get('overlayPosition');\n        $privacyPolicyLinkText = $perc.widget.item.properties.get('privacyPolicyLinkText');\n        $cookiePolicyLinkText = $perc.widget.item.properties.get('cookiePolicyLinkText');\n        $ariaLabel = $perc.widget.item.properties.get('ariaLabel');\n        $ariaRole = $perc.widget.item.properties.get('ariaRole');\n        $hideInPreview = $perc.widget.item.properties.get('hideInPreview');\n\n        if ($overlayPosition == 'bottom') {\n            $overlayPosClass = 'perc-consent-bottom';\n        }\n        else if ($overlayPosition == 'top') {\n            $overlayPosClass = 'perc-consent-top';\n        }\n\n        if ($privacyPolicyLinkText == '' || $privacyPolicyLinkText == null) {\n            $privacyPolicyLinkText = 'Privacy Policy';\n        }\n\n        if ($cookiePolicyLinkText == '' || $cookiePolicyLinkText == null) {\n            $cookiePolicyLinkText = 'Cookie Policy';\n        }\n\n        if ($ariaLabel != '' || $ariaLabel != null) {\n            $ariaLabelHtml = 'aria-label=\"' + $ariaLabel + '\"';\n        }\n\n        if ($ariaRole != '' || $ariaRole != null) {\n            $ariaRoleHtml = 'role=\"' + $ariaRole + '\"';\n        }\n\n        if ( ! $assets.isEmpty() )\n        {\n            $assetItem = $assets.get(0); ## Get first item (which may be only item)\n            $assetContentId = $assetItem.getNode().getProperty('sys_contentid').String;\n\n            $consentText = $rx.pageutils.html($assetItem, 'consenttext');\n\n            $privacypolicy_linkId = $assetItem.getNode().getProperty('privacypolicy_linkId').String;\n            $privacypolicy_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $privacypolicy_linkId);\n\n            $cookiepolicy_linkId = $assetItem.getNode().getProperty('cookiepolicy_linkId').String;\n            $cookiepolicy_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $cookiepolicy_linkId);\n\n            $baseUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n            if( ! empty($pageId))\n            {\n                $finderPath = $rx.pageutils.getItemPath($pageId);\n                $pathParts = $finderPath.split(\"\\/\");\n                $siteName = $pathParts[2];\n            }\n\n            ##Build the query string for the delivery side auto list\n            $dynamicListData = \"{\" + \"&quot;siteName&quot;:&quot;\" + $siteName + \"&quot;\";\n            $dynamicListData = $dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $baseUrl + \"&quot;\";\n            $dynamicListData = $dynamicListData + \"}\";\n        }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percCookieConsentContent",
+      "allowedContentTypes": [
+        "percCookieConsent"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percCookieConsentIcon.png",
+      "target": "rx_resources/widgets/percCookieConsent/images/percCookieConsentIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "overlayPosition",
+      "displayName": "Position of the dialog on the screen",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "bottom",
+      "enumValues": [
+        {
+          "value": "top",
+          "displayValue": "Top"
+        },
+        {
+          "value": "bottom",
+          "displayValue": "Bottom"
+        }
+      ]
+    },
+    {
+      "name": "privacyPolicyLinkText",
+      "displayName": "Text to use for privacy policy link text",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Privacy Policy",
+      "enumValues": []
+    },
+    {
+      "name": "cookiePolicyLinkText",
+      "displayName": "Text to use for cookie policy link text",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Cookie Policy",
+      "enumValues": []
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Text to use for 'aria-label' attribute. E.g 'cookie consent'",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "ariaRole",
+      "displayName": "Text to use for 'role' attribute. E.g 'dialog'",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "hideInPreview",
+      "displayName": "Hide cookie consent dialog in preview mode",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/widgets/percCookieConsent/templates/percCookieConsentSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.cookieConsent/widgets/percCookieConsent/templates/percCookieConsentSnippet.vm
@@ -1,0 +1,33 @@
+#if ($assetItem)##
+    ## If the asset has been populated, we don't want to display the overlay as it will overlay widgets. ##
+    ## For this reason, only show in preview mode. ##
+    #if ($perc.isEditMode())##
+       #createEmptyWidgetContent("cookie-consent-preview-content", "This page should be previewed to display the cookie-consent dialog.")##
+    #elseif( $perc.isPreviewMode() && $hideInPreview)##
+        ## do nothing
+    #else##
+    <div id="perc-cookie-consent" $!{ariaRoleHtml} aria-live="polite" $!{ariaLabelHtml} class="perc-consent-window perc-consent-banner $!{overlayPosClass}" data-query="$!{dynamicListData}">
+        <div id="perc-cookieconsent" class="perc-consent-msg">$!{consentText}</div>
+
+        <div class="perc-policy-links">
+            #if ($privacypolicy_path != '#')##
+                <a href="$!{privacypolicy_path}">$!{privacyPolicyLinkText}</a>
+            #end##
+            #if ($cookiepolicy_path != '#')##
+                <a href="$!{cookiepolicy_path}">$!{cookiePolicyLinkText}</a>
+            #end##
+        </div>
+
+        #if ( $perc.isEditMode() || $perc.isPreviewMode() )##
+            <button id="accept-btn-preview" class="perc-consent-btn">Accept</button>
+        #else##
+            <div>
+				<button id="accept-btn" class="perc-consent-btn">Accept</button>
+				<button id="deny-btn" class="perc-consent-btn">Deny</button>
+			</div>
+        #end##
+    </div>
+    #end##
+#elseif ($perc.isEditMode())##
+   #createEmptyWidgetContent("cookie-consent-sample-content", "This cookie consent widget is showing sample content.")##
+#end

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDepartment/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDepartment/component-package.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percDepartment",
+  "name": "Department",
+  "version": "2.1.0",
+  "description": "This widget is used to store details for a department of an organization.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "Percussion Software Inc."
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.7",
+      "implied": false
+    },
+    {
+      "name": "perc.SystemObjects",
+      "version": "1.0.0",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Department",
+    "description": "This widget is used to store details for a department of an organization.",
+    "thumbnail": "resources/percDepartmentIcon.png",
+    "icon": "resources/percDepartmentIcon.png",
+    "author": "Percussion Software Inc.",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 800,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percDepartment",
+      "ref": "contentTypes/percDepartment"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percDepartmentSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percDepartmentSnippet.vm",
+      "contentType": "percDepartment",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percDepartment'"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetContentId",
+          "expression": "$assetItem.getNode().getProperty('sys_contentid').String"
+        },
+        {
+          "variable": "pageName",
+          "expression": "$perc.page.name"
+        },
+        {
+          "variable": "folderName",
+          "expression": "$perc.page.folderPaths.get(0)"
+        },
+        {
+          "variable": "temp",
+          "expression": "$folderName.replace(\"//Sites/\",\"\")"
+        },
+        {
+          "variable": "pathArray",
+          "expression": "$temp.split(\"/\")"
+        },
+        {
+          "variable": "siteDomain",
+          "expression": "$pathArray.get(0)"
+        },
+        {
+          "variable": "dptNameFormat",
+          "expression": "$perc.widget.item.properties.get('dptNameFormat')"
+        },
+        {
+          "variable": "dptNameFormatStartTag",
+          "expression": "'<' + $dptNameFormat + '>'"
+        },
+        {
+          "variable": "dptNameFormatEndTag",
+          "expression": "'</' + $dptNameFormat + '>'"
+        },
+        {
+          "variable": "percHideFieldOrgName",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_orgNameField')"
+        },
+        {
+          "variable": "percHideFieldDptAddress",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_dptAddressField')"
+        },
+        {
+          "variable": "percHideFieldDptPhone",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_dptPhoneField')"
+        },
+        {
+          "variable": "percHideFieldDptFax",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_dptFaxField')"
+        },
+        {
+          "variable": "percHideFieldDptEmail",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_dptEmailField')"
+        },
+        {
+          "variable": "percHideFieldDptPage",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_dptPageField')"
+        },
+        {
+          "variable": "dptName",
+          "expression": "$assetItem.getNode().getProperty('dptName').String"
+        },
+        {
+          "variable": "orgContentId",
+          "expression": "$assetItem.getNode().getProperty('dptOrganization').String"
+        },
+        {
+          "variable": "orgPage_path",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orgPage_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "'select rx:sys_contentid, rx:sys_folderid from rx:percOrganization where rx:sys_contentid = :orgContentId'"
+        },
+        {
+          "variable": "finderName",
+          "expression": "'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder'"
+        },
+        {
+          "variable": "orgResult",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "orgName",
+          "expression": "$orgResult.get(0).getNode().getProperty(\"orgName\").String"
+        },
+        {
+          "variable": "orgPage_linkId",
+          "expression": "$orgResult.get(0).getNode().getProperty(\"orgPage_linkId\").String"
+        },
+        {
+          "variable": "orgPage_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $orgPage_linkId)"
+        },
+        {
+          "variable": "orgPage_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($orgPage_linkId)"
+        },
+        {
+          "variable": "orgPage_pageMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $orgPage_sys_contentId)"
+        },
+        {
+          "variable": "orgPage_title",
+          "expression": "$orgPage_pageMap.get('resource_link_title')"
+        },
+        {
+          "variable": "orgPageExt",
+          "expression": "$orgResult.get(0).getNode().getProperty(\"orgPageExt\").String"
+        },
+        {
+          "variable": "orgPage_path",
+          "expression": "$orgPageExt"
+        },
+        {
+          "variable": "orgPage_title",
+          "expression": "$orgPageExt"
+        },
+        {
+          "variable": "dptAddress1",
+          "expression": "$assetItem.getNode().getProperty('dptAddress1').String"
+        },
+        {
+          "variable": "dptAddress2",
+          "expression": "$assetItem.getNode().getProperty('dptAddress2').String"
+        },
+        {
+          "variable": "dptCity",
+          "expression": "$assetItem.getNode().getProperty('dptCity').String"
+        },
+        {
+          "variable": "dptState",
+          "expression": "$assetItem.getNode().getProperty('dptState').String"
+        },
+        {
+          "variable": "dptPostCode",
+          "expression": "$assetItem.getNode().getProperty('dptPostCode').String"
+        },
+        {
+          "variable": "dptCountry",
+          "expression": "$assetItem.getNode().getProperty('dptCountry').String"
+        },
+        {
+          "variable": "dptAddress3",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dptAddress3",
+          "expression": "$dptAddress3 + $dptCity"
+        },
+        {
+          "variable": "dptAddress3",
+          "expression": "$dptAddress3 + \", \""
+        },
+        {
+          "variable": "dptAddress3",
+          "expression": "$dptAddress3 + $dptState"
+        },
+        {
+          "variable": "dptAddress3",
+          "expression": "$dptAddress3 + \" \" + $dptPostCode"
+        },
+        {
+          "variable": "dptEmail",
+          "expression": "$assetItem.getNode().getProperty('dptEmail').String"
+        },
+        {
+          "variable": "dptPhone",
+          "expression": "$assetItem.getNode().getProperty('dptPhone').String"
+        },
+        {
+          "variable": "dptFax",
+          "expression": "$assetItem.getNode().getProperty('dptFax').String"
+        },
+        {
+          "variable": "dptWebsite_linkId",
+          "expression": "$assetItem.getNode().getProperty('dptWebsite_linkId').String"
+        },
+        {
+          "variable": "dptWebsite_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $dptWebsite_linkId)"
+        },
+        {
+          "variable": "dptWebsite_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dptWebsite_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($dptWebsite_linkId)"
+        },
+        {
+          "variable": "dptWebsite_pageMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $dptWebsite_sys_contentId)"
+        },
+        {
+          "variable": "dptWebsite_title",
+          "expression": "$dptWebsite_pageMap.get('resource_link_title')"
+        },
+        {
+          "variable": "dptWebsiteExt",
+          "expression": "$assetItem.getNode().getProperty('dptWebsiteExt').String"
+        },
+        {
+          "variable": "dptWebsite_path",
+          "expression": "$dptWebsiteExt"
+        },
+        {
+          "variable": "dptWebsite_title",
+          "expression": "$dptWebsiteExt"
+        },
+        {
+          "variable": "scriptSchemaId",
+          "expression": "\"perc-department-schema-\" + $assetContentId"
+        },
+        {
+          "variable": "dptSchema",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "orgWebsiteURL",
+          "expression": "\"//\" + $siteDomain"
+        },
+        {
+          "variable": "departmentSubSchema",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "dptMailTo",
+          "expression": "\"mailto:\" + $dptEmail"
+        },
+        {
+          "variable": "dptWebsiteURL",
+          "expression": "\"//\" + $siteDomain + $dptWebsite_path"
+        },
+        {
+          "variable": "dptAddressSchema",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "dptStreetAddress",
+          "expression": "$dptAddress1 + '' + $dptAddress2"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = 'percDepartment';\n\n       ## Get asset item(s)\n       $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n       $perc.setWidgetContents($assets);\n\n       if (! $assets.isEmpty())\n       {\n            $assetItem = $assets.get(0); ## Get first item (which may be only item)\n            $assetContentId = $assetItem.getNode().getProperty('sys_contentid').String;\n\n            ## Get site domain name\n            $pageName = $perc.page.name;\n            $folderName = $perc.page.folderPaths.get(0);\n            $temp = $folderName.replace(\"//Sites/\",\"\");\n            $pathArray = $temp.split(\"/\");\n            $siteDomain = $pathArray.get(0);\n\n            ## Get Widget Layout Properties\n            ##\n            $dptNameFormat = $perc.widget.item.properties.get('dptNameFormat');\n            if (!empty($dptNameFormat))\n            {\n                $dptNameFormatStartTag = '<' + $dptNameFormat + '>';\n                $dptNameFormatEndTag = '</' + $dptNameFormat + '>';\n            }\n            $percHideFieldOrgName = $perc.widget.item.properties.get('perc_hidefield_orgNameField');\n            $percHideFieldDptAddress = $perc.widget.item.properties.get('perc_hidefield_dptAddressField');\n            $percHideFieldDptPhone = $perc.widget.item.properties.get('perc_hidefield_dptPhoneField');\n            $percHideFieldDptFax = $perc.widget.item.properties.get('perc_hidefield_dptFaxField');\n            $percHideFieldDptEmail = $perc.widget.item.properties.get('perc_hidefield_dptEmailField');\n            $percHideFieldDptPage = $perc.widget.item.properties.get('perc_hidefield_dptPageField');\n\n            ## Get Widget Content Properties\n            ##\n            $dptName = $assetItem.getNode().getProperty('dptName').String;\n\n            ##\n            ## Get Organization Name from contentId\n            ##\n            $orgContentId = $assetItem.getNode().getProperty('dptOrganization').String;\n            $orgPage_path = \"\";\n            $orgPage_title = \"\";\n            if ($orgContentId != \"\" && $orgContentId != \"#\")\n            {\n                $params = $rx.string.stringToMap(null);\n                $params.put('orgContentId', $orgContentId );\n                $query = 'select rx:sys_contentid, rx:sys_folderid from rx:percOrganization where rx:sys_contentid = :orgContentId';\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder';\n                $orgResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                    if( $orgResult.size() > 0 )\n                    {\n                        $orgName = $orgResult.get(0).getNode().getProperty(\"orgName\").String;\n                        $orgPage_linkId = $orgResult.get(0).getNode().getProperty(\"orgPage_linkId\").String;\n                        $orgPage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $orgPage_linkId);\n                        $orgPage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($orgPage_linkId);\n                        if ($orgPage_sys_contentId != \"\")\n                        {\n                            $orgPage_pageMap = $rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $orgPage_sys_contentId);\n                            $orgPage_title = $orgPage_pageMap.get('resource_link_title');\n                        }\n                        $orgPageExt = $orgResult.get(0).getNode().getProperty(\"orgPageExt\").String;\n                        if ($orgPageExt != \"\"){\n                            $orgPage_path = $orgPageExt;\n                            $orgPage_title = $orgPageExt;\n                        }\n                    }\n            }\n\n            $dptAddress1 = $assetItem.getNode().getProperty('dptAddress1').String;\n            $dptAddress2 = $assetItem.getNode().getProperty('dptAddress2').String;\n            $dptCity = $assetItem.getNode().getProperty('dptCity').String;\n            $dptState = $assetItem.getNode().getProperty('dptState').String;\n            $dptPostCode = $assetItem.getNode().getProperty('dptPostCode').String;\n            $dptCountry = $assetItem.getNode().getProperty('dptCountry').String;\n\n            $dptAddress3 = \"\";\n            if ($dptCity != \"\")\n            {\n                $dptAddress3 = $dptAddress3 + $dptCity;\n            }\n            if ($dptCity != \"\" && $dptState != \"\")\n            {\n                $dptAddress3 = $dptAddress3 + \", \";\n            }\n            if ($dptState != \"\")\n            {\n                $dptAddress3 = $dptAddress3 + $dptState;\n            }\n            if ($dptPostCode != \"\")\n            {\n                $dptAddress3 = $dptAddress3 + \" \" + $dptPostCode;\n            }\n\n            $dptEmail = $assetItem.getNode().getProperty('dptEmail').String;\n            $dptPhone = $assetItem.getNode().getProperty('dptPhone').String;\n            $dptFax = $assetItem.getNode().getProperty('dptFax').String;\n            $dptWebsite_linkId = $assetItem.getNode().getProperty('dptWebsite_linkId').String;\n            $dptWebsite_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $dptWebsite_linkId);\n            $dptWebsite_title = \"\";\n            $dptWebsite_sys_contentId = $rx.pageutils.getManagedLinkDependentId($dptWebsite_linkId);\n            if ($dptWebsite_sys_contentId != \"\")\n            {\n                $dptWebsite_pageMap = $rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $dptWebsite_sys_contentId);\n                $dptWebsite_title = $dptWebsite_pageMap.get('resource_link_title');\n            }\n\n            $dptWebsiteExt = $assetItem.getNode().getProperty('dptWebsiteExt').String;\n            if ($dptWebsiteExt != \"\")\n            {\n                $dptWebsite_path = $dptWebsiteExt;\n                $dptWebsite_title = $dptWebsiteExt;\n            }\n            ##\n            ## Schema.org Markup\n            ##\n            $scriptSchemaId = \"perc-department-schema-\" + $assetContentId;\n            $dptSchema = $rx.string.getJSONObject();\n            $dptSchema.put(\"@context\", \"http://schema.org\");\n            $dptSchema.put(\"@type\", \"Organization\");\n            if (! empty($dptOrganization)) {\n                $dptSchema.put(\"name\", $orgName);\n            }\n            if (! empty($orgPage_path) && $orgPage_path != \"#\") {\n                $orgWebsiteURL = \"//\" + $siteDomain;\n                $dptSchema.put(\"url\", $orgWebsiteURL);\n            }\n            if (! empty($dptName)) {\n                $departmentSubSchema = $rx.string.getJSONObject();\n                $departmentSubSchema.put(\"@type\", \"Organization\");\n                if (! empty($dptName)) {\n                    $departmentSubSchema.put(\"name\", $dptName);\n                }\n                if (! empty($dptEmail) && !($percHideFieldDptEmail)) {\n                    $dptMailTo = \"mailto:\" + $dptEmail;\n                    $departmentSubSchema.put(\"email\", $dptMailTo);\n                }\n                if (! empty($dptPhone) ) {\n                    $departmentSubSchema.put(\"telephone\", $dptPhone);\n                }\n                if (! empty($dptFax)) {\n                    $departmentSubSchema.put(\"faxNumber\", $dptFax);\n                }\n                if (! empty($dptWebsite_path)) {\n                    $dptWebsiteURL = \"//\" + $siteDomain + $dptWebsite_path;\n                    $departmentSubSchema.put(\"url\", $dptWebsiteURL);\n                }\n                $dptAddressSchema = $rx.string.getJSONObject();\n                $dptStreetAddress = $dptAddress1 + '' + $dptAddress2;\n                if(! empty($dptStreetAddress)){\n                    $dptAddressSchema.put(\"streetAddress\", $dptStreetAddress);\n                }\n                if(! empty($dptCity) ){\n                    $dptAddressSchema.put(\"addressLocality\", $dptCity);\n                }\n                if(! empty($dptState) ){\n                    $dptAddressSchema.put(\"addressRegion\", $dptState);\n                }\n                if(! empty($dptCountry)){\n                    $dptAddressSchema.put(\"addressCountry\", $dptCountry);\n                }\n                if(! empty($dptPostCode) ){\n                    $dptAddressSchema.put(\"postalCode\", $dptPostCode);\n                }\n                $departmentSubSchema.put(\"address\", $dptAddressSchema);\n                $dptSchema.put(\"department\", $departmentSubSchema);\n            }\n            ## End Schema.org Markup\n       }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percDepartmentContent",
+      "allowedContentTypes": [
+        "percDepartment"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percDepartmentIcon.png",
+      "target": "rx_resources/widgets/percDepartment/images/percDepartmentIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "dptNameFormat",
+      "displayName": "Format of Department Name",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        }
+      ]
+    },
+    {
+      "name": "perc_hidefield_orgNameField",
+      "displayName": "Hide Organization Name",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_dptAddressField",
+      "displayName": "Hide Department Address",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_dptPhoneField",
+      "displayName": "Hide Department Phone",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_dptFaxField",
+      "displayName": "Hide Department Fax",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_dptEmailField",
+      "displayName": "Hide Department Email",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_dptPageField",
+      "displayName": "Hide Department Page",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_dptOrganizationField",
+      "displayName": "Hide Organization",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDepartment/templates/percDepartmentSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDepartment/templates/percDepartmentSnippet.vm
@@ -1,0 +1,51 @@
+<div class="$!rootclass">
+#if( ! $perc.widgetContents.isEmpty() )
+            <div>
+#set($addlHead = $perc.page.getAdditionalHeadContent())##
+## Check for existing Schema if using multiple instances of widget on same page
+#if( !($addlHead.contains($scriptSchemaId)) )##
+                    $perc.page.setAdditionalHeadContent("$!{addlHead}<script async id='$!{scriptSchemaId}' type='application/ld+json'>$!{dptSchema}</script>")##
+#end##
+## Display Department Name with selected formatting HTML tags
+#if( !($percHideFieldOrgName) )##
+                    <div class="perc-org-name">$!{orgName}</div>
+#end##
+                <div class="perc-dpt-name">
+#if( "$!{dptWebsite_path}" != "" && "$!{dptWebsite_path}" != "#" )##
+                        <a href="$dptWebsite_path" title="$dptWebsite_title">
+                            $!{dptNameFormatStartTag}${dptName}$!{dptNameFormatEndTag}
+                        </a>
+#else##
+                        $!{dptNameFormatStartTag}${dptName}$!{dptNameFormatEndTag}
+#end##
+                </div>
+#if( !($percHideFieldDptAddress) )##
+                    <div class="perc-dpt-address">
+#if( "$!{dptAddress1}" != "" && "$!{dptAddress1}" != "#" )##
+                            <div class="perc-address-street-1"><p>$!{dptAddress1}</p></div>
+#end##
+#if( "$!{dptAddress2}" != "" && "$!{dptAddress2}" != "#" )##
+                            <div class="perc-address-street-2"><p>$!{dptAddress2}</p></div>
+#end##
+#if( "$!{dptAddress3}" != "" && "$!{dptAddress3}" != "#" )##
+                            <div class="perc-address-city-state-post"><p>$!{dptAddress3}</p></div>
+#end##
+#if( "$!{dptCountry}" != "" && "$!{dptCountry}" != "#" )##
+                            <div class="perc-address-country"><p>$!{dptCountry}</p></div>
+#end##
+                    </div>
+#end##
+#if( !($percHideFieldDptPhone) && "$!{dptPhone}" != "" && "$!{dptPhone}" != "#" )##
+                    <div class="perc-dpt-phone"><p>$!{dptPhone}</p></div>
+#end##
+#if( !($percHideFieldDptFax) && $!{dptFax} != "" && $!{dptFax} != "#" )##
+                    <div class="perc-dpt-fax"><p>$!{dptFax}</p></div>
+#end##
+#if( !($percHideFieldDptEmail) && $!{dptEmail} != "" && $!{dptEmail} != "#" )##
+                    <div class="perc-dpt-email"><p>$!{dptEmail}</p></div>
+#end##
+            </div>
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("percDepartment-empty-style", "This widget is showing sample content")
+#end
+       </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDirectory/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDirectory/component-package.json
@@ -1,0 +1,418 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percDirectory",
+  "name": "Directory",
+  "version": "2.1.0",
+  "description": "This widget is used to display a paginated list of people belonging to a selected organization and enable users to search through the list.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "Percussion Software Inc."
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.7",
+      "implied": false
+    },
+    {
+      "name": "perc.SystemObjects",
+      "version": "1.0.0",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Directory",
+    "description": "This widget is used to display a paginated list of people belonging to a selected organization and enable users to search through the list.",
+    "thumbnail": "resources/percDirectoryIcon.png",
+    "icon": "resources/percDirectoryIcon.png",
+    "author": "Percussion Software Inc.",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percDirectory",
+      "ref": "contentTypes/percDirectory"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percDirectorySnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percDirectorySnippet.vm",
+      "contentType": "percDirectory",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percDirectory'"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetContentId",
+          "expression": "$assetItem.getNode().getProperty('sys_contentid').String"
+        },
+        {
+          "variable": "dirTitleFormat",
+          "expression": "$perc.widget.item.properties.get('dirTitleFormat')"
+        },
+        {
+          "variable": "dirTitleFormatStartTag",
+          "expression": "'<' + $dirTitleFormat + ' class=\"perc-directory-title\">'"
+        },
+        {
+          "variable": "dirTitleFormatEndTag",
+          "expression": "'</' + $dirTitleFormat + '>'"
+        },
+        {
+          "variable": "directoryLayoutFormat",
+          "expression": "$perc.widget.item.properties.get('directoryLayoutFormat')"
+        },
+        {
+          "variable": "percHideFieldTextSearch",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_textSearch')"
+        },
+        {
+          "variable": "percHideFieldFilterDropdown",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_filter_dropdown')"
+        },
+        {
+          "variable": "percHideFieldFilterByDpt",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_filter_by_dpt')"
+        },
+        {
+          "variable": "percHideFieldPersonOrganization",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personOrganization')"
+        },
+        {
+          "variable": "percHideFieldPersonDepartment",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personDepartment')"
+        },
+        {
+          "variable": "percHideFieldPersonTitle",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personTitle')"
+        },
+        {
+          "variable": "percHideFieldPersonPhone",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personPhoneField')"
+        },
+        {
+          "variable": "percHideFieldPersonOfficeLocation",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personOfficeLocation')"
+        },
+        {
+          "variable": "percHideFieldPersonEmail",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personEmailField')"
+        },
+        {
+          "variable": "percHideFieldPersonImage",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personImageField')"
+        },
+        {
+          "variable": "percDisplayFullDir",
+          "expression": "$perc.widget.item.properties.get('perc_display_full_dir')"
+        },
+        {
+          "variable": "directoryTitle",
+          "expression": "$assetItem.getNode().getProperty('directoryTitle').String"
+        },
+        {
+          "variable": "customPlaceholderImg_linkId",
+          "expression": "$assetItem.getNode().getProperty('customPlaceholderImg_linkId').String"
+        },
+        {
+          "variable": "customPlaceholderImg_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $customPlaceholderImg_linkId, $sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "customPlaceholderImg_alt_text",
+          "expression": "\"\""
+        },
+        {
+          "variable": "customPlaceholderImg_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "customPlaceholderImg_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($customPlaceholderImg_linkId)"
+        },
+        {
+          "variable": "customPlaceholderImg_assetMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percImageAsset', 'displaytitle,alttext', $customPlaceholderImg_sys_contentId)"
+        },
+        {
+          "variable": "customPlaceholderImg_alt_text",
+          "expression": "$customPlaceholderImg_assetMap.get('alttext')"
+        },
+        {
+          "variable": "customPlaceholderImg_title",
+          "expression": "$customPlaceholderImg_assetMap.get('displaytitle')"
+        },
+        {
+          "variable": "organizationSearch",
+          "expression": "$assetItem.getNode().getProperty('organizationSearch').String"
+        },
+        {
+          "variable": "departmentId",
+          "expression": "$assetItem.getNode().getProperty('departmentID').String"
+        },
+        {
+          "variable": "deptId",
+          "expression": "$tools.math.toInteger($departmentId)"
+        },
+        {
+          "variable": "orgSearchId",
+          "expression": "$tools.math.toInteger($organizationSearch)"
+        },
+        {
+          "variable": "orgName",
+          "expression": "\"\""
+        },
+        {
+          "variable": "doNotShowDeptFilter",
+          "expression": "'data-show-dpt-filter=\"false\"'"
+        },
+        {
+          "variable": "doNotShowDeptFilter",
+          "expression": "'data-show-dpt-filter=\"true\"'"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "directoryResults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "'select rx:orgName from rx:percOrganization where rx:sys_contentid = :orgSearchId'"
+        },
+        {
+          "variable": "finderName",
+          "expression": "'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder'"
+        },
+        {
+          "variable": "orgResult",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "orgName",
+          "expression": "$orgResult.get(0).getNode().getProperty('orgName').String"
+        },
+        {
+          "variable": "orgFiltersArray",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "'select rx:sys_contentid, rx:sys_folderid from rx:percOrganization order by rx:orgName asc'"
+        },
+        {
+          "variable": "finderName",
+          "expression": "'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder'"
+        },
+        {
+          "variable": "orgResults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "orgFilter",
+          "expression": "$org.getNode().getProperty('orgName').String"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = 'percDirectory';\n\n       ## Get asset item(s)\n       $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n       $perc.setWidgetContents($assets);\n\n       if (! $assets.isEmpty())\n       {\n            $assetItem = $assets.get(0); ## Get first item (which may be only item)\n            $assetContentId = $assetItem.getNode().getProperty('sys_contentid').String;\n\n            ## Get Widget Layout Properties\n            ##\n            $dirTitleFormat = $perc.widget.item.properties.get('dirTitleFormat');\n            if (!empty($dirTitleFormat))\n            {\n                $dirTitleFormatStartTag = '<' + $dirTitleFormat + ' class=\"perc-directory-title\">';\n                $dirTitleFormatEndTag = '</' + $dirTitleFormat + '>';\n            }\n            $directoryLayoutFormat = $perc.widget.item.properties.get('directoryLayoutFormat');\n            $percHideFieldTextSearch = $perc.widget.item.properties.get('perc_hidefield_textSearch');\n            $percHideFieldFilterDropdown = $perc.widget.item.properties.get('perc_hidefield_filter_dropdown');\n            $percHideFieldFilterByDpt = $perc.widget.item.properties.get('perc_hidefield_filter_by_dpt');\n            $percHideFieldPersonOrganization = $perc.widget.item.properties.get('perc_hidefield_personOrganization');\n            $percHideFieldPersonDepartment = $perc.widget.item.properties.get('perc_hidefield_personDepartment');\n            $percHideFieldPersonTitle = $perc.widget.item.properties.get('perc_hidefield_personTitle');\n            $percHideFieldPersonPhone = $perc.widget.item.properties.get('perc_hidefield_personPhoneField');\n            $percHideFieldPersonOfficeLocation= $perc.widget.item.properties.get('perc_hidefield_personOfficeLocation');\n\n            $percHideFieldPersonEmail = $perc.widget.item.properties.get('perc_hidefield_personEmailField');\n            $percHideFieldPersonImage = $perc.widget.item.properties.get('perc_hidefield_personImageField');\n            $percDisplayFullDir = $perc.widget.item.properties.get('perc_display_full_dir');\n\n            ##\n            ## Get Widget Content Properties\n            ##\n            $directoryTitle = $assetItem.getNode().getProperty('directoryTitle').String;\n\n            ##\n            ## Get custom placeholder image\n            ##\n            $customPlaceholderImg_linkId = $assetItem.getNode().getProperty('customPlaceholderImg_linkId').String;\n            $customPlaceholderImg_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $customPlaceholderImg_linkId, $sys.assemblyItem.PubServerId);\n            $customPlaceholderImg_alt_text = \"\";\n            $customPlaceholderImg_title = \"\";\n            $customPlaceholderImg_sys_contentId = $rx.pageutils.getManagedLinkDependentId($customPlaceholderImg_linkId);\n            if ($customPlaceholderImg_sys_contentId != \"\")\n            {\n                $customPlaceholderImg_assetMap = $rx.pageutils.findItemFieldValues('percImageAsset', 'displaytitle,alttext', $customPlaceholderImg_sys_contentId);\n                $customPlaceholderImg_alt_text = $customPlaceholderImg_assetMap.get('alttext');\n                $customPlaceholderImg_title = $customPlaceholderImg_assetMap.get('displaytitle');\n            }\n\n            $organizationSearch = $assetItem.getNode().getProperty('organizationSearch').String;\n            $departmentId = $assetItem.getNode().getProperty('departmentID').String;\n            $deptId = $tools.math.toInteger($departmentId);\n            $orgSearchId = $tools.math.toInteger($organizationSearch);\n            $orgName = \"\";\n\n            ##\n            ## If a department filter has been selected, we want to hide the department filter/selector\n            ##\n            if ($deptId != -1) {\n                $doNotShowDeptFilter = 'data-show-dpt-filter=\"false\"';\n            }\n            else {\n                $doNotShowDeptFilter = 'data-show-dpt-filter=\"true\"';\n            }\n\n            if ($orgSearchId != 0)\n            {\n                ##\n                ## Retreive List of People tagged to this Organization\n                ##\n                $params = $rx.string.stringToMap(null);\n                if ($orgSearchId > 0)\n                {\n                    $params.put('orgSearchId', $orgSearchId);\n                    if ($deptId == -1)\n                    {\n                        $params.put('query', \"select rx:sys_contentid, rx:sys_folderid from rx:percPerson where rx:personOrganization = :orgSearchId and rx:sys_contentstateid != 7 order by rx:personLastName\");\n                    }\n                    else if ($deptId > 0)\n                    {\n                        $params.put('deptSearchId', $deptId);\n                        $params.put('query', \"select rx:sys_contentid, rx:sys_folderid from rx:percPerson where rx:personOrganization = :orgSearchId and rx:personDepartment = :deptSearchId and rx:sys_contentstateid != 7 order by rx:personLastName\");\n                    }\n                }\n                else if ($orgSearchId == -1)\n                {\n                    if ($deptId == -1) {\n                        $params.put('query', \"select rx:sys_contentid, rx:sys_folderid from rx:percPerson where rx:personOrganization != '#' and rx:sys_contentstateid != 7 order by rx:personLastName\");\n                    }\n                    else if ($deptId > 0)\n                    {\n                        $params.put('deptSearchId', $deptId);\n                        $params.put('query', \"select rx:sys_contentid, rx:sys_folderid from rx:percPerson where rx:personOrganization != '#' and rx:personDepartment = :deptSearchId and rx:sys_contentstateid != 7 order by rx:personLastName\");\n                    }\n                }\n                $params.put('max_results', 5000);\n                $finderName =\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n                $directoryResults =  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n\n                if ($orgSearchId > 0)\n                {\n                    ##\n                    ## Get Label Name for selected Organization\n                    ##\n                    ##\n                    $params = $rx.string.stringToMap(null);\n                    $params.put('orgSearchId', $orgSearchId);\n                    $query = 'select rx:orgName from rx:percOrganization where rx:sys_contentid = :orgSearchId';\n                    $params.put('query', $query);\n                    $params.put('max_results', 1);\n                    $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder';\n                    $orgResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n\n                    if( $orgResult.size() > 0 )\n                    {\n                        $orgName = $orgResult.get(0).getNode().getProperty('orgName').String;\n                    }\n                }\n            }\n            if ($orgSearchId == -1)\n            {\n                $orgFiltersArray = $rx.string.stringToMap(null);\n\n                $params = $rx.string.stringToMap(null);\n                $query = 'select rx:sys_contentid, rx:sys_folderid from rx:percOrganization order by rx:orgName asc';\n                $params.put('query', $query);\n                $params.put('max_results', 2000);\n                $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder';\n                $orgResults = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                if( $orgResults.size() > 0 )\n                {\n                    for ($org : $orgResults)\n                    {\n                        $orgFilter = $org.getNode().getProperty('orgName').String;\n                        $orgFiltersArray.put($orgFilter, $orgFilter);\n                    }\n                }\n            }\n       }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percDirectoryContent",
+      "allowedContentTypes": [
+        "percDirectory"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percDirectoryIcon.png",
+      "target": "rx_resources/widgets/percDirectory/images/percDirectoryIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "dirTitleFormat",
+      "displayName": "Format of directory title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "h2",
+      "enumValues": [
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        }
+      ]
+    },
+    {
+      "name": "directoryLayoutFormat",
+      "displayName": "Layout format: Table or Card",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "table",
+      "enumValues": [
+        {
+          "value": "table",
+          "displayValue": "Table"
+        },
+        {
+          "value": "card",
+          "displayValue": "Card"
+        }
+      ]
+    },
+    {
+      "name": "perc_hidefield_textSearch",
+      "displayName": "Hide text search box",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_filter_dropdown",
+      "displayName": "Hide dropdown filter menu",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personOrganization",
+      "displayName": "Hide organization",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personDepartment",
+      "displayName": "Hide department",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personTitle",
+      "displayName": "Hide position/title",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personPhoneField",
+      "displayName": "Hide phone number",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personOfficeLocation",
+      "displayName": "Hide Office Location",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personEmailField",
+      "displayName": "Hide 'Send Email' link",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personImageField",
+      "displayName": "Hide image",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_display_full_dir",
+      "displayName": "Display full directory",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDirectory/templates/percDirectorySnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percDirectory/templates/percDirectorySnippet.vm
@@ -1,0 +1,554 @@
+<div class="$!rootclass">
+#if( ! $perc.widgetContents.isEmpty() )
+##
+## Schema.org ItemList JSON-LD (built while iterating $directoryResults)
+## Multi-instance de-dupe uses script id, same pattern as percPerson / percOrganization / percDepartment.
+##
+#set( $scriptSchemaId = "perc-directory-schema-" + $assetContentId )##
+#set( $directorySchema = $rx.string.getJSONObject() )##
+#set( $dummy = $directorySchema.put("@context", "http://schema.org") )##
+#set( $dummy = $directorySchema.put("@type", "ItemList") )##
+#if( "$!{directoryTitle}" != "" )##
+#set( $dummy = $directorySchema.put("name", $directoryTitle) )##
+#end##
+#set( $itemListElement = $rx.string.getJSONArray() )##
+#set( $schemaItemPosition = 0 )##
+##
+## Script to Initialize perc-directory.js
+##
+#if( $orgSearchId == -1 )##
+            <div id="percDirectoryList" data-directory-results-size="$directoryResults.size()" data-directory-org-name="$!{orgName}" data-search-all-orgs="true" data-display-full-directory="$!{percDisplayFullDir}" $!{doNotShowDeptFilter}>
+#else##
+            <div id="percDirectoryList" data-directory-results-size="$directoryResults.size()" data-directory-org-name="$!{orgName}" data-search-all-orgs="false" data-display-full-directory="$!{percDisplayFullDir}" $!{doNotShowDeptFilter}>
+#end##
+##
+## Search Box HTML
+##
+                <div class="perc-directory-name">
+                    $!{dirTitleFormatStartTag}${directoryTitle}$!{dirTitleFormatEndTag}
+                </div>
+                <div id="perc-directory-search">
+#if( !($percHideFieldTextSearch) )##
+                    <label for="search-directory" role="search" id="perc-search-directory">Search Directory</label>
+                    <input id="search-directory" role="search" class="search" placeholder="Search Directory" />
+#end##
+##
+## Search Results HTML
+##
+                </div>
+## end perc-directory-search
+                <div id="perc-directory-alphabet-sort">
+                    <div class="perc-alpha-sort-label">Filter by Last Name</div>
+                    <!-- populate letters for filter sorting here -->
+                    <span id="perc-alpha-sort-letters"></span>
+                    <button id="perc-clear-alpha-filter" class="perc-directory-button" style="display:none;" aria-label="Clear Filter">Clear Filter</button>
+                </div>
+#if( !($percHideFieldFilterDropdown) && $orgSearchId == -1 )##
+                <div class="perc-filter-wrapper">
+                    <select name="perc-org-filter" id="perc-org-filter">
+                        <option value="all">Filter by Organization</option>
+#foreach( $org in $orgFiltersArray )##
+                        <option value="$!{org}">$!{org}</option>
+#end##
+                    </select>
+                </div>
+                <div class="perc-filter-wrapper">
+#if( $orgSearchId > 0 && $deptId == -1 )##
+                    <select name="perc-dpt-filter" data-tezt="tezt" id="perc-dpt-filter">
+                    </select>
+#else##
+                    <select name="perc-dpt-filter" id="perc-dpt-filter" style="display:none;">
+                    </select>
+#end##
+                </div>
+#end##
+##
+#if( $directoryLayoutFormat == "table" )##
+##
+                <table role="table" summary="This table organizes the directory using last name, organizaton, department, title, phone number, or email">
+                    <thead role="rowgroup">
+                        <tr>
+#if( !($percHideFieldPersonImage) )##
+                            <th id="perc-sort-image" class="perc-sort-field">
+                            </th>
+#end##
+                            <!--<th id="perc-sort-first-name" class="perc-sort-field" role="columnheader"></th>-->
+                            <th id="perc-sort-last-name" class="perc-sort-field" role="columnheader">
+                                <a class="sort" tabindex="0" aria-label="Filter by last name" data-sort="perc-person-last-name">Name</a>
+                            </th>
+#if( !($percHideFieldPersonOrganization) )##
+                            <th id="perc-sort-org" class="perc-sort-field">
+                                <a class="sort" tabindex="0" aria-label="Sort by organization" data-sort="perc-person-org">Organization</a>
+                            </th>
+#end##
+#if( !($percHideFieldPersonDepartment) )##
+                            <th id="perc-sort-dpt" class="perc-sort-field">
+                                <a class="sort" tabindex="0" aria-label="Sort by department" data-sort="perc-person-dpt">Department</a>
+                            </th>
+#end##
+#if( !($percHideFieldPersonTitle) )##
+                            <th id="perc-sort-title" class="perc-sort-field">
+                                <a class="sort" tabindex="0" aria-label="Sort by title" data-sort="perc-person-title">Title</a>
+                            </th>
+#end##
+#if( !($percHideFieldPersonPhone) )##
+                            <th id="perc-sort-phone" class="perc-sort-field">
+                                <a class="sort" tabindex="0" aria-label="Sort by phone" data-sort="perc-person-phone">Phone</a>
+                            </th>
+#end##
+#if( !($percHideFieldPersonOfficeLocation) )##
+                            <th id="perc-sort-office-location" class="perc-sort-field">
+                                <a class="sort" tabindex="0" aria-label="Sort by Office Location" data-sort="perc-person-office-location">Office Location</a>
+                            </th>
+#end##
+
+#if( !($percHideFieldPersonEmail) )##
+                            <th id="perc-sort-email" class="perc-sort-field">
+                                <a class="sort" tabindex="0" aria-label="Sort by email" data-sort="perc-person-email">Email</a>
+                            </th>
+#end##
+                        </tr>
+                    </thead>
+                    <tbody class="list perc-directory-list">
+##
+#else## If format layout is Card generate buttons for cards
+##
+                <div class="perc-directory-sort-buttons">
+                    <button class="sort perc-directory-button" aria-label="Filter by last name" data-sort="perc-person-last-name">Filter by Last Name</button>
+#if( !($percHideFieldPersonOrganization))##
+                    <button class="sort perc-directory-button" aria-label="Sort by organization" data-sort="perc-person-org">Sort by Organization</button>
+#end##
+#if( !($percHideFieldPersonDepartment) )##
+                    <button class="sort perc-directory-button" aria-label="Sort by department" data-sort="perc-person-dpt">Sort by Department</button>
+#end##
+#if( !($percHideFieldPersonTitle) )##
+                    <button class="sort perc-directory-button" aria-label="Sort by title" data-sort="perc-person-title">Sort by Title</button>
+#end##
+#if( !($percHideFieldPersonPhone) )##
+                    <button class="sort perc-directory-button" aria-label="Sort by phone" data-sort="perc-person-phone">Sort by Phone</button>
+#end##
+#if( !($percHideFieldPersonOfficeLocation) )##
+                    <button class="sort perc-directory-button" aria-label="Sort by office location" data-sort="perc-person-office-location">Sort by Office Location</button>
+#end##
+#if( !($percHideFieldPersonEmail) )##
+                    <button class="sort perc-directory-button" aria-label="Sort by email" data-sort="perc-person-email">Sort by Email</button>
+#end##
+                </div>
+## End perc-directory-sort-buttons
+##
+                <ul class="list perc-directory-list">
+#end##
+##
+#if( $directoryResults.size() > 0 )##
+##
+#foreach( $person in $directoryResults )##
+##
+## Reset variable values for each loop
+#set( $personAssetContentId = "" )##
+#set( $personNamePrefix = "" )##
+#set( $personFirstName = "" )##
+#set( $personLastName = "" )##
+#set( $personPhone = "" )##
+#set( $personOfficeLocation = "")##
+#set( $personEmail = "" )##
+#set( $emailFormPage_linkId = "" )##
+#set( $sendMailName = "" )##
+#set( $sendMailLink = "" )##
+##
+#set( $person = $person.getNode() )##
+#if( $person.hasProperty("sys_contentid") )##
+#set( $personAssetContentId = $person.getProperty('sys_contentid').String )##
+#end##
+#if( $person.hasProperty("personNamePrefix") )##
+#set( $personNamePrefix = $person.getProperty('personNamePrefix').String.trim() )##
+#end##
+#if( $person.hasProperty("personFirstName") )##
+#set( $personFirstName = $person.getProperty('personFirstName').String.trim() )##
+#end##
+#if( $person.hasProperty("personLastName") )##
+#set( $personLastName = $person.getProperty('personLastName').String.trim() )##
+#end##
+#if( $person.hasProperty("personPhone") )##
+#set( $personPhone = $person.getProperty('personPhone').String )##
+#end##
+#if( $person.hasProperty("personOfficeLocation") )##
+#set( $personOfficeLocation = $person.getProperty('personOfficeLocation').String )##
+#end##
+
+#if( $person.hasProperty("personEmail") )##
+#set( $personEmail = $person.getProperty('personEmail').String )##
+#end##
+##
+## Get email form page details
+##
+#if( $person.hasProperty("emailFormPage_linkId") )##
+#set( $emailFormPage_linkId = $person.getProperty('emailFormPage_linkId').String )##
+#set( $emailFormPage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $emailFormPage_linkId) )##
+#set( $emailFormPage_title = "" )##
+#set( $emailFormPage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($emailFormPage_linkId) )##
+#if( $emailFormPage_sys_contentId != "" )##
+    #set( $emailFormPage_pageMap = $rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $emailFormPage_sys_contentId) )##
+    #set( $emailFormPage_title = $emailFormPage_pageMap.get('resource_link_title') )##
+#end##
+#set( $$sendMailName = $personFirstName + "-" + $personLastName )##
+#set( $sendMailLink = $emailFormPage_path + "?name=" + $sendMailName )##
+##
+#end## --( $person.hasProperty("emailFormPage_linkId") )--
+##
+#set( $personOrgId = "" )## Reset personOrgId
+##
+#if( $orgSearchId == -1 )##
+##
+#set( $orgName = "" )## Reset orgName to empty
+##
+#if( $person.hasProperty("personOrganization") )##
+#set( $personOrgId = $tools.math.toInteger($person.getProperty('personOrganization').String) )##
+##
+#if( $personOrgId > 0 )##
+##
+#set( $params = $rx.string.stringToMap(null) )##
+#set( $dummy = $params.put('orgId', $personOrgId)  )##
+#set( $query = 'select * from rx:percOrganization where rx:sys_contentid = :orgId' )##
+#set( $dummy = $params.put('max_results', 1) )##
+#set( $dummy = $params.put('query', $query) )##
+#set( $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder' )##
+#set( $orgResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params) )##
+##
+#if( $orgResult.size() > 0 )##
+##
+#set( $orgName = $orgResult.get(0).getNode().getProperty('orgName').String )##
+##
+#end## --( $orgResult.size() > 0 )--
+##
+#end## --( $personOrgId > 0 )--
+##
+#end## --( $person.hasProperty("personOrganization") )--
+##
+#end## --( $orgSearchId == -1 )--
+##
+#set( $personDeptId = "" )## Reset personDeptId
+#set( $personDeptId = $tools.math.toInteger($person.getProperty('personDepartment').String) )##
+#set( $dptName = "" )##
+##
+##
+#if( $personDeptId > 0 )##
+##
+#set( $params = $rx.string.stringToMap(null) )##
+#set( $dummy = $params.put('deptId', $personDeptId)  )##
+#set( $query = 'select * from rx:percDepartment where rx:sys_contentid = :deptId' )##
+#set( $dummy = $params.put('max_results', 1) )##
+#set( $dummy = $params.put('query', $query) )##
+#set( $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder' )##
+#set( $deptResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params) )##
+##
+#if( $deptResult.size() > 0 )##
+##
+#set( $dptName = $deptResult.get(0).getNode().getProperty('dptName').String )##
+##
+#end## --( $deptResult.size() > 0 )--
+##
+#end## --( $personDeptId > 0 )--
+##
+#set( $personTitle = $person.getProperty('personTitle').String )##
+##
+## Get Image details
+## Clear Image CSS parameter for each loop
+#set( $imageCSS = "" )##
+#set( $personImage_linkId = $person.getProperty('personImage_linkId').String )##
+#set( $personImage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $personImage_linkId, $sys.assemblyItem.PubServerId) )##
+#set( $personImage_alt_text = "" )##
+#set( $personImage_title = "" )##
+#set( $personImage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($personImage_linkId) )##
+#if( $personImage_sys_contentId != "" )##
+#set( $personImage_assetMap = $rx.pageutils.findItemFieldValues('percImageAsset', 'displaytitle,alttext', $personImage_sys_contentId) )##
+#set( $personImage_alt_text = $personImage_assetMap.get('alttext') )##
+#set( $personImage_title = $personImage_assetMap.get('displaytitle') )##
+#end## --( $personImage_sys_contentId != "" )--
+##
+## Get Page details
+#set( $personPage_linkId = $person.getProperty('personPage_linkId').String )##
+#set( $personPage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $personPage_linkId) )##
+#set( $personPage_title = "" )##
+#set( $personPage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($personPage_linkId) )##
+#if( $personPage_sys_contentId != "")##
+#set( $personPage_pageMap = $rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $personPage_sys_contentId) )##
+#set( $personPage_title = $personPage_pageMap.get('resource_link_title') )##
+#end## --( $personPage_sys_contentId != "")--
+##
+#set( $personCaption = $person.getProperty('personCaption').String )##
+##
+## Schema.org Person entry for this directory result (ItemList element)
+##
+#set( $personSchema = $rx.string.getJSONObject() )##
+#set( $dummy = $personSchema.put("@type", "Person") )##
+#set( $personFullName = "" )##
+#if( "$!{personNamePrefix}" != "" && "$!{personNamePrefix}" != "#" )##
+#set( $personFullName = $personFullName + $personNamePrefix + " " )##
+#set( $dummy = $personSchema.put("honorificPrefix", $personNamePrefix) )##
+#end##
+#if( "$!{personFirstName}" != "" && "$!{personFirstName}" != "#" )##
+#set( $personFullName = $personFullName + $personFirstName + " " )##
+#set( $dummy = $personSchema.put("givenName", $personFirstName) )##
+#end##
+#if( "$!{personLastName}" != "" && "$!{personLastName}" != "#" )##
+#set( $personFullName = $personFullName + $personLastName )##
+#set( $dummy = $personSchema.put("familyName", $personLastName) )##
+#end##
+#set( $personFullName = $personFullName.trim() )##
+#if( "$!{personFullName}" != "" )##
+#set( $dummy = $personSchema.put("name", $personFullName) )##
+#end##
+#if( "$!{dptName}" != "" && "$!{dptName}" != "#" )##
+#set( $worksForOrg = $rx.string.getJSONObject() )##
+#set( $dummy = $worksForOrg.put("@type", "Organization") )##
+#if( "$!{orgName}" != "" && "$!{orgName}" != "#" )##
+#set( $dummy = $worksForOrg.put("name", $orgName) )##
+#end##
+#set( $deptOrg = $rx.string.getJSONObject() )##
+#set( $dummy = $deptOrg.put("@type", "Organization") )##
+#set( $dummy = $deptOrg.put("name", $dptName) )##
+#set( $dummy = $worksForOrg.put("department", $deptOrg) )##
+#set( $dummy = $personSchema.put("worksFor", $worksForOrg) )##
+#elseif( "$!{orgName}" != "" && "$!{orgName}" != "#" )##
+#set( $dummy = $personSchema.put("worksFor", $orgName) )##
+#end##
+#if( "$!{personTitle}" != "" && "$!{personTitle}" != "#" )##
+#set( $dummy = $personSchema.put("jobTitle", $personTitle) )##
+#end##
+#if( "$!{personPhone}" != "" && "$!{personPhone}" != "#" )##
+#set( $dummy = $personSchema.put("telephone", $personPhone) )##
+#end##
+#if( "$!{personEmail}" != "" && "$!{personEmail}" != "#" )##
+#set( $personMailTo = "mailto:" + $personEmail )##
+#set( $dummy = $personSchema.put("email", $personMailTo) )##
+#end##
+#set( $schemaItemPosition = $schemaItemPosition + 1 )##
+#set( $listItem = $rx.string.getJSONObject() )##
+#set( $dummy = $listItem.put("@type", "ListItem") )##
+#set( $dummy = $listItem.put("position", $schemaItemPosition) )##
+#set( $dummy = $listItem.put("item", $personSchema) )##
+#set( $dummy = $itemListElement.put($listItem) )##
+##
+##
+## HTML for disply
+##
+##
+#if( $directoryLayoutFormat == "table" )##
+##
+                        <tr class="perc-person">
+#if( !($percHideFieldPersonImage) )##
+                            <td role="gridcell">
+#if( "$!{personImage_path}" != ""  && "$!{personImage_path}" != "#" )## If person Asset has a valid Profile Image
+##
+#if( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                                <a href="$personPage_path" title="$personPage_title">
+                                    <span class="perc-person-field perc-person-image">
+                                        <img src="$personImage_path" title="$personImage_title" alt="$personImage_alt_text" />
+                                    </span>
+                                </a>
+#else##
+                                <span class="perc-person-field perc-person-image">
+                                    <img src="$personImage_path" title="$personImage_title" alt="$personImage_alt_text" />
+                                </span>
+#end## --( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )--
+##
+#elseif( "$!{customPlaceholderImg_path}" != "" && "$!{customPlaceholderImg_path}" != "#" )## If custom placeholder image is valid
+##
+#if( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                                <a href="$personPage_path" title="$personPage_title">
+                                    <span class="perc-person-field perc-person-image">
+                                        <img src="$!{customPlaceholderImg_path}" title="$!{customPlaceholderImg_title}" alt="$!{customPlaceholderImg_alt_text}" />
+                                    </span>
+                                </a>
+#else##
+                                <span class="perc-person-field perc-person-image">
+                                    <img src="$!{customPlaceholderImg_path}" title="$!{customPlaceholderImg_title}" alt="$!{customPlaceholderImg_alt_text}" />
+                                </span>
+#end## --( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )--
+##
+#else## Else use Default PLaceholder image
+##
+#if( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                                <a href="$personPage_path" title="$personPage_title">
+                                    <span class="perc-person-field perc-person-image">
+                                        <img src="/web_resources/widgets/directory/img/person-directory-placeholder-min.png" title="Percussion directory image placeholder" alt="Percussion directory image placeholder" />
+                                    </span>
+                                </a>
+#else##
+                                <span class="perc-person-field perc-person-image">
+                                    <img src="/web_resources/widgets/directory/img/person-directory-placeholder-min.png" title="Percussion directory image placeholder" alt="Percussion directory image placeholder" />
+                                </span>
+#end## --( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )--
+##
+#end## --( "$!{personImage_path}" != ""  && "$!{personImage_path}" != "#" )--
+                            </td>
+#end## --( !($percHideFieldPersonImage) )--
+                            <td role="gridcell" class="perc-person-field perc-person-name" >
+#if( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                                <a href="$personPage_path" title="$personPage_title">
+##
+#if( "$!{personNamePrefix}" != "" && "$!{personNamePrefix}" != "#" )##
+                                    <span class="perc-person-name-prefix">$!{personNamePrefix} </span>
+#end##
+#if( "$!{personFirstName}" != "" && "$!{personFirstName}" != "#" )##
+                                    <span class="perc-person-first-name">$!{personFirstName}</span>
+#end##
+#if( "$!{personLastName}" != "" && "$!{personLastName}" != "#" )##
+                                    <span class="perc-person-last-name">$!{personLastName}</span>
+#end##
+                                </a>
+#else##
+#if( "$!{personNamePrefix}" != "" && "$!{personNamePrefix}" != "#" )##
+                                <span class="perc-person-name-prefix">$!{personNamePrefix} </span>
+#end##
+#if( "$!{personFirstName}" != "" && "$!{personFirstName}" != "#" )##
+                                <span class="perc-person-first-name">$!{personFirstName}</span>
+#end##
+#if( "$!{personLastName}" != "" && "$!{personLastName}" != "#" )##
+                                <span class="perc-person-last-name">$!{personLastName}</span>
+#end##
+##
+#end## --( "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )--
+                            </td>
+##
+#if( !($percHideFieldPersonOrganization) )##
+                            <td role="gridcell">
+#if( "$!{orgName}" != "" && "$!{orgName}" != "#")##
+                                <span class="perc-person-field perc-person-org">$!{orgName}</span>
+#end##
+                            </td>
+#end## --( !($percHideFieldPersonOrganization) )--
+#if( !($percHideFieldPersonDepartment) )##
+                            <td role="gridcell">
+#if( "$!{dptName}" != "" && "$!{dptName}" != "#")##
+                                <span class="perc-person-field perc-person-dpt">$!{dptName}</span>
+#end##
+                            </td>
+#end## --( !($percHideFieldPersonDepartment) )--
+#if( !($percHideFieldPersonTitle) )##
+                            <td role="gridcell">
+#if( "$!{personTitle}" != "" && "$!{personTitle}" != "#")##
+                                <span class="perc-person-field perc-person-title">$!{personTitle}</span>
+#end##
+                            </td>
+#end## --( !($percHideFieldPersonTitle) )--
+#if( !($percHideFieldPersonPhone) )##
+                            <td role="gridcell">
+#if( "$!{personPhone}" != "" && "$!{personPhone}" != "#")##
+                                <span class="perc-person-field perc-person-phone">$!{personPhone}</span>
+#end##
+                            </td>
+#end## --( !($percHideFieldPersonOfficeLocation) )--
+#if( !($percHideFieldPersonOfficeLocation) )##
+                            <td role="gridcell">
+#if( "$!{personOfficeLocation}" != "" && "$!{personOfficeLocation}" != "#")##
+                                <span class="perc-person-field perc-person-office-location">$!{personOfficeLocation}</span>
+#end##
+                            </td>
+#end## --( !($percHideFieldPersonOfficeLocation) )--
+#if( !($percHideFieldPersonEmail) )##
+                            <td role="gridcell">
+                                <span class="perc-person-field perc-person-email">
+#if( "$!{sendMailLink}" != "" && "$!{sendMailLink}" != "#" )##
+                                    <a href="$sendMailLink" title="Send Email">Send Email</a>
+#end## --( "$!{sendMailLink}" != "" )--
+                                </span>
+                            </td>
+#end## --( !($percHideFieldPersonEmail) )--
+                        </tr>
+##
+#else## directoryLayoutFormat is Card
+##
+                    <li class="perc-person">
+#if( !($percHideFieldPersonImage) && "$!{personImage_path}" != ""  && "$!{personImage_path}" != "#" )##
+##
+                        <div class="perc-person-image">
+#if( !($percHideFieldPersonPage) && "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                            <a href="$personPage_path" title="$personPage_title">
+                                <img src="$personImage_path" title="$personImage_title" alt="$personImage_alt_text" />
+                            </a>
+#else##
+                            <img src="$personImage_path" title="$personImage_title" alt="$personImage_alt_text" />
+#end## --( !($percHideFieldPersonPage) && "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )--
+                        </div>
+##
+#end## --( !($percHideFieldPersonImage) && "$!{personImage_path}" != ""  && "$!{personImage_path}" != "#" )--
+                        <div class="perc-person-name">
+#if( !($percHideFieldPersonPage) && "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                            <a href="$personPage_path" title="$personPage_title">
+                                <span class="perc-person-name-prefix">$!{personNamePrefix} </span>
+                                <span class="perc-person-first-name">$!{personFirstName}</span>
+                                <span class="perc-person-last-name">$!{personLastName}</span>
+                            </a>
+#else##
+                            <span class="perc-person-name-prefix">$!{personNamePrefix} </span>
+                            <span class="perc-person-first-name">$!{personFirstName}</span>
+                            <span class="perc-person-last-name">$!{personLastName}</span>
+#end## --( !($percHideFieldPersonImage) && "$!{personImage_path}" != ""  && "$!{personImage_path}" != "#" )--
+                        </div>
+##
+#if( !($percHideFieldPersonOrganization) && "$!{orgName}" != "" && "$!{orgName}" != "#" )##
+##
+                        <div class="perc-person-org">$!{orgName}</div>
+##
+#end##
+#if( !($percHideFieldPersonDepartment) && "$!{dptName}" != "" && "$!{dptName}" != "#" )##
+##
+                        <div class="perc-person-dpt">$!{dptName}</div>
+##
+#end##
+#if( !($percHideFieldPersonTitle) && "$!{personTitle}" != "" && "$!{personTitle}" != "#" )##
+##
+                        <div class="perc-person-title">$!{personTitle}</div>
+##
+#end##
+#if( !($percHideFieldPersonPhone) && "$!{personPhone}" != "" && "$!{personPhone}" != "#" )##
+##
+                        <div class="perc-person-phone">$!{personPhone}</div>
+##
+#end##
+#if( !($percHideFieldPersonOfficeLocation) && "$!{personOfficeLocation}" != "" && "$!{personOfficeLocation}" != "#" )##
+##
+                        <div class="perc-person-office-location">$!{personOfficeLocation}</div>
+##
+#end##
+#if( !($percHideFieldPersonEmail) && "$!{personEmail}" != "" && "$!{personEmail}" != "#" )##
+##
+                        <div class="perc-person-email">
+#if( "$!{sendMailLink}" != "" && "$!{sendMailLink}" != "#" )##
+                            <a href="$sendMailLink" title="Send Email">Send Email</a>
+#end##
+                        </div>
+##
+#end##
+                    </li>
+#end## --( $directoryLayoutFormat == "table" )--
+##
+#end## --( $person in $directoryResults )--
+##
+#end## --( $directoryResults.size() > 0 )--
+##
+## Emit Schema.org ItemList JSON-LD into page head (once per widget instance)
+##
+#if( $itemListElement.length() > 0 )##
+#set( $dummy = $directorySchema.put("numberOfItems", $itemListElement.length()) )##
+#set( $dummy = $directorySchema.put("itemListElement", $itemListElement) )##
+#set( $addlHead = $perc.page.getAdditionalHeadContent() )##
+#if( !($addlHead.contains($scriptSchemaId)) )##
+$perc.page.setAdditionalHeadContent("$!{addlHead}<script async id='$!{scriptSchemaId}' type='application/ld+json'>$!{directorySchema}</script>")##
+#end##
+#end## --( $itemListElement.length() > 0 )--
+##
+#if( $directoryLayoutFormat == "table" )##
+                    </tbody>
+                </table> <!-- end perc-directory-list Table-->
+#else##
+                </ul> <!-- end perc-directory-list Cards-->
+#end## --( $directoryLayoutFormat == "table" )--
+            </div>
+## end percDirectoryList
+##
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("percDirectory-empty-style", "This widget is showing sample content")
+#end
+        </div> <!-- end "$!rootclass" -->

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percOrganization/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percOrganization/component-package.json
@@ -1,0 +1,433 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percOrganization",
+  "name": "Organization",
+  "version": "2.1.0",
+  "description": "This widget is used to store the information details of an Organization.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "Percussion Software Inc."
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.7",
+      "implied": false
+    },
+    {
+      "name": "perc.SystemObjects",
+      "version": "1.0.0",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Organization",
+    "description": "This widget is used to store the information details of an Organization.",
+    "thumbnail": "resources/percOrganizationIcon.png",
+    "icon": "resources/percOrganizationIcon.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 800,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percOrganization",
+      "ref": "contentTypes/percOrganization"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percOrganizationSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percOrganizationSnippet.vm",
+      "contentType": "percOrganization",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percOrganization'"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "orgNameFormat",
+          "expression": "$perc.widget.item.properties.get('orgNameFormat')"
+        },
+        {
+          "variable": "orgNameFormatStartTag",
+          "expression": "'<' + $orgNameFormat + '>'"
+        },
+        {
+          "variable": "orgNameFormatEndTag",
+          "expression": "'</' + $orgNameFormat + '>'"
+        },
+        {
+          "variable": "percHideFieldOrgName",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_organizationName')"
+        },
+        {
+          "variable": "percHideFieldOrgAddress",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_organizationAddress')"
+        },
+        {
+          "variable": "percHideFieldOrgPhone",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_organizationPhone')"
+        },
+        {
+          "variable": "percHideFieldOrgFax",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_organizationFax')"
+        },
+        {
+          "variable": "percHideFieldOrgEmail",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_organizationEmail')"
+        },
+        {
+          "variable": "percHideFieldOrgLogo",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_organizationLogo')"
+        },
+        {
+          "variable": "percHideFieldOrgPage",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_organizationPage')"
+        },
+        {
+          "variable": "assetContentId",
+          "expression": "$assetItem.getNode().getProperty('sys_contentid').String"
+        },
+        {
+          "variable": "pageName",
+          "expression": "$perc.page.name"
+        },
+        {
+          "variable": "folderName",
+          "expression": "$perc.page.folderPaths.get(0)"
+        },
+        {
+          "variable": "temp",
+          "expression": "$folderName.replace(\"//Sites/\",\"\")"
+        },
+        {
+          "variable": "pathArray",
+          "expression": "$temp.split(\"/\")"
+        },
+        {
+          "variable": "siteDomain",
+          "expression": "$pathArray.get(0)"
+        },
+        {
+          "variable": "orgName",
+          "expression": "$assetItem.getNode().getProperty('orgName').String"
+        },
+        {
+          "variable": "parentOrgId",
+          "expression": "$assetItem.getNode().getProperty('parentOrganization').String"
+        },
+        {
+          "variable": "orgAddress1",
+          "expression": "$assetItem.getNode().getProperty('orgAddress1').String"
+        },
+        {
+          "variable": "orgAddress2",
+          "expression": "$assetItem.getNode().getProperty('orgAddress2').String"
+        },
+        {
+          "variable": "orgCity",
+          "expression": "$assetItem.getNode().getProperty('orgCity').String"
+        },
+        {
+          "variable": "orgState",
+          "expression": "$assetItem.getNode().getProperty('orgState').String"
+        },
+        {
+          "variable": "orgPostCode",
+          "expression": "$assetItem.getNode().getProperty('orgPostCode').String"
+        },
+        {
+          "variable": "orgCountry",
+          "expression": "$assetItem.getNode().getProperty('orgCountry').String"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "'select rx:orgName from rx:percOrganization where rx:sys_contentid = :parentOrgId'"
+        },
+        {
+          "variable": "finderName",
+          "expression": "'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder'"
+        },
+        {
+          "variable": "parentOrgResult",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "parentOrgName",
+          "expression": "$parentOrgResult.get(0).getNode().getProperty(\"orgName\").String"
+        },
+        {
+          "variable": "orgPhone",
+          "expression": "$assetItem.getNode().getProperty('orgPhone').String"
+        },
+        {
+          "variable": "orgFax",
+          "expression": "$assetItem.getNode().getProperty('orgFax').String"
+        },
+        {
+          "variable": "orgEmail",
+          "expression": "$assetItem.getNode().getProperty('orgEmail').String"
+        },
+        {
+          "variable": "orgAddress3",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orgAddress3",
+          "expression": "$orgAddress3 + $orgCity"
+        },
+        {
+          "variable": "orgAddress3",
+          "expression": "$orgAddress3 + \", \""
+        },
+        {
+          "variable": "orgAddress3",
+          "expression": "$orgAddress3 + $orgState"
+        },
+        {
+          "variable": "orgAddress3",
+          "expression": "$orgAddress3 + \" \" + $orgPostCode"
+        },
+        {
+          "variable": "orgLogo_linkId",
+          "expression": "$assetItem.getNode().getProperty('orgLogo_linkId').String"
+        },
+        {
+          "variable": "orgLogo_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $orgLogo_linkId, $sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "orgLogo_alt_text",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orgLogo_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orgLogo_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($orgLogo_linkId)"
+        },
+        {
+          "variable": "orgLogo_assetMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percImageAsset', 'displaytitle,alttext', $orgLogo_sys_contentId)"
+        },
+        {
+          "variable": "orgLogo_alt_text",
+          "expression": "$orgLogo_assetMap.get('alttext')"
+        },
+        {
+          "variable": "orgLogo_title",
+          "expression": "$orgLogo_assetMap.get('displaytitle')"
+        },
+        {
+          "variable": "orgPage_linkId",
+          "expression": "$assetItem.getNode().getProperty('orgPage_linkId').String"
+        },
+        {
+          "variable": "orgPage_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $orgPage_linkId)"
+        },
+        {
+          "variable": "orgPage_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "orgPage_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($orgPage_linkId)"
+        },
+        {
+          "variable": "orgPage_pageMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $orgPage_sys_contentId)"
+        },
+        {
+          "variable": "orgPage_title",
+          "expression": "$orgPage_pageMap.get('resource_link_title')"
+        },
+        {
+          "variable": "orgPageExt",
+          "expression": "$assetItem.getNode().getProperty('orgPageExt').String"
+        },
+        {
+          "variable": "orgPage_path",
+          "expression": "$orgPageExt"
+        },
+        {
+          "variable": "orgPage_title",
+          "expression": "$orgPageExt"
+        },
+        {
+          "variable": "scriptSchemaId",
+          "expression": "\"perc-organization-schema-\" + $assetContentId"
+        },
+        {
+          "variable": "orgSchema",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "orgAddress",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "orgStreetAddress",
+          "expression": "$orgAddress1 + ' ' + $orgAddress2"
+        },
+        {
+          "variable": "orgURL",
+          "expression": "\"//\" + $siteDomain + $orgPage_path"
+        },
+        {
+          "variable": "orgLogoURL",
+          "expression": "\"//\" + $siteDomain + $orgLogo_path"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = 'percOrganization';\n\n       ## Get asset item(s)\n       $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n       $perc.setWidgetContents($assets);\n\n       if (! $assets.isEmpty())\n       {\n            ## Get Widget Layout Properties\n            $orgNameFormat = $perc.widget.item.properties.get('orgNameFormat');\n            if (!empty($orgNameFormat))\n            {\n                $orgNameFormatStartTag = '<' + $orgNameFormat + '>';\n                $orgNameFormatEndTag = '</' + $orgNameFormat + '>';\n            }\n            $percHideFieldOrgName = $perc.widget.item.properties.get('perc_hidefield_organizationName');\n            $percHideFieldOrgAddress = $perc.widget.item.properties.get('perc_hidefield_organizationAddress');\n            $percHideFieldOrgPhone = $perc.widget.item.properties.get('perc_hidefield_organizationPhone');\n            $percHideFieldOrgFax = $perc.widget.item.properties.get('perc_hidefield_organizationFax');\n            $percHideFieldOrgEmail = $perc.widget.item.properties.get('perc_hidefield_organizationEmail');\n            $percHideFieldOrgLogo = $perc.widget.item.properties.get('perc_hidefield_organizationLogo');\n            $percHideFieldOrgPage = $perc.widget.item.properties.get('perc_hidefield_organizationPage');\n\n            ## Get Widget Content Properties\n            $assetItem = $assets.get(0); ## Get first item (which may be only item)\n            $assetContentId = $assetItem.getNode().getProperty('sys_contentid').String;\n\n            ## Get site domain name\n            $pageName = $perc.page.name;\n            $folderName = $perc.page.folderPaths.get(0);\n            $temp = $folderName.replace(\"//Sites/\",\"\");\n            $pathArray = $temp.split(\"/\");\n            $siteDomain = $pathArray.get(0);\n\n            $orgName = $assetItem.getNode().getProperty('orgName').String;\n            $parentOrgId = $assetItem.getNode().getProperty('parentOrganization').String;\n            $orgAddress1 = $assetItem.getNode().getProperty('orgAddress1').String;\n            $orgAddress2 = $assetItem.getNode().getProperty('orgAddress2').String;\n            $orgCity = $assetItem.getNode().getProperty('orgCity').String;\n            $orgState = $assetItem.getNode().getProperty('orgState').String;\n            $orgPostCode = $assetItem.getNode().getProperty('orgPostCode').String;\n            $orgCountry = $assetItem.getNode().getProperty('orgCountry').String;\n\n            if ($parentOrgId != '' && $parentOrgId != null && $parentOrgId != '#') {\n                $params = $rx.string.stringToMap(null);\n                $params.put('parentOrgId', $parentOrgId );\n                $query = 'select rx:orgName from rx:percOrganization where rx:sys_contentid = :parentOrgId';\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder';\n                $parentOrgResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n\n                if ($parentOrgResult.size() > 0) {\n                    $parentOrgName = $parentOrgResult.get(0).getNode().getProperty(\"orgName\").String;\n                }\n            }\n\n            $orgPhone = $assetItem.getNode().getProperty('orgPhone').String;\n            $orgFax = $assetItem.getNode().getProperty('orgFax').String;\n            $orgEmail = $assetItem.getNode().getProperty('orgEmail').String;\n\n            $orgAddress3 = \"\";\n            if ($orgCity != \"\")\n            {\n                $orgAddress3 = $orgAddress3 + $orgCity;\n            }\n            if ($orgCity != \"\" && $orgState != \"\")\n            {\n                $orgAddress3 = $orgAddress3 + \", \";\n            }\n            if ($orgState != \"\")\n            {\n                $orgAddress3 = $orgAddress3 + $orgState;\n            }\n            if ($orgPostCode != \"\")\n            {\n                $orgAddress3 = $orgAddress3 + \" \" + $orgPostCode;\n            }\n\n            $orgLogo_linkId = $assetItem.getNode().getProperty('orgLogo_linkId').String;\n            $orgLogo_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $orgLogo_linkId, $sys.assemblyItem.PubServerId);\n            $orgLogo_alt_text=\"\";\n            $orgLogo_title=\"\";\n            $orgLogo_sys_contentId = $rx.pageutils.getManagedLinkDependentId($orgLogo_linkId);\n            if ($orgLogo_sys_contentId != \"\")\n            {\n                $orgLogo_assetMap = $rx.pageutils.findItemFieldValues('percImageAsset', 'displaytitle,alttext', $orgLogo_sys_contentId);\n                $orgLogo_alt_text = $orgLogo_assetMap.get('alttext');\n                $orgLogo_title = $orgLogo_assetMap.get('displaytitle');\n            }\n            $orgPage_linkId = $assetItem.getNode().getProperty('orgPage_linkId').String;\n            $orgPage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $orgPage_linkId);\n            $orgPage_title = \"\";\n            $orgPage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($orgPage_linkId);\n            if ($orgPage_sys_contentId != \"\")\n            {\n                $orgPage_pageMap = $rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $orgPage_sys_contentId);\n                $orgPage_title = $orgPage_pageMap.get('resource_link_title');\n            }\n            $orgPageExt = $assetItem.getNode().getProperty('orgPageExt').String;\n            if ($orgPageExt != \"\"){\n                $orgPage_path = $orgPageExt;\n                $orgPage_title = $orgPageExt;\n            }\n            ##\n            ## Schema.org Definition\n            ##\n            $scriptSchemaId = \"perc-organization-schema-\" + $assetContentId;\n            $orgSchema = $rx.string.getJSONObject();\n            $orgSchema.put(\"@context\", \"http://schema.org\");\n            $orgSchema.put(\"@type\", \"Organization\");\n            $orgSchema.put(\"name\", $orgName);\n            if ($orgName != \"\") {\n                $orgAddress = $rx.string.getJSONObject();\n                    $orgAddress.put(\"@type\", \"PostalAddress\");\n                    $orgStreetAddress = $orgAddress1 + ' ' + $orgAddress2;\n                    if ($orgStreetAddress != \"\"){\n                        $orgAddress.put(\"streetAddress\", $orgStreetAddress);\n                    }\n                    if ($orgCity != \"\"){\n                        $orgAddress.put(\"addressLocality\", $orgCity);\n                    }\n                    if ($orgState != \"\"){\n                        $orgAddress.put(\"addressRegion\", $orgState);\n                    }\n                    if ($orgCountry != \"\"){\n                        $orgAddress.put(\"addressCountry\", $orgCountry);\n                    }\n                    if ($orgPostCode != \"\"){\n                        $orgAddress.put(\"postalCode\", $orgPostCode);\n                    }\n                $orgSchema.put(\"address\", $orgAddress);\n                if ($parentOrgName != '' && $parentOrgName != null) {\n                    $orgSchema.put(\"parentOrganization\", $parentOrgName);\n                }\n                if ($orgPage_path != \"\" && $orgPage_path != \"#\"){\n                    $orgURL = \"//\" + $siteDomain + $orgPage_path;\n                    $orgSchema.put(\"url\", $orgURL);\n                }\n                if ($orgLogo_path != \"\" && $orgLogo_path != \"#\")\n                {\n                    $orgLogoURL = \"//\" + $siteDomain + $orgLogo_path;\n                    $orgSchema.put(\"image\", $orgLogoURL);\n                }\n            }\n            ## End Schema.org Markup\n       }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percOrganizationContent",
+      "allowedContentTypes": [
+        "percOrganization"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percOrganizationIcon.png",
+      "target": "rx_resources/widgets/percOrganization/images/percOrganizationIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "orgNameFormat",
+      "displayName": "Format of Organization Name",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "h2",
+      "enumValues": [
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        }
+      ]
+    },
+    {
+      "name": "perc_hidefield_organizationName",
+      "displayName": "Hide Organization Name",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_organizationAddress",
+      "displayName": "Hide Organization Address",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_organizationPhone",
+      "displayName": "Hide Organization Phone Number",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_organizationFax",
+      "displayName": "Hide Organization Fax Number",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_organizationEmail",
+      "displayName": "Hide Organization Email Address",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_organizationLogo",
+      "displayName": "Hide Organization Logo",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_organizationPage",
+      "displayName": "Hide Organization Page",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percOrganization/templates/percOrganizationSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percOrganization/templates/percOrganizationSnippet.vm
@@ -1,0 +1,68 @@
+<div class="$!rootclass">
+#if( ! $perc.widgetContents.isEmpty() )
+            <div>
+#set($addlHead = $perc.page.getAdditionalHeadContent())##
+## Check for existing Schema if using multiple instances of widget on same page
+#if( !($addlHead.contains($scriptSchemaId)) )##
+$perc.page.setAdditionalHeadContent("$!{addlHead}<script async id='$!{scriptSchemaId}' type='application/ld+json'>$!{orgSchema}</script>")##
+#end##
+## Display Organization Name with selected formatting HTML tags
+#if( !($percHideFieldOrgName) )##
+#if( !($percHideFieldOrgPage) && "$!{orgPage_path}" != ""  && "$!{orgPage_path}" != "#")##
+                        <div class="perc-org-name">
+                            <a href="$orgPage_path" title="$orgPage_title">
+                            $!{orgNameFormatStartTag}${orgName}$!{orgNameFormatEndTag}
+                            </a>
+                        </div>
+#else##
+#if( "$!{orgName}" != "" && "$!{orgName}" != "" )##
+                            <div class="perc-org-name">
+                                $!{orgNameFormatStartTag}$!{orgName}$!{orgNameFormatEndTag}
+                            </div>
+#end##
+#end##
+#end## --( !($percHideFieldOrgName) )--
+##
+#if( !($percHideFieldOrgAddress) )##
+                    <div class="perc-org-address">
+#if( "$!{orgAddress1}" != "" && "$!{orgAddress1}" != "#" )##
+                            <div class="perc-org-address-1"><p>$!{orgAddress1}</p></div>
+#end##
+#if( "$!{orgAddress2}" != "" && "$!{orgAddress2}" != "#" )##
+                            <div class="perc-org-address-2"><p>$!{orgAddress2}</p></div>
+#end##
+#if( "$!{orgAddress3}" != "" && "$!{orgAddress3}" != "#" )##
+                            <div class="perc-org-address-city-state-post"><p>$!{orgAddress3}</p></div>
+#end##
+#if( "$!{orgCountry}" != "" && "$!{orgCountry}" != "#" )##
+                            <div class="perc-org-address-country"><p>$!{orgCountry}</p></div>
+#end##
+                    </div>
+#end##
+#if( !($percHideFieldOrgPhone) && "$!{orgPhone}" != "" && "$!{orgPhone}" != "#" )##
+                    <div class="perc-org-phone"><p>$!{orgPhone}</p></div>
+#end##
+#if( !($percHideFieldOrgFax) && "$!{orgFax}" != "" && "$!{orgFax}" != "#" )##
+                    <div class="perc-org-fax"><p>$!{orgFax}</p></div>
+#end##
+#if( !($percHideFieldOrgEmail) && "$!{orgEmail}" != "" && "$!{orgEmail}" != "#" )##
+                    <div class="perc-org-email"><p>$!{orgEmail}</p></div>
+#end##
+#if( !($percHideFieldOrgLogo) )##
+                    <div class="perc-org-logo">
+#if( !($percHideFieldOrgPage) && "$!{orgPage_path}" != ""  && "$!{orgPage_path}" != "#" && "$!{orgLogo_path}" != "" && "$!{orgLogo_path}" != "#")##
+                            <a href="$orgPage_path" title="$orgPage_title">
+                                <img src="$orgLogo_path" title="$orgLogo_title" alt="$orgLogo_alt_text" />
+                            </a>
+#else##
+#if( "$!{orgLogo_path}" != "" && "$!{orgLogo_path}" != "#" )##
+                                <img src="$orgLogo_path" title="$orgLogo_title" alt="$orgLogo_alt_text" />
+#end##
+#end##
+                    </div>
+#end##
+            </div>
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("percOrganization-empty-style", "This widget is showing sample content")
+#end
+       </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percPerson/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percPerson/component-package.json
@@ -1,0 +1,444 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percPerson",
+  "name": "Person",
+  "version": "2.1.0",
+  "description": "This widget is used to store the details of a Person for use with the Directory widget",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "Percussion Software Inc."
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.7",
+      "implied": false
+    },
+    {
+      "name": "perc.SystemObjects",
+      "version": "1.0.0",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Person",
+    "description": "This widget is used to store the details of a Person for use with the Directory widget",
+    "thumbnail": "resources/percPersonIcon.png",
+    "icon": "resources/percPersonIcon.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 800,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percPerson",
+      "ref": "contentTypes/percPerson"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percPersonSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percPersonSnippet.vm",
+      "contentType": "percPerson",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percPerson'"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetContentId",
+          "expression": "$assetItem.getNode().getProperty('sys_contentid').String"
+        },
+        {
+          "variable": "pageName",
+          "expression": "$perc.page.name"
+        },
+        {
+          "variable": "folderName",
+          "expression": "$perc.page.folderPaths.get(0)"
+        },
+        {
+          "variable": "temp",
+          "expression": "$folderName.replace(\"//Sites/\",\"\")"
+        },
+        {
+          "variable": "pathArray",
+          "expression": "$temp.split(\"/\")"
+        },
+        {
+          "variable": "siteDomain",
+          "expression": "$pathArray.get(0)"
+        },
+        {
+          "variable": "percHideFieldPersonOrganization",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personOrgField')"
+        },
+        {
+          "variable": "percHideFieldPersonDepartment",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personDptField')"
+        },
+        {
+          "variable": "percHideFieldPersonTitle",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personTitleField')"
+        },
+        {
+          "variable": "percHidefieldPersonPhone",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personPhoneField')"
+        },
+        {
+          "variable": "percHidefieldPersonOfficeLocation",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personOfficeLocation')"
+        },
+        {
+          "variable": "percHidefieldPersonEmail",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personEmailField')"
+        },
+        {
+          "variable": "percHideFieldPersonImage",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personImageField')"
+        },
+        {
+          "variable": "percHideFieldPersonPage",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personPageField')"
+        },
+        {
+          "variable": "percHideFieldPersonCaption",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_personCaptionField')"
+        },
+        {
+          "variable": "honorificPrefix",
+          "expression": "$assetItem.getNode().getProperty('honorificPrefix').String"
+        },
+        {
+          "variable": "personFirstName",
+          "expression": "$assetItem.getNode().getProperty('personFirstName').String"
+        },
+        {
+          "variable": "personLastName",
+          "expression": "$assetItem.getNode().getProperty('personLastName').String"
+        },
+        {
+          "variable": "personName",
+          "expression": "\"\""
+        },
+        {
+          "variable": "personName",
+          "expression": "$personName + $honorificPrefix + \" \""
+        },
+        {
+          "variable": "personName",
+          "expression": "$personName + $personFirstName + \" \""
+        },
+        {
+          "variable": "personName",
+          "expression": "$personName + $personLastName"
+        },
+        {
+          "variable": "personPhone",
+          "expression": "$assetItem.getNode().getProperty('personPhone').String"
+        },
+        {
+          "variable": "personEmail",
+          "expression": "$assetItem.getNode().getProperty('personEmail').String"
+        },
+        {
+          "variable": "personOfficeLocation",
+          "expression": "$assetItem.getNode().getProperty('personOfficeLocation').String"
+        },
+        {
+          "variable": "emailFormPage_linkId",
+          "expression": "$assetItem.getNode().getProperty('emailFormPage_linkId').String"
+        },
+        {
+          "variable": "emailFormPage_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $emailFormPage_linkId)"
+        },
+        {
+          "variable": "emailFormPage_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "emailFormPage_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($emailFormPage_linkId)"
+        },
+        {
+          "variable": "emailFormPage_pageMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $emailFormPage_sys_contentId)"
+        },
+        {
+          "variable": "emailFormPage_title",
+          "expression": "$emailFormPage_pageMap.get('resource_link_title')"
+        },
+        {
+          "variable": "sendMailName",
+          "expression": "$personFirstName.trim() + \"-\" + $personLastName.trim()"
+        },
+        {
+          "variable": "sendMailLink",
+          "expression": "$emailFormPage_path + \"?name=\" + $sendMailName"
+        },
+        {
+          "variable": "orgContentId",
+          "expression": "$assetItem.getNode().getProperty('personOrganization').String"
+        },
+        {
+          "variable": "orgName",
+          "expression": "\"\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "'select rx:sys_contentid, rx:sys_folderid from rx:percOrganization where rx:sys_contentid = :orgContentId'"
+        },
+        {
+          "variable": "finderName",
+          "expression": "'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder'"
+        },
+        {
+          "variable": "orgResult",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "orgName",
+          "expression": "$orgResult.get(0).getNode().getProperty(\"orgName\").String"
+        },
+        {
+          "variable": "dptContetnId",
+          "expression": "$assetItem.getNode().getProperty('personDepartment').String"
+        },
+        {
+          "variable": "dptName",
+          "expression": "\"\""
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "'select rx:sys_contentid, rx:sys_folderid from rx:percDepartment where rx:sys_contentid = :dptContetnId'"
+        },
+        {
+          "variable": "finderName",
+          "expression": "'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder'"
+        },
+        {
+          "variable": "dptResult",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "dptName",
+          "expression": "$dptResult.get(0).getNode().getProperty(\"dptName\").String"
+        },
+        {
+          "variable": "personTitle",
+          "expression": "$assetItem.getNode().getProperty('personTitle').String"
+        },
+        {
+          "variable": "personImage_linkId",
+          "expression": "$assetItem.getNode().getProperty('personImage_linkId').String"
+        },
+        {
+          "variable": "personImage_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $personImage_linkId, $sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "personImage_alt_text",
+          "expression": "\"\""
+        },
+        {
+          "variable": "personImage_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "personImage_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($personImage_linkId)"
+        },
+        {
+          "variable": "personImage_assetMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percImageAsset', 'displaytitle,alttext', $personImage_sys_contentId)"
+        },
+        {
+          "variable": "personImage_alt_text",
+          "expression": "$personImage_assetMap.get('alttext')"
+        },
+        {
+          "variable": "personImage_title",
+          "expression": "$personImage_assetMap.get('displaytitle')"
+        },
+        {
+          "variable": "personPage_linkId",
+          "expression": "$assetItem.getNode().getProperty('personPage_linkId').String"
+        },
+        {
+          "variable": "personPage_path",
+          "expression": "$rx.pageutils.renderManagedItemPath($perc.linkContext, $personPage_linkId)"
+        },
+        {
+          "variable": "personPage_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "personPage_sys_contentId",
+          "expression": "$rx.pageutils.getManagedLinkDependentId($personPage_linkId)"
+        },
+        {
+          "variable": "personPage_pageMap",
+          "expression": "$rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $personPage_sys_contentId)"
+        },
+        {
+          "variable": "personPage_title",
+          "expression": "$personPage_pageMap.get('resource_link_title')"
+        },
+        {
+          "variable": "personCaption",
+          "expression": "$assetItem.getNode().getProperty('personCaption').String"
+        },
+        {
+          "variable": "scriptSchemaId",
+          "expression": "\"perc-person-schema-\" + $assetContentId"
+        },
+        {
+          "variable": "personSchema",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "personalImageURL",
+          "expression": "\"//\" + $siteDomain + $personImage_path"
+        },
+        {
+          "variable": "personSchemaImage",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "personMailTo",
+          "expression": "\"mailto:\" + $personEmail"
+        },
+        {
+          "variable": "personURL",
+          "expression": "\"//\" + $siteDomain + $personPage_path"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = 'percPerson';\n\n       ## Get asset item(s)\n       $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n       $perc.setWidgetContents($assets);\n\n        if (! $assets.isEmpty())\n        {\n            $assetItem = $assets.get(0); ## Get first item (which may be only item)\n            $assetContentId = $assetItem.getNode().getProperty('sys_contentid').String;\n\n            ## Get site domain name\n            $pageName = $perc.page.name;\n            $folderName = $perc.page.folderPaths.get(0);\n            $temp = $folderName.replace(\"//Sites/\",\"\");\n            $pathArray = $temp.split(\"/\");\n            $siteDomain = $pathArray.get(0);\n\n            ## Get Widget Layout Properties\n            $percHideFieldPersonOrganization = $perc.widget.item.properties.get('perc_hidefield_personOrgField');\n            $percHideFieldPersonDepartment = $perc.widget.item.properties.get('perc_hidefield_personDptField');\n            $percHideFieldPersonTitle = $perc.widget.item.properties.get('perc_hidefield_personTitleField');\n            $percHidefieldPersonPhone = $perc.widget.item.properties.get('perc_hidefield_personPhoneField');\n            $percHidefieldPersonOfficeLocation = $perc.widget.item.properties.get('perc_hidefield_personOfficeLocation');\n            $percHidefieldPersonEmail = $perc.widget.item.properties.get('perc_hidefield_personEmailField');\n            $percHideFieldPersonImage = $perc.widget.item.properties.get('perc_hidefield_personImageField');\n            $percHideFieldPersonPage = $perc.widget.item.properties.get('perc_hidefield_personPageField');\n            $percHideFieldPersonCaption = $perc.widget.item.properties.get('perc_hidefield_personCaptionField');\n\n            ## Get Widget Content Properties\n            $honorificPrefix = $assetItem.getNode().getProperty('honorificPrefix').String;\n            $personFirstName = $assetItem.getNode().getProperty('personFirstName').String;\n            $personLastName = $assetItem.getNode().getProperty('personLastName').String;\n            $personName = \"\";\n            if ($honorificPrefix != \"\" && $honorificPrefix != \"#\")\n            {\n                $personName = $personName + $honorificPrefix + \" \";\n            }\n            if ($personFirstName != \"\" && $personFirstName != \"#\")\n            {\n                $personName = $personName + $personFirstName + \" \";\n            }\n            if ($personLastName != \"\" && $personLastName != \"#\")\n            {\n                $personName = $personName + $personLastName;\n            }\n\n            $personPhone = $assetItem.getNode().getProperty('personPhone').String;\n            $personEmail = $assetItem.getNode().getProperty('personEmail').String;\n            $personOfficeLocation = $assetItem.getNode().getProperty('personOfficeLocation').String;\n\n            ##\n            ## Configure form page for Send Email link\n            ##\n            $emailFormPage_linkId = $assetItem.getNode().getProperty('emailFormPage_linkId').String;\n            $emailFormPage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $emailFormPage_linkId);\n            $emailFormPage_title = \"\";\n            $emailFormPage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($emailFormPage_linkId);\n            if ($emailFormPage_sys_contentId != \"\")\n            {\n                $emailFormPage_pageMap = $rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $emailFormPage_sys_contentId);\n                $emailFormPage_title = $emailFormPage_pageMap.get('resource_link_title');\n            }\n            $sendMailName = $personFirstName.trim() + \"-\" + $personLastName.trim();\n            $sendMailLink = $emailFormPage_path + \"?name=\" + $sendMailName;\n\n            ##\n            ## Get Organization Name from contentId\n            ##\n            $orgContentId = $assetItem.getNode().getProperty('personOrganization').String;\n            $orgName = \"\";\n            if ($orgContentId != \"\" && $orgContentId != \"#\")\n            {\n                $params = $rx.string.stringToMap(null);\n                $params.put('orgContentId', $orgContentId );\n                $query = 'select rx:sys_contentid, rx:sys_folderid from rx:percOrganization where rx:sys_contentid = :orgContentId';\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder';\n                $orgResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                    if( $orgResult.size() > 0 )\n                    {\n                        $orgName = $orgResult.get(0).getNode().getProperty(\"orgName\").String;\n                    }\n            }\n\n            ##\n            ## Get Department Name from Dept Content Id\n            ##\n            $dptContetnId = $assetItem.getNode().getProperty('personDepartment').String;\n            $dptName = \"\";\n            if ($dptContetnId != \"\" && $dptContetnId != \"#\")\n            {\n                $params = $rx.string.stringToMap(null);\n                $params.put('dptContetnId', $dptContetnId );\n                $query = 'select rx:sys_contentid, rx:sys_folderid from rx:percDepartment where rx:sys_contentid = :dptContetnId';\n                $params.put('max_results', 1);\n                $params.put('query', $query);\n                $finderName = 'Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder';\n                $dptResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n                    if( $dptResult.size() > 0 )\n                    {\n                        $dptName = $dptResult.get(0).getNode().getProperty(\"dptName\").String;\n                    }\n            }\n\n            $personTitle = $assetItem.getNode().getProperty('personTitle').String;\n\n            ## Get Image details\n            $personImage_linkId = $assetItem.getNode().getProperty('personImage_linkId').String;\n            $personImage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $personImage_linkId, $sys.assemblyItem.PubServerId);\n            $personImage_alt_text = \"\";\n            $personImage_title = \"\";\n            $personImage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($personImage_linkId);\n            if ($personImage_sys_contentId != \"\")\n            {\n                $personImage_assetMap = $rx.pageutils.findItemFieldValues('percImageAsset', 'displaytitle,alttext', $personImage_sys_contentId);\n                $personImage_alt_text = $personImage_assetMap.get('alttext');\n                $personImage_title = $personImage_assetMap.get('displaytitle');\n            }\n\n            ## Get Page details\n            $personPage_linkId = $assetItem.getNode().getProperty('personPage_linkId').String;\n            $personPage_path = $rx.pageutils.renderManagedItemPath($perc.linkContext, $personPage_linkId);\n            $personPage_title = \"\";\n            $personPage_sys_contentId = $rx.pageutils.getManagedLinkDependentId($personPage_linkId);\n            if ($personPage_sys_contentId != \"\")\n            {\n                $personPage_pageMap = $rx.pageutils.findItemFieldValues('percPage', 'resource_link_title', $personPage_sys_contentId);\n                $personPage_title = $personPage_pageMap.get('resource_link_title');\n            }\n\n            $personCaption = $assetItem.getNode().getProperty('personCaption').String;\n\n            ##\n            ## Schema.org Markup\n            ##\n            $scriptSchemaId = \"perc-person-schema-\" + $assetContentId;\n            $personSchema = $rx.string.getJSONObject();\n            $personSchema.put(\"@context\", \"http://schema.org\");\n            $personSchema.put(\"@type\", \"Person\");\n            $personSchema.put(\"givenName\", $personFirstName);\n            $personSchema.put(\"familyName\", $personLastName);\n\n            if ($honorificPrefix != \"\") {\n                $personSchema.put(\"honorificPrefix\", $honorificPrefix);\n            }\n            if ($personOrganization != \"\") {\n                $personSchema.put(\"worksFor\", $orgName);\n            }\n            if ($personTitle != \"\") {\n                $personSchema.put(\"jobTitle\", $personTitle);\n            }\n            if ($personImage_path != \"\" && $personImage_path != \"#\") {\n                $personalImageURL = \"//\" + $siteDomain + $personImage_path;\n                $personSchemaImage = $rx.string.getJSONObject();\n                $personSchemaImage.put(\"@type\", \"ImageObject\");\n                $personSchemaImage.put(\"url\", $personalImageURL);\n                if ($personImage_title != \"\") {\n                    $personSchemaImage.put(\"name\", $personImage_title);\n                }\n                if ($personImage_alt_text != \"\") {\n                    $personSchemaImage.put(\"alternateName\", $personImage_alt_text);\n                }\n                $personSchema.put(\"image\", $personSchemaImage);\n            }\n            if ($personEmail != \"\") {\n                $personMailTo = \"mailto:\" + $personEmail;\n                $personSchema.put(\"email\", $personMailTo);\n            }\n            if ($personPhone != \"\") {\n                $personSchema.put(\"telephone\", $personPhone);\n            }\n            if ($personPage_path != \"\" && $personPage_path != \"#\") {\n                $personURL = \"//\" + $siteDomain + $personPage_path;\n                $personSchema.put(\"url\", $personURL);\n            }\n        }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percPersonContent",
+      "allowedContentTypes": [
+        "percPerson"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percPersonIcon.png",
+      "target": "rx_resources/widgets/percPerson/images/percPersonIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_hidefield_personOrgField",
+      "displayName": "Hide Organization",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personDptField",
+      "displayName": "Hide Department",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personTitleField",
+      "displayName": "Hide Position / Title",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personPhoneField",
+      "displayName": "Hide Phone Number",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personOfficeLocation",
+      "displayName": "Hide Office Location",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personEmailField",
+      "displayName": "Hide 'Send Email' link",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personImageField",
+      "displayName": "Hide Image",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personPageField",
+      "displayName": "Hide Personal Page",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_personCaptionField",
+      "displayName": "Hide Personal Caption",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percPerson/templates/percPersonSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/widgets/percPerson/templates/percPersonSnippet.vm
@@ -1,0 +1,73 @@
+<div class="$!rootclass">
+#if( ! $perc.widgetContents.isEmpty() )
+#set($addlHead = $perc.page.getAdditionalHeadContent())##
+## Check for existing Schema if using multiple instances of widget on same page
+#if( !($addlHead.contains($scriptSchemaId)) )##
+$perc.page.setAdditionalHeadContent("$!{addlHead}<script async id='$!{scriptSchemaId}' type='application/ld+json'>$!{personSchema}</script>")##
+#end##
+            <div class="perc-person">
+#if( !($percHideFieldPersonImage) && "$!{personImage_path}" != ""  && "$!{personImage_path}" != "#" )##
+                <div class="perc-person-image">
+#if( !($percHideFieldPersonPage) && "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                    <a href="$personPage_path" title="$personPage_title">
+                        <img src="$personImage_path" title="$personImage_title" alt="$personImage_alt_text" />
+                    </a>
+#else##
+                    <img src="$personImage_path" title="$personImage_title" alt="$personImage_alt_text" />
+#end##
+                </div>
+#end##
+                <div class="perc-person-details">
+#if( !($percHideFieldPersonPage) && "$!{personPage_path}" != ""  && "$!{personPage_path}" != "#" )##
+                    <a href="$personPage_path" title="$personPage_title">
+                        <div class="perc-person-name">$!{personName}</div>
+                    </a>
+#else##
+                    <div class="perc-person-name">$!{personName}</div>
+#end##
+##
+#if( !($percHideFieldPersonOrganization) && "$!{orgName}" != "" && "$!{orgName}" != "#" )##
+                    <div class="perc-person-org"><p>$!{orgName}</p></div>
+#end##
+#if( !($percHideFieldPersonDepartment) && "$!{dptName}" != "" && "$!{dptName}" != "#" )##
+                    <div class="perc-person-dpt"><p>$!{dptName}</p></div>
+#end##
+#if( !($percHideFieldPersonTitle) && "$!{personTitle}" != "" && "$!{personTitle}" != "#" )##
+                    <div class="perc-person-title"><p>$!{personTitle}</p></div>
+#end##
+#if( !($percHidefieldPersonPhone) && "$!{personPhone}" != "" && "$!{personPhone}" != "#" )##
+                    <div class="perc-person-phone"><p>$!{personPhone}</p></div>
+#end##
+#if( !($percHidefieldPersonOfficeLocation) && "$!{personOfficeLocation}" != "" && "$!{personOfficeLocation}" != "#" )##
+                    <div class="perc-person-office-location"><p>$!{personOfficeLocation}</p></div>
+#end##
+
+#if( !($percHidefieldPersonEmail) && "$!{personEmail}" != "" && "$!{emailFormPage_path}" != "" && "$!{emailFormPage_path}" != "#")##
+                    <div class="perc-person-email">
+                        <a href="$sendMailLink" title="Send Email">Send Email</a>
+                    </div>
+#end##
+                </div>
+#if( !($percHideFieldPersonCaption) && "$!{personCaption}" != "" )##
+                <div class="perc-person-caption">$!{personCaption}</div>
+#end##
+            </div>
+## set Dollar symbol for use in embedded jQuery script
+#set( $d = "$" )##
+            <script>
+                window.addEventListener('DOMContentLoaded', function() {
+                    // Presubmit Event handler to encode
+                    ${d}('#percPerson').on('click', '.perc-person-email a', function (element) {
+                        // grab the href value
+                        var url = ${d}(this).attr("href");
+                        // URI encode param
+                        url = encodeURI(url);
+                        // update the element href attribute prior to navigation
+                        ${d}(this).attr("href", url)
+                    });
+                });
+            </script>
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("percPerson-empty-style", "This widget is showing sample content")
+#end
+       </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/widgets/percFileAutoList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/widgets/percFileAutoList/component-package.json
@@ -1,0 +1,935 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percFileAutoList",
+  "name": "File Auto List",
+  "version": "1.1.12",
+  "description": "Display a list of files",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "File Auto List",
+    "category": "rich media,search",
+    "description": "Display a list of files",
+    "thumbnail": "resources/widgetIconFileAutoList.png",
+    "icon": "resources/widgetIconFileAutoList.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 665,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percFileAutoList",
+      "ref": "contentTypes/percFileAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percFileAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percFileAutoListSnippet.vm",
+      "contentType": "percFileAutoList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "rendering",
+          "expression": "$perc.widget.item.properties.get('listType')"
+        },
+        {
+          "variable": "listTitleFormat",
+          "expression": "$perc.widget.item.properties.get('listTitleFormat')"
+        },
+        {
+          "variable": "listItemFormat",
+          "expression": "$perc.widget.item.properties.get('listItemFormat')"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "$perc.widget.item.properties.get('listAriaLabel')"
+        },
+        {
+          "variable": "showPostDate",
+          "expression": "$perc.widget.item.properties.get('showPostDate')"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "$perc.widget.item.properties.get('listAriaRole')"
+        },
+        {
+          "variable": "postDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('postDateTimeFormat')"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.properties.get('autoListDivId')"
+        },
+        {
+          "variable": "perc_hide_when_empty",
+          "expression": "$perc.widget.item.properties.get('perc_hide_when_empty')"
+        },
+        {
+          "variable": "target",
+          "expression": "$perc.widget.item.properties.get('target')"
+        },
+        {
+          "variable": "layout",
+          "expression": "$perc.widget.item.properties.get('layout')"
+        },
+        {
+          "variable": "locale",
+          "expression": "$perc.widget.item.properties.get('locale')"
+        },
+        {
+          "variable": "locale",
+          "expression": "\"en-US\""
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "autoListDivId",
+          "expression": "$perc.widget.item.id + \"_list\""
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "''"
+        },
+        {
+          "variable": "listAriaRole",
+          "expression": "'role=\"' + $listAriaRole + '\"'"
+        },
+        {
+          "variable": "headerId",
+          "expression": "$autoListDivId + '_header'"
+        },
+        {
+          "variable": "listclass",
+          "expression": "$perc.widget.item.cssProperties.get('listclass')"
+        },
+        {
+          "variable": "listclass",
+          "expression": "$listclass.trim()"
+        },
+        {
+          "variable": "sortDirection",
+          "expression": "$perc.widget.item.properties.get('sortDirection')"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "$perc.widget.item.properties.get('maxlength')"
+        },
+        {
+          "variable": "maxlength",
+          "expression": "0"
+        },
+        {
+          "variable": "sortby",
+          "expression": "$perc.widget.item.properties.get('sortby')"
+        },
+        {
+          "variable": "target",
+          "expression": "$perc.widget.item.properties.get('target')"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "query",
+          "expression": "$assetItem.getNode().getProperty('query').String"
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortby + \"  desc\""
+        },
+        {
+          "variable": "query",
+          "expression": "$query + \" order by \" + $sortby + \" \" + $sortDirection"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem, 'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('perc-list-odd', 'perc-list-even')"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "'<' + $listTitleFormat + ' id=\"' + $headerId + '\"' + ' class=\"perc-list-title\" aria-label=\"' + $title + '\" title=\"' + $title + '\"' + '>'"
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "'</' + $listTitleFormat + '>'"
+        },
+        {
+          "variable": "itemFormatStartTag",
+          "expression": "'<' + $listItemFormat + '>'"
+        },
+        {
+          "variable": "itemFormatEndTag",
+          "expression": "'</' + $listItemFormat + '>'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $title + ' file list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"File list\"'"
+        },
+        {
+          "variable": "listAriaLabel",
+          "expression": "'aria-label=\"' + $listAriaLabel + '\"'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n   $rendering = $perc.widget.item.properties.get('listType');\n   $listTitleFormat = $perc.widget.item.properties.get('listTitleFormat');\n   $listItemFormat = $perc.widget.item.properties.get('listItemFormat');\n   $listAriaLabel = $perc.widget.item.properties.get('listAriaLabel');\n   $showPostDate = $perc.widget.item.properties.get('showPostDate');\n   $listAriaRole = $perc.widget.item.properties.get('listAriaRole');\n   $postDateTimeFormat = $perc.widget.item.properties.get('postDateTimeFormat');\n   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $autoListDivId = $perc.widget.item.properties.get('autoListDivId');\n   $perc_hide_when_empty = $perc.widget.item.properties.get('perc_hide_when_empty');\n   $perc.setWidgetContents($assetItems);\n   $target = $perc.widget.item.properties.get('target');\n   $layout = $perc.widget.item.properties.get('layout');\n   $locale = $perc.widget.item.properties.get('locale');\n   if($locale == null) {\n      $locale = \"en-US\";\n   }\n   $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n   if (!empty($rootclass)) {\n      $rootclass = $rootclass;\n   }\n   if($autoListDivId == '' || $autoListDivId == null) {\n      $autoListDivId = $perc.widget.item.id + \"_list\";\n   }\n   if ($listAriaRole == '' || $listAriaRole == null) {\n      $listAriaRole = '';\n   }\n   else {\n       $listAriaRole = 'role=\"' + $listAriaRole + '\"';\n   }\n   $headerId = $autoListDivId + '_header';\n   $listclass = $perc.widget.item.cssProperties.get('listclass');\n   if (!empty($listclass)) {\n      $listclass = $listclass.trim();\n   }\n   $sortDirection = $perc.widget.item.properties.get('sortDirection');\n\n   $maxlength = $perc.widget.item.properties.get('maxlength');\n   if (empty($maxlength)) {\n      $maxlength = 0;\n   }\n   $sortby = $perc.widget.item.properties.get('sortby');\n\n   $target = $perc.widget.item.properties.get('target');\n\n   if ( ! $assetItems.isEmpty() ) {\n      $assetItem = $assetItems.get(0);\n      $params = $rx.string.stringToMap(null);\n      $query = $assetItem.getNode().getProperty('query').String;\n      if ($sortby != \"none\"  && $sortby != null) {\n\n        if($sortDirection == null){\n               $query = $query + \" order by \" + $sortby + \"  desc\";\n            }else{\n               $query = $query + \" order by \" + $sortby + \" \" + $sortDirection;\n          }\n\n      }\n\n      $params.put('query', $query);\n      $params.put('max_results', $maxlength);\n      $finderName=\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n      $title = $rx.pageutils.html($assetItem, 'displaytitle');\n      $rowtag = $tools.alternator.auto('perc-list-odd', 'perc-list-even');\n\n      if ($listTitleFormat != 'none') {\n         $titleFormatStartTag = '<' + $listTitleFormat + ' id=\"' + $headerId + '\"' + ' class=\"perc-list-title\" aria-label=\"' + $title + '\" title=\"' + $title + '\"' + '>';\n         $titleFormatEndTag = '</' + $listTitleFormat + '>';\n      }\n\n      if ($listItemFormat != 'none') {\n         $itemFormatStartTag = '<' + $listItemFormat + '>';\n         $itemFormatEndTag = '</' + $listItemFormat + '>';\n      }\n\n      if ($listAriaLabel == '' || $listAriaLabel == null) {\n          if ($title != null && $title != '') {\n              $listAriaLabel = 'aria-label=\"' + $title + ' file list\"';\n          } else {\n              $listAriaLabel = 'aria-label=\"File list\"';\n          }\n      } else {\n          $listAriaLabel = 'aria-label=\"' + $listAriaLabel + '\"';\n      }\n   }\n   else {\n      ;\n   }\n\n   $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n   $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percFileAutoListContent",
+      "allowedContentTypes": [
+        "percFileAutoList"
+      ],
+      "layout": {
+        "maxlength": "",
+        "layout": "perc-list-vertical"
+      },
+      "styles": {
+        "rootclass": "",
+        "listclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconFileAutoList.png",
+      "target": "rx_resources/widgets/fileAutoList/images/widgetIconFileAutoList.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "listType",
+      "displayName": "List Type",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "unordered",
+      "enumValues": [
+        {
+          "value": "unordered",
+          "displayValue": "Unordered List"
+        },
+        {
+          "value": "ordered",
+          "displayValue": "Ordered List"
+        }
+      ]
+    },
+    {
+      "name": "listTitleFormat",
+      "displayName": "Format of list title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    },
+    {
+      "name": "autoListDivId",
+      "displayName": "File Auto List div id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listItemFormat",
+      "displayName": "Format of list items",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "none",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "none",
+          "displayValue": "None"
+        }
+      ]
+    },
+    {
+      "name": "showPostDate",
+      "displayName": "Show Post Date",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "postDateTimeFormat",
+      "displayName": "Format of page post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEEE MM dd, yyyy",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt)    Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "maxlength",
+      "displayName": "Max list length",
+      "datatype": "number",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "sortby",
+      "displayName": "Sort by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "rx:sys_contentpostdate",
+      "enumValues": [
+        {
+          "value": "none",
+          "displayValue": "None"
+        },
+        {
+          "value": "rx:displaytitle",
+          "displayValue": "Title"
+        },
+        {
+          "value": "rx:sys_contentpostdate",
+          "displayValue": "Post date"
+        }
+      ]
+    },
+    {
+      "name": "sortDirection",
+      "displayName": "Sort Order",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "desc",
+      "enumValues": [
+        {
+          "value": "desc",
+          "displayValue": "Descending"
+        },
+        {
+          "value": "asc",
+          "displayValue": "Ascending"
+        }
+      ]
+    },
+    {
+      "name": "listAriaLabel",
+      "displayName": "File Auto List aria-label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "listAriaRole",
+      "displayName": "File Auto List aria-role",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "perc_hide_when_empty",
+      "displayName": "Hide auto list when empty",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "perc-list-vertical",
+      "enumValues": [
+        {
+          "value": "perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    },
+    {
+      "name": "target",
+      "displayName": "Link target",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "_self",
+      "enumValues": [
+        {
+          "value": "_self",
+          "displayValue": "Current window"
+        },
+        {
+          "value": "_blank",
+          "displayValue": "New window"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "listclass",
+      "displayName": "CSS file list class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/widgets/percFileAutoList/templates/percFileAutoListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.fileAutoList/widgets/percFileAutoList/templates/percFileAutoListSnippet.vm
@@ -1,0 +1,88 @@
+#define($ariaLabelString)##
+#if($title && $title.length() > 0)##
+aria-labelledby="$!{headerId}"##
+#else##
+$!{listAriaLabel}##
+#end##
+#end##
+##Setup Date Formatting
+#set($formatterOut = $rx.pageutils.getDateFormatFromLocale("$!{postDateTimeFormat}",$locale))##
+#set($postDateObject="")##
+#set($postDate="")##
+<div id="$!{autoListDivId}" $!{ariaLabelString} class="$!{rootclass} $!{layout} perc-file-auto-list" $!{listAriaRole} #if($perc_hide_when_empty && $relresults.size() <= 0)hidden #end data-query="$!{dynamicListData}">
+#if( ! $perc.widgetContents.isEmpty() )
+#if($title && $title.length() > 0)##
+$!{titleFormatStartTag}$title$!{titleFormatEndTag}
+#end
+#if($relresults && $relresults.size() > 0)
+#if($rendering == "ordered")##
+<ol class="$!{listclass} perc-list-main">##
+#else##
+<ul class="$!{listclass} perc-list-main">##
+#end##
+#foreach($result in $relresults)
+#set($postDateObject=$result.node.getProperty('rx:sys_contentpostdate'))##
+#set($postDateObjectString=$result.node.getProperty('rx:sys_contentpostdate').String)##
+#if("$!{postDateObjectString}" == "")##
+#set($postDateObject=$tools.date.getDate())##
+#else##
+#set($postDateObject=$result.node.getProperty('rx:sys_contentpostdate').getDate())##
+#end##
+#if("$!{postDateObject}" != "")##
+#set($postDate = $formatterOut.format($postDateObject.getTime()))##
+#end##
+#if($velocityCount == 1)##
+#set($firstrow = 'perc-list-first')##
+#else##
+#set($firstrow = ' ')##
+#end##
+#if($velocityCount == $relresults.size())##
+#set($lastrow = 'perc-list-last')##
+#else
+#set($lastrow = ' ')##
+#end
+#set($pagelink=$tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+#set($linkTitle=$rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+#set($link=$tools.esc.html($rx.pageutils.itemLink($linkContext, $result, "percSystem.fileBinary")))##
+#set($file_title=$rx.pageutils.html($result,'displaytitle'))##
+##
+#set( $analyticsId = "" )##
+#if ( $result.getNode().hasProperty('analyticsId') )##
+#set( $analyticsId_raw = $result.getNode().getProperty('analyticsId').String )##
+#if( $analyticsId_raw.length() == 1 && $analyticsId_raw != "?" )##
+#set( $analyticsId = $tools.esc.url($analyticsId_raw) )##
+#end##
+#if ($analyticsId_raw.length() > 1 )
+#set( $analyticsId_Array = $analyticsId_raw.toCharArray() )##
+#set( $analyticsId_firstChar = $analyticsId_Array.get(0).toString() )##
+#if( $analyticsId_firstChar == "?" )##
+#set( $analyticsId = "?" + $tools.esc.url( $analyticsId_raw.substring( 1, $analyticsId_raw.length() ) ) )##
+#else##
+#set( $analyticsId = $tools.esc.url( $analyticsId_raw ) )##
+#end##
+#end##
+#end##
+#if($perc.isEditMode() && $file_title == "")##
+#set($file_title_attr = "")##
+#else##
+#set($file_title_attr = 'title="' + $file_title + '"')##
+#end
+<li class="$rowtag $!{firstrow} $!{lastrow} perc-list-element">$!{itemFormatStartTag}
+<a href="${link}$!{analyticsId}" $file_title_attr target="$target">$file_title</a>
+#if($showPostDate)##
+#if("$!{postDate}" != "")##
+<span class="perc-file-auto-list-date">$!{postDate}</span>
+#end##
+#end##
+$!{itemFormatEndTag}</li>
+#end##
+#if($rendering == "ordered")##
+</ol>##
+#else##
+</ul>##
+#end##
+#end##
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("filelist-sample-content", "This file auto list widget is showing sample content.")
+#end
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.form/widgets/percForm/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.form/widgets/percForm/component-package.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percForm",
+  "name": "Form",
+  "version": "1.4.8",
+  "description": "Widget to build and render form data.",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Form",
+    "category": "integration",
+    "description": "Widget to build and render form data.",
+    "thumbnail": "resources/widgetIconForm.gif",
+    "icon": "resources/widgetIconForm.gif",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 965,
+    "preferredEditorHeight": 600,
+    "responsive": false,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percFormAsset",
+      "ref": "contentTypes/percFormAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percFormSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percFormSnippet.vm",
+      "contentType": "percFormAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"perc-label-location-top\""
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"perc-label-location-left\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n            if(!empty($rootclass)) {\n                $rootclass = $rootclass;\n            }\n            $props = $perc.widget.item.properties;\n            $labelalignclass = \"perc-label-location-top\";\n            if($props.get(\"labelalign\") != null && $props.get(\"labelalign\").equals(\"left\"))\n                $labelalignclass = \"perc-label-location-left\";\n\n\t\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n            $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percFormContent",
+      "allowedContentTypes": [
+        "percFormAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconForm.gif",
+      "target": "rx_resources/widgets/form/images/widgetIconForm.gif",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "labelalign",
+      "displayName": "Label align",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "top",
+      "enumValues": [
+        {
+          "value": "top",
+          "displayValue": "Top of the control"
+        },
+        {
+          "value": "left",
+          "displayValue": "Left of the control"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.form/widgets/percForm/templates/percFormSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.form/widgets/percForm/templates/percFormSnippet.vm
@@ -1,0 +1,47 @@
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty())##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+<div class = "perc-form $!{rootclass} $!{labelalignclass}" data="$!{dynamicListData}">
+#if( ! $perc.widgetContents.isEmpty())##
+#set($formString = $node.getProperty('rx:renderedform').getString())##
+#set($returnString = $rx.pageutils.processForm($sys.assemblyItem, $perc.widget, $formString))##
+<div class = "perc-form-name">$returnString </div>
+#set($formData = $node.getProperty('rx:formdata').String)##
+#if($formData.contains('honeypot') || $formData.contains('recaptcha'))##
+<script>
+    function validatePercForm() {
+        var ret = false;
+        #if($formData.contains('honeypot'))##
+        if(!document.getElementById('topyenoh').value) {
+            ret=true;
+        }
+        else {
+            ret=false;
+        }
+        #end##
+        #if($formData.contains('recaptcha'))##
+         if (grecaptcha.getResponse() === '') {
+         	ret = false;
+         }else {
+         	ret = true;
+         }
+        #end##
+        return ret;
+    }
+</script>
+#end##
+
+#elseif ($perc.isEditMode())
+#createEmptyWidgetContent("form-sample-content", "This Form widget is showing sample content.")
+#end
+
+#if($perc.isPreviewMode())
+<script>
+window.addEventListener('DOMContentLoaded', function() {
+jQuery("form").on('submit',function(){return false;});
+jQuery("input[type = 'submit']").attr('disabled', 'disabled');
+});
+</script>
+#end
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/widgets/percIframe/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/widgets/percIframe/component-package.json
@@ -1,0 +1,330 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percIframe",
+  "name": "Iframe",
+  "version": "1.1.4",
+  "description": "Embed an external web page within a Percussion page",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.3.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Iframe",
+    "category": "integration",
+    "description": "Embed an external web page within a Percussion page",
+    "thumbnail": "resources/widgetIconIframe.jpg",
+    "icon": "resources/widgetIconIframe.jpg",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percIframeSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percIframeSnippet.vm",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "iframeurl",
+          "expression": "$props.get(\"iframeurl\")"
+        },
+        {
+          "variable": "referalPolicy",
+          "expression": "$props.get(\"referalPolicy\")"
+        },
+        {
+          "variable": "iframeurl",
+          "expression": "\"http://\" + $iframeurl"
+        },
+        {
+          "variable": "height",
+          "expression": "$props.get(\"height\")"
+        },
+        {
+          "variable": "defaultHeight",
+          "expression": "$props.get(\"height\")"
+        },
+        {
+          "variable": "width",
+          "expression": "$props.get(\"width\")"
+        },
+        {
+          "variable": "defaultWidth",
+          "expression": "$props.get(\"width\")"
+        },
+        {
+          "variable": "frameborder",
+          "expression": "$props.get(\"frameborder\")"
+        },
+        {
+          "variable": "scrollbar",
+          "expression": "$props.get(\"scrollbar\")"
+        },
+        {
+          "variable": "iframeid",
+          "expression": "\"perc-iframe-\" + $perc.widget.item.id"
+        },
+        {
+          "variable": "title",
+          "expression": "$props.get(\"title\")"
+        },
+        {
+          "variable": "marginheight",
+          "expression": "$props.get(\"marginheight\")"
+        },
+        {
+          "variable": "marginwidth",
+          "expression": "$props.get(\"marginwidth\")"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$props.get(\"ariaLabel\")"
+        },
+        {
+          "variable": "alternateContent",
+          "expression": "$props.get(\"alternateContent\")"
+        },
+        {
+          "variable": "frameborder",
+          "expression": "\"0\""
+        },
+        {
+          "variable": "frameborder",
+          "expression": "\"1\""
+        },
+        {
+          "variable": "overflow",
+          "expression": "\"auto\""
+        },
+        {
+          "variable": "overflow",
+          "expression": "'visible'"
+        },
+        {
+          "variable": "overflow",
+          "expression": "'hidden'"
+        },
+        {
+          "variable": "height",
+          "expression": "'100%'"
+        },
+        {
+          "variable": "width",
+          "expression": "'100%'"
+        },
+        {
+          "variable": "marginheight",
+          "expression": "'0px'"
+        },
+        {
+          "variable": "marginwidth",
+          "expression": "'0px'"
+        },
+        {
+          "variable": "width",
+          "expression": "$width + 'px'"
+        },
+        {
+          "variable": "height",
+          "expression": "$height + 'px'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n\t\t\tif(!empty($rootclass)) {\n\t\t\t\t$rootclass = $rootclass;\n\t\t\t}\n\t\t\t$props = $perc.widget.item.properties;\n\t\t\t$iframeurl = $props.get(\"iframeurl\");\n\t\t\t$referalPolicy = $props.get(\"referalPolicy\");\n\t\t\tif($iframeurl.startsWith(\"www\"))\n\t\t\t\t$iframeurl = \"http://\" + $iframeurl;\n\t\t\t$height = $props.get(\"height\");\n\t\t\t$defaultHeight = $props.get(\"height\");\n\t\t\t$width = $props.get(\"width\");\n\t\t\t$defaultWidth = $props.get(\"width\");\n\t\t\t$frameborder = $props.get(\"frameborder\");\n\t\t\t$scrollbar = $props.get(\"scrollbar\");\n\t\t\t$iframeid=\"perc-iframe-\" + $perc.widget.item.id;\n\t\t\t$title = $props.get(\"title\");\n\t\t\t$marginheight = $props.get(\"marginheight\");\n\t\t\t$marginwidth = $props.get(\"marginwidth\");\n\t\t\t$ariaLabel = $props.get(\"ariaLabel\");\n\t\t\t$alternateContent = $props.get(\"alternateContent\");\n\n\t\t\tif($frameborder == \"disable\"){\n\t\t\t\t$frameborder = \"0\";\n\t\t\t}\n\t\t\telse{\n\t\t\t\t$frameborder = \"1\";\n\t\t\t}\n\t\t\t$overflow = \"auto\";\n\t\t\tif($scrollbar == \"yes\"){\n\t\t\t\t$overflow='visible';\n\t\t\t}\n\t\t\telse if($scrollbar == \"no\"){\n\t\t\t\t$overflow='hidden';\n\t\t\t}\n\n\t\t\tif(empty($height)){\n\t\t\t\t$height='100%';\n\t\t\t}\n\t\t\tif(empty($width)){\n\t\t\t\t$width='100%';\n\t\t\t}\n\n\t\t\tif(empty($marginheight)){\n\t\t\t\t$marginheight = '0px';\n\t\t\t}\n\t\t\tif(empty($marginwidth)){\n\t\t\t\t$marginwidth = '0px';\n\t\t\t}\n\n\t\t\tif($width.indexOf('p') == -1 && $width.indexOf('%') == -1){\n\t\t\t\t$width = $width + 'px';\n\t\t\t}\n\t\t\tif($height.indexOf('p') == -1 && $height.indexOf('%') == -1){\n\t\t\t\t$height = $height + 'px';\n\t\t\t}\n\n            $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        \tif ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t    $dsUrl = \"\";\n            $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percIframeChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconIframe.jpg",
+      "target": "rx_resources/widgets/iframe/images/widgetIconIframe.jpg",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "title",
+      "displayName": "Title",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "iframeurl",
+      "displayName": "URL",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "height",
+      "displayName": "Height in pixels or percent",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "width",
+      "displayName": "Width in pixels or percent",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "marginheight",
+      "displayName": "Top and Bottom margin in pixels",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "marginwidth",
+      "displayName": "Left and Right margin in pixels",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "frameborder",
+      "displayName": "Frame border",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "disable",
+      "enumValues": [
+        {
+          "value": "disable",
+          "displayValue": "Disable border"
+        },
+        {
+          "value": "enable",
+          "displayValue": "Enable border"
+        }
+      ]
+    },
+    {
+      "name": "referalPolicy",
+      "displayName": "Referrer-Policy",
+      "datatype": "enum",
+      "required": false,
+      "enumValues": [
+        {
+          "value": "no-referrer",
+          "displayValue": "no-referrer"
+        },
+        {
+          "value": "no-referrer-when-downgrade",
+          "displayValue": "no-referrer-when-downgrade"
+        },
+        {
+          "value": "origin",
+          "displayValue": "origin"
+        },
+        {
+          "value": "origin-when-cross-origin",
+          "displayValue": "origin-when-cross-origin"
+        },
+        {
+          "value": "same-origin",
+          "displayValue": "same-origin"
+        },
+        {
+          "value": "strict-origin",
+          "displayValue": "strict-origin"
+        },
+        {
+          "value": "strict-origin-when-cross-origin",
+          "displayValue": "strict-origin-when-cross-origin"
+        },
+        {
+          "value": "unsafe-url",
+          "displayValue": "unsafe-url"
+        }
+      ]
+    },
+    {
+      "name": "scrollbar",
+      "displayName": "Scrolling",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "auto",
+      "enumValues": [
+        {
+          "value": "auto",
+          "displayValue": "Auto"
+        },
+        {
+          "value": "no",
+          "displayValue": "No"
+        },
+        {
+          "value": "yes",
+          "displayValue": "Yes"
+        }
+      ]
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Aria Label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "alternateContent",
+      "displayName": "Alternate Content",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/widgets/percIframe/templates/percIframeSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.iframe/widgets/percIframe/templates/percIframeSnippet.vm
@@ -1,0 +1,32 @@
+<div class = "perc-iframe $!{rootclass}" data="$!{dynamicListData}">
+				#if ($perc.isEditMode())
+					#if($iframeurl.isEmpty())
+                        #createEmptyWidgetContent("iframe-sample-content", "This iframe widget is showing sample content.")
+					#else
+						#if($defaultHeight.isEmpty()|| $defaultWidth.isEmpty() )
+                            #createEmptyWidgetContent("iframe-edit-content", "Preview the page or asset to view this iframe.")
+						#else
+                            #createEmptyWidgetContent("iframe-edit-content", "Preview the page or asset to view this iframe.", "width:$!{width} ; height:$!{height}")
+						#end
+                    #end
+
+				#else
+                    ## Absolute paths must be start with http:// or https://
+                    #if($perc.isPreviewMode() && (!$iframeurl.isEmpty() && !$iframeurl.startsWith("http://") && !$iframeurl.startsWith("https://")))
+                        <div style = "width:$!{width}; height:$!{height}; border: $!{frameborder}px solid" class="iframe-relative-url" title="$!{title}">
+						#if("$!alternateContent" != "")<p #if("$!ariaLabel" != "")aria-label="$ariaLabel"#end>$alternateContent</p>#end
+
+                            <p>Relative page urls are not supported in preview mode</p>
+                        </div>
+                    #else
+                        <iframe src = "$!{iframeurl}"   referrerpolicy="$!{referalPolicy}" style = "width: $!{width}; height: $!{height}; overflow: $!{overflow} !important; border: $!{frameborder}; margin-top: $!{marginheight}; margin-bottom: $!{marginheight}; margin-left: $!{marginwidth}; margin-right: $!{marginwidth};" title="$!{title}" #if($title.isEmpty() && "$!ariaLabel" != "")aria-label="$!{ariaLabel}"#end >
+
+						#if("$!alternateContent" != "")<p #if("$!ariaLabel" != "")aria-label="$ariaLabel"#end>$alternateContent</p>#end
+
+							<p>Your browser does not support frames or is currently configured
+                            not to display frames. However, you may browse the content of frames by
+                            <a href="$!{iframeurl}">clicking here.</a></p>
+                        </iframe>
+                    #end
+			   #end
+			</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/widgets/percImageSlider/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/widgets/percImageSlider/component-package.json
@@ -1,0 +1,636 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percImageSlider",
+  "name": "Image Slider",
+  "version": "1.4.4",
+  "description": " ",
+  "publisher": {
+    "name": "https://www.percussion.com",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Image Slider",
+    "category": "content,rich media",
+    "description": " ",
+    "thumbnail": "resources/percImageSliderIcon.png",
+    "icon": "resources/percImageSliderIcon.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 1200,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percImageSlider",
+      "ref": "contentTypes/percImageSlider"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percImageSliderSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percImageSliderSnippet.vm",
+      "contentType": "percImageSlider",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percImageSlider'"
+        },
+        {
+          "variable": "captionclass",
+          "expression": "$perc.widget.item.cssProperties.get('captionclass')"
+        },
+        {
+          "variable": "captionclass",
+          "expression": "$captionclass.trim()"
+        },
+        {
+          "variable": "captionclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "widgetProps",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "perc_slide_show_number_desktop",
+          "expression": "$widgetProps.get(\"perc_slide_show_number_desktop\")"
+        },
+        {
+          "variable": "perc_slide_show_number_tablet",
+          "expression": "$widgetProps.get(\"perc_slide_show_number_tablet\")"
+        },
+        {
+          "variable": "perc_slide_show_number_mobile",
+          "expression": "$widgetProps.get(\"perc_slide_show_number_mobile\")"
+        },
+        {
+          "variable": "perc_slides_to_scroll",
+          "expression": "$widgetProps.get(\"perc_slide_scroll_number\")"
+        },
+        {
+          "variable": "perc_autoplay_speed",
+          "expression": "$widgetProps.get(\"perc_autoplay_speed\")"
+        },
+        {
+          "variable": "perc_scroll_speed",
+          "expression": "$widgetProps.get(\"perc_scroll_speed\")"
+        },
+        {
+          "variable": "perc_slide_image_height",
+          "expression": "$widgetProps.get(\"perc_slide_image_height\")"
+        },
+        {
+          "variable": "perc_slide_caption_location",
+          "expression": "$widgetProps.get(\"perc_slide_caption_location\")"
+        },
+        {
+          "variable": "perc_slide_caption_alignment",
+          "expression": "$widgetProps.get(\"perc_slide_caption_alignment\")"
+        },
+        {
+          "variable": "perc_slide_caption_vertical_alignment",
+          "expression": "$widgetProps.get(\"perc_slide_caption_vertical_alignment\")"
+        },
+        {
+          "variable": "perc_slide_fade",
+          "expression": "$widgetProps.get(\"perc_slide_fade\")"
+        },
+        {
+          "variable": "perc_show_dots",
+          "expression": "$widgetProps.get(\"perc_show_dots\")"
+        },
+        {
+          "variable": "perc_show_arrows",
+          "expression": "$widgetProps.get(\"perc_show_arrows\")"
+        },
+        {
+          "variable": "perc_slider_tablet_breakpoint",
+          "expression": "$widgetProps.get(\"perc_slider_tablet_breakpoint\")"
+        },
+        {
+          "variable": "perc_slider_mobile_breakpoint",
+          "expression": "$widgetProps.get(\"perc_slider_mobile_breakpoint\")"
+        },
+        {
+          "variable": "perc_slide_layout",
+          "expression": "$widgetProps.get(\"perc_slide_layout\")"
+        },
+        {
+          "variable": "perc_slide_thumbnail_height",
+          "expression": "$widgetProps.get(\"perc_slide_thumbnail_height\")"
+        },
+        {
+          "variable": "perc_slide_theme",
+          "expression": "$widgetProps.get(\"perc_slide_theme\")"
+        },
+        {
+          "variable": "perc_enable_custom_arrows",
+          "expression": "$widgetProps.get(\"perc_enable_custom_arrows\")"
+        },
+        {
+          "variable": "perc_prev_arrow_class",
+          "expression": "$widgetProps.get(\"perc_prev_arrow_class\")"
+        },
+        {
+          "variable": "perc_next_arrow_class",
+          "expression": "$widgetProps.get(\"perc_next_arrow_class\")"
+        },
+        {
+          "variable": "perc_slide_autoplay",
+          "expression": "$widgetProps.get(\"perc_slide_autoplay\")"
+        },
+        {
+          "variable": "perc_thumbnail_height",
+          "expression": "$widgetProps.get(\"perc_thumbnail_height\")"
+        },
+        {
+          "variable": "perc_slide_caption_tag_type",
+          "expression": "$widgetProps.get(\"perc_slide_caption_tag_type\")"
+        },
+        {
+          "variable": "perc_slide_caption_2_tag_type",
+          "expression": "$widgetProps.get(\"perc_slide_caption_2_tag_type\")"
+        },
+        {
+          "variable": "perc_slide_caption_alignment",
+          "expression": "$widgetProps.get(\"perc_slide_caption_alignment\")"
+        },
+        {
+          "variable": "perc_slide_targetblank",
+          "expression": "$widgetProps.get(\"perc_slide_targetblank\")"
+        },
+        {
+          "variable": "perc_slide_image_link",
+          "expression": "$widgetProps.get(\"perc_slide_image_link\")"
+        },
+        {
+          "variable": "perc_slide_fade",
+          "expression": "'true'"
+        },
+        {
+          "variable": "perc_slide_show_number_desktop",
+          "expression": "1"
+        },
+        {
+          "variable": "perc_slide_show_number_tablet",
+          "expression": "1"
+        },
+        {
+          "variable": "perc_slide_show_number_mobile",
+          "expression": "1"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "friendlySliderName",
+          "expression": "$assetItem.getNode().getProperty('sliderName').String"
+        },
+        {
+          "variable": "data",
+          "expression": "$assetItem.Node.getProperty('rx:sliderImageJSON').getString()"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($data)"
+        },
+        {
+          "variable": "sliderJsonData",
+          "expression": "$json.toString()"
+        },
+        {
+          "variable": "sliderJsonData",
+          "expression": "$json.toString().replace('config','percJSONConfig')"
+        },
+        {
+          "variable": "updatedData",
+          "expression": "$rx.pageutils.updateManagedLinksInJSON($perc.linkContext, $sliderJsonData)"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($updatedData)"
+        },
+        {
+          "variable": "sliderId",
+          "expression": "$assetItem.Node.getProperty('rx:sys_contentid').getString()"
+        },
+        {
+          "variable": "sliderName",
+          "expression": "$json.sliderName"
+        },
+        {
+          "variable": "imageSliderArray",
+          "expression": "$rx.pageutils.createJsonArray($json, \"percJSONConfig\")"
+        },
+        {
+          "variable": "validNumbers",
+          "expression": "'true'"
+        },
+        {
+          "variable": "validNumbers",
+          "expression": "'false'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass)) {\n       $rootclass = $rootclass;\n    }\n    else {\n      $rootclass = 'percImageSlider';\n    }\n    $captionclass = $perc.widget.item.cssProperties.get('captionclass');\n    if (!empty($captionclass)) {\n       $captionclass = $captionclass.trim();\n    }\n    else {\n       $captionclass= \"\";\n    }\n\n       $pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $widgetProps = $perc.widget.item.properties;\n       $perc_slide_show_number_desktop = $widgetProps.get(\"perc_slide_show_number_desktop\");\n       $perc_slide_show_number_tablet = $widgetProps.get(\"perc_slide_show_number_tablet\");\n       $perc_slide_show_number_mobile = $widgetProps.get(\"perc_slide_show_number_mobile\");\n       $perc_slides_to_scroll = $widgetProps.get(\"perc_slide_scroll_number\");\n       $perc_autoplay_speed = $widgetProps.get(\"perc_autoplay_speed\");\n       $perc_scroll_speed = $widgetProps.get(\"perc_scroll_speed\");\n       $perc_slide_image_height = $widgetProps.get(\"perc_slide_image_height\");\n       $perc_slide_caption_location = $widgetProps.get(\"perc_slide_caption_location\");\n       $perc_slide_caption_alignment = $widgetProps.get(\"perc_slide_caption_alignment\");\n       $perc_slide_caption_vertical_alignment = $widgetProps.get(\"perc_slide_caption_vertical_alignment\");\n       $perc_slide_fade = $widgetProps.get(\"perc_slide_fade\");\n       $perc_show_dots = $widgetProps.get(\"perc_show_dots\");\n       $perc_show_arrows = $widgetProps.get(\"perc_show_arrows\");\n       $perc_slider_tablet_breakpoint = $widgetProps.get(\"perc_slider_tablet_breakpoint\");\n       $perc_slider_mobile_breakpoint = $widgetProps.get(\"perc_slider_mobile_breakpoint\");\n       $perc_slide_layout = $widgetProps.get(\"perc_slide_layout\");\n       $perc_slide_thumbnail_height = $widgetProps.get(\"perc_slide_thumbnail_height\");\n       $perc_slide_theme = $widgetProps.get(\"perc_slide_theme\");\n       $perc_enable_custom_arrows = $widgetProps.get(\"perc_enable_custom_arrows\");\n       $perc_prev_arrow_class = $widgetProps.get(\"perc_prev_arrow_class\");\n       $perc_next_arrow_class = $widgetProps.get(\"perc_next_arrow_class\");\n       $perc_slide_autoplay = $widgetProps.get(\"perc_slide_autoplay\");\n       $perc_thumbnail_height = $widgetProps.get(\"perc_thumbnail_height\");\n       $perc_slide_caption_tag_type = $widgetProps.get(\"perc_slide_caption_tag_type\");\n       $perc_slide_caption_2_tag_type = $widgetProps.get(\"perc_slide_caption_2_tag_type\");\n\t   $perc_slide_caption_alignment = $widgetProps.get(\"perc_slide_caption_alignment\");\n\t   $perc_slide_targetblank = $widgetProps.get(\"perc_slide_targetblank\");\n\t   $perc_slide_image_link = $widgetProps.get(\"perc_slide_image_link\");\n\n       ## sets the required default values if the navigation layout is selected ##\n       if (  $perc_slide_layout == 'navigation') {\n        $perc_slide_fade = 'true';\n        $perc_slide_show_number_desktop = 1;\n        $perc_slide_show_number_tablet = 1;\n        $perc_slide_show_number_mobile = 1;\n       }\n\n       ## Get asset item(s)\n       $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n       $perc.setWidgetContents($assets);\n\n       if (! $assets.isEmpty())\n       {\n          $assetItem = $assets.get(0); ## Get first item (which may be only item)\n          ## Friendly slider name is error for displaying errors\n          $friendlySliderName = $assetItem.getNode().getProperty('sliderName').String;\n          $data = $assetItem.Node.getProperty('rx:sliderImageJSON').getString();\n          $json = $rx.pageutils.createJsonObject($data);\n          $sliderJsonData = $json.toString();\n          ##$isPresent=false;\n\t      if($json.has('config')){\n            ##$isPresent=true;\n            $sliderJsonData = $json.toString().replace('config','percJSONConfig');\n\t      }\n\n          $updatedData = $rx.pageutils.updateManagedLinksInJSON($perc.linkContext, $sliderJsonData);\n          $json = $rx.pageutils.createJsonObject($updatedData);\n          $sliderId = $assetItem.Node.getProperty('rx:sys_contentid').getString();\n          $sliderName = $json.sliderName;\n          ##$debug = $json.toString();\n          $imageSliderArray = $rx.pageutils.createJsonArray($json, \"percJSONConfig\");\n\n          ## this logic is needed to prevent a slider crash if slide show or scroll values are set to zero ##\n          if( $perc_slide_show_number_desktop != 0 && $perc_slide_show_number_tablet != 0 && $perc_slide_show_number_mobile !=0 && $perc_slides_to_scroll != 0) {\n            $validNumbers = 'true';\n          }\n          else {\n            $validNumbers = 'false';\n          }\n\n        }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percImageSliderContent",
+      "allowedContentTypes": [
+        "percImageSlider"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": "",
+        "captionclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percImageSliderIcon.png",
+      "target": "rx_resources/widgets/percImageSlider/images/percImageSliderIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc_slide_autoplay",
+      "displayName": "Autoplay",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_show_dots",
+      "displayName": "Show dots",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_show_arrows",
+      "displayName": "Show arrows",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc_enable_custom_arrows",
+      "displayName": "Enable custom arrows",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_prev_arrow_class",
+      "displayName": "External class for previous arrow (ex: fa fa-chevron-left)",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "perc_next_arrow_class",
+      "displayName": "External class for next arrow (ex: fa fa-chevron-right)",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_fade",
+      "displayName": "Fade effect (1 slide at a time must be selected)",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_theme",
+      "displayName": "Theme",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "dark",
+      "enumValues": [
+        {
+          "value": "dark",
+          "displayValue": "Dark"
+        },
+        {
+          "value": "light",
+          "displayValue": "Light"
+        }
+      ]
+    },
+    {
+      "name": "perc_slide_layout",
+      "displayName": "Slider Layout (will override \"slides to show\" values)",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "standard",
+      "enumValues": [
+        {
+          "value": "standard",
+          "displayValue": "Standard"
+        },
+        {
+          "value": "navigation",
+          "displayValue": "Navigation"
+        }
+      ]
+    },
+    {
+      "name": "perc_thumbnail_height",
+      "displayName": "Thumbnail height (Navigation layout only)",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "8vw",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_caption_tag_type",
+      "displayName": "Format for slide text field 1",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "p",
+      "enumValues": [
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        }
+      ]
+    },
+    {
+      "name": "perc_slide_caption_2_tag_type",
+      "displayName": "Format for slide text field 2",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "p",
+      "enumValues": [
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        }
+      ]
+    },
+    {
+      "name": "perc_slide_caption_location",
+      "displayName": "Slide text location",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "above",
+      "enumValues": [
+        {
+          "value": "above",
+          "displayValue": "Above"
+        },
+        {
+          "value": "over",
+          "displayValue": "Over"
+        },
+        {
+          "value": "below",
+          "displayValue": "Below"
+        }
+      ]
+    },
+    {
+      "name": "perc_slide_caption_alignment",
+      "displayName": "Slide text horizontal alignment",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "left",
+      "enumValues": [
+        {
+          "value": "left",
+          "displayValue": "Left"
+        },
+        {
+          "value": "center",
+          "displayValue": "Center"
+        },
+        {
+          "value": "right",
+          "displayValue": "Right"
+        }
+      ]
+    },
+    {
+      "name": "perc_slide_caption_vertical_alignment",
+      "displayName": "Slide text vertical alignment (overlay)",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "top",
+      "enumValues": [
+        {
+          "value": "top",
+          "displayValue": "Top"
+        },
+        {
+          "value": "middle",
+          "displayValue": "Middle"
+        },
+        {
+          "value": "bottom",
+          "displayValue": "Bottom"
+        }
+      ]
+    },
+    {
+      "name": "perc_slide_image_height",
+      "displayName": "Slide Height",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "250px",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_show_number_desktop",
+      "displayName": "Number of slides to show at a time on desktop",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_show_number_tablet",
+      "displayName": "Number of slides to show at a time on tablet",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_show_number_mobile",
+      "displayName": "Number of slides to show at a time on mobile",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_scroll_number",
+      "displayName": "Number of slides to scroll at a time",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1",
+      "enumValues": []
+    },
+    {
+      "name": "perc_autoplay_speed",
+      "displayName": "Autoplay speed (milliseconds)",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "2000",
+      "enumValues": []
+    },
+    {
+      "name": "perc_scroll_speed",
+      "displayName": "Scroll speed (milliseconds)",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "500",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slider_tablet_breakpoint",
+      "displayName": "<span style=\"font-size:125%;\"><br><br><b>Responsive Breakpoints</b></span><br><br>Tablet",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1024",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slider_mobile_breakpoint",
+      "displayName": "Mobile",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "480",
+      "enumValues": []
+    },
+    {
+      "name": "perc_slide_targetblank",
+      "displayName": "Link Target",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "_blank",
+      "enumValues": [
+        {
+          "value": "_blank",
+          "displayValue": "Blank"
+        },
+        {
+          "value": "_self",
+          "displayValue": "Self"
+        },
+        {
+          "value": "_parent",
+          "displayValue": "Parent"
+        },
+        {
+          "value": "_top",
+          "displayValue": "Top"
+        }
+      ]
+    },
+    {
+      "name": "perc_slide_image_link",
+      "displayName": "Images are links",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "captionclass",
+      "displayName": "CSS image text class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/widgets/percImageSlider/templates/percImageSliderSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.imageSlider/widgets/percImageSlider/templates/percImageSliderSnippet.vm
@@ -1,0 +1,381 @@
+<div class="$!rootclass">
+        #if( ! $perc.widgetContents.isEmpty() )
+        ## only output slider content if valid slider values are selected ##
+        #if( $validNumbers == 'true' )##
+        <script>
+         $(function() {
+                 /* main slider settings */
+                $('.${sliderName}-${sliderId}').slick({
+                #if( $perc_slide_layout == 'navigation')##
+                asNavFor: ".${sliderName}-${sliderId}-navigation",
+                #end##
+                fade: $perc_slide_fade,
+                ## override dot and arrow settings for navigation layout ##
+                #if( $perc_slide_layout != 'navigation')##
+                arrows: $perc_show_arrows,
+                dots: $perc_show_dots,
+                #else
+                arrows: false,
+                dots: false,
+                #end##
+                infinite: true,
+                slidesToShow: $perc_slide_show_number_desktop,
+                slidesToScroll: $perc_slides_to_scroll,
+                autoplay: $perc_slide_autoplay,
+                autoplaySpeed: $perc_autoplay_speed,
+                speed: $perc_scroll_speed,#if ( $perc_enable_custom_arrows == true && $perc_prev_arrow_class != "" && $perc_next_arrow_class != "" )
+                prevArrow: '<a class="slick-prev $perc_prev_arrow_class"></a>',
+                nextArrow: '<a class="slick-next $perc_next_arrow_class"></a>',#end##
+                responsive: [
+                  {
+                    breakpoint: $perc_slider_tablet_breakpoint,
+                    settings: {
+                      slidesToShow: $perc_slide_show_number_tablet,
+                      slidesToScroll: 1
+                    }
+                  },
+                  {
+                    breakpoint: $perc_slider_mobile_breakpoint,
+                    settings: {
+                      slidesToShow: $perc_slide_show_number_mobile,
+                      slidesToScroll: 1
+                    }
+                  }
+              ]
+                });
+
+                #if( $perc_slide_layout == 'navigation')##
+                /* nav slider settings */
+                $('.${sliderName}-${sliderId}-navigation').slick({
+                  asNavFor: ".${sliderName}-${sliderId}",
+                  centerMode: true,
+                  focusOnSelect: true,
+                  arrows: true,
+                  dots: true,
+                  infinite: true,
+                  slidesToShow: 3,
+                  slidesToScroll: 1,
+                  autoplay: $perc_slide_autoplay,
+                  autoplaySpeed: $perc_autoplay_speed,
+                  speed: $perc_scroll_speed#if ( $perc_enable_custom_arrows == true && $perc_prev_arrow_class != "" && $perc_next_arrow_class != "" ),
+                  prevArrow: '<a class="slick-prev $perc_prev_arrow_class"></a>',
+                  nextArrow: '<a class="slick-next $perc_next_arrow_class"></a>'#end##
+                });
+                #end
+             });
+        </script>
+
+        <style>
+          ## enables fontawesome if both arrow classes are populated and the checkbox is selected
+          #if ( $perc_enable_custom_arrows == true && $perc_prev_arrow_class != "" && $perc_next_arrow_class != "" )
+          .slick-arrow:before {
+            font-family: fontawesome !important;
+          }
+          #end
+
+          #if( $perc_slide_theme == 'dark' )
+          .slick-prev:before {
+            color: #000000;
+          }
+          .perc-slide-caption-container p {
+            margin-bottom: 0px;
+          }
+          .slick-next:before
+          {
+              color: #000000;
+          }
+          .slick-dots li button:before {
+              color: #000000;
+          }
+          .slick-dots li.slick-active button:before
+          {
+              color: #000000;
+          }
+          #else
+          .slick-prev:before {
+            color: #ffffff;
+          }
+          .slick-next:before
+          {
+              color: #ffffff;
+          }
+          .slick-dots li button:before {
+              color: #ffffff;
+          }
+          .slick-dots li.slick-active button:before
+          {
+              color: #ffffff;
+          }
+          #end
+          .slick-dots button {
+            box-shadow: none !important;
+          }
+          .slick-next, .slick-prev {
+            box-shadow: none !important;
+            z-index: 9999;
+          }
+          .slick-prev {
+            left: 10px;
+          }
+          .slick-next {
+            right: 10px;
+          }
+          .perc-slide-image-container {
+            background-size: cover;
+            background-repeat: no-repeat;
+            background-position: 50% 50%;
+            height: ${perc_slide_image_height};
+            position: relative;
+          }
+          .perc-slide-image-container p {
+            width:100%;
+            position: absolute;
+          }
+          .perc-slide-image-container h2 {
+            width:100%;
+            position: absolute;
+          }
+          .perc-slide-image-container h3 {
+            width:100%;
+            position: absolute;
+          }
+          .perc-slide-image-container h4 {
+            width:100%;
+            position: absolute;
+          }
+          .perc-slide-image-container h5 {
+            width:100%;
+            position: absolute;
+          }
+          .perc-slide-image-container h6 {
+            width:100%;
+            position: absolute;
+          }
+          .perc-slide-thumbnail-container {
+            margin:5px;
+            background-size: cover;
+            background-repeat: no-repeat;
+            background-position: 50% 50%;
+            height: $perc_thumbnail_height;
+            position: relative;
+          }
+          .perc-slide-caption-horizontal-left {
+            text-align: left;
+          }
+          .perc-slide-caption-horizontal-center {
+            text-align: center;
+          }
+          .perc-slide-caption-horizontal-right {
+            text-align: right;
+          }
+          .perc-slide-caption-overlay-container-vertical-middle {
+            top:50% !important;
+            transform: translateY(-50%) !important;
+            width: 100%;
+            position: absolute;
+          }
+          .perc-slide-caption-overlay-container-vertical-top {
+            top:0;
+          }
+          .perc-slide-caption-overlay-container-vertical-bottom {
+            bottom:10%;
+            position: absolute;
+            width: 100%;
+          }
+          .image-caption-overlay-divider {
+            display: inline-block;
+          }
+          .perc-slide-caption-container {
+            margin:5px;
+            padding: 0px 10px 0px 10px;
+          }
+        </style>
+
+          ##create empty array for qualified images
+          #set( $qualifiedImages = [] )##
+
+          #foreach($image in $imageSliderArray)##
+
+          ## First check if path is broken
+          ## If path is broken the image has been deleted and should not be included in the slider
+           #if( $image.percImagePath && $image.percImagePath != '#' )##
+          #set( $query = "" )##
+          #if($rx.pageutils.isValidString(${image.percImageContentId}))##
+          #set( $query = "select * from rx:percImageAsset where rx:sys_contentid = ${image.percImageContentId}")##
+          #set( $maxResults = 1 )##
+          #set( $params= $rx.string.stringToMap(null) )##
+          #set( $dummy = $params.put('query', $query) )##
+          #set( $dummy = $params.put('max_results', $maxResults) )##
+          #set( $finderName = "Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder" )##
+          #set( $result = "" )##
+          #set( $result = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params) )##
+
+          ## Debug $result will show the database response to help troubleshoot
+          ## content status
+
+          ## Once the additional image data is retreived from the database, set those values as new properties
+          #set( $image.altText = $result.get(0).fields.alttext )##
+          #set( $image.imageContentStateId = $result.get(0).fields.sys_contentstateid )##
+
+          ## start setting caption flags
+
+          #if( $image.imageCaption != "" || $image.imageCaption2 != "")##
+            #set( $image.hasCaptions = "Y" )##
+          #else##
+            #set( $image.hasCaptions = "N")##
+          #end##
+
+          #if( $image.imageCaption != "" )##
+            #set( $image.hasCaption1 = "Y")##
+          #else##
+            #set( $image.hasCaption1 = "N")##
+          #end##
+
+          #if( $image.imageCaption2 != "" )##
+            #set( $image.hasCaption2 = "Y")##
+          #else##
+            #set( $image.hasCaption2 = "N")##
+          #end##
+
+          ## end of setting caption flags
+
+          ## set the clickable link
+          #if( $image.linkSetting == "internal")##
+
+          ## Only run queries if we have a valid internal page path
+          #if( $image.percPagePath && $image.percPagePath != "#" )
+          ## check the content status of the linked internal page
+          #set( $query = "" )##
+          #set( $query = "select * from rx:percPage where rx:sys_contentid = ${image.percPageContentId}")##
+          #set( $maxResults = 1 )##
+          #set( $params = $rx.string.stringToMap(null) )##
+          #set( $dummy = $params.put('query', $query) )##
+
+          #set( $dummy = $params.put('max_results', $maxResults) )##
+          #set( $finderName = "Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder" )##
+          #set( $pageResult = "" )##
+          #set( $pageResult = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params) )##
+
+          ## if the linked internal page is approved, or we are in preview or edit mode, assign the links
+            #if( $pageResult.get(0).fields.sys_contentstateid == '4' || $pageResult.get(0).fields.sys_contentstateid == '5' || $perc.isEditMode() || $perc.isPreviewMode() )##
+              #set( $image.clickableLink = $image.percPagePath)##
+            #else##
+              #set( $image.clickableLink = "")##
+            #end
+          ## If we do not have a valid internal page path do not set a clickable link
+          #else##
+          #set( $image.clickableLink = "")##
+          #end##
+
+          #elseif( $image.linkSetting == "external" )##
+          #set( $image.clickableLink = $image.externalLink)##
+
+          #else##
+          #set( $image.clickableLink = "")##
+          #end##
+
+          ## Image should only be shown if it is approved, live, or if we are in preview or edit mode
+          #if( ($image.imageContentStateId == '4' || $image.imageContentStateId == '5' || $perc.isEditMode() || $perc.isPreviewMode()) )##
+          #set( $dummy = $qualifiedImages.add($image) )##
+          #end##
+
+          #end##End if valid image percImageContentId
+          #end## end if valid image
+          #end## end foreach original image
+
+          ## Debug $qualifiedImages will show the JSON object of slides that have
+          ## been verified to show in the slider
+
+          <div class="perc-image-slider ${sliderName}-${sliderId}" >
+            #foreach ($image in $qualifiedImages)##
+              <div class="perc-slide-outer-container">
+                #if( $perc_slide_caption_location == "above" && $image.hasCaptions == "Y" )##
+                <div class="perc-slide-caption-container">
+                  #if( $image.clickableLink != "" )##
+					<a href="$image.clickableLink" target="$perc_slide_targetblank" rel="noopener noreferrer">
+                  #end##
+                  <$perc_slide_caption_tag_type class="perc-slide-image-caption perc-slide-caption-horizontal-${perc_slide_caption_alignment} $captionclass">${image.imageCaption}</$perc_slide_caption_tag_type>
+                  #if( $image.clickableLink != "" )##
+                  </a>
+                  #end
+                  <$perc_slide_caption_2_tag_type class="perc-slide-image-caption-2 perc-slide-caption-horizontal-${perc_slide_caption_alignment} $captionclass">${image.imageCaption2}</$perc_slide_caption_2_tag_type>
+                </div>
+                #end##
+
+				#if( $perc_slide_image_link == "false" )##
+
+                  <div class="perc-slide-image-container" style="background-image: url('${image.percImagePath}')" role="img" aria-label="$image.altText">
+				  #if( $image.clickableLink != "" )##
+				    <a href="$image.clickableLink" target="$perc_slide_targetblank" rel="noopener noreferrer">
+				  #end##
+                  #if( $perc_slide_caption_location == "over" && $image.hasCaptions == "Y" )##
+                  <div class="perc-slide-caption-overlay-container perc-slide-caption-overlay-container-vertical-${perc_slide_caption_vertical_alignment}">
+                  <$perc_slide_caption_tag_type class="perc-slide-image-caption perc-slide-caption-horizontal-${perc_slide_caption_alignment} perc-slide-caption-vertical-${perc_slide_caption_vertical_alignment} $captionclass">${image.imageCaption}</$perc_slide_caption_tag_type>
+                  #if( $image.hasCaption1 == "Y" && $image.hasCaption2 == "Y")##
+                  <span class="image-caption-overlay-divider"></span>
+                  #end##
+                  <$perc_slide_caption_2_tag_type class="perc-slide-image-caption-2 perc-slide-caption-horizontal-${perc_slide_caption_alignment} perc-slide-caption-vertical-${perc_slide_caption_vertical_alignment} $captionclass">${image.imageCaption2}</$perc_slide_caption_2_tag_type>
+                  </div>
+                  #end##
+				  </div>
+				  #if( $image.clickableLink != "" )##
+				  </a>
+                  #end
+				#else
+
+                  #if( $image.clickableLink != "" )##
+					<a href="$image.clickableLink" target="$perc_slide_targetblank" rel="noopener noreferrer">
+                  #end##
+                  <div class="perc-slide-image-container" style="background-image: url('${image.percImagePath}')" role="img" aria-label="$image.altText">
+                  #if( $perc_slide_caption_location == "over" && $image.hasCaptions == "Y" )##
+                  <div class="perc-slide-caption-overlay-container perc-slide-caption-overlay-container-vertical-${perc_slide_caption_vertical_alignment}">
+                  <$perc_slide_caption_tag_type class="perc-slide-image-caption perc-slide-caption-horizontal-${perc_slide_caption_alignment} perc-slide-caption-vertical-${perc_slide_caption_vertical_alignment} $captionclass">${image.imageCaption}</$perc_slide_caption_tag_type>
+                  #if( $image.hasCaption1 == "Y" && $image.hasCaption2 == "Y")##
+                  <span class="image-caption-overlay-divider"></span>
+                  #end##
+                  <$perc_slide_caption_2_tag_type class="perc-slide-image-caption-2 perc-slide-caption-horizontal-${perc_slide_caption_alignment} perc-slide-caption-vertical-${perc_slide_caption_vertical_alignment} $captionclass">${image.imageCaption2}</$perc_slide_caption_2_tag_type>
+                  </div>
+                  #end##
+                  </div>
+                  #if( $image.clickableLink != "" )##
+                  </a>
+                  #end
+				#end
+
+
+
+                #if( $perc_slide_caption_location == "below" && $image.hasCaptions == "Y" )##
+                <div class="perc-slide-caption-container">
+                  #if( $image.clickableLink != "" )##
+				    <a href="$image.clickableLink" target="$perc_slide_targetblank" rel="noopener noreferrer">
+                  #end##
+                  <$perc_slide_caption_tag_type class="perc-slide-image-caption perc-slide-caption-horizontal-${perc_slide_caption_alignment} $captionclass">${image.imageCaption}</$perc_slide_caption_tag_type>
+                  #if( $image.clickableLink != "" )##
+                  </a>
+                  #end
+                  <$perc_slide_caption_2_tag_type class="perc-slide-image-caption-2 perc-slide-caption-horizontal-${perc_slide_caption_alignment} $captionclass">${image.imageCaption2}</$perc_slide_caption_2_tag_type>
+                </div>
+                #end##
+              </div>
+            #end##
+          </div>
+
+        ## navigation slide area ##
+        #if( $perc_slide_layout == 'navigation')##
+        <div class="perc-image-slider ${sliderName}-${sliderId}-navigation" data-slick='{}'>
+          #foreach ($image in $qualifiedImages)##
+            <div class="perc-slide-outer-container">
+              <div class="perc-slide-thumbnail-container" style="background-image: url('${image.percImagePath}')" role="img" aria-label="$image.altText" >
+              </div>
+            </div>
+          #end##
+        </div>
+        #end##
+        #elseif( $validNumbers == 'false' )##
+        ## show this warning if 0 slides are entered for any of the slides to show numbers ##
+        <b>Slider warning ($friendlySliderName): Please choose at least 1 slide to show for each screen size and at least 1 slide to scroll</b>
+        #end##
+        #elseif ($perc.isEditMode())
+            #createEmptyWidgetContent("percImageSlider-empty-style", "This widget is showing sample content")
+        #end
+       </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/widgets/percJQueryWidget/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/widgets/percJQueryWidget/component-package.json
@@ -1,0 +1,173 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percJQueryWidget",
+  "name": "jQuery Widget",
+  "version": "1.1.4",
+  "description": "Select your desired version of jQuery",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "jQuery Widget",
+    "category": "Design",
+    "description": "Select your desired version of jQuery",
+    "thumbnail": "resources/widgeticonjquery.png",
+    "icon": "resources/widgeticonjquery.png",
+    "author": "Percussion Software, Inc.",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percJQueryWidgetSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percJQueryWidgetSnippet.vm",
+      "bindings": [
+        {
+          "variable": "jQueryLocation",
+          "expression": "$perc.widget.item.properties.get('jQueryLocation')"
+        },
+        {
+          "variable": "jQueryMigrateLocation",
+          "expression": "$perc.widget.item.properties.get('jQueryMigrateLocation')"
+        },
+        {
+          "variable": "isDeferred",
+          "expression": "$perc.widget.item.properties.get('isDeferred')"
+        },
+        {
+          "variable": "scriptLocation",
+          "expression": "$perc.widget.item.properties.get('scriptLocation')"
+        },
+        {
+          "variable": "includeOnPublishedPage",
+          "expression": "$perc.widget.item.properties.get('includeOnPublishedPage')"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$jQueryLocation = $perc.widget.item.properties.get('jQueryLocation');\n    $jQueryMigrateLocation = $perc.widget.item.properties.get('jQueryMigrateLocation');\n    $isDeferred = $perc.widget.item.properties.get('isDeferred');\n    $scriptLocation = $perc.widget.item.properties.get('scriptLocation');\n    $includeOnPublishedPage = $perc.widget.item.properties.get('includeOnPublishedPage');"
+        }
+      ]
+    }
+  ],
+  "slots": [],
+  "resources": [
+    {
+      "path": "resources/widgeticonjquery.png",
+      "target": "rx_resources/widgets/percJQueryWidget/images/widgeticonjquery.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "jQueryLocation",
+      "displayName": "jQuery CDN Link (http or https):",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "/web_resources/cm/jslib/jquery.js",
+      "enumValues": []
+    },
+    {
+      "name": "jQueryLocationIntegrity",
+      "displayName": "jQuery SRI Hash",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "jQueryLocationCrossOrigin",
+      "displayName": "jQuery Cross Origin",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "jQueryMigrateLocation",
+      "displayName": "jQuery Migrate location (Absolute, Relative, or Remote paths are allowed)",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "jQueryMigrateLocationIntegrity",
+      "displayName": "jQuery Migrate SRI Hash",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "jQueryMigrateLocationCrossOrigin",
+      "displayName": "jQuery Migrate Cross Origin",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "isDeferred",
+      "displayName": "Defer Loading",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "no",
+      "enumValues": [
+        {
+          "value": "no",
+          "displayValue": "No"
+        },
+        {
+          "value": "yes",
+          "displayValue": "Yes"
+        }
+      ]
+    },
+    {
+      "name": "scriptLocation",
+      "displayName": "Script Location",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "additionalHeadContent",
+      "enumValues": [
+        {
+          "value": "additionalHeadContent",
+          "displayValue": "Head"
+        },
+        {
+          "value": "afterBodyStart",
+          "displayValue": "After Body Start"
+        },
+        {
+          "value": "beforeBodyClose",
+          "displayValue": "Before Body Close"
+        }
+      ]
+    },
+    {
+      "name": "includeOnPublishedPage",
+      "displayName": "Include on Published Page",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "yes",
+      "enumValues": [
+        {
+          "value": "no",
+          "displayValue": "No"
+        },
+        {
+          "value": "yes",
+          "displayValue": "Yes"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/widgets/percJQueryWidget/templates/percJQueryWidgetSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jquery/widgets/percJQueryWidget/templates/percJQueryWidgetSnippet.vm
@@ -1,0 +1,3 @@
+#if ($perc.isEditMode())##
+        #createEmptyWidgetContent("jquery-widget-sample-content", "This jQuery widget is showing sample content.","height: 32px;background: transparent url(/Rhythmyx/rx_resources/widgets/percJQueryWidget/images/widgeticonjqueryempty.png) no-repeat scroll center center;filter: alpha(opacity=50);opacity: .50;")##
+    #end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/widgets/percJQueryUIWidget/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/widgets/percJQueryUIWidget/component-package.json
@@ -1,0 +1,156 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percJQueryUIWidget",
+  "name": "jQuery UI Widget",
+  "version": "1.1.4",
+  "description": "Select your desired version of jQuery UI",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "jQuery UI Widget",
+    "category": "Design",
+    "description": "Select your desired version of jQuery UI",
+    "thumbnail": "resources/widgeticonjqueryui.png",
+    "icon": "resources/widgeticonjqueryui.png",
+    "author": "Percussion Software, Inc.",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percJQueryUIWidgetSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percJQueryUIWidgetSnippet.vm",
+      "bindings": [
+        {
+          "variable": "jQueryUILocation",
+          "expression": "$perc.widget.item.properties.get('jQueryUILocation')"
+        },
+        {
+          "variable": "isUIDeferred",
+          "expression": "$perc.widget.item.properties.get('isUIDeferred')"
+        },
+        {
+          "variable": "scriptUILocation",
+          "expression": "$perc.widget.item.properties.get('scriptUILocation')"
+        },
+        {
+          "variable": "includeUIOnPublishedPage",
+          "expression": "$perc.widget.item.properties.get('includeUIOnPublishedPage')"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$jQueryUILocation = $perc.widget.item.properties.get('jQueryUILocation');\n    $isUIDeferred = $perc.widget.item.properties.get('isUIDeferred');\n    $scriptUILocation = $perc.widget.item.properties.get('scriptUILocation');\n    $includeUIOnPublishedPage = $perc.widget.item.properties.get('includeUIOnPublishedPage');"
+        }
+      ]
+    }
+  ],
+  "slots": [],
+  "resources": [
+    {
+      "path": "resources/widgeticonjqueryui.png",
+      "target": "rx_resources/widgets/percJQueryUIWidget/images/widgeticonjqueryui.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "jQueryUILocation",
+      "displayName": "jQuery UI CDN Link (http or https):",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "/web_resources/cm/jslib/jquery-ui.js",
+      "enumValues": []
+    },
+    {
+      "name": "jQueryUILocationIntegrity",
+      "displayName": "jQuery UI SRI Hash",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "jQueryUILocationCrossOrigin",
+      "displayName": "jQuery UI Cross Origin",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "jQueryUICSSTheme",
+      "displayName": "jQuery UI CSS",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "/web_resources/cm/themes/smoothness/jquery-ui-1.8.9.custom.css",
+      "enumValues": []
+    },
+    {
+      "name": "isUIDeferred",
+      "displayName": "Defer Loading",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "no",
+      "enumValues": [
+        {
+          "value": "no",
+          "displayValue": "No"
+        },
+        {
+          "value": "yes",
+          "displayValue": "Yes"
+        }
+      ]
+    },
+    {
+      "name": "scriptUILocation",
+      "displayName": "Script Location",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "additionalHeadContent",
+      "enumValues": [
+        {
+          "value": "additionalHeadContent",
+          "displayValue": "Head"
+        },
+        {
+          "value": "afterBodyStart",
+          "displayValue": "After Body Start"
+        },
+        {
+          "value": "beforeBodyClose",
+          "displayValue": "Before Body Close"
+        }
+      ]
+    },
+    {
+      "name": "includeUIOnPublishedPage",
+      "displayName": "Include on Published Page",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "yes",
+      "enumValues": [
+        {
+          "value": "no",
+          "displayValue": "No"
+        },
+        {
+          "value": "yes",
+          "displayValue": "Yes"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/widgets/percJQueryUIWidget/templates/percJQueryUIWidgetSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.jqueryUI/widgets/percJQueryUIWidget/templates/percJQueryUIWidgetSnippet.vm
@@ -1,0 +1,3 @@
+#if ($perc.isEditMode())##
+        #createEmptyWidgetContent("jquery-ui-widget-sample-content", "This jQuery UI widget is showing sample content.","height: 32px;background: transparent url(/Rhythmyx/rx_resources/widgets/percJQueryUIWidget/images/widgeticonjqueryuiempty.png) no-repeat scroll center center;filter: alpha(opacity=50);opacity: .50;")##
+    #end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.login/widgets/percLogin/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.login/widgets/percLogin/component-package.json
@@ -1,0 +1,212 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percLogin",
+  "name": "Login",
+  "version": "1.1.8",
+  "description": "User login for membership services.",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.5.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Login",
+    "category": "integration",
+    "description": "User login for membership services.",
+    "thumbnail": "resources/widgetIconLogin.gif",
+    "icon": "resources/widgetIconLogin.gif",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 500,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percLoginAsset",
+      "ref": "contentTypes/percLoginAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percLoginSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percLoginSnippet.vm",
+      "contentType": "percLoginAsset",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "percLabelLayout",
+          "expression": "$perc.widget.item.properties.get('perc-label-layout')"
+        },
+        {
+          "variable": "renderMode",
+          "expression": "$perc.widget.item.properties.get('perc-render-mode')"
+        },
+        {
+          "variable": "isLoginPage",
+          "expression": "false"
+        },
+        {
+          "variable": "loginPage",
+          "expression": "\"\""
+        },
+        {
+          "variable": "pwresetPage",
+          "expression": "\"\""
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "loginPage",
+          "expression": "$rx.pageutils.getSiteLoginPage($pathParts[2])"
+        },
+        {
+          "variable": "pwresetPage",
+          "expression": "$rx.pageutils.getSiteResetRequestPasswordPage($pathParts[2])"
+        },
+        {
+          "variable": "loginPagePath",
+          "expression": "$pathParts[0] + '/' + $pathParts[1] + '/' + $pathParts[2] + $loginPage"
+        },
+        {
+          "variable": "isLoginPage",
+          "expression": "$finderPath.equals($loginPagePath)"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "percEmailLabel",
+          "expression": "$rx.pageutils.html($assetItem, 'email_label')"
+        },
+        {
+          "variable": "percPasswordLabel",
+          "expression": "$rx.pageutils.html($assetItem, 'password_label')"
+        },
+        {
+          "variable": "percSubmitLabel",
+          "expression": "$rx.pageutils.html($assetItem, 'submit_label')"
+        },
+        {
+          "variable": "notLoggedInMessage",
+          "expression": "$rx.pageutils.html($assetItem, 'not_logged_in_message')"
+        },
+        {
+          "variable": "loggedInMessage",
+          "expression": "$rx.pageutils.html($assetItem, 'logged_in_message')"
+        },
+        {
+          "variable": "showUsername",
+          "expression": "$rx.pageutils.html($assetItem, 'show_username')"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n        $widgetId = $perc.widget.item.id;\n\n        ## Retrieve User prefs (Layout Tab)\n        $percLabelLayout = $perc.widget.item.properties.get('perc-label-layout');\n        $renderMode = $perc.widget.item.properties.get('perc-render-mode');\n\n        ## Set a default value for $isLoginPage, since we could be in a template, a normal page, the login page, etc\n        $isLoginPage = false;\n        $loginPage = \"\";\n        $pwresetPage = \"\";\n        ## This checks if we are in the login page only when we are in a page\n        ## The check is not performed in a template, because it doesn't have a $pageId\n        if (! empty($pageId)) {\n            ## Retrieve loginPage for the current site\n            $finderPath = $rx.pageutils.getItemPath($pageId);\n            $pathParts = $finderPath.split(\"\\/\");\n            ## current site name == $pathParts[2]\n            $loginPage = $rx.pageutils.getSiteLoginPage($pathParts[2]);\n            $pwresetPage = $rx.pageutils.getSiteResetRequestPasswordPage($pathParts[2]);\n            if (! empty($loginPage)) {\n                $loginPagePath = $pathParts[0] + '/' + $pathParts[1] + '/' + $pathParts[2] + $loginPage;\n                $isLoginPage = $finderPath.equals($loginPagePath);\n            }\n        }\n\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if (empty($rootclass)) {\n            $rootclass = \"\";\n        }\n\n        $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\n        if ( ! $assetItems.isEmpty() ) {\n            $assetItem = $assetItems.get(0);\n            $percEmailLabel = $rx.pageutils.html($assetItem, 'email_label');\n            $percPasswordLabel = $rx.pageutils.html($assetItem, 'password_label');\n            $percSubmitLabel = $rx.pageutils.html($assetItem, 'submit_label');\n            $notLoggedInMessage = $rx.pageutils.html($assetItem, 'not_logged_in_message');\n            $loggedInMessage = $rx.pageutils.html($assetItem, 'logged_in_message');\n            $showUsername = $rx.pageutils.html($assetItem, 'show_username');\n\t\t}\n\n\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t$dsUrl = \"\";"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percLoginContent",
+      "allowedContentTypes": [
+        "percLoginAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLogin.gif",
+      "target": "rx_resources/widgets/login/images/widgetIconLogin.gif",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc-label-layout",
+      "displayName": "Label layout",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "align_above",
+      "enumValues": [
+        {
+          "value": "align_above",
+          "displayValue": "Align above the field"
+        },
+        {
+          "value": "align_left",
+          "displayValue": "Align to the left of the field"
+        }
+      ]
+    },
+    {
+      "name": "perc-render-mode",
+      "displayName": "Render mode",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "show_as_link",
+      "enumValues": [
+        {
+          "value": "show_as_link",
+          "displayValue": "Show as link/text"
+        },
+        {
+          "value": "show_login_form",
+          "displayValue": "Show login form"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.login/widgets/percLogin/templates/percLoginSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.login/widgets/percLogin/templates/percLoginSnippet.vm
@@ -1,0 +1,57 @@
+#loadRelatedWidgetContents()
+        <div class="$!{rootclass} percLogin" data="{&quot;notLoggedInMessage&quot;:&quot;$notLoggedInMessage&quot;
+                                                    ,&quot;loggedInMessage&quot;:&quot;$loggedInMessage&quot;
+													,&quot;deliveryurl&quot;:&quot;$dsUrl&quot;
+                                                    ,&quot;showUsername&quot;:&quot;$!showUsername&quot;}">
+        #if( ! $perc.widgetContents.isEmpty() )
+            <div class="login-contents-box">
+            ###############################################################################
+            ## Render the login form only if render preference is set as show_login_form.
+            ###############################################################################
+            #if( $renderMode == "show_login_form" )
+                <form name="perc-login-form" class="perc-login-form" id="perc-login-form" method="post" action="#">
+                    <div class="field-row">
+                        <div class="field-label-container $percLabelLayout fixed-width">
+                            <span class="perc-form-error-asterisk">*</span>
+                            <label for="perc-login-email-field">$percEmailLabel</label>
+                        </div>
+                        <div class="field-input-container">
+                            <input value="" name="perc-login-email-field" id="perc-login-email-field" type="text"/>
+                        </div>
+                    </div>
+                    <div class="field-row">
+                        <div class="field-label-container $percLabelLayout fixed-width">
+                            <span class="perc-form-error-asterisk">*</span>
+                            <label for="perc-login-password-field">$percPasswordLabel</label>
+                        </div>
+                        <div class="field-input-container">
+                            <input value="" name="perc-login-password-field" id="perc-login-password-field" type="password" />
+                        </div>
+                    </div>
+                    <div class="field-row">
+                        <a href="$pwresetPage">Forgot password?</a>
+                    </div>
+                    <div class="field-row">
+                        <input value="$percSubmitLabel" type="submit" />
+                    </div>
+                </form>
+                <div class="perc-login-error-message form-error-msg" style="display:none"></div>
+            #################################################################################################
+            ## If the render preference is set to show_link, then show a link to the site's global login page.
+            #################################################################################################
+            #else
+                <a class="perc-login-page-link" href="$!loginPage">$!notLoggedInMessage</a>
+            #end
+            </div>
+        #elseif ($perc.isEditMode())
+            #createEmptyWidgetContent("login-sample-content", "This login widget is showing sample content.")
+        #end
+        #if($perc.isPreviewMode())
+            <script>
+            window.addEventListener('DOMContentLoaded', function() {
+                jQuery(".perc-login-form").on("submit", function(){return false;});
+                jQuery(".perc-login-form").find("input[type = 'submit']").prop("disabled", true);
+                });
+            </script>
+        #end
+        </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/widgets/percPoll/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/widgets/percPoll/component-package.json
@@ -1,0 +1,239 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percPoll",
+  "name": "Polls",
+  "version": "1.2.0",
+  "description": "Widget to build and render polls.",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.5.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Polls",
+    "category": "social,blog",
+    "description": "Widget to build and render polls.",
+    "thumbnail": "resources/widgetIconPoll.png",
+    "icon": "resources/widgetIconPoll.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percPollAsset",
+      "ref": "contentTypes/percPollAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percPollSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percPollSnippet.vm",
+      "contentType": "percPollAsset",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "viewResultsLink",
+          "expression": "$props.get(\"viewResultsLink\")"
+        },
+        {
+          "variable": "viewResultsLinkText",
+          "expression": "$props.get(\"viewResultsLinkText\")"
+        },
+        {
+          "variable": "pollSubmitLabel",
+          "expression": "$props.get(\"submitLabel\")"
+        },
+        {
+          "variable": "restrictionType",
+          "expression": "$props.get(\"pollRestrictionType\")"
+        },
+        {
+          "variable": "validationText",
+          "expression": "$props.get(\"validationText\")"
+        },
+        {
+          "variable": "backToPollText",
+          "expression": "$props.get(\"backToPollText\")"
+        },
+        {
+          "variable": "totalVotesText",
+          "expression": "$props.get(\"totalVotesText\")"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "pollQuestion",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "pollName",
+          "expression": "$assetItem.Node.getProperty('rx:sys_title').getString()"
+        },
+        {
+          "variable": "pollTitle",
+          "expression": "$assetItem.Node.getProperty('rx:pollTitle').getString()"
+        },
+        {
+          "variable": "pollQuestion",
+          "expression": "$assetItem.Node.getProperty('rx:pollQuestion').getString()"
+        },
+        {
+          "variable": "qJson",
+          "expression": "$rx.pageutils.createJsonObject($pollQuestion)"
+        },
+        {
+          "variable": "question",
+          "expression": "$qJson.getString(\"question\")"
+        },
+        {
+          "variable": "answerType",
+          "expression": "$qJson.getString(\"answerType\")"
+        },
+        {
+          "variable": "inputType",
+          "expression": "\"radio\""
+        },
+        {
+          "variable": "inputType",
+          "expression": "\"checkbox\""
+        },
+        {
+          "variable": "ansArray",
+          "expression": "$qJson.getJSONArray(\"answerChoices\").toArray()"
+        },
+        {
+          "variable": "dataJson",
+          "expression": "$rx.pageutils.createJsonObject(\"{}\")"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "## Widget Properties\n\t\t\t$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n            $props = $perc.widget.item.properties;\n            $viewResultsLink = $props.get(\"viewResultsLink\");\n            $viewResultsLinkText = $props.get(\"viewResultsLinkText\");\n\t\t\t$pollSubmitLabel = $props.get(\"submitLabel\");\n\t\t\t$restrictionType = $props.get(\"pollRestrictionType\");\n\t\t\t$validationText = $props.get(\"validationText\");\n\t\t\t$backToPollText = $props.get(\"backToPollText\");\n\t\t\t$totalVotesText = $props.get(\"totalVotesText\");\n\n\t\t\t## Asset properties\n\t\t\t$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\t\t\t$perc.setWidgetContents($assetItems);\n\t\t\t$pollQuestion = \"\";\n\t        if ( ! $assetItems.isEmpty() ) {\n\t\t\t\t$assetItem = $assetItems.get(0);\n\t\t\t\t$pollName = $assetItem.Node.getProperty('rx:sys_title').getString();\n\t\t\t\t$pollTitle = $assetItem.Node.getProperty('rx:pollTitle').getString();\n\t\t\t\t$pollQuestion = $assetItem.Node.getProperty('rx:pollQuestion').getString();\n\t\t\t\t$qJson = $rx.pageutils.createJsonObject($pollQuestion);\n\t\t\t\t$question = $qJson.getString(\"question\");\n\t\t\t\t$answerType = $qJson.getString(\"answerType\");\n\t\t\t\t$inputType = \"radio\";\n\t\t\t\tif($answerType.equals(\"multi\"))\n\t\t\t\t\t$inputType = \"checkbox\";\n\t\t\t\t$ansArray = $qJson.getJSONArray(\"answerChoices\").toArray();\n\n\t\t\t\t## Create data JSON object\n\t\t\t\t$dataJson = $rx.pageutils.createJsonObject(\"{}\");\n\t\t\t\t$dataJson.put(\"pollName\",$pollName);\n\t\t\t\t$dataJson.put(\"restrictionType\",$restrictionType);\n\t\t\t}\n\n\t\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percPollContent",
+      "allowedContentTypes": [
+        "percPollAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconPoll.png",
+      "target": "rx_resources/widgets/percPoll/images/widgetIconPoll.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "pollRestrictionType",
+      "displayName": "Restrict poll submission by",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "Unrestricted",
+      "enumValues": [
+        {
+          "value": "Unrestricted",
+          "displayValue": "Unrestricted"
+        },
+        {
+          "value": "Session",
+          "displayValue": "Session"
+        },
+        {
+          "value": "Cookie",
+          "displayValue": "Cookie"
+        }
+      ]
+    },
+    {
+      "name": "submitLabel",
+      "displayName": "Submit button label",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Vote",
+      "enumValues": []
+    },
+    {
+      "name": "viewResultsLink",
+      "displayName": "Show view results link",
+      "datatype": "bool",
+      "required": true,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "viewResultsLinkText",
+      "displayName": "Text for view results",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "View results",
+      "enumValues": []
+    },
+    {
+      "name": "validationText",
+      "displayName": "Validation text",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Please choose an answer first!",
+      "enumValues": []
+    },
+    {
+      "name": "totalVotesText",
+      "displayName": "Text for total votes",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Total votes",
+      "enumValues": []
+    },
+    {
+      "name": "backToPollText",
+      "displayName": "Text to return",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "Back to poll",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/widgets/percPoll/templates/percPollSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.poll/widgets/percPoll/templates/percPollSnippet.vm
@@ -1,0 +1,54 @@
+#if( ! $perc.widgetContents.isEmpty())
+			<div class = "perc-polls $!{rootclass}" data-poll='{"pollName":"$pollName","restrictionType":"$restrictionType","deliveryurl":"$dsUrl"}'>
+				#if($perc.isEditMode())
+					<div class="perc-poll-render-container">
+				#else
+					<div class="perc-poll-render-container" style="display:none">
+				#end
+					<div class="perc-poll-title">$!{pollTitle}</div>
+					<div class="perc-poll-question">$!{question}</div>
+					#foreach($ans in $ansArray)
+						<div class="perc-poll-answer-container"><input type="$inputType" name="perc-poll-answer"/><span class="perc-poll-answer">$ans</span></div>
+					#end
+					#if($perc.isEditMode() || $perc.isPreviewMode() )
+						#set($subspanclass = "perc-poll-submit-button-span")
+					#else
+						#set($subspanclass = "perc-poll-submit-button-span perc-poll-submit-button-span-action")
+					#end
+					<div class="poll-submit-button"><input type="button" value="$pollSubmitLabel" name="perc-poll-submit-button"/><span class="$subspanclass" >$pollSubmitLabel</span></div>
+					#if($viewResultsLink)
+						#if($perc.isEditMode() || $perc.isPreviewMode() )
+							#set($rlclass = "view-results-link")
+						#else
+							#set($rlclass = "view-results-link view-results-link-action")
+						#end
+						<div class="$rlclass"><a href="javascript:void(0)">$viewResultsLinkText</a></div>
+					#else
+						#set($rlclass = "view-results-link view-results-link-action")
+						<div class="$rlclass"></div>
+					#end
+					<div class="poll-validation-text" style="display:none;">$validationText</div>
+				</div>
+				<div class="perc-poll-results-container" style="display:none">
+					<div class="perc-poll-title">$!{pollTitle}</div>
+					<div class="perc-poll-question">$!{question}</div>
+					#foreach($ans in $ansArray)
+						<div class="perc-poll-answer-container"><span class="perc-poll-answer">$ans</span><span class="perc-poll-result-percent"></span><span class="perc-poll-result-count"></span></div>
+						<div class="perc-poll-result-container"><span class="perc-poll-result-fill"></span><span class="perc-poll-result-empty"></span></div>
+					#end
+					<div class="perc-poll-total-votes">$totalVotesText:<span></span></div>
+					<div class="perc-poll-backto-poll"><a href="javascript:void(0)">$backToPollText</a></div>
+				</div>
+
+			</div>
+		#elseif ($perc.isEditMode())
+            #createEmptyWidgetContent("poll-sample-content", "This polls widget is showing sample content.")
+		#end
+		#if($perc.isPreviewMode())
+				<script>
+				window.addEventListener('DOMContentLoaded', function() {
+					jQuery("input[name = 'perc-poll-submit-button']").attr('disabled', 'disabled');
+					jQuery(".perc-poll-render-container").show();
+				});
+				</script>
+		#end

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/widgets/percRegistration/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/widgets/percRegistration/component-package.json
@@ -1,0 +1,244 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percRegistration",
+  "name": "Registration (Deprecated)",
+  "version": "1.1.8",
+  "description": "Widget to build and render a registration form. (Deprecated)",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.5.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Registration (Deprecated)",
+    "category": "integration",
+    "description": "Widget to build and render a registration form. (Deprecated)",
+    "thumbnail": "resources/widgetIconRegistration.gif",
+    "icon": "resources/widgetIconRegistration.gif",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 450,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percRegistrationAsset",
+      "ref": "contentTypes/percRegistrationAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percRegistrationSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percRegistrationSnippet.vm",
+      "contentType": "percRegistrationAsset",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "widgetProps",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "percLabelLayout",
+          "expression": "$widgetProps.get('perc-label-layout')"
+        },
+        {
+          "variable": "percregMode",
+          "expression": "$widgetProps.get('perc-registration-mode')"
+        },
+        {
+          "variable": "percEmailConfirmRequired",
+          "expression": "$widgetProps.get('perc-email-verification-required')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "siteName",
+          "expression": "\"\""
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "siteName",
+          "expression": "$pathParts[2]"
+        },
+        {
+          "variable": "percConfirmationPage",
+          "expression": "$rx.pageutils.getSiteRegistrationConfirmationPage($pathParts[2])"
+        },
+        {
+          "variable": "percConfirmationPage",
+          "expression": "\"\""
+        },
+        {
+          "variable": "data",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "percEmailLabel",
+          "expression": "$rx.pageutils.html($assetItem, 'email_label')"
+        },
+        {
+          "variable": "percPasswordLabel",
+          "expression": "$rx.pageutils.html($assetItem, 'password_label')"
+        },
+        {
+          "variable": "percConfirmPasswordLabel",
+          "expression": "$rx.pageutils.html($assetItem, 'confirm_password_label')"
+        },
+        {
+          "variable": "percSubmitLabel",
+          "expression": "$rx.pageutils.html($assetItem, 'submit_label')"
+        },
+        {
+          "variable": "pwResetPage",
+          "expression": "\"\""
+        },
+        {
+          "variable": "pwResetPage",
+          "expression": "$rx.pageutils.getSiteResetPage($siteName)"
+        },
+        {
+          "variable": "finder",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finder, null, true)"
+        },
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "nav",
+          "expression": "$assetItems.get(0).getNode()"
+        },
+        {
+          "variable": "homePageLink",
+          "expression": "$tools.esc.html($rx.pageutils.navLink($linkContext, $nav))"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n        $widgetId = $perc.widget.item.id;\n        $widgetProps =  $perc.widget.item.properties;\n        $percLabelLayout = $widgetProps.get('perc-label-layout');\n        $percregMode = $widgetProps.get('perc-registration-mode');\n        $percEmailConfirmRequired = $widgetProps.get('perc-email-verification-required');\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if (!empty($rootclass))\n        {\n            $rootclass = $rootclass + \" \";\n        }\n        ## If we are in a template it doesn't have a $pageId\n        $siteName = \"\";\n        if (!empty($pageId))\n        {\n            $finderPath = $rx.pageutils.getItemPath($pageId);\n            $pathParts = $finderPath.split(\"\\/\");\n            $siteName = $pathParts[2];\n            $percConfirmationPage  = $rx.pageutils.getSiteRegistrationConfirmationPage($pathParts[2]);\n        }\n\n        ## Set default values for some variables if they are empty\n        if (empty($percConfirmationPage)) {\n            $percConfirmationPage = \"\";\n        }\n\n        $data = \"\";\n        $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n        $perc.setWidgetContents($assetItems);\n        if ( ! $assetItems.isEmpty())\n        {\n            $assetItem = $assetItems.get(0);\n            $percEmailLabel = $rx.pageutils.html($assetItem, 'email_label');\n            $percPasswordLabel = $rx.pageutils.html($assetItem, 'password_label');\n            $percConfirmPasswordLabel = $rx.pageutils.html($assetItem, 'confirm_password_label');\n            $percSubmitLabel = $rx.pageutils.html($assetItem, 'submit_label');\n            $pwResetPage = \"\";\n            if(!empty($siteName))\n            {\n                $pwResetPage = $rx.pageutils.getSiteResetPage($siteName);\n            }\n\n            ## If the user didn't configure the Confirmation page, we must redirect to the home page\n            $finder=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n            $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finder, null, true);\n            if ( ! $assetItems.isEmpty() ) {\n                $linkContext = $perc.linkContext;\n                $nav = $assetItems.get(0).getNode();\n                $homePageLink = $tools.esc.html($rx.pageutils.navLink($linkContext, $nav));\n            }\n        }\n\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t$dsUrl = \"\";"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percRegistrationContent",
+      "allowedContentTypes": [
+        "percRegistrationAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconRegistration.gif",
+      "target": "rx_resources/widgets/registration/images/widgetIconRegistration.gif",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc-label-layout",
+      "displayName": "Label layout",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "align_above",
+      "enumValues": [
+        {
+          "value": "align_above",
+          "displayValue": "Align above the field"
+        },
+        {
+          "value": "align_left",
+          "displayValue": "Align to the left of the field"
+        }
+      ]
+    },
+    {
+      "name": "perc-registration-mode",
+      "displayName": "Registration mode",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "registration",
+      "enumValues": [
+        {
+          "value": "registration",
+          "displayValue": "Registration"
+        },
+        {
+          "value": "password_request",
+          "displayValue": "Password request"
+        },
+        {
+          "value": "password_reset",
+          "displayValue": "Password reset"
+        }
+      ]
+    },
+    {
+      "name": "perc-email-verification-required",
+      "displayName": "Email verification required",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/widgets/percRegistration/templates/percRegistrationSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/widgets/percRegistration/templates/percRegistrationSnippet.vm
@@ -1,0 +1,124 @@
+<div class="$!{rootclass} percRegistration" data="{&quot;homePageLink&quot;:&quot;$homePageLink&quot;,&quot;deliveryurl&quot;:&quot;$dsUrl&quot;}">
+        #if( ! $perc.widgetContents.isEmpty())
+            #if($percregMode == "registration")
+            <div class="perc-registration-mode">
+                    #if($percEmailConfirmRequired)
+                        <form name="perc-registration-cform" id="perc-registration-cform" method="post" action="#">
+                    #else
+                        <form name="perc-registration-form" id="perc-registration-form" method="post" action="#">
+                    #end
+                        <input value="$percConfirmationPage" name="perc-confirmation-page" id="perc-confirmation-page" type="hidden" />
+
+                        <div class = "perc-registration-mode">
+                            <div class="field-row">
+                                <div class="field-label-container $percLabelLayout fixed-width">
+                                    <span class="perc-form-error-asterisk">*</span>
+                                    <label for="perc-registration-email-field">$percEmailLabel</label>
+                                </div>
+                                <div class="field-input-container">
+                                    <input value="" name="perc-registration-email-field" id="perc-registration-email-field" type="text"/>
+                                </div>
+                            </div>
+                            <div class="field-row">
+                                <div class="field-label-container $percLabelLayout fixed-width">
+                                    <span class="perc-form-error-asterisk">*</span>
+                                    <label for="perc-registration-password-field">$percPasswordLabel</label>
+                                </div>
+                                <div class="field-input-container">
+                                    <input value="" name="perc-registration-password-field" id="perc-registration-password-field" type="password" />
+                                </div>
+                            </div>
+                            <div class="field-row">
+                                <div class="field-label-container $percLabelLayout fixed-width">
+                                    <span class="perc-form-error-asterisk">*</span>
+                                    <label for="perc-registration-password-confirm-field">$percConfirmPasswordLabel</label>
+                                </div>
+                                <div class="field-input-container">
+                                    <input value="" name="perc-registration-password-confirm-field" id="perc-registration-password-confirm-field" type="password"/>
+                                </div>
+                            </div>
+                            <div class="field-row">
+                                <input value="$percSubmitLabel" type="submit" />
+                            </div>
+                        </div>
+                    </form>
+                </div>
+                <div class="perc-reg-confirmation-mode" style="display:none">
+                    <div class="perc-reg-confirmation-message">
+                        Please wait while your registration is confirmed...
+                    </div>
+                </div>
+            #elseif($percregMode == "password_request")
+                <form name="perc-password-request" id="perc-password-request" method="post" action="#">
+                    <input type="hidden" name="perc_password_reset_page" value="$pwResetPage"/>
+                    <div class = "perc-reset-mode">
+                        <div class="field-row">
+                            <div class="field-label-container $percLabelLayout fixed-width">
+                                <span class="perc-form-error-asterisk">*</span>
+                                <label for="perc-registration-email-field">$percEmailLabel</label>
+                            </div>
+                            <div class="field-input-container">
+                                <input value="" name="perc-registration-email-field" id="perc-registration-email-field" type="text"/>
+                            </div>
+                        </div>
+                        <div class="field-row">
+                            <input value="$percSubmitLabel" type="submit" />
+                        </div>
+                    </div>
+                </form>
+            #elseif($percregMode == "password_reset")
+                <form name="perc-password-reset" id="perc-password-reset" method="post" action="#" style = "display:none">
+                    <div class = "perc-update-mode">
+                        <div class="field-row">
+                            <div class="field-label-container $percLabelLayout fixed-width">
+                                <span class="perc-form-error-asterisk">*</span>
+                                <label for="perc-registration-email-field">$percEmailLabel</label>
+                            </div>
+                            <div class="field-input-container">
+                                <input disabled = '' readonly = "" class = "datadisplay" value="" name="perc-registration-email-field" id="perc-registration-email-field" type="text"/>
+                            </div>
+                        </div>
+                        <div class="field-row">
+                            <div class="field-label-container $percLabelLayout fixed-width">
+                                <span class="perc-form-error-asterisk">*</span>
+                                <label for="perc-registration-password-field">$percPasswordLabel</label>
+                            </div>
+                            <div class="field-input-container">
+                                <input value="" name="perc-registration-password-field" id="perc-registration-password-field" type="password" />
+                            </div>
+                        </div>
+                        <div class="field-row">
+                            <div class="field-label-container $percLabelLayout fixed-width">
+                                <span class="perc-form-error-asterisk">*</span>
+                                <label for="perc-registration-password-confirm-field">$percConfirmPasswordLabel</label>
+                            </div>
+                            <div class="field-input-container">
+                                <input value="" name="perc-registration-password-confirm-field" id="perc-registration-password-confirm-field" type="password"/>
+                            </div>
+                        </div>
+                        <div class="field-row">
+                            <input value="$percSubmitLabel" type="submit" />
+                        </div>
+                    </div>
+                </form>
+            #end
+                <div class = "perc-reg-error-message" style = "display:none"></div>
+                <div class = "perc-confirmation-message" style = "display:none">
+                    <p>An email has been sent to the account provided. Please follow the link in your email to reset your password.</p>
+                </div>
+        #elseif ($perc.isEditMode())
+            #createEmptyWidgetContent("registration-sample-content", "This registration widget is showing sample content.")
+        #end
+        #if($perc.isPreviewMode() || $perc.linkContext.mode == "PUBLISH")
+            <script>
+            window.addEventListener('DOMContentLoaded', function() {
+             #if($perc.isPreviewMode())
+                    jQuery("#perc-registration-form, #perc-registration-cform, #perc-password-request, #perc-password-reset").on("submit", function(){return false;});
+                    jQuery("#perc-registration-form, #perc-registration-cform, #perc-password-request, #perc-password-reset").find("input[type = 'submit']").prop("disabled", true);
+                #end
+                jQuery("#perc-password-request, #perc-password-reset").show();
+                //var urlParams = jQuery.deparam.querystring();
+			});
+            </script>
+        #end
+    </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/widgets/percRss/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/widgets/percRss/component-package.json
@@ -1,0 +1,550 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percRss",
+  "name": "RSS",
+  "version": "1.1.8",
+  "description": "Display a list of external RSS feeds",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.2.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "RSS",
+    "category": "blog,social",
+    "description": "Display a list of external RSS feeds",
+    "thumbnail": "resources/widgetIconRss.gif",
+    "icon": "resources/widgetIconRss.gif",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 275,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percRssAsset",
+      "ref": "contentTypes/percRssAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percRssSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percRssSnippet.vm",
+      "contentType": "percRssAsset",
+      "bindings": [
+        {
+          "variable": "percFeedItemLimit",
+          "expression": "$perc.widget.item.properties.get('perc-feed-item-limit')"
+        },
+        {
+          "variable": "percFeedShowTitle",
+          "expression": "$perc.widget.item.properties.get('perc-feed-show-title')"
+        },
+        {
+          "variable": "percFeedShowItemTitle",
+          "expression": "$perc.widget.item.properties.get('perc-feed-show-item-title')"
+        },
+        {
+          "variable": "percFeedShowItemDate",
+          "expression": "$perc.widget.item.properties.get('perc-feed-show-item-date')"
+        },
+        {
+          "variable": "percFeedShowItemDescription",
+          "expression": "$perc.widget.item.properties.get('perc-feed-show-item-description')"
+        },
+        {
+          "variable": "percFeedRemoveHtml",
+          "expression": "$perc.widget.item.properties.get('perc-feed-remove-html')"
+        },
+        {
+          "variable": "percFeedDescriptionLength",
+          "expression": "$perc.widget.item.properties.get('perc-feed-description-length')"
+        },
+        {
+          "variable": "percFeedDescriptionEmpty",
+          "expression": "$perc.widget.item.properties.get('perc-feed-description-length').toString().isEmpty()"
+        },
+        {
+          "variable": "percFeedItemDateFormat",
+          "expression": "$perc.widget.item.properties.get('perc-feed-item-date-format')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "wrappingElement",
+          "expression": "$perc.widget.item.properties.get('wrappingElement')"
+        },
+        {
+          "variable": "itemElement",
+          "expression": "\"li\""
+        },
+        {
+          "variable": "itemElement",
+          "expression": "\"div\""
+        },
+        {
+          "variable": "titleElement",
+          "expression": "$perc.widget.item.properties.get('titleElement')"
+        },
+        {
+          "variable": "itemTitleElement",
+          "expression": "$perc.widget.item.properties.get('itemTitleElement')"
+        },
+        {
+          "variable": "itemDateElement",
+          "expression": "$perc.widget.item.properties.get('itemDateElement')"
+        },
+        {
+          "variable": "itemDescriptionElement",
+          "expression": "$perc.widget.item.properties.get('itemDescriptionElement')"
+        },
+        {
+          "variable": "titleElement",
+          "expression": "'div'"
+        },
+        {
+          "variable": "itemTitleElement",
+          "expression": "'div'"
+        },
+        {
+          "variable": "itemDateElement",
+          "expression": "'div'"
+        },
+        {
+          "variable": "itemDescriptionElement",
+          "expression": "'div'"
+        },
+        {
+          "variable": "feedId",
+          "expression": "$perc.widget.item.properties.get('feedId')"
+        },
+        {
+          "variable": "feedId",
+          "expression": "$perc.widget.item.id + \"_feed\""
+        },
+        {
+          "variable": "wrappingElemAriaLabel",
+          "expression": "$perc.widget.item.properties.get('wrappingElemAriaLabel')"
+        },
+        {
+          "variable": "ariaRole",
+          "expression": "$perc.widget.item.properties.get('ariaRole')"
+        },
+        {
+          "variable": "ariaRole",
+          "expression": "' role = \"' + $ariaRole + '\"'"
+        },
+        {
+          "variable": "q",
+          "expression": "$tools.esc.q"
+        },
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "percUrlFeed",
+          "expression": "$rx.pageutils.html($assetItem, 'rss_url')"
+        },
+        {
+          "variable": "percUrlFeed",
+          "expression": "\"\""
+        },
+        {
+          "variable": "percFeedDescriptionLength",
+          "expression": "-1"
+        },
+        {
+          "variable": "dLdata",
+          "expression": "$rx.string.getJSONObject()"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.xml($dLdata)"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$percFeedItemLimit = $perc.widget.item.properties.get('perc-feed-item-limit');\n        $percFeedShowTitle = $perc.widget.item.properties.get('perc-feed-show-title');\n        $percFeedShowItemTitle = $perc.widget.item.properties.get('perc-feed-show-item-title');\n        $percFeedShowItemDate = $perc.widget.item.properties.get('perc-feed-show-item-date');\n        $percFeedShowItemDescription = $perc.widget.item.properties.get('perc-feed-show-item-description');\n        $percFeedRemoveHtml = $perc.widget.item.properties.get('perc-feed-remove-html');\n        $percFeedDescriptionLength = $perc.widget.item.properties.get('perc-feed-description-length');\n        $percFeedDescriptionEmpty = $perc.widget.item.properties.get('perc-feed-description-length').toString().isEmpty();\n        $percFeedItemDateFormat = $perc.widget.item.properties.get('perc-feed-item-date-format');\n        $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        $wrappingElement = $perc.widget.item.properties.get('wrappingElement');\n        if ($wrappingElement.equals('ol') || $wrappingElement.equals('ul') )\n        {\n        $itemElement = \"li\";\n        } else {\n        $itemElement = \"div\";\n        }\n\n        $titleElement = $perc.widget.item.properties.get('titleElement');\n        $itemTitleElement = $perc.widget.item.properties.get('itemTitleElement');\n        $itemDateElement = $perc.widget.item.properties.get('itemDateElement');\n        $itemDescriptionElement = $perc.widget.item.properties.get('itemDescriptionElement');\n\n        if ($titleElement == '' || $titleElement == null) {\n            $titleElement = 'div';\n        }\n        if ($itemTitleElement == '' || $itemTitleElement == null) {\n            $itemTitleElement = 'div';\n        }\n        if ($itemDateElement == '' || $itemDateElement == null) {\n            $itemDateElement = 'div';\n        }\n        if ($itemDescriptionElement == '' || $itemDescriptionElement == null) {\n          $itemDescriptionElement = 'div';\n        }\n\n        $feedId = $perc.widget.item.properties.get('feedId');\n        if ($feedId == '' || $feedId == null) {\n          $feedId = $perc.widget.item.id + \"_feed\";\n        }\n\n        $wrappingElemAriaLabel = $perc.widget.item.properties.get('wrappingElemAriaLabel');\n\n        $ariaRole = $perc.widget.item.properties.get('ariaRole');\n        if ($ariaRole != '' && $ariaRole != null) {\n          $ariaRole = ' role = \"' + $ariaRole + '\"';\n        }\n\n        $q = $tools.esc.q;\n\n        $linkContext = $perc.linkContext;\n        $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n        if ( ! $assetItems.isEmpty() ) {\n            $assetItem = $assetItems.get(0);\n            $percUrlFeed = $rx.pageutils.html($assetItem, 'rss_url');\n        } else {\n            $percUrlFeed = \"\";\n        }\n\n        if($percFeedDescriptionLength == ''){\n            $percFeedDescriptionLength = -1;\n        }\n\n        $dLdata = $rx.string.getJSONObject();\n        $dLdata.put(\"urlFeed\",$rx.pageutils.encryptString($percUrlFeed));\n        $dLdata.put(\"itemLimit\",$percFeedItemLimit);\n        $dLdata.put(\"showTitle\",$percFeedShowTitle);\n        $dLdata.put(\"showItemTitle\",$percFeedShowItemTitle);\n        $dLdata.put(\"showItemDate\",$percFeedShowItemDate);\n        $dLdata.put(\"showItemDescription\",$percFeedShowItemDescription);\n        $dLdata.put(\"itemRemoveHtml\",$percFeedRemoveHtml);\n        $dLdata.put(\"itemDescriptionLength\",$percFeedDescriptionLength);\n        $dLdata.put(\"itemDescriptionEmpty\",$percFeedDescriptionEmpty);\n        $dLdata.put(\"itemDateFormat\",$percFeedItemDateFormat);\n        $dLdata.put(\"wrappingElement\",$wrappingElement);\n        $dLdata.put(\"titleElement\",$titleElement);\n        $dLdata.put(\"itemElement\",$itemElement);\n        $dLdata.put(\"itemTitleElement\",$itemTitleElement);\n        $dLdata.put(\"itemDateElement\",$itemDateElement);\n        $dLdata.put(\"itemDescriptionElement\",$itemDescriptionElement);\n        $dLdata.put(\"feedId\",$feedId);\n        $dLdata.put(\"wrappingElemAriaLabel\",$wrappingElemAriaLabel);\n\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n        $dLdata.put(\"deliveryurl\",$dsUrl);\n        $dynamicListData = $tools.esc.xml($dLdata);"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percRssContent",
+      "allowedContentTypes": [
+        "percRssAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconRss.gif",
+      "target": "rx_resources/widgets/rss/images/widgetIconRss.gif",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "perc-feed-item-limit",
+      "displayName": "Feed item limit",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "1",
+      "enumValues": [
+        {
+          "value": "limit_1",
+          "displayValue": "1"
+        },
+        {
+          "value": "limit_5",
+          "displayValue": "5"
+        },
+        {
+          "value": "limit_10",
+          "displayValue": "10"
+        },
+        {
+          "value": "limit_15",
+          "displayValue": "15"
+        },
+        {
+          "value": "limit_20",
+          "displayValue": "20"
+        },
+        {
+          "value": "limit_25",
+          "displayValue": "25"
+        },
+        {
+          "value": "limit_50",
+          "displayValue": "50"
+        },
+        {
+          "value": "limit_100",
+          "displayValue": "100"
+        },
+        {
+          "value": "limit_-1",
+          "displayValue": "Unlimited"
+        }
+      ]
+    },
+    {
+      "name": "perc-feed-show-title",
+      "displayName": "Show feed title",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc-feed-show-item-title",
+      "displayName": "Show item title",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc-feed-show-item-date",
+      "displayName": "Show date",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc-feed-show-item-description",
+      "displayName": "Show description",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc-feed-remove-html",
+      "displayName": "Remove HTML from fields before displaying",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "perc-feed-description-length",
+      "displayName": "Maximum characters in description",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "100",
+      "enumValues": []
+    },
+    {
+      "name": "perc-feed-item-date-format",
+      "displayName": "Published date format",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "D M d, yy 'at' hh:nn",
+      "enumValues": []
+    },
+    {
+      "name": "wrappingElement",
+      "displayName": "HTML element to wrap feed items",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "none",
+      "enumValues": [
+        {
+          "value": "ul",
+          "displayValue": "Unordered List (ul)"
+        },
+        {
+          "value": "ol",
+          "displayValue": "Ordered List (ol)"
+        },
+        {
+          "value": "div",
+          "displayValue": "Block (div)"
+        },
+        {
+          "value": "none",
+          "displayValue": "None - Items are unwrapped"
+        }
+      ]
+    },
+    {
+      "name": "wrappingElemAriaLabel",
+      "displayName": "Wrapped feed items aria label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "titleElement",
+      "displayName": "HTML Format to use for feed title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "span",
+          "displayValue": "Span"
+        }
+      ]
+    },
+    {
+      "name": "itemTitleElement",
+      "displayName": "HTML Format to use for feed Item Titles",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "span",
+          "displayValue": "Span"
+        }
+      ]
+    },
+    {
+      "name": "itemDateElement",
+      "displayName": "HTML Format to use for feed Item Dates",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "span",
+          "displayValue": "Span"
+        }
+      ]
+    },
+    {
+      "name": "itemDescriptionElement",
+      "displayName": "HTML Format to use for feed item Descriptions",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "div",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        },
+        {
+          "value": "span",
+          "displayValue": "Span"
+        }
+      ]
+    },
+    {
+      "name": "feedId",
+      "displayName": "id attribute for feed",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "ariaRole",
+      "displayName": "RSS Feed aria-role",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "region",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/widgets/percRss/templates/percRssSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.rss/widgets/percRss/templates/percRssSnippet.vm
@@ -1,0 +1,17 @@
+#loadRelatedWidgetContents()
+
+    <div aria-busy="true" id="$!{feedId}" $!{ariaRole} aria-live="polite" aria-relevant="additions" aria-atomic="true" class="perc-feed-widget $!{rootclass}" data-query="$!dynamicListData">
+        #if ($perc.isEditMode())
+            #if ($percUrlFeed == "")
+                #createEmptyWidgetContent("feed-sample-content", "This rss widget is showing sample content.")
+            #else
+                #createEmptyWidgetContent("feed-edit-content", "Preview the page or asset to view this rss.")
+            #end
+        #else
+            #if ($percUrlFeed != "" && $perc.isPreviewMode())
+                <${itemElement} class="feed-edit-content" title="Preview the page or asset to view this rss"></$itemElement>
+            #else
+
+            #end
+        #end
+    </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/widgets/percSecureLogin/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/widgets/percSecureLogin/component-package.json
@@ -1,0 +1,253 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percSecureLogin",
+  "name": "Secure Login (Deprecated)",
+  "version": "1.1.7",
+  "description": "Login widget to access secured content. (Deprecated)",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "2.6.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Secure Login (Deprecated)",
+    "category": "integration",
+    "description": "Login widget to access secured content. (Deprecated)",
+    "thumbnail": "resources/widgetIconLogin.gif",
+    "icon": "resources/widgetIconLogin.gif",
+    "author": "Percussion Software Inc.",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 450,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSecureLogin",
+      "ref": "contentTypes/percSecureLogin"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percSecureLoginSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percSecureLoginSnippet.vm",
+      "contentType": "percSecureLogin",
+      "bindings": [
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "cssprops",
+          "expression": "$perc.widget.item.cssProperties"
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"percLogin-form-label-top\""
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$cssprops.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"percLogin-form\""
+        },
+        {
+          "variable": "labelclass",
+          "expression": "$cssprops.get('labelclass')"
+        },
+        {
+          "variable": "labelclass",
+          "expression": "\"percLogin-form-label-top\""
+        },
+        {
+          "variable": "labelclass",
+          "expression": "\"field-label-container\""
+        },
+        {
+          "variable": "inputclass",
+          "expression": "$cssprops.get('inputclass')"
+        },
+        {
+          "variable": "inputclass",
+          "expression": "\"percLogin-form-input\""
+        },
+        {
+          "variable": "inputclass",
+          "expression": "\"field-input-container\""
+        },
+        {
+          "variable": "buttonclass",
+          "expression": "$cssprops.get('buttonclass')"
+        },
+        {
+          "variable": "buttonclass",
+          "expression": "\"percLogin-form-button\""
+        },
+        {
+          "variable": "thisItem",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "innerItem",
+          "expression": "$thisItem.get(0)"
+        },
+        {
+          "variable": "mainTitle",
+          "expression": "$innerItem.getNode().getProperty('mainTitle').String"
+        },
+        {
+          "variable": "usernameLabel",
+          "expression": "$innerItem.getNode().getProperty('usernameLabel').String"
+        },
+        {
+          "variable": "passwordLabel",
+          "expression": "$innerItem.getNode().getProperty('passwordLabel').String"
+        },
+        {
+          "variable": "buttonLabel",
+          "expression": "$innerItem.getNode().getProperty('buttonLabel').String"
+        },
+        {
+          "variable": "labelalignclass",
+          "expression": "\"percLogin-form-label-left\""
+        },
+        {
+          "variable": "forgotPasswordLinkHTML",
+          "expression": "\"\""
+        },
+        {
+          "variable": "pwresetPage",
+          "expression": "\"\""
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "pwresetPage",
+          "expression": "$rx.pageutils.getSiteResetRequestPasswordPage($pathParts[2])"
+        },
+        {
+          "variable": "pwresetPageLink",
+          "expression": "\"#\""
+        },
+        {
+          "variable": "pwresetPageLink",
+          "expression": "$pwresetPage"
+        },
+        {
+          "variable": "forgotPasswordLinkHTML",
+          "expression": "'<div class=\"percLogin-form-field-row\"><a href=\"' + $pwresetPageLink + '\">Forgot password?</a></div>'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$props = $perc.widget.item.properties;\n\t\t$cssprops = $perc.widget.item.cssProperties;\n\n\t\t$labelalignclass = \"percLogin-form-label-top\";\n\n\t\t$pageId = $perc.page.id;\n\t\t$widgetId = $perc.widget.item.id;\n\t\t$rootclass = $cssprops.get('rootclass');\n\t\tif (empty($rootclass)) {\n\t\t\t$rootclass = \"percLogin-form\";\n\t\t}\n\t\t$labelclass = $cssprops.get('labelclass');\n\t\tif (empty($labelclass)) {\n\t\t\t$labelclass = \"percLogin-form-label-top\";\n\t\t\t$labelclass = \"field-label-container\";\n\t\t}\n\t\t$inputclass = $cssprops.get('inputclass');\n\t\tif (empty($inputclass)) {\n\t\t\t$inputclass = \"percLogin-form-input\";\n\t\t\t$inputclass = \"field-input-container\";\n\t\t}\n\t\t$buttonclass = $cssprops.get('buttonclass');\n\t\tif (empty($buttonclass)) {\n\t\t\t$buttonclass = \"percLogin-form-button\";\n\t\t}\n\n\t\t$thisItem = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n\n\t\tif(! $thisItem.isEmpty()) {\n\n\t\t\t$innerItem = $thisItem.get(0);\n\t\t\t$mainTitle = $innerItem.getNode().getProperty('mainTitle').String;\n\t\t\t$usernameLabel = $innerItem.getNode().getProperty('usernameLabel').String;\n\t\t\t$passwordLabel = $innerItem.getNode().getProperty('passwordLabel').String;\n\t\t\t$buttonLabel = $innerItem.getNode().getProperty('buttonLabel').String;\n\t\t}\n\t\tif($props.get(\"labelAlign\") != null && $props.get(\"labelAlign\").equals(\"left\")) {\n\t\t\t$labelalignclass = \"percLogin-form-label-left\";\n\t\t}\n\n        ## Code to include the forgot password link (which redirects to the reset password\n        ## page configured in site preferences)\n        $forgotPasswordLinkHTML = \"\";\n        if($props.get(\"showForgotPasswordLink\") != null && $props.get(\"showForgotPasswordLink\")) {\n            $pwresetPage = \"\";\n            ## Only retrieve the password reset page if the option is enabled\n            if (! empty($pageId)) {\n                ## Retrieve loginPage for the current site\n                $finderPath = $rx.pageutils.getItemPath($pageId);\n                $pathParts = $finderPath.split(\"\\/\");\n                ## current site name == $pathParts[2]\n                $pwresetPage = $rx.pageutils.getSiteResetRequestPasswordPage($pathParts[2]);\n            }\n            ## If it's empty, won't redirect anywhere\n            if ($pwresetPage == null || $pwresetPage == \"\")\n            {\n                $pwresetPageLink = \"#\";\n            }\n            else\n            {\n                $pwresetPageLink = $pwresetPage;\n            }\n\n            $forgotPasswordLinkHTML = '<div class=\"percLogin-form-field-row\"><a href=\"' + $pwresetPageLink + '\">Forgot password?</a></div>';\n\t\t}\n\n\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t$dsUrl = \"\";\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percSecureLoginContent",
+      "allowedContentTypes": [
+        "percSecureLogin"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": "",
+        "labelclass": "",
+        "inputclass": "",
+        "buttonclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLogin.gif",
+      "target": "rx_resources/widgets/percSecureLogin/images/widgetIconLogin.gif",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "labelAlign",
+      "displayName": "Label align",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "top",
+      "enumValues": [
+        {
+          "value": "top",
+          "displayValue": "Top of the control"
+        },
+        {
+          "value": "left",
+          "displayValue": "Left of the control"
+        }
+      ]
+    },
+    {
+      "name": "showForgotPasswordLink",
+      "displayName": "Show forgot password link",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "labelclass",
+      "displayName": "CSS field label class",
+      "datatype": "string"
+    },
+    {
+      "name": "inputclass",
+      "displayName": "CSS input class",
+      "datatype": "string"
+    },
+    {
+      "name": "buttonclass",
+      "displayName": "CSS button class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/widgets/percSecureLogin/templates/percSecureLoginSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/widgets/percSecureLogin/templates/percSecureLoginSnippet.vm
@@ -1,0 +1,44 @@
+#loadRelatedWidgetContents()
+		<div class="$!{rootclass} percLogin-form" data="$!{dynamicListData}">
+	#if(! $thisItem.isEmpty())
+			<form name="login_form" method="POST" id="login-form" action="/perc-login" >
+		#if($mainTitle.length()>0)
+				<h2>$mainTitle</h2>
+		#end
+				<div class="percLogin-form-field-row">
+					<div class="$labelalignclass">
+						<span class="perc-form-error-asterisk">*</span>
+						<label> $!usernameLabel</label>
+					</div>
+					<div class="$inputclass">
+						<input type="text" value="" name="j_username" class="form200" size="20" maxlength="64" tabindex="1">
+					</div>
+				</div>
+				<div class="percLogin-form-field-row">
+					<div class="$labelalignclass">
+						<span class="perc-form-error-asterisk">*</span>
+						<label> $!passwordLabel</label>
+					</div>
+					<div class="$inputclass">
+						<input type="password" name="j_password" class="form200" size="20" autocomplete="off" tabindex="2">
+					</div>
+				</div>
+                $!forgotPasswordLinkHTML
+                    <div class="perc-secure-login-error-message form-error-msg" style="display:none">
+                        Authentication failed, invalid username or password
+                    </div>
+					<div class="percLogin-form-field-row $buttonclass">
+						<input type="submit" value="$buttonLabel">
+					</div>
+		#if($perc.isPreviewMode())
+					<script>
+					window.addEventListener('DOMContentLoaded', function() {
+						jQuery("input[type = 'submit']").attr('disabled', true);
+						});
+					</script>
+		#end
+			</form>
+	#elseif ($perc.isEditMode())
+        #createEmptyWidgetContent("secure-login-sample-content", "This login form widget is showing sample content.")
+	#end
+		</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/widgets/percSocialButtons/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/widgets/percSocialButtons/component-package.json
@@ -1,0 +1,288 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percSocialButtons",
+  "name": "Social Buttons",
+  "version": "1.2.4",
+  "description": " ",
+  "publisher": {
+    "name": "https://www.percussion.com",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Social Buttons",
+    "category": "social",
+    "description": " ",
+    "thumbnail": "resources/percSocialButtonsIcon.png",
+    "icon": "resources/percSocialButtonsIcon.png",
+    "author": "https://www.percussion.com",
+    "preferredEditorWidth": 1000,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSocialButtons",
+      "ref": "contentTypes/percSocialButtons"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percSocialButtonsSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percSocialButtonsSnippet.vm",
+      "contentType": "percSocialButtons",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percSocialButtons'"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "colorScheme",
+          "expression": "$perc.widget.item.properties.get('colorScheme')"
+        },
+        {
+          "variable": "desktopButtonLocation",
+          "expression": "$perc.widget.item.properties.get('desktopButtonLocation')"
+        },
+        {
+          "variable": "mobileButtonLocation",
+          "expression": "$perc.widget.item.properties.get('mobileButtonLocation')"
+        },
+        {
+          "variable": "hideMobile",
+          "expression": "$perc.widget.item.properties.get('hideMobile')"
+        },
+        {
+          "variable": "hideDesktop",
+          "expression": "$perc.widget.item.properties.get('hideDesktop')"
+        },
+        {
+          "variable": "desktopVerticalOffset",
+          "expression": "$perc.widget.item.properties.get('desktopVerticalOffset')"
+        },
+        {
+          "variable": "mobileVerticalOffset",
+          "expression": "$perc.widget.item.properties.get('mobileVerticalOffset')"
+        },
+        {
+          "variable": "mobileBreakpoint",
+          "expression": "$perc.widget.item.properties.get('mobileBreakpoint')"
+        },
+        {
+          "variable": "mobileButtonSize",
+          "expression": "$perc.widget.item.properties.get('mobileButtonSize')"
+        },
+        {
+          "variable": "baseUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "standardColor",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "grayscaleColor",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "outputColor",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "outputColor",
+          "expression": "$standardColor"
+        },
+        {
+          "variable": "outputColor",
+          "expression": "$grayscaleColor"
+        },
+        {
+          "variable": "data",
+          "expression": "$assetItem.Node.getProperty('rx:buttonConfiguration').getString()"
+        },
+        {
+          "variable": "json",
+          "expression": "$rx.pageutils.createJsonObject($data)"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = 'percSocialButtons';\n\n       ## Get asset item(s)\n       $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n       $perc.setWidgetContents($assets);\n\n       if (! $assets.isEmpty())\n       {\n           $assetItem = $assets.get(0); ## Get first item (which may be only item)\n           $colorScheme = $perc.widget.item.properties.get('colorScheme');\n           $desktopButtonLocation = $perc.widget.item.properties.get('desktopButtonLocation');\n           $mobileButtonLocation = $perc.widget.item.properties.get('mobileButtonLocation');\n           $hideMobile = $perc.widget.item.properties.get('hideMobile');\n           $hideDesktop = $perc.widget.item.properties.get('hideDesktop');\n           $desktopVerticalOffset = $perc.widget.item.properties.get('desktopVerticalOffset');\n           $mobileVerticalOffset = $perc.widget.item.properties.get('mobileVerticalOffset');\n           $mobileBreakpoint = $perc.widget.item.properties.get('mobileBreakpoint');\n           $mobileButtonSize = $perc.widget.item.properties.get('mobileButtonSize');\n           $baseUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n           ## assign standard colors\n           $standardColor = $rx.string.stringToMap(null);\n           $standardColor.put('facebook', '3b5998');\n           $standardColor.put('twitter', '111111');\n           $standardColor.put('linkedIn', '0077b5');\n           $standardColor.put('pinterest', 'c92228');\n           $standardColor.put('youtube', 'cd201f');\n           $standardColor.put('whatsapp', '25d366');\n           $standardColor.put('email', '787878');\n           $standardColor.put('text', 'ffffff');\n\n           ## assign grayscale colors\n           $grayscaleColor = $rx.string.stringToMap(null);\n           $grayscaleColor.put('facebook', '666666');\n           $grayscaleColor.put('twitter', '666666');\n           $grayscaleColor.put('linkedIn', '666666');\n           $grayscaleColor.put('pinterest', '666666');\n           $grayscaleColor.put('youtube', '666666');\n           $grayscaleColor.put('whatsapp', '666666');\n           $grayscaleColor.put('email', '666666');\n           $grayscaleColor.put('text', 'ffffff');\n\n           $outputColor = $rx.string.stringToMap(null);\n\n           if( $colorScheme == 'standard') {\n            $outputColor = $standardColor;\n           }\n           else {\n            $outputColor = $grayscaleColor;\n           }\n\n          $data = $assetItem.Node.getProperty('rx:buttonConfiguration').getString();\n          $json = $rx.pageutils.createJsonObject($data);\n\n       }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percSocialButtonsContent",
+      "allowedContentTypes": [
+        "percSocialButtons"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/percSocialButtonsIcon.png",
+      "target": "rx_resources/widgets/percSocialButtons/images/percSocialButtonsIcon.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "colorScheme",
+      "displayName": "Button color scheme",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "standard",
+      "enumValues": [
+        {
+          "value": "standard",
+          "displayValue": "Standard"
+        },
+        {
+          "value": "grayscale",
+          "displayValue": "Grayscale"
+        }
+      ]
+    },
+    {
+      "name": "desktopButtonLocation",
+      "displayName": "Desktop button location",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "inline",
+      "enumValues": [
+        {
+          "value": "inline",
+          "displayValue": "Inline"
+        },
+        {
+          "value": "left",
+          "displayValue": "Fixed Left"
+        },
+        {
+          "value": "right",
+          "displayValue": "Fixed Right"
+        },
+        {
+          "value": "bottom",
+          "displayValue": "Fixed Bottom"
+        }
+      ]
+    },
+    {
+      "name": "mobileButtonLocation",
+      "displayName": "Mobile button location",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "inline",
+      "enumValues": [
+        {
+          "value": "inline",
+          "displayValue": "Inline"
+        },
+        {
+          "value": "left",
+          "displayValue": "Fixed Left"
+        },
+        {
+          "value": "right",
+          "displayValue": "Fixed Right"
+        },
+        {
+          "value": "bottom",
+          "displayValue": "Fixed Bottom"
+        }
+      ]
+    },
+    {
+      "name": "mobileBreakpoint",
+      "displayName": "Mobile breakpoint screen size (Specify units px, em, %)",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "1024px",
+      "enumValues": []
+    },
+    {
+      "name": "hideMobile",
+      "displayName": "Hide buttons when <= Mobile breakpoint",
+      "datatype": "bool",
+      "required": true,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "hideDesktop",
+      "displayName": "Hide buttons when > Mobile breakpoint",
+      "datatype": "bool",
+      "required": true,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "desktopVerticalOffset",
+      "displayName": "Desktop vertical offset (side position only)",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "200px",
+      "enumValues": []
+    },
+    {
+      "name": "mobileVerticalOffset",
+      "displayName": "Mobile vertical offset (side position only)",
+      "datatype": "string",
+      "required": true,
+      "defaultValue": "100px",
+      "enumValues": []
+    },
+    {
+      "name": "mobileButtonSize",
+      "displayName": "Mobile button size (will not affect inline placement)",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "small",
+      "enumValues": [
+        {
+          "value": "1em",
+          "displayValue": "Small"
+        },
+        {
+          "value": "1.2em",
+          "displayValue": "Medium"
+        },
+        {
+          "value": "1.5em",
+          "displayValue": "Large"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/widgets/percSocialButtons/templates/percSocialButtonsSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/widgets/percSocialButtons/templates/percSocialButtonsSnippet.vm
@@ -1,0 +1,360 @@
+<div class="$!rootclass">
+        #if( ! $perc.widgetContents.isEmpty() )
+        <style>
+
+          .perc-social-button-container-bottom {
+            width: 100% !important;
+            display: flex;
+            bottom: 0;
+            left: 0;
+            position: fixed;
+            margin:0px;
+            padding:0px;
+          }
+
+          .perc-social-button-container-bottom .perc-social-button {
+            display: inline-block;
+            width: 100%;
+          }
+
+          .perc-social-button-container-bottom a {
+            width: 100%;
+          }
+
+          .perc-social-button-container-left {
+            left: 0;
+            top: ${desktopVerticalOffset};
+            position: fixed;
+            margin:0px;
+            padding:0px;
+            height: 100%;
+          }
+
+          .perc-social-button-container-left .perc-social-button {
+            float: left;
+            clear: left;
+            font-size: 2em;
+            padding: 12px;
+          }
+
+          .perc-social-button-container-right {
+            right: 0;
+            top: ${desktopVerticalOffset};
+            position: fixed;
+            margin:0px;
+            padding:0px;
+            height: 100%;
+          }
+
+          .perc-social-button-container-right .perc-social-button {
+            float: right;
+            clear: right;
+            font-size: 2em;
+            padding: 12px;
+          }
+
+          .perc-social-button-container-inline {
+            position: relative;
+            width: 100%;
+            display: inline-block;
+          }
+
+          .perc-social-button-container-inline .perc-social-button {
+            font-size: 2em;
+          }
+
+          .perc-social-button {
+            float:left;
+            text-align: center;
+            border: 0px;
+            margin: 0px;
+            cursor: pointer;
+            padding-top: 5px;
+            padding-bottom: 5px;
+            font-size: 2em;
+          }
+
+          .perc-social-button:hover {
+            opacity: 0.9;
+            filter: alpha(opacity=90); /* For IE8 and earlier */
+          }
+
+          .perc-facebook-social-button {
+            background-color: #$outputColor.facebook;
+            color: #$outputColor.text;
+          }
+
+          .perc-twitter-social-button {
+            background-color: #$outputColor.twitter;
+            color: #$outputColor.text;
+          }
+
+          /* X glyph mask URI intentionally inlined here (and in SupportFile + UserDependency CSS). Keep path data in sync. */
+          .perc-twitter-social-button i::before {
+            content: "" !important;
+            display: inline-block;
+            width: 1em;
+            height: 1em;
+            background-color: currentColor;
+            vertical-align: -0.125em;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+            mask-size: contain;
+            -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+            -webkit-mask-size: contain;
+          }
+
+          .perc-linkedin-social-button {
+            background-color: #$outputColor.linkedIn;
+            color: #$outputColor.text;
+          }
+
+          .perc-pinterest-social-button {
+            background-color: #$outputColor.pinterest;
+            color: #$outputColor.text;
+          }
+
+          .perc-youtube-social-button {
+            background-color: #$outputColor.youtube;
+            color: #$outputColor.text;
+          }
+
+          .perc-whatsapp-social-button {
+            background-color: #$outputColor.whatsapp;
+            color: #$outputColor.text;
+          }
+
+          .perc-email-social-button {
+            background-color: #$outputColor.email;
+            color: #$outputColor.text;
+          }
+
+          /*CMS-8196 : updated fontawesome needs different font families as per fab & fas classes. So updating css.*/
+          .perc-social-button i .fab{
+            font-family: 'Font Awesome 5 Brands' !important;
+          }
+
+		  .perc-social-button i .fas{
+            font-family: 'Font Awesome 5 Free' !important;
+          }
+
+          #if( $hideDesktop == "true" )##
+          @media (min-width: ${mobileBreakpoint}) {
+            .perc-social-button-container {
+              display: none !important;
+            }
+          }
+          #end##
+
+          #if( $hideMobile == "true" )##
+          @media (max-width: ${mobileBreakpoint}) {
+            .perc-social-button-container {
+              display: none !important;
+            }
+          }
+          #end##
+
+          @media (max-width: ${mobileBreakpoint}) {
+
+            .perc-social-button {
+              font-size: ${mobileButtonSize} !important;
+            }
+
+            .perc-social-button-container-mobile-left {
+              left: 0;
+              top: ${mobileVerticalOffset};
+            }
+
+            .perc-social-button-container-mobile-bottom {
+              width: 100% !important;
+              display: flex;
+              bottom: 0;
+              left: 0;
+              top: auto;
+              height: auto;
+              position: fixed;
+              margin:0px;
+              padding:0px;
+            }
+
+            .perc-social-button-container-mobile-bottom .perc-social-button {
+              display: inline-block;
+              width: 100%;
+              padding-bottom: 10px;
+              padding-top: 10px;
+            }
+
+            .perc-social-button-container-mobile-bottom a {
+              width: 100%;
+            }
+
+            .perc-social-button-container-mobile-left {
+              left: 0;
+              top: ${mobileVerticalOffset};
+              position: fixed;
+              margin:0px;
+              padding:0px;
+              height: 100%;
+              display: block;
+              width: auto !important;
+            }
+
+            .perc-social-button-container-mobile-left .perc-social-button {
+              float: left;
+              clear: left;
+              padding: 12px;
+            }
+
+            .perc-social-button-container-mobile-right {
+              right: 0;
+              left: auto;
+              top: ${mobileVerticalOffset};
+              position: fixed;
+              margin:0px;
+              padding:0px;
+              height: 100%;
+              display: block;
+              width: auto !important;
+            }
+
+            .perc-social-button-container-mobile-right .perc-social-button {
+              float: right;
+              clear: right;
+              padding: 12px;
+            }
+
+            .perc-social-button-container-mobile-inline {
+              position: relative;
+              display: inline-block;
+              width: 100%;
+              top: auto;
+              bottom: auto;
+              left: auto;
+              right: auto;
+            }
+
+            .perc-social-button-container-mobile-inline .perc-social-button {
+              font-size: 1.2em !important;
+              clear: none;
+              float: none;
+              padding: 5px;
+              width: auto;
+            }
+
+          }
+
+        </style>
+
+        <script>
+			window.addEventListener('DOMContentLoaded', function() {
+            // Sets current URL, and then encodes it for use in the share links
+            var percCurrentUrl = $(location).attr('href');
+            var percEncodedCurrentUrl = encodeURIComponent(percCurrentUrl);
+
+            // Sets page title and encodes it for use in the share links
+            var percPageTitle = '$!{perc.page.linkTitle}';
+            var percEncodedPageTitle = encodeURIComponent(percPageTitle);
+            var percPageSummary = '$!perc.page.description';
+            var percEncodedPageSummary = encodeURIComponent(percPageSummary);
+
+            var percSocial = {};
+            var percButtonConfiguration = {};
+            percButtonConfiguration = $json;
+
+            $(document).ready( function() {
+
+              // When social buttons are clicked, there is first a check to make sure that data
+              // push is enabled for that button
+              $(document).on('click', '.perc-social-button', function() {
+                if ( $(this).parent().data('enablepush') == true ) {
+                  dataLayer.push({'event': $(this).parent().data('pushvalue') });
+                }
+              });
+
+              // Constructs a new object of only the enabled social buttons
+              jQuery.each(percButtonConfiguration.config, function(index, value) {
+                if( value.enableButton === true) {
+                  constructSocialObject(value.platform);
+                  percSocial[value.platform]['enableDataPush'] = value.enableDataPush;
+                  percSocial[value.platform]['socialLink'] = value.socialLink;
+                  //percSocial[value.platform]['baseUrl'] = value.baseUrl;
+                }
+              });
+
+              // Creates links and buttons and appends to the button container
+              //CMS-8196 : updated fontawesome needs different class for mail/envelope icon so adding class dynamically.
+              var iframeClass="";
+              jQuery.each(percSocial, function(index, value) {
+
+                if(value.buttonClass==='perc-email-social-button'){
+                   iframeClass="fas fa-fw";
+                 }else{
+                   iframeClass="fab fa-fw";
+                }
+
+                $('.perc-social-button-container').append('<a href="" target="_blank" rel = "noopener noreferrer" data-enablepush="" data-pushvalue="" ><button class="perc-social-button"><i class="'+iframeClass+'" aria-hidden="true"></i></button></a>');
+                if( percButtonConfiguration.buttonType == 'share' ) {
+                  $('.perc-social-button-container a').last().attr("href", value.shareLink);
+                }
+                else {
+                  $('.perc-social-button-container a').last().attr("href", value.socialLink);
+                }
+                $('.perc-social-button-container a').last().attr("data-enablepush", value.enableDataPush);
+                $('.perc-social-button-container a').last().attr("data-pushvalue", index + '-' + percButtonConfiguration.buttonType);
+                $('.perc-social-button-container button').last().addClass(value.buttonClass);
+                $('.perc-social-button-container i').last().addClass(value.iconClass);
+              });
+
+            });
+
+            function constructSocialObject(platform) {
+
+              // Initializes the object of enabled buttons
+              percSocial[platform] = {};
+
+              switch (platform) {
+                case 'facebook':
+                  percSocial[platform]['shareLink'] = 'https://www.facebook.com/sharer/sharer.php?u=' + percEncodedCurrentUrl;
+                  percSocial[platform]['buttonClass'] = 'perc-facebook-social-button';
+                  percSocial[platform]['iconClass'] = 'fa-facebook';
+                  break;
+                case 'twitter':
+                  percSocial[platform]['shareLink'] = 'https://x.com/intent/tweet?text=' + percEncodedPageSummary + '&url=' + percEncodedCurrentUrl;
+                  percSocial[platform]['buttonClass'] = 'perc-twitter-social-button';
+                  percSocial[platform]['iconClass'] = 'fa-twitter';
+                  break;
+                case 'linkedin':
+                  percSocial[platform]['shareLink'] = 'https://www.linkedin.com/shareArticle?mini=true&url=' + percEncodedCurrentUrl + '&title=' + percEncodedPageTitle + '&summary=' + percEncodedPageSummary;
+                  percSocial[platform]['buttonClass'] = 'perc-linkedin-social-button';
+                  percSocial[platform]['iconClass'] = 'fa-linkedin';
+                  break;
+                case 'pinterest':
+                  percSocial[platform]['shareLink'] = 'http://pinterest.com/pin/create/button/?url=' + percEncodedCurrentUrl + '&name=' + percEncodedPageTitle + '&description=' + percEncodedPageSummary;
+                  percSocial[platform]['buttonClass'] = 'perc-pinterest-social-button';
+                  percSocial[platform]['iconClass'] = 'fa-pinterest';
+                  break;
+                case 'youtube':
+                  percSocial[platform]['shareLink'] = null;
+                  percSocial[platform]['buttonClass'] = 'perc-youtube-social-button';
+                  percSocial[platform]['iconClass'] = 'fa-youtube';
+                  break;
+                case 'whatsapp':
+                  percSocial[platform]['shareLink'] = 'https://api.whatsapp.com/send?text=' + percEncodedPageTitle + ' ' + percEncodedPageSummary + ' ' + percEncodedCurrentUrl;
+                  percSocial[platform]['buttonClass'] = 'perc-whatsapp-social-button';
+                  percSocial[platform]['iconClass'] = 'fa-whatsapp';
+                  break;
+                case 'email':
+                  percSocial[platform]['shareLink'] = 'mailto:someone@example.com?subject=' + percEncodedPageTitle + '&body=' + percEncodedPageSummary + ' ' + percEncodedCurrentUrl + "%0D%0A";
+                  percSocial[platform]['buttonClass'] = 'perc-email-social-button';
+                  percSocial[platform]['iconClass'] = 'fa-envelope';
+                  break;
+              }
+
+            }
+			});
+        </script>
+        <div class="perc-social-button-container perc-social-button-container-${desktopButtonLocation} perc-social-button-container-mobile-${mobileButtonLocation}">
+        </div>
+        #elseif ($perc.isEditMode())
+            #createEmptyWidgetContent("percSocialButtons-empty-style", "This widget is showing sample content")
+        #end
+       </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/widgets/percTagList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/widgets/percTagList/component-package.json
@@ -1,0 +1,348 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percTagList",
+  "name": "Tags",
+  "version": "1.2.0",
+  "description": " Displays a list of tags",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Tags",
+    "category": "blog,search",
+    "description": " Displays a list of tags",
+    "thumbnail": "resources/widgetIconLinkTagList.png",
+    "icon": "resources/widgetIconLinkTagList.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 685,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTagList",
+      "ref": "contentTypes/percTagList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTagListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTagListSnippet.vm",
+      "contentType": "percTagList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "isEditMode",
+          "expression": "$perc.isEditMode() || $perc.isPreviewMode()"
+        },
+        {
+          "variable": "tagRenderOption",
+          "expression": "$perc.widget.item.properties.get('tag_render_option')"
+        },
+        {
+          "variable": "tagSortOption",
+          "expression": "$perc.widget.item.properties.get('tag_sort_option')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "processedTags",
+          "expression": "$rx.pageutils.getProcessedTags($relresults,$tagSortOption)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem, 'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('perc-list-odd', 'perc-list-even')"
+        },
+        {
+          "variable": "titleContains",
+          "expression": "$assetItem.getNode().getProperty('title_contains').String"
+        },
+        {
+          "variable": "starDate",
+          "expression": "$assetItem.getNode().getProperty('start_date').String"
+        },
+        {
+          "variable": "endDate",
+          "expression": "$assetItem.getNode().getProperty('end_date').String"
+        },
+        {
+          "variable": "sitePath",
+          "expression": "$assetItem.getNode().getProperty('site_path').String"
+        },
+        {
+          "variable": "templatesList",
+          "expression": "$assetItem.getNode().getProperty('page_templates_list').String"
+        },
+        {
+          "variable": "tagPageResult",
+          "expression": "$assetItem.getNode().getProperty('tag_page_result').String"
+        },
+        {
+          "variable": "criteria",
+          "expression": "\"[\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"&quot;type = 'page'&quot;\""
+        },
+        {
+          "variable": "criteriaSep",
+          "expression": "\", \""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + $criteriaSep + \"&quot;dcterms:title LIKE '%\" + $titleContains +\"%'&quot;\""
+        },
+        {
+          "variable": "sd",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$starDate)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\""
+        },
+        {
+          "variable": "ed",
+          "expression": "$tools.date.toDate(\"MM/dd/yyyy\",$endDate)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$sitePath.replace(\"//Sites/\", \"\")"
+        },
+        {
+          "variable": "temppaths",
+          "expression": "$temppath.split(\"/\")"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\""
+        },
+        {
+          "variable": "folderpath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "counter",
+          "expression": "1"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$folderpath + \"/\" + $temppaths[$counter]"
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\""
+        },
+        {
+          "variable": "templateNameList",
+          "expression": "$rx.pageutils.templateNames($templatesList)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "\"(\""
+        },
+        {
+          "variable": "counter",
+          "expression": "0"
+        },
+        {
+          "variable": "templNameArray",
+          "expression": "$templateNameList.toArray()"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \"'\" + $templNameArray[$counter] + \"'\""
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \", \""
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "inCl",
+          "expression": "$inCl + \")\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"]\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{\" + \"&quot;criteria&quot;:\" + $criteria"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;tag_render_option&quot;:&quot;\" +$tagRenderOption + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $tagSortOption + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;tag_page_result&quot;:&quot;\" +$tagPageResult + \"&quot;\""
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $perc.setWidgetContents($assetItems);\n   $isEditMode = $perc.isEditMode() || $perc.isPreviewMode();\n   $tagRenderOption = $perc.widget.item.properties.get('tag_render_option');\n   $tagSortOption = $perc.widget.item.properties.get('tag_sort_option');\n   $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n   if (!empty($rootclass)) {\n      $rootclass = $rootclass + \" \";\n   }\n   if ( ! $assetItems.isEmpty() ) {\n        $assetItem = $assetItems.get(0);\n        $params = $rx.string.stringToMap(null);\n        $params.put('query', ($assetItem.getNode().getProperty('query').String));\n\t\t$finderName=\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n        $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n        $processedTags = $rx.pageutils.getProcessedTags($relresults,$tagSortOption);\n        $title = $rx.pageutils.html($assetItem, 'displaytitle');\n\t\t$rowtag = $tools.alternator.auto('perc-list-odd', 'perc-list-even');\n        ##Tag list query starts\n        ##Gets the individual field values\n        $titleContains = $assetItem.getNode().getProperty('title_contains').String;\n        $starDate = $assetItem.getNode().getProperty('start_date').String;\n        $endDate = $assetItem.getNode().getProperty('end_date').String;\n        $sitePath = $assetItem.getNode().getProperty('site_path').String;\n        $templatesList = $assetItem.getNode().getProperty('page_templates_list').String;\n\t\t$tagPageResult = $assetItem.getNode().getProperty('tag_page_result').String;\n        ##Builds the criteria\n        $criteria = \"[\";\n        $criteria = $criteria + \"&quot;type = 'page'&quot;\";\n        $criteriaSep = \", \";\n        if ($titleContains != null && $titleContains != \"\")\n        {\n             $criteria = $criteria + $criteriaSep + \"&quot;dcterms:title LIKE '%\" + $titleContains +\"%'&quot;\";\n        }\n        if ($starDate != null && $starDate != \"\"){\n             $sd = $tools.date.toDate(\"MM/dd/yyyy\",$starDate);\n             $criteria = $criteria +  $criteriaSep + \"&quot;dcterms:created >= '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $sd) + \"'&quot;\";\n        }\n        if ($endDate != null && $endDate != \"\"){\n             $ed = $tools.date.toDate(\"MM/dd/yyyy\",$endDate);\n             $criteria = $criteria +  $criteriaSep +  \"&quot;dcterms:created < '\" + $tools.date.format(\"yyyy-MM-dd'T'HH:mm:ss\", $ed) + \"'&quot;\";\n        }\n        if ($sitePath != null && $sitePath != \"\" && $sitePath != \"//Sites\")\n        {\n            $temppath = $sitePath.replace(\"//Sites/\", \"\");\n            if($temppath.indexOf(\"/\") > 0)\n            {\n                $temppaths = $temppath.split(\"/\");\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\";\n                $folderpath = \"\";\n                $counter = 1;\n                while($counter < $temppaths.size())\n                {\n                    $folderpath = $folderpath + \"/\" + $temppaths[$counter];\n                    $counter = $counter + 1;\n                }\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\";\n            }\n            else\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\";\n            }\n        }\n        if($templatesList != null && $templatesList != \"\")\n        {\n            $templateNameList = $rx.pageutils.templateNames($templatesList);\n            if($templateNameList.size() == 1)\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\";\n            }\n            else if($templateNameList.size() > 1)\n            {\n                $inCl = \"(\";\n                $counter = 0;\n                $templNameArray = $templateNameList.toArray();\n\n                while($counter < $templNameArray.size())\n                {\n                    $inCl = $inCl + \"'\" + $templNameArray[$counter] + \"'\";\n                    if($counter != $templNameArray.size()-1)\n                        $inCl = $inCl + \", \";\n                    $counter = $counter + 1;\n                }\n                $inCl = $inCl + \")\";\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source IN \" + $inCl + \"&quot;\";\n            }\n        }\n\n        $criteria = $criteria + \"]\";\n\n        ##Build the query string for the delivery side tag list\n\t\t##builds the order by clause\n\n        $dynamicListData = \"{\" + \"&quot;criteria&quot;:\" + $criteria;\n\n        $dynamicListData = $dynamicListData + \", &quot;tag_render_option&quot;:&quot;\" +$tagRenderOption + \"&quot;\";\n\n\t\tif(!empty($orderby))\n        {\n            $dynamicListData = $dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $tagSortOption + \"&quot;\";\n        }\n\n\t\t$dynamicListData = $dynamicListData + \", &quot;tag_page_result&quot;:&quot;\" +$tagPageResult + \"&quot;\";\n\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n\n        $dynamicListData = $dynamicListData + \", &quot;deliveryurl&quot;:&quot;\" + $dsUrl + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isEditMode&quot;:&quot;\" + $isEditMode + \"&quot;\";\n        $dynamicListData = $dynamicListData + \"}\";\n        ##Tag list query ends\n   }\n   else {\n      ;\n   }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percTagListContent",
+      "allowedContentTypes": [
+        "percTagList"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": "",
+        "summaryclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLinkTagList.png",
+      "target": "rx_resources/widgets/tagList/images/widgetIconLinkTagList.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/perc_common_ui.js",
+      "target": "perc-common-ui/js/perc_common_ui.js",
+      "type": "javascript",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "tag_render_option",
+      "displayName": "Display format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "list",
+      "enumValues": [
+        {
+          "value": "list",
+          "displayValue": "List"
+        },
+        {
+          "value": "commaSeparated",
+          "displayValue": "Comma separated (wrap text)"
+        }
+      ]
+    },
+    {
+      "name": "tag_sort_option",
+      "displayName": "Sort method",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "alpha",
+      "enumValues": [
+        {
+          "value": "alpha",
+          "displayValue": "Alphabetic"
+        },
+        {
+          "value": "count",
+          "displayValue": "Count of tags"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    },
+    {
+      "name": "summaryclass",
+      "displayName": "CSS page summary class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/widgets/percTagList/templates/percTagListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.taglist/widgets/percTagList/templates/percTagListSnippet.vm
@@ -1,0 +1,64 @@
+<div class="$!{rootclass} perc-tag-list" data-query="$!{dynamicListData}">
+##This is a hidden div that holds the structure of the list when the tag list output structure changes this hidden div and delivery side view
+##should be modified to match the new structure.
+<div style="display:none" class="perc-tag-list-structure">
+#if($rendering == "ordered")##
+<ol class="perc-list-main">##
+#else##
+<ul class="perc-list-main">##
+#end##
+<li class="perc-list-element">
+<a href="#"></a>
+</li>
+#if($rendering == "ordered")##
+</ol>##
+#else##
+</ul>##
+#end##
+</div>
+#if( ! $perc.widgetContents.isEmpty() )##
+#if ($title && $title.length() > 0)##
+<div class="perc-tag-title">$title</div>
+#end##
+#if($processedTags && $processedTags.size() > 0)##
+#if($rendering == "ordered")##
+<ol class="perc-list-main">##
+#else##
+#end##
+#if($tagRenderOption == "list")##
+<ul class="perc-list-main-container">##
+#foreach ($tag in $processedTags)##
+<li class="perc-tag-element $rowtag  perc-list-element">
+<a href="#">$tag.getFirst() ($tag.getSecond())</a>
+</li>
+#end##
+</ul>
+#else##
+<ul class="perc-comma-separated-main-container">##
+<li class="perc-comma-separated perc-tag-element $rowtag perc-list-element">
+#set($flag = false)##
+#set($separator = ",")##
+#foreach ($tag in $processedTags)##
+#if ($velocityCount == $processedTags.size())##
+#set($separator = "")##
+#end##
+#if($flag == false)##
+<a href="#">$tag.getFirst() ($tag.getSecond())$separator</a>
+#set($flag = true)##
+#else##
+<a href="#">$tag.getFirst() ($tag.getSecond())$separator</a>
+#end##
+#end##
+</li>
+</ul>
+#end##
+#if($rendering == "ordered")##
+</ol>##
+#else##
+</ul>##
+#end##
+#end##
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("taglist-sample-content", "This tag list widget is showing sample content.")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.title/widgets/percTitle/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.title/widgets/percTitle/component-package.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percTitle",
+  "name": "Title",
+  "version": "1.1.4",
+  "description": "Widget to enter the Page title",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.9.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.1",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Title",
+    "category": "content",
+    "description": "Widget to enter the Page title",
+    "thumbnail": "resources/widgetTitle.png",
+    "icon": "resources/widgetTitle.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 302,
+    "createSharedAsset": false,
+    "editableOnTemplate": false,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percTitleAsset",
+      "ref": "contentTypes/percTitleAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percTitleSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percTitleSnippet.vm",
+      "contentType": "percTitleAsset",
+      "bindings": [
+        {
+          "variable": "wrapper",
+          "expression": "$perc.widget.item.properties.get('wrapper')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "' class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$wrapper = $perc.widget.item.properties.get('wrapper');\n    $rootclass= $perc.widget.item.cssProperties.get('rootclass');\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    if (!empty($rootclass))\n        $classAttribute = ' class=\"' + $rootclass + '\"';\n\n\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n    if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t    $dsUrl = \"\";\n    $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percTitleContent",
+      "allowedContentTypes": [
+        "percTitleAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetTitle.png",
+      "target": "rx_resources/widgets/title/images/widgetTitle.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "wrapper",
+      "displayName": "Choose format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "h1",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "paragraph",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.title/widgets/percTitle/templates/percTitleSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.title/widgets/percTitle/templates/percTitleSnippet.vm
@@ -1,0 +1,13 @@
+<div>
+#loadRelatedWidgetContents()##
+#if( ! $perc.widgetContents.isEmpty() )##
+#set($node = $perc.widgetContents.get(0).node)##
+#end##
+#if(! $sys.assemblyItem.getNode().hasProperty("resource_link_title"))##
+#createEmptyWidgetContent("title-sample-content", "This title widget is showing sample content.")##
+#elseif ($assets.isEmpty())##
+<$!{wrapper}$!{classAttribute}>$tools.esc.html($!{perc.page.linkTitle})</$!{wrapper}>
+#else##
+<$!{wrapper}$!{classAttribute}>$rx.pageutils.html($node,'rx:text')</$!{wrapper}>
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/widgets/percRedirect/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/widgets/percRedirect/component-package.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percRedirect",
+  "name": "Redirect",
+  "version": "1.1.5",
+  "description": "Adds a client side redirect to a Page.",
+  "publisher": {
+    "name": "Percussion Software, Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "5.3.15",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.SystemObjects",
+      "version": "1.0.0",
+      "implied": false
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Redirect",
+    "description": "Adds a client side redirect to a Page.",
+    "thumbnail": "resources/redirect-widget-icon-tray.png",
+    "icon": "resources/redirect-widget-icon-tray.png",
+    "author": "www.percussion.com",
+    "preferredEditorWidth": 800,
+    "preferredEditorHeight": 600,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percRedirect",
+      "ref": "contentTypes/percRedirect"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percRedirectSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percRedirectSnippet.vm",
+      "contentType": "percRedirect",
+      "bindings": [
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "'percRedirect'"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "targetUrl",
+          "expression": "$assetItem.getNode().getProperty('targetUrl').String"
+        },
+        {
+          "variable": "enabled",
+          "expression": "$assetItem.getNode().getProperty('enabled').String"
+        },
+        {
+          "variable": "delayInSeconds",
+          "expression": "$assetItem.getNode().getProperty('delayInSeconds').String"
+        },
+        {
+          "variable": "enabled",
+          "expression": "\"yes\""
+        },
+        {
+          "variable": "delayInSeconds",
+          "expression": "0"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$pageId = $perc.page.id;\n       $widgetId = $perc.widget.item.id;\n       $rootclass = 'percRedirect';\n\n       ## Get asset item(s)\n       $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n       $perc.setWidgetContents($assets);\n\n       if (! $assets.isEmpty())\n       {\n           $assetItem = $assets.get(0); ## Get first item (which may be only item)\n           $targetUrl = $assetItem.getNode().getProperty('targetUrl').String;\n\t   $enabled = $assetItem.getNode().getProperty('enabled').String;\n\t   $delayInSeconds = $assetItem.getNode().getProperty('delayInSeconds').String;\n\n\t   if($enabled == null)\n\t\t$enabled = \"yes\";\n\n\t   if($delayInSeconds == null || $delayInSeconds < 0)\n\t\t$delayInSeconds = 0;\n       }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percRedirectContent",
+      "allowedContentTypes": [
+        "percRedirect"
+      ],
+      "layout": {},
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/redirect-widget-icon-tray.png",
+      "target": "rx_resources/widgets/percRedirect/images/redirect-widget-icon-tray.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/widgets/percRedirect/templates/percRedirectSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.Redirect/widgets/percRedirect/templates/percRedirectSnippet.vm
@@ -1,0 +1,13 @@
+#if(($perc.widget.item.definitionId !='percRedirect' && ! $perc.widgetContents.isEmpty() && ! $perc.isEditMode()) ||  (! $perc.isEditMode() && ! $perc.isPreviewMode()))##
+	#if( "$!enabled" != "no")##
+
+		#set($addlHead = $perc.page.getAdditionalHeadContent())##
+		#set($quot = '"')##
+		$perc.page.setAdditionalHeadContent("<meta http-equiv=$!{quot}refresh$!{quot} content=$!{quot}$!{delayInSeconds};URL='$!{targetUrl}'$!{quot} />")##
+       #end##
+        #end##
+        #if ($perc.isEditMode())##
+           <div style="background: transparent url(/Rhythmyx/rx_resources/widgets/percRedirect/images/redirect-widget-placeholder-small.png) no-repeat scroll center center;filter: alpha(opacity=50);opacity: .50;" title="Client Side Redirect Widget">
+	   <h3>Client side redirect widget</h3>
+	   </div>
+        #end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/widgets/percBlogPost/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/widgets/percBlogPost/component-package.json
@@ -1,0 +1,1040 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percBlogPost",
+  "name": "Blog Post",
+  "version": "1.1.7",
+  "description": "Blog Post for your site",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.6.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.widget.title",
+      "version": "1.0.0",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Blog Post",
+    "category": "blog",
+    "description": "Blog Post for your site",
+    "thumbnail": "resources/WidgetIconBlog.png",
+    "icon": "resources/WidgetIconBlog.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 780,
+    "preferredEditorHeight": 723,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percBlogPostAsset",
+      "ref": "contentTypes/percBlogPostAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percBlogPostSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percBlogPostSnippet.vm",
+      "contentType": "percBlogPostAsset",
+      "bindings": [
+        {
+          "variable": "rootClass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "isEditMode",
+          "expression": "$perc.isEditMode() || $perc.isPreviewMode()"
+        },
+        {
+          "variable": "titleFormat",
+          "expression": "$perc.widget.item.properties.get('titleFormat')"
+        },
+        {
+          "variable": "blogPostNextPost",
+          "expression": "$perc.widget.item.properties.get('blogPostNextPost')"
+        },
+        {
+          "variable": "blogPostPrePost",
+          "expression": "$perc.widget.item.properties.get('blogPostPrePost')"
+        },
+        {
+          "variable": "blogPostDateTimeFormat",
+          "expression": "$perc.widget.item.properties.get('blogPostDateTimeFormat')"
+        },
+        {
+          "variable": "newerText",
+          "expression": "$blogPostNextPost"
+        },
+        {
+          "variable": "olderText",
+          "expression": "$blogPostPrePost"
+        },
+        {
+          "variable": "newerPostClass",
+          "expression": "'perc-newer-post'"
+        },
+        {
+          "variable": "olderPostClass",
+          "expression": "'perc-older-post'"
+        },
+        {
+          "variable": "blogPostBylineText",
+          "expression": "$perc.widget.item.properties.get('blogPostBylineText')"
+        },
+        {
+          "variable": "locale",
+          "expression": "$perc.widget.item.properties.get('locale')"
+        },
+        {
+          "variable": "locale",
+          "expression": "\"en-US\""
+        },
+        {
+          "variable": "blogNavigationContext",
+          "expression": "$perc.widget.item.properties.get('blogNavigationContext')"
+        },
+        {
+          "variable": "newerText",
+          "expression": "'Newer Post Title'"
+        },
+        {
+          "variable": "olderText",
+          "expression": "'Older Post Title'"
+        },
+        {
+          "variable": "olderPostClass",
+          "expression": "'perc-older-post-title'"
+        },
+        {
+          "variable": "newerPostClass",
+          "expression": "'perc-newer-post-title'"
+        },
+        {
+          "variable": "blogNavigationLocation",
+          "expression": "$perc.widget.item.properties.get('blogNavigationLocation')"
+        },
+        {
+          "variable": "assets",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "titleFormatStartTag",
+          "expression": "'<' + $titleFormat + ' class=\"perc-blog-title\">'"
+        },
+        {
+          "variable": "titleFormatEndTag",
+          "expression": "'</' + $titleFormat + '>'"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assets.get(0)"
+        },
+        {
+          "variable": "blogAuthorName",
+          "expression": "$assetItem.Node.getProperty('authorname').getString()"
+        },
+        {
+          "variable": "bylineStart",
+          "expression": "'<div class=\"perc-blog-byline\"><span class=\"perc-blog-author-label\">' + $blogPostBylineText + ' </span><span class=\"perc-blog-author-name\">'"
+        },
+        {
+          "variable": "bylineEnd",
+          "expression": "'</span></div>'"
+        },
+        {
+          "variable": "percHidefieldByline",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_byline')"
+        },
+        {
+          "variable": "percHidefieldBlogDate",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_blog_date')"
+        },
+        {
+          "variable": "percHidefieldTags",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_tags')"
+        },
+        {
+          "variable": "percTagsLabel",
+          "expression": "$perc.widget.item.properties.get('perc_tags_label')"
+        },
+        {
+          "variable": "percHidefieldCategories",
+          "expression": "$perc.widget.item.properties.get('perc_hidefield_categories')"
+        },
+        {
+          "variable": "percCategoriesLabel",
+          "expression": "$perc.widget.item.properties.get('perc_categories_label')"
+        },
+        {
+          "variable": "trackBlogPost",
+          "expression": "$perc.widget.item.properties.get('trackBlogPost')"
+        },
+        {
+          "variable": "blogPostFullPath",
+          "expression": "$rx.pageutils.itemLink($perc.linkContext, $perc.getPage()).toString()"
+        },
+        {
+          "variable": "navFinder",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "navContainer",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $navFinder, null, true)"
+        },
+        {
+          "variable": "navLoc",
+          "expression": "\"\""
+        },
+        {
+          "variable": "navSelf",
+          "expression": "\"\""
+        },
+        {
+          "variable": "blogIndexName",
+          "expression": "\"\""
+        },
+        {
+          "variable": "blogPostTempId",
+          "expression": "null"
+        },
+        {
+          "variable": "navLoc",
+          "expression": "$navContainer.get(0).getFolderPath()"
+        },
+        {
+          "variable": "landingPage",
+          "expression": "$navContainer.get(0).getNode().getProperty(\"nav:landingPage\")"
+        },
+        {
+          "variable": "navSelf",
+          "expression": "$navContainer.get(0).getNode().getProperty(\"nav:landingPage\").getNode()"
+        },
+        {
+          "variable": "blogIndexName",
+          "expression": "$navSelf.getName()"
+        },
+        {
+          "variable": "blogPostTempId",
+          "expression": "$rx.pageutils.getBlogPostTemplateId($navLoc)"
+        },
+        {
+          "variable": "siteName",
+          "expression": "\"\""
+        },
+        {
+          "variable": "pagePath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "\"[\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"&quot;type = 'page'&quot;\""
+        },
+        {
+          "variable": "criteriaSep",
+          "expression": "\", \""
+        },
+        {
+          "variable": "temppath",
+          "expression": "$navLoc.replace(\"//Sites/\", \"\")"
+        },
+        {
+          "variable": "pagePath",
+          "expression": "$navLoc.replace(\"//Sites\", \"\")"
+        },
+        {
+          "variable": "temppaths",
+          "expression": "$temppath.split(\"/\")"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\""
+        },
+        {
+          "variable": "siteName",
+          "expression": "$temppaths[0]"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "\"\""
+        },
+        {
+          "variable": "counter",
+          "expression": "1"
+        },
+        {
+          "variable": "folderpath",
+          "expression": "$folderpath + \"/\" + $temppaths[$counter]"
+        },
+        {
+          "variable": "counter",
+          "expression": "$counter + 1"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\""
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\""
+        },
+        {
+          "variable": "siteName",
+          "expression": "$temppath"
+        },
+        {
+          "variable": "templateNameList",
+          "expression": "$rx.pageutils.templateNames($blogPostTempId)"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\""
+        },
+        {
+          "variable": "tagValues",
+          "expression": "\"\""
+        },
+        {
+          "variable": "categoryValues",
+          "expression": "\"\""
+        },
+        {
+          "variable": "tagValues",
+          "expression": "$sys.item.getProperty('page_tags').getValues()"
+        },
+        {
+          "variable": "categoryValues",
+          "expression": "$sys.item.getProperty('page_categories_tree').getValues()"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "siteName",
+          "expression": "$pathParts[2]"
+        },
+        {
+          "variable": "criteria",
+          "expression": "$criteria + \"]\""
+        },
+        {
+          "variable": "orderby",
+          "expression": "\"dcterms:created desc\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{\" + \"&quot;criteria&quot;:\" + $criteria"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;navType&quot;:&quot;\" + $blogNavigationContext + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;blogPostNextPost&quot;:&quot;\" + $blogPostNextPost + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;blogPostPrePost&quot;:&quot;\" + $blogPostPrePost + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;blogPostFullPath&quot;:&quot;/\" + $siteName + $blogPostFullPath + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;folderPath&quot;:&quot;\" + $pagePath + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;siteName&quot;:&quot;\" +  $siteName + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;trackBlogPost&quot;:\" +  $trackBlogPost"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;deliveryurl&quot; : &quot;\" + $dsUrl + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;isEditMode&quot; : &quot;\" + $isEditMode + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \", &quot;blogIndexName&quot; : &quot;\" + $blogIndexName + \"&quot;\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$dynamicListData + \"}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootClass = $perc.widget.item.cssProperties.get('rootclass');\n    $isEditMode = $perc.isEditMode() || $perc.isPreviewMode();\n    $titleFormat = $perc.widget.item.properties.get('titleFormat');\n    $blogPostNextPost = $perc.widget.item.properties.get('blogPostNextPost');\n    $blogPostPrePost = $perc.widget.item.properties.get('blogPostPrePost');\n    $blogPostDateTimeFormat = $perc.widget.item.properties.get('blogPostDateTimeFormat');\n    $newerText = $blogPostNextPost;\n    $olderText = $blogPostPrePost;\n    $newerPostClass = 'perc-newer-post';\n    $olderPostClass = 'perc-older-post';\n    $blogPostBylineText = $perc.widget.item.properties.get('blogPostBylineText');\n    $locale = $perc.widget.item.properties.get('locale');\n    if($locale == null)\n       $locale = \"en-US\";\n    $blogNavigationContext = $perc.widget.item.properties.get('blogNavigationContext');\n    if($blogNavigationContext == 'blogTitle')\n    {\n        $newerText = 'Newer Post Title';\n        $olderText = 'Older Post Title';\n        $olderPostClass = 'perc-older-post-title';\n        $newerPostClass = 'perc-newer-post-title';\n    }\n\n\n\n    $blogNavigationLocation = $perc.widget.item.properties.get('blogNavigationLocation');\n    $assets = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n    $perc.setWidgetContents($assets);\n    if (!empty($titleFormat))\n    {\n        $titleFormatStartTag = '<' + $titleFormat + ' class=\"perc-blog-title\">';\n        $titleFormatEndTag = '</' + $titleFormat + '>';\n    }\n    if (! $assets.isEmpty())\n    {\n        $assetItem = $assets.get(0);\n        $blogAuthorName = $assetItem.Node.getProperty('authorname').getString();\n        $bylineStart = '<div class=\"perc-blog-byline\"><span class=\"perc-blog-author-label\">' + $blogPostBylineText + ' </span><span class=\"perc-blog-author-name\">';\n        $bylineEnd = '</span></div>';\n        $percHidefieldByline = $perc.widget.item.properties.get('perc_hidefield_byline');\n        $percHidefieldBlogDate = $perc.widget.item.properties.get('perc_hidefield_blog_date');\n        $percHidefieldTags = $perc.widget.item.properties.get('perc_hidefield_tags');\n        $percTagsLabel = $perc.widget.item.properties.get('perc_tags_label');\n        $percHidefieldCategories = $perc.widget.item.properties.get('perc_hidefield_categories');\n        $percCategoriesLabel = $perc.widget.item.properties.get('perc_categories_label');\n        $trackBlogPost = $perc.widget.item.properties.get('trackBlogPost');\n        $blogPostFullPath = $rx.pageutils.itemLink($perc.linkContext, $perc.getPage()).toString();\n\n\n        ## Get navigation.  If we can't find it, we're probably in a template.\n        $navFinder=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n        $navContainer = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $navFinder, null, true);\n        $navLoc = \"\";\n        $navSelf = \"\";\n        $blogIndexName = \"\";\n        $blogPostTempId = null;\n        if ($navContainer != null && ! $navContainer.isEmpty() ) {\n            $navLoc = $navContainer.get(0).getFolderPath();\n            $landingPage = $navContainer.get(0).getNode().getProperty(\"nav:landingPage\");\n            if($landingPage != null){\n                $navSelf = $navContainer.get(0).getNode().getProperty(\"nav:landingPage\").getNode();\n                $blogIndexName = $navSelf.getName();\n                $blogPostTempId = $rx.pageutils.getBlogPostTemplateId($navLoc);\n            }\n        }\n        $siteName = \"\";\n        $pagePath = \"\";\n        $criteria = \"[\";\n        if ($navLoc != null && $navLoc != \"\" && $navLoc != \"//Sites\")\n        {\n            $criteria = $criteria + \"&quot;type = 'page'&quot;\";\n            $criteriaSep = \", \";\n            $temppath = $navLoc.replace(\"//Sites/\", \"\");\n            $pagePath = $navLoc.replace(\"//Sites\", \"\");\n            if($temppath.indexOf(\"/\") > 0)\n            {\n                $temppaths = $temppath.split(\"/\");\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppaths[0] + \"'&quot;\";\n                $siteName = $temppaths[0];\n                $folderpath = \"\";\n                $counter = 1;\n                while($counter < $temppaths.size())\n                {\n                    $folderpath = $folderpath + \"/\" + $temppaths[$counter];\n                    $counter = $counter + 1;\n                }\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;folder LIKE '\" + $folderpath + \"/%'&quot;\";\n            }\n            else\n            {\n                $criteria = $criteria  +  $criteriaSep +  \"&quot;site = '\" + $temppath + \"'&quot;\";\n                $siteName = $temppath;\n            }\n\n            if ($blogPostTempId != null)\n            {\n               $templateNameList = $rx.pageutils.templateNames($blogPostTempId);\n               if($templateNameList.size() > 0)\n               {\n                   $criteria = $criteria  +  $criteriaSep +  \"&quot;dcterms:source = '\" + $templateNameList.get(0).toString() + \"'&quot;\";\n               }\n            }\n\n            ## Get tags and category values only if one of the conditions below is matched\n            $tagValues = \"\";\n            $categoryValues = \"\";\n            if(($blogPostTempId == null) || (! $perc.widgetContents.isEmpty() && $pagePath != \"\"))\n            {\n               ## Get tag and categories values, only when we are not in a template.\n               $tagValues = $sys.item.getProperty('page_tags').getValues();\n               $rx.pageutils.alphaOrderTag($tagValues);\n\n               $categoryValues = $sys.item.getProperty('page_categories_tree').getValues();\n               $rx.pageutils.alphaOrderCategory($categoryValues);\n           }\n\n        }\n\n\t\t$pageId = $perc.page.id;\n        if(!empty($pageId))\n        {\n           $finderPath = $rx.pageutils.getItemPath($pageId);\n           $pathParts  = $finderPath.split(\"\\/\");\n           $siteName   = $pathParts[2];\n        }\n        $criteria = $criteria + \"]\";\n\n        ##Builds the criteria\n\n        ##builds the order by clause\n        $orderby = \"dcterms:created desc\";\n\n        ##Build the query string for the delivery side\n\n        $dynamicListData = \"{\" + \"&quot;criteria&quot;:\" + $criteria;\n        $dynamicListData = $dynamicListData + \", &quot;navType&quot;:&quot;\" + $blogNavigationContext + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;orderBy&quot;:&quot;\" + $orderby + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;blogPostNextPost&quot;:&quot;\" + $blogPostNextPost + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;blogPostPrePost&quot;:&quot;\" + $blogPostPrePost + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;blogPostFullPath&quot;:&quot;/\" + $siteName + $blogPostFullPath + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;folderPath&quot;:&quot;\" + $pagePath + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;siteName&quot;:&quot;\" +  $siteName + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;trackBlogPost&quot;:\" +  $trackBlogPost;\n        $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n        $dynamicListData = $dynamicListData + \", &quot;deliveryurl&quot; : &quot;\" + $dsUrl + \"&quot;\";\n        $dynamicListData = $dynamicListData + \", &quot;isEditMode&quot; : &quot;\" + $isEditMode + \"&quot;\";\n\n        $dynamicListData = $dynamicListData + \", &quot;blogIndexName&quot; : &quot;\" + $blogIndexName + \"&quot;\";\n        $dynamicListData = $dynamicListData + \"}\";\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percBlogPostContent",
+      "allowedContentTypes": [
+        "percBlogPostAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/WidgetIconBlog.png",
+      "target": "rx_resources/widgets/blogPost/images/WidgetIconBlog.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "titleFormat",
+      "displayName": "Format of blog post title",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "h1",
+      "enumValues": [
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        }
+      ]
+    },
+    {
+      "name": "blogPostDateTimeFormat",
+      "displayName": "Format of blog post date",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "EEE MMM d, yyyy 'at' hh:mm a",
+      "enumValues": []
+    },
+    {
+      "name": "locale",
+      "displayName": "Date Format Locale",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "en-US",
+      "enumValues": [
+        {
+          "value": "sq-AL",
+          "displayValue": "Albanian Albania (AL)"
+        },
+        {
+          "value": "ar-DZ",
+          "displayValue": "Arabic Algeria (DZ)"
+        },
+        {
+          "value": "ar-BH",
+          "displayValue": "Arabic Bahrain (BH)"
+        },
+        {
+          "value": "ar-EG",
+          "displayValue": "Arabic Egypt (EG)"
+        },
+        {
+          "value": "ar-IQ",
+          "displayValue": "Arabic Iraq (IQ)"
+        },
+        {
+          "value": "ar-JO",
+          "displayValue": "Arabic Jordan (JO)"
+        },
+        {
+          "value": "ar-KW",
+          "displayValue": "Arabic Kuwait (KW)"
+        },
+        {
+          "value": "ar-LB",
+          "displayValue": "Arabic Lebanon (LB)"
+        },
+        {
+          "value": "ar-LY",
+          "displayValue": "Arabic Libya (LY)"
+        },
+        {
+          "value": "ar-MA",
+          "displayValue": "Arabic Morocco (MA)"
+        },
+        {
+          "value": "ar-OM",
+          "displayValue": "Arabic Oman (OM)"
+        },
+        {
+          "value": "ar-QA",
+          "displayValue": "Arabic Qatar (QA)"
+        },
+        {
+          "value": "ar-SA",
+          "displayValue": "Arabic Saudi Arabia (SA)"
+        },
+        {
+          "value": "ar-SD",
+          "displayValue": "Arabic Sudan (SD)"
+        },
+        {
+          "value": "ar-SY",
+          "displayValue": "Arabic Syria (SY)"
+        },
+        {
+          "value": "ar-TN",
+          "displayValue": "Arabic Tunisia (TN)"
+        },
+        {
+          "value": "ar-AE",
+          "displayValue": "Arabic United Arab Emirates (AE)"
+        },
+        {
+          "value": "ar-YE",
+          "displayValue": "Arabic Yemen (YE)"
+        },
+        {
+          "value": "be-BY",
+          "displayValue": "Belarusian Belarus (BY)"
+        },
+        {
+          "value": "bg-BG",
+          "displayValue": "Bulgarian Bulgaria (BG)"
+        },
+        {
+          "value": "ca-ES",
+          "displayValue": "Catalan Spain (ES)"
+        },
+        {
+          "value": "zh-CN",
+          "displayValue": "Chinese China (CN)"
+        },
+        {
+          "value": "zh-SG",
+          "displayValue": "Chinese Singapore (SG)"
+        },
+        {
+          "value": "zh-HK",
+          "displayValue": "Chinese Hong Kong (HK)"
+        },
+        {
+          "value": "zh-TW",
+          "displayValue": "Chinese Taiwan (TW)"
+        },
+        {
+          "value": "hr-HR",
+          "displayValue": "Croatian Croatia (HR)"
+        },
+        {
+          "value": "cs-CZ",
+          "displayValue": "Czech Czech Republic (CZ)"
+        },
+        {
+          "value": "da-DK",
+          "displayValue": "Danish Denmark (DK)"
+        },
+        {
+          "value": "nl-BE",
+          "displayValue": "Dutch Belgium (BE)"
+        },
+        {
+          "value": "nl-NL",
+          "displayValue": "Dutch Netherlands (NL)"
+        },
+        {
+          "value": "en-AU",
+          "displayValue": "English Australia (AU)"
+        },
+        {
+          "value": "en-CA",
+          "displayValue": "English Canada (CA)"
+        },
+        {
+          "value": "en-IN",
+          "displayValue": "English India (IN)"
+        },
+        {
+          "value": "en-IE",
+          "displayValue": "English Ireland (IE)"
+        },
+        {
+          "value": "en-MT",
+          "displayValue": "English Malta (MT)"
+        },
+        {
+          "value": "en-NZ",
+          "displayValue": "English New Zealand (NZ)"
+        },
+        {
+          "value": "en-PH",
+          "displayValue": "English Philippines (PH)"
+        },
+        {
+          "value": "en-SG",
+          "displayValue": "English Singapore (SG)"
+        },
+        {
+          "value": "en-ZA",
+          "displayValue": "English South Africa (ZA)"
+        },
+        {
+          "value": "en-GB",
+          "displayValue": "English United Kingdom (GB)"
+        },
+        {
+          "value": "en-US",
+          "displayValue": "English United States (US)"
+        },
+        {
+          "value": "et-EE",
+          "displayValue": "Estonian Estonia (EE)"
+        },
+        {
+          "value": "fi-FI",
+          "displayValue": "Finnish Finland (FI)"
+        },
+        {
+          "value": "fr-BE",
+          "displayValue": "French Belgium (BE)"
+        },
+        {
+          "value": "fr-CA",
+          "displayValue": "French Canada (CA)"
+        },
+        {
+          "value": "fr-FR",
+          "displayValue": "French France (FR)"
+        },
+        {
+          "value": "fr-LU",
+          "displayValue": "French Luxembourg (LU)"
+        },
+        {
+          "value": "fr-CH",
+          "displayValue": "French Switzerland (CH)"
+        },
+        {
+          "value": "de-AT",
+          "displayValue": "German Austria (AT)"
+        },
+        {
+          "value": "de-DE",
+          "displayValue": "German Germany (DE)"
+        },
+        {
+          "value": "de-LU",
+          "displayValue": "German Luxembourg (LU)"
+        },
+        {
+          "value": "de-CH",
+          "displayValue": "German Switzerland (CH)"
+        },
+        {
+          "value": "el-CY",
+          "displayValue": "Greek Cyprus (CY)"
+        },
+        {
+          "value": "el-GR",
+          "displayValue": "Greek Greece (GR)"
+        },
+        {
+          "value": "iw-IL",
+          "displayValue": "Hebrew Israel (IL)"
+        },
+        {
+          "value": "hi-IN",
+          "displayValue": "Hindi India (IN)"
+        },
+        {
+          "value": "hu-HU",
+          "displayValue": "Hungarian Hungary (HU)"
+        },
+        {
+          "value": "is-IS",
+          "displayValue": "Icelandic Iceland (IS)"
+        },
+        {
+          "value": "in-ID",
+          "displayValue": "Indonesian Indonesia (ID)"
+        },
+        {
+          "value": "ga-IE",
+          "displayValue": "Irish Ireland (IE)"
+        },
+        {
+          "value": "it-IT",
+          "displayValue": "Italian Italy (IT)"
+        },
+        {
+          "value": "it-CH",
+          "displayValue": "Italian Switzerland (CH)"
+        },
+        {
+          "value": "ja-JP",
+          "displayValue": "Japanese Japan (JP)"
+        },
+        {
+          "value": "ko-KR",
+          "displayValue": "Korean South Korea (KR)"
+        },
+        {
+          "value": "lv-LV",
+          "displayValue": "Latvian Latvia (LV)"
+        },
+        {
+          "value": "lt-LT",
+          "displayValue": "Lithuanian Lithuania (LT)"
+        },
+        {
+          "value": "mk-MK",
+          "displayValue": "Macedonian Macedonia (MK)"
+        },
+        {
+          "value": "ms-MY",
+          "displayValue": "Malay Malaysia (MY)"
+        },
+        {
+          "value": "mt-MT",
+          "displayValue": "Maltese (mt) Malta (MT)"
+        },
+        {
+          "value": "no-NO",
+          "displayValue": "Norwegian Norway (NO)"
+        },
+        {
+          "value": "nb-NO",
+          "displayValue": "Norwegian Bokmal Norway (NO)"
+        },
+        {
+          "value": "nn-NO",
+          "displayValue": "Norwegian Nynorsk Norway (NO)"
+        },
+        {
+          "value": "pl-PL",
+          "displayValue": "Polish Poland (PL)"
+        },
+        {
+          "value": "pt-BR",
+          "displayValue": "Portuguese Brazil (BR)"
+        },
+        {
+          "value": "pt-PT",
+          "displayValue": "Portuguese Portugal (PT)"
+        },
+        {
+          "value": "ro-RO",
+          "displayValue": "Romanian Romania (RO)"
+        },
+        {
+          "value": "ru-RU",
+          "displayValue": "Russian Russia (RU)"
+        },
+        {
+          "value": "sr-BA",
+          "displayValue": "Serbian Bosnia and Herzegovina (BA)"
+        },
+        {
+          "value": "sr-ME",
+          "displayValue": "Serbian Montenegro (ME)"
+        },
+        {
+          "value": "sr-RS",
+          "displayValue": "Serbian Serbia (RS)"
+        },
+        {
+          "value": "sk-SK",
+          "displayValue": "Slovak Slovakia (SK)"
+        },
+        {
+          "value": "sl-SI",
+          "displayValue": "Slovenian Slovenia (SI)"
+        },
+        {
+          "value": "es-AR",
+          "displayValue": "Spanish Argentina (AR)"
+        },
+        {
+          "value": "es-BO",
+          "displayValue": "Spanish Bolivia (BO)"
+        },
+        {
+          "value": "es-CL",
+          "displayValue": "Spanish Chile (CL)"
+        },
+        {
+          "value": "es-CO",
+          "displayValue": "Spanish Colombia (CO)"
+        },
+        {
+          "value": "es-CR",
+          "displayValue": "Spanish Costa Rica (CR)"
+        },
+        {
+          "value": "es-DO",
+          "displayValue": "Spanish Dominican Republic (DO)"
+        },
+        {
+          "value": "es-EC",
+          "displayValue": "Spanish Ecuador (EC)"
+        },
+        {
+          "value": "es-SV",
+          "displayValue": "Spanish El Salvador (SV)"
+        },
+        {
+          "value": "es-GT",
+          "displayValue": "Spanish Guatemala (GT)"
+        },
+        {
+          "value": "es-HN",
+          "displayValue": "Spanish Honduras (HN)"
+        },
+        {
+          "value": "es-MX",
+          "displayValue": "Spanish Mexico (MX)"
+        },
+        {
+          "value": "es-NI",
+          "displayValue": "Spanish Nicaragua (NL)"
+        },
+        {
+          "value": "es-PA",
+          "displayValue": "Spanish Panama (PA)"
+        },
+        {
+          "value": "es-PY",
+          "displayValue": "Spanish Paraguay (PY)"
+        },
+        {
+          "value": "es-PE",
+          "displayValue": "Spanish Peru (PE)"
+        },
+        {
+          "value": "es-PR",
+          "displayValue": "Spanish Puerto Rico (PR)"
+        },
+        {
+          "value": "es-ES",
+          "displayValue": "Spanish Spain (ES)"
+        },
+        {
+          "value": "es-US",
+          "displayValue": "Spanish United States (US)"
+        },
+        {
+          "value": "es-UY",
+          "displayValue": "Spanish Uruguay (UY)"
+        },
+        {
+          "value": "es-VE",
+          "displayValue": "Spanish Venezuela (VE)"
+        },
+        {
+          "value": "sv-SE",
+          "displayValue": "Swedish Sweden (SE)"
+        },
+        {
+          "value": "th-TH",
+          "displayValue": "Thai Thailand (TH)"
+        },
+        {
+          "value": "tr-TR",
+          "displayValue": "Turkish Turkey (TR)"
+        },
+        {
+          "value": "uk-UA",
+          "displayValue": "Ukrainian Ukraine (UA)"
+        },
+        {
+          "value": "vi-VN",
+          "displayValue": "Vietnamese Vietnam (VN)"
+        }
+      ]
+    },
+    {
+      "name": "perc_hidefield_blog_date",
+      "displayName": "Hide date and time",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "blogPostBylineText",
+      "displayName": "Text to use for \"Author Byline\"",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "by",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_byline",
+      "displayName": "Hide byline",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_tags",
+      "displayName": "Hide tags",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_tags_label",
+      "displayName": "Text to use for \"tags\" label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Tags:",
+      "enumValues": []
+    },
+    {
+      "name": "perc_hidefield_categories",
+      "displayName": "Hide categories",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "perc_categories_label",
+      "displayName": "Text to use for \"categories\" label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Categories:",
+      "enumValues": []
+    },
+    {
+      "name": "blogNavigationLocation",
+      "displayName": "Location of blog navigation",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "none",
+      "enumValues": [
+        {
+          "value": "none",
+          "displayValue": "None"
+        },
+        {
+          "value": "above",
+          "displayValue": "Above blog post"
+        },
+        {
+          "value": "beneath",
+          "displayValue": "Beneath blog post"
+        },
+        {
+          "value": "aboveBeneath",
+          "displayValue": "Above and beneath blog posting"
+        }
+      ]
+    },
+    {
+      "name": "blogNavigationContext",
+      "displayName": "Blog navigation context",
+      "datatype": "enum",
+      "required": false,
+      "defaultValue": "preNext",
+      "enumValues": [
+        {
+          "value": "preNext",
+          "displayValue": "User defined"
+        },
+        {
+          "value": "blogTitle",
+          "displayValue": "Use blog title"
+        }
+      ]
+    },
+    {
+      "name": "blogPostNextPost",
+      "displayName": "Text to navigate to newer post",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Newer Post",
+      "enumValues": []
+    },
+    {
+      "name": "blogPostPrePost",
+      "displayName": "Text to navigate to older post",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Older Post",
+      "enumValues": []
+    },
+    {
+      "name": "trackBlogPost",
+      "displayName": "Track blog post",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/widgets/percBlogPost/templates/percBlogPostSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.blog/widgets/percBlogPost/templates/percBlogPostSnippet.vm
@@ -1,0 +1,107 @@
+<div class="perc-blog $!rootClass" data-query="$!dynamicListData">
+#if( ! $perc.widgetContents.isEmpty() )##
+<div class = "perc-blog-wrapper">
+#set($node = $perc.widgetContents.get(0).node)##
+#if( ($blogNavigationLocation == "above") || ($blogNavigationLocation == "aboveBeneath") )##
+<div class = "perc-blog-nav-top perc-blog-navigation-container">
+<div class = "perc-blog-navigation-wrapper">
+<div class="perc-blog-nav-left-wrapper">
+<div class = "perc-blog-left-arrow">
+</div>
+<div class = "perc-older-post-wrapper">
+<a href = "#" title="$!{olderText}"><span class="$!{olderPostClass}">$!{olderText}</span></a>
+</div>
+</div>
+<div class = "perc-place-holder">&nbsp;
+</div>
+<div class="perc-blog-nav-right-wrapper">
+<div class = "perc-newer-post-wrapper">
+<a href="#" title="$!{newerText}"><span class="$!{newerPostClass}">$!{newerText}</span></a>
+</div >
+<div class = "perc-blog-right-arrow">
+</div>
+</div>
+</div>
+<div class = "perc-clear-both"> </div>
+</div>
+#end##
+$!{titleFormatStartTag}$tools.esc.html($node.getProperty('rx:displaytitle').getString())$!{titleFormatEndTag}
+<div class="perc-blog-dateByline-container">
+#if(!($percHidefieldByline) && "$!{blogAuthorName}" != "")##
+$bylineStart$tools.esc.html($blogAuthorName)$bylineEnd
+#end##
+#if(!($percHidefieldBlogDate))##
+#set( $postDateTz = $sys.item.getProperty('rx:sys_contentpostdatetz').String )##
+#if($postDateTz == "Default")##
+#set( $postDateTz = "" )##
+#end##
+<div class="perc-blog-date">
+#perc_displayXdsDateTimeWithFormat($blogPostDateTimeFormat, 'rx:sys_contentpostdate') $postDateTz ##
+</div>
+#end##
+</div>
+<div class="perc-blog-post">
+$node.getProperty('rx:postbody').getString()##
+</div>
+#set($tag-novalue = "")##
+#if(! $sys.item.hasProperty("page_tags") || $tagValues.size() == 0)##
+#set($tag-novalue = "perc-blog-hide-container")##
+#end##
+#if(!($percHidefieldTags))##
+<div class="perc-blog-post-tag-container $tag-novalue">
+<span>$!{percTagsLabel}</span>
+#set($separator = ",")##
+#foreach($tag in $tagValues)##
+#if($velocityCount == $tagValues.size())##
+#set($separator = "")##
+#end##
+<a href="#">$tools.esc.html($tag.String)$!{separator}</a>
+#end##
+</div>
+#end##
+#set($category-novalue = "")##
+#if(!$sys.item.hasProperty("page_categories_tree") || ($categoryValues.size() == 0))##
+#set($category-novalue = "perc-blog-hide-container")##
+#end##
+#if(!($percHidefieldCategories))##
+<div class="perc-blog-post-category-container $category-novalue">
+<span>$!{percCategoriesLabel}</span>
+#set($separator = ",")##
+#foreach($categoryPath in $categoryValues)##
+#if($velocityCount == $categoryValues.size())##
+#set($separator = "")##
+#end##
+#foreach($categorySingle in $categoryPath.String.split("/"))##
+#set($category = $!{categorySingle})##
+#end##
+<a href="#" data-categories="$categoryPath.getString()">$tools.esc.html($!{category})$!{separator}</a>
+#end##
+</div>
+#end##
+#if( ($blogNavigationLocation == "beneath") || ($blogNavigationLocation == "aboveBeneath") )##
+<div class = "perc-blog-nav-bottom perc-blog-navigation-container">
+<div class = "perc-blog-navigation-wrapper">
+<div class="perc-blog-nav-left-wrapper">
+<div class = "perc-blog-left-arrow">
+</div>
+<div class = "perc-older-post-wrapper">
+<a href = "#"><span class="$!{olderPostClass}">$!{olderText}</span></a>
+</div>
+</div>
+<div class = "perc-place-holder">&nbsp;</div>
+<div class="perc-blog-nav-right-wrapper">
+<div class = "perc-newer-post-wrapper">
+<a href = "#"><span class ="$!{newerPostClass}">$!{newerText}</span></a>
+</div >
+<div class = "perc-blog-right-arrow">
+</div>
+</div>
+</div>
+<div class = "perc-clear-both"></div>
+</div>
+#end##
+</div>
+#elseif ($perc.isEditMode())##
+#createEmptyWidgetContent("blog-post-sample-content", "This blog post widget is showing sample content")##
+#end##
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/widgets/percComments/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/widgets/percComments/component-package.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percComments",
+  "name": "Comments",
+  "version": "1.1.4",
+  "description": "Display a list of comments submitted to the page",
+  "publisher": {
+    "name": "Percussion Software Inc",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.7.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Comments",
+    "category": "blog,social",
+    "description": "Display a list of comments submitted to the page",
+    "thumbnail": "resources/WidgetIconComment.png",
+    "icon": "resources/WidgetIconComment.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 965,
+    "preferredEditorHeight": 680,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percCommentsSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percCommentsSnippet.vm",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "titleFormat",
+          "expression": "$perc.widget.item.properties.get('titleFormat')"
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "widgetId",
+          "expression": "$perc.widget.item.id"
+        },
+        {
+          "variable": "dUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$dUrl + \"/perc-comments-services/comment/jsonp\""
+        },
+        {
+          "variable": "dUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "\"{&quot;serviceurl&quot;: &quot;\" + $dsUrl +\"&quot;, &quot;finderpath&quot;: &quot;\" + $rx.pageutils.getItemPath($pageId) + \"&quot;, &quot;deliveryurl&quot;: &quot;\" + $dUrl + \"&quot;, &quot;titleFormat&quot;: &quot;\" + $titleFormat + \"&quot;}\""
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "if(! $perc.isPreviewMode())\n      {\n          $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n\n          if (empty($rootclass)) {\n            $rootclass = \"\";\n          }\n\n          $titleFormat = $perc.widget.item.properties.get('titleFormat');\n\n          $pageId = $perc.page.id;\n          $widgetId = $perc.widget.item.id;\n\n          $dUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n          $dsUrl = $dUrl + \"/perc-comments-services/comment/jsonp\";\n          if ($dUrl.indexOf(\"http://localhost\") != -1 )\n          $dUrl = \"\";\n           $dynamicListData =\"{&quot;serviceurl&quot;: &quot;\" + $dsUrl +\"&quot;, &quot;finderpath&quot;: &quot;\" + $rx.pageutils.getItemPath($pageId) + \"&quot;, &quot;deliveryurl&quot;: &quot;\" + $dUrl + \"&quot;, &quot;titleFormat&quot;: &quot;\" + $titleFormat + \"&quot;}\";\n      }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percCommentsChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/WidgetIconComment.png",
+      "target": "rx_resources/widgets/comments/images/WidgetIconComment.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "titleFormat",
+      "displayName": "Heading format for Title field",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "h3",
+      "enumValues": [
+        {
+          "value": "h1",
+          "displayValue": "Heading 1"
+        },
+        {
+          "value": "h2",
+          "displayValue": "Heading 2"
+        },
+        {
+          "value": "h3",
+          "displayValue": "Heading 3"
+        },
+        {
+          "value": "h4",
+          "displayValue": "Heading 4"
+        },
+        {
+          "value": "h5",
+          "displayValue": "Heading 5"
+        },
+        {
+          "value": "h6",
+          "displayValue": "Heading 6"
+        },
+        {
+          "value": "p",
+          "displayValue": "Paragraph"
+        },
+        {
+          "value": "div",
+          "displayValue": "Div"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/widgets/percComments/templates/percCommentsSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.comments/widgets/percComments/templates/percCommentsSnippet.vm
@@ -1,0 +1,5 @@
+#if ($perc.isEditMode())
+         #createEmptyWidgetContent("comments-sample-content", "This Comments widget is showing sample content.")
+     #elseif (!$perc.isPreviewMode())
+         <div class="$!rootclass perc-comments perc-comments-view" data-query="$dynamicListData"></div>
+     #end

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/widgets/percImage/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/widgets/percImage/component-package.json
@@ -1,0 +1,295 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percImage",
+  "name": "Image",
+  "version": "1.1.8",
+  "description": "Display an image on a page",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "http://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.1",
+    "max": "9.0.0"
+  },
+  "dependencies": [
+    {
+      "name": "perc.Baseline",
+      "version": "1.0.3",
+      "implied": true
+    }
+  ],
+  "catalog": {
+    "kind": "component",
+    "title": "Image",
+    "category": "content,rich media",
+    "description": "Display an image on a page",
+    "thumbnail": "resources/widgetIconImage.png",
+    "icon": "resources/widgetIconImage.png",
+    "author": "Percussion Software Inc",
+    "preferredEditorWidth": 965,
+    "preferredEditorHeight": 680,
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percImageAsset",
+      "ref": "contentTypes/percImageAsset"
+    }
+  ],
+  "templates": [
+    {
+      "name": "percImageSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percImageSnippet.vm",
+      "contentType": "percImageAsset",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "props",
+          "expression": "$perc.widget.item.properties"
+        },
+        {
+          "variable": "referalPolicy",
+          "expression": "$props.get(\"referalPolicy\")"
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "classAttribute",
+          "expression": "'class=\"' + $rootclass + '\"'"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "link",
+          "expression": "$rx.pageutils.itemLink($linkContext, $assetItem, \"percSystem.imageThumbBinary\")"
+        },
+        {
+          "variable": "biglink",
+          "expression": "$rx.pageutils.itemLink($linkContext, $assetItem, \"percSystem.imageMainBinary\")"
+        },
+        {
+          "variable": "img_alt",
+          "expression": "$rx.pageutils.html($assetItem,'alttext')"
+        },
+        {
+          "variable": "img_alt",
+          "expression": "$rx.pageutils.html($props, 'altText')"
+        },
+        {
+          "variable": "img_title",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "img_title",
+          "expression": "$rx.pageutils.html($props, 'title')"
+        },
+        {
+          "variable": "img_title",
+          "expression": "\"\""
+        },
+        {
+          "variable": "img_title_attr",
+          "expression": "''"
+        },
+        {
+          "variable": "img_title_attr",
+          "expression": "'title=\"' + $img_title + '\"'"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$props.get(\"ariaLabel\")"
+        },
+        {
+          "variable": "longdesc",
+          "expression": "$props.get(\"longdesc\")"
+        },
+        {
+          "variable": "rendering",
+          "expression": "$props.get('rendering')"
+        },
+        {
+          "variable": "img_height",
+          "expression": "$assetItem.Node.getProperty('img_height').String"
+        },
+        {
+          "variable": "img_width",
+          "expression": "$assetItem.Node.getProperty('img_width').String"
+        },
+        {
+          "variable": "img_height",
+          "expression": "$assetItem.Node.getProperty('img2_height').String"
+        },
+        {
+          "variable": "img_width",
+          "expression": "$assetItem.Node.getProperty('img2_width').String"
+        },
+        {
+          "variable": "link",
+          "expression": "$tools.esc.html($link)"
+        },
+        {
+          "variable": "biglink",
+          "expression": "$tools.esc.html($biglink)"
+        },
+        {
+          "variable": "biglink",
+          "expression": "$biglink.replace(\"(\", \"%28\")"
+        },
+        {
+          "variable": "biglink",
+          "expression": "$biglink.replace(\")\", \"%29\")"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n      $props = $perc.widget.item.properties;\n      $referalPolicy = $props.get(\"referalPolicy\");\n      $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n      $perc.setWidgetContents($assetItems);\n      $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n      if ( ! empty($rootclass))\n         $classAttribute = 'class=\"' + $rootclass + '\"';\n      if ( ! $assetItems.isEmpty() ) {\n\n         $assetItem = $assetItems.get(0);\n\n         $link = $rx.pageutils.itemLink($linkContext, $assetItem, \"percSystem.imageThumbBinary\");\n         $biglink = $rx.pageutils.itemLink($linkContext, $assetItem, \"percSystem.imageMainBinary\");\n         if(empty($props.altText)){\n            $img_alt = $rx.pageutils.html($assetItem,'alttext');\n         } else {\n            $img_alt = $rx.pageutils.html($props, 'altText');\n         }\n         if( ! $perc.isEditMode()) {\n            if(empty($props.title)) {\n               $img_title = $rx.pageutils.html($assetItem,'displaytitle');\n            } else {\n               $img_title = $rx.pageutils.html($props, 'title');\n            }\n         } else {\n            $img_title=\"\";\n         }\n\n         if( $perc.isEditMode() && $img_title == \"\") {\n            $img_title_attr = '';\n         } else {\n            $img_title_attr = 'title=\"' + $img_title + '\"';\n         }\n\n\t\t$ariaLabel = $props.get(\"ariaLabel\");\n\t\t$longdesc = $props.get(\"longdesc\");\n\n         $rendering = $props.get('rendering');\n         if( $rendering == 'image') {\n            $img_height = $assetItem.Node.getProperty('img_height').String;\n            $img_width = $assetItem.Node.getProperty('img_width').String;\n         } else {\n            $img_height = $assetItem.Node.getProperty('img2_height').String;\n            $img_width = $assetItem.Node.getProperty('img2_width').String;\n         }\n\n         $link = $tools.esc.html($link);\n         $biglink = $tools.esc.html($biglink);\n         $biglink = $biglink.replace(\"(\", \"%28\");\n         $biglink = $biglink.replace(\")\", \"%29\");\n\n      } else {\n        ;\n      }\n\n\t  $dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n      if ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t      $dsUrl = \"\";\n      $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percImageContent",
+      "allowedContentTypes": [
+        "percImageAsset"
+      ],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconImage.png",
+      "target": "rx_resources/widgets/image/images/widgetIconImage.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/image/css/style.css",
+      "type": "css",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "rendering",
+      "displayName": "Rendering format",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "image",
+      "enumValues": [
+        {
+          "value": "image",
+          "displayValue": "Normal image"
+        },
+        {
+          "value": "lightbox",
+          "displayValue": "Thumbnail and light box"
+        }
+      ]
+    },
+    {
+      "name": "altText",
+      "displayName": "Alt text override",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "title",
+      "displayName": "Title override",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "longdesc",
+      "displayName": "Long Description",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Aria Label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "referalPolicy",
+      "displayName": "Referrer-Policy",
+      "datatype": "enum",
+      "required": false,
+      "enumValues": [
+        {
+          "value": "no-referrer",
+          "displayValue": "no-referrer"
+        },
+        {
+          "value": "no-referrer-when-downgrade",
+          "displayValue": "no-referrer-when-downgrade"
+        },
+        {
+          "value": "origin",
+          "displayValue": "origin"
+        },
+        {
+          "value": "origin-when-cross-origin",
+          "displayValue": "origin-when-cross-origin"
+        },
+        {
+          "value": "same-origin",
+          "displayValue": "same-origin"
+        },
+        {
+          "value": "strict-origin",
+          "displayValue": "strict-origin"
+        },
+        {
+          "value": "strict-origin-when-cross-origin",
+          "displayValue": "strict-origin-when-cross-origin"
+        },
+        {
+          "value": "unsafe-url",
+          "displayValue": "unsafe-url"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/widgets/percImage/templates/percImageSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.image/widgets/percImage/templates/percImageSnippet.vm
@@ -1,0 +1,20 @@
+#if( $assetItem)##
+        <div $!classAttribute data="$!{dynamicListData}">
+        #if( $rendering == 'image')##
+            #if( $img_height.length() > 0 && $img_width.length() > 0)##
+               <img src="$!{biglink}"  referrerpolicy="$!{referalPolicy}"  $!{img_title_attr} alt="$!{img_alt}" #if( "$!ariaLabel" != "")aria-label="$!ariaLabel"#end #if( "$!longdesc" != "")longdesc="$!longdesc"#end height="$!{img_height}" width="$!{img_width}"/>
+            #else##
+               <img src="$!{biglink}" referrerpolicy="$!{referalPolicy}"  $!{img_title_attr} alt="$!{img_alt}" #if( "$!ariaLabel" != "")aria-label="$!ariaLabel"#end #if( "$!longdesc" != "")longdesc="$!longdesc"#end/>
+            #end##
+        #end##
+        #if( $rendering == 'lightbox')##
+            <div class="ui-widget ui-widget-content" id="percImageTWLBBox-$!{assetItem.id}">
+            <a href="$!{biglink}" $!{img_title_attr} data-lightbox="$!{assetItem.id}" #if("$!ariaLabel" != "")aria-label="$!ariaLabel"#end>
+               <img src="$!{link}" referrerpolicy="$!{referalPolicy}"  alt="$!{img_alt}" #if("$!longdesc" != "")longdesc="$!longdesc"#end #if("$!ariaLabel" != "")aria-label="$!ariaLabel"#end height="$!{img_height}" width="$!{img_width}" />
+            </a>
+            </div>
+        #end##
+        </div>
+    #elseif ($perc.isEditMode())##
+        #createEmptyWidgetContent("image-sample-content", "This image widget is showing sample content.")
+    #end##

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/widgets/percLiked/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/widgets/percLiked/component-package.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percLiked",
+  "name": "Like",
+  "version": "1.1.4",
+  "description": "Allow site visitors to indicate they like a page",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.7.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Like",
+    "category": "social",
+    "description": "Allow site visitors to indicate they like a page",
+    "thumbnail": "resources/widgetIconLiked.png",
+    "icon": "resources/widgetIconLiked.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percLikedSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percLikedSnippet.vm",
+      "bindings": [
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "pageId",
+          "expression": "$perc.page.id"
+        },
+        {
+          "variable": "finderPath",
+          "expression": "$rx.pageutils.getItemPath($pageId)"
+        },
+        {
+          "variable": "pathParts",
+          "expression": "$finderPath.split(\"\\/\")"
+        },
+        {
+          "variable": "siteName",
+          "expression": "$pathParts[2]"
+        },
+        {
+          "variable": "finder",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finder, null, true)"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "''"
+        },
+        {
+          "variable": "tooltip",
+          "expression": "$rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This liked widget is showing sample content.\")"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "'title=\"' + $tooltip + '\"'"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "$rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId)"
+        },
+        {
+          "variable": "dsUrl",
+          "expression": "\"\""
+        },
+        {
+          "variable": "dynamicListData",
+          "expression": "$tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\")"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$rootclass = $perc.widget.item.cssProperties.get('rootclass');\n        if (!empty($rootclass)) {\n            $rootclass = $rootclass + \" \";\n        }\n        $pageId = $perc.page.id;\n        if(!empty($pageId))\n        {\n           $finderPath = $rx.pageutils.getItemPath($pageId);\n           $pathParts  = $finderPath.split(\"\\/\");\n           $siteName   = $pathParts[2];\n        }\n        $finder=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n        $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finder, null, true);\n        if ( ! $assetItems.isEmpty() ) {\n            $sampleTooltip = '';\n        }\n        else if ($perc.isEditMode()){\n            $tooltip = $rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This liked widget is showing sample content.\");\n            $sampleTooltip = 'title=\"' + $tooltip + '\"';\n        }\n\n\t\t$dsUrl = $rx.pageutils.getDeliveryServer($sys.assemblyItem.PubServerId);\n       \tif ($dsUrl.indexOf(\"http://localhost\") != -1 )\n\t\t\t$dsUrl = \"\";\n        $dynamicListData = $tools.esc.html(\"{ deliveryurl : '\" + $dsUrl + \"'}\");"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percLikedChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLiked.png",
+      "target": "rx_resources/widgets/liked/images/widgetIconLiked.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/widgets/percLiked/templates/percLikedSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.liked/widgets/percLiked/templates/percLikedSnippet.vm
@@ -1,0 +1,18 @@
+<div class="$!{rootclass} perc-like-widget perc-disabled"  style="width:100%" siteName="$siteName" $sampleTooltip data="$!{dynamicListData}">
+        <div class="perc-like-button">
+            <button type="button" title="Like">
+                <span class="perc-likedWidget-button-noScript">Like This</span>
+            </button>
+        </div>
+        <div class="perc-like-counter">
+            <div class="perc-like-counter-left">
+                <div class="perc-like-counter-right">
+                    <div class="perc-like-counter-value">
+                        <div class="perc-like-counter-text">
+                            <span class="perc-like-total-likes">0</span> <span class="perc-like-people">people</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simplePageAutoList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simplePageAutoList/component-package.json
@@ -1,0 +1,156 @@
+{
+  "schemaVersion": "1.0",
+  "id": "simplePageAutoList",
+  "name": "Auto List",
+  "version": "1.1.5",
+  "description": "Simple List widget for page links",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Auto List",
+    "category": "content,search",
+    "description": "Simple List widget for page links",
+    "thumbnail": "resources/widgetIconLinkAutoList.png",
+    "icon": "resources/widgetIconLinkAutoList.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSimpleAutoList",
+      "ref": "contentTypes/percSimpleAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "simplePageAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/simplePageAutoListSnippet.vm",
+      "contentType": "percSimpleAutoList",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "\"\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even')"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n   $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n   if (empty($rootclass)) {\n      $rootclass = \"\";\n   }\n   $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $perc.setWidgetContents($assetItems);\n   if ( ! $assetItems.isEmpty() ) {\n      $assetItem = $assetItems.get(0);\n      $params = $rx.string.stringToMap(null);\n      $params.put('query', $assetItem.getNode().getProperty('query').String);\n      $params.put('max_results', $assetItem.node.getProperty('max_results').Long);\n      $finderName = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n      $relresults=  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n      $title = $rx.pageutils.html($assetItem,'displaytitle');\n      $rowtag = $tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even');\n   }\n   else {\n      ;\n   }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "simplePageAutoListContent",
+      "allowedContentTypes": [
+        "percSimpleAutoList"
+      ],
+      "layout": {
+        "maxlength": "0",
+        "layout": ""
+      },
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconLinkAutoList.png",
+      "target": "rx_resources/widgets/simpleList/images/widgetIconLinkAutoList.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/simpleList/css/style.css",
+      "type": "css",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "maxlength",
+      "displayName": "Max List Length",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "0",
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "string",
+      "required": true,
+      "enumValues": [
+        {
+          "value": "ui-perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "ui-perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    },
+    {
+      "name": "target",
+      "displayName": "Link Target",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simplePageAutoList/templates/simplePageAutoListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simplePageAutoList/templates/simplePageAutoListSnippet.vm
@@ -1,0 +1,40 @@
+<div class="$rootclass $layout .ui-widget .ui-widget-content .ui-perc-list-widget">
+#if (!$assetItems.isEmpty())
+    #if($title && $title.length() > 0)##
+       <div class=".ui-perc-list-title">$title</div>
+    #end
+    #if($relresults && $relresults.size() > 0)
+       #if($rendering == "ordered")##
+          <ol class=".ui-perc-list-main">##
+       #else##
+	  <ul class=".ui-perc-list-main">##
+       #end##
+       #foreach($result in $relresults)
+          #if($velocityCount == 1)##
+             #set($firstrow = '.ui-perc-list-first')##
+          #else##
+             #set($firstrow = ' ')##
+          #end##
+          #if($velocityCount == $relresults.size())##
+             #set($lastrow = '.ui-perc-list-last')##
+          #else
+             #set($lastrow = ' ')##
+          #end
+             #set($pagelink = $tools.esc.html($rx.pageutils.itemLink($linkContext, $result)))##
+             #set($linkTitle = $rx.pageutils.html($result.node,"resource_link_title,sys_title", "-no-title-"))##
+             <li class="$rowtag $firstrow $lastrow .ui-perc-list-element"><a href="$!{pagelink}"
+             #if($target.length() > 0)##
+                target="${target}"
+             #end
+                >$!{linkTitle}</a></li>
+       #end##
+       #if($rendering == "ordered")##
+          </ol>##
+       #else##
+          </ul>##
+       #end##
+    #end##
+#elseif ($perc.isEditMode())
+        Insert list of links based on query here.
+#end
+    </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simpleTextAutoList/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simpleTextAutoList/component-package.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": "1.0",
+  "id": "simpleTextAutoList",
+  "name": "Text Auto List",
+  "version": "1.1.5",
+  "description": "Simple Auto List widget for text blocks",
+  "publisher": {
+    "name": "Percussion Software",
+    "url": "www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Text Auto List",
+    "category": "content,search",
+    "description": "Simple Auto List widget for text blocks",
+    "thumbnail": "resources/widgetIconTextAutoList.png",
+    "icon": "resources/widgetIconTextAutoList.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [
+    {
+      "name": "percSimpleAutoList",
+      "ref": "contentTypes/percSimpleAutoList"
+    }
+  ],
+  "templates": [
+    {
+      "name": "simpleTextAutoListSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/simpleTextAutoListSnippet.vm",
+      "contentType": "percSimpleAutoList",
+      "bindings": [
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null)"
+        },
+        {
+          "variable": "assetItem",
+          "expression": "$assetItems.get(0)"
+        },
+        {
+          "variable": "params",
+          "expression": "$rx.string.stringToMap(null)"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\""
+        },
+        {
+          "variable": "relresults",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params)"
+        },
+        {
+          "variable": "title",
+          "expression": "$rx.pageutils.html($assetItem,'displaytitle')"
+        },
+        {
+          "variable": "rowtag",
+          "expression": "$tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even')"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, null, null);\n   $perc.setWidgetContents($assetItems);\n   if ( ! $assetItems.isEmpty() ) {\n      $assetItem = $assetItems.get(0);\n      $params = $rx.string.stringToMap(null);\n      $params.put('query', $assetItem.getNode().getProperty('query').String);\n      $params.put('max_results', $assetItem.getNode().getProperty('max_results').Long);\n      $finderName = \"Java/global/percussion/widgetcontentfinder/perc_AutoWidgetContentFinder\";\n      $relresults =  $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, $params);\n      $title = $rx.pageutils.html($assetItem,'displaytitle');\n      $rowtag = $tools.alternator.auto('.ui-perc-list-odd', '.ui-perc-list-even');\n   }\n   else {\n      ;\n   }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "simpleTextAutoListContent",
+      "allowedContentTypes": [
+        "percSimpleAutoList"
+      ],
+      "layout": {
+        "maxlength": "0",
+        "layout": ""
+      },
+      "styles": {}
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconTextAutoList.png",
+      "target": "rx_resources/widgets/simpleList/images/widgetIconTextAutoList.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/style.css",
+      "target": "rx_resources/widgets/simpleList/css/style.css",
+      "type": "css",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "maxlength",
+      "displayName": "Max List Length",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "0",
+      "enumValues": []
+    },
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "string",
+      "required": true,
+      "enumValues": [
+        {
+          "value": "ui-perc-list-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "ui-perc-list-vertical",
+          "displayValue": "Vertical"
+        }
+      ]
+    }
+  ],
+  "cssPreferences": []
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simpleTextAutoList/templates/simpleTextAutoListSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.lists/widgets/simpleTextAutoList/templates/simpleTextAutoListSnippet.vm
@@ -1,0 +1,34 @@
+<div class="$rootclass $layout ui-widget ui-widget-content ui-perc-list-widget">
+#if (!$assetItems.isEmpty())
+    #if($title.length() > 0)##
+       <div class=".ui-perc-list-title">$title</div>
+    #end
+    #if($relresults && $relresults.size() > 0)
+       #if($rendering == "ordered")##
+          <ol class="ui-perc-list-main">##
+       #else##
+          <ul class="ui-perc-list-main">##
+       #end##
+       #foreach($result in $relresults)
+          #if($velocityCount == 1)##
+             #set($firstrow = 'ui-perc-list-first')##
+          #else##
+             #set($firstrow = ' ')##
+          #end##
+          #if($velocityCount == $relresults.size())##
+             #set($lastrow = 'ui-perc-list-last')##
+          #else
+             #set($lastrow = ' ')##
+          #end
+          <li class="$rowtag $firstrow $lastrow ui-perc-list-element">$rx.pageutils.html($result, "text")</li>
+       #end##
+       #if($rendering == "ordered")##
+          </ol>##
+       #else##
+          </ul>##
+       #end##
+    #end##
+#elseif ($perc.isEditMode())
+        Insert list of text blocks based on query here.
+#end
+    </div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBar/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBar/component-package.json
@@ -1,0 +1,294 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percNavBar",
+  "name": "Navigation",
+  "version": "1.3.3",
+  "description": "Add Navigation links to a page",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Navigation",
+    "category": "navigation",
+    "description": "Add Navigation links to a page",
+    "thumbnail": "resources/widgetIconNavBar.png",
+    "icon": "resources/widgetIconNavBar.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percNavBarSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percNavBarSnippet.vm",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "layout",
+          "expression": "$perc.widget.item.properties.get('layout')"
+        },
+        {
+          "variable": "maxlevels",
+          "expression": "$perc.widget.item.properties.get('maxlevels')"
+        },
+        {
+          "variable": "maxRootItems",
+          "expression": "$perc.widget.item.properties.get('maxRootItems')"
+        },
+        {
+          "variable": "maxSubItems",
+          "expression": "$perc.widget.item.properties.get('maxSubItems')"
+        },
+        {
+          "variable": "rootlevel",
+          "expression": "$tools.math.toNumber($perc.widget.item.properties.get('rootlevel'))"
+        },
+        {
+          "variable": "titleNavigateToText",
+          "expression": "$perc.widget.item.properties.get('titleNavigateToText')"
+        },
+        {
+          "variable": "generateSkipLink",
+          "expression": "$perc.widget.item.properties.get('generateSkipLink')"
+        },
+        {
+          "variable": "skipLinkRegionId",
+          "expression": "$perc.widget.item.properties.get('skipLinkRegionId')"
+        },
+        {
+          "variable": "skipLinkText",
+          "expression": "$perc.widget.item.properties.get('skipLinkText')"
+        },
+        {
+          "variable": "tabindexValue",
+          "expression": "$perc.widget.item.properties.get('tabindexValue')"
+        },
+        {
+          "variable": "generateSkipLink",
+          "expression": "false"
+        },
+        {
+          "variable": "titleNavigateToText",
+          "expression": "$titleNavigateToText.trim()"
+        },
+        {
+          "variable": "ata",
+          "expression": "$perc.widget.item.properties.get('addtitleattributes')"
+        },
+        {
+          "variable": "addTitleAttrs",
+          "expression": "\"no\""
+        },
+        {
+          "variable": "addTitleAttrs",
+          "expression": "\"yes\""
+        },
+        {
+          "variable": "maxlevels",
+          "expression": "1"
+        },
+        {
+          "variable": "rootlevel",
+          "expression": "$rootlevel - 1"
+        },
+        {
+          "variable": "rootlevel",
+          "expression": "0"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "finder",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finder, null, true)"
+        },
+        {
+          "variable": "nav",
+          "expression": "$assetItems.get(0).getNode()"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "''"
+        },
+        {
+          "variable": "navTooltip",
+          "expression": "$rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navbar is showing sample content.\")"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "' title=\"' + $navTooltip + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n    $layout = $perc.widget.item.properties.get('layout');\n    $maxlevels = $perc.widget.item.properties.get('maxlevels');\n    $maxRootItems = $perc.widget.item.properties.get('maxRootItems');\n    $maxSubItems = $perc.widget.item.properties.get('maxSubItems');\n    $rootlevel = $tools.math.toNumber($perc.widget.item.properties.get('rootlevel'));\n    $titleNavigateToText = $perc.widget.item.properties.get('titleNavigateToText');\n    $generateSkipLink = $perc.widget.item.properties.get('generateSkipLink');\n    $skipLinkRegionId = $perc.widget.item.properties.get('skipLinkRegionId');\n    $skipLinkText = $perc.widget.item.properties.get('skipLinkText');\n    $tabindexValue = $perc.widget.item.properties.get('tabindexValue');\n\n    if($generateSkipLink == null)\n       $generateSkipLink = false;\n\n    if($titleNavigateToText)\n        $titleNavigateToText = $titleNavigateToText.trim();\n\n    $ata = $perc.widget.item.properties.get('addtitleattributes');\n\n    $addTitleAttrs = \"no\";\n    if($ata){\n        $addTitleAttrs = \"yes\";\n    }\n\n    if($maxlevels < 1)\n    {\n      $maxlevels = 1;\n   }\n   if ($rootlevel >= 1) {\n        $rootlevel = $rootlevel - 1;\n    }\n    else {\n        $rootlevel = 0;\n    }\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $rootclass = $rootclass + \" \";\n    $finder=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finder, null, true);\n    if ( ! $assetItems.isEmpty() ) {\n        $nav = $assetItems.get(0).getNode();\n        $sampleTooltip = '';\n    }\n    else if ($perc.isEditMode()){\n        $navTooltip = $rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navbar is showing sample content.\");\n        $sampleTooltip = ' title=\"' + $navTooltip + '\"';\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percNavBarChrome",
+      "allowedContentTypes": [],
+      "layout": {
+        "layout": "sf-menu perc-navbar-sfhorizontal"
+      },
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconNavBar.png",
+      "target": "web_resources/widgets/navBar/images/widgetIconNavBar.png",
+      "type": "image"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "maxlevels",
+      "displayName": "Maximum number of levels to be shown",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "3",
+      "enumValues": []
+    },
+    {
+      "name": "rootlevel",
+      "displayName": "Set the primary node for your navigation",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "1",
+      "enumValues": []
+    },
+    {
+      "name": "maxRootItems",
+      "displayName": "Set the maximum number of navigation items to display at the root level (-1 for unlimited )",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "-1",
+      "enumValues": []
+    },
+    {
+      "name": "maxSubItems",
+      "displayName": "Set the maximum number or navigation items to display at each navigation sub level (-1 for unlimited )",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "-1",
+      "enumValues": []
+    },
+    {
+      "name": "layout",
+      "displayName": "Layout",
+      "datatype": "enum",
+      "required": true,
+      "defaultValue": "sf-menu perc-navbar-sfhorizontal",
+      "enumValues": [
+        {
+          "value": "perc-navbar-horizontal",
+          "displayValue": "Horizontal"
+        },
+        {
+          "value": "perc-navbar-vertical",
+          "displayValue": "Vertical"
+        },
+        {
+          "value": "sf-menu perc-navbar-sfhorizontal",
+          "displayValue": "Horizontal rollover"
+        },
+        {
+          "value": "sf-menu sf-vertical perc-navbar-sfvertical",
+          "displayValue": "Vertical rollover"
+        },
+        {
+          "value": "sf-menu sf-navbar perc-navbar-sfnavbar",
+          "displayValue": "NavBar rollover"
+        }
+      ]
+    },
+    {
+      "name": "addtitleattributes",
+      "displayName": "Add title attributes",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "titleNavigateToText",
+      "displayName": "'Navigate to' Title Text",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Navigate to",
+      "enumValues": []
+    },
+    {
+      "name": "generateSkipLink",
+      "displayName": "Generate Skip Link",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "false",
+      "enumValues": []
+    },
+    {
+      "name": "skipLinkText",
+      "displayName": "Skip Link Text",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Skip to content",
+      "enumValues": []
+    },
+    {
+      "name": "skipLinkRegionId",
+      "displayName": "Skip Link target Region Id",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "tabindexValue",
+      "displayName": "Skip link tabindex value",
+      "datatype": "number",
+      "required": false,
+      "defaultValue": "-1",
+      "enumValues": []
+    },
+    {
+      "name": "navLabel",
+      "displayName": "Navigation Label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Main Navigation",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS Root Class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBar/templates/percNavBarSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBar/templates/percNavBarSnippet.vm
@@ -1,0 +1,155 @@
+<div class="$!{rootclass} perc-navbar"$!{sampleTooltip}>
+#if("$generateSkipLink"=="true" && ! $perc.isEditMode())##
+<script >
+window.addEventListener('DOMContentLoaded', function() {
+// bind a click event to the 'skip' link
+$(".perc-navigation-skiplink").on("click",function(event) {
+// strip the leading hash and declare
+// the content we're skipping to
+var skipTo="#"+this.href.split('#')[1];
+// Setting 'tabindex' to -1 takes an element out of normal
+// tab flow but allows it to be focused via javascript
+$(skipTo).attr('tabindex', -1).on('blur focusout', function () {
+// when focus leaves this element,
+// remove the tabindex attribute
+$(this).removeAttr('tabindex');
+}).trigger("focus"); // focus on the content container
+});
+});
+</script>
+<a href="#$!{skipLinkRegionId}" class="perc-navigation-skiplink" tabindex="$!{tabindexValue}">$!{skipLinkText}</a>
+#end##
+<nav aria-label="$!{navLabel}">
+<ul class="$!{layout}">
+#if($!{nav})##
+#perc_processNavigationNode($nav.getRoot(), 1, 1, $addTitleAttrs, $titleNavigateToText, $maxRootItems, $maxSubItems)##
+#elseif ($perc.isEditMode())##
+<li class="perc-navbar-current">
+<a href="#a">Section 1</a>
+#if($maxlevels > 1)##
+<ul>
+<li>
+<a href="#">Section 2</a>
+#if($maxlevels > 2)##
+<ul>
+<li>
+<a href="#aa">menu item that is quite long</a>
+</li>
+<li class="perc-navbar-current">
+<a href="#ab">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li class="perc-navbar-current"><a href="#">menu item</a></li>
+<li><a href="#aba">menu item</a></li>
+<li><a href="#abb">menu item</a></li>
+<li><a href="#abc">menu item</a></li>
+<li><a href="#abd">menu item</a></li>
+</ul>
+#end##
+</li>
+<li>
+<a href="#">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+</ul>
+#end##
+</li>
+<li>
+<a href="#">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+</ul>
+#end##
+</li>
+</ul>
+#end##
+</li>
+<li>
+<li>
+<a href="#">Section 3</a>
+#if($maxlevels > 2)##
+<ul>
+<li>
+<a href="#">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li><a href="#">short</a></li>
+<li><a href="#">short</a></li>
+<li><a href="#">short</a></li>
+<li><a href="#">short</a></li>
+<li><a href="#">short</a></li>
+</ul>
+#end##
+</li>
+<li>
+<a href="#">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+</ul>
+#end##
+</li>
+<li>
+<a href="#">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+</ul>
+#end##
+</li>
+<li>
+<a href="#">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+</ul>
+#end##
+</li>
+<li>
+<a href="#">menu item</a>
+#if($maxlevels > 3)##
+<ul>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+<li><a href="#">menu item</a></li>
+</ul>
+#end##
+</li>
+</ul>
+#end##
+</li>
+<li>
+<a href="#">Section 4</a>
+</li>
+</ul>
+#end##
+</li>
+#end##
+</ul>
+</nav>
+<div style="clear:both"></div>
+</div>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBreadcrumb/component-package.json
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBreadcrumb/component-package.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": "1.0",
+  "id": "percNavBreadcrumb",
+  "name": "Breadcrumb",
+  "version": "1.3.3",
+  "description": "Display a navigation breadcrumb in your site",
+  "publisher": {
+    "name": "Percussion Software Inc.",
+    "url": "https://www.percussion.com"
+  },
+  "cmsVersion": {
+    "min": "1.0.0",
+    "max": "9.0.0"
+  },
+  "dependencies": [],
+  "catalog": {
+    "kind": "component",
+    "title": "Breadcrumb",
+    "category": "navigation",
+    "description": "Display a navigation breadcrumb in your site",
+    "thumbnail": "resources/widgetIconBreadcrumb.png",
+    "icon": "resources/widgetIconBreadcrumb.png",
+    "author": "Percussion Software Inc",
+    "responsive": true,
+    "paletteVisible": true
+  },
+  "contentTypes": [],
+  "templates": [
+    {
+      "name": "percNavBreadcrumbSnippet",
+      "type": "snippet",
+      "assembler": "velocityAssembler",
+      "sourceRef": "templates/percNavBreadcrumbSnippet.vm",
+      "bindings": [
+        {
+          "variable": "linkContext",
+          "expression": "$perc.linkContext"
+        },
+        {
+          "variable": "showHome",
+          "expression": "$perc.widget.item.properties.get('showHome')"
+        },
+        {
+          "variable": "showCurrentPage",
+          "expression": "$perc.widget.item.properties.get('showCurrentPage')"
+        },
+        {
+          "variable": "ariaLabel",
+          "expression": "$perc.widget.item.properties.get('ariaLabel')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$perc.widget.item.cssProperties.get('rootclass')"
+        },
+        {
+          "variable": "rootclass",
+          "expression": "$rootclass + \" \""
+        },
+        {
+          "variable": "separator",
+          "expression": "$perc.widget.item.properties.get('separator')"
+        },
+        {
+          "variable": "finderName",
+          "expression": "\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\""
+        },
+        {
+          "variable": "assetItems",
+          "expression": "$rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true)"
+        },
+        {
+          "variable": "navSelf",
+          "expression": "$assetItems.get(0).getNode()"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "''"
+        },
+        {
+          "variable": "navTooltip",
+          "expression": "$rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navBreadCrumb is showing sample content.\")"
+        },
+        {
+          "variable": "sampleTooltip",
+          "expression": "' title=\"' + $navTooltip + '\"'"
+        },
+        {
+          "variable": "__widgetCode",
+          "expression": "$linkContext = $perc.linkContext;\n    $showHome = $perc.widget.item.properties.get('showHome');\n    $showCurrentPage = $perc.widget.item.properties.get('showCurrentPage');\n    $ariaLabel = $perc.widget.item.properties.get('ariaLabel');\n    $rootclass = $perc.widget.item.cssProperties.get('rootclass');\n    if (!empty($rootclass))\n        $rootclass = $rootclass + \" \";\n    $separator = $perc.widget.item.properties.get('separator');\n    $finderName=\"Java/global/percussion/widgetcontentfinder/perc_NavWidgetContentFinder\";\n    $assetItems = $rx.pageutils.widgetContents($sys.assemblyItem, $perc.widget, $finderName, null, true);\n    if ( ! $assetItems.isEmpty() ) {\n        $navSelf = $assetItems.get(0).getNode();\n        $sampleTooltip = '';\n    }\n    else if ($perc.isEditMode()){\n\t\t$navTooltip = $rx.pageutils.getWidgetTooltip($perc, $perc.widget, \"This navBreadCrumb is showing sample content.\");\n        $sampleTooltip = ' title=\"' + $navTooltip + '\"';\n    }"
+        }
+      ]
+    }
+  ],
+  "slots": [
+    {
+      "name": "percNavBreadcrumbChrome",
+      "allowedContentTypes": [],
+      "layout": {},
+      "styles": {
+        "rootclass": ""
+      }
+    }
+  ],
+  "resources": [
+    {
+      "path": "resources/widgetIconBreadcrumb.png",
+      "target": "web_resources/widgets/navBar/images/widgetIconBreadcrumb.png",
+      "type": "image"
+    },
+    {
+      "path": "resources/breadcrumb.css",
+      "target": "web_resources/widgets/navBar/css/breadcrumb.css",
+      "type": "css",
+      "placement": "head"
+    }
+  ],
+  "userPreferences": [
+    {
+      "name": "showHome",
+      "displayName": "Show home",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "showCurrentPage",
+      "displayName": "Show current page",
+      "datatype": "bool",
+      "required": false,
+      "defaultValue": "true",
+      "enumValues": []
+    },
+    {
+      "name": "separator",
+      "displayName": "Separator",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": " > ",
+      "enumValues": []
+    },
+    {
+      "name": "ariaLabel",
+      "displayName": "Aria Label",
+      "datatype": "string",
+      "required": false,
+      "enumValues": []
+    },
+    {
+      "name": "navLabel",
+      "displayName": "Navigation Label",
+      "datatype": "string",
+      "required": false,
+      "defaultValue": "Breadcrumb Navigation",
+      "enumValues": []
+    }
+  ],
+  "cssPreferences": [
+    {
+      "name": "rootclass",
+      "displayName": "CSS root class",
+      "datatype": "string"
+    }
+  ]
+}

--- a/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBreadcrumb/templates/percNavBreadcrumbSnippet.vm
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widgets.nav/widgets/percNavBreadcrumb/templates/percNavBreadcrumbSnippet.vm
@@ -1,0 +1,69 @@
+<div class="$!{rootclass}perc-breadcrumb" aria-label="$!{ariaLabel}" role="navigation">
+#if ($navSelf)##
+#set($ancestors = $navSelf.getAncestors())##
+#if($ancestors.size()>0 && !$showHome)##
+#set($d=$ancestors.remove(0))##
+#end##
+#if($showCurrentPage)##
+#set($d=$ancestors.add($navSelf))##
+#end##
+#if ($ancestors.size() > 0)##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main">
+#foreach($node in $ancestors)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $ancestors.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($landing_page = $tools.esc.html($rx.pageutils.navLink($linkContext, $node)))##
+#set($title = $rx.pageutils.html($node,"displaytitle"))##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+<a href="$landing_page">$!{title}</a>##
+#else##
+<a href="$landing_page">$!{title}</a>##
+#end##
+</li>
+#end##
+</ul>
+</nav>
+#end##
+#elseif ($perc.isEditMode())##
+<nav aria-label="$!{navLabel}">
+<ul class="perc-breadcrumb-main" $sampleTooltip>
+#set ($sampleContent = ["Section 1", "Section 2"])##
+#foreach($node in $sampleContent)##
+#set($liclass="perc-list-element")##
+#if ($velocityCount==1)##
+#set($liclass="$liclass perc-list-first")##
+#end##
+#if ($velocityCount == $sampleContent.size())##
+#set($liclass="$liclass perc-list-last")##
+#end##
+#if ($velocityCount % 2 == 0)##
+#set($liclass="$liclass perc-list-even")##
+#else##
+#set($liclass="$liclass perc-list-odd")##
+#end##
+#set($title = $node)##
+<li class="$liclass">##
+#if ($velocityCount > 1 )$separator#end##
+#if($velocityCount == $ancestors.size() && $showCurrentPage)##
+$!{title}
+#else##
+<a href="#">$title</a>##
+#end</li>##
+#end##
+</ul>
+</nav>
+#end##
+</div>

--- a/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/pagexml/PSPageXmlNativeInstallTest.java
@@ -229,6 +229,7 @@ class PSPageXmlNativeInstallTest {
 
     // GUID map keys are lower-cased (same as dual-ship); on-disk templateDef keeps product case.
     Map<String, String> guids = PSPageXmlDualShip.loadGuidsFromMapping(staging);
+    // GUID map keys are Locale.ROOT lowercase (mixed-case product ids).
     assertEquals("0-4-597", guids.get("perc.resp.banded"));
     assertEquals("0-4-599", guids.get("perc.resp.basic"));
     assertEquals("0-4-627", guids.get("perc.resp.plain"));

--- a/modules/perc-packages/src/test/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShimTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShimTest.java
@@ -115,6 +115,27 @@ class PSLegacyDefinitionXmlShimTest {
   }
 
   @Test
+  void selectForPackageRoot_prefersDualShipWidgetsDirOverLegacyXml() throws Exception {
+    Path pkg = tempDir.resolve("perc.baseWidgets");
+    Path modernWidget = pkg.resolve("widgets").resolve("percSimpleText");
+    Files.createDirectories(modernWidget);
+    Path manifest = modernWidget.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME);
+    Files.writeString(
+        manifest,
+        "{\"schemaVersion\":\"1.0\",\"id\":\"percSimpleText\",\"name\":\"Simple Text\",\"version\":\"1.0.0\"}",
+        StandardCharsets.UTF_8);
+
+    Path widgets = pkg.resolve("sys__UserDependency--rxconfig").resolve("Widgets");
+    Files.createDirectories(widgets);
+    Files.writeString(widgets.resolve("percSimpleText.xml"), "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s = PSLegacyDefinitionXmlShim.selectForPackageRoot(pkg);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, s.getKind());
+    assertEquals(manifest, s.getPrimaryPath().orElseThrow());
+    assertFalse(PSLegacyDefinitionXmlShim.wouldUseLegacyShim(pkg));
+  }
+
+  @Test
   void selectForPackageRoot_installRelativeWidgetsPath() throws Exception {
     Path pkg = tempDir.resolve("installStyle");
     Path widgets = pkg.resolve("rxconfig").resolve("Widgets");

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Dual-ship modern widget authoring tests (issue #2831 batch A / parent #2630).
+ * Dual-ship modern widget authoring tests (issues #2831 batch A, #2832 batch B / parent #2630).
  *
  * <p>Product packages keep install Widget XML under {@code
  * sys__UserDependency--rxconfig/Widgets} while committing modern {@code widgets/&lt;stem&gt;/}
@@ -225,6 +225,111 @@ class PSWidgetXmlDualShipTest {
     assertEquals(
         PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS,
         PSWidgetXmlPackageCompiler.DUAL_SHIP_BATCH_A_PACKAGE_DIRS);
+  }
+
+  @Test
+  void productBatchB_modernAuthoringRoots_presentAndParityWithXmlCompile() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping product batch B dual-ship test");
+      return;
+    }
+
+    Set<String> foundStems = new HashSet<>();
+    int packagesWithModern = 0;
+
+    for (String pkgName : PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS) {
+      Path product = packagesRoot.resolve(pkgName);
+      if (!Files.isDirectory(product)) {
+        System.err.println("WARN: missing package " + pkgName + "; soft-skip");
+        continue;
+      }
+
+      assertTrue(
+          PSWidgetXmlDualShip.hasModernWidgetSources(product),
+          pkgName + " must author modern widgets/ sources (#2832 batch B)");
+
+      // Dual-run: install Widget XML remains until native install path (do not mass-delete).
+      Path xmlDir = PSWidgetXmlPackageCompiler.resolveWidgetsDir(product);
+      assertTrue(Files.isDirectory(xmlDir), pkgName + " still dual-ships Widget XML for install");
+
+      List<PSWidgetXmlCompileResult> fromXml = PSWidgetXmlPackageCompiler.compilePackage(product);
+      List<PSWidgetXmlCompileResult> fromModern = PSWidgetXmlDualShip.compileModernWidgets(product);
+      assertEquals(
+          fromXml.size(),
+          fromModern.size(),
+          pkgName + " modern widget count must match Widget XML count");
+
+      Map<String, PSWidgetXmlCompileResult> xmlById =
+          fromXml.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+      Map<String, PSWidgetXmlCompileResult> modernById =
+          fromModern.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+      for (Map.Entry<String, PSWidgetXmlCompileResult> e : xmlById.entrySet()) {
+        String id = e.getKey();
+        assertTrue(modernById.containsKey(id), pkgName + " missing modern widget " + id);
+        PSComponentPackageManifest expected = e.getValue().getManifest();
+        PSComponentPackageManifest actual = modernById.get(id).getManifest();
+        PSComponentPackageManifest expectedRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(expected));
+        PSComponentPackageManifest actualRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(actual));
+        assertEquals(expectedRound, actualRound, "modern manifest parity for " + id);
+
+        String templateKey =
+            expected.getTemplates().isEmpty()
+                ? null
+                : expected.getTemplates().get(0).getSourceRef();
+        if (templateKey != null) {
+          assertEquals(
+              normalizeNewlines(e.getValue().getTextArtifacts().get(templateKey)),
+              normalizeNewlines(modernById.get(id).getTextArtifacts().get(templateKey)),
+              "template parity for " + id);
+        }
+        foundStems.add(id);
+      }
+
+      PSDefinitionSourceSelection sel = PSLegacyDefinitionXmlShim.selectForPackageRoot(product);
+      assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, sel.getKind(), pkgName);
+      assertFalse(
+          PSLegacyDefinitionXmlShim.wouldUseLegacyShim(product),
+          pkgName + " dual-ship modern roots should win selection");
+
+      packagesWithModern++;
+    }
+
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS.size(),
+        packagesWithModern,
+        "all batch B packages should be present with modern roots");
+    assertEquals(
+        new HashSet<>(PSWidgetXmlDualShip.BATCH_B_WIDGET_STEMS),
+        foundStems,
+        "batch B must cover the 20 named widget stems");
+  }
+
+  @Test
+  void batchB_packageDirs_disjointFromBatchAAndTestAndSized() {
+    assertFalse(PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS.contains("perc.Test"));
+    assertEquals(14, PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS.size());
+    assertEquals(20, PSWidgetXmlDualShip.BATCH_B_WIDGET_STEMS.size());
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS,
+        PSWidgetXmlPackageCompiler.DUAL_SHIP_BATCH_B_PACKAGE_DIRS);
+    // Batches must not overlap packages.
+    Set<String> batchA = new HashSet<>(PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS);
+    for (String pkg : PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS) {
+      assertFalse(batchA.contains(pkg), "batch B must not re-cover batch A package " + pkg);
+    }
+    // High-traffic + residual long-tail coverage alignment.
+    assertTrue(
+        PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS.containsAll(
+            PSWidgetXmlPackageCompiler.HIGH_TRAFFIC_PACKAGE_DIRS));
+    assertTrue(
+        PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS.containsAll(
+            PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS));
   }
 
   @Test

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.packages.manifest.PSComponentPackageManifest;
+import com.percussion.packages.manifest.PSComponentPackageManifestIo;
+import com.percussion.packages.manifest.PSComponentPackageManifestValidator;
+import com.percussion.packages.shim.PSDefinitionSourceKind;
+import com.percussion.packages.shim.PSDefinitionSourceSelection;
+import com.percussion.packages.shim.PSLegacyDefinitionXmlShim;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Dual-ship modern widget authoring tests (issue #2831 batch A / parent #2630).
+ *
+ * <p>Product packages keep install Widget XML under {@code
+ * sys__UserDependency--rxconfig/Widgets} while committing modern {@code widgets/&lt;stem&gt;/}
+ * roots. Selection prefers modern when both exist.
+ */
+class PSWidgetXmlDualShipTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void materializeModern_fromWidgetXml_writesComponentPackageAndTemplate() throws Exception {
+    Path packageDir = tempDir.resolve("demoPkg");
+    Path widgetsXml =
+        packageDir
+            .resolve("sys__UserDependency--rxconfig")
+            .resolve("Widgets");
+    Files.createDirectories(widgetsXml);
+
+    // Minimal valid-shaped simple text fixture if product package unavailable.
+    Path product = locatePackage("perc.baseWidgets");
+    if (product != null) {
+      Path src =
+          product
+              .resolve("sys__UserDependency--rxconfig")
+              .resolve("Widgets")
+              .resolve("percSimpleText.xml");
+      Files.copy(src, widgetsXml.resolve("percSimpleText.xml"), StandardCopyOption.REPLACE_EXISTING);
+      // Copy package props so context version matches product
+      Path props = product.resolve("psx_archiveInfo.xml");
+      if (Files.isRegularFile(props)) {
+        Files.copy(props, packageDir.resolve("psx_archiveInfo.xml"), StandardCopyOption.REPLACE_EXISTING);
+      }
+    } else {
+      Files.writeString(
+          widgetsXml.resolve("percSimpleText.xml"),
+          """
+          <Widget>
+            <Title>Simple Text</Title>
+            <Content type="velocity"><![CDATA[#loadRelatedWidgetContents()]]></Content>
+            <Code type="jexl"><![CDATA[$x = 1;]]></Code>
+            <contenttype_name>percSimpleTextAsset</contenttype_name>
+            <Category>content</Category>
+          </Widget>
+          """,
+          StandardCharsets.UTF_8);
+    }
+
+    int written = PSWidgetXmlDualShip.materializeModernWidgetSources(packageDir);
+    assertEquals(1, written);
+    assertTrue(PSWidgetXmlDualShip.hasModernWidgetSources(packageDir));
+
+    Path modernRoot =
+        packageDir.resolve(PSWidgetXmlDualShip.WIDGETS_DIR_NAME).resolve("percSimpleText");
+    assertTrue(
+        Files.isRegularFile(
+            modernRoot.resolve(PSComponentPackageManifest.DEFAULT_MANIFEST_FILE_NAME)));
+
+    PSWidgetXmlCompileResult loaded = PSWidgetXmlDualShip.loadModernAsCompileResult(modernRoot);
+    PSComponentPackageManifestValidator.validate(loaded.getManifest());
+    assertEquals("percSimpleText", loaded.getManifest().getId());
+    assertFalse(loaded.getTextArtifacts().isEmpty());
+  }
+
+  @Test
+  void productBatchA_modernAuthoringRoots_presentAndParityWithXmlCompile() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping product batch A dual-ship test");
+      return;
+    }
+
+    Set<String> foundStems = new HashSet<>();
+    int packagesWithModern = 0;
+
+    for (String pkgName : PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS) {
+      Path product = packagesRoot.resolve(pkgName);
+      if (!Files.isDirectory(product)) {
+        System.err.println("WARN: missing package " + pkgName + "; soft-skip");
+        continue;
+      }
+
+      assertTrue(
+          PSWidgetXmlDualShip.hasModernWidgetSources(product),
+          pkgName + " must author modern widgets/ sources (#2831 batch A)");
+
+      // Dual-run: install Widget XML remains until native install path (do not mass-delete).
+      Path xmlDir = PSWidgetXmlPackageCompiler.resolveWidgetsDir(product);
+      assertTrue(Files.isDirectory(xmlDir), pkgName + " still dual-ships Widget XML for install");
+
+      List<PSWidgetXmlCompileResult> fromXml = PSWidgetXmlPackageCompiler.compilePackage(product);
+      List<PSWidgetXmlCompileResult> fromModern = PSWidgetXmlDualShip.compileModernWidgets(product);
+      assertEquals(
+          fromXml.size(),
+          fromModern.size(),
+          pkgName + " modern widget count must match Widget XML count");
+
+      Map<String, PSWidgetXmlCompileResult> xmlById =
+          fromXml.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+      Map<String, PSWidgetXmlCompileResult> modernById =
+          fromModern.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+      for (Map.Entry<String, PSWidgetXmlCompileResult> e : xmlById.entrySet()) {
+        String id = e.getKey();
+        assertTrue(modernById.containsKey(id), pkgName + " missing modern widget " + id);
+        PSComponentPackageManifest expected = e.getValue().getManifest();
+        PSComponentPackageManifest actual = modernById.get(id).getManifest();
+        // Reparse both so map/list equality is stable.
+        PSComponentPackageManifest expectedRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(expected));
+        PSComponentPackageManifest actualRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(actual));
+        assertEquals(expectedRound, actualRound, "modern manifest parity for " + id);
+
+        String templateKey =
+            expected.getTemplates().isEmpty()
+                ? null
+                : expected.getTemplates().get(0).getSourceRef();
+        if (templateKey != null) {
+          assertEquals(
+              normalizeNewlines(e.getValue().getTextArtifacts().get(templateKey)),
+              normalizeNewlines(modernById.get(id).getTextArtifacts().get(templateKey)),
+              "template parity for " + id);
+        }
+        foundStems.add(id);
+      }
+
+      // Shim: package root with modern widgets/ prefers modern over legacy XML.
+      PSDefinitionSourceSelection sel = PSLegacyDefinitionXmlShim.selectForPackageRoot(product);
+      assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, sel.getKind(), pkgName);
+      assertFalse(
+          PSLegacyDefinitionXmlShim.wouldUseLegacyShim(product),
+          pkgName + " dual-ship modern roots should win selection");
+
+      packagesWithModern++;
+    }
+
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS.size(),
+        packagesWithModern,
+        "all batch A packages should be present with modern roots");
+    assertEquals(
+        new HashSet<>(PSWidgetXmlDualShip.BATCH_A_WIDGET_STEMS),
+        foundStems,
+        "batch A must cover the 8 named widget stems");
+  }
+
+  @Test
+  void selectDefinition_prefersNestedWidgetsManifest() throws Exception {
+    Path pkg = tempDir.resolve("perc.baseWidgets");
+    Path modern =
+        pkg.resolve("widgets").resolve("percSimpleText");
+    Files.createDirectories(modern);
+    Path manifest = modern.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME);
+    Files.writeString(
+        manifest,
+        "{\"schemaVersion\":\"1.0\",\"id\":\"percSimpleText\",\"name\":\"Simple Text\",\"version\":\"1.0.0\"}",
+        StandardCharsets.UTF_8);
+
+    Path widgetsXml = pkg.resolve("sys__UserDependency--rxconfig").resolve("Widgets");
+    Files.createDirectories(widgetsXml);
+    Files.writeString(widgetsXml.resolve("percSimpleText.xml"), "<Widget/>", StandardCharsets.UTF_8);
+
+    PSDefinitionSourceSelection s =
+        PSLegacyDefinitionXmlShim.selectDefinition(
+            "percSimpleText",
+            List.of(pkg),
+            widgetsXml,
+            null,
+            null);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, s.getKind());
+    assertEquals(manifest, s.getPrimaryPath().orElseThrow());
+  }
+
+  @Test
+  void batchA_packageDirs_disjointFromTestAndSized() {
+    assertFalse(PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS.contains("perc.Test"));
+    assertEquals(5, PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS.size());
+    assertEquals(8, PSWidgetXmlDualShip.BATCH_A_WIDGET_STEMS.size());
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS,
+        PSWidgetXmlPackageCompiler.DUAL_SHIP_BATCH_A_PACKAGE_DIRS);
+  }
+
+  @Test
+  void resolvePackageRelative_rejectsDotDot() {
+    Path root = tempDir.resolve("root");
+    try {
+      PSWidgetXmlDualShip.resolvePackageRelative(root, "../escape");
+      throw new AssertionError("expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains(".."));
+    }
+  }
+
+  private static String normalizeNewlines(String s) {
+    return s == null ? null : s.replace("\r\n", "\n").replace('\r', '\n');
+  }
+
+  private static Path locatePackage(String packageDirName) {
+    Path packages = locatePackagesRoot();
+    if (packages == null) {
+      return null;
+    }
+    Path candidate = packages.resolve(packageDirName);
+    return Files.isDirectory(candidate) ? candidate : null;
+  }
+
+  private static Path locatePackagesRoot() {
+    Path candidate = Path.of("src", "main", "resources", "Packages");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src").resolve("main").resolve("resources").resolve("Packages");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java
@@ -41,7 +41,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Dual-ship modern widget authoring tests (issues #2831 batch A, #2832 batch B / parent #2630).
+ * Dual-ship modern widget authoring tests (issues #2831 batch A, #2832 batch B, #2844 batch C /
+ * parent #2630).
  *
  * <p>Product packages keep install Widget XML under {@code
  * sys__UserDependency--rxconfig/Widgets} while committing modern {@code widgets/&lt;stem&gt;/}
@@ -330,6 +331,111 @@ class PSWidgetXmlDualShipTest {
     assertTrue(
         PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS.containsAll(
             PSWidgetXmlPackageCompiler.RESIDUAL_PRODUCT_PACKAGE_DIRS));
+  }
+
+  @Test
+  void productBatchC_modernAuthoringRoots_presentAndParityWithXmlCompile() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    if (packagesRoot == null) {
+      System.err.println("WARN: Packages root not found; skipping product batch C dual-ship test");
+      return;
+    }
+
+    Set<String> foundStems = new HashSet<>();
+    int packagesWithModern = 0;
+
+    for (String pkgName : PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS) {
+      Path product = packagesRoot.resolve(pkgName);
+      if (!Files.isDirectory(product)) {
+        System.err.println("WARN: missing package " + pkgName + "; soft-skip");
+        continue;
+      }
+
+      assertTrue(
+          PSWidgetXmlDualShip.hasModernWidgetSources(product),
+          pkgName + " must author modern widgets/ sources (#2844 batch C)");
+
+      // Dual-run: install Widget XML remains until native install path (do not mass-delete).
+      Path xmlDir = PSWidgetXmlPackageCompiler.resolveWidgetsDir(product);
+      assertTrue(Files.isDirectory(xmlDir), pkgName + " still dual-ships Widget XML for install");
+
+      List<PSWidgetXmlCompileResult> fromXml = PSWidgetXmlPackageCompiler.compilePackage(product);
+      List<PSWidgetXmlCompileResult> fromModern = PSWidgetXmlDualShip.compileModernWidgets(product);
+      assertEquals(
+          fromXml.size(),
+          fromModern.size(),
+          pkgName + " modern widget count must match Widget XML count");
+
+      Map<String, PSWidgetXmlCompileResult> xmlById =
+          fromXml.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+      Map<String, PSWidgetXmlCompileResult> modernById =
+          fromModern.stream()
+              .collect(Collectors.toMap(r -> r.getManifest().getId(), r -> r, (a, b) -> a));
+
+      for (Map.Entry<String, PSWidgetXmlCompileResult> e : xmlById.entrySet()) {
+        String id = e.getKey();
+        assertTrue(modernById.containsKey(id), pkgName + " missing modern widget " + id);
+        PSComponentPackageManifest expected = e.getValue().getManifest();
+        PSComponentPackageManifest actual = modernById.get(id).getManifest();
+        PSComponentPackageManifest expectedRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(expected));
+        PSComponentPackageManifest actualRound =
+            PSComponentPackageManifestIo.parse(PSComponentPackageManifestIo.toJson(actual));
+        assertEquals(expectedRound, actualRound, "modern manifest parity for " + id);
+
+        String templateKey =
+            expected.getTemplates().isEmpty()
+                ? null
+                : expected.getTemplates().get(0).getSourceRef();
+        if (templateKey != null) {
+          assertEquals(
+              normalizeNewlines(e.getValue().getTextArtifacts().get(templateKey)),
+              normalizeNewlines(modernById.get(id).getTextArtifacts().get(templateKey)),
+              "template parity for " + id);
+        }
+        foundStems.add(id);
+      }
+
+      PSDefinitionSourceSelection sel = PSLegacyDefinitionXmlShim.selectForPackageRoot(product);
+      assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, sel.getKind(), pkgName);
+      assertFalse(
+          PSLegacyDefinitionXmlShim.wouldUseLegacyShim(product),
+          pkgName + " dual-ship modern roots should win selection");
+
+      packagesWithModern++;
+    }
+
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS.size(),
+        packagesWithModern,
+        "all batch C packages should be present with modern roots");
+    assertEquals(
+        new HashSet<>(PSWidgetXmlDualShip.BATCH_C_WIDGET_STEMS),
+        foundStems,
+        "batch C must cover the 19 named widget stems");
+  }
+
+  @Test
+  void batchC_packageDirs_disjointFromBatchABAndTestAndSized() {
+    assertFalse(PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS.contains("perc.Test"));
+    assertEquals(19, PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS.size());
+    assertEquals(19, PSWidgetXmlDualShip.BATCH_C_WIDGET_STEMS.size());
+    assertEquals(
+        PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS,
+        PSWidgetXmlPackageCompiler.DUAL_SHIP_BATCH_C_PACKAGE_DIRS);
+    // Batches must not overlap packages.
+    Set<String> earlier = new HashSet<>(PSWidgetXmlDualShip.BATCH_A_PACKAGE_DIRS);
+    earlier.addAll(PSWidgetXmlDualShip.BATCH_B_PACKAGE_DIRS);
+    for (String pkg : PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS) {
+      assertFalse(earlier.contains(pkg), "batch C must not re-cover batch A/B package " + pkg);
+    }
+    // Batch C is the remaining residual product set after A took openGraph/twitter/event/defaultLang.
+    for (String pkg : PSWidgetXmlDualShip.BATCH_C_PACKAGE_DIRS) {
+      assertTrue(
+          PSWidgetXmlPackageCompiler.REMAINING_PRODUCT_PACKAGE_DIRS.contains(pkg),
+          "batch C package " + pkg + " should be in REMAINING_PRODUCT_PACKAGE_DIRS");
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

**Same-file thrash absorption** for overnight dual-ship Widget XML exit batches A/B/C. Three stacked PRs repeatedly rewrote the same dual-ship registry, inventory docs, and modern `widgets/<stem>/` roots. This cluster merges them oldest-first against `main` so human review/merge is one PR.

### Thrash files (high-signal)

- `modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShip.java`
- `modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetXmlDualShipTest.java`
- `modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetXmlPackageCompiler.java`
- `modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java`
- `docs/ai-generated/tasks/template-assembler-normalization/dual-ship-widget-xml-exit.md`
- `docs/ai-generated/tasks/template-assembler-normalization/widget-xml-inventory.md`
- `docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md`
- Plus cumulative modern widget roots under `modules/perc-packages/src/main/resources/Packages/**/widgets/**`

### Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #2841 | `fix/issue-2831-widget-xml-exit-batch-a` | yes | Batch A modern roots + `PSWidgetXmlDualShip` foundation |
| yes | #2843 | `fix/issue-2832-widget-xml-exit-batch-b` | yes | Batch B stacked on A |
| yes | #2854 | `fix/issue-2844-widget-xml-exit-batch-c` | yes | Batch C stacked on B; shim `WIDGETS_DIR_NAME` follow-up |

Tree content matches tip of #2854 (empty `git diff` vs `origin/fix/issue-2844-widget-xml-exit-batch-c`).

Closes product work for #2831, #2832, #2844 (issues already closed by overnight issue agents).

### Not absorbed (no thrash threshold)

- Explorer pair #2855/#2857 share `ContentExplorerShell.tsx` but only 2 MERGEABLE members (cluster_min_prs=3).
- Docs #2853/#2845 share template-assembler README only (2 members).
- Unrelated #2860 deployer, #2859 system rawtypes, #2838 p-trans disposition.

## Test plan / gates evidence

```bat
cd modules\perc-packages
..\..\mvnw.cmd clean install
```

After each absorb (A, B, C) and final:

- **BUILD SUCCESS**
- Final: **Tests run: 113, Failures: 0, Errors: 0, Skipped: 0**
- Module: `modules/perc-packages` only (docs + perc-packages sources)
- Pre-PR Maven: standalone clean install (not reactor)

### Product documentation

- [x] N/A — engineering dual-ship exit under `docs/ai-generated/`; install XML retained; no operator-facing product-docs change in these batches

### Checklist

- [x] Same-file thrash group ≥3 absorbed
- [x] Union semantics via stacked merge (C ⊇ B ⊇ A)
- [x] Standalone module clean install green
- [ ] Human review (do not merge without review)

**Operator:** Grok: night-issue-prs (model grok-4.5)
