### PR TITLE
feat(auditlog): Webservices/WebDAV/Servlet ErrorCodes + isAuditable (#2865)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -60,6 +60,8 @@ import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 
 // Prefer enum when available:
@@ -68,12 +70,15 @@ audit.log(ContentErrorCodes.CREATE, ctx, AuditOutcome.SUCCESS, "guid", "42", "/S
 audit.log(WorkflowErrorCodes.ACCESS_DENIED, ctx, "5", "jdoe");
 audit.log(PathItemErrorCodes.FOLDER_PERMISSION_DENIED, ctx);
 audit.log(DesignErrorCodes.SRV_ACL_NO_ADMIN, ctx);
+audit.log(WebserviceErrorCodes.NOT_AUTHORIZED, ctx, "jdoe", "save", "denied");
+audit.log(ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE, ctx, "jdoe", "****");
 
 // Central handlers with only a legacy int (e.g. PSException.getErrorCode()):
 LegacyErrorCodeRegistry.logIfAuditable(audit, 9002, ctx, "Directory", "ldap1", "jdoe"); // SEC
 LegacyErrorCodeRegistry.logIfAuditable(audit, 17001, ctx); // CONT conversion — non-auditable skip
 LegacyErrorCodeRegistry.logIfAuditable(audit, 6, ctx, "5", "jdoe"); // WF access denied
-// Provider/config/conversion/path/design noise (isAuditable=false) and unknown ints → no dual-write
+LegacyErrorCodeRegistry.logIfAuditable(audit, 72, ctx, "jdoe", "save", "denied"); // WS not authorized
+// Provider/config/conversion/path/design/WebDAV/servlet noise (isAuditable=false) and unknown ints → no dual-write
 ```
 
 | Catalog | Ranges | Notes |
@@ -83,6 +88,11 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 6, ctx, "5", "jdoe"); // WF access
 | `WorkflowErrorCodes` | 4001 transition; 1–10 service | Aligns Phase 2a transition numbering |
 | `PathItemErrorCodes` | CMS path/item/folder (e.g. 13007) | Folder/path permission bridge |
 | `DesignErrorCodes` | Design lifecycle + objectstore ACL (e.g. 2353) | Design server ACL bridge |
+| `WebserviceErrorCodes` | package-local 1–73 (flat-registers 28–73 only) | ACL/session dual-write; WF/assembly own 1–27 |
+| `ServerWebServicesErrorCodes` | 14001–14026 | Legacy server SOAP; login dual-write |
+| `WebdavErrorCodes` | 70001–70125 | All non-auditable protocol/config |
+| `ServletErrorCodes` | 10151–10158 | All non-auditable connection/request |
+| `TransformationErrorCodes` | package-local 1 (no flat register) | Prefer enum; WF owns bare int 1 |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -20,6 +20,11 @@ import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import java.util.Map;
 import java.util.Objects;
@@ -33,9 +38,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Phase 2b registers {@link SecurityErrorCodes} (full SEC range), {@link ContentErrorCodes}
  * (content lifecycle + conversion), {@link WorkflowErrorCodes} (workflow transition + service),
- * {@link PathItemErrorCodes} (CMS path/item/folder), and {@link DesignErrorCodes} (design lifecycle
- * + objectstore ACL). Residual slices may register additional catalogs via {@link #register(int,
- * SystemErrorCode)}.
+ * {@link PathItemErrorCodes} (CMS path/item/folder), {@link DesignErrorCodes} (design lifecycle +
+ * objectstore ACL), non-colliding {@link WebserviceErrorCodes} package-local ints (28–73), fully
+ * unique {@link ServerWebServicesErrorCodes} / {@link WebdavErrorCodes} / {@link ServletErrorCodes},
+ * and bootstrap-only {@link TransformationErrorCodes} (no flat register). Residual slices may
+ * register additional catalogs via {@link #register(int, SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -48,8 +55,10 @@ public final class LegacyErrorCodeRegistry {
   private LegacyErrorCodeRegistry() {}
 
   /**
-   * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design). Safe
-   * to call repeatedly; catalogs register themselves in their own static initializers.
+   * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design,
+   * webservices, WebDAV, servlet, transformation). Safe to call repeatedly; catalogs register
+   * themselves in their own static initializers. {@link WebserviceErrorCodes} skips package-local
+   * ints {@code 1–27}; {@link TransformationErrorCodes} does not flat-register.
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
@@ -58,6 +67,13 @@ public final class LegacyErrorCodeRegistry {
       WorkflowErrorCodes.ensureRegistered();
       PathItemErrorCodes.ensureRegistered();
       DesignErrorCodes.ensureRegistered();
+      // Wire-facing residual (#2865): non-colliding webservice ints after WF ownership of 1–10.
+      WebserviceErrorCodes.ensureRegistered();
+      ServerWebServicesErrorCodes.ensureRegistered();
+      WebdavErrorCodes.ensureRegistered();
+      ServletErrorCodes.ensureRegistered();
+      // Transformation: no-op flat register (WF collision on bare int 1).
+      TransformationErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodes.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Legacy server webservices error catalog bridging {@code
+ * com.percussion.server.webservices.IPSWebServicesErrors} ints (14001–14026).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: login failure and unauthorized client /
+ * checkout-user denials dual-write; content/search operational noise does not.
+ *
+ * <p>All ints are globally unique in the historical error map and are fully flat-registered in
+ * {@link LegacyErrorCodeRegistry}. Module code is {@link AuditModule#SYS}.
+ */
+public enum ServerWebServicesErrorCodes implements SystemErrorCode {
+
+  WEB_SERVICE_CONTENT_ITEM_NOT_FOUND(
+      14001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service content item not found",
+      "Web service content item not found detail={}"),
+
+  WEB_SERVICE_CHECKOUT_FAILURE(
+      14002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service checkout failure",
+      "Web service checkout failure detail={}"),
+
+  WEB_SERVICE_CONTENT_TYPE_NOT_FOUND(
+      14003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service content type not found",
+      "Web service content type not found detail={}"),
+
+  WEB_SERVICE_INSERT_FAILURE(
+      14004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service insert failure",
+      "Web service insert failure detail={}"),
+
+  WEB_SERVICE_CHECKOUT_USER_FAILURE(
+      14005,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Web service checkout user failure",
+      "Web service checkout user failure detail={}"),
+
+  WEB_SERVICE_TRANSITION_NOT_FOUND(
+      14006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service transition not found",
+      "Web service transition not found detail={}"),
+
+  WEB_SERVICE_TRANSITION_COMMENT_REQUIRED(
+      14007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service transition comment required",
+      "Web service transition comment required detail={}"),
+
+  WEB_SERVICE_VALIDATION_FAILURE(
+      14008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service validation failure",
+      "Web service validation failure detail={}"),
+
+  WEB_SERVICE_INTERNAL_SEARCH_NOT_FOUND(
+      14009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service internal search not found",
+      "Web service internal search not found detail={}"),
+
+  WEB_SERVICE_LOGIN_FAILURE(
+      14010,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Web service login failure",
+      "Web service login failure detail={}"),
+
+  WEB_SERVICE_INVALID_CLIENT_ACESS(
+      14011,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Web service invalid client acess",
+      "Web service invalid client acess detail={}"),
+
+  WEB_SERVICE_INVALID_SEARCH_PARAMS(
+      14012,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service invalid search params",
+      "Web service invalid search params detail={}"),
+
+  WEB_SERVICE_INVALID_SEARCH_CONTENTTYPE(
+      14013,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service invalid search contenttype",
+      "Web service invalid search contenttype detail={}"),
+
+  WEB_SERVICE_INTERNAL_REQUEST_FAILED(
+      14014,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service internal request failed",
+      "Web service internal request failed detail={}"),
+
+  WEB_SERVICE_ACTION_NOT_FOUND(
+      14015,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service action not found",
+      "Web service action not found detail={}"),
+
+  WEB_SERVICE_ITEM_CHILD_NOT_FOUND(
+      14016,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service item child not found",
+      "Web service item child not found detail={}"),
+
+  WEB_SERVICE_MISSING_ELEMENT(
+      14017,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service missing element",
+      "Web service missing element detail={}"),
+
+  WEB_SERVICE_MISSING_PARAMETER(
+      14018,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service missing parameter",
+      "Web service missing parameter detail={}"),
+
+  WEB_SERVICE_DISPATCH_ERROR(
+      14019,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service dispatch error",
+      "Web service dispatch error detail={}"),
+
+  WEB_SERVICE_MISSING_ID(
+      14020,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service missing id",
+      "Web service missing id detail={}"),
+
+  INVALID_MIXED_CHILD_IDS(
+      14021,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid mixed child ids",
+      "Invalid mixed child ids detail={}"),
+
+  WEB_SERVICE_INVALID_FOLDER(
+      14022,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service invalid folder",
+      "Web service invalid folder detail={}"),
+
+  WEB_SERVICE_PROMOTE_FAILED_CHECKOUT(
+      14023,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service promote failed checkout",
+      "Web service promote failed checkout detail={}"),
+
+  WEB_SERVICE_PROMOTE_FAILED_CHECKIN(
+      14024,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service promote failed checkin",
+      "Web service promote failed checkin detail={}"),
+
+  WEB_SERVICE_INTERNAL_REQUEST_NOT_FOUND(
+      14025,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service internal request not found",
+      "Web service internal request not found detail={}"),
+
+  WEB_SERVICE_SEARCH_RESOURCE_NOT_FOUND(
+      14026,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service search resource not found",
+      "Web service search resource not found detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  ServerWebServicesErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ServerWebServicesErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodes.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Servlet hook error catalog bridging legacy {@code com.percussion.hooks.IPSServletErrors} ints
+ * (10151–10158: connection, port, request parameters, status).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: servlet connection / request
+ * failures are operational noise, not security dual-write events.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum ServletErrorCodes implements SystemErrorCode {
+
+  CONNECTION_ERROR(
+      10151,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Connection error",
+      "Connection error detail={}"),
+
+  INVALID_PORT_NUMBER(
+      10152,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid port number",
+      "Invalid port number detail={}"),
+
+  INVALID_REQUEST_PARAMETERS(
+      10153,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid request parameters",
+      "Invalid request parameters detail={}"),
+
+  SERVLET_DESTROYED(
+      10154,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Servlet destroyed",
+      "Servlet destroyed detail={}"),
+
+  CONNECTION_FAILURE(
+      10155,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Connection failure",
+      "Connection failure detail={}"),
+
+  INVALID_STATUS_CODE(
+      10156,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid status code",
+      "Invalid status code detail={}"),
+
+  SERVLET_INFORMATION(
+      10157,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Servlet information",
+      "Servlet information detail={}"),
+
+  VERSION_STRING(
+      10158,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Version string",
+      "Version string detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  ServletErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ServletErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodes.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Webservices transformation error catalog bridging legacy {@code
+ * com.percussion.webservices.transformation.IPSTransformationErrors} package-local ints (only
+ * {@code NO_CONVERTER_FOUND = 1}).
+ *
+ * <p>All constants set {@link #isAuditable()} to {@code false}: converter lookup failures are
+ * operational noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local int {@code 1} already belongs to
+ * {@link WorkflowErrorCodes}. This catalog therefore does <strong>not</strong> flat-register any
+ * ints. Prefer this enum directly until a composite-key registry exists. Module code is {@link
+ * AuditModule#SYS}.
+ */
+public enum TransformationErrorCodes implements SystemErrorCode {
+
+  NO_CONVERTER_FOUND(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No converter found",
+      "No converter found detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  TransformationErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat {@link com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry}: package-local
+   * int {@code 1} collides with {@link WorkflowErrorCodes}. Prefer this enum directly. Safe to call
+   * repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodes.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * WebDAV error catalog bridging legacy {@code com.percussion.webdav.error.IPSWebdavErrors} ints
+ * (70001–70125: XML config, protocol methods, locks, content-type mapping).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: WebDAV protocol / config failures
+ * are operational noise. Authentication dual-write remains on {@link SecurityErrorCodes}.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry} so
+ * bare legacy ints resolve as non-auditable (safe skip). Module code is {@link AuditModule#SYS}.
+ */
+public enum WebdavErrorCodes implements SystemErrorCode {
+
+  XML_ATTRIBUTE_MUST_BE_SPECIFIED(
+      70001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml attribute must be specified",
+      "Xml attribute must be specified detail={}"),
+
+  XML_INVALID_FORMAT(
+      70002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml invalid format",
+      "Xml invalid format detail={}"),
+
+  XML_ELEMENT_CANNOT_BE_EMPTY(
+      70003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml element cannot be empty",
+      "Xml element cannot be empty detail={}"),
+
+  XML_FAILED_CREATE_DOC_FROM_CONTENT(
+      70004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml failed create doc from content",
+      "Xml failed create doc from content detail={}"),
+
+  UNSUPPORTED_METHOD(
+      70101,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported method",
+      "Unsupported method detail={}"),
+
+  MIMETYPES_REQUIRED(
+      70102,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mimetypes required",
+      "Mimetypes required detail={}"),
+
+  CANNOT_HAVE_DUPLICATE_PROPERTIES(
+      70103,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot have duplicate properties",
+      "Cannot have duplicate properties detail={}"),
+
+  MISSING_REQUIRED_PROPERTY(
+      70104,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing required property",
+      "Missing required property detail={}"),
+
+  CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE(
+      70105,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Can only have one default contenttype",
+      "Can only have one default contenttype detail={}"),
+
+  IO_EXCEPTION_OCCURED(
+      70106,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Io exception occured",
+      "Io exception occured detail={}"),
+
+  SAX_EXCEPTION_OCCURED(
+      70107,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sax exception occured",
+      "Sax exception occured detail={}"),
+
+  FILE_DOES_NOT_EXIST(
+      70108,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "File does not exist",
+      "File does not exist detail={}"),
+
+  PARSER_CONFIG_ERROR(
+      70109,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Parser config error",
+      "Parser config error detail={}"),
+
+  DUPLICATE_CONTENTTYPE_NAMES(
+      70110,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate contenttype names",
+      "Duplicate contenttype names detail={}"),
+
+  RESOURCE_NOT_FIND(
+      70111,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Resource not find",
+      "Resource not find detail={}"),
+
+  FORBIDDEN_GET_FOLDER(
+      70112,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Forbidden get folder",
+      "Forbidden get folder detail={}"),
+
+  HEADER_MISSING(
+      70113,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Header missing",
+      "Header missing detail={}"),
+
+  FORBIDDEN_SRC_TARGET_SAME(
+      70114,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Forbidden src target same",
+      "Forbidden src target same detail={}"),
+
+  METHOD_FAIL_CANNOT_OVERWRITE(
+      70115,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Method fail cannot overwrite",
+      "Method fail cannot overwrite detail={}"),
+
+  ITEMFIELD_NOT_EXIST(
+      70116,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Itemfield not exist",
+      "Itemfield not exist detail={}"),
+
+  LOCKSCOPE_NOT_ALLOWED(
+      70117,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Lockscope not allowed",
+      "Lockscope not allowed detail={}"),
+
+  LOCKTYPE_NOT_ALLOWED(
+      70118,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Locktype not allowed",
+      "Locktype not allowed detail={}"),
+
+  FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING(
+      70119,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Fieldname cannot be empty or missing",
+      "Fieldname cannot be empty or missing detail={}"),
+
+  CONTENTTYPE_NOT_CONFIGURED(
+      70120,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Contenttype not configured",
+      "Contenttype not configured detail={}"),
+
+  UNKNOWN_BODY_IN_MKCOL_REQ(
+      70121,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown body in mkcol req",
+      "Unknown body in mkcol req detail={}"),
+
+  UNKNOWN_URL_FROM_HEADER(
+      70122,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown url from header",
+      "Unknown url from header detail={}"),
+
+  MALFORMED_URL_FROM_HEADER(
+      70123,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Malformed url from header",
+      "Malformed url from header detail={}"),
+
+  NO_PUBLIC_AUTO_TRANSITION(
+      70124,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No public auto transition",
+      "No public auto transition detail={}"),
+
+  NO_QE_AUTO_TRANSITION(
+      70125,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No qe auto transition",
+      "No qe auto transition detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  WebdavErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (WebdavErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodes.java
@@ -1,0 +1,700 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Modern SOAP / design webservices error catalog bridging legacy {@code
+ * com.percussion.webservices.IPSWebserviceErrors} package-local ints (1–73).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: session and ACL / authorization
+ * failures dual-write; design CRUD and lookup operational noise does not.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–10} already belong to
+ * {@link WorkflowErrorCodes}; ints {@code 11–27} are claimed by residual assembly / job catalogs
+ * (PR #2867 / #2866). This catalog therefore flat-registers only non-colliding ints ({@code
+ * 28–73}), which includes the security-relevant {@code ACCESS_CONTROL_ERROR} and {@code
+ * NOT_AUTHORIZED} codes. Prefer this enum directly for ints {@code 1–27} until a composite-key
+ * registry exists. Module code is {@link AuditModule#SYS}.
+ */
+public enum WebserviceErrorCodes implements SystemErrorCode {
+
+  INVALID_CONTRACT(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid contract",
+      "Invalid contract detail={}"),
+
+  OBJECT_NOT_FOUND(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not found",
+      "Object not found detail={}"),
+
+  INVALID_SESSION(
+      3,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Invalid session",
+      "Invalid session detail={}"),
+
+  MISSING_SESSION(
+      4,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Missing session",
+      "Missing session detail={}"),
+
+  CREATE_LOCK_FAILED(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Create lock failed",
+      "Create lock failed detail={}"),
+
+  SAVE_FAILED(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Save failed",
+      "Save failed detail={}"),
+
+  DELETE_FAILED(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Delete failed",
+      "Delete failed detail={}"),
+
+  OBJECT_NOT_LOCKED(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not locked",
+      "Object not locked detail={}"),
+
+  OBJECT_NOT_LOCKED_FOR_REQUESTOR(
+      9,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not locked for requestor",
+      "Object not locked for requestor detail={}"),
+
+  CREATE_EXTEND_LOCK_FAILED(
+      10,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Create extend lock failed",
+      "Create extend lock failed detail={}"),
+
+  OBJECT_ALREADY_EXISTS(
+      11,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object already exists",
+      "Object already exists detail={}"),
+
+  MISSING_HIERARCHY_NODE_FOR_PARENT(
+      12,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing hierarchy node for parent",
+      "Missing hierarchy node for parent detail={}"),
+
+  DUPLICATE_HIERARCHY_NODE_FOR_PARENT(
+      13,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate hierarchy node for parent",
+      "Duplicate hierarchy node for parent detail={}"),
+
+  DELETE_FAILED_DEPENDENTS(
+      14,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Delete failed dependents",
+      "Delete failed dependents detail={}"),
+
+  LOAD_FAILED(
+      15,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Load failed",
+      "Load failed detail={}"),
+
+  FIND_FAILED(
+      16,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Find failed",
+      "Find failed detail={}"),
+
+  FAILED_LOAD_REL_CONFIGS(
+      17,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load rel configs",
+      "Failed load rel configs detail={}"),
+
+  FAILED_COMMUNITY_VISIBILITY_LOOKUP(
+      18,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed community visibility lookup",
+      "Failed community visibility lookup detail={}"),
+
+  UNSUPPORTD_COMMUNITY_VISIBILITY_LOOKUP_TYPE(
+      19,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupportd community visibility lookup type",
+      "Unsupportd community visibility lookup type detail={}"),
+
+  FAILED_LOAD_WORKFLOW(
+      20,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load workflow",
+      "Failed load workflow detail={}"),
+
+  CANNOT_FIND_WORKFLOW_STATE_ID(
+      21,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find workflow state id",
+      "Cannot find workflow state id detail={}"),
+
+  CURR_STATE_NOT_MATCH(
+      22,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Curr state not match",
+      "Curr state not match detail={}"),
+
+  CANNOT_FIND_TRANS_TO_QE_STATE(
+      23,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find trans to qe state",
+      "Cannot find trans to qe state detail={}"),
+
+  CANNOT_FIND_TRANS_4_STATE_2_STATE(
+      24,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find trans 4 state 2 state",
+      "Cannot find trans 4 state 2 state detail={}"),
+
+  FAILED_TRANSITION_ITEM(
+      25,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed transition item",
+      "Failed transition item detail={}"),
+
+  FAILED_CHECK_OUT_ITEM(
+      26,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed check out item",
+      "Failed check out item detail={}"),
+
+  FAILED_CHECK_IN_ITEM(
+      27,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed check in item",
+      "Failed check in item detail={}"),
+
+  FAILED_SAVE_RELATIONSHIPS(
+      28,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed save relationships",
+      "Failed save relationships detail={}"),
+
+  FAILED_LOAD_RELATIONSHIP(
+      29,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load relationship",
+      "Failed load relationship detail={}"),
+
+  CANNOT_FIND_RELATIONSHIP(
+      30,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find relationship",
+      "Cannot find relationship detail={}"),
+
+  FAILED_DELETE_RELATIONSHIPS(
+      31,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed delete relationships",
+      "Failed delete relationships detail={}"),
+
+  ACCESS_CONTROL_ERROR(
+      32,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Access control error",
+      "Access control error detail={}"),
+
+  LOAD_OBJECTS_ERROR(
+      33,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Load objects error",
+      "Load objects error detail={}"),
+
+  OBJECT_NOT_FOUND_BY_NAME(
+      34,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not found by name",
+      "Object not found by name detail={}"),
+
+  NO_FOLDER_PATH_FOR_FOLDERID(
+      35,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No folder path for folderid",
+      "No folder path for folderid detail={}"),
+
+  FAILED_LOAD_FOLDER_PATH(
+      36,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load folder path",
+      "Failed load folder path detail={}"),
+
+  ITEM_NOT_CHECKED_OUT(
+      37,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Item not checked out",
+      "Item not checked out detail={}"),
+
+  INVALID_CHILD_ID(
+      38,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid child id",
+      "Invalid child id detail={}"),
+
+  CHILD_ENTRY_NOT_FOUND(
+      39,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Child entry not found",
+      "Child entry not found detail={}"),
+
+  CHILD_ENTRY_ALREADY_EXISTS(
+      40,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Child entry already exists",
+      "Child entry already exists detail={}"),
+
+  UNKNOWN_CONTENT_TYPE(
+      41,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown content type",
+      "Unknown content type detail={}"),
+
+  FAILED_FIND_ID_FROM_PATH(
+      42,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find id from path",
+      "Failed find id from path detail={}"),
+
+  PATH_NOT_EXIST(
+      43,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Path not exist",
+      "Path not exist detail={}"),
+
+  UNKNOWN_COMMUNITY_ID(
+      44,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown community id",
+      "Unknown community id detail={}"),
+
+  FAILED_ADD_FOLDER_CHILDREN(
+      45,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed add folder children",
+      "Failed add folder children detail={}"),
+
+  FAILED_FIND_FOLDER_CHILDREN(
+      46,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find folder children",
+      "Failed find folder children detail={}"),
+
+  FAILED_FIND_CHILD_ITEMS(
+      47,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find child items",
+      "Failed find child items detail={}"),
+
+  FAILED_FIND_PARENT_ITEMS(
+      48,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find parent items",
+      "Failed find parent items detail={}"),
+
+  ITEM_NOT_CHECKOUT_BY_USER(
+      49,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Item not checkout by user",
+      "Item not checkout by user detail={}"),
+
+  INVALID_EDIT_REVISION(
+      50,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid edit revision",
+      "Invalid edit revision detail={}"),
+
+  INVALID_CURRENT_REVISION(
+      51,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid current revision",
+      "Invalid current revision detail={}"),
+
+  USER_NOT_MEMBER_COMMUNITY(
+      52,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "User not member community",
+      "User not member community detail={}"),
+
+  INVALID_LOCALE(
+      53,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid locale",
+      "Invalid locale detail={}"),
+
+  INVALID_FOLDER_CHILD(
+      54,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid folder child",
+      "Invalid folder child detail={}"),
+
+  FAILED_FIND_PATH_FROM_ID(
+      55,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find path from id",
+      "Failed find path from id detail={}"),
+
+  FAILED_SAVE_ITEM(
+      56,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed save item",
+      "Failed save item detail={}"),
+
+  FAILED_LOAD_ITEM(
+      57,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load item",
+      "Failed load item detail={}"),
+
+  ITEM_NOT_CHECKED_IN(
+      58,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Item not checked in",
+      "Item not checked in detail={}"),
+
+  INAVLID_ACTION_FOR_STATE(
+      59,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Inavlid action for state",
+      "Inavlid action for state detail={}"),
+
+  NEWCOPY_FAILED(
+      60,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Newcopy failed",
+      "Newcopy failed detail={}"),
+
+  NEWPROMOTABLEVERSION_FAILED(
+      61,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Newpromotableversion failed",
+      "Newpromotableversion failed detail={}"),
+
+  NEWTRANSLATION_FAILED(
+      62,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Newtranslation failed",
+      "Newtranslation failed detail={}"),
+
+  FAILED_VIEW_ITEM(
+      63,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed view item",
+      "Failed view item detail={}"),
+
+  UNKNOWN_FIELD_NAME(
+      64,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown field name",
+      "Unknown field name detail={}"),
+
+  FAILED_SYS_SHARED_DEF_VALIDATION(
+      65,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed sys shared def validation",
+      "Failed sys shared def validation detail={}"),
+
+  DELETE_ASSOCIATION_FAILED_DEPENDENTS(
+      66,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Delete association failed dependents",
+      "Delete association failed dependents detail={}"),
+
+  FAILED_LOAD_FOLDER(
+      67,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load folder",
+      "Failed load folder detail={}"),
+
+  OPERATION_FAILED_ERROR(
+      68,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Operation failed error",
+      "Operation failed error detail={}"),
+
+  UNEXPECTED_ERROR(
+      69,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected error",
+      "Unexpected error detail={}"),
+
+  UNABLE_SAVE_SHARED_DEF_VALIDATION(
+      70,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unable save shared def validation",
+      "Unable save shared def validation detail={}"),
+
+  FAILED_RENAMING_ACLS(
+      71,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed renaming acls",
+      "Failed renaming acls detail={}"),
+
+  NOT_AUTHORIZED(
+      72,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Not authorized",
+      "Not authorized detail={}"),
+
+  FAILED_TO_OBTAIN_PATH_FROM_OBJECT_ID(
+      73,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to obtain path from object id",
+      "Failed to obtain path from object id detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  WebserviceErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register non-colliding webservice ints in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly. Skips package-local ints {@code 1–27} that collide with workflow / assembly / job
+   * catalogs in the flat map.
+   */
+  public static void ensureRegistered() {
+    for (WebserviceErrorCodes code : values()) {
+      if (code.numericCode <= 27) {
+        // Preserve WorkflowErrorCodes (1–10) and residual assembly/job ownership of 11–27.
+        continue;
+      }
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -25,6 +25,11 @@ import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,8 +62,9 @@ class LegacyErrorCodeRegistryTest {
 
   @Test
   void unregisteredLegacyCodeIsNotAuditable() {
-    assertFalse(LegacyErrorCodeRegistry.isAuditable(42));
-    assertTrue(LegacyErrorCodeRegistry.find(42).isEmpty());
+    // 99999 is outside every cataloged IPS*Errors range (WS 1–73 / 14001–14026, WebDAV 70001+, …)
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(99999));
+    assertTrue(LegacyErrorCodeRegistry.find(99999).isEmpty());
   }
 
   @Test
@@ -313,5 +319,158 @@ class LegacyErrorCodeRegistryTest {
     assertTrue(LegacyErrorCodeRegistry.find(2353).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(2001).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(6).isPresent());
+  }
+
+  @Test
+  void webserviceAccessControlIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(32));
+    assertSame(
+        WebserviceErrorCodes.ACCESS_CONTROL_ERROR,
+        LegacyErrorCodeRegistry.find(32).orElseThrow());
+    assertTrue(WebserviceErrorCodes.ACCESS_CONTROL_ERROR.isAuditable());
+  }
+
+  @Test
+  void webserviceNotAuthorizedDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WebserviceErrorCodes.NOT_AUTHORIZED.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "jdoe",
+            "save",
+            "denied");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(WebserviceErrorCodes.NOT_AUTHORIZED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-72]-"));
+  }
+
+  @Test
+  void webserviceSaveFailedIsNotAuditableButRegistered() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(28));
+    assertSame(
+        WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS,
+        LegacyErrorCodeRegistry.find(28).orElseThrow());
+    assertFalse(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS.isAuditable());
+  }
+
+  @Test
+  void webserviceSaveFailedNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "detail");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void webservicePackageLocalOneRemainsWorkflowInFlatRegistry() {
+    // Bare int 1 is WorkflowErrorCodes.WORKFLOW_NOT_FOUND, not Webservice INVALID_CONTRACT
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertEquals(1, WebserviceErrorCodes.INVALID_CONTRACT.numericCode());
+    assertTrue(WebserviceErrorCodes.INVALID_SESSION.isAuditable());
+    assertEquals(3, WebserviceErrorCodes.INVALID_SESSION.numericCode());
+  }
+
+  @Test
+  void serverWebServicesLoginFailureIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(14010));
+    assertSame(
+        ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE,
+        LegacyErrorCodeRegistry.find(14010).orElseThrow());
+  }
+
+  @Test
+  void serverWebServicesLoginFailureDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "jdoe",
+            "****");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(
+        ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-14010]-"));
+  }
+
+  @Test
+  void serverWebServicesContentNotFoundSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ServerWebServicesErrorCodes.WEB_SERVICE_CONTENT_ITEM_NOT_FOUND.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "42",
+            "1");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void webdavUnsupportedMethodIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(70101));
+    assertSame(WebdavErrorCodes.UNSUPPORTED_METHOD, LegacyErrorCodeRegistry.find(70101).orElseThrow());
+    assertFalse(WebdavErrorCodes.UNSUPPORTED_METHOD.isAuditable());
+  }
+
+  @Test
+  void webdavNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WebdavErrorCodes.UNSUPPORTED_METHOD.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "PROPFIND");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void servletConnectionErrorIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(10151));
+    assertSame(ServletErrorCodes.CONNECTION_ERROR, LegacyErrorCodeRegistry.find(10151).orElseThrow());
+  }
+
+  @Test
+  void transformationNotFlatRegisteredButEnumIsNonAuditable() {
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertFalse(TransformationErrorCodes.NO_CONVERTER_FOUND.isAuditable());
+    assertEquals(1, TransformationErrorCodes.NO_CONVERTER_FOUND.numericCode());
+  }
+
+  @Test
+  void registryCoversWebservicesWebdavAndServlet() {
+    assertTrue(LegacyErrorCodeRegistry.size() >= 150);
+    assertTrue(LegacyErrorCodeRegistry.find(32).isPresent()); // webservice ACCESS_CONTROL
+    assertTrue(LegacyErrorCodeRegistry.find(72).isPresent()); // webservice NOT_AUTHORIZED
+    assertTrue(LegacyErrorCodeRegistry.find(14010).isPresent()); // server WS login
+    assertTrue(LegacyErrorCodeRegistry.find(70101).isPresent()); // webdav
+    assertTrue(LegacyErrorCodeRegistry.find(10151).isPresent()); // servlet
   }
 }

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ServerWebServicesErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ServerWebServicesErrorCodes code : ServerWebServicesErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 14001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(26, ServerWebServicesErrorCodes.values().length);
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (ServerWebServicesErrorCodes code : ServerWebServicesErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void loginAndAccessFailuresAreAuditable() {
+    assertTrue(ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.isAuditable());
+    assertEquals(
+        AuditEventType.AUTH_FAILURE,
+        ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.eventType());
+    assertTrue(ServerWebServicesErrorCodes.WEB_SERVICE_CHECKOUT_USER_FAILURE.isAuditable());
+    assertTrue(ServerWebServicesErrorCodes.WEB_SERVICE_INVALID_CLIENT_ACESS.isAuditable());
+  }
+
+  @Test
+  void operationalContentSearchIsNotAuditable() {
+    assertFalse(ServerWebServicesErrorCodes.WEB_SERVICE_CONTENT_ITEM_NOT_FOUND.isAuditable());
+    assertFalse(ServerWebServicesErrorCodes.WEB_SERVICE_INSERT_FAILURE.isAuditable());
+    assertFalse(ServerWebServicesErrorCodes.WEB_SERVICE_INTERNAL_SEARCH_NOT_FOUND.isAuditable());
+  }
+
+  @Test
+  void preservesLegacyIpsWebServicesErrorsNumericValues() {
+    assertEquals(14001, ServerWebServicesErrorCodes.WEB_SERVICE_CONTENT_ITEM_NOT_FOUND.numericCode());
+    assertEquals(14010, ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.numericCode());
+    assertEquals(14026, ServerWebServicesErrorCodes.WEB_SERVICE_SEARCH_RESOURCE_NOT_FOUND.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ServletErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ServletErrorCodes code : ServletErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 10151, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(8, ServletErrorCodes.values().length);
+  }
+
+  @Test
+  void allServletCodesAreNonAuditable() {
+    for (ServletErrorCodes code : ServletErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsServletErrorsNumericValues() {
+    assertEquals(10151, ServletErrorCodes.CONNECTION_ERROR.numericCode());
+    assertEquals(10155, ServletErrorCodes.CONNECTION_FAILURE.numericCode());
+    assertEquals(10158, ServletErrorCodes.VERSION_STRING.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import org.junit.jupiter.api.Test;
+
+class TransformationErrorCodesTest {
+
+  @Test
+  void singleConverterMissingConstantIsNonAuditableSys() {
+    assertEquals(1, TransformationErrorCodes.values().length);
+    TransformationErrorCodes code = TransformationErrorCodes.NO_CONVERTER_FOUND;
+    assertEquals(AuditModule.SYS, code.module());
+    assertEquals(1, code.numericCode());
+    assertFalse(code.isAuditable());
+    assertNull(code.eventType());
+    assertNotNull(code.userMessageTemplate());
+    assertNotNull(code.logMessageTemplate());
+    assertTrue(code.qualifiedCode().startsWith("SYS-"));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class WebdavErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (WebdavErrorCodes code : WebdavErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 70001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(29, WebdavErrorCodes.values().length);
+  }
+
+  @Test
+  void allWebdavCodesAreNonAuditable() {
+    for (WebdavErrorCodes code : WebdavErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsWebdavErrorsNumericValues() {
+    assertEquals(70001, WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED.numericCode());
+    assertEquals(70101, WebdavErrorCodes.UNSUPPORTED_METHOD.numericCode());
+    assertEquals(70125, WebdavErrorCodes.NO_QE_AUTO_TRANSITION.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class WebserviceErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (WebserviceErrorCodes code : WebserviceErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(73, WebserviceErrorCodes.values().length);
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (WebserviceErrorCodes code : WebserviceErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void sessionAndAccessFailuresAreAuditable() {
+    assertTrue(WebserviceErrorCodes.INVALID_SESSION.isAuditable());
+    assertEquals(AuditEventType.AUTH_FAILURE, WebserviceErrorCodes.INVALID_SESSION.eventType());
+    assertTrue(WebserviceErrorCodes.MISSING_SESSION.isAuditable());
+    assertTrue(WebserviceErrorCodes.ACCESS_CONTROL_ERROR.isAuditable());
+    assertEquals(
+        AuditEventType.ACCESS_DENIED, WebserviceErrorCodes.ACCESS_CONTROL_ERROR.eventType());
+    assertTrue(WebserviceErrorCodes.NOT_AUTHORIZED.isAuditable());
+    assertTrue(WebserviceErrorCodes.ITEM_NOT_CHECKED_OUT.isAuditable());
+    assertTrue(WebserviceErrorCodes.USER_NOT_MEMBER_COMMUNITY.isAuditable());
+  }
+
+  @Test
+  void operationalDesignCrudIsNotAuditable() {
+    assertFalse(WebserviceErrorCodes.INVALID_CONTRACT.isAuditable());
+    assertFalse(WebserviceErrorCodes.OBJECT_NOT_FOUND.isAuditable());
+    assertFalse(WebserviceErrorCodes.SAVE_FAILED.isAuditable());
+    assertFalse(WebserviceErrorCodes.DELETE_FAILED.isAuditable());
+    assertFalse(WebserviceErrorCodes.UNEXPECTED_ERROR.isAuditable());
+  }
+
+  @Test
+  void preservesLegacyIpsWebserviceErrorsNumericValues() {
+    assertEquals(1, WebserviceErrorCodes.INVALID_CONTRACT.numericCode());
+    assertEquals(3, WebserviceErrorCodes.INVALID_SESSION.numericCode());
+    assertEquals(32, WebserviceErrorCodes.ACCESS_CONTROL_ERROR.numericCode());
+    assertEquals(72, WebserviceErrorCodes.NOT_AUTHORIZED.numericCode());
+    assertEquals(73, WebserviceErrorCodes.FAILED_TO_OBTAIN_PATH_FROM_OBJECT_ID.numericCode());
+  }
+}


### PR DESCRIPTION
## Summary
Parent **#2616** residual slice **#2865**: migrate webservices / WebDAV / servlet legacy `IPS*Errors` catalogs into package `*ErrorCodes` with explicit `isAuditable` and `LegacyErrorCodeRegistry` registration.

### Changes
- **`WebserviceErrorCodes`** — full `IPSWebserviceErrors` (1–73); session/ACL dual-write; flat-registers only **28–73** (WF owns 1–10; residual assembly/job own 11–27)
- **`ServerWebServicesErrorCodes`** — full `IPSWebServicesErrors` (14001–14026); login / checkout-user / invalid-client dual-write
- **`TransformationErrorCodes`** — `IPSTransformationErrors` (package-local 1); all non-auditable; **no flat register** (WF collision)
- **`WebdavErrorCodes`** — full `IPSWebdavErrors` (70001–70125); all non-auditable; full flat register
- **`ServletErrorCodes`** — full `IPSServletErrors` (10151–10158); all non-auditable; full flat register
- Bootstrap wired in `LegacyErrorCodeRegistry`
- Unit tests: dual-write skip + auditable dual-write; package-local collision ownership
- README catalog table updated

No mass call-site rewrite (out of scope).

### Out of scope / leftovers (parent #2616)
- Server/HTTP/Job (#2863 / PR #2866)
- Assembly/Extension/Delivery (#2864 / PR #2867)
- Remaining unmigrated catalogs: locale, mail, clone, deployment, UI, navigation, backend/data, connection, search/lucene, publisher, site manager, filter, lock, catalog, table factory, utils/xml, site manage, content explorer, remote, beans, jboss, etc.

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw.cmd clean install`
- [x] Tests run: **107**, Failures: 0
- [x] BUILD SUCCESS
- [x] No new compiler/surefire failures attributable to this change

## Product documentation
- [x] N/A — internal audit error catalog / dual-write bridge only; no operator-, admin-, integrator-, or end-user-facing surface change

## C3 build evidence
- **modules_built:** `modules/perc-auditlog`
- **build_evidence:** `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 107, Failures: 0
- **downstream_checked:** none (C2 N/A — additive enums + registry bootstrap only; no `final`/`sealed` or public signature breakage)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2616
Fixes #2865
Refs #2616

> Co-Authored by Grok Build using grok-4.5 with agent main.