### PR TITLE
cluster(auditlog): absorb ErrorCodes thrash #2866 #2867 #2868

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -12,7 +12,11 @@ System-wide Percussion CMS audit logging and unified error-code support.
 * **Phase 2b:** `SecurityErrorCodes` (full SEC range), `ContentErrorCodes`, `WorkflowErrorCodes`,
   `PathItemErrorCodes` (CMS path/item/folder), `DesignErrorCodes` (design lifecycle + objectstore ACL),
   `ServerErrorCodes` (`IPSServerErrors`), `HttpErrorCodes` (`IPSHttpErrors`, all non-auditable),
-  `JobErrorCodes` (`IPSJobErrors`; only non-colliding int `11` in flat registry)
+  `JobErrorCodes` (`IPSJobErrors`; only non-colliding int `11` in flat registry),
+  `ExtensionErrorCodes` (globally unique; auth/checkout dual-write),
+  `AssemblyErrorCodes` (package-local 11–27 flat-registered), `DeliveryErrorCodes` (enum-only),
+  `WebserviceErrorCodes` (package-local 28–73), `ServerWebServicesErrorCodes`, `WebdavErrorCodes`,
+  `ServletErrorCodes`, `TransformationErrorCodes` (enum-only)
   + `LegacyErrorCodeRegistry` bridge legacy `IPS*Errors` ints. Non-auditable / unregistered ints never
   dual-write. Central `PSErrorHandler.appendError` dual-writes only when the registry marks the legacy
   int auditable.
@@ -58,13 +62,21 @@ audit.log(
 
 ```java
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 
 // Prefer enum when available:
@@ -83,7 +95,7 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 1101, ctx, "sess", "/app"); // SYS
 LegacyErrorCodeRegistry.logIfAuditable(audit, 1001, ctx); // SYS native — non-auditable skip
 LegacyErrorCodeRegistry.logIfAuditable(audit, 401, ctx); // HTTP status — non-auditable skip
 // Prefer JobErrorCodes enum for job ints 1–10 (flat registry keeps WF ownership of 1–10)
-// Provider/config/conversion/path/design/server/http/job noise (isAuditable=false) and unknown ints → no dual-write
+// Provider/config/conversion/path/design/server/http/job/assembly/extension/webservice noise (isAuditable=false) and unknown ints → no dual-write
 ```
 
 | Catalog | Ranges | Notes |
@@ -95,7 +107,15 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 401, ctx); // HTTP status — non-
 | `DesignErrorCodes` | Design lifecycle + objectstore ACL (e.g. 2353) | Design server ACL bridge |
 | `ServerErrorCodes` | 1001–1709 (`IPSServerErrors`) | Authz/login/community auditable; rest operational |
 | `HttpErrorCodes` | HTTP status (`IPSHttpErrors`) | All non-auditable protocol codes |
-| `JobErrorCodes` | 1–11 (`IPSJobErrors`) | All non-auditable; registry only int `11` (1–10 = WF) |
+| `JobErrorCodes` | 1–11 (`IPSJobErrors`) | All non-auditable; registry only int `11` (1–10 = WF; wins flat 11 over assembly) |
+| `ExtensionErrorCodes` | 7001–7039, 7301–7304, 7401–7480, 7621–7636 | Globally unique; auth/checkout dual-write |
+| `AssemblyErrorCodes` | package-local 1–27 (flat-registers 11–27 only) | WF owns bare 1–10; all non-auditable; prefer enum for 11 |
+| `DeliveryErrorCodes` | package-local 1–12 (no flat register) | Prefer enum; decrypt-credentials auditable |
+| `WebserviceErrorCodes` | package-local 1–73 (flat-registers 28–73) | Authz dual-write; skip 1–27 (WF/assembly) |
+| `ServerWebServicesErrorCodes` | 14001+ (`IPSWebServicesErrors`) | Login/auth dual-write; content not-found skip |
+| `WebdavErrorCodes` | 70101+ (`IPSWebdavErrors`) | All non-auditable protocol/ops codes |
+| `ServletErrorCodes` | 10151+ (`IPSServletErrors`) | All non-auditable |
+| `TransformationErrorCodes` | package-local (no flat register) | Prefer enum; WF collision on bare 1 |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -16,13 +16,21 @@
  */
 package com.intsof.percussioncms.auditlog;
 
+import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import java.util.Map;
 import java.util.Objects;
@@ -38,8 +46,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * (content lifecycle + conversion), {@link WorkflowErrorCodes} (workflow transition + service),
  * {@link PathItemErrorCodes} (CMS path/item/folder), {@link DesignErrorCodes} (design lifecycle +
  * objectstore ACL), {@link ServerErrorCodes} ({@code IPSServerErrors}), {@link HttpErrorCodes}
- * ({@code IPSHttpErrors}, all non-auditable), and non-colliding {@link JobErrorCodes} ints. Residual
- * slices may register additional catalogs via {@link #register(int, SystemErrorCode)}.
+ * ({@code IPSHttpErrors}, all non-auditable), non-colliding {@link JobErrorCodes} ints, {@link
+ * ExtensionErrorCodes} (globally unique extension ints), non-colliding {@link AssemblyErrorCodes}
+ * package-local ints, non-colliding {@link WebserviceErrorCodes} package-local ints (28–73), fully
+ * unique {@link ServerWebServicesErrorCodes} / {@link WebdavErrorCodes} / {@link ServletErrorCodes},
+ * and bootstrap-only {@link TransformationErrorCodes} / {@link DeliveryErrorCodes} (no flat
+ * register). Residual slices may register additional catalogs via {@link #register(int,
+ * SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -53,9 +66,14 @@ public final class LegacyErrorCodeRegistry {
 
   /**
    * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design,
-   * server, HTTP, job). Safe to call repeatedly; catalogs register themselves in their own static
-   * initializers. {@link JobErrorCodes} skips package-local ints {@code 1–10} that collide with
-   * {@link WorkflowErrorCodes} in this flat map.
+   * server, HTTP, assembly, extension, delivery, job, webservices, WebDAV, servlet,
+   * transformation). Safe to call repeatedly; catalogs register themselves in their own static
+   * initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip package-local ints
+   * {@code 1–10} that collide with {@link WorkflowErrorCodes}. {@link JobErrorCodes} is
+   * bootstrapped after assembly so flat int {@code 11} ({@code CONFIG_FILE_NOT_FOUND}) wins over
+   * assembly package-local {@code MISSING_SLOT} (prefer enum for assembly {@code 11}). {@link
+   * WebserviceErrorCodes} skips package-local ints {@code 1–27}; {@link TransformationErrorCodes}
+   * and {@link DeliveryErrorCodes} do not flat-register.
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
@@ -66,7 +84,20 @@ public final class LegacyErrorCodeRegistry {
       DesignErrorCodes.ensureRegistered();
       ServerErrorCodes.ensureRegistered();
       HttpErrorCodes.ensureRegistered();
+      // Assembly after Workflow so package-local 11–27 do not fight WF ownership of 1–10.
+      AssemblyErrorCodes.ensureRegistered();
+      ExtensionErrorCodes.ensureRegistered();
+      // Delivery: no-op flat register (WF/assembly collisions); enum still loadable.
+      DeliveryErrorCodes.ensureRegistered();
+      // Job after Assembly so flat int 11 (CONFIG_FILE_NOT_FOUND) wins over assembly 11.
       JobErrorCodes.ensureRegistered();
+      // Wire-facing residual (#2865): non-colliding webservice ints after assembly 11–27.
+      WebserviceErrorCodes.ensureRegistered();
+      ServerWebServicesErrorCodes.ensureRegistered();
+      WebdavErrorCodes.ensureRegistered();
+      ServletErrorCodes.ensureRegistered();
+      // Transformation: no-op flat register (WF collision on bare int 1).
+      TransformationErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AssemblyErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/AssemblyErrorCodes.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Assembly error catalog bridging legacy {@code com.percussion.services.assembly.IPSAssemblyErrors}
+ * package-local ints (1–27: template, assembler, slot, finder, binary hash, inline).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: assembly failures are
+ * operational / rendering noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–10} already belong to
+ * {@link WorkflowErrorCodes} in {@link LegacyErrorCodeRegistry}. This catalog therefore registers
+ * only non-colliding ints ({@code 11–27}). Call sites should prefer this enum directly for ints
+ * {@code 1–10} until a composite-key registry exists. Module code is {@link AuditModule#PUB}.
+ */
+public enum AssemblyErrorCodes implements SystemErrorCode {
+
+  TEMPLATE_MISSING(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Template missing",
+      "Template missing detail={}"),
+
+  ASSEMBLER_MISSING(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Assembler missing",
+      "Assembler missing detail={}"),
+
+  ASSEMBLER_INST(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Assembler inst",
+      "Assembler inst detail={}"),
+
+  PARAMS_VARIANT_OR_TEMPLATE(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Params variant or template",
+      "Params variant or template detail={}"),
+
+  UNKNOWN_ERROR(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown error",
+      "Unknown error detail={}"),
+
+  PARAMS_AUTHTYPE_OR_FILTER(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Params authtype or filter",
+      "Params authtype or filter detail={}"),
+
+  PARAMS_ITEM_SPEC(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Params item spec",
+      "Params item spec detail={}"),
+
+  INVALID_PATH(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid path",
+      "Invalid path detail={}"),
+
+  MISSING_PATH(
+      9,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing path",
+      "Missing path detail={}"),
+
+  UNKNOWN_CRUD_ERROR(
+      10,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown crud error",
+      "Unknown crud error detail={}"),
+
+  MISSING_SLOT(
+      11,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing slot",
+      "Missing slot detail={}"),
+
+  MISSING_FINDER(
+      12,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing finder",
+      "Missing finder detail={}"),
+
+  ITEM_CREATION(
+      13,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Item creation",
+      "Item creation detail={}"),
+
+  LANDING_PAGE_URL_1(
+      14,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Landing page url 1",
+      "Landing page url 1 detail={}"),
+
+  MISSING_PAGELINK(
+      15,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing pagelink",
+      "Missing pagelink detail={}"),
+
+  TEMPLATE_BY_ID_MISSING(
+      16,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Template by id missing",
+      "Template by id missing detail={}"),
+
+  NO_DEFAULT_TEMPLATE(
+      17,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No default template",
+      "No default template detail={}"),
+
+  NAME_NOT_UNIQUE(
+      18,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Name not unique",
+      "Name not unique detail={}"),
+
+  FINDER_ERROR(
+      19,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Finder error",
+      "Finder error detail={}"),
+
+  PARAMS_ITEM_ID_MISMATCH(
+      20,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Params item id mismatch",
+      "Params item id mismatch detail={}"),
+
+  PARAMS_ITEM_FOLDER_MISMATCH(
+      21,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Params item folder mismatch",
+      "Params item folder mismatch detail={}"),
+
+  HASHED_BINARY_NOT_FOUND(
+      22,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Hashed binary not found",
+      "Hashed binary not found detail={}"),
+
+  HASHED_BINARY_NO_HASH(
+      23,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Hashed binary no hash",
+      "Hashed binary no hash detail={}"),
+
+  HASHED_BINARY_ERROR(
+      24,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Hashed binary error",
+      "Hashed binary error detail={}"),
+
+  INLINE_TEMPLATE_NON_HTML(
+      25,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Inline template non html",
+      "Inline template non html detail={}"),
+
+  INLINE_TEMPLATE_ERROR(
+      26,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Inline template error",
+      "Inline template error detail={}"),
+
+  INLINE_LINK_ERROR(
+      27,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Inline link error",
+      "Inline link error detail={}");
+
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  AssemblyErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register non-colliding assembly ints in {@link LegacyErrorCodeRegistry}. Safe to call repeatedly.
+   * Skips package-local ints {@code 1–10} that collide with {@link WorkflowErrorCodes}.
+   */
+  public static void ensureRegistered() {
+    for (AssemblyErrorCodes code : values()) {
+      if (code.numericCode <= 10) {
+        // Preserve WorkflowErrorCodes ownership of bare ints 1–10 in the flat registry.
+        continue;
+      }
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.PUB;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/DeliveryErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/DeliveryErrorCodes.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Delivery error catalog bridging legacy {@code com.percussion.rx.delivery.IPSDeliveryErrors}
+ * package-local ints (1–12: abort, directory, copy, temp write, credentials, Amazon, Solr).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: credential decrypt failures are
+ * security-relevant when observed via this enum; other delivery I/O noise is not.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–10} already belong to
+ * {@link WorkflowErrorCodes}; ints {@code 11–12} are claimed by {@link AssemblyErrorCodes} (and
+ * residual job catalogs). This catalog therefore does <strong>not</strong> flat-register any
+ * ints. Call sites should prefer this enum directly (including {@link
+ * #COULD_NOT_DECRYPT_CREDENTIALS}) until a composite-key registry exists. Module code is {@link
+ * AuditModule#PUB}.
+ */
+public enum DeliveryErrorCodes implements SystemErrorCode {
+
+  ABORT_FAILURE(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Abort failure",
+      "Abort failure detail={}"),
+
+  DIR_CANT_CREATE(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dir cant create",
+      "Dir cant create detail={}"),
+
+  CREATE_DIR_W_EXCEPTION(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Create dir w exception",
+      "Create dir w exception detail={}"),
+
+  COPY_FILE_FAILED(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Copy file failed",
+      "Copy file failed detail={}"),
+
+  UNEXPECTED_ERROR(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected error",
+      "Unexpected error detail={}"),
+
+  COULD_NOT_WRITE_TEMP(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Could not write temp",
+      "Could not write temp detail={}"),
+
+  COULD_NOT_DECRYPT_CREDENTIALS(
+      7,
+      true,
+      AuditEventType.OTHER,
+      AuditOutcome.FAILURE,
+      "Could not decrypt credentials",
+      "Could not decrypt credentials detail={}"),
+
+  COULD_NOT_COPY_TO_AMAMZON(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Could not copy to amamzon",
+      "Could not copy to amamzon detail={}"),
+
+  COULD_NOT_DELETE_FROM_AMAZON(
+      9,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Could not delete from amazon",
+      "Could not delete from amazon detail={}"),
+
+  BAD_DELIVERY_SERVER_CONFIGURATION(
+      10,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Bad delivery server configuration",
+      "Bad delivery server configuration detail={}"),
+
+  SOLR_COMMUNICATION_EXCEPTION(
+      11,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Solr communication exception",
+      "Solr communication exception detail={}"),
+
+  CANNOT_DELIVER_NO_DELIVERYTYPE(
+      12,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot deliver no deliverytype",
+      "Cannot deliver no deliverytype detail={}");
+
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  DeliveryErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat {@link com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry}: every
+   * package-local delivery int collides with {@link WorkflowErrorCodes} (1–10) or {@link
+   * AssemblyErrorCodes} (11–12). Prefer this enum directly for dual-write decisions. Safe to call
+   * repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.PUB;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ExtensionErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ExtensionErrorCodes.java
@@ -1,0 +1,1144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Extension error catalog bridging legacy {@code com.percussion.extension.IPSExtensionErrors}
+ * ints (7001–7039 extension framework, 7301–7304 JS, 7401–7480 workflow/exit, 7621–7636
+ * folder/JEXL/scheme).
+ *
+ * <p>{@link #numericCode()} preserves historical globally unique ints so exception constructors
+ * and bundles stay stable. Every constant sets {@link #isAuditable()} explicitly:
+ * authentication / authorization / checkout-checkin security failures dual-write;
+ * parameter validation, installer, JS compile, and effect processing noise does not.
+ *
+ * <p>Module code is {@link AuditModule#SYS}. All ints are registered in the flat
+ * {@link LegacyErrorCodeRegistry} (no package-local collision).
+ */
+public enum ExtensionErrorCodes implements SystemErrorCode {
+
+  BACKEND_COLUMN_ERROR(
+      7001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Backend column error",
+      "Backend column error detail={}"),
+
+  UNKNOWN_PARAMETER_TYPE(
+      7002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown parameter type",
+      "Unknown parameter type detail={}"),
+
+  CATALOG_EXT_RESOURCE_ERROR(
+      7003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog ext resource error",
+      "Catalog ext resource error detail={}"),
+
+  EXT_MISSING_REQUIRED_PARAMETER_ERROR(
+      7004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext missing required parameter error",
+      "Ext missing required parameter error detail={}"),
+
+  EXT_MISSING_HTML_PARAMETER_ERROR(
+      7005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext missing html parameter error",
+      "Ext missing html parameter error detail={}"),
+
+  EXT_PARAM_VALUE_MISMATCH(
+      7006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext param value mismatch",
+      "Ext param value mismatch detail={}"),
+
+  EXT_PARAM_VALUE_INVALID(
+      7007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext param value invalid",
+      "Ext param value invalid detail={}"),
+
+  EXT_INSTALLER_DEPLOY_NAME_EXPECTED(
+      7008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext installer deploy name expected",
+      "Ext installer deploy name expected detail={}"),
+
+  EXT_INSTALLER_UNSUPPORTED_RESOURCE(
+      7009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext installer unsupported resource",
+      "Ext installer unsupported resource detail={}"),
+
+  EXT_INSTALLER_RESOURCE_NOT_EXITING(
+      7010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext installer resource not exiting",
+      "Ext installer resource not exiting detail={}"),
+
+  EXT_INSTALLER_RESOURCE_NOT_READABLE(
+      7011,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext installer resource not readable",
+      "Ext installer resource not readable detail={}"),
+
+  EXT_PROCESSOR_EXCEPTION(
+      7012,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext processor exception",
+      "Ext processor exception detail={}"),
+
+  UNEXPECTED_EXT_TYPE_EXCEPTION(
+      7013,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected ext type exception",
+      "Unexpected ext type exception detail={}"),
+
+  EXT_HANDLER_LOAD_UNLOAD_ERROR(
+      7014,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext handler load unload error",
+      "Ext handler load unload error detail={}"),
+
+  EXT_HANDLER_PREPARE_ERROR(
+      7015,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext handler prepare error",
+      "Ext handler prepare error detail={}"),
+
+  EXT_HANDLER_DEF_STORE_ERROR(
+      7016,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext handler def store error",
+      "Ext handler def store error detail={}"),
+
+  EXT_INSTALL_UPDATE_ERROR(
+      7017,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext install update error",
+      "Ext install update error detail={}"),
+
+  EXT_RESOURCE_STORE_ERROR(
+      7018,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext resource store error",
+      "Ext resource store error detail={}"),
+
+  EXT_RESOURCE_DELETE_ERROR(
+      7019,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext resource delete error",
+      "Ext resource delete error detail={}"),
+
+  EXT_NOT_FOUND(
+      7020,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext not found",
+      "Ext not found detail={}"),
+
+  EXT_ALREADY_EXISTS(
+      7021,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext already exists",
+      "Ext already exists detail={}"),
+
+  EXT_MANAGER_INIT_FAILED(
+      7022,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext manager init failed",
+      "Ext manager init failed detail={}"),
+
+  EXT_MANAGER_SHUTDOWN_FAILED(
+      7023,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext manager shutdown failed",
+      "Ext manager shutdown failed detail={}"),
+
+  EXT_HANDLER_INIT_FAILED(
+      7024,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext handler init failed",
+      "Ext handler init failed detail={}"),
+
+  EXT_HANDLER_SHUTDOWN_FAILED(
+      7025,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext handler shutdown failed",
+      "Ext handler shutdown failed detail={}"),
+
+  EXT_INIT_FAILED(
+      7026,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Ext init failed",
+      "Ext init failed detail={}"),
+
+  INVALID_EXT_TYPE_EXCEPTION(
+      7027,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid ext type exception",
+      "Invalid ext type exception detail={}"),
+
+  UNKNOWN_EFFECT_PROCESSING_ERROR(
+      7028,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown effect processing error",
+      "Unknown effect processing error detail={}"),
+
+  INVALID_XML_ELEMENT(
+      7029,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid xml element",
+      "Invalid xml element detail={}"),
+
+  MISSING_REQUIRED_ATTRIBUTE(
+      7030,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing required attribute",
+      "Missing required attribute detail={}"),
+
+  CLASS_NOT_FOUND(
+      7031,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Class not found",
+      "Class not found detail={}"),
+
+  INVALID_NULL_PARAMS(
+      7032,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid null params",
+      "Invalid null params detail={}"),
+
+  MISSING_REQUIRED_PARAM_NO(
+      7033,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing required param no",
+      "Missing required param no detail={}"),
+
+  INVALID_STRING_PARAM(
+      7034,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid string param",
+      "Invalid string param detail={}"),
+
+  INVALID_NUMBER_PARAM(
+      7035,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid number param",
+      "Invalid number param detail={}"),
+
+  INVALID_BOOLEAN_PARAM(
+      7036,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid boolean param",
+      "Invalid boolean param detail={}"),
+
+  INVALID_DATE_PARAM(
+      7037,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid date param",
+      "Invalid date param detail={}"),
+
+  INVALID_INDEX_VALUE(
+      7038,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid index value",
+      "Invalid index value detail={}"),
+
+  INVALID_NUMBER_DEFAULT(
+      7039,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid number default",
+      "Invalid number default detail={}"),
+
+  JS_COMPILE_FAILED(
+      7301,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Js compile failed",
+      "Js compile failed detail={}"),
+
+  JS_COMPILE_FAILED_SRC(
+      7302,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Js compile failed src",
+      "Js compile failed src detail={}"),
+
+  JS_CALL_FAILED(
+      7303,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Js call failed",
+      "Js call failed detail={}"),
+
+  JS_CALL_FAILED_SRC(
+      7304,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Js call failed src",
+      "Js call failed src detail={}"),
+
+  SET_EMPTYXML_STYLESHEET_NULL_SS(
+      7401,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Set emptyxml stylesheet null ss",
+      "Set emptyxml stylesheet null ss detail={}"),
+
+  SET_EMPTYXML_STYLESHEET_INVALID_URL(
+      7402,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Set emptyxml stylesheet invalid url",
+      "Set emptyxml stylesheet invalid url detail={}"),
+
+  MISSING_HTML_PARAMETER(
+      7403,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing html parameter",
+      "Missing html parameter detail={}"),
+
+  COMMUNITIES_AUTHENTICATION_FAILED_NOCOMMUNITY(
+      7404,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Communities authentication failed nocommunity",
+      "Communities authentication failed nocommunity detail={}"),
+
+  COMMUNITIES_AUTHENTICATION_FAILED_INVALID_COMMUNITY(
+      7405,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Communities authentication failed invalid community",
+      "Communities authentication failed invalid community detail={}"),
+
+  EMPTY_USRNAME1(
+      7406,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Empty usrname1",
+      "Empty usrname1 detail={}"),
+
+  EMPTY_USRNAME2(
+      7407,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Empty usrname2",
+      "Empty usrname2 detail={}"),
+
+  EMPTY_ROLE_LIST(
+      7408,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Empty role list",
+      "Empty role list detail={}"),
+
+  INVALID_WORKFLOWID(
+      7409,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid workflowid",
+      "Invalid workflowid detail={}"),
+
+  ILLEGAL_CONTENTTYPE(
+      7410,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Illegal contenttype",
+      "Illegal contenttype detail={}"),
+
+  ILLEGAL_IF_CHECKEDOUT(
+      7411,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Illegal if checkedout",
+      "Illegal if checkedout detail={}"),
+
+  ILLEGAL_IFNOT_CHECKEDOUT(
+      7412,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Illegal ifnot checkedout",
+      "Illegal ifnot checkedout detail={}"),
+
+  ROLE_ERROR_STATEID_WORKFLOWID(
+      7413,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Role error stateid workflowid",
+      "Role error stateid workflowid detail={}"),
+
+  ROLES_NOT_ASSIGNED(
+      7414,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Roles not assigned",
+      "Roles not assigned detail={}"),
+
+  AUTHENTICATION_FAILED1(
+      7415,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Authentication failed1",
+      "Authentication failed1 detail={}"),
+
+  AUTHENTICATION_FAILED2(
+      7416,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Authentication failed2",
+      "Authentication failed2 detail={}"),
+
+  WKFLOW_ACTIONLIST_EMPTY(
+      7417,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Wkflow actionlist empty",
+      "Wkflow actionlist empty detail={}"),
+
+  WKFLOW_CONTEXT_NULL(
+      7418,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Wkflow context null",
+      "Wkflow context null detail={}"),
+
+  INVALID_WKFLOW_EXT(
+      7419,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid wkflow ext",
+      "Invalid wkflow ext detail={}"),
+
+  EXEC_EXT_NOTFOUND(
+      7420,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec ext notfound",
+      "Exec ext notfound detail={}"),
+
+  STATUS_DOC_EMPTY(
+      7421,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Status doc empty",
+      "Status doc empty detail={}"),
+
+  CONTENTID_NODENAME_EMPTY(
+      7422,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Contentid nodename empty",
+      "Contentid nodename empty detail={}"),
+
+  CONTENTID_NODE_MISSING_EMPTY(
+      7423,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Contentid node missing empty",
+      "Contentid node missing empty detail={}"),
+
+  CONTENTID_NODE_MISSING(
+      7424,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Contentid node missing",
+      "Contentid node missing detail={}"),
+
+  EXIT_PARAM_NULL(
+      7425,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exit param null",
+      "Exit param null detail={}"),
+
+  CONTENTID_NULL(
+      7426,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Contentid null",
+      "Contentid null detail={}"),
+
+  PUBDOC_UPDATE_ERROR(
+      7427,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Pubdoc update error",
+      "Pubdoc update error detail={}"),
+
+  HTML_PARAM_NULL1(
+      7428,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Html param null1",
+      "Html param null1 detail={}"),
+
+  HTML_PARAM_NULL2(
+      7429,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Html param null2",
+      "Html param null2 detail={}"),
+
+  TABLE_NAME_NULL(
+      7430,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table name null",
+      "Table name null detail={}"),
+
+  PRIMARY_KEY_NULL(
+      7431,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Primary key null",
+      "Primary key null detail={}"),
+
+  ROLEINFO_OBJ_NULL(
+      7432,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Roleinfo obj null",
+      "Roleinfo obj null detail={}"),
+
+  ROLELIST_EMPTY(
+      7433,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Rolelist empty",
+      "Rolelist empty detail={}"),
+
+  INVALID_PARAM_NUM(
+      7434,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid param num",
+      "Invalid param num detail={}"),
+
+  ADMIN_CHECKOUT_ONLY(
+      7435,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Admin checkout only",
+      "Admin checkout only detail={}"),
+
+  INVALID_TRANSITION_ROLE(
+      7436,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Invalid transition role",
+      "Invalid transition role detail={}"),
+
+  TRANSITION_COMMENT_NOT_SPECIFIED(
+      7437,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Transition comment not specified",
+      "Transition comment not specified detail={}"),
+
+  DOC_NOT_CHECKEDOUT(
+      7438,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Doc not checkedout",
+      "Doc not checkedout detail={}"),
+
+  EDIT_REVISION_MISSING(
+      7439,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Edit revision missing",
+      "Edit revision missing detail={}"),
+
+  CHECKIN_REVISION_MISMATCH(
+      7440,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Checkin revision mismatch",
+      "Checkin revision mismatch detail={}"),
+
+  CHECKIN_NOT_ALLOWED(
+      7441,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Checkin not allowed",
+      "Checkin not allowed detail={}"),
+
+  CHECKOUT_NOT_ALLOWED(
+      7442,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Checkout not allowed",
+      "Checkout not allowed detail={}"),
+
+  CHECKOUT_REVISION_MISMATCH(
+      7443,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Checkout revision mismatch",
+      "Checkout revision mismatch detail={}"),
+
+  CHECKOUT_REVISION_LIMIT(
+      7444,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Checkout revision limit",
+      "Checkout revision limit detail={}"),
+
+  TRANSITION_ATTEMPT(
+      7445,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Transition attempt",
+      "Transition attempt detail={}"),
+
+  MAIL_DOMAIN_NULL(
+      7446,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail domain null",
+      "Mail domain null detail={}"),
+
+  MAIL_DOMAIN_EMPTY(
+      7447,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail domain empty",
+      "Mail domain empty detail={}"),
+
+  SMTP_HOST_NULL(
+      7448,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Smtp host null",
+      "Smtp host null detail={}"),
+
+  SMTP_HOST_EMPTY(
+      7449,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Smtp host empty",
+      "Smtp host empty detail={}"),
+
+  USERNAME_NULL_EMPTY_TRIM(
+      7450,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Username null empty trim",
+      "Username null empty trim detail={}"),
+
+  INVALID_ADHOC(
+      7451,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid adhoc",
+      "Invalid adhoc detail={}"),
+
+  STATEROLE_NULL_EMPTY_TRIM(
+      7452,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Staterole null empty trim",
+      "Staterole null empty trim detail={}"),
+
+  NO_RECORDS(
+      7453,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No records",
+      "No records detail={}"),
+
+  ADHOC_ASSIGNMENT_NOT_FOUND(
+      7454,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Adhoc assignment not found",
+      "Adhoc assignment not found detail={}"),
+
+  TRANSLATION_ALREADY_EXISTS(
+      7455,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Translation already exists",
+      "Translation already exists detail={}"),
+
+  ILLEGAL_IF_CHECKEDOUT_OVERRIDE(
+      7456,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Illegal if checkedout override",
+      "Illegal if checkedout override detail={}"),
+
+  VALIDATE_SLOTNAME_NOT_UNIQUE(
+      7457,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Validate slotname not unique",
+      "Validate slotname not unique detail={}"),
+
+  CHECKOUT_FROM_PUBLIC_STATE(
+      7458,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Checkout from public state",
+      "Checkout from public state detail={}"),
+
+  INVALID_TRANSITION(
+      7459,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid transition",
+      "Invalid transition detail={}"),
+
+  MISSING_TRANSITION(
+      7460,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing transition",
+      "Missing transition detail={}"),
+
+  AUTHENTICATION_FAILED_DIFFERENT_ITEM_USER_COMMUNITIES(
+      7461,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Authentication failed different item user communities",
+      "Authentication failed different item user communities detail={}"),
+
+  ILLEGAL_EXECUTION_CONTEXT(
+      7462,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Illegal execution context",
+      "Illegal execution context detail={}"),
+
+  NONPROMOTABLE_RELATIONSHIP(
+      7463,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Nonpromotable relationship",
+      "Nonpromotable relationship detail={}"),
+
+  WORKFLOWID_IN_REQUEST_ISNULL(
+      7464,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Workflowid in request isnull",
+      "Workflowid in request isnull detail={}"),
+
+  INVALID_WORKFLOW_ACTION(
+      7465,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid workflow action",
+      "Invalid workflow action detail={}"),
+
+  ITEM_NOT_IN_PUBLIC_STATE(
+      7466,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Item not in public state",
+      "Item not in public state detail={}"),
+
+  EFFECT_SELF_TRIGGERED(
+      7467,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Effect self triggered",
+      "Effect self triggered detail={}"),
+
+  INVALID_OPTION_FOR_FORCETRANSITION(
+      7468,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid option for forcetransition",
+      "Invalid option for forcetransition detail={}"),
+
+  INVALID_TRANSITION_FOR_EFFECT(
+      7469,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid transition for effect",
+      "Invalid transition for effect detail={}"),
+
+  MISSING_INTERNAL_REQUEST_RESOURCE(
+      7470,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing internal request resource",
+      "Missing internal request resource detail={}"),
+
+  DEPENDENT_ITEM_NOT_IN_DESIRED_STATE(
+      7471,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dependent item not in desired state",
+      "Dependent item not in desired state detail={}"),
+
+  DEPENDENT_ITEM_CANNOT_GOTO_DESIRED_STATE(
+      7472,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dependent item cannot goto desired state",
+      "Dependent item cannot goto desired state detail={}"),
+
+  EFFECT_VALIDATE_MESSAGE(
+      7473,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Effect validate message",
+      "Effect validate message detail={}"),
+
+  PROMOTE_TRANSITION_FAILED(
+      7474,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Promote transition failed",
+      "Promote transition failed detail={}"),
+
+  BAD_PUBLISH_CONTENT_INITIALIZATION_DATA(
+      7475,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Bad publish content initialization data",
+      "Bad publish content initialization data detail={}"),
+
+  BAD_PUBLISH_CONTENT_FILE_DATA(
+      7476,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Bad publish content file data",
+      "Bad publish content file data detail={}"),
+
+  AUTHTYPE_REGISTRATION_MISSING(
+      7477,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Authtype registration missing",
+      "Authtype registration missing detail={}"),
+
+  AUTHTYPE_RESOURCE_MISSING(
+      7478,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Authtype resource missing",
+      "Authtype resource missing detail={}"),
+
+  WF_COMMENT_CANNOT_EXCEED_255(
+      7479,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Wf comment cannot exceed 255",
+      "Wf comment cannot exceed 255 detail={}"),
+
+  MANDATORY_TRANSITION_VALIDATION_FAILURE(
+      7480,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mandatory transition validation failure",
+      "Mandatory transition validation failure detail={}"),
+
+  VARIANT_HAS_RELATIONSHIPS_ERROR(
+      7621,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Variant has relationships error",
+      "Variant has relationships error detail={}"),
+
+  FOLDER_PATH_ERROR(
+      7622,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Folder path error",
+      "Folder path error detail={}"),
+
+  JEXL_WRONG_RETURN_TYPE(
+      7623,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Jexl wrong return type",
+      "Jexl wrong return type detail={}"),
+
+  JEXL_EVALUATION_FAILED(
+      7634,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Jexl evaluation failed",
+      "Jexl evaluation failed detail={}"),
+
+  ERROR_GETTING_FOLDER_NAMES(
+      7635,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Error getting folder names",
+      "Error getting folder names detail={}"),
+
+  SCHEME_CANT_BE_FOUND(
+      7636,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Scheme cant be found",
+      "Scheme cant be found detail={}");
+
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  ExtensionErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ExtensionErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodes.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Legacy server webservices error catalog bridging {@code
+ * com.percussion.server.webservices.IPSWebServicesErrors} ints (14001–14026).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: login failure and unauthorized client /
+ * checkout-user denials dual-write; content/search operational noise does not.
+ *
+ * <p>All ints are globally unique in the historical error map and are fully flat-registered in
+ * {@link LegacyErrorCodeRegistry}. Module code is {@link AuditModule#SYS}.
+ */
+public enum ServerWebServicesErrorCodes implements SystemErrorCode {
+
+  WEB_SERVICE_CONTENT_ITEM_NOT_FOUND(
+      14001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service content item not found",
+      "Web service content item not found detail={}"),
+
+  WEB_SERVICE_CHECKOUT_FAILURE(
+      14002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service checkout failure",
+      "Web service checkout failure detail={}"),
+
+  WEB_SERVICE_CONTENT_TYPE_NOT_FOUND(
+      14003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service content type not found",
+      "Web service content type not found detail={}"),
+
+  WEB_SERVICE_INSERT_FAILURE(
+      14004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service insert failure",
+      "Web service insert failure detail={}"),
+
+  WEB_SERVICE_CHECKOUT_USER_FAILURE(
+      14005,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Web service checkout user failure",
+      "Web service checkout user failure detail={}"),
+
+  WEB_SERVICE_TRANSITION_NOT_FOUND(
+      14006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service transition not found",
+      "Web service transition not found detail={}"),
+
+  WEB_SERVICE_TRANSITION_COMMENT_REQUIRED(
+      14007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service transition comment required",
+      "Web service transition comment required detail={}"),
+
+  WEB_SERVICE_VALIDATION_FAILURE(
+      14008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service validation failure",
+      "Web service validation failure detail={}"),
+
+  WEB_SERVICE_INTERNAL_SEARCH_NOT_FOUND(
+      14009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service internal search not found",
+      "Web service internal search not found detail={}"),
+
+  WEB_SERVICE_LOGIN_FAILURE(
+      14010,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Web service login failure",
+      "Web service login failure detail={}"),
+
+  WEB_SERVICE_INVALID_CLIENT_ACESS(
+      14011,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Web service invalid client acess",
+      "Web service invalid client acess detail={}"),
+
+  WEB_SERVICE_INVALID_SEARCH_PARAMS(
+      14012,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service invalid search params",
+      "Web service invalid search params detail={}"),
+
+  WEB_SERVICE_INVALID_SEARCH_CONTENTTYPE(
+      14013,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service invalid search contenttype",
+      "Web service invalid search contenttype detail={}"),
+
+  WEB_SERVICE_INTERNAL_REQUEST_FAILED(
+      14014,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service internal request failed",
+      "Web service internal request failed detail={}"),
+
+  WEB_SERVICE_ACTION_NOT_FOUND(
+      14015,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service action not found",
+      "Web service action not found detail={}"),
+
+  WEB_SERVICE_ITEM_CHILD_NOT_FOUND(
+      14016,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service item child not found",
+      "Web service item child not found detail={}"),
+
+  WEB_SERVICE_MISSING_ELEMENT(
+      14017,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service missing element",
+      "Web service missing element detail={}"),
+
+  WEB_SERVICE_MISSING_PARAMETER(
+      14018,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service missing parameter",
+      "Web service missing parameter detail={}"),
+
+  WEB_SERVICE_DISPATCH_ERROR(
+      14019,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service dispatch error",
+      "Web service dispatch error detail={}"),
+
+  WEB_SERVICE_MISSING_ID(
+      14020,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service missing id",
+      "Web service missing id detail={}"),
+
+  INVALID_MIXED_CHILD_IDS(
+      14021,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid mixed child ids",
+      "Invalid mixed child ids detail={}"),
+
+  WEB_SERVICE_INVALID_FOLDER(
+      14022,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service invalid folder",
+      "Web service invalid folder detail={}"),
+
+  WEB_SERVICE_PROMOTE_FAILED_CHECKOUT(
+      14023,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service promote failed checkout",
+      "Web service promote failed checkout detail={}"),
+
+  WEB_SERVICE_PROMOTE_FAILED_CHECKIN(
+      14024,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service promote failed checkin",
+      "Web service promote failed checkin detail={}"),
+
+  WEB_SERVICE_INTERNAL_REQUEST_NOT_FOUND(
+      14025,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service internal request not found",
+      "Web service internal request not found detail={}"),
+
+  WEB_SERVICE_SEARCH_RESOURCE_NOT_FOUND(
+      14026,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Web service search resource not found",
+      "Web service search resource not found detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  ServerWebServicesErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ServerWebServicesErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodes.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Servlet hook error catalog bridging legacy {@code com.percussion.hooks.IPSServletErrors} ints
+ * (10151–10158: connection, port, request parameters, status).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: servlet connection / request
+ * failures are operational noise, not security dual-write events.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum ServletErrorCodes implements SystemErrorCode {
+
+  CONNECTION_ERROR(
+      10151,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Connection error",
+      "Connection error detail={}"),
+
+  INVALID_PORT_NUMBER(
+      10152,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid port number",
+      "Invalid port number detail={}"),
+
+  INVALID_REQUEST_PARAMETERS(
+      10153,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid request parameters",
+      "Invalid request parameters detail={}"),
+
+  SERVLET_DESTROYED(
+      10154,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Servlet destroyed",
+      "Servlet destroyed detail={}"),
+
+  CONNECTION_FAILURE(
+      10155,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Connection failure",
+      "Connection failure detail={}"),
+
+  INVALID_STATUS_CODE(
+      10156,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid status code",
+      "Invalid status code detail={}"),
+
+  SERVLET_INFORMATION(
+      10157,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Servlet information",
+      "Servlet information detail={}"),
+
+  VERSION_STRING(
+      10158,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Version string",
+      "Version string detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  ServletErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ServletErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodes.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Webservices transformation error catalog bridging legacy {@code
+ * com.percussion.webservices.transformation.IPSTransformationErrors} package-local ints (only
+ * {@code NO_CONVERTER_FOUND = 1}).
+ *
+ * <p>All constants set {@link #isAuditable()} to {@code false}: converter lookup failures are
+ * operational noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local int {@code 1} already belongs to
+ * {@link WorkflowErrorCodes}. This catalog therefore does <strong>not</strong> flat-register any
+ * ints. Prefer this enum directly until a composite-key registry exists. Module code is {@link
+ * AuditModule#SYS}.
+ */
+public enum TransformationErrorCodes implements SystemErrorCode {
+
+  NO_CONVERTER_FOUND(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No converter found",
+      "No converter found detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  TransformationErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat {@link com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry}: package-local
+   * int {@code 1} collides with {@link WorkflowErrorCodes}. Prefer this enum directly. Safe to call
+   * repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodes.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * WebDAV error catalog bridging legacy {@code com.percussion.webdav.error.IPSWebdavErrors} ints
+ * (70001–70125: XML config, protocol methods, locks, content-type mapping).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: WebDAV protocol / config failures
+ * are operational noise. Authentication dual-write remains on {@link SecurityErrorCodes}.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry} so
+ * bare legacy ints resolve as non-auditable (safe skip). Module code is {@link AuditModule#SYS}.
+ */
+public enum WebdavErrorCodes implements SystemErrorCode {
+
+  XML_ATTRIBUTE_MUST_BE_SPECIFIED(
+      70001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml attribute must be specified",
+      "Xml attribute must be specified detail={}"),
+
+  XML_INVALID_FORMAT(
+      70002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml invalid format",
+      "Xml invalid format detail={}"),
+
+  XML_ELEMENT_CANNOT_BE_EMPTY(
+      70003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml element cannot be empty",
+      "Xml element cannot be empty detail={}"),
+
+  XML_FAILED_CREATE_DOC_FROM_CONTENT(
+      70004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml failed create doc from content",
+      "Xml failed create doc from content detail={}"),
+
+  UNSUPPORTED_METHOD(
+      70101,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported method",
+      "Unsupported method detail={}"),
+
+  MIMETYPES_REQUIRED(
+      70102,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mimetypes required",
+      "Mimetypes required detail={}"),
+
+  CANNOT_HAVE_DUPLICATE_PROPERTIES(
+      70103,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot have duplicate properties",
+      "Cannot have duplicate properties detail={}"),
+
+  MISSING_REQUIRED_PROPERTY(
+      70104,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing required property",
+      "Missing required property detail={}"),
+
+  CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE(
+      70105,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Can only have one default contenttype",
+      "Can only have one default contenttype detail={}"),
+
+  IO_EXCEPTION_OCCURED(
+      70106,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Io exception occured",
+      "Io exception occured detail={}"),
+
+  SAX_EXCEPTION_OCCURED(
+      70107,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sax exception occured",
+      "Sax exception occured detail={}"),
+
+  FILE_DOES_NOT_EXIST(
+      70108,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "File does not exist",
+      "File does not exist detail={}"),
+
+  PARSER_CONFIG_ERROR(
+      70109,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Parser config error",
+      "Parser config error detail={}"),
+
+  DUPLICATE_CONTENTTYPE_NAMES(
+      70110,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate contenttype names",
+      "Duplicate contenttype names detail={}"),
+
+  RESOURCE_NOT_FIND(
+      70111,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Resource not find",
+      "Resource not find detail={}"),
+
+  FORBIDDEN_GET_FOLDER(
+      70112,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Forbidden get folder",
+      "Forbidden get folder detail={}"),
+
+  HEADER_MISSING(
+      70113,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Header missing",
+      "Header missing detail={}"),
+
+  FORBIDDEN_SRC_TARGET_SAME(
+      70114,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Forbidden src target same",
+      "Forbidden src target same detail={}"),
+
+  METHOD_FAIL_CANNOT_OVERWRITE(
+      70115,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Method fail cannot overwrite",
+      "Method fail cannot overwrite detail={}"),
+
+  ITEMFIELD_NOT_EXIST(
+      70116,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Itemfield not exist",
+      "Itemfield not exist detail={}"),
+
+  LOCKSCOPE_NOT_ALLOWED(
+      70117,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Lockscope not allowed",
+      "Lockscope not allowed detail={}"),
+
+  LOCKTYPE_NOT_ALLOWED(
+      70118,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Locktype not allowed",
+      "Locktype not allowed detail={}"),
+
+  FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING(
+      70119,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Fieldname cannot be empty or missing",
+      "Fieldname cannot be empty or missing detail={}"),
+
+  CONTENTTYPE_NOT_CONFIGURED(
+      70120,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Contenttype not configured",
+      "Contenttype not configured detail={}"),
+
+  UNKNOWN_BODY_IN_MKCOL_REQ(
+      70121,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown body in mkcol req",
+      "Unknown body in mkcol req detail={}"),
+
+  UNKNOWN_URL_FROM_HEADER(
+      70122,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown url from header",
+      "Unknown url from header detail={}"),
+
+  MALFORMED_URL_FROM_HEADER(
+      70123,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Malformed url from header",
+      "Malformed url from header detail={}"),
+
+  NO_PUBLIC_AUTO_TRANSITION(
+      70124,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No public auto transition",
+      "No public auto transition detail={}"),
+
+  NO_QE_AUTO_TRANSITION(
+      70125,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No qe auto transition",
+      "No qe auto transition detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  WebdavErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (WebdavErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodes.java
@@ -1,0 +1,700 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Modern SOAP / design webservices error catalog bridging legacy {@code
+ * com.percussion.webservices.IPSWebserviceErrors} package-local ints (1–73).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: session and ACL / authorization
+ * failures dual-write; design CRUD and lookup operational noise does not.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–10} already belong to
+ * {@link WorkflowErrorCodes}; ints {@code 11–27} are claimed by residual assembly / job catalogs
+ * (PR #2867 / #2866). This catalog therefore flat-registers only non-colliding ints ({@code
+ * 28–73}), which includes the security-relevant {@code ACCESS_CONTROL_ERROR} and {@code
+ * NOT_AUTHORIZED} codes. Prefer this enum directly for ints {@code 1–27} until a composite-key
+ * registry exists. Module code is {@link AuditModule#SYS}.
+ */
+public enum WebserviceErrorCodes implements SystemErrorCode {
+
+  INVALID_CONTRACT(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid contract",
+      "Invalid contract detail={}"),
+
+  OBJECT_NOT_FOUND(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not found",
+      "Object not found detail={}"),
+
+  INVALID_SESSION(
+      3,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Invalid session",
+      "Invalid session detail={}"),
+
+  MISSING_SESSION(
+      4,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Missing session",
+      "Missing session detail={}"),
+
+  CREATE_LOCK_FAILED(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Create lock failed",
+      "Create lock failed detail={}"),
+
+  SAVE_FAILED(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Save failed",
+      "Save failed detail={}"),
+
+  DELETE_FAILED(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Delete failed",
+      "Delete failed detail={}"),
+
+  OBJECT_NOT_LOCKED(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not locked",
+      "Object not locked detail={}"),
+
+  OBJECT_NOT_LOCKED_FOR_REQUESTOR(
+      9,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not locked for requestor",
+      "Object not locked for requestor detail={}"),
+
+  CREATE_EXTEND_LOCK_FAILED(
+      10,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Create extend lock failed",
+      "Create extend lock failed detail={}"),
+
+  OBJECT_ALREADY_EXISTS(
+      11,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object already exists",
+      "Object already exists detail={}"),
+
+  MISSING_HIERARCHY_NODE_FOR_PARENT(
+      12,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing hierarchy node for parent",
+      "Missing hierarchy node for parent detail={}"),
+
+  DUPLICATE_HIERARCHY_NODE_FOR_PARENT(
+      13,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate hierarchy node for parent",
+      "Duplicate hierarchy node for parent detail={}"),
+
+  DELETE_FAILED_DEPENDENTS(
+      14,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Delete failed dependents",
+      "Delete failed dependents detail={}"),
+
+  LOAD_FAILED(
+      15,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Load failed",
+      "Load failed detail={}"),
+
+  FIND_FAILED(
+      16,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Find failed",
+      "Find failed detail={}"),
+
+  FAILED_LOAD_REL_CONFIGS(
+      17,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load rel configs",
+      "Failed load rel configs detail={}"),
+
+  FAILED_COMMUNITY_VISIBILITY_LOOKUP(
+      18,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed community visibility lookup",
+      "Failed community visibility lookup detail={}"),
+
+  UNSUPPORTD_COMMUNITY_VISIBILITY_LOOKUP_TYPE(
+      19,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupportd community visibility lookup type",
+      "Unsupportd community visibility lookup type detail={}"),
+
+  FAILED_LOAD_WORKFLOW(
+      20,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load workflow",
+      "Failed load workflow detail={}"),
+
+  CANNOT_FIND_WORKFLOW_STATE_ID(
+      21,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find workflow state id",
+      "Cannot find workflow state id detail={}"),
+
+  CURR_STATE_NOT_MATCH(
+      22,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Curr state not match",
+      "Curr state not match detail={}"),
+
+  CANNOT_FIND_TRANS_TO_QE_STATE(
+      23,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find trans to qe state",
+      "Cannot find trans to qe state detail={}"),
+
+  CANNOT_FIND_TRANS_4_STATE_2_STATE(
+      24,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find trans 4 state 2 state",
+      "Cannot find trans 4 state 2 state detail={}"),
+
+  FAILED_TRANSITION_ITEM(
+      25,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed transition item",
+      "Failed transition item detail={}"),
+
+  FAILED_CHECK_OUT_ITEM(
+      26,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed check out item",
+      "Failed check out item detail={}"),
+
+  FAILED_CHECK_IN_ITEM(
+      27,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed check in item",
+      "Failed check in item detail={}"),
+
+  FAILED_SAVE_RELATIONSHIPS(
+      28,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed save relationships",
+      "Failed save relationships detail={}"),
+
+  FAILED_LOAD_RELATIONSHIP(
+      29,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load relationship",
+      "Failed load relationship detail={}"),
+
+  CANNOT_FIND_RELATIONSHIP(
+      30,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find relationship",
+      "Cannot find relationship detail={}"),
+
+  FAILED_DELETE_RELATIONSHIPS(
+      31,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed delete relationships",
+      "Failed delete relationships detail={}"),
+
+  ACCESS_CONTROL_ERROR(
+      32,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Access control error",
+      "Access control error detail={}"),
+
+  LOAD_OBJECTS_ERROR(
+      33,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Load objects error",
+      "Load objects error detail={}"),
+
+  OBJECT_NOT_FOUND_BY_NAME(
+      34,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object not found by name",
+      "Object not found by name detail={}"),
+
+  NO_FOLDER_PATH_FOR_FOLDERID(
+      35,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No folder path for folderid",
+      "No folder path for folderid detail={}"),
+
+  FAILED_LOAD_FOLDER_PATH(
+      36,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load folder path",
+      "Failed load folder path detail={}"),
+
+  ITEM_NOT_CHECKED_OUT(
+      37,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Item not checked out",
+      "Item not checked out detail={}"),
+
+  INVALID_CHILD_ID(
+      38,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid child id",
+      "Invalid child id detail={}"),
+
+  CHILD_ENTRY_NOT_FOUND(
+      39,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Child entry not found",
+      "Child entry not found detail={}"),
+
+  CHILD_ENTRY_ALREADY_EXISTS(
+      40,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Child entry already exists",
+      "Child entry already exists detail={}"),
+
+  UNKNOWN_CONTENT_TYPE(
+      41,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown content type",
+      "Unknown content type detail={}"),
+
+  FAILED_FIND_ID_FROM_PATH(
+      42,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find id from path",
+      "Failed find id from path detail={}"),
+
+  PATH_NOT_EXIST(
+      43,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Path not exist",
+      "Path not exist detail={}"),
+
+  UNKNOWN_COMMUNITY_ID(
+      44,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown community id",
+      "Unknown community id detail={}"),
+
+  FAILED_ADD_FOLDER_CHILDREN(
+      45,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed add folder children",
+      "Failed add folder children detail={}"),
+
+  FAILED_FIND_FOLDER_CHILDREN(
+      46,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find folder children",
+      "Failed find folder children detail={}"),
+
+  FAILED_FIND_CHILD_ITEMS(
+      47,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find child items",
+      "Failed find child items detail={}"),
+
+  FAILED_FIND_PARENT_ITEMS(
+      48,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find parent items",
+      "Failed find parent items detail={}"),
+
+  ITEM_NOT_CHECKOUT_BY_USER(
+      49,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Item not checkout by user",
+      "Item not checkout by user detail={}"),
+
+  INVALID_EDIT_REVISION(
+      50,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid edit revision",
+      "Invalid edit revision detail={}"),
+
+  INVALID_CURRENT_REVISION(
+      51,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid current revision",
+      "Invalid current revision detail={}"),
+
+  USER_NOT_MEMBER_COMMUNITY(
+      52,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "User not member community",
+      "User not member community detail={}"),
+
+  INVALID_LOCALE(
+      53,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid locale",
+      "Invalid locale detail={}"),
+
+  INVALID_FOLDER_CHILD(
+      54,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid folder child",
+      "Invalid folder child detail={}"),
+
+  FAILED_FIND_PATH_FROM_ID(
+      55,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed find path from id",
+      "Failed find path from id detail={}"),
+
+  FAILED_SAVE_ITEM(
+      56,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed save item",
+      "Failed save item detail={}"),
+
+  FAILED_LOAD_ITEM(
+      57,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load item",
+      "Failed load item detail={}"),
+
+  ITEM_NOT_CHECKED_IN(
+      58,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Item not checked in",
+      "Item not checked in detail={}"),
+
+  INAVLID_ACTION_FOR_STATE(
+      59,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Inavlid action for state",
+      "Inavlid action for state detail={}"),
+
+  NEWCOPY_FAILED(
+      60,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Newcopy failed",
+      "Newcopy failed detail={}"),
+
+  NEWPROMOTABLEVERSION_FAILED(
+      61,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Newpromotableversion failed",
+      "Newpromotableversion failed detail={}"),
+
+  NEWTRANSLATION_FAILED(
+      62,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Newtranslation failed",
+      "Newtranslation failed detail={}"),
+
+  FAILED_VIEW_ITEM(
+      63,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed view item",
+      "Failed view item detail={}"),
+
+  UNKNOWN_FIELD_NAME(
+      64,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown field name",
+      "Unknown field name detail={}"),
+
+  FAILED_SYS_SHARED_DEF_VALIDATION(
+      65,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed sys shared def validation",
+      "Failed sys shared def validation detail={}"),
+
+  DELETE_ASSOCIATION_FAILED_DEPENDENTS(
+      66,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Delete association failed dependents",
+      "Delete association failed dependents detail={}"),
+
+  FAILED_LOAD_FOLDER(
+      67,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed load folder",
+      "Failed load folder detail={}"),
+
+  OPERATION_FAILED_ERROR(
+      68,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Operation failed error",
+      "Operation failed error detail={}"),
+
+  UNEXPECTED_ERROR(
+      69,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected error",
+      "Unexpected error detail={}"),
+
+  UNABLE_SAVE_SHARED_DEF_VALIDATION(
+      70,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unable save shared def validation",
+      "Unable save shared def validation detail={}"),
+
+  FAILED_RENAMING_ACLS(
+      71,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed renaming acls",
+      "Failed renaming acls detail={}"),
+
+  NOT_AUTHORIZED(
+      72,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Not authorized",
+      "Not authorized detail={}"),
+
+  FAILED_TO_OBTAIN_PATH_FROM_OBJECT_ID(
+      73,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to obtain path from object id",
+      "Failed to obtain path from object id detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  WebserviceErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register non-colliding webservice ints in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly. Skips package-local ints {@code 1–27} that collide with workflow / assembly / job
+   * catalogs in the flat map.
+   */
+  public static void ensureRegistered() {
+    for (WebserviceErrorCodes code : values()) {
+      if (code.numericCode <= 27) {
+        // Preserve WorkflowErrorCodes (1–10) and residual assembly/job ownership of 11–27.
+        continue;
+      }
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -21,13 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
 import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,8 +68,9 @@ class LegacyErrorCodeRegistryTest {
 
   @Test
   void unregisteredLegacyCodeIsNotAuditable() {
-    assertFalse(LegacyErrorCodeRegistry.isAuditable(42));
-    assertTrue(LegacyErrorCodeRegistry.find(42).isEmpty());
+    // Sentinel outside all cataloged ranges (webservice package-local now claims 42).
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(999_999));
+    assertTrue(LegacyErrorCodeRegistry.find(999_999).isEmpty());
   }
 
   @Test
@@ -436,13 +445,260 @@ class LegacyErrorCodeRegistryTest {
   }
 
   @Test
-  void registryCoversServerHttpAndJob() {
-    // prior catalogs + full IPSServerErrors (295) + IPSHttpErrors (37) + job int 11
+  void registryCoversServerHttpJobExtensionAssemblyAndWebservices() {
+    // prior catalogs + server/http/job + extension + assembly non-colliding ints
     assertTrue(LegacyErrorCodeRegistry.size() >= 350);
     assertTrue(LegacyErrorCodeRegistry.find(1101).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(401).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(11).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(1001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(7442).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(7007).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(12).isPresent()); // assembly MISSING_FINDER
+    assertTrue(LegacyErrorCodeRegistry.find(27).isPresent()); // assembly INLINE_LINK_ERROR
+    // webservice/webdav/servlet residual (#2865)
+    assertTrue(LegacyErrorCodeRegistry.find(32).isPresent()); // webservice ACCESS_CONTROL
+    assertTrue(LegacyErrorCodeRegistry.find(72).isPresent()); // webservice NOT_AUTHORIZED
+    assertTrue(LegacyErrorCodeRegistry.find(14010).isPresent()); // server WS login
+    assertTrue(LegacyErrorCodeRegistry.find(70101).isPresent()); // webdav
+    assertTrue(LegacyErrorCodeRegistry.find(10151).isPresent()); // servlet
   }
-}
 
+  // --- Assembly / Extension / Delivery residual (#2864) ---
+
+  @Test
+  void extensionCheckoutNotAllowedIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(7442));
+    assertSame(
+        ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED,
+        LegacyErrorCodeRegistry.find(7442).orElseThrow());
+    assertTrue(ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED.isAuditable());
+  }
+
+  @Test
+  void extensionParamNoiseIsNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(7007));
+    assertSame(
+        ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID,
+        LegacyErrorCodeRegistry.find(7007).orElseThrow());
+    assertFalse(ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID.isAuditable());
+  }
+
+  @Test
+  void extensionNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void extensionAuditableDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "detail");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-7442]-"));
+  }
+
+  @Test
+  void assemblyNonCollidingLegacyCodeIsRegisteredButNotAuditable() {
+    // 12 is package-local MISSING_FINDER; non-colliding with WF 1–10 so flat-registered
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(12));
+    assertSame(AssemblyErrorCodes.MISSING_FINDER, LegacyErrorCodeRegistry.find(12).orElseThrow());
+    assertFalse(AssemblyErrorCodes.MISSING_FINDER.isAuditable());
+  }
+
+  @Test
+  void assemblyNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            AssemblyErrorCodes.MISSING_FINDER.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void assemblyPackageLocalOneRemainsWorkflowInFlatRegistry() {
+    // Bare int 1 is WorkflowErrorCodes.WORKFLOW_NOT_FOUND, not Assembly TEMPLATE_MISSING
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertEquals(1, AssemblyErrorCodes.TEMPLATE_MISSING.numericCode());
+  }
+
+  @Test
+  void deliveryDecryptCredentialsNotFlatRegisteredButEnumIsAuditable() {
+    // package-local 7 collides with WF; flat registry keeps WorkflowErrorCodes
+    assertSame(WorkflowErrorCodes.TRANSITION_NOT_FOUND, LegacyErrorCodeRegistry.find(7).orElseThrow());
+    assertTrue(DeliveryErrorCodes.COULD_NOT_DECRYPT_CREDENTIALS.isAuditable());
+    assertEquals(7, DeliveryErrorCodes.COULD_NOT_DECRYPT_CREDENTIALS.numericCode());
+  }
+
+
+  // --- Webservices / WebDAV / Servlet residual (#2865) ---
+
+  @Test
+  void webserviceAccessControlIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(32));
+    assertSame(
+        WebserviceErrorCodes.ACCESS_CONTROL_ERROR,
+        LegacyErrorCodeRegistry.find(32).orElseThrow());
+    assertTrue(WebserviceErrorCodes.ACCESS_CONTROL_ERROR.isAuditable());
+  }
+
+  @Test
+  void webserviceNotAuthorizedDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WebserviceErrorCodes.NOT_AUTHORIZED.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "jdoe",
+            "save",
+            "denied");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(WebserviceErrorCodes.NOT_AUTHORIZED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-72]-"));
+  }
+
+  @Test
+  void webserviceSaveFailedIsNotAuditableButRegistered() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(28));
+    assertSame(
+        WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS,
+        LegacyErrorCodeRegistry.find(28).orElseThrow());
+    assertFalse(WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS.isAuditable());
+  }
+
+  @Test
+  void webserviceSaveFailedNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WebserviceErrorCodes.FAILED_SAVE_RELATIONSHIPS.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "detail");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void webservicePackageLocalOneRemainsWorkflowInFlatRegistry() {
+    // Bare int 1 is WorkflowErrorCodes.WORKFLOW_NOT_FOUND, not Webservice INVALID_CONTRACT
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertEquals(1, WebserviceErrorCodes.INVALID_CONTRACT.numericCode());
+    assertTrue(WebserviceErrorCodes.INVALID_SESSION.isAuditable());
+    assertEquals(3, WebserviceErrorCodes.INVALID_SESSION.numericCode());
+  }
+
+  @Test
+  void serverWebServicesLoginFailureIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(14010));
+    assertSame(
+        ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE,
+        LegacyErrorCodeRegistry.find(14010).orElseThrow());
+  }
+
+  @Test
+  void serverWebServicesLoginFailureDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "jdoe",
+            "****");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(
+        ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-14010]-"));
+  }
+
+  @Test
+  void serverWebServicesContentNotFoundSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ServerWebServicesErrorCodes.WEB_SERVICE_CONTENT_ITEM_NOT_FOUND.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "42",
+            "1");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void webdavUnsupportedMethodIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(70101));
+    assertSame(WebdavErrorCodes.UNSUPPORTED_METHOD, LegacyErrorCodeRegistry.find(70101).orElseThrow());
+    assertFalse(WebdavErrorCodes.UNSUPPORTED_METHOD.isAuditable());
+  }
+
+  @Test
+  void webdavNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            WebdavErrorCodes.UNSUPPORTED_METHOD.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "PROPFIND");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void servletConnectionErrorIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(10151));
+    assertSame(ServletErrorCodes.CONNECTION_ERROR, LegacyErrorCodeRegistry.find(10151).orElseThrow());
+  }
+
+  @Test
+  void transformationNotFlatRegisteredButEnumIsNonAuditable() {
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertFalse(TransformationErrorCodes.NO_CONVERTER_FOUND.isAuditable());
+    assertEquals(1, TransformationErrorCodes.NO_CONVERTER_FOUND.numericCode());
+  }
+
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/AssemblyErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/AssemblyErrorCodesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AssemblyErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModulePubAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (AssemblyErrorCodes code : AssemblyErrorCodes.values()) {
+      assertEquals(AuditModule.PUB, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("PUB-"));
+    }
+    assertEquals(27, AssemblyErrorCodes.values().length);
+  }
+
+  @Test
+  void allAssemblyCodesAreNonAuditable() {
+    for (AssemblyErrorCodes code : AssemblyErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsAssemblyErrorsNumericValues() {
+    assertEquals(1, AssemblyErrorCodes.TEMPLATE_MISSING.numericCode());
+    assertEquals(5, AssemblyErrorCodes.UNKNOWN_ERROR.numericCode());
+    assertEquals(12, AssemblyErrorCodes.MISSING_FINDER.numericCode());
+    assertEquals(27, AssemblyErrorCodes.INLINE_LINK_ERROR.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/DeliveryErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/DeliveryErrorCodesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DeliveryErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModulePubAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (DeliveryErrorCodes code : DeliveryErrorCodes.values()) {
+      assertEquals(AuditModule.PUB, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("PUB-"));
+    }
+    assertEquals(12, DeliveryErrorCodes.values().length);
+  }
+
+  @Test
+  void decryptCredentialsIsAuditableViaEnum() {
+    assertTrue(DeliveryErrorCodes.COULD_NOT_DECRYPT_CREDENTIALS.isAuditable());
+    assertEquals(
+        AuditEventType.OTHER, DeliveryErrorCodes.COULD_NOT_DECRYPT_CREDENTIALS.eventType());
+    assertEquals(7, DeliveryErrorCodes.COULD_NOT_DECRYPT_CREDENTIALS.numericCode());
+  }
+
+  @Test
+  void operationalDeliveryNoiseIsNotAuditable() {
+    assertFalse(DeliveryErrorCodes.ABORT_FAILURE.isAuditable());
+    assertNull(DeliveryErrorCodes.ABORT_FAILURE.eventType());
+    assertFalse(DeliveryErrorCodes.SOLR_COMMUNICATION_EXCEPTION.isAuditable());
+    assertFalse(DeliveryErrorCodes.CANNOT_DELIVER_NO_DELIVERYTYPE.isAuditable());
+  }
+
+  @Test
+  void preservesLegacyIpsDeliveryErrorsNumericValues() {
+    assertEquals(1, DeliveryErrorCodes.ABORT_FAILURE.numericCode());
+    assertEquals(4, DeliveryErrorCodes.COPY_FILE_FAILED.numericCode());
+    assertEquals(11, DeliveryErrorCodes.SOLR_COMMUNICATION_EXCEPTION.numericCode());
+    assertEquals(12, DeliveryErrorCodes.CANNOT_DELIVER_NO_DELIVERYTYPE.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ExtensionErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ExtensionErrorCodesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ExtensionErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ExtensionErrorCodes code : ExtensionErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(129, ExtensionErrorCodes.values().length);
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (ExtensionErrorCodes code : ExtensionErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void authAndAccessControlFailuresAreAuditable() {
+    assertTrue(ExtensionErrorCodes.AUTHENTICATION_FAILED1.isAuditable());
+    assertEquals(AuditEventType.AUTH_FAILURE, ExtensionErrorCodes.AUTHENTICATION_FAILED1.eventType());
+    assertTrue(ExtensionErrorCodes.AUTHENTICATION_FAILED2.isAuditable());
+    assertTrue(ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED.isAuditable());
+    assertEquals(AuditEventType.ACCESS_DENIED, ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED.eventType());
+    assertTrue(ExtensionErrorCodes.CHECKIN_NOT_ALLOWED.isAuditable());
+    assertTrue(
+        ExtensionErrorCodes.COMMUNITIES_AUTHENTICATION_FAILED_NOCOMMUNITY.isAuditable());
+    assertTrue(
+        ExtensionErrorCodes.AUTHENTICATION_FAILED_DIFFERENT_ITEM_USER_COMMUNITIES.isAuditable());
+  }
+
+  @Test
+  void operationalExtensionNoiseIsNotAuditable() {
+    assertFalse(ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID.isAuditable());
+    assertFalse(ExtensionErrorCodes.JS_COMPILE_FAILED.isAuditable());
+    assertFalse(ExtensionErrorCodes.EXT_NOT_FOUND.isAuditable());
+    assertFalse(ExtensionErrorCodes.JEXL_EVALUATION_FAILED.isAuditable());
+  }
+
+  @Test
+  void preservesLegacyIpsExtensionErrorsNumericValues() {
+    assertEquals(7001, ExtensionErrorCodes.BACKEND_COLUMN_ERROR.numericCode());
+    assertEquals(7007, ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID.numericCode());
+    assertEquals(7442, ExtensionErrorCodes.CHECKOUT_NOT_ALLOWED.numericCode());
+    assertEquals(7480, ExtensionErrorCodes.MANDATORY_TRANSITION_VALIDATION_FAILURE.numericCode());
+    assertEquals(7636, ExtensionErrorCodes.SCHEME_CANT_BE_FOUND.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServerWebServicesErrorCodesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ServerWebServicesErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ServerWebServicesErrorCodes code : ServerWebServicesErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 14001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(26, ServerWebServicesErrorCodes.values().length);
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (ServerWebServicesErrorCodes code : ServerWebServicesErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void loginAndAccessFailuresAreAuditable() {
+    assertTrue(ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.isAuditable());
+    assertEquals(
+        AuditEventType.AUTH_FAILURE,
+        ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.eventType());
+    assertTrue(ServerWebServicesErrorCodes.WEB_SERVICE_CHECKOUT_USER_FAILURE.isAuditable());
+    assertTrue(ServerWebServicesErrorCodes.WEB_SERVICE_INVALID_CLIENT_ACESS.isAuditable());
+  }
+
+  @Test
+  void operationalContentSearchIsNotAuditable() {
+    assertFalse(ServerWebServicesErrorCodes.WEB_SERVICE_CONTENT_ITEM_NOT_FOUND.isAuditable());
+    assertFalse(ServerWebServicesErrorCodes.WEB_SERVICE_INSERT_FAILURE.isAuditable());
+    assertFalse(ServerWebServicesErrorCodes.WEB_SERVICE_INTERNAL_SEARCH_NOT_FOUND.isAuditable());
+  }
+
+  @Test
+  void preservesLegacyIpsWebServicesErrorsNumericValues() {
+    assertEquals(14001, ServerWebServicesErrorCodes.WEB_SERVICE_CONTENT_ITEM_NOT_FOUND.numericCode());
+    assertEquals(14010, ServerWebServicesErrorCodes.WEB_SERVICE_LOGIN_FAILURE.numericCode());
+    assertEquals(14026, ServerWebServicesErrorCodes.WEB_SERVICE_SEARCH_RESOURCE_NOT_FOUND.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ServletErrorCodesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ServletErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ServletErrorCodes code : ServletErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 10151, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(8, ServletErrorCodes.values().length);
+  }
+
+  @Test
+  void allServletCodesAreNonAuditable() {
+    for (ServletErrorCodes code : ServletErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsServletErrorsNumericValues() {
+    assertEquals(10151, ServletErrorCodes.CONNECTION_ERROR.numericCode());
+    assertEquals(10155, ServletErrorCodes.CONNECTION_FAILURE.numericCode());
+    assertEquals(10158, ServletErrorCodes.VERSION_STRING.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/TransformationErrorCodesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import org.junit.jupiter.api.Test;
+
+class TransformationErrorCodesTest {
+
+  @Test
+  void singleConverterMissingConstantIsNonAuditableSys() {
+    assertEquals(1, TransformationErrorCodes.values().length);
+    TransformationErrorCodes code = TransformationErrorCodes.NO_CONVERTER_FOUND;
+    assertEquals(AuditModule.SYS, code.module());
+    assertEquals(1, code.numericCode());
+    assertFalse(code.isAuditable());
+    assertNull(code.eventType());
+    assertNotNull(code.userMessageTemplate());
+    assertNotNull(code.logMessageTemplate());
+    assertTrue(code.qualifiedCode().startsWith("SYS-"));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebdavErrorCodesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class WebdavErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (WebdavErrorCodes code : WebdavErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 70001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(29, WebdavErrorCodes.values().length);
+  }
+
+  @Test
+  void allWebdavCodesAreNonAuditable() {
+    for (WebdavErrorCodes code : WebdavErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsWebdavErrorsNumericValues() {
+    assertEquals(70001, WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED.numericCode());
+    assertEquals(70101, WebdavErrorCodes.UNSUPPORTED_METHOD.numericCode());
+    assertEquals(70125, WebdavErrorCodes.NO_QE_AUTO_TRANSITION.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/WebserviceErrorCodesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class WebserviceErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (WebserviceErrorCodes code : WebserviceErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(73, WebserviceErrorCodes.values().length);
+  }
+
+  @Test
+  void auditableCodesRequireEventType() {
+    for (WebserviceErrorCodes code : WebserviceErrorCodes.values()) {
+      if (code.isAuditable()) {
+        assertNotNull(code.eventType(), code.name() + " auditable without eventType");
+      } else {
+        assertNull(code.eventType(), code.name() + " non-auditable should not force eventType");
+      }
+    }
+  }
+
+  @Test
+  void sessionAndAccessFailuresAreAuditable() {
+    assertTrue(WebserviceErrorCodes.INVALID_SESSION.isAuditable());
+    assertEquals(AuditEventType.AUTH_FAILURE, WebserviceErrorCodes.INVALID_SESSION.eventType());
+    assertTrue(WebserviceErrorCodes.MISSING_SESSION.isAuditable());
+    assertTrue(WebserviceErrorCodes.ACCESS_CONTROL_ERROR.isAuditable());
+    assertEquals(
+        AuditEventType.ACCESS_DENIED, WebserviceErrorCodes.ACCESS_CONTROL_ERROR.eventType());
+    assertTrue(WebserviceErrorCodes.NOT_AUTHORIZED.isAuditable());
+    assertTrue(WebserviceErrorCodes.ITEM_NOT_CHECKED_OUT.isAuditable());
+    assertTrue(WebserviceErrorCodes.USER_NOT_MEMBER_COMMUNITY.isAuditable());
+  }
+
+  @Test
+  void operationalDesignCrudIsNotAuditable() {
+    assertFalse(WebserviceErrorCodes.INVALID_CONTRACT.isAuditable());
+    assertFalse(WebserviceErrorCodes.OBJECT_NOT_FOUND.isAuditable());
+    assertFalse(WebserviceErrorCodes.SAVE_FAILED.isAuditable());
+    assertFalse(WebserviceErrorCodes.DELETE_FAILED.isAuditable());
+    assertFalse(WebserviceErrorCodes.UNEXPECTED_ERROR.isAuditable());
+  }
+
+  @Test
+  void preservesLegacyIpsWebserviceErrorsNumericValues() {
+    assertEquals(1, WebserviceErrorCodes.INVALID_CONTRACT.numericCode());
+    assertEquals(3, WebserviceErrorCodes.INVALID_SESSION.numericCode());
+    assertEquals(32, WebserviceErrorCodes.ACCESS_CONTROL_ERROR.numericCode());
+    assertEquals(72, WebserviceErrorCodes.NOT_AUTHORIZED.numericCode());
+    assertEquals(73, WebserviceErrorCodes.FAILED_TO_OBTAIN_PATH_FROM_OBJECT_ID.numericCode());
+  }
+}


### PR DESCRIPTION
## Summary

**Same-file thrash absorption** for Phase 2b residual ErrorCodes under `modules/perc-auditlog`. Overnight PRs thrashing the same registry bootstrap/tests/README:

### Thrash files
- `modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java`
- `modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java`
- `modules/perc-auditlog/README.md`

### Content union
1. **#2866** (Server/HTTP/Job) — **already merged to `main`** during cluster build; cluster rebased onto that tip
2. **#2867** — `AssemblyErrorCodes` (flat 11–27), `ExtensionErrorCodes`, `DeliveryErrorCodes` (enum-only) — **fully absorbed**
3. **#2868** — `WebserviceErrorCodes` (flat 28–73), `ServerWebServicesErrorCodes`, `WebdavErrorCodes`, `ServletErrorCodes`, `TransformationErrorCodes` (enum-only) — **fully absorbed**

**Collision notes (last-writer-wins documented in registry):**
- Job after Assembly so flat int `11` = `JobErrorCodes.CONFIG_FILE_NOT_FOUND` (prefer Assembly enum for package-local `MISSING_SLOT`)
- Webservice skips 1–27 (WF + assembly); Delivery/Transformation do not flat-register
- Unregistered-sentinel test uses `999_999` (webservice claims package-local `42`)

### Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| n/a (merged) | #2866 | `fix/issue-2863-server-http-job-errorcodes` | already on main | Merged separately while clustering |
| yes | #2867 | `fix/issue-2864-assembly-extension-delivery-errorcodes` | yes | Closed as superseded |
| yes | #2868 | `fix/issue-2865-webservices-webdav-servlet-errorcodes` | yes | Closed as superseded |

## Test plan / gates evidence

```bat
cd modules\perc-auditlog
..\..\mvnw.cmd clean install
```

- **BUILD SUCCESS**
- **Tests run: 147, Failures: 0, Errors: 0, Skipped: 0**
- No new production warnings attributable to this union (baseline javadoc/analyze noise unchanged)

## Product documentation

- [x] N/A — engineering residual catalog migration under `modules/perc-auditlog`; no operator/admin/end-user surface change beyond existing Phase 2b bridge docs in module README.

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok using grok-4.5 with agent night-issue-prs-cluster.
