### PR TITLE
feat(auditlog): Search/Lucene/Locale/Mail ErrorCodes + isAuditable (#2880)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -16,7 +16,9 @@ System-wide Percussion CMS audit logging and unified error-code support.
   `ExtensionErrorCodes` (globally unique; auth/checkout dual-write),
   `AssemblyErrorCodes` (package-local 11–27 flat-registered), `DeliveryErrorCodes` (enum-only),
   `WebserviceErrorCodes` (package-local 28–73), `ServerWebServicesErrorCodes`, `WebdavErrorCodes`,
-  `ServletErrorCodes`, `TransformationErrorCodes` (enum-only)
+  `ServletErrorCodes`, `TransformationErrorCodes` (enum-only),
+  `SearchErrorCodes` (`IPSSearchErrors`; auth failure dual-write), `LuceneErrorCodes`,
+  `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable)
   + `LegacyErrorCodeRegistry` bridge legacy `IPS*Errors` ints. Non-auditable / unregistered ints never
   dual-write. Central `PSErrorHandler.appendError` dual-writes only when the registry marks the legacy
   int auditable.
@@ -69,7 +71,11 @@ import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
@@ -94,6 +100,8 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 6, ctx, "5", "jdoe"); // WF access
 LegacyErrorCodeRegistry.logIfAuditable(audit, 1101, ctx, "sess", "/app"); // SYS authz dual-write
 LegacyErrorCodeRegistry.logIfAuditable(audit, 1001, ctx); // SYS native — non-auditable skip
 LegacyErrorCodeRegistry.logIfAuditable(audit, 401, ctx); // HTTP status — non-auditable skip
+LegacyErrorCodeRegistry.logIfAuditable(audit, 16052, ctx); // search auth failed — dual-write
+LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir — non-auditable skip
 // Prefer JobErrorCodes enum for job ints 1–10 (flat registry keeps WF ownership of 1–10)
 // Provider/config/conversion/path/design/server/http/job/assembly/extension/webservice noise (isAuditable=false) and unknown ints → no dual-write
 ```
@@ -116,6 +124,10 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 401, ctx); // HTTP status — non-
 | `WebdavErrorCodes` | 70101+ (`IPSWebdavErrors`) | All non-auditable protocol/ops codes |
 | `ServletErrorCodes` | 10151+ (`IPSServletErrors`) | All non-auditable |
 | `TransformationErrorCodes` | package-local (no flat register) | Prefer enum; WF collision on bare 1 |
+| `SearchErrorCodes` | 16001–16054 (`IPSSearchErrors`) | Auth failure dual-write; rest operational |
+| `LuceneErrorCodes` | 16311–16456 (`IPSLuceneErrors`) | All non-auditable index/query codes |
+| `LocaleErrorCodes` | 1801–1804 (`IPSLocaleErrors`) | All non-auditable |
+| `MailErrorCodes` | 3501–3508 (`IPSMailErrors`) | All non-auditable |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -23,7 +23,11 @@ import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
@@ -50,9 +54,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * ExtensionErrorCodes} (globally unique extension ints), non-colliding {@link AssemblyErrorCodes}
  * package-local ints, non-colliding {@link WebserviceErrorCodes} package-local ints (28–73), fully
  * unique {@link ServerWebServicesErrorCodes} / {@link WebdavErrorCodes} / {@link ServletErrorCodes},
- * and bootstrap-only {@link TransformationErrorCodes} / {@link DeliveryErrorCodes} (no flat
- * register). Residual slices may register additional catalogs via {@link #register(int,
- * SystemErrorCode)}.
+ * fully unique {@link SearchErrorCodes} / {@link LuceneErrorCodes} / {@link LocaleErrorCodes} /
+ * {@link MailErrorCodes}, and bootstrap-only {@link TransformationErrorCodes} / {@link
+ * DeliveryErrorCodes} (no flat register). Residual slices may register additional catalogs via
+ * {@link #register(int, SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -66,14 +71,15 @@ public final class LegacyErrorCodeRegistry {
 
   /**
    * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design,
-   * server, HTTP, assembly, extension, delivery, job, webservices, WebDAV, servlet,
-   * transformation). Safe to call repeatedly; catalogs register themselves in their own static
-   * initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip package-local ints
-   * {@code 1–10} that collide with {@link WorkflowErrorCodes}. {@link JobErrorCodes} is
-   * bootstrapped after assembly so flat int {@code 11} ({@code CONFIG_FILE_NOT_FOUND}) wins over
-   * assembly package-local {@code MISSING_SLOT} (prefer enum for assembly {@code 11}). {@link
-   * WebserviceErrorCodes} skips package-local ints {@code 1–27}; {@link TransformationErrorCodes}
-   * and {@link DeliveryErrorCodes} do not flat-register.
+   * server, HTTP, assembly, extension, delivery, job, webservices, WebDAV, servlet, search,
+   * Lucene, locale, mail, transformation). Safe to call repeatedly; catalogs register themselves
+   * in their own static initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip
+   * package-local ints {@code 1–10} that collide with {@link WorkflowErrorCodes}. {@link
+   * JobErrorCodes} is bootstrapped after assembly so flat int {@code 11} ({@code
+   * CONFIG_FILE_NOT_FOUND}) wins over assembly package-local {@code MISSING_SLOT} (prefer enum for
+   * assembly {@code 11}). {@link WebserviceErrorCodes} skips package-local ints {@code 1–27};
+   * {@link TransformationErrorCodes} and {@link DeliveryErrorCodes} do not flat-register. Search /
+   * Lucene / Locale / Mail ints are globally unique and fully registered.
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
@@ -98,6 +104,11 @@ public final class LegacyErrorCodeRegistry {
       ServletErrorCodes.ensureRegistered();
       // Transformation: no-op flat register (WF collision on bare int 1).
       TransformationErrorCodes.ensureRegistered();
+      // Search/Lucene/Locale/Mail residual (#2880): globally unique ranges, full register.
+      SearchErrorCodes.ensureRegistered();
+      LuceneErrorCodes.ensureRegistered();
+      LocaleErrorCodes.ensureRegistered();
+      MailErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/LocaleErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/LocaleErrorCodes.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Locale manager error catalog bridging legacy {@code com.percussion.i18n.IPSLocaleErrors} ints
+ * (1801–1804: column restore, locale manager init).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: locale persistence / init
+ * failures are operational noise, not security dual-write events.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum LocaleErrorCodes implements SystemErrorCode {
+
+  INVALID_COLUMN_VALUE(
+      1801,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid locale column value",
+      "Invalid locale column value column={} value={}"),
+
+  MISSING_COLUMN(
+      1802,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing locale column",
+      "Missing locale column name={}"),
+
+  LOCALE_MGR_INIT(
+      1803,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Locale manager init error",
+      "Locale manager init error detail={}"),
+
+  LOCALE_MGR_UNEXPECTED_ERROR(
+      1804,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Locale manager unexpected error",
+      "Locale manager unexpected error detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  LocaleErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (LocaleErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/LuceneErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/LuceneErrorCodes.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Lucene search-engine error catalog bridging legacy {@code
+ * com.percussion.search.lucene.IPSLuceneErrors} ints (16311–16456: index directory, indexing,
+ * query).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: Lucene index / query failures are
+ * operational noise. Search-engine authentication dual-write remains on {@link
+ * SearchErrorCodes#SEARCH_ENGINE_AUTHENTICATION_FAILED}.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum LuceneErrorCodes implements SystemErrorCode {
+
+  INDEX_DIR_PARAM_INVALID_MISSING(
+      16311,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Index directory parameter invalid or missing",
+      "Index directory parameter invalid or missing param={}"),
+
+  INVALID_INDEX_DIRECTORY(
+      16366,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid index directory",
+      "Invalid index directory contentTypeId={} path={}"),
+
+  INDEX_CURRUPTED_EXCEPTION_INDEXING(
+      16402,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Corrupt index during indexing",
+      "Corrupt index during indexing contentTypeId={}"),
+
+  INDEX_IO_EXCEPTION_INDEXING(
+      16403,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Index IO exception during indexing",
+      "Index IO exception during indexing contentTypeId={}"),
+
+  INDEX_OPTIMIZATION_ERROR(
+      16404,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Index optimization error",
+      "Index optimization error contentTypeIds={}"),
+
+  INDEX_CURRUPTED_EXCEPTION_SEARCHING(
+      16451,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Corrupt index during search",
+      "Corrupt index during search contentTypeId={}"),
+
+  INDEX_IO_EXCEPTION_SEARCHING(
+      16452,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Index IO exception during search",
+      "Index IO exception during search contentTypeId={}"),
+
+  REPOSITORY_EXCEPTION(
+      16453,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Lucene repository exception",
+      "Lucene repository exception"),
+
+  HITS_IOEXCEPTION(
+      16454,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Hits IO exception",
+      "Hits IO exception"),
+
+  SEARCH_QUERY_PARSEEXCEPTION(
+      16455,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search query parse exception",
+      "Search query parse exception"),
+
+  SEARCH_QUERY_MULTISEARCHER(
+      16456,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search query multi-searcher error",
+      "Search query multi-searcher error");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  LuceneErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (LuceneErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/MailErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/MailErrorCodes.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Mail error catalog bridging legacy {@code com.percussion.mail.IPSMailErrors} ints (3501–3508:
+ * address validation, send failures, mail server connectivity).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: mail address / transport failures
+ * are operational noise, not security dual-write events.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum MailErrorCodes implements SystemErrorCode {
+
+  MAIL_ADDRESS_EMPTY(
+      3501,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail address empty",
+      "Mail address empty"),
+
+  MAIL_ADDRESS_INVALID(
+      3502,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail address invalid",
+      "Mail address invalid address={}"),
+
+  MAIL_CUSTOM_TO_HEADER_INVALID(
+      3503,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail custom To header invalid",
+      "Mail custom To header invalid header={}"),
+
+  MAIL_CUSTOM_TO_HEADER_EMPTY(
+      3504,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail custom To header empty",
+      "Mail custom To header empty"),
+
+  MAIL_SEND_UNEXPECTED_EXCEPTION(
+      3505,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail send unexpected exception",
+      "Mail send unexpected exception detail={}"),
+
+  MAIL_SERVER_UP_EXCEPTION(
+      3506,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail server up exception",
+      "Mail server up exception detail={}"),
+
+  MAIL_SERVER_CONNECTION_ERROR(
+      3507,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail server connection error",
+      "Mail server connection error detail={}"),
+
+  HOST_NOT_VALID(
+      3508,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mail host not valid",
+      "Mail host not valid detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  MailErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (MailErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SearchErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SearchErrorCodes.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Search engine error catalog bridging legacy {@code com.percussion.search.IPSSearchErrors} ints
+ * (16001–16054: general search engine, init/config). Lucene-specific ints live in {@link
+ * LuceneErrorCodes} (16311+).
+ *
+ * <p>{@link #SEARCH_ENGINE_AUTHENTICATION_FAILED} dual-writes ({@link
+ * AuditEventType#AUTH_FAILURE}); all other constants are operational noise ({@link
+ * #isAuditable()} {@code false}).
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum SearchErrorCodes implements SystemErrorCode {
+
+  SEARCH_ENGINE_UNIMPLEMENTED_OPERATION(
+      16001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine unimplemented operation",
+      "Search engine unimplemented operation"),
+
+  SEARCH_ENGINE_OBJECT_NOT_FOUND(
+      16002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine object not found",
+      "Search engine object not found library={}"),
+
+  SEARCH_ENGINE_NO_SEARCH_TERMS(
+      16003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine no search terms",
+      "Search engine no search terms"),
+
+  SEARCH_ENGINE_FATAL_ERROR(
+      16004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine fatal error",
+      "Search engine fatal error"),
+
+  SEARCH_ENGINE_BAD_PARAMETERS(
+      16005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine bad parameters",
+      "Search engine bad parameters"),
+
+  SEARCH_ENGINE_WILDCARD_LIMIT(
+      16006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine wildcard limit",
+      "Search engine wildcard limit"),
+
+  SEARCH_ENGINE_UNEXPECTED_ERROR(
+      16007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine unexpected error",
+      "Search engine unexpected error code={} system={}"),
+
+  SEARCH_ENGINE_QUERY_PARSE_ERROR(
+      16008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine query parse error",
+      "Search engine query parse error engine={} detail={}"),
+
+  ADMIN_HANDLER_LOCKED(
+      16009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search admin handler locked",
+      "Search admin handler locked"),
+
+  UNRELEASED_OBJECTS(
+      16010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search unreleased objects",
+      "Search unreleased objects admin={} query={} indexer={}"),
+
+  SEARCH_ENGINE_REQUIRED(
+      16011,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine required",
+      "Search engine required"),
+
+  INVALID_INDEX_CONTENTTYPE(
+      16012,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid index content type",
+      "Invalid index content type contentId={} contentTypeId={}"),
+
+  SEARCH_ENGINE_FAILED_INIT(
+      16051,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search engine failed init",
+      "Search engine failed init class={} detail={}"),
+
+  SEARCH_ENGINE_AUTHENTICATION_FAILED(
+      16052,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Search engine authentication failed",
+      "Search engine authentication failed"),
+
+  HTML_SEARCH_MISSING_PARAMETER(
+      16053,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Html search missing parameter",
+      "Html search missing parameter name={} type={}"),
+
+  USE_GET_INSTANCE(
+      16054,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Use getInstance instead of new",
+      "Use getInstance instead of new");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  SearchErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (SearchErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -28,7 +28,11 @@ import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
@@ -699,6 +703,148 @@ class LegacyErrorCodeRegistryTest {
     assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
     assertFalse(TransformationErrorCodes.NO_CONVERTER_FOUND.isAuditable());
     assertEquals(1, TransformationErrorCodes.NO_CONVERTER_FOUND.numericCode());
+  }
+
+  // --- Search / Lucene / Locale / Mail residual (#2880) ---
+
+  @Test
+  void searchAuthenticationFailedIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(16052));
+    assertSame(
+        SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED,
+        LegacyErrorCodeRegistry.find(16052).orElseThrow());
+    assertTrue(SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED.isAuditable());
+  }
+
+  @Test
+  void searchAuthenticationFailedDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(
+        SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-16052]-"));
+  }
+
+  @Test
+  void searchOperationalCodeIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(16001));
+    assertSame(
+        SearchErrorCodes.SEARCH_ENGINE_UNIMPLEMENTED_OPERATION,
+        LegacyErrorCodeRegistry.find(16001).orElseThrow());
+    assertFalse(SearchErrorCodes.SEARCH_ENGINE_UNIMPLEMENTED_OPERATION.isAuditable());
+  }
+
+  @Test
+  void searchNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SearchErrorCodes.SEARCH_ENGINE_FATAL_ERROR.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void luceneIndexCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(16311));
+    assertSame(
+        LuceneErrorCodes.INDEX_DIR_PARAM_INVALID_MISSING,
+        LegacyErrorCodeRegistry.find(16311).orElseThrow());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(16451));
+    assertSame(
+        LuceneErrorCodes.INDEX_CURRUPTED_EXCEPTION_SEARCHING,
+        LegacyErrorCodeRegistry.find(16451).orElseThrow());
+  }
+
+  @Test
+  void luceneNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            LuceneErrorCodes.SEARCH_QUERY_PARSEEXCEPTION.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void localeCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(1801));
+    assertSame(
+        LocaleErrorCodes.INVALID_COLUMN_VALUE, LegacyErrorCodeRegistry.find(1801).orElseThrow());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(1804));
+    assertSame(
+        LocaleErrorCodes.LOCALE_MGR_UNEXPECTED_ERROR,
+        LegacyErrorCodeRegistry.find(1804).orElseThrow());
+  }
+
+  @Test
+  void localeNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            LocaleErrorCodes.LOCALE_MGR_INIT.numericCode(),
+            AuditContext.empty(),
+            "init failed");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void mailCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(3501));
+    assertSame(MailErrorCodes.MAIL_ADDRESS_EMPTY, LegacyErrorCodeRegistry.find(3501).orElseThrow());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(3507));
+    assertSame(
+        MailErrorCodes.MAIL_SERVER_CONNECTION_ERROR,
+        LegacyErrorCodeRegistry.find(3507).orElseThrow());
+  }
+
+  @Test
+  void mailNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            MailErrorCodes.MAIL_ADDRESS_INVALID.numericCode(),
+            AuditContext.empty(),
+            "bad@");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void registryCoversSearchLuceneLocaleAndMail() {
+    assertTrue(LegacyErrorCodeRegistry.size() >= 380);
+    assertTrue(LegacyErrorCodeRegistry.find(16052).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(16311).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(1801).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(3501).isPresent());
   }
 
 }

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/LocaleErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/LocaleErrorCodesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class LocaleErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (LocaleErrorCodes code : LocaleErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 1801, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(4, LocaleErrorCodes.values().length);
+  }
+
+  @Test
+  void allLocaleCodesAreNonAuditable() {
+    for (LocaleErrorCodes code : LocaleErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsLocaleErrorsNumericValues() {
+    assertEquals(1801, LocaleErrorCodes.INVALID_COLUMN_VALUE.numericCode());
+    assertEquals(1802, LocaleErrorCodes.MISSING_COLUMN.numericCode());
+    assertEquals(1803, LocaleErrorCodes.LOCALE_MGR_INIT.numericCode());
+    assertEquals(1804, LocaleErrorCodes.LOCALE_MGR_UNEXPECTED_ERROR.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/LuceneErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/LuceneErrorCodesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class LuceneErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (LuceneErrorCodes code : LuceneErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 16311, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(11, LuceneErrorCodes.values().length);
+  }
+
+  @Test
+  void allLuceneCodesAreNonAuditable() {
+    for (LuceneErrorCodes code : LuceneErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsLuceneErrorsNumericValues() {
+    assertEquals(16311, LuceneErrorCodes.INDEX_DIR_PARAM_INVALID_MISSING.numericCode());
+    assertEquals(16366, LuceneErrorCodes.INVALID_INDEX_DIRECTORY.numericCode());
+    assertEquals(16402, LuceneErrorCodes.INDEX_CURRUPTED_EXCEPTION_INDEXING.numericCode());
+    assertEquals(16451, LuceneErrorCodes.INDEX_CURRUPTED_EXCEPTION_SEARCHING.numericCode());
+    assertEquals(16456, LuceneErrorCodes.SEARCH_QUERY_MULTISEARCHER.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/MailErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/MailErrorCodesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class MailErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (MailErrorCodes code : MailErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 3501, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(8, MailErrorCodes.values().length);
+  }
+
+  @Test
+  void allMailCodesAreNonAuditable() {
+    for (MailErrorCodes code : MailErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsMailErrorsNumericValues() {
+    assertEquals(3501, MailErrorCodes.MAIL_ADDRESS_EMPTY.numericCode());
+    assertEquals(3502, MailErrorCodes.MAIL_ADDRESS_INVALID.numericCode());
+    assertEquals(3505, MailErrorCodes.MAIL_SEND_UNEXPECTED_EXCEPTION.numericCode());
+    assertEquals(3507, MailErrorCodes.MAIL_SERVER_CONNECTION_ERROR.numericCode());
+    assertEquals(3508, MailErrorCodes.HOST_NOT_VALID.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SearchErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SearchErrorCodesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class SearchErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (SearchErrorCodes code : SearchErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 16001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(16, SearchErrorCodes.values().length);
+  }
+
+  @Test
+  void onlyAuthenticationFailedIsAuditable() {
+    for (SearchErrorCodes code : SearchErrorCodes.values()) {
+      if (code == SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED) {
+        assertTrue(code.isAuditable(), code.name());
+        assertEquals(AuditEventType.AUTH_FAILURE, code.eventType());
+        assertEquals(AuditOutcome.FAILURE, code.defaultOutcome());
+      } else {
+        assertFalse(code.isAuditable(), code.name());
+        assertNull(code.eventType(), code.name());
+      }
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsSearchErrorsNumericValues() {
+    assertEquals(16001, SearchErrorCodes.SEARCH_ENGINE_UNIMPLEMENTED_OPERATION.numericCode());
+    assertEquals(16012, SearchErrorCodes.INVALID_INDEX_CONTENTTYPE.numericCode());
+    assertEquals(16051, SearchErrorCodes.SEARCH_ENGINE_FAILED_INIT.numericCode());
+    assertEquals(16052, SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED.numericCode());
+    assertEquals(16054, SearchErrorCodes.USE_GET_INSTANCE.numericCode());
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2b residual of #2616: migrate **Search / Lucene / Locale / Mail** legacy `IPS*Errors` catalogs into package `*ErrorCodes` enums with explicit `isAuditable` and full `LegacyErrorCodeRegistry` registration.

### Catalogs
| Enum | Legacy | Range | Auditable |
|------|--------|-------|-----------|
| `SearchErrorCodes` | `IPSSearchErrors` | 16001–16054 | Only `SEARCH_ENGINE_AUTHENTICATION_FAILED` (16052) |
| `LuceneErrorCodes` | `IPSLuceneErrors` | 16311–16456 | None (operational index/query) |
| `LocaleErrorCodes` | `IPSLocaleErrors` | 1801–1804 | None |
| `MailErrorCodes` | `IPSMailErrors` | 3501–3508 | None |

All ranges are globally unique — no flat-int collisions with existing catalogs; full register.

Parent: #2616

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **170**, Failures: **0** (includes new enum tests + dual-write registry tests)
- [x] Assert search auth dual-writes (`[SYS-16052]-…`); Lucene/Locale/Mail/non-auditable search skip

## Product documentation
- [x] N/A — internal error-code catalog migration only; no operator/UI/REST/install surface change

## Build evidence (C3)
- **modules_built:** `modules/perc-auditlog`
- **build_evidence:** `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 170, Failures: 0
- **downstream_checked:** none (new enums + registry bootstrap only; no public API signature/`final`/`sealed` changes on types consumed outside this module)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2880
Refs #2616

> Co-Authored by Grok Build using grok-4.5 with agent main.
