### PR TITLE
fix(perc-content-explorer): PSSearchView ActionManager/Catalog rawtypes (#2326)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2326-pssearchview-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2326-pssearchview-rawtypes-erlang.md
@@ -1,0 +1,26 @@
+# Erlang review: issue #2326 PSSearchViewActionManager + Catalog rawtypes
+
+**Scope:** `PSSearchViewActionManager`, `PSSearchViewCatalog`, new `PSSearchViewActionManagerTest`
+**Date:** 2026-08-10
+**Verdict:** PASS
+
+## Bugs
+- None found. Generics only; empty-search map null put preserved; custom-search field inclusion still uses historic `List#toString()` emptiness check.
+- `final` on `PSSearchViewCatalog` OK — no subclasses in monorepo.
+- `ms_nodeTypesInitializable` made `List<String>` + `final` (list still mutable); no reassignment sites.
+
+## Behavioral tests
+- New tests cover `isNodeInitializable`, `setAsInitialized`, static type list. Full loadChildren/catalog needs live applet (documented).
+
+## Cross-platform
+- N/A (no path/file I/O changes).
+
+## Change-class companions
+- Unit tests added; module standalone clean install green (109 tests).
+- Product docs N/A (compiler tech-debt, no operator surface).
+- No Playwright (no WebUI).
+
+## Residual
+- Module inventory ~517 → ~469 under `-Xmaxwarns 5000`.
+- Avoid #2439 PSFolderAclEditorDialog (In Progress).
+- Next PR-sized clusters: display panel models, ACL new user dialog, PSSearchDialog, etc.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewActionManager.java
@@ -143,7 +143,7 @@ public class PSSearchViewActionManager {
     PSSearch contentItemSearch;
     try {
       contentItemSearch = m_searchViewCatalog.getContentIdSearch(contentid);
-      searchNode.setSearchId(m_searchViewCatalog.getSearchId(contentItemSearch));
+      searchNode.setSearchId(PSSearchViewCatalog.getSearchId(contentItemSearch));
       setAsInitialized(searchNode);
     } catch (PSCmsException e) {
       throw new RuntimeException("Severe error while creating adhoc search", e);
@@ -237,23 +237,20 @@ public class PSSearchViewActionManager {
    *     <code>empty</code>.
    * @throws PSCmsException if an error happens while processing the request.
    */
-  public void delete(Iterator nodeList) throws PSCmsException {
+  public void delete(Iterator<? extends PSNode> nodeList) throws PSCmsException {
     if (nodeList == null) throw new IllegalArgumentException("nodeList must not be null");
 
     if (nodeList.hasNext()) {
-      PSNode node = null;
-      String searchid = null;
-      List list = new ArrayList();
-      PSSearch searchObj = null;
+      List<PSSearch> list = new ArrayList<>();
       while (nodeList.hasNext()) {
-        node = (PSNode) nodeList.next();
-        searchid = node.getProperties().getProperty(IPSConstants.PROPERTY_SEARCHID);
+        PSNode node = nodeList.next();
+        String searchid = node.getProperties().getProperty(IPSConstants.PROPERTY_SEARCHID);
         if (searchid == null || searchid.trim().length() < 1) continue;
-        searchObj = m_searchViewCatalog.getSearchById(searchid);
+        PSSearch searchObj = m_searchViewCatalog.getSearchById(searchid);
         if (searchObj != null) list.add(searchObj);
       }
       // Convert the list to array
-      PSSearch comp[] = (PSSearch[]) list.toArray(new PSSearch[list.size()]);
+      PSSearch[] comp = list.toArray(new PSSearch[0]);
       m_proxy.delete(comp);
     }
   }
@@ -301,9 +298,9 @@ public class PSSearchViewActionManager {
       throw new IllegalArgumentException("formatid may not be null or empty.");
 
     PSDisplayFormat match = null;
-    Iterator iter = getDisplayFormats();
+    Iterator<PSDisplayFormat> iter = getDisplayFormats();
     while (iter.hasNext()) {
-      PSDisplayFormat format = (PSDisplayFormat) iter.next();
+      PSDisplayFormat format = iter.next();
       String id = String.valueOf(format.getDisplayId());
       if (id.equals(formatid)) {
         match = format;
@@ -311,7 +308,7 @@ public class PSSearchViewActionManager {
       }
     }
 
-    if (match == null && getDefault) match = (PSDisplayFormat) getDisplayFormats().next();
+    if (match == null && getDefault) match = getDisplayFormats().next();
 
     return match;
   }
@@ -335,7 +332,7 @@ public class PSSearchViewActionManager {
    * @throws PSCmsException if an error occurs while loading the search results.
    * @throws PSContentExplorerException if an error happens executing search.
    */
-  public Iterator loadChildren(PSNode searchNode)
+  public Iterator<PSNode> loadChildren(PSNode searchNode)
       throws PSCmsException, PSContentExplorerException {
     if (searchNode == null || !searchNode.isSearchType()) {
       throw new IllegalArgumentException(
@@ -343,8 +340,7 @@ public class PSSearchViewActionManager {
     }
 
     // Call listeners for start of search
-    for (Iterator iter = m_searchListenerList.iterator(); iter.hasNext(); ) {
-      IPSSearchListener listener = (IPSSearchListener) iter.next();
+    for (IPSSearchListener listener : m_searchListenerList) {
       listener.searchInitiated(searchNode);
     }
 
@@ -391,16 +387,14 @@ public class PSSearchViewActionManager {
               // For custom searches we always post the parameters as input XML
               // document
               if (search.isCustomSearch()) {
-                Map namevalues = new HashMap();
-                Iterator fields = search.getFields();
-                PSSearchField field = null;
-                Object obj = null;
+                Map<String, Object> namevalues = new HashMap<>();
+                Iterator<PSSearchField> fields = search.getFields();
                 while (fields.hasNext()) {
-                  field = (PSSearchField) fields.next();
-                  obj = field.getFieldValues();
-                  // Do not include any null or empty fields
-                  if (obj != null && obj.toString().trim().length() > 0) {
-                    namevalues.put(field.getFieldName(), field.getFieldValues());
+                  PSSearchField field = fields.next();
+                  List<String> values = field.getFieldValues();
+                  // Do not include any null or empty fields (preserve historic List#toString check)
+                  if (values != null && values.toString().trim().length() > 0) {
+                    namevalues.put(field.getFieldName(), values);
                     namevalues.put(
                         field.getFieldName() + PSHtmlParamDocument.OPERATOR_SUFFIX,
                         field.getOperator());
@@ -415,7 +409,7 @@ public class PSSearchViewActionManager {
                 PSHtmlParamDocument paramDoc = new PSHtmlParamDocument(namevalues);
                 result = m_applet.getActionManager().postXmlData(sUrl, paramDoc.getXmlString());
               } else {
-                Map params = new HashMap();
+                Map<String, Object> params = new HashMap<>();
                 result = m_applet.getActionManager().postData(sUrl, params);
               }
             } catch (PSException e) {
@@ -424,8 +418,8 @@ public class PSSearchViewActionManager {
             resultDoc = PSXmlDocumentBuilder.createXmlDocument(new StringReader(result), false);
             NodeList nl = resultDoc.getElementsByTagName("Item");
             Element item = null;
-            Set idList = new HashSet();
-            Set typeList = new HashSet();
+            Set<Integer> idList = new HashSet<>();
+            Set<Integer> typeList = new HashSet<>();
             String temp = null;
             for (int i = 0; nl != null && i < nl.getLength(); i++) {
               String typeid;
@@ -444,14 +438,8 @@ public class PSSearchViewActionManager {
               searchNode.setChildren(Collections.emptyIterator());
               return searchNode.getChildren();
             }
-            List<Integer> retIdList = new ArrayList<>();
-            for (Object idObj : idList) {
-              retIdList.add((Integer) idObj);
-            }
-            Collection<Integer> typeIds = new ArrayList<>();
-            for (Object typeObj : typeList) {
-              typeIds.add((Integer) typeObj);
-            }
+            List<Integer> retIdList = new ArrayList<>(idList);
+            Collection<Integer> typeIds = new ArrayList<>(typeList);
             searchEx =
                 new PSExecutableSearch(m_urlBase, format, retIdList, typeIds, search, m_applet);
           } else {
@@ -477,8 +465,7 @@ public class PSSearchViewActionManager {
       }
     } finally {
       // Call listeners for end of search
-      for (Iterator iter = m_searchListenerList.iterator(); iter.hasNext(); ) {
-        IPSSearchListener listener = (IPSSearchListener) iter.next();
+      for (IPSSearchListener listener : m_searchListenerList) {
         listener.searchCompleted(searchNode);
       }
     }
@@ -582,8 +569,7 @@ public class PSSearchViewActionManager {
 
   /** Call all the {@link IPSSearchListener#searchReset()} methods. */
   public void resetSearchListeners() {
-    for (Iterator i = m_searchListenerList.iterator(); i.hasNext(); ) {
-      IPSSearchListener listener = (IPSSearchListener) i.next();
+    for (IPSSearchListener listener : m_searchListenerList) {
       listener.searchReset();
     }
   }
@@ -721,7 +707,7 @@ public class PSSearchViewActionManager {
    * appear under search results category in the Content Explorer. This falg is useful to hide the
    * results until user actually has edited (or at least has seen) the query.
    */
-  public static List ms_nodeTypesInitializable = new ArrayList();
+  public static final List<String> ms_nodeTypesInitializable = new ArrayList<>();
 
   /**
    * Stores the case sensitivity of the database. If <code>true</code> then the database is
@@ -761,7 +747,7 @@ public class PSSearchViewActionManager {
    * executed. Only modified by {@link #addSearchListener(IPSSearchListener)} and {@link
    * #removeSearchListener(IPSSearchListener)}. Never <code>null</code> but may be empty.
    */
-  private List m_searchListenerList = new ArrayList();
+  private final List<IPSSearchListener> m_searchListenerList = new ArrayList<>();
 
   /** static initializer for {@link #ms_nodeTypesInitializable}. */
   static {

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchViewCatalog.java
@@ -39,7 +39,7 @@ import org.w3c.dom.Text;
  * and provide an easy lookup access to the desired search or view. Searches are stored using the
  * unique search id.
  */
-public class PSSearchViewCatalog {
+public final class PSSearchViewCatalog {
   /**
    * Constructs the catalog and loads all available searches and views.
    *
@@ -62,6 +62,7 @@ public class PSSearchViewCatalog {
     m_proxy = proxy;
 
     m_isFtsEnabled = isFtsAvailable;
+    // Class is final; load after fields are assigned so this-escape is intentional post-init.
     loadSearches();
   }
 
@@ -84,8 +85,9 @@ public class PSSearchViewCatalog {
       /* Remember the empty search to preserve changes the user may have
        * made.
        */
-      Object emptySearch = m_searches.get(EMPTY_SEARCHID);
+      PSSearch emptySearch = m_searches.get(EMPTY_SEARCHID);
       m_searches.clear();
+      // Preserve prior empty-search entry (value may be null on first load)
       m_searches.put(EMPTY_SEARCHID, emptySearch);
       m_rcSearch = null;
 
@@ -147,7 +149,7 @@ public class PSSearchViewCatalog {
     if (searchid == null || searchid.trim().length() == 0)
       throw new IllegalArgumentException("searchid may not be null or empty.");
 
-    return (PSSearch) m_searches.get(searchid);
+    return m_searches.get(searchid);
   }
 
   /**
@@ -193,9 +195,9 @@ public class PSSearchViewCatalog {
       // Add to the catalog
       m_searches.put("contentidinternalsearch", rval);
     } else {
-      Iterator iter = rval.getFields();
+      Iterator<PSSearchField> iter = rval.getFields();
       while (iter.hasNext()) {
-        PSSearchField sField = (PSSearchField) iter.next();
+        PSSearchField sField = iter.next();
         if (sField.getFieldName().equals(IPSConstants.PROPERTY_CONTENTID)) {
           sField.setFieldValue(PSSearchField.OP_EQUALS, contentid);
         }
@@ -289,12 +291,12 @@ public class PSSearchViewCatalog {
    * @see java.lang.Object#toString()
    */
   public String toString() {
-    StringBuffer rval = new StringBuffer(80);
+    StringBuilder rval = new StringBuilder(80);
     rval.append("PSSearchViewCatalog: ");
-    Iterator iter = m_searches.values().iterator();
+    Iterator<PSSearch> iter = m_searches.values().iterator();
     while (iter.hasNext()) {
-      PSSearch search = (PSSearch) iter.next();
-      rval.append(search.getLocator().getPart() + "(" + search.getDisplayName() + ")");
+      PSSearch search = iter.next();
+      rval.append(search.getLocator().getPart()).append('(').append(search.getDisplayName()).append(')');
       if (iter.hasNext()) rval.append(", ");
     }
     return rval.toString();
@@ -304,7 +306,7 @@ public class PSSearchViewCatalog {
    * Registry of all search view objects cataloged, setup as part of search loading and never <code>
    * null</code>, empty after that.
    */
-  private Map m_searches = new HashMap();
+  private final Map<String, PSSearch> m_searches = new HashMap<>();
 
   /**
    * Holds a reference to the first related content search found. Initialized in {@link

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSSearchViewActionManagerTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSSearchViewActionManagerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cx.objectstore.PSNode;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for pure helpers on {@link PSSearchViewActionManager} after rawtypes cleanup.
+ * Full search execution / catalog load requires a live applet and server.
+ */
+public class PSSearchViewActionManagerTest {
+
+  @Test
+  public void isNodeInitializableAcceptsConfiguredSearchTypes() {
+    assertTrue(PSSearchViewActionManager.isNodeInitializable(node(PSNode.TYPE_NEW_SRCH)));
+    assertTrue(PSSearchViewActionManager.isNodeInitializable(node(PSNode.TYPE_STANDARD_SRCH)));
+    assertTrue(PSSearchViewActionManager.isNodeInitializable(node(PSNode.TYPE_CUSTOM_SRCH)));
+    assertTrue(PSSearchViewActionManager.isNodeInitializable(node(PSNode.TYPE_EMPTY_SRCH)));
+  }
+
+  @Test
+  public void isNodeInitializableRejectsNonSearchTypes() {
+    assertFalse(PSSearchViewActionManager.isNodeInitializable(node(PSNode.TYPE_FOLDER)));
+    assertFalse(PSSearchViewActionManager.isNodeInitializable(node(PSNode.TYPE_ITEM)));
+  }
+
+  @Test
+  public void isNodeInitializableRejectsNull() {
+    assertThrows(
+        IllegalArgumentException.class, () -> PSSearchViewActionManager.isNodeInitializable(null));
+  }
+
+  @Test
+  public void setAsInitializedMarksNewSearchProperty() {
+    PSNode searchNode = node(PSNode.TYPE_NEW_SRCH);
+    PSSearchViewActionManager.setAsInitialized(searchNode);
+    assertEquals("1", searchNode.getProp("isInitialized"));
+  }
+
+  @Test
+  public void setAsInitializedRejectsNonInitializableNode() {
+    PSNode folder = node(PSNode.TYPE_FOLDER);
+    assertThrows(
+        IllegalArgumentException.class, () -> PSSearchViewActionManager.setAsInitialized(folder));
+  }
+
+  @Test
+  public void setAsInitializedRejectsNull() {
+    assertThrows(
+        IllegalArgumentException.class, () -> PSSearchViewActionManager.setAsInitialized(null));
+  }
+
+  @Test
+  public void msNodeTypesInitializableContainsExpectedTypes() {
+    List<String> types = PSSearchViewActionManager.ms_nodeTypesInitializable;
+    assertTrue(types.contains(PSNode.TYPE_STANDARD_SRCH));
+    assertTrue(types.contains(PSNode.TYPE_CUSTOM_SRCH));
+    assertTrue(types.contains(PSNode.TYPE_NEW_SRCH));
+    assertTrue(types.contains(PSNode.TYPE_EMPTY_SRCH));
+    // intentionally not TYPE_SAVE_SRCH (commented for backward compatibility)
+    assertFalse(types.contains(PSNode.TYPE_SAVE_SRCH));
+  }
+
+  private static PSNode node(String type) {
+    // Folders require non-negative permissions; other types use -1.
+    int perms = PSNode.TYPE_FOLDER.equals(type) ? 1 : -1;
+    return new PSNode("n", "Label", type, null, null, false, perms);
+  }
+}


### PR DESCRIPTION
## Summary
Residual javac `-Xlint` batch for `perc-content-explorer` (#2326 / parent #2045 / #2200): clear **PSSearchViewActionManager** (~39 → **0**) and **PSSearchViewCatalog** (~9 → **0**) under full inventory.

- Typed `delete(Iterator<? extends PSNode>)`, `loadChildren` → `Iterator<PSNode>`, listener list, maps/sets for custom search
- `PSSearchViewCatalog` `Map<String, PSSearch>`, field iterators; class made `final` (no subclasses; this-escape inventory)
- Static `getSearchId` qualified by type name
- Behavioral tests: `PSSearchViewActionManagerTest` (7 tests)
- Erlang pre-commit: `docs/ai-generated/code-reviews/issue-2326-pssearchview-rawtypes-erlang.md`

**Did not touch** `PSFolderAclEditorDialog` (#2439 In Progress).

**Partial for #2326.** Module inventory under `-Xmaxwarns 5000`: **~517 → ~469**.

### Residuals filed
- (see PR comments / issue create) display table/panel/view cluster

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Tests run: **109**, Failures: 0 (includes 7 new `PSSearchViewActionManagerTest`)
- [x] Full inventory: PSSearchViewActionManager + PSSearchViewCatalog clean

## Gates
- Erlang self-review: pass
- Per-module clean install: perc-content-explorer
- Product documentation: **N/A** — compiler tech-debt / rawtypes only; no operator or UI behavior change
- Downstream (C2): `extends PSSearchViewCatalog` — none; `delete`/`loadChildren` callers already use `Iterator<PSNode>`

### C3 evidence
- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `cd modules/DesktopContentExplorer; ..\..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 109, Failures: 0
- **downstream_checked:** grepped monorepo for `extends PSSearchViewCatalog` / `ms_nodeTypesInitializable` reassignment — none; callers of `delete`/`loadChildren` compile in module suite

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes partial #2326. Refs #2045 #2200.

> Co-Authored by Grok Build using grok-4.5 with agent main.
