### PR TITLE
fix(sitemanage): Xlint batch 2 — remaining serialVersionUID (#2421)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2421-sitemanage-xlint-batch2-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2421-sitemanage-xlint-batch2-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review — issue #2421 sitemanage Xlint batch 2
+
+**Reviewer persona:** independent of implementer  
+**Date:** 2026-08-10  
+**Scope:** residual `serialVersionUID` on main-source DTOs / nested exceptions after batch 1 (#2032 / PR #2422)
+
+## Change class
+
+Mechanical serial lint cleanup on Serializable DTOs and exception types. No product behavior, REST contracts, paths, or Spring wiring changes.
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / logic regressions | **Pass** — only `private static final long serialVersionUID = 1L` fields; `@SuppressWarnings("serial")` removed where replaced with real UID (`PSCreateRedirectRequest`) |
+| Behavioral unit tests | **Pass** — `PSSerializableListWrappersTest#residualDtoAndExceptionTypesDefineSerialVersionUid` asserts UID fields exist for batch-2 types |
+| Cross-platform paths | **N/A** — no path/I/O changes |
+| Change-class companions | **Pass** — list-wrapper pattern from batch 1 extended; no new beans / REST surfaces |
+| API shape / `final` / signature changes | **N/A** — no public API signature changes; C2 not required |
+| Product docs | **N/A** — non-product-facing tech debt |
+
+## Findings
+
+None (no bugs). Residual main-source Xlint remains dominated by **serial-field**, **this-escape**, and **unchecked** — tracked as residual child under #2032 / #2200.
+
+## Build evidence
+
+```text
+cd projects/sitemanage && ../../mvnw.cmd clean install
+BUILD SUCCESS
+Tests run: 968, Failures: 0, Errors: 0, Skipped: 127
+```
+
+Main-source `serialVersionUID` warnings in capped Maven log: **23+ → 0** (additional DTO UIDs also added beyond the first-100 cap).

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSContentEditCriteria.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSContentEditCriteria.java
@@ -32,6 +32,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  */
 @XmlRootElement(name = "ContentEditCriteria")
 public class PSContentEditCriteria extends PSAssetEditor {
+  private static final long serialVersionUID = 1L;
 
   private boolean producesResource = false;
   private String contentName = "";

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSUnusedAssetSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSUnusedAssetSummary.java
@@ -37,6 +37,7 @@ import net.sf.oval.constraint.NotNull;
 @JsonRootName("UnusedAssetSummary")
 public class PSUnusedAssetSummary extends PSDataItemSummary
     implements IPSItemSummary, Comparable<PSUnusedAssetSummary> {
+  private static final long serialVersionUID = 1L;
 
   /**
    * This field is used to label the asset on the UI, in the unused assets tray. The items will have

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategory.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategory.java
@@ -34,6 +34,7 @@ import tools.jackson.databind.json.JsonMapper;
 @JsonRootName(value = "CategoryTree")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PSCategory extends PSAbstractDataObject implements Cloneable {
+  private static final long serialVersionUID = 1L;
 
   @JsonProperty private String title;
 

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryNode.java
@@ -40,6 +40,7 @@ import tools.jackson.databind.json.JsonMapper;
 @JsonInclude()
 public class PSCategoryNode extends PSAbstractDataObject
     implements Comparable<PSCategoryNode>, Cloneable {
+  private static final long serialVersionUID = 1L;
 
   @JsonProperty("id")
   private String id;

--- a/projects/sitemanage/src/main/java/com/percussion/cloudservice/IPSCloudService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/cloudservice/IPSCloudService.java
@@ -89,6 +89,8 @@ public interface IPSCloudService {
 
   /** Runtime exception thrown when an error occurs in this service. */
   class PSCloudServiceException extends PSDataServiceException {
+    private static final long serialVersionUID = 1L;
+
     public PSCloudServiceException() {
       super();
     }

--- a/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSDashboardConfiguration.java
+++ b/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSDashboardConfiguration.java
@@ -26,6 +26,8 @@ import java.util.List;
     name = "",
     propOrder = {"gadgets"})
 public class PSDashboardConfiguration extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
   private List<PSGadget> gadgets;
 
   public List<PSGadget> getGadgets() {

--- a/projects/sitemanage/src/main/java/com/percussion/designmanagement/service/IPSFileSystemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/designmanagement/service/IPSFileSystemService.java
@@ -182,15 +182,25 @@ public interface IPSFileSystemService {
    */
   boolean containsInvalidChars(String name);
 
-  public static class PSFolderOperationException extends Exception {}
+  public static class PSFolderOperationException extends Exception {
+    private static final long serialVersionUID = 1L;
+  }
 
-  public static class PSFolderNameLengthLimitException extends PSFolderOperationException {}
+  public static class PSFolderNameLengthLimitException extends PSFolderOperationException {
+    private static final long serialVersionUID = 1L;
+  }
 
-  public static class PSInvalidFolderNameException extends PSFolderOperationException {}
+  public static class PSInvalidFolderNameException extends PSFolderOperationException {
+    private static final long serialVersionUID = 1L;
+  }
 
-  public static class PSExistingFolderException extends PSFolderOperationException {}
+  public static class PSExistingFolderException extends PSFolderOperationException {
+    private static final long serialVersionUID = 1L;
+  }
 
   public static class PSInvalidCharacterInFolderNameException extends PSFolderOperationException {
+    private static final long serialVersionUID = 1L;
+
     private String invalidChars;
 
     public PSInvalidCharacterInFolderNameException(String chars) {
@@ -207,6 +217,8 @@ public interface IPSFileSystemService {
   }
 
   public static class PSFileOperationException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     public PSFileOperationException(String message, Exception ex) {
       super(message, ex);
     }
@@ -217,30 +229,40 @@ public interface IPSFileSystemService {
   }
 
   public static class PSFileAlreadyExistsException extends PSFileOperationException {
+    private static final long serialVersionUID = 1L;
+
     public PSFileAlreadyExistsException(String message) {
       super(message);
     }
   }
 
   public static class PSFileNameInUseByFolderException extends PSFileOperationException {
+    private static final long serialVersionUID = 1L;
+
     public PSFileNameInUseByFolderException(String message) {
       super(message);
     }
   }
 
   public static class PSReservedFileNameException extends PSFileOperationException {
+    private static final long serialVersionUID = 1L;
+
     public PSReservedFileNameException(String message) {
       super(message);
     }
   }
 
   public static class PSInvalidCharacterInFileNameException extends PSFileOperationException {
+    private static final long serialVersionUID = 1L;
+
     public PSInvalidCharacterInFileNameException(String message) {
       super(message);
     }
   }
 
   public static class PSFileSizeExceededException extends PSFileOperationException {
+    private static final long serialVersionUID = 1L;
+
     public PSFileSizeExceededException(String message) {
       super(message);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolderItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolderItem.java
@@ -32,6 +32,8 @@ import org.apache.commons.lang3.StringUtils;
     propOrder = {"name", "id", "workflowName", "allChildrenAssociatedWithWorkflow", "children"})
 @XmlAccessorType(XmlAccessType.FIELD)
 public class PSFolderItem extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
   /** The name of the folder or site. */
   private String name;
 

--- a/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolders.java
+++ b/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolders.java
@@ -28,6 +28,8 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class PSFolders extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
   @XmlElement(name = "child")
   private List<PSFolderItem> children;
 

--- a/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSGetAssignedFoldersJobStatus.java
+++ b/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSGetAssignedFoldersJobStatus.java
@@ -27,6 +27,8 @@ import java.util.List;
  */
 @XmlRootElement(name = "GetAssignedFoldersJobStatus")
 public class PSGetAssignedFoldersJobStatus extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
   private List<PSFolderItem> folderItems;
   private String status;
   private String message;

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSComment.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSComment.java
@@ -28,6 +28,7 @@ import net.sf.oval.constraint.NotEmpty;
  */
 @XmlRootElement(name = "Comment")
 public class PSComment extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
 
   private String comment;
   @NotEmpty private String commenter;

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemDates.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemDates.java
@@ -30,6 +30,7 @@ import net.sf.oval.constraint.NotNull;
  */
 @XmlRootElement(name = "ItemDates")
 public class PSItemDates extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
 
   @NotNull @NotEmpty private String itemId;
   private String startDate;

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSRevision.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSRevision.java
@@ -33,6 +33,7 @@ import net.sf.oval.constraint.NotEmpty;
 @XmlRootElement(name = "Revision")
 @JsonRootName("Revision")
 public class PSRevision extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
 
   private int revId;
 

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSSoProMetadata.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSSoProMetadata.java
@@ -28,6 +28,7 @@ import net.sf.oval.constraint.NotNull;
  */
 @XmlRootElement(name = "SoProMetadata")
 public class PSSoProMetadata extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
 
   @NotNull @NotEmpty private String itemId;
   private String metadata;

--- a/projects/sitemanage/src/main/java/com/percussion/licensemanagement/data/PSLicenseStatus.java
+++ b/projects/sitemanage/src/main/java/com/percussion/licensemanagement/data/PSLicenseStatus.java
@@ -55,6 +55,7 @@ import org.apache.commons.lang3.StringUtils;
     })
 @XmlRootElement(name = "licenseStatus")
 public class PSLicenseStatus implements Serializable {
+  private static final long serialVersionUID = 1L;
 
   private String company;
   private String licenseType;

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSMetadataProperty.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSMetadataProperty.java
@@ -267,6 +267,7 @@ public class PSMetadataProperty {
  */
 @Embeddable
 class PropertyId implements Serializable {
+  private static final long serialVersionUID = 1L;
 
   private static final HashCalculator hashCalculator = new HashCalculator();
 

--- a/projects/sitemanage/src/main/java/com/percussion/pageoptimizer/IPSPageOptimizerService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pageoptimizer/IPSPageOptimizerService.java
@@ -51,6 +51,8 @@ public interface IPSPageOptimizerService {
 
   /** Exception thrown when an error occurs in this service. */
   class PageOptimizerException extends PSDataServiceException {
+    private static final long serialVersionUID = 1L;
+
     public PageOptimizerException() {
       super();
     }

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSGenerateSiteMapOptions.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSGenerateSiteMapOptions.java
@@ -25,6 +25,8 @@ import com.percussion.share.data.PSAbstractDataObject;
  * @author yubingchen
  */
 public class PSGenerateSiteMapOptions extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
+
   private String generateSitemapExcludeImage;
   private String generateSitemap;
 

--- a/projects/sitemanage/src/main/java/com/percussion/redirect/data/PSCreateRedirectRequest.java
+++ b/projects/sitemanage/src/main/java/com/percussion/redirect/data/PSCreateRedirectRequest.java
@@ -22,9 +22,9 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 
 /** Encapsulates a request for a new redirect. Used for creating or updating redirect rules. */
-@SuppressWarnings("serial")
 @XmlRootElement
 public class PSCreateRedirectRequest implements Serializable {
+  private static final long serialVersionUID = 1L;
 
   private String category;
   private String condition;

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSEnumVals.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSEnumVals.java
@@ -101,6 +101,8 @@ public class PSEnumVals implements Serializable {
 
   /** Encapsulates an enumerated value, which consists of a value and display value (label). */
   public static class EnumVal implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     @NotNull private String value;
     private String displayValue;
 

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/data/PSImportLogEntry.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/data/PSImportLogEntry.java
@@ -33,6 +33,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSImportLogEntry")
 @Table(name = "PSX_IMPORTLOGENTRY")
 public class PSImportLogEntry extends PSAbstractDataObject {
+  private static final long serialVersionUID = 1L;
 
   @Id
   @Column(name = "LOGENTRYID")

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSCurrentUser.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSCurrentUser.java
@@ -29,6 +29,8 @@ import java.util.List;
 @XmlRootElement(name = "CurrentUser")
 @JsonRootName("CurrentUser")
 public class PSCurrentUser extends PSUser {
+  private static final long serialVersionUID = 1L;
+
   private boolean accessibilityUser = false;
   private boolean adminUser = false;
   private boolean designerUser = false;

--- a/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
@@ -47,6 +47,46 @@ public class PSSerializableListWrappersTest {
     assertSerialVersionUid(PSPublishingActionList.class);
   }
 
+  /**
+   * Guards serialVersionUID for residual DTO / nested-exception types cleaned in issue #2421 batch
+   * 2 (after #2032 batch 1).
+   */
+  @Test
+  public void residualDtoAndExceptionTypesDefineSerialVersionUid() throws Exception {
+    assertSerialVersionUid(PSEnumVals.EnumVal.class);
+    assertSerialVersionUid(com.percussion.pathmanagement.data.PSGenerateSiteMapOptions.class);
+    assertSerialVersionUid(com.percussion.foldermanagement.data.PSFolderItem.class);
+    assertSerialVersionUid(com.percussion.foldermanagement.data.PSFolders.class);
+    assertSerialVersionUid(
+        com.percussion.foldermanagement.data.PSGetAssignedFoldersJobStatus.class);
+    assertSerialVersionUid(com.percussion.user.data.PSCurrentUser.class);
+    assertSerialVersionUid(com.percussion.assetmanagement.data.PSContentEditCriteria.class);
+    assertSerialVersionUid(com.percussion.itemmanagement.data.PSItemDates.class);
+    assertSerialVersionUid(com.percussion.itemmanagement.data.PSSoProMetadata.class);
+    assertSerialVersionUid(com.percussion.itemmanagement.data.PSRevision.class);
+    assertSerialVersionUid(com.percussion.itemmanagement.data.PSComment.class);
+    assertSerialVersionUid(com.percussion.assetmanagement.data.PSUnusedAssetSummary.class);
+    assertSerialVersionUid(com.percussion.category.data.PSCategory.class);
+    assertSerialVersionUid(com.percussion.category.data.PSCategoryNode.class);
+    assertSerialVersionUid(com.percussion.dashboardmanagement.data.PSDashboardConfiguration.class);
+    assertSerialVersionUid(com.percussion.sitemanage.importer.data.PSImportLogEntry.class);
+    assertSerialVersionUid(com.percussion.licensemanagement.data.PSLicenseStatus.class);
+    assertSerialVersionUid(com.percussion.redirect.data.PSCreateRedirectRequest.class);
+    assertSerialVersionUid(
+        com.percussion.designmanagement.service.IPSFileSystemService.PSFolderOperationException
+            .class);
+    assertSerialVersionUid(
+        com.percussion.designmanagement.service.IPSFileSystemService.PSFileOperationException
+            .class);
+    assertSerialVersionUid(
+        com.percussion.designmanagement.service.IPSFileSystemService.PSFileAlreadyExistsException
+            .class);
+    assertSerialVersionUid(
+        com.percussion.cloudservice.IPSCloudService.PSCloudServiceException.class);
+    assertSerialVersionUid(
+        com.percussion.pageoptimizer.IPSPageOptimizerService.PageOptimizerException.class);
+  }
+
   @Test
   public void itemPropertiesListPreservesOrderAndContents() {
     var a = new PSItemProperties();


### PR DESCRIPTION
## Summary

Partial Xlint cleanup for **sitemanage** residual issue **#2421** (parent module issue **#2032**, monorepo tracker **#2200**). Batch 2 clears remaining mechanical **serialVersionUID** diagnostics on main-source DTOs and nested exceptions after batch 1 (PR #2422).

### Main changes

- **serialVersionUID = 1L** on residual Serializable DTOs (folder, item, asset, user, category, dashboard, license, redirect, import log, path, enum nested type, unused asset summary, metadata `PropertyId`, etc.)
- **IPSFileSystemService** nested folder/file operation exceptions (11 types)
- **IPSCloudService.PSCloudServiceException**, **IPSPageOptimizerService.PageOptimizerException**
- Replace `@SuppressWarnings("serial")` with real UID on `PSCreateRedirectRequest`

### Tests

- Extended `PSSerializableListWrappersTest#residualDtoAndExceptionTypesDefineSerialVersionUid`

### Residual

Remaining main-source diagnostics are dominated by **serial-field**, **this-escape**, and **unchecked** (higher design cost). Residual child issue will track the next PR-sized cluster(s). Test-source Xlint remains separate.

## Test plan

- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **968**, Failures: **0**, Errors: **0**, Skipped: **127**
- [x] Main-source `serialVersionUID` warnings cleared (capped Maven log: 0 remaining of that kind)
- [x] No production behavior / REST contract changes

## Product documentation

- [x] N/A — pure compiler lint tech debt; no operator/user/API surface change

## Gates / evidence (C3)

- **modules_built:** `projects/sitemanage`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 968, Failures: 0, Errors: 0, Skipped: 127
- **downstream_checked:** none (no public API signature / final / sealed changes; C2 N/A)
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2421-sitemanage-xlint-batch2-erlang.md`
- Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2421  
Refs #2032 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.
