### PR TITLE
fix(perc-system): type process package rawtypes/unchecked (#2299)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2299-process-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2299-process-rawtypes-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — issue #2299 process package rawtypes (slice 5g)
+
+**Branch:** `fix/issue-2299-process-rawtypes-5g`  
+**Scope:** `com.percussion.process` rawtypes/unchecked cleanup under perc-system  
+**Date:** 2026-08-10  
+**Reviewer persona:** Erlang (implementer self-review)
+
+## Summary
+
+PR-sized batch types process-framework collections with real generics (prefer
+`Map<String,String>` / `Map<String,?>` / `List<byte[]>` / `List<?>` / typed
+fields) across interfaces and implementations. Behavioral unit tests cover
+manager load, command param resolution, resolvers, request XML round-trip, and
+null-contract guards. No product behavior change intended.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found  
+- Behavioral tests: present (`PSProcessPackageTypedTest`, 9 tests green)  
+- Cross-platform path checklist: N/A for new path I/O (no new separators /
+  absolute-path assumptions); existing daemon/local path guards unchanged  
+- **May commit/push: yes**
+
+## Issues
+
+None.
+
+## Notes
+
+- Public signature tightening (`Map` → `Map<String,String>` / `Map<String,?>`)
+  is source-compatible for typical callers using string maps / null. Grep found
+  no production subclasses of `PSSimpleProcess` / alternate `IPSProcess`
+  implementors outside the package. Legacy cactus tests under
+  `modules/CMLight-Main-cactus-tests` are out of main reactor; they pass null /
+  untyped maps which remain assignable with unchecked conversion.
+- `Class.newInstance()` → `getDeclaredConstructor().newInstance()` for
+  resolver instantiation only; broader catch via `ReflectiveOperationException`.
+- Stayed out of open search/objectstore Xlint PRs (#2874, #2872, etc.).
+
+## Build evidence
+
+- `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**  
+- Tests run: **1697**, Failures: **0**, Errors: **0**, Skipped: **240**

--- a/system/src/main/java/com/percussion/process/IPSCommandHandler.java
+++ b/system/src/main/java/com/percussion/process/IPSCommandHandler.java
@@ -57,7 +57,8 @@ public interface IPSCommandHandler {
    *     If the return code is not 0, the exception text includes the console output.
    */
   public PSProcessRequestResult executeProcess(
-      String procName, Map extraParams, int wait, boolean terminate) throws PSProcessException;
+      String procName, Map<String, String> extraParams, int wait, boolean terminate)
+      throws PSProcessException;
 
   /**
    * Method will not return until the process associated with the supplied handle has finished.

--- a/system/src/main/java/com/percussion/process/IPSProcess.java
+++ b/system/src/main/java/com/percussion/process/IPSProcess.java
@@ -75,7 +75,7 @@ public interface IPSProcess {
    *     </code>.
    * @throws PSProcessException if any error occurs starting the process
    */
-  public PSProcessAction start(Map ctx) throws PSProcessException;
+  public PSProcessAction start(Map<String, String> ctx) throws PSProcessException;
 
   /**
    * Tag name of the root node for the element which can be specified in the <code>fromXml</code>

--- a/system/src/main/java/com/percussion/process/IPSVariableResolver.java
+++ b/system/src/main/java/com/percussion/process/IPSVariableResolver.java
@@ -43,5 +43,5 @@ public interface IPSVariableResolver {
    * @return the resolved string, may be empty, never <code>null</code>
    * @throws PSResolveException if any error occurs resolving the specified string
    */
-  public String getValue(String value, Map ctx) throws PSResolveException;
+  public String getValue(String value, Map<String, ?> ctx) throws PSResolveException;
 }

--- a/system/src/main/java/com/percussion/process/PSBasicResolver.java
+++ b/system/src/main/java/com/percussion/process/PSBasicResolver.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class PSBasicResolver implements IPSVariableResolver {
   // see interface
-  public String getValue(String value, Map ctx) throws PSResolveException {
+  public String getValue(String value, Map<String, ?> ctx) throws PSResolveException {
     if (null == value) value = "";
 
     if (null == ctx) {
@@ -46,7 +46,7 @@ public class PSBasicResolver implements IPSVariableResolver {
    *     </code>. Each entry has <code>String</code> keys which are case-sensitive to template
    *     variabled and values are <code>toString</code>'d.
    */
-  protected String resolve(String template, Map ctx) throws PSResolveException {
+  protected String resolve(String template, Map<String, ?> ctx) throws PSResolveException {
     if (null == ctx) {
       throw new IllegalArgumentException("context cannot be null");
     }

--- a/system/src/main/java/com/percussion/process/PSEnvironmentResolver.java
+++ b/system/src/main/java/com/percussion/process/PSEnvironmentResolver.java
@@ -30,7 +30,7 @@ public class PSEnvironmentResolver extends PSBasicResolver {
    *
    * @param ctx Unused.
    */
-  public String resolve(String var, Map ctx) throws PSResolveException {
+  public String resolve(String var, Map<String, ?> ctx) throws PSResolveException {
     // suppress eclipse warning
     if (null == ctx)
       ;

--- a/system/src/main/java/com/percussion/process/PSLiteralResolver.java
+++ b/system/src/main/java/com/percussion/process/PSLiteralResolver.java
@@ -28,7 +28,7 @@ public class PSLiteralResolver extends PSBasicResolver {
    * Just returns the supplied template except if it was <code>null</code>, in which case "" is
    * returned.
    */
-  protected String resolve(String template, Map ctx) throws PSResolveException {
+  protected String resolve(String template, Map<String, ?> ctx) throws PSResolveException {
     if ((template == null)) {
       template = "";
     }

--- a/system/src/main/java/com/percussion/process/PSLocalCommandHandler.java
+++ b/system/src/main/java/com/percussion/process/PSLocalCommandHandler.java
@@ -61,7 +61,7 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
    * @throws PSProcessException If the content of the config file doesn't conform to dtd as
    *     specified in {@link PSProcessManager} description.
    */
-  public PSLocalCommandHandler(Map env, File config)
+  public PSLocalCommandHandler(Map<String, String> env, File config)
       throws IOException, SAXException, PSProcessException {
     setEnvironment(env);
     validatePath(config, "PSLocalCommandHandler");
@@ -78,14 +78,15 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
    *     these variables, then the <code>extraParams</code> are added. The final result is used for
    *     the process execution context.
    */
-  public void setEnvironment(Map env) {
-    m_environment = null == env ? new HashMap() : env;
+  public void setEnvironment(Map<String, String> env) {
+    m_environment = null == env ? new HashMap<>() : env;
   }
 
   // see base class method for details
   public PSProcessRequestResult executeProcess(
-      String procName, Map extraParams, int wait, boolean terminate) throws PSProcessException {
-    Map vars = new HashMap();
+      String procName, Map<String, String> extraParams, int wait, boolean terminate)
+      throws PSProcessException {
+    Map<String, String> vars = new HashMap<>();
     vars.putAll(m_environment);
     // supplied vars have highest precedence
     if (null != extraParams) vars.putAll(extraParams);
@@ -162,7 +163,7 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
   static PSProcessRequestResult doExecuteProcess(
       PSProcessManager mgr,
       String procName,
-      Map params,
+      Map<String, String> params,
       int wait,
       boolean terminate,
       Logger outputSink) {
@@ -181,8 +182,8 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
     String resultText = "";
     int spawnedActionHandle = -1;
     try {
-      Map vars = new HashMap();
-      if (null != params) vars.putAll(params);
+      Map<String, String> vars = new HashMap<>();
+      vars.putAll(params);
 
       IPSProcess proc = mgr.getProcess(procName);
       if (null == proc) {
@@ -291,7 +292,7 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
    * @return The originally stored action, or <code>null</code> if the handle is not in the map.
    */
   private static PSProcessAction getAction(int handle) {
-    return (PSProcessAction) ms_spawnedActions.get(Integer.valueOf(handle));
+    return ms_spawnedActions.get(Integer.valueOf(handle));
   }
 
   /**
@@ -302,7 +303,7 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
    *     handle.
    */
   private static PSProcessAction removeAction(int handle) {
-    return (PSProcessAction) ms_spawnedActions.remove(Integer.valueOf(handle));
+    return ms_spawnedActions.remove(Integer.valueOf(handle));
   }
 
   /**
@@ -318,7 +319,7 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
    * Integer</code> whose value is the next available value of <code>ms_nextHandle</code>. The value
    * is the <code>PSProcessAction</code> that was spawned. Never <code>null</code>.
    */
-  private static Map ms_spawnedActions = new HashMap();
+  private static final Map<Integer, PSProcessAction> ms_spawnedActions = new HashMap<>();
 
   /**
    * Removes the file or directory specified by <code>path</code>. If <code>path</code> is a
@@ -577,7 +578,7 @@ public class PSLocalCommandHandler implements IPSCommandHandler {
    * Set during construction, then never <code>null</code> or modified after that. See ctor param
    * <code>env</code> description for details.
    */
-  private Map m_environment;
+  private Map<String, String> m_environment;
 
   /**
    * Set in ctor, then never <code>null</code> or modified after that. It is used to fulfill

--- a/system/src/main/java/com/percussion/process/PSPathResolver.java
+++ b/system/src/main/java/com/percussion/process/PSPathResolver.java
@@ -39,7 +39,7 @@ import java.util.Map;
  */
 public class PSPathResolver extends PSBasicResolver {
   // see base class
-  public String resolve(String var, Map ctx) throws PSResolveException {
+  public String resolve(String var, Map<String, ?> ctx) throws PSResolveException {
     // use super to check contract
     boolean isDoubleQuoted = false;
 

--- a/system/src/main/java/com/percussion/process/PSProcessDaemon.java
+++ b/system/src/main/java/com/percussion/process/PSProcessDaemon.java
@@ -38,10 +38,8 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -368,11 +366,10 @@ public class PSProcessDaemon extends Thread {
     m_pathRoot = filePath;
 
     // pull out all process environment props and store in separate map
-    Enumeration iter = props.propertyNames();
-    while (iter.hasMoreElements()) {
-      String prop = (String) iter.nextElement();
-      if (prop.startsWith(PROC_ENV_PREFIX))
-        m_procEnv.put(prop.substring(PROC_ENV_PREFIX.length()), props.get(prop));
+    for (String prop : props.stringPropertyNames()) {
+      if (prop.startsWith(PROC_ENV_PREFIX)) {
+        m_procEnv.put(prop.substring(PROC_ENV_PREFIX.length()), props.getProperty(prop));
+      }
     }
 
     String procDefFilename = props.getProperty("procDefFilename");
@@ -424,7 +421,7 @@ public class PSProcessDaemon extends Thread {
    *     If a non-zero value is returned, result will contain the error text.
    */
   public static int sendCommand(
-      String server, int port, String cmdName, List params, StringBuilder result)
+      String server, int port, String cmdName, List<?> params, StringBuilder result)
       throws IOException {
     if (null == server || server.trim().length() == 0)
       throw new IllegalArgumentException("server can't be null or empty");
@@ -448,8 +445,7 @@ public class PSProcessDaemon extends Thread {
       // assume there are no funky chars in the cmd name
       dos.write(cmdName.getBytes());
 
-      for (Iterator iter = params.iterator(); iter.hasNext(); ) {
-        Object o = iter.next();
+      for (Object o : params) {
         InputStream is;
         byte[] buf;
         int count;
@@ -625,7 +621,7 @@ public class PSProcessDaemon extends Thread {
 
         // get all params
         boolean done = false;
-        List params = new ArrayList();
+        List<byte[]> params = new ArrayList<>();
         do {
           int bytes = dis.readInt();
           if (bytes == -1) {
@@ -705,7 +701,7 @@ public class PSProcessDaemon extends Thread {
      * @throws SAXException If the byte[] supplied as the first param cannot be parsed as a UTF8
      *     encoded xml document.
      */
-    private String handleExecProcess(List params) throws SAXException {
+    private String handleExecProcess(List<byte[]> params) throws SAXException {
       if (params.isEmpty()) {
         // let the processing below handle the error
         params.add(0, new byte[0]);
@@ -713,7 +709,7 @@ public class PSProcessDaemon extends Thread {
 
       String result = "";
       try {
-        byte[] buf = (byte[]) params.get(0);
+        byte[] buf = params.get(0);
         String request = new String(buf, "UTF8");
         Document inputDoc =
             PSXmlDocumentBuilder.createXmlDocument(new StringReader(request), false);
@@ -744,7 +740,7 @@ public class PSProcessDaemon extends Thread {
      *     PSXProcessRequestResult.dtd.
      * @throws Exception If the byte[] supplied as the params cannot be parsed as integers.
      */
-    private String handleWaitForProcess(List params) throws Exception {
+    private String handleWaitForProcess(List<byte[]> params) throws Exception {
       if (params.size() != 2) {
         throw new RuntimeException(
             "Command requires 2 parameters, " + params.size() + " supplied.");
@@ -752,8 +748,8 @@ public class PSProcessDaemon extends Thread {
 
       String result = "";
       try {
-        int handle = Integer.parseInt(new String((byte[]) params.get(0), "UTF8"));
-        int wait = Integer.parseInt(new String((byte[]) params.get(1), "UTF8"));
+        int handle = Integer.parseInt(new String(params.get(0), "UTF8"));
+        int wait = Integer.parseInt(new String(params.get(1), "UTF8"));
 
         PSProcessRequestResult processResult = PSLocalCommandHandler.doWaitOnProcess(handle, wait);
 
@@ -779,9 +775,8 @@ public class PSProcessDaemon extends Thread {
      * @throws Exception if the supplied path is not valid or all specified directories cannot be
      *     created.
      */
-    private String handleRm(List params) throws Exception {
-      StringBuilder validateResult = new StringBuilder(1000);
-      File path = validatePath((byte[]) params.get(0));
+    private String handleRm(List<byte[]> params) throws Exception {
+      File path = validatePath(params.get(0));
       PSLocalCommandHandler.doRemoveFileSystemObject(path);
       return "";
     }
@@ -796,9 +791,8 @@ public class PSProcessDaemon extends Thread {
      *     the file system or "0" otherwise.
      * @throws Exception if the supplied path is not valid.
      */
-    private String handleCheckFSObject(List params) throws Exception {
-      StringBuilder validateResult = new StringBuilder(1000);
-      File path = validatePath((byte[]) params.get(0));
+    private String handleCheckFSObject(List<byte[]> params) throws Exception {
+      File path = validatePath(params.get(0));
       return path.exists() ? "1" : "0";
     }
 
@@ -812,9 +806,8 @@ public class PSProcessDaemon extends Thread {
      * @throws Exception if the supplied path is not valid or all specified directories cannot be
      *     created.
      */
-    private String handleMkdir(List params) throws Exception {
-      StringBuilder validateResult = new StringBuilder(1000);
-      File dirs = validatePath((byte[]) params.get(0));
+    private String handleMkdir(List<byte[]> params) throws Exception {
+      File dirs = validatePath(params.get(0));
       PSLocalCommandHandler.doMakeDirectories(dirs);
       return "";
     }
@@ -870,9 +863,9 @@ public class PSProcessDaemon extends Thread {
      * @throws Exception if the supplied path is not valid or the file cannot be written for any
      *     reason.
      */
-    private String handlePut(List params) throws Exception {
-      File path = validatePath((byte[]) params.get(0));
-      String content = new String((byte[]) params.get(1), "UTF8");
+    private String handlePut(List<byte[]> params) throws Exception {
+      File path = validatePath(params.get(0));
+      String content = new String(params.get(1), "UTF8");
       PSLocalCommandHandler.doSaveTextFile(path, content);
       return "";
     }
@@ -887,9 +880,9 @@ public class PSProcessDaemon extends Thread {
      * @throws Exception if the supplied path is not valid or the file cannot be written for any
      *     reason.
      */
-    private String handlePutBinary(List params) throws Exception {
-      File path = validatePath((byte[]) params.get(0));
-      InputStream content = new ByteArrayInputStream((byte[]) params.get(1));
+    private String handlePutBinary(List<byte[]> params) throws Exception {
+      File path = validatePath(params.get(0));
+      InputStream content = new ByteArrayInputStream(params.get(1));
       PSLocalCommandHandler.doSaveBinaryFile(path, content);
       return "";
     }
@@ -904,8 +897,8 @@ public class PSProcessDaemon extends Thread {
      * @throws Exception if the supplied path is not valid or the file cannot be read for any
      *     reason.
      */
-    private String handleGet(List params) throws Exception {
-      File path = validatePath((byte[]) params.get(0));
+    private String handleGet(List<byte[]> params) throws Exception {
+      File path = validatePath(params.get(0));
       return PSLocalCommandHandler.doGetTextFile(path);
     }
 
@@ -934,7 +927,7 @@ public class PSProcessDaemon extends Thread {
         }
         PSProcessRequest req = new PSProcessRequest(root);
         procName = req.getName();
-        Map env = new HashMap(m_procEnv);
+        Map<String, String> env = new HashMap<>(m_procEnv);
         env.putAll(req.getParams());
         resultObj =
             PSLocalCommandHandler.doExecuteProcess(
@@ -1002,7 +995,7 @@ public class PSProcessDaemon extends Thread {
    * This map holds the parameters used when processing the process defininitions. Each entry has a
    * key and value as <code>String</code>. Never <code>null</code>, may be empty.
    */
-  private Map m_procEnv = new HashMap();
+  private final Map<String, String> m_procEnv = new HashMap<>();
 
   /** Contains the process definitions. Set in ctor, then never <code>null</code> or modified. */
   private PSProcessManager m_procMgr;
@@ -1019,7 +1012,7 @@ public class PSProcessDaemon extends Thread {
    * </code> in the dot notation of an IP address, e.g. 144.122.111.1. If empty, all remote
    * addresses are allowed.
    */
-  private Set m_remoteIpFilters = new HashSet();
+  private final Set<String> m_remoteIpFilters = new HashSet<>();
 
   /**
    * The log4j logger for this class. Initialized in <code>main</code>, then never <code>null</code>

--- a/system/src/main/java/com/percussion/process/PSProcessDef.java
+++ b/system/src/main/java/com/percussion/process/PSProcessDef.java
@@ -20,7 +20,6 @@ package com.percussion.process;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -71,15 +70,13 @@ public class PSProcessDef {
     if (tmp.trim().length() < 1)
       throw new PSProcessException("supported OS may not be null or empty");
 
-    List list = new ArrayList();
+    List<String> list = new ArrayList<>();
     StringTokenizer st = new StringTokenizer(tmp.trim(), ",", false);
     while (st.hasMoreTokens()) list.add(st.nextToken().trim());
 
     m_supportedOS = new int[list.size()];
-    Iterator it = list.iterator();
     int index = 0;
-    while (it.hasNext()) {
-      String strOS = (String) it.next();
+    for (String strOS : list) {
       int iOS = PSProcessManager.getOSType(strOS);
       m_supportedOS[index] = iOS;
       index++;
@@ -121,7 +118,7 @@ public class PSProcessDef {
    * @throws PSResolveException if any error occurs resolving the working directory
    * @throws PSProcessException if the resolver cannot be obtained
    */
-  public File getWorkingDir(Map ctx) throws PSResolveException, PSProcessException {
+  public File getWorkingDir(Map<String, ?> ctx) throws PSResolveException, PSProcessException {
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
 
     File dir = null;
@@ -142,7 +139,7 @@ public class PSProcessDef {
    * @throws PSResolveException if any error occurs resolving the executable
    * @throws PSProcessException if the resolver cannot be obtained
    */
-  public String getExecutable(Map ctx) throws PSResolveException, PSProcessException {
+  public String getExecutable(Map<String, ?> ctx) throws PSResolveException, PSProcessException {
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
 
     return getResolvedValue(m_execValue, ctx);
@@ -157,12 +154,13 @@ public class PSProcessDef {
    * @throws PSResolveException if any error occurs resolving the command parameters
    * @throws PSProcessException if the resolver cannot be obtained
    */
-  public String[] getCommandParams(Map ctx) throws PSResolveException, PSProcessException {
+  public String[] getCommandParams(Map<String, ?> ctx)
+      throws PSResolveException, PSProcessException {
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
 
     if (m_cmdParams == null) return null;
 
-    List cmdList = new ArrayList();
+    List<String> cmdList = new ArrayList<>();
     String param = "";
     boolean isGroup = false;
     for (int i = 0; i < m_cmdParams.length; i++) {
@@ -224,9 +222,7 @@ public class PSProcessDef {
     }
 
     // Create return array and fill it
-    String[] rval = (String[]) cmdList.toArray(new String[cmdList.size()]);
-
-    return rval;
+    return cmdList.toArray(new String[0]);
   }
 
   /**
@@ -240,10 +236,10 @@ public class PSProcessDef {
    * @throws PSResolveException if any error occurs resolving the environment parameters
    * @throws PSProcessException if a resolver cannot be obtained.
    */
-  public String[] getEnvParams(Map ctx) throws PSResolveException, PSProcessException {
+  public String[] getEnvParams(Map<String, ?> ctx) throws PSResolveException, PSProcessException {
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
 
-    List cmdList = new ArrayList();
+    List<String> cmdList = new ArrayList<>();
     String[] cmdArray = null;
     if (m_envParams != null) {
       for (int i = 0; i < m_envParams.length; i++) {
@@ -254,7 +250,7 @@ public class PSProcessDef {
               m_envParams[i].getName() + "=" + getResolvedValue(m_envParams[i].getValue(), ctx));
         }
       }
-      cmdArray = (String[]) cmdList.toArray(new String[cmdList.size()]);
+      cmdArray = cmdList.toArray(new String[0]);
     }
 
     return cmdArray;
@@ -269,7 +265,8 @@ public class PSProcessDef {
    * @throws PSResolveException If there is an error resolving the value.
    * @throws PSProcessException If there is an error creating the resolver.
    */
-  private String getResolvedValue(PSResolvableValue val, Map ctx) throws PSProcessException {
+  private String getResolvedValue(PSResolvableValue val, Map<String, ?> ctx)
+      throws PSProcessException {
     IPSVariableResolver resolver = createResolver(val);
     return resolver.getValue(val.getValue(), ctx);
   }
@@ -287,20 +284,23 @@ public class PSProcessDef {
     if (resolverClass == null) resolverClass = DEFAULT_RESOLVER;
 
     try {
-
-      IPSVariableResolver varResolver = (IPSVariableResolver) ms_resolvers.get(resolverClass);
+      IPSVariableResolver varResolver = ms_resolvers.get(resolverClass);
       if (varResolver == null) {
-        varResolver = (IPSVariableResolver) Class.forName(resolverClass).newInstance();
+        varResolver =
+            (IPSVariableResolver)
+                Class.forName(resolverClass).getDeclaredConstructor().newInstance();
         ms_resolvers.put(resolverClass, varResolver);
       }
 
       return varResolver;
     } catch (ClassNotFoundException cls) {
       throw new PSProcessException("Class not found exception: " + cls.getLocalizedMessage());
-    } catch (IllegalAccessException iae) {
-      throw new PSProcessException("Illegal access exception: " + iae.getLocalizedMessage());
-    } catch (InstantiationException ins) {
-      throw new PSProcessException("Class not found exception: " + ins.getLocalizedMessage());
+    } catch (ReflectiveOperationException roe) {
+      throw new PSProcessException(
+          "Unable to instantiate resolver "
+              + resolverClass
+              + ": "
+              + roe.getLocalizedMessage());
     }
   }
 
@@ -313,10 +313,9 @@ public class PSProcessDef {
    * @throws PSProcessException if the element is invalid
    */
   private PSParamDef[] createParams(Element childEl) throws PSProcessException {
-    List list = new ArrayList();
+    List<PSParamDef> list = new ArrayList<>();
     NodeList nl = childEl.getChildNodes();
     int length = nl.getLength();
-    ;
     for (int i = 0; i < length; i++) {
       Node node = nl.item(i);
       if (node instanceof Element) {
@@ -339,7 +338,7 @@ public class PSProcessDef {
       }
     }
 
-    return (PSParamDef[]) list.toArray(new PSParamDef[list.size()]);
+    return list.toArray(new PSParamDef[0]);
   }
 
   /**
@@ -388,7 +387,7 @@ public class PSProcessDef {
    * IPSVariableResolver</code>. Never <code>null</code>, entries are added by calls to {@link
    * #createResolver(PSResolvableValue)}.
    */
-  private static Map ms_resolvers = new ConcurrentHashMap();
+  private static final Map<String, IPSVariableResolver> ms_resolvers = new ConcurrentHashMap<>();
 
   /** Constant for the default resolver class. */
   public static final String DEFAULT_RESOLVER = "com.percussion.process.PSLiteralResolver";

--- a/system/src/main/java/com/percussion/process/PSProcessManager.java
+++ b/system/src/main/java/com/percussion/process/PSProcessManager.java
@@ -117,7 +117,7 @@ public class PSProcessManager {
       throw new IllegalArgumentException("process name may not be null or empty");
     }
 
-    return (IPSProcess) m_processMap.get(processName);
+    return m_processMap.get(processName);
   }
 
   /**
@@ -210,7 +210,7 @@ public class PSProcessManager {
    * Stores the process definitions, initialized in the ctor, never <code>null</code> or modified
    * after that.
    */
-  private Map m_processMap = new HashMap();
+  private final Map<String, IPSProcess> m_processMap = new HashMap<>();
 
   /**
    * Stores the current Operating System, initialized in the static initializer, never modified

--- a/system/src/main/java/com/percussion/process/PSProcessRequest.java
+++ b/system/src/main/java/com/percussion/process/PSProcessRequest.java
@@ -20,7 +20,6 @@ import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -41,7 +40,7 @@ public class PSProcessRequest {
    * @param terminate Whether to terminate.
    * @param processEnv The process environment variables.
    */
-  public PSProcessRequest(String name, int wait, boolean terminate, Map processEnv) {
+  public PSProcessRequest(String name, int wait, boolean terminate, Map<?, ?> processEnv) {
     if (null == name || name.trim().length() == 0) {
       throw new IllegalArgumentException("name cannot be null or empty");
     }
@@ -127,7 +126,7 @@ public class PSProcessRequest {
    * @return Each entry has a key as <code>String</code> and a value as <code>String</code>. Never
    *     <code>null</code>, may be empty. No <code>null</code> or empty keys or values.
    */
-  public Map getParams() {
+  public Map<String, String> getParams() {
     return m_params;
   }
 
@@ -146,12 +145,10 @@ public class PSProcessRequest {
     root.setAttribute(TERMINATE_ATTR, String.valueOf(m_terminate));
     if (m_params.size() > 0) {
       Element paramsEl = PSXmlDocumentBuilder.addElement(doc, root, PARAMS_ELEM, null);
-      Iterator params = m_params.keySet().iterator();
-      while (params.hasNext()) {
-        String name = (String) params.next();
+      for (Map.Entry<String, String> entry : m_params.entrySet()) {
         Element paramEl =
-            PSXmlDocumentBuilder.addElement(doc, paramsEl, PARAM_ELEM, (String) m_params.get(name));
-        paramEl.setAttribute(PARAM_NAME_ATTR, name);
+            PSXmlDocumentBuilder.addElement(doc, paramsEl, PARAM_ELEM, entry.getValue());
+        paramEl.setAttribute(PARAM_NAME_ATTR, entry.getKey());
       }
     }
     return root;
@@ -185,17 +182,14 @@ public class PSProcessRequest {
    * </code> on each key and value and validates that they are not empty. <code>null</code> keys and
    *     values are skipped.
    */
-  private void setParams(Map params) {
-    if (null == params || params.size() == 0) return;
-    Iterator paramsIt = params.keySet().iterator();
-    while (paramsIt.hasNext()) {
-      Object o = paramsIt.next();
-      if (null != o) {
-        String name = o.toString();
-        o = params.get(name);
-        if (null != o) {
-          m_params.put(name, o.toString());
-        }
+  private void setParams(Map<?, ?> params) {
+    if (null == params || params.isEmpty()) return;
+    for (Map.Entry<?, ?> entry : params.entrySet()) {
+      Object key = entry.getKey();
+      Object value = entry.getValue();
+      if (null != key && null != value) {
+        // Match historic behavior: toString both sides; skip only nulls.
+        m_params.put(key.toString(), value.toString());
       }
     }
   }
@@ -216,7 +210,7 @@ public class PSProcessRequest {
    * Container for parameter defs. Each entry is a non-<code>null</code>, non- empty <code>String
    * </code>, <code>String</code>. Entries added in ctor then never modified.
    */
-  private Map m_params = new HashMap();
+  private final Map<String, String> m_params = new HashMap<>();
 
   // xml element/attribute constants
   static final String XML_NODE_NAME = "PSXProcessRequest";

--- a/system/src/main/java/com/percussion/process/PSRemoteCommandHandler.java
+++ b/system/src/main/java/com/percussion/process/PSRemoteCommandHandler.java
@@ -66,7 +66,8 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
 
   // see base class method for details
   public PSProcessRequestResult executeProcess(
-      String procName, Map extraParams, int wait, boolean terminate) throws PSProcessException {
+      String procName, Map<String, String> extraParams, int wait, boolean terminate)
+      throws PSProcessException {
     Document request = null;
     Document resultDoc = null;
     try {
@@ -75,7 +76,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
           request, new PSProcessRequest(procName, wait, terminate, extraParams).toXml(request));
 
       StringBuilder result = new StringBuilder();
-      List params = new ArrayList();
+      List<Object> params = new ArrayList<>();
       params.add(PSXmlDocumentBuilder.toString(request));
       PSProcessDaemon.sendCommand(
           m_server, m_port, PSProcessDaemon.CMD_EXEC_PROCESS, params, result);
@@ -96,7 +97,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
     Document resultDoc = null;
     try {
       StringBuilder result = new StringBuilder();
-      List params = new ArrayList();
+      List<Object> params = new ArrayList<>();
       params.add(String.valueOf(handle));
       params.add(String.valueOf(wait));
       PSProcessDaemon.sendCommand(
@@ -119,7 +120,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
     }
     try {
       StringBuilder result = new StringBuilder();
-      List params = new ArrayList();
+      List<Object> params = new ArrayList<>();
       String virtualPath = convertPath(path);
       params.add(virtualPath);
       int resultCode =
@@ -139,7 +140,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
     }
     try {
       StringBuilder result = new StringBuilder();
-      List params = new ArrayList();
+      List<Object> params = new ArrayList<>();
       String virtualPath = convertPath(path);
       params.add(virtualPath);
       int resultCode =
@@ -158,7 +159,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
     }
     try {
       StringBuilder result = new StringBuilder();
-      List params = new ArrayList();
+      List<Object> params = new ArrayList<>();
       String virtualPath = convertPath(path);
       params.add(virtualPath);
       int resultCode =
@@ -176,7 +177,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
       throw new IllegalArgumentException("path cannot be null");
     }
     StringBuilder result = new StringBuilder();
-    List params = new ArrayList();
+    List<Object> params = new ArrayList<>();
     String virtualPath = convertPath(path);
     params.add(virtualPath);
     if (content == null) content = "";
@@ -193,7 +194,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
       throw new IllegalArgumentException("path cannot be null");
     }
     StringBuilder result = new StringBuilder();
-    List params = new ArrayList();
+    List<Object> params = new ArrayList<>();
     String virtualPath = convertPath(path);
     params.add(virtualPath);
     if (src == null) src = new ByteArrayInputStream(new byte[0]);
@@ -210,7 +211,7 @@ public class PSRemoteCommandHandler implements IPSCommandHandler {
       throw new IllegalArgumentException("path cannot be null");
     }
     StringBuilder result = new StringBuilder();
-    List params = new ArrayList();
+    List<Object> params = new ArrayList<>();
     String virtualPath = convertPath(path);
     params.add(virtualPath);
     int resultCode =

--- a/system/src/main/java/com/percussion/process/PSSimpleProcess.java
+++ b/system/src/main/java/com/percussion/process/PSSimpleProcess.java
@@ -96,11 +96,11 @@ public class PSSimpleProcess implements IPSProcess {
   // see interface
   public PSProcessDef getProcessDef() {
     int os = PSProcessManager.getOS();
-    return (PSProcessDef) m_processDefs.get(Integer.valueOf(os));
+    return m_processDefs.get(Integer.valueOf(os));
   }
 
   // see interface
-  public PSProcessAction start(Map ctx) throws PSProcessException {
+  public PSProcessAction start(Map<String, String> ctx) throws PSProcessException {
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
     PSProcessDef pdef = getProcessDef();
     String[] cmdArray = getCommand(pdef, ctx);
@@ -120,7 +120,8 @@ public class PSSimpleProcess implements IPSProcess {
    *     directory is defined.
    * @throws PSProcessException if any error occurs resolving the working directory
    */
-  protected File getWorkingDir(PSProcessDef pdef, Map ctx) throws PSProcessException {
+  protected File getWorkingDir(PSProcessDef pdef, Map<String, String> ctx)
+      throws PSProcessException {
     if (pdef == null) throw new IllegalArgumentException("process definition may not be null");
 
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
@@ -140,7 +141,8 @@ public class PSSimpleProcess implements IPSProcess {
    * @throws PSProcessException if any error occurs resolving the executable or the command
    *     parameters
    */
-  protected String[] getCommand(PSProcessDef pdef, Map ctx) throws PSProcessException {
+  protected String[] getCommand(PSProcessDef pdef, Map<String, String> ctx)
+      throws PSProcessException {
     if (pdef == null) throw new IllegalArgumentException("process definition may not be null");
 
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
@@ -170,7 +172,7 @@ public class PSSimpleProcess implements IPSProcess {
    *     setting is specified.
    * @throws PSProcessException if any error occurs resolving the environment parameters
    */
-  protected String[] getEnv(PSProcessDef pdef, Map ctx) throws PSProcessException {
+  protected String[] getEnv(PSProcessDef pdef, Map<String, String> ctx) throws PSProcessException {
     if (ctx == null) throw new IllegalArgumentException("process context may not be null");
 
     if (pdef == null) throw new IllegalArgumentException("process definition may not be null");
@@ -188,7 +190,7 @@ public class PSSimpleProcess implements IPSProcess {
    * Map for storing the process definition (<code>PSProcessDef</code>) as value and the supported
    * OS (as <code>Integer</code>) as key. Never <code>null</code>.
    */
-  protected Map m_processDefs = new HashMap();
+  protected final Map<Integer, PSProcessDef> m_processDefs = new HashMap<>();
 
   /**
    * Stores the type of the function, initialized in the <code>fromXml</code> method, never modified

--- a/system/src/test/java/com/percussion/process/PSProcessPackageTypedTest.java
+++ b/system/src/test/java/com/percussion/process/PSProcessPackageTypedTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.process;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral tests for typed {@code com.percussion.process} collection APIs after rawtypes cleanup
+ * (#2299 / #2022 slice 5g).
+ */
+@Tag("UnitTest")
+@DisplayName("process package generics")
+class PSProcessPackageTypedTest {
+
+  @Test
+  @DisplayName("PSProcessManager loads typed process map from fixture")
+  void processManagerLoadsTypedMap() throws Exception {
+    try (InputStream in = getClass().getResourceAsStream("processes.xml")) {
+      assertNotNull(in, "test fixture processes.xml must be on test classpath");
+      PSProcessManager mgr = new PSProcessManager(in);
+      IPSProcess create = mgr.getProcess("sindex_create");
+      IPSProcess listing = mgr.getProcess("dirlisting");
+      assertNotNull(create);
+      assertEquals("sindex_create", create.getName());
+      assertEquals("com.percussion.process.PSSimpleProcess", create.getType());
+      assertNotNull(listing);
+      assertNull(mgr.getProcess("missing-process"));
+    }
+  }
+
+  @Test
+  @DisplayName("PSProcessDef resolves command params with typed String context")
+  void processDefResolvesTypedCommandParams() throws Exception {
+    try (InputStream in = getClass().getResourceAsStream("processes.xml")) {
+      assertNotNull(in);
+      PSProcessManager mgr = new PSProcessManager(in);
+      IPSProcess proc = mgr.getProcess("sindex_create");
+      assertNotNull(proc);
+      PSProcessDef def = proc.getProcessDef();
+      assertNotNull(def, "fixture defines process for current OS");
+
+      Map<String, String> ctx = new HashMap<>();
+      ctx.put("WORKING_DIR", "testdir");
+      ctx.put("RW_LIBRARY_NAME", "ce2");
+
+      assertEquals("sindex", def.getExecutable(ctx));
+      String[] params = def.getCommandParams(ctx);
+      assertNotNull(params);
+      assertTrue(params.length >= 4);
+      // Path resolver expands {WORKING_DIR}; value includes platform absolute form of testdir
+      boolean sawCfg = false;
+      boolean sawLibrary = false;
+      boolean sawNew = false;
+      boolean sawCreate = false;
+      for (String p : params) {
+        if (p != null && p.contains("config") && p.contains("rware.cfg")) {
+          sawCfg = true;
+        }
+        if ("-library".equals(p) || (p != null && p.contains("ce2"))) {
+          sawLibrary = true;
+        }
+        if ("-new".equals(p)) {
+          sawNew = true;
+        }
+        if ("-create".equals(p)) {
+          sawCreate = true;
+        }
+      }
+      assertTrue(sawCfg, "expected path-resolved cfg param");
+      assertTrue(sawLibrary, "expected library param from typed ctx");
+      assertTrue(sawNew);
+      assertTrue(sawCreate);
+    }
+  }
+
+  @Test
+  @DisplayName("PSBasicResolver expands templates from typed Map")
+  void basicResolverTypedContext() throws Exception {
+    IPSVariableResolver resolver = new PSBasicResolver();
+    Map<String, String> ctx = new HashMap<>();
+    ctx.put("HOST", "localhost");
+    ctx.put("PORT", "9992");
+    String expanded = resolver.getValue("{HOST}:{PORT}", ctx);
+    assertEquals("localhost:9992", expanded);
+  }
+
+  @Test
+  @DisplayName("PSLiteralResolver ignores context and returns value")
+  void literalResolverTypedContext() throws Exception {
+    PSLiteralResolver resolver = new PSLiteralResolver();
+    Map<String, String> ctx = new HashMap<>();
+    ctx.put("IGNORED", "x");
+    assertEquals("plain", resolver.resolve("plain", ctx));
+    assertEquals("", resolver.resolve(null, ctx));
+  }
+
+  @Test
+  @DisplayName("PSProcessRequest stores typed params and round-trips toXml")
+  void processRequestTypedParamsRoundTrip() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    env.put("HOST", "localhost");
+    env.put("PORT", "9992");
+    PSProcessRequest req = new PSProcessRequest("dirlisting", 5000, true, env);
+
+    Map<String, String> params = req.getParams();
+    assertEquals(2, params.size());
+    assertEquals("localhost", params.get("HOST"));
+    assertEquals("9992", params.get("PORT"));
+    assertEquals("dirlisting", req.getName());
+    assertEquals(5000, req.getWait());
+    assertTrue(req.isTerminate());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = req.toXml(doc);
+    PSProcessRequest restored = new PSProcessRequest(el);
+    assertEquals("dirlisting", restored.getName());
+    assertEquals(5000, restored.getWait());
+    assertTrue(restored.isTerminate());
+    assertEquals("localhost", restored.getParams().get("HOST"));
+    assertEquals("9992", restored.getParams().get("PORT"));
+  }
+
+  @Test
+  @DisplayName("PSProcessRequest rejects empty name")
+  void processRequestRejectsEmptyName() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSProcessRequest("  ", 0, false, Map.of()));
+  }
+
+  @Test
+  @DisplayName("start rejects null typed context")
+  void startRejectsNullContext() throws Exception {
+    try (InputStream in = getClass().getResourceAsStream("processes.xml")) {
+      assertNotNull(in);
+      IPSProcess proc = new PSProcessManager(in).getProcess("dirlisting");
+      assertNotNull(proc);
+      assertThrows(IllegalArgumentException.class, () -> proc.start(null));
+    }
+  }
+
+  @Test
+  @DisplayName("getValue rejects null context")
+  void getValueRejectsNullContext() {
+    IPSVariableResolver resolver = new PSBasicResolver();
+    assertThrows(IllegalArgumentException.class, () -> resolver.getValue("x", null));
+  }
+
+  @Test
+  @DisplayName("PSProcessManager OS helpers remain stable")
+  void processManagerOsHelpers() throws Exception {
+    assertTrue(PSProcessManager.getOS() >= 0);
+    String name = PSProcessManager.getOSType(PSProcessManager.getOS());
+    assertNotNull(name);
+    assertFalse(name.isEmpty());
+    assertEquals(PSProcessManager.OS_WIN, PSProcessManager.getOSType("win"));
+  }
+}


### PR DESCRIPTION
## Summary
Partial fix for **#2299** (parent epic **#2022**, grandparent **#2200**).

PR-sized **`com.percussion.process`** `-Xlint` rawtypes/unchecked batch with real generics. Avoided open search/objectstore/HTTPClient slices.

### Changed
- `IPSProcess` / `IPSVariableResolver` / `IPSCommandHandler` — typed `Map` parameters
- `PSSimpleProcess`, `PSProcessDef`, resolvers — `Map<String,String>` / `Map<String,?>` context; `List<String>` / `List<PSParamDef>` builders
- `PSProcessManager` — `Map<String,IPSProcess>`
- `PSLocalCommandHandler` / `PSRemoteCommandHandler` — typed env/params; `List<Object>` for daemon command payloads
- `PSProcessDaemon` — `List<?>` sendCommand, `List<byte[]>` handlers, `Map<String,String>` proc env, `Set<String>` IP filters
- `PSProcessRequest` — `Map<String,String>` params + typed toXml iteration
- Resolver instantiation via `getDeclaredConstructor().newInstance()`

### Out of scope (residual)
- #2877 — remaining install/server/services/security/xml/extension rawtypes under #2299

## Test plan
- [x] `cd system && ../mvnw.cmd test -Dtest=PSProcessPackageTypedTest,PSLocalCommandHandlerSecurityTest,PSProcessDaemonPathInjectionTest` → Tests run: 40, Failures: 0
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**, **Tests run: 1697, Failures: 0, Errors: 0, Skipped: 240**
- [x] No new product-facing behavior; typing only

## Product documentation
- [x] N/A — pure tech-debt generics/`-Xlint` cleanup; no operator/user/API behavior change

## Gates / evidence
- Erlang self-review: PASS — `docs/ai-generated/code-reviews/issue-2299-process-rawtypes-erlang.md`
- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1697, Failures: 0
- **downstream_checked:** grepped `extends PSSimpleProcess` / `implements IPSProcess|IPSCommandHandler|IPSVariableResolver` — only in-package implementors; cactus module not in reactor
- Operator: Grok: night-issue-prs (model grok-4.5)

## Links
- Partial: #2299
- Residual: #2877
- Parent tracker: #2022
- Related: #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.
