### PR TITLE
feat(auditlog): Data/BackEnd/Connection/Clone ErrorCodes + isAuditable (#2881)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -18,7 +18,8 @@ System-wide Percussion CMS audit logging and unified error-code support.
   `WebserviceErrorCodes` (package-local 28–73), `ServerWebServicesErrorCodes`, `WebdavErrorCodes`,
   `ServletErrorCodes`, `TransformationErrorCodes` (enum-only),
   `SearchErrorCodes` (`IPSSearchErrors`; auth failure dual-write), `LuceneErrorCodes`,
-  `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable)
+  `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable),
+  `DataErrorCodes` / `BackEndErrorCodes` / `ConnectionErrorCodes` / `CloneErrorCodes` (data-plane)
   + `LegacyErrorCodeRegistry` bridge legacy `IPS*Errors` ints. Non-auditable / unregistered ints never
   dual-write. Central `PSErrorHandler.appendError` dual-writes only when the registry marks the legacy
   int auditable.
@@ -65,7 +66,11 @@ audit.log(
 ```java
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CloneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ConnectionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
@@ -102,8 +107,12 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 1001, ctx); // SYS native — non-
 LegacyErrorCodeRegistry.logIfAuditable(audit, 401, ctx); // HTTP status — non-auditable skip
 LegacyErrorCodeRegistry.logIfAuditable(audit, 16052, ctx); // search auth failed — dual-write
 LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir — non-auditable skip
+LegacyErrorCodeRegistry.logIfAuditable(audit, 5001, ctx, "host", "user", "driver", "srv"); // BE authz
+LegacyErrorCodeRegistry.logIfAuditable(audit, 5201, ctx); // data query — non-auditable skip
+LegacyErrorCodeRegistry.logIfAuditable(audit, 3107, ctx); // connection unauthorized dual-write
+LegacyErrorCodeRegistry.logIfAuditable(audit, 17503, ctx, "msg"); // clone not authorized dual-write
 // Prefer JobErrorCodes enum for job ints 1–10 (flat registry keeps WF ownership of 1–10)
-// Provider/config/conversion/path/design/server/http/job/assembly/extension/webservice noise (isAuditable=false) and unknown ints → no dual-write
+// Provider/config/conversion/path/design/server/http/job/assembly/extension/webservice/data noise (isAuditable=false) and unknown ints → no dual-write
 ```
 
 | Catalog | Ranges | Notes |
@@ -128,6 +137,10 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir �
 | `LuceneErrorCodes` | 16311–16456 (`IPSLuceneErrors`) | All non-auditable index/query codes |
 | `LocaleErrorCodes` | 1801–1804 (`IPSLocaleErrors`) | All non-auditable |
 | `MailErrorCodes` | 3501–3508 (`IPSMailErrors`) | All non-auditable |
+| `DataErrorCodes` | 5201–5267, 6003–6046 (`IPSDataErrors`) | All non-auditable data/XML pipeline codes |
+| `BackEndErrorCodes` | 5001–5057, 5401–5402, 5999 (`IPSBackEndErrors`) | Only `AUTHORIZATION_ERROR` dual-writes |
+| `ConnectionErrorCodes` | 3001–3012, 3101–3107 (`IPSConnectionErrors`) | Only `UNAUTHORIZED` dual-writes; 3001–3005 overlap USER package-local (USER not flat-registered) |
+| `CloneErrorCodes` | 17501–17506 (`IPSCloneErrors`) | `NOT_AUTHENTICACATED` / `NOT_AUTHORIZED` dual-write |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -17,7 +17,11 @@
 package com.intsof.percussioncms.auditlog;
 
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CloneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ConnectionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
@@ -55,9 +59,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * package-local ints, non-colliding {@link WebserviceErrorCodes} package-local ints (28–73), fully
  * unique {@link ServerWebServicesErrorCodes} / {@link WebdavErrorCodes} / {@link ServletErrorCodes},
  * fully unique {@link SearchErrorCodes} / {@link LuceneErrorCodes} / {@link LocaleErrorCodes} /
- * {@link MailErrorCodes}, and bootstrap-only {@link TransformationErrorCodes} / {@link
- * DeliveryErrorCodes} (no flat register). Residual slices may register additional catalogs via
- * {@link #register(int, SystemErrorCode)}.
+ * {@link MailErrorCodes}, data-plane {@link DataErrorCodes} / {@link BackEndErrorCodes} / {@link
+ * ConnectionErrorCodes} / {@link CloneErrorCodes}, and bootstrap-only {@link
+ * TransformationErrorCodes} / {@link DeliveryErrorCodes} (no flat register). Residual slices may
+ * register additional catalogs via {@link #register(int, SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -72,14 +77,19 @@ public final class LegacyErrorCodeRegistry {
   /**
    * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design,
    * server, HTTP, assembly, extension, delivery, job, webservices, WebDAV, servlet, search,
-   * Lucene, locale, mail, transformation). Safe to call repeatedly; catalogs register themselves
-   * in their own static initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip
-   * package-local ints {@code 1–10} that collide with {@link WorkflowErrorCodes}. {@link
-   * JobErrorCodes} is bootstrapped after assembly so flat int {@code 11} ({@code
-   * CONFIG_FILE_NOT_FOUND}) wins over assembly package-local {@code MISSING_SLOT} (prefer enum for
-   * assembly {@code 11}). {@link WebserviceErrorCodes} skips package-local ints {@code 1–27};
-   * {@link TransformationErrorCodes} and {@link DeliveryErrorCodes} do not flat-register. Search /
-   * Lucene / Locale / Mail ints are globally unique and fully registered.
+   * Lucene, locale, mail, transformation, data/back-end/connection/clone). Safe to call
+   * repeatedly; catalogs register themselves in their own static initializers. {@link
+   * AssemblyErrorCodes} and {@link JobErrorCodes} skip package-local ints {@code 1–10} that
+   * collide with {@link WorkflowErrorCodes}. {@link JobErrorCodes} is bootstrapped after assembly
+   * so flat int {@code 11} ({@code CONFIG_FILE_NOT_FOUND}) wins over assembly package-local
+   * {@code MISSING_SLOT} (prefer enum for assembly {@code 11}). {@link WebserviceErrorCodes}
+   * skips package-local ints {@code 1–27}; {@link TransformationErrorCodes} and {@link
+   * DeliveryErrorCodes} do not flat-register. Search / Lucene / Locale / Mail ints are globally
+   * unique and fully registered. Data-plane catalogs ({@link DataErrorCodes}, {@link
+   * BackEndErrorCodes}, {@link ConnectionErrorCodes}, {@link CloneErrorCodes}) use globally unique
+   * legacy ranges and fully flat-register (connection 3001–3005 overlap Phase-2a {@code
+   * UserManagementErrorCodes} package-local numbers only — those USER codes are not
+   * flat-registered).
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
@@ -109,6 +119,11 @@ public final class LegacyErrorCodeRegistry {
       LuceneErrorCodes.ensureRegistered();
       LocaleErrorCodes.ensureRegistered();
       MailErrorCodes.ensureRegistered();
+      // Data-plane residual (#2881): globally unique ranges (5001+, 5201+, 3001+, 17501+).
+      DataErrorCodes.ensureRegistered();
+      BackEndErrorCodes.ensureRegistered();
+      ConnectionErrorCodes.ensureRegistered();
+      CloneErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/BackEndErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/BackEndErrorCodes.java
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+
+/**
+ * Error catalog bridging legacy {@code com.percussion.data.IPSBackEndErrors} ints
+ * (5001–5057, 5401–5402, 5999: connectivity, SQL builder, exec plan, activity log).
+ *
+ * <p>{@link #numericCode()} preserves historical ints. Every constant sets {@link #isAuditable()}
+ * explicitly. Only {@link #AUTHORIZATION_ERROR} dual-writes; JDBC/SQL/pool failures do not.
+ *
+ * <p>All ints in this catalog are flat-registered in {@link LegacyErrorCodeRegistry} (no
+ * package-local collision with already-bootstrapped catalogs). Module code is
+ * {@link AuditModule#SYS}.
+ */
+public enum BackEndErrorCodes implements SystemErrorCode {
+
+  AUTHORIZATION_ERROR(
+      5001,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Authorization error",
+      "Authorization error detail={}"),
+  REQUEST_QUEUE_FULL(
+      5002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Request queue full",
+      "Request queue full detail={}"),
+  SERVER_DOWN_ERROR(
+      5003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server down error",
+      "Server down error detail={}"),
+  SET_CATALOG_RETRY(
+      5004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Set catalog retry",
+      "Set catalog retry detail={}"),
+  SET_CATALOG_FAILED(
+      5005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Set catalog failed",
+      "Set catalog failed detail={}"),
+  CONNECT_INTERRUPTED(
+      5006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Connect interrupted",
+      "Connect interrupted detail={}"),
+  LOGIN_TIMEOUT_INVALID_USING_DEFAULT(
+      5007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Login timeout invalid using default",
+      "Login timeout invalid using default detail={}"),
+  JDBC_DRIVER_LOAD_FAILED(
+      5008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Jdbc driver load failed",
+      "Jdbc driver load failed detail={}"),
+  JDBC_CLASS_NOT_FOUND(
+      5009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Jdbc class not found",
+      "Jdbc class not found detail={}"),
+  CONN_RELEASE_MONITOR_LOST(
+      5010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Conn release monitor lost",
+      "Conn release monitor lost detail={}"),
+  SQL_BUILDER_NO_BACK_ENDS(
+      5011,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder no back ends",
+      "Sql builder no back ends detail={}"),
+  SQL_BUILDER_NO_BACK_END_TABLES(
+      5012,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder no back end tables",
+      "Sql builder no back end tables detail={}"),
+  SQL_BUILDER_NO_CONN_DEFINED(
+      5013,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder no conn defined",
+      "Sql builder no conn defined detail={}"),
+  SQL_BUILDER_GET_DATATYPE_EXCEPTION(
+      5014,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder get datatype exception",
+      "Sql builder get datatype exception detail={}"),
+  SQL_BUILDER_VAR_NOT_TERMINATED(
+      5015,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder var not terminated",
+      "Sql builder var not terminated detail={}"),
+  SQL_BUILDER_NO_BECOL_IN_MAP(
+      5016,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder no becol in map",
+      "Sql builder no becol in map detail={}"),
+  SQL_BUILDER_NO_SELECT_COLS_IN_BECOL(
+      5017,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder no select cols in becol",
+      "Sql builder no select cols in becol detail={}"),
+  SQL_BUILDER_ORDER_BY_COL_NULL(
+      5018,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder order by col null",
+      "Sql builder order by col null detail={}"),
+  EXEC_PLAN_APP_HANDLER_NULL(
+      5019,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan app handler null",
+      "Exec plan app handler null detail={}"),
+  EXEC_PLAN_DATA_SET_NULL(
+      5020,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan data set null",
+      "Exec plan data set null detail={}"),
+  EXEC_PLAN_PIPES_NULL(
+      5021,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan pipes null",
+      "Exec plan pipes null detail={}"),
+  EXEC_PLAN_NO_QUERY_PIPES(
+      5022,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan no query pipes",
+      "Exec plan no query pipes detail={}"),
+  EXEC_PLAN_MULTIPLE_QUERY_PIPES(
+      5023,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan multiple query pipes",
+      "Exec plan multiple query pipes detail={}"),
+  EXEC_PLAN_NO_BETABLES_IN_PIPE(
+      5024,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan no betables in pipe",
+      "Exec plan no betables in pipe detail={}"),
+  EXEC_DATA_CLOSE_RESULT_SET(
+      5025,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec data close result set",
+      "Exec data close result set detail={}"),
+  EXEC_DATA_CLOSE_PREP_STMT(
+      5026,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec data close prep stmt",
+      "Exec data close prep stmt detail={}"),
+  EXEC_DATA_NO_CONNECTIONS(
+      5027,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec data no connections",
+      "Exec data no connections detail={}"),
+  EXEC_DATA_BAD_CONN_KEY(
+      5028,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec data bad conn key",
+      "Exec data bad conn key detail={}"),
+  LOAD_DEF_CREDENTIALS_EXCEPTION(
+      5029,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Load def credentials exception",
+      "Load def credentials exception detail={}"),
+  DBPOOL_CONN_INIT_EXCEEDS_MAX(
+      5030,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dbpool conn init exceeds max",
+      "Dbpool conn init exceeds max detail={}"),
+  DBPOOL_CONN_INIT_EXCEPTION(
+      5031,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dbpool conn init exception",
+      "Dbpool conn init exception detail={}"),
+  SQL_BUILDER_NO_JOINS(
+      5032,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder no joins",
+      "Sql builder no joins detail={}"),
+  EXEC_PLAN_MULTIPLE_BETABLES_IN_PIPE(
+      5033,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan multiple betables in pipe",
+      "Exec plan multiple betables in pipe detail={}"),
+  SQL_BUILDER_MOD_SINGLE_TAB_ONLY(
+      5034,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder mod single tab only",
+      "Sql builder mod single tab only detail={}"),
+  SQL_BUILDER_UDF_NOT_SUPPORTED_IN_MOD(
+      5035,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder udf not supported in mod",
+      "Sql builder udf not supported in mod detail={}"),
+  SQL_BUILDER_MOD_TABLE_REQD(
+      5036,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder mod table reqd",
+      "Sql builder mod table reqd detail={}"),
+  SQL_BUILDER_UPDATABLE_COL_REQD(
+      5037,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder updatable col reqd",
+      "Sql builder updatable col reqd detail={}"),
+  SQL_BUILDER_UPD_OR_DEL_NO_WHERE(
+      5038,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder upd or del no where",
+      "Sql builder upd or del no where detail={}"),
+  SQL_BUILDER_MOD_MAP_REQD(
+      5039,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder mod map reqd",
+      "Sql builder mod map reqd detail={}"),
+  EXEC_PLAN_NO_UPDATE_PIPES(
+      5040,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan no update pipes",
+      "Exec plan no update pipes detail={}"),
+  EXEC_PLAN_MULTIPLE_UPDATE_PIPES(
+      5041,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan multiple update pipes",
+      "Exec plan multiple update pipes detail={}"),
+  EXEC_PLAN_COL_UPD_AND_KEY_NOT_SUPPORTED(
+      5042,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan col upd and key not supported",
+      "Exec plan col upd and key not supported detail={}"),
+  LOAD_META_DATA_EXCEPTION(
+      5043,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Load meta data exception",
+      "Load meta data exception detail={}"),
+  NO_LOOKUP_INDEX_DEFINED(
+      5044,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No lookup index defined",
+      "No lookup index defined detail={}"),
+  UPDATE_MAP_NOT_TO_BECOL(
+      5045,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Update map not to becol",
+      "Update map not to becol detail={}"),
+  DBPOOL_CONN_RELEASE_EXCEPTION(
+      5046,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dbpool conn release exception",
+      "Dbpool conn release exception detail={}"),
+  DATA_MOD_UNSUPPORTED_FOR_XDEPEND(
+      5047,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Data mod unsupported for xdepend",
+      "Data mod unsupported for xdepend detail={}"),
+  EXEC_PLAN_UPD_COL_NOT_MAPPED(
+      5048,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan upd col not mapped",
+      "Exec plan upd col not mapped detail={}"),
+  EXEC_PLAN_KEY_COL_NOT_MAPPED(
+      5049,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan key col not mapped",
+      "Exec plan key col not mapped detail={}"),
+  DATABASE_ACCESS_ERROR(
+      5050,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Database access error",
+      "Database access error detail={}"),
+  BE_CONN_EXCEPTION(
+      5051,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Be conn exception",
+      "Be conn exception detail={}"),
+  NO_AVAILABLE_BE_CONNS(
+      5052,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No available be conns",
+      "No available be conns detail={}"),
+  SQL_BUILDER_LITSET_REQD_FOR_OP(
+      5053,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder litset reqd for op",
+      "Sql builder litset reqd for op detail={}"),
+  SQL_BUILDER_LITSET_INVALID_FOR_OP(
+      5054,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder litset invalid for op",
+      "Sql builder litset invalid for op detail={}"),
+  SQL_BUILDER_LITSET_WRONG_SIZE(
+      5055,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder litset wrong size",
+      "Sql builder litset wrong size detail={}"),
+  SQL_BUILDER_LITSET_EMPTY(
+      5056,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder litset empty",
+      "Sql builder litset empty detail={}"),
+  SQL_BUILDER_ALIAS_UNSUPPORTED(
+      5057,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder alias unsupported",
+      "Sql builder alias unsupported detail={}"),
+  LOG_PREPARED_STMT(
+      5401,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Log prepared stmt",
+      "Log prepared stmt detail={}"),
+  LOG_BOUND_COL_DATA(
+      5402,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Log bound col data",
+      "Log bound col data detail={}"),
+  NOT_YET_SUPPORTED(
+      5999,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Not yet supported",
+      "Not yet supported detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  BackEndErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (BackEndErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/CloneErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/CloneErrorCodes.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+
+/**
+ * Error catalog bridging legacy {@code com.percussion.server.clone.IPSCloneErrors} ints
+ * (17501–17506: clone source id, authz, internal request, resource, role).
+ *
+ * <p>{@link #numericCode()} preserves historical ints. Every constant sets {@link #isAuditable()}
+ * explicitly. {@link #NOT_AUTHENTICACATED} and {@link #NOT_AUTHORIZED} dual-write; parse/resource noise does not.
+ *
+ * <p>All ints in this catalog are flat-registered in {@link LegacyErrorCodeRegistry} (no
+ * package-local collision with already-bootstrapped catalogs). Module code is
+ * {@link AuditModule#SYS}.
+ */
+public enum CloneErrorCodes implements SystemErrorCode {
+
+  INVALID_CLONESOURCEID(
+      17501,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid clonesourceid",
+      "Invalid clonesourceid detail={}"),
+  /** Legacy IPS name misspells “authenticated”; message uses correct spelling. */
+  NOT_AUTHENTICACATED(
+      17502,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Not authenticated",
+      "Not authenticated detail={}"),
+  NOT_AUTHORIZED(
+      17503,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Not authorized",
+      "Not authorized detail={}"),
+  INTERNAL_REQUEST_ERROR(
+      17504,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Internal request error",
+      "Internal request error detail={}"),
+  REQUIRED_RESOURCE_MISSING(
+      17505,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Required resource missing",
+      "Required resource missing detail={}"),
+  ROLE_CREATION_ERROR(
+      17506,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Role creation error",
+      "Role creation error detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  CloneErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (CloneErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ConnectionErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ConnectionErrorCodes.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+
+/**
+ * Error catalog bridging legacy {@code com.percussion.conn.IPSConnectionErrors} ints
+ * (3001–3012, 3101–3107: client connection / socket / response).
+ *
+ * <p>{@link #numericCode()} preserves historical ints. Every constant sets {@link #isAuditable()}
+ * explicitly. Only {@link #UNAUTHORIZED} dual-writes; port/host/socket/config noise does not. Numeric ints 3001–3005 overlap Phase-2a {@link UserManagementErrorCodes} package-local numbers; those USER codes are not flat-registered, so legacy connection ints own the flat registry keys.
+ *
+ * <p>All ints in this catalog are flat-registered in {@link LegacyErrorCodeRegistry} (no
+ * package-local collision with already-bootstrapped catalogs). Module code is
+ * {@link AuditModule#SYS}.
+ */
+public enum ConnectionErrorCodes implements SystemErrorCode {
+
+  PORT_NUMBER_INVALID(
+      3001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Port number invalid",
+      "Port number invalid detail={}"),
+  PORT_NUMBER_REQD(
+      3002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Port number reqd",
+      "Port number reqd detail={}"),
+  HOST_ADDRESS_INVALID(
+      3003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Host address invalid",
+      "Host address invalid detail={}"),
+  HOST_ADDRESS_REQD(
+      3004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Host address reqd",
+      "Host address reqd detail={}"),
+  QUEUE_LIMIT_INVALID(
+      3005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Queue limit invalid",
+      "Queue limit invalid detail={}"),
+  CONN_ALREADY_CLOSED(
+      3006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Conn already closed",
+      "Conn already closed detail={}"),
+  CONN_PROPS_REQD(
+      3007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Conn props reqd",
+      "Conn props reqd detail={}"),
+  SERVER_NOT_RESPONDING(
+      3008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server not responding",
+      "Server not responding detail={}"),
+  CONN_ALREADY_OPENED(
+      3009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Conn already opened",
+      "Conn already opened detail={}"),
+  CONN_PROP_MISSING(
+      3010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Conn prop missing",
+      "Conn prop missing detail={}"),
+  UNSUPPORTED_SSL_CIPHER(
+      3011,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported ssl cipher",
+      "Unsupported ssl cipher detail={}"),
+  SOCKET_TIMEOUT_INVALID(
+      3012,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Socket timeout invalid",
+      "Socket timeout invalid detail={}"),
+  UNKNOWN_SERVER_EXCEPTION(
+      3101,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown server exception",
+      "Unknown server exception detail={}"),
+  SERVER_GENERATED_EXCEPTION(
+      3102,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server generated exception",
+      "Server generated exception detail={}"),
+  RESPONSE_INVALID_MIME_TYPE(
+      3103,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Response invalid mime type",
+      "Response invalid mime type detail={}"),
+  RESPONSE_PARSE_EXCEPTION(
+      3104,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Response parse exception",
+      "Response parse exception detail={}"),
+  RESPONSE_PARSE_EXCEPTION_NOLINEINFO(
+      3105,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Response parse exception nolineinfo",
+      "Response parse exception nolineinfo detail={}"),
+  NULL_SOCKET(
+      3106,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Null socket",
+      "Null socket detail={}"),
+  UNAUTHORIZED(
+      3107,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Unauthorized",
+      "Unauthorized detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  ConnectionErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ConnectionErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/DataErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/DataErrorCodes.java
@@ -1,0 +1,867 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+
+/**
+ * Error catalog bridging legacy {@code com.percussion.data.IPSDataErrors} ints
+ * (5201–6046: back-end data processing + XML/general data).
+ *
+ * <p>{@link #numericCode()} preserves historical ints. Every constant sets {@link #isAuditable()}
+ * explicitly. Data pipeline / result-set / XML processing failures are operational noise (all non-auditable).
+ *
+ * <p>All ints in this catalog are flat-registered in {@link LegacyErrorCodeRegistry} (no
+ * package-local collision with already-bootstrapped catalogs). Module code is
+ * {@link AuditModule#SYS}.
+ */
+public enum DataErrorCodes implements SystemErrorCode {
+
+  QUERY_PROCESSING_ERROR(
+      5201,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Query processing error",
+      "Query processing error detail={}"),
+  UPDATE_PROCESSING_ERROR(
+      5202,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Update processing error",
+      "Update processing error detail={}"),
+  COLMAPPER_BE_COL_NOT_STMTCOL(
+      5203,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Colmapper be col not stmtcol",
+      "Colmapper be col not stmtcol detail={}"),
+  REQ_LINK_BE_VALS_INVALID(
+      5204,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Req link be vals invalid",
+      "Req link be vals invalid detail={}"),
+  REPLACEMENT_VALUE_REQD(
+      5205,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Replacement value reqd",
+      "Replacement value reqd detail={}"),
+  REQ_LINK_SOURCE_DS_NULL(
+      5206,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Req link source ds null",
+      "Req link source ds null detail={}"),
+  REQ_LINK_TARGET_DS_NULL(
+      5207,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Req link target ds null",
+      "Req link target ds null detail={}"),
+  BE_COL_EXTR_INVALID_COL(
+      5209,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Be col extr invalid col",
+      "Be col extr invalid col detail={}"),
+  BE_COL_EXTR_EXCEPTION(
+      5210,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Be col extr exception",
+      "Be col extr exception detail={}"),
+  BE_COL_GET_INDEX_EXCEPTION(
+      5211,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Be col get index exception",
+      "Be col get index exception detail={}"),
+  REQ_LINK_TYPE_UNSUPPORTED(
+      5212,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Req link type unsupported",
+      "Req link type unsupported detail={}"),
+  QUERY_LINK_TARGET_NOT_QUERY(
+      5213,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Query link target not query",
+      "Query link target not query detail={}"),
+  QUERY_LINK_TARGET_SELECTOR_REQD(
+      5214,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Query link target selector reqd",
+      "Query link target selector reqd detail={}"),
+  UPDATE_LINK_TARGET_NOT_UPDATE(
+      5215,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Update link target not update",
+      "Update link target not update detail={}"),
+  UPDATE_LINK_TARGET_SYNC_REQD(
+      5216,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Update link target sync reqd",
+      "Update link target sync reqd detail={}"),
+  UPDATE_LINK_KEY_NOT_MAPPED(
+      5217,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Update link key not mapped",
+      "Update link key not mapped detail={}"),
+  INDEX_JOINER_RESULT_SET_REQD(
+      5218,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Index joiner result set reqd",
+      "Index joiner result set reqd detail={}"),
+  INDEX_JOINER_LCOL_NOT_FOUND(
+      5219,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Index joiner lcol not found",
+      "Index joiner lcol not found detail={}"),
+  SORTED_JOINER_2_RESULT_SETS_REQD(
+      5220,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sorted joiner 2 result sets reqd",
+      "Sorted joiner 2 result sets reqd detail={}"),
+  SORTED_JOINER_LCOL_NOT_FOUND(
+      5221,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sorted joiner lcol not found",
+      "Sorted joiner lcol not found detail={}"),
+  SORTED_JOINER_RCOL_NOT_FOUND(
+      5222,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sorted joiner rcol not found",
+      "Sorted joiner rcol not found detail={}"),
+  SORTED_JOINER_COL_COUNT_MISMATCH(
+      5223,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sorted joiner col count mismatch",
+      "Sorted joiner col count mismatch detail={}"),
+  JOINED_ROW_BUF_RCOL_COUNT_MISMATCH(
+      5224,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Joined row buf rcol count mismatch",
+      "Joined row buf rcol count mismatch detail={}"),
+  CACHER_LOAD_XML_EXCEPTION(
+      5225,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cacher load xml exception",
+      "Cacher load xml exception detail={}"),
+  CACHER_STORE_XML_EXCEPTION(
+      5226,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cacher store xml exception",
+      "Cacher store xml exception detail={}"),
+  CACHER_LOAD_RESPAGE_EXCEPTION(
+      5227,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cacher load respage exception",
+      "Cacher load respage exception detail={}"),
+  CACHER_STORE_RESPAGE_EXCEPTION(
+      5228,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cacher store respage exception",
+      "Cacher store respage exception detail={}"),
+  CACHER_FULL(
+      5229,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cacher full",
+      "Cacher full detail={}"),
+  CACHER_FILE_REMOVE_EXCEPTION(
+      5230,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cacher file remove exception",
+      "Cacher file remove exception detail={}"),
+  EXEC_PLAN_LOG_DTD_OCCURS(
+      5231,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log dtd occurs",
+      "Exec plan log dtd occurs detail={}"),
+  EXEC_PLAN_LOG_COLLAPSED_XML_FIELD(
+      5232,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log collapsed xml field",
+      "Exec plan log collapsed xml field detail={}"),
+  CACHE_FILE_SEND_EXCEPTION(
+      5233,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cache file send exception",
+      "Cache file send exception detail={}"),
+  EXEC_PLAN_LOG_UPDATE_XML_WALKER_ROOT(
+      5234,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log update xml walker root",
+      "Exec plan log update xml walker root detail={}"),
+  EXEC_PLAN_LOG_UPDATE_XML_STMT_WALKER(
+      5235,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log update xml stmt walker",
+      "Exec plan log update xml stmt walker detail={}"),
+  EXEC_PLAN_LOG_REBASED_STMT_WALKER(
+      5236,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log rebased stmt walker",
+      "Exec plan log rebased stmt walker detail={}"),
+  UDF_HANDLER_NOT_LOADED(
+      5237,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Udf handler not loaded",
+      "Udf handler not loaded detail={}"),
+  EXEC_PLAN_IGNORE_NO_UPDCOL_UPDATE(
+      5238,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan ignore no updcol update",
+      "Exec plan ignore no updcol update detail={}"),
+  EXEC_PLAN_LOG_SQL_PLAN(
+      5239,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log sql plan",
+      "Exec plan log sql plan detail={}"),
+  EXEC_PLAN_NO_INDEX_LOOKUP_FULL_OUTER(
+      5240,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan no index lookup full outer",
+      "Exec plan no index lookup full outer detail={}"),
+  EXEC_PLAN_NO_INDEX_LOOKUP_RIGHT_OUTER(
+      5241,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan no index lookup right outer",
+      "Exec plan no index lookup right outer detail={}"),
+  CANNOT_LOAD_TABLE_META(
+      5242,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot load table meta",
+      "Cannot load table meta detail={}"),
+  CANNOT_LOAD_INDEX_META(
+      5243,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot load index meta",
+      "Cannot load index meta detail={}"),
+  EXEC_PLAN_NO_INDEX_LOOKUP_INDICES(
+      5244,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan no index lookup indices",
+      "Exec plan no index lookup indices detail={}"),
+  EXEC_PLAN_JOIN_CARDINALITY_NOT_FOUND(
+      5245,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan join cardinality not found",
+      "Exec plan join cardinality not found detail={}"),
+  EXEC_PLAN_LOG_JOIN_CARDINALITY(
+      5246,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log join cardinality",
+      "Exec plan log join cardinality detail={}"),
+  EXEC_PLAN_LOG_TABLE_CARDINALITY(
+      5247,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log table cardinality",
+      "Exec plan log table cardinality detail={}"),
+  EXEC_PLAN_LOG_UNIQUE_ROW_ESTIMATE(
+      5248,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log unique row estimate",
+      "Exec plan log unique row estimate detail={}"),
+  EXEC_PLAN_LOG_SELECTIVITY(
+      5249,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan log selectivity",
+      "Exec plan log selectivity detail={}"),
+  INSUFFICIENT_JOINS_FOR_TABLES(
+      5250,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Insufficient joins for tables",
+      "Insufficient joins for tables detail={}"),
+  EXEC_PLAN_JOIN_CARDINALITY_EXCEPTION(
+      5251,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan join cardinality exception",
+      "Exec plan join cardinality exception detail={}"),
+  EXEC_PLAN_JOIN_SELECTIVITY_EXCEPTION(
+      5252,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exec plan join selectivity exception",
+      "Exec plan join selectivity exception detail={}"),
+  SQL_BUILDER_HOMOGENEOUS_JOIN_ONLY(
+      5253,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder homogeneous join only",
+      "Sql builder homogeneous join only detail={}"),
+  SQL_BUILDER_MULTIPLE_OUTERS_NOT_SUPPORTED(
+      5254,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder multiple outers not supported",
+      "Sql builder multiple outers not supported detail={}"),
+  SQL_BUILDER_XLATOR_UNSUPPORTED_IN_HOMEGENEOUS(
+      5255,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sql builder xlator unsupported in homegeneous",
+      "Sql builder xlator unsupported in homegeneous detail={}"),
+  NO_JOIN_PATH_BETWEEN_TABLES(
+      5256,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No join path between tables",
+      "No join path between tables detail={}"),
+  OPTIMIZER_TABLE_STATS_NOT_LOADED(
+      5257,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Optimizer table stats not loaded",
+      "Optimizer table stats not loaded detail={}"),
+  WHERE_VAR_MUST_BE_BACKEND_COL(
+      5258,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Where var must be backend col",
+      "Where var must be backend col detail={}"),
+  EXECDATA_PRIVATE_OBJ_KEY_NULL(
+      5259,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Execdata private obj key null",
+      "Execdata private obj key null detail={}"),
+  UNKNOWN_OPCODE_LOAD_TYPE(
+      5260,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown opcode load type",
+      "Unknown opcode load type detail={}"),
+  WRONG_OPERATOR_USAGE(
+      5261,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Wrong operator usage",
+      "Wrong operator usage detail={}"),
+  WRONG_DATA_COMPARISON(
+      5262,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Wrong data comparison",
+      "Wrong data comparison detail={}"),
+  LVALUE_INVALID_TYPE(
+      5263,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Lvalue invalid type",
+      "Lvalue invalid type detail={}"),
+  RVALUE_INVALID_TYPE(
+      5264,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Rvalue invalid type",
+      "Rvalue invalid type detail={}"),
+  UNSUPPORTED_CONVERSION(
+      5265,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported conversion",
+      "Unsupported conversion detail={}"),
+  TYPE_COMPARISON_UNSUPPORTED(
+      5266,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Type comparison unsupported",
+      "Type comparison unsupported detail={}"),
+  OPERATOR_INVALID_FOR_TYPE(
+      5267,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Operator invalid for type",
+      "Operator invalid for type detail={}"),
+  USER_CTX_INVALID_TYPE(
+      5268,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "User ctx invalid type",
+      "User ctx invalid type detail={}"),
+  DATA_EXTRACTOR_CREATE_ERROR(
+      5269,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Data extractor create error",
+      "Data extractor create error detail={}"),
+  HTML_GENERATION_ERROR(
+      6003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Html generation error",
+      "Html generation error detail={}"),
+  NO_DATA_FOR_CONVERSION(
+      6004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No data for conversion",
+      "No data for conversion detail={}"),
+  CANNOT_CONVERT_MULTIPLE_RESULT_SETS(
+      6005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot convert multiple result sets",
+      "Cannot convert multiple result sets detail={}"),
+  HTML_CONV_EXT_NOT_SUPPORTED(
+      6006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Html conv ext not supported",
+      "Html conv ext not supported detail={}"),
+  XML_CONV_EXT_NOT_SUPPORTED(
+      6007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml conv ext not supported",
+      "Xml conv ext not supported detail={}"),
+  NO_RESPONSE_OBJECT(
+      6008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No response object",
+      "No response object detail={}"),
+  HTML_GEN_BAD_STYLESHEET_URL(
+      6009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Html gen bad stylesheet url",
+      "Html gen bad stylesheet url detail={}"),
+  HTML_GEN_NO_STYLESHEET(
+      6010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Html gen no stylesheet",
+      "Html gen no stylesheet detail={}"),
+  SEND_RESPONSE_EXCEPTION(
+      6011,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Send response exception",
+      "Send response exception detail={}"),
+  XML_CONV_EXCEPTION(
+      6012,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml conv exception",
+      "Xml conv exception detail={}"),
+  STYLESHEET_MERGE_EXCEPTION(
+      6013,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Stylesheet merge exception",
+      "Stylesheet merge exception detail={}"),
+  COLMAPPER_XML_FIELD_NOT_STRING(
+      6014,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Colmapper xml field not string",
+      "Colmapper xml field not string detail={}"),
+  REDIRECT_NOT_SUPPORTED_BY_CONVERTERS(
+      6015,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Redirect not supported by converters",
+      "Redirect not supported by converters detail={}"),
+  MIME_CONV_INVALID_OUTPUT_TYPE(
+      6016,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mime conv invalid output type",
+      "Mime conv invalid output type detail={}"),
+  MIME_CONV_ONE_PIPE_REQD(
+      6017,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mime conv one pipe reqd",
+      "Mime conv one pipe reqd detail={}"),
+  MIME_CONV_QUERY_PIPE_REQD(
+      6018,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mime conv query pipe reqd",
+      "Mime conv query pipe reqd detail={}"),
+  MIME_CONV_ONE_MAPPING_REQD(
+      6019,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mime conv one mapping reqd",
+      "Mime conv one mapping reqd detail={}"),
+  MIME_CONV_ONE_COLUMN_REQD(
+      6020,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mime conv one column reqd",
+      "Mime conv one column reqd detail={}"),
+  MIME_CONV_MULTICOL_RESULT(
+      6021,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mime conv multicol result",
+      "Mime conv multicol result detail={}"),
+  MIME_CONV_MULTIROW_RESULT(
+      6022,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mime conv multirow result",
+      "Mime conv multirow result detail={}"),
+  XML_TWO_ROOT_ELEMENTS(
+      6023,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml two root elements",
+      "Xml two root elements detail={}"),
+  XML_VAR_LINK_AND_MAPPING(
+      6024,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml var link and mapping",
+      "Xml var link and mapping detail={}"),
+  XML_PARENT_MAPPING_NOT_SUPPORTED(
+      6029,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml parent mapping not supported",
+      "Xml parent mapping not supported detail={}"),
+  VFS_CONVERT_PATH_ERROR(
+      6030,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Vfs convert path error",
+      "Vfs convert path error detail={}"),
+  DATA_INVALID_CONVERSION(
+      6031,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Data invalid conversion",
+      "Data invalid conversion detail={}"),
+  WARN_CALL_MAPPED_KEY_COLUMN_ON_LINK(
+      6032,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Warn call mapped key column on link",
+      "Warn call mapped key column on link detail={}"),
+  DATA_CANNOT_CONVERT_WITH_REASON(
+      6033,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Data cannot convert with reason",
+      "Data cannot convert with reason detail={}"),
+  CANNOT_RETURN_MULTIPLE_RESULT_SETS(
+      6034,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot return multiple result sets",
+      "Cannot return multiple result sets detail={}"),
+  INVALID_INTERNAL_RESULT_CALL(
+      6035,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid internal result call",
+      "Invalid internal result call detail={}"),
+  INTERNAL_RESULT_CALL_EXCEPTION(
+      6036,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Internal result call exception",
+      "Internal result call exception detail={}"),
+  INTERNAL_REQUEST_CALL_EXCEPTION(
+      6037,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Internal request call exception",
+      "Internal request call exception detail={}"),
+  INTERNAL_REQUEST_AUTHORIZATION_EXCEPTION(
+      6038,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Internal request authorization exception",
+      "Internal request authorization exception detail={}"),
+  VIEW_NOT_FOUND(
+      6039,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "View not found",
+      "View not found detail={}"),
+  INTERNAL_REQUEST_AUTHENTICATION_FAILED_EXCEPTION(
+      6040,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Internal request authentication failed exception",
+      "Internal request authentication failed exception detail={}"),
+  MACRO_EXTRACTOR_CLASS_NOT_FOUND(
+      6041,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Macro extractor class not found",
+      "Macro extractor class not found detail={}"),
+  MACRO_EXTRACTOR_INSTANTIATION_FAILED(
+      6042,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Macro extractor instantiation failed",
+      "Macro extractor instantiation failed detail={}"),
+  MACRO_EXTRACTOR_ILLEGAL_ACCESS(
+      6043,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Macro extractor illegal access",
+      "Macro extractor illegal access detail={}"),
+  MACRO_EXTRACTOR_INVOCATION_TARGET_ERROR(
+      6044,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Macro extractor invocation target error",
+      "Macro extractor invocation target error detail={}"),
+  MACRO_EXTRACTOR_NO_SUCH_METHOD(
+      6045,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Macro extractor no such method",
+      "Macro extractor no such method detail={}"),
+  MACRO_EXTRACTOR_INVALID_PARAMETER(
+      6046,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Macro extractor invalid parameter",
+      "Macro extractor invalid parameter detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  DataErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (DataErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -41,6 +41,10 @@ import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CloneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ConnectionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
 import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -845,6 +849,196 @@ class LegacyErrorCodeRegistryTest {
     assertTrue(LegacyErrorCodeRegistry.find(16311).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(1801).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(3501).isPresent());
+  }
+
+  // --- Data / BackEnd / Connection / Clone residual (#2881) ---
+
+  @Test
+  void dataQueryProcessingIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(5201));
+    assertSame(
+        DataErrorCodes.QUERY_PROCESSING_ERROR, LegacyErrorCodeRegistry.find(5201).orElseThrow());
+    assertFalse(DataErrorCodes.QUERY_PROCESSING_ERROR.isAuditable());
+  }
+
+  @Test
+  void dataNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "sess1");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void backEndAuthorizationIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(5001));
+    assertSame(
+        BackEndErrorCodes.AUTHORIZATION_ERROR, LegacyErrorCodeRegistry.find(5001).orElseThrow());
+    assertTrue(BackEndErrorCodes.AUTHORIZATION_ERROR.isAuditable());
+  }
+
+  @Test
+  void backEndAuthorizationDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode(),
+            AuditContext.builder().actor("jdoe").sourceIp("10.0.0.1").build(),
+            "10.0.0.1",
+            "jdoe",
+            "jtds",
+            "dbserver");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(BackEndErrorCodes.AUTHORIZATION_ERROR, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-5001]-"));
+  }
+
+  @Test
+  void backEndJdbcNoiseIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(5008));
+    assertSame(
+        BackEndErrorCodes.JDBC_DRIVER_LOAD_FAILED, LegacyErrorCodeRegistry.find(5008).orElseThrow());
+    assertFalse(BackEndErrorCodes.JDBC_DRIVER_LOAD_FAILED.isAuditable());
+  }
+
+  @Test
+  void backEndJdbcNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            BackEndErrorCodes.JDBC_DRIVER_LOAD_FAILED.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "driver",
+            "detail");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void connectionUnauthorizedIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(3107));
+    assertSame(ConnectionErrorCodes.UNAUTHORIZED, LegacyErrorCodeRegistry.find(3107).orElseThrow());
+    assertTrue(ConnectionErrorCodes.UNAUTHORIZED.isAuditable());
+  }
+
+  @Test
+  void connectionUnauthorizedDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ConnectionErrorCodes.UNAUTHORIZED.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(ConnectionErrorCodes.UNAUTHORIZED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-3107]-"));
+  }
+
+  @Test
+  void connectionPortInvalidIsRegisteredButNotAuditable() {
+    // 3001 overlaps Phase-2a UserManagementErrorCodes.CREATE package-local int; USER codes are
+    // not flat-registered, so connection owns the flat registry key.
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(3001));
+    assertSame(
+        ConnectionErrorCodes.PORT_NUMBER_INVALID, LegacyErrorCodeRegistry.find(3001).orElseThrow());
+    assertFalse(ConnectionErrorCodes.PORT_NUMBER_INVALID.isAuditable());
+  }
+
+  @Test
+  void connectionPortInvalidNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc, ConnectionErrorCodes.PORT_NUMBER_INVALID.numericCode(), AuditContext.empty(), "abc");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void cloneNotAuthenticatedIsAuditableAndResolves() {
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(17502));
+    assertSame(
+        CloneErrorCodes.NOT_AUTHENTICACATED, LegacyErrorCodeRegistry.find(17502).orElseThrow());
+    assertTrue(CloneErrorCodes.NOT_AUTHENTICACATED.isAuditable());
+  }
+
+  @Test
+  void cloneNotAuthorizedDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            CloneErrorCodes.NOT_AUTHORIZED.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "denied");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(CloneErrorCodes.NOT_AUTHORIZED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-17503]-"));
+  }
+
+  @Test
+  void cloneInvalidSourceIdIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(17501));
+    assertSame(
+        CloneErrorCodes.INVALID_CLONESOURCEID, LegacyErrorCodeRegistry.find(17501).orElseThrow());
+    assertFalse(CloneErrorCodes.INVALID_CLONESOURCEID.isAuditable());
+  }
+
+  @Test
+  void cloneInvalidSourceIdNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            CloneErrorCodes.INVALID_CLONESOURCEID.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "x",
+            "parse");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void registryCoversDataBackEndConnectionAndClone() {
+    // prior catalogs + data (108) + backend (60) + connection (19) + clone (6)
+    assertTrue(LegacyErrorCodeRegistry.size() >= 540);
+    assertTrue(LegacyErrorCodeRegistry.find(5201).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(5001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(3001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(3107).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(17502).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(17503).isPresent());
   }
 
 }

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/BackEndErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/BackEndErrorCodesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class BackEndErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (BackEndErrorCodes code : BackEndErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 5001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(60, BackEndErrorCodes.values().length);
+  }
+
+  @Test
+  void onlyAuthorizationErrorIsAuditable() {
+    for (BackEndErrorCodes code : BackEndErrorCodes.values()) {
+      if (code == BackEndErrorCodes.AUTHORIZATION_ERROR) {
+        assertTrue(code.isAuditable());
+        assertSame(AuditEventType.ACCESS_DENIED, code.eventType());
+        assertSame(AuditOutcome.FAILURE, code.defaultOutcome());
+      } else {
+        assertFalse(code.isAuditable(), code.name());
+        assertNull(code.eventType(), code.name());
+      }
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsBackEndErrorsNumericValues() {
+    assertEquals(5001, BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode());
+    assertEquals(5008, BackEndErrorCodes.JDBC_DRIVER_LOAD_FAILED.numericCode());
+    assertEquals(5401, BackEndErrorCodes.LOG_PREPARED_STMT.numericCode());
+    assertEquals(5999, BackEndErrorCodes.NOT_YET_SUPPORTED.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/CloneErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/CloneErrorCodesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class CloneErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (CloneErrorCodes code : CloneErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 17501, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(6, CloneErrorCodes.values().length);
+  }
+
+  @Test
+  void onlyAuthzCodesAreAuditable() {
+    for (CloneErrorCodes code : CloneErrorCodes.values()) {
+      if (code == CloneErrorCodes.NOT_AUTHENTICACATED) {
+        assertTrue(code.isAuditable());
+        assertSame(AuditEventType.AUTH_FAILURE, code.eventType());
+        assertSame(AuditOutcome.FAILURE, code.defaultOutcome());
+      } else if (code == CloneErrorCodes.NOT_AUTHORIZED) {
+        assertTrue(code.isAuditable());
+        assertSame(AuditEventType.ACCESS_DENIED, code.eventType());
+        assertSame(AuditOutcome.FAILURE, code.defaultOutcome());
+      } else {
+        assertFalse(code.isAuditable(), code.name());
+        assertNull(code.eventType(), code.name());
+      }
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsCloneErrorsNumericValues() {
+    assertEquals(17501, CloneErrorCodes.INVALID_CLONESOURCEID.numericCode());
+    assertEquals(17502, CloneErrorCodes.NOT_AUTHENTICACATED.numericCode());
+    assertEquals(17503, CloneErrorCodes.NOT_AUTHORIZED.numericCode());
+    assertEquals(17506, CloneErrorCodes.ROLE_CREATION_ERROR.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ConnectionErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ConnectionErrorCodesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ConnectionErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ConnectionErrorCodes code : ConnectionErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 3001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(19, ConnectionErrorCodes.values().length);
+  }
+
+  @Test
+  void onlyUnauthorizedIsAuditable() {
+    for (ConnectionErrorCodes code : ConnectionErrorCodes.values()) {
+      if (code == ConnectionErrorCodes.UNAUTHORIZED) {
+        assertTrue(code.isAuditable());
+        assertSame(AuditEventType.ACCESS_DENIED, code.eventType());
+        assertSame(AuditOutcome.FAILURE, code.defaultOutcome());
+      } else {
+        assertFalse(code.isAuditable(), code.name());
+        assertNull(code.eventType(), code.name());
+      }
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsConnectionErrorsNumericValues() {
+    assertEquals(3001, ConnectionErrorCodes.PORT_NUMBER_INVALID.numericCode());
+    assertEquals(3005, ConnectionErrorCodes.QUEUE_LIMIT_INVALID.numericCode());
+    assertEquals(3101, ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION.numericCode());
+    assertEquals(3107, ConnectionErrorCodes.UNAUTHORIZED.numericCode());
+  }
+
+  @Test
+  void documentsNumericOverlapWithUserManagementPackageLocal() {
+    // Phase-2a USER lifecycle codes reuse 3001–3005 package-locally but are not flat-registered.
+    assertEquals(3001, UserManagementErrorCodes.CREATE.numericCode());
+    assertEquals(3001, ConnectionErrorCodes.PORT_NUMBER_INVALID.numericCode());
+    assertEquals(3005, UserManagementErrorCodes.REVOKE.numericCode());
+    assertEquals(3005, ConnectionErrorCodes.QUEUE_LIMIT_INVALID.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/DataErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/DataErrorCodesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DataErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (DataErrorCodes code : DataErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 5201, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(108, DataErrorCodes.values().length);
+  }
+
+  @Test
+  void allDataCodesAreNonAuditable() {
+    for (DataErrorCodes code : DataErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsDataErrorsNumericValues() {
+    assertEquals(5201, DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode());
+    assertEquals(5202, DataErrorCodes.UPDATE_PROCESSING_ERROR.numericCode());
+  }
+}


### PR DESCRIPTION
## Summary

Parent epic **#2616** residual **#2881**: migrate data-plane / connection / clone `IPS*Errors` catalogs into package `*ErrorCodes` with explicit `isAuditable` and `LegacyErrorCodeRegistry` dual-write bridge.

| Catalog | Legacy source | Constants | Auditable dual-write |
|---------|---------------|-----------|----------------------|
| `DataErrorCodes` | `IPSDataErrors` | 108 (5201–6046) | none (all operational) |
| `BackEndErrorCodes` | `IPSBackEndErrors` | 60 (5001–5057, 5401–5402, 5999) | `AUTHORIZATION_ERROR` (5001) |
| `ConnectionErrorCodes` | `IPSConnectionErrors` | 19 (3001–3012, 3101–3107) | `UNAUTHORIZED` (3107) |
| `CloneErrorCodes` | `IPSCloneErrors` | 6 (17501–17506) | `NOT_AUTHENTICACATED` (17502), `NOT_AUTHORIZED` (17503) |

**Collision note:** Connection ints `3001–3005` numerically overlap Phase-2a `UserManagementErrorCodes` package-local numbers. USER codes are **not** flat-registered, so connection owns those flat registry keys; call sites for user lifecycle should prefer the USER enum. No flat-register skips required for data/back-end/clone ranges (globally unique).

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2881  
Refs #2616

## Test plan

1. `cd modules/perc-auditlog && ../../mvnw.cmd clean install` (or `../..//mvnw clean install` on Unix)
2. Confirm `BUILD SUCCESS` and unit tests green (expect ~175 tests)
3. Spot-check dual-write: registry resolves 5001 / 3107 / 17503 as auditable; 5201 / 3001 / 17501 as registered non-auditable

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing: internal audit error-code catalog migration only; module README updated)
- [x] **Unit / module tests** — catalog unit tests + `LegacyErrorCodeRegistryTest` dual-write/skip coverage; standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `modules/perc-auditlog` standalone clean install; no public API shape/final changes requiring reverse-dep matrix
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### Build evidence (C3)

- **modules_built:** `modules/perc-auditlog`
- **build_evidence:** `cd modules/perc-auditlog; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: **175**, Failures: 0, Errors: 0, Skipped: 0
- **downstream_checked:** none (no `final`/signature/package-visible API change; additive enums + registry bootstrap only)

> Co-Authored by Grok Build using grok-4.5 with agent main.
