### PR TITLE
feat(perc-auditlog): Publisher/SiteMgr/Filter/Lock/Catalog + Deployment/Nav/UI ErrorCodes (#2882)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -19,6 +19,10 @@ System-wide Percussion CMS audit logging and unified error-code support.
   `ServletErrorCodes`, `TransformationErrorCodes` (enum-only),
   `SearchErrorCodes` (`IPSSearchErrors`; auth failure dual-write), `LuceneErrorCodes`,
   `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable)
+  `PublisherErrorCodes` / `SiteManagerErrorCodes` / `FilterServiceErrorCodes` / `LockErrorCodes` /
+  `UiErrorCodes` (enum-only package-local collisions), `CatalogErrorCodes` (design 4101–4311 flat;
+  service 1–6 enum-only), `DeploymentErrorCodes` (74–85 flat; lock codes enum-only),
+  `NavigationErrorCodes` (18001–18009 full flat)
   + `LegacyErrorCodeRegistry` bridge legacy `IPS*Errors` ints. Non-auditable / unregistered ints never
   dual-write. Central `PSErrorHandler.appendError` dual-writes only when the registry marks the legacy
   int auditable.
@@ -65,8 +69,10 @@ audit.log(
 ```java
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
@@ -76,11 +82,15 @@ import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LockErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.NavigationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.PublisherErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.UiErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
@@ -92,6 +102,10 @@ audit.log(WorkflowErrorCodes.ACCESS_DENIED, ctx, "5", "jdoe");
 audit.log(PathItemErrorCodes.FOLDER_PERMISSION_DENIED, ctx);
 audit.log(DesignErrorCodes.SRV_ACL_NO_ADMIN, ctx);
 audit.log(ServerErrorCodes.AUTHORIZATION_ERROR, ctx, "sess", "/app");
+audit.log(PublisherErrorCodes.JOB_FAILED, ctx, "job-9", "detail");
+audit.log(LockErrorCodes.PERMISSION_DENIED, ctx);
+audit.log(UiErrorCodes.ACCESS_DENIED, ctx, "delete", "node-1");
+audit.log(DeploymentErrorCodes.LOCK_ALREADY_HELD, ctx);
 
 // Central handlers with only a legacy int (e.g. PSException.getErrorCode()):
 LegacyErrorCodeRegistry.logIfAuditable(audit, 9002, ctx, "Directory", "ldap1", "jdoe"); // SEC
@@ -103,6 +117,11 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 401, ctx); // HTTP status — non-
 LegacyErrorCodeRegistry.logIfAuditable(audit, 16052, ctx); // search auth failed — dual-write
 LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir — non-auditable skip
 // Prefer JobErrorCodes enum for job ints 1–10 (flat registry keeps WF ownership of 1–10)
+LegacyErrorCodeRegistry.logIfAuditable(audit, 4101, ctx, "prop"); // catalog design — non-auditable
+LegacyErrorCodeRegistry.logIfAuditable(audit, 74, ctx, "1.0", "1.1"); // deploy version — non-auditable
+LegacyErrorCodeRegistry.logIfAuditable(audit, 18001, ctx, "/Sites/x"); // nav — non-auditable
+// Prefer JobErrorCodes / PublisherErrorCodes / LockErrorCodes enum for colliding package-local ints
+// (flat registry keeps WF ownership of 1–10, assembly/job 11–27, webservice 28–73)
 // Provider/config/conversion/path/design/server/http/job/assembly/extension/webservice noise (isAuditable=false) and unknown ints → no dual-write
 ```
 
@@ -128,6 +147,14 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir �
 | `LuceneErrorCodes` | 16311–16456 (`IPSLuceneErrors`) | All non-auditable index/query codes |
 | `LocaleErrorCodes` | 1801–1804 (`IPSLocaleErrors`) | All non-auditable |
 | `MailErrorCodes` | 3501–3508 (`IPSMailErrors`) | All non-auditable |
+| `PublisherErrorCodes` | package-local 10–24 (no flat register) | Prefer enum; job/item publish failures auditable |
+| `SiteManagerErrorCodes` | package-local 1–9 (no flat register) | All non-auditable; prefer enum |
+| `FilterServiceErrorCodes` | package-local 1–8 (no flat register) | All non-auditable; prefer enum |
+| `LockErrorCodes` | package-local 1–9 (no flat register) | Prefer enum; session/permission dual-write |
+| `CatalogErrorCodes` | service 1–6 enum-only; design 4101–4311 flat | All non-auditable catalog protocol |
+| `DeploymentErrorCodes` | package-local 1–85 (flat-registers 74–85) | Prefer enum for lock 46/47/53; version/config flat |
+| `NavigationErrorCodes` | 18001–18009 full flat | All non-auditable nav structure |
+| `UiErrorCodes` | package-local 1–8 (no flat register) | Prefer enum; ACCESS_DENIED dual-write |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -17,10 +17,13 @@
 package com.intsof.percussioncms.auditlog;
 
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.FilterServiceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
@@ -28,11 +31,16 @@ import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LockErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.NavigationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.PublisherErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SiteManagerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.UiErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
@@ -55,9 +63,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * package-local ints, non-colliding {@link WebserviceErrorCodes} package-local ints (28–73), fully
  * unique {@link ServerWebServicesErrorCodes} / {@link WebdavErrorCodes} / {@link ServletErrorCodes},
  * fully unique {@link SearchErrorCodes} / {@link LuceneErrorCodes} / {@link LocaleErrorCodes} /
- * {@link MailErrorCodes}, and bootstrap-only {@link TransformationErrorCodes} / {@link
- * DeliveryErrorCodes} (no flat register). Residual slices may register additional catalogs via
- * {@link #register(int, SystemErrorCode)}.
+ * {@link MailErrorCodes}, bootstrap-only {@link TransformationErrorCodes} / {@link
+ * DeliveryErrorCodes} / {@link PublisherErrorCodes} / {@link SiteManagerErrorCodes} / {@link
+ * FilterServiceErrorCodes} / {@link LockErrorCodes} / {@link UiErrorCodes} (package-local
+ * collisions — no flat register), design range of {@link CatalogErrorCodes} (4101–4311),
+ * non-colliding {@link DeploymentErrorCodes} (74–85), and fully unique {@link
+ * NavigationErrorCodes}. Residual slices may register additional catalogs via {@link
+ * #register(int, SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -72,14 +84,20 @@ public final class LegacyErrorCodeRegistry {
   /**
    * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design,
    * server, HTTP, assembly, extension, delivery, job, webservices, WebDAV, servlet, search,
-   * Lucene, locale, mail, transformation). Safe to call repeatedly; catalogs register themselves
-   * in their own static initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip
+   * Lucene, locale, mail, transformation, publisher/site/filter/lock/catalog/deployment/
+   * navigation/UI). Safe to call repeatedly; catalogs register themselves in their own
+   * static initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip
    * package-local ints {@code 1–10} that collide with {@link WorkflowErrorCodes}. {@link
    * JobErrorCodes} is bootstrapped after assembly so flat int {@code 11} ({@code
-   * CONFIG_FILE_NOT_FOUND}) wins over assembly package-local {@code MISSING_SLOT} (prefer enum for
-   * assembly {@code 11}). {@link WebserviceErrorCodes} skips package-local ints {@code 1–27};
-   * {@link TransformationErrorCodes} and {@link DeliveryErrorCodes} do not flat-register. Search /
-   * Lucene / Locale / Mail ints are globally unique and fully registered.
+   * CONFIG_FILE_NOT_FOUND}) wins over assembly package-local {@code MISSING_SLOT} (prefer
+   * enum for assembly {@code 11}). {@link WebserviceErrorCodes} skips package-local ints
+   * {@code 1–27}; {@link TransformationErrorCodes} and {@link DeliveryErrorCodes} do not
+   * flat-register. Search / Lucene / Locale / Mail ints are globally unique and fully
+   * registered. {@link PublisherErrorCodes}, {@link SiteManagerErrorCodes}, {@link
+   * FilterServiceErrorCodes}, {@link LockErrorCodes}, and {@link UiErrorCodes} are
+   * enum-only (package-local collisions). {@link CatalogErrorCodes} flat-registers design
+   * range 4101–4311 only. {@link DeploymentErrorCodes} flat-registers 74–85. {@link
+   * NavigationErrorCodes} is fully unique and fully registered.
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
@@ -109,6 +127,18 @@ public final class LegacyErrorCodeRegistry {
       LuceneErrorCodes.ensureRegistered();
       LocaleErrorCodes.ensureRegistered();
       MailErrorCodes.ensureRegistered();
+      // Publisher/site/filter/lock/UI: enum-only (package-local collisions with WF/assembly/job).
+      PublisherErrorCodes.ensureRegistered();
+      SiteManagerErrorCodes.ensureRegistered();
+      FilterServiceErrorCodes.ensureRegistered();
+      LockErrorCodes.ensureRegistered();
+      UiErrorCodes.ensureRegistered();
+      // Catalog: design range 4101–4311 only (service 1–6 collide with WF).
+      CatalogErrorCodes.ensureRegistered();
+      // Deployment after webservice so only non-colliding 74–85 enter the flat map.
+      DeploymentErrorCodes.ensureRegistered();
+      // Navigation: globally unique 18001–18009.
+      NavigationErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/CatalogErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/CatalogErrorCodes.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Catalog error catalog bridging:
+ *
+ * <ul>
+ *   <li>{@code com.percussion.services.catalog.IPSCatalogErrors} package-local ints (1–6)
+ *   <li>{@code com.percussion.design.catalog.IPSCatalogErrors} design-client/server ints
+ *       (4101–4311)
+ * </ul>
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: catalog protocol and repository
+ * noise is not a security dual-write event.
+ *
+ * <p><strong>Flat registry collision:</strong> service package-local ints {@code 1–6} already
+ * belong to {@link WorkflowErrorCodes}. Only the design-catalog range ({@code 4101–4311}) is
+ * flat-registered. Prefer this enum for service ints {@code 1–6}. Module code is {@link
+ * AuditModule#SYS}.
+ */
+public enum CatalogErrorCodes implements SystemErrorCode {
+
+  SUMMARY_ERROR(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog summary enumeration error",
+      "Catalog summary error"),
+
+  UNKNOWN_TYPE(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown catalog type: {}",
+      "Catalog unknown type name={}"),
+
+  REPOSITORY(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog repository error for object {}",
+      "Catalog repository error objectId={}"),
+
+  XML(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog XML error",
+      "Catalog XML error source={}"),
+
+  IO(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog I/O error for object {}",
+      "Catalog IO error objectId={}"),
+
+  TOXML(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog serialize-to-XML error",
+      "Catalog toXml error"),
+
+  REQD_PROP_NOT_SPECIFIED(
+      4101,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Required catalog property not specified: {}",
+      "Catalog required property not specified prop={}"),
+
+  REQ_CATEGORY_INVALID(
+      4102,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog request category invalid",
+      "Catalog request category invalid expected={} specified={}"),
+
+  REQ_TYPE_INVALID(
+      4103,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog request type invalid",
+      "Catalog request type invalid expected={} specified={}"),
+
+  REQ_HANDLER_EXCEPTION(
+      4104,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog request handler exception",
+      "Catalog request handler exception category={} type={} detail={}"),
+
+  CONN_OBJ_NULL(
+      4105,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cataloger connection object is null",
+      "Cataloger connection object null"),
+
+  REQ_DOC_MISSING(
+      4301,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog request document missing",
+      "Catalog request document missing category={} type={} dtd={}"),
+
+  REQ_DOC_MISSING_GENERIC(
+      4302,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog request document missing",
+      "Catalog request document missing generic"),
+
+  REQ_DOC_ROOT_MISSING_GENERIC(
+      4303,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog request document root missing",
+      "Catalog request document root missing generic"),
+
+  REQ_DOC_INVALID_TYPE(
+      4304,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog request document type invalid",
+      "Catalog request document invalid type expected={} specified={}"),
+
+  NO_REQ_HANDLER_FOUND(
+      4305,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No catalog request handler found",
+      "Catalog no request handler category={} type={}"),
+
+  PROPS_LOAD_EXCEPTION(
+      4306,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog properties load exception",
+      "Catalog props load exception category={} type={} detail={}"),
+
+  EXIT_HANDLER_CLASS_NOT_FOUND(
+      4307,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog exit handler class not found: {}",
+      "Catalog exit handler class not found class={}"),
+
+  IPSEXITHANDLER_NOT_IMPLEMENTED(
+      4308,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exit handler interface not implemented: {}",
+      "Catalog IPSExtensionHandler not implemented class={}"),
+
+  EXIT_HANDLER_CLASS_LOAD_EXCEPTION(
+      4309,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Exit handler class load exception",
+      "Catalog exit handler class load exception class={} detail={}"),
+
+  CATALOG_ERROR(
+      4310,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog error",
+      "Catalog error session={} category={} type={}"),
+
+  CATALOG_EXCEPTION(
+      4311,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog exception: {}",
+      "Catalog exception detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  CatalogErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register non-colliding design-catalog ints in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly. Skips package-local service ints {@code 1–6} that collide with {@link
+   * WorkflowErrorCodes}.
+   */
+  public static void ensureRegistered() {
+    for (CatalogErrorCodes code : values()) {
+      if (code.numericCode <= 6) {
+        // Preserve WorkflowErrorCodes ownership of bare ints 1–6.
+        continue;
+      }
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/DeploymentErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/DeploymentErrorCodes.java
@@ -1,0 +1,766 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Deployment / package manager error catalog bridging legacy {@code
+ * com.percussion.error.IPSDeploymentErrors} package-local ints (1–85).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: exclusive deploy-lock contention codes
+ * dual-write as {@link AuditEventType#ACCESS_DENIED}; archive/repository/dependency operational
+ * noise does not. Legacy aliases that share an int ({@code SERVER_VERSION_LOWER}/{@code
+ * SERVER_VERSION_MISMATCH}, {@code SERVER_VERSION_HIGHER}/{@code SERVER_BUILD_MISMATCH}) are
+ * represented once under the primary name.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–73} already belong to
+ * {@link WorkflowErrorCodes} (1–10), residual assembly/job (11–27), and {@link
+ * WebserviceErrorCodes} (28–73). This catalog flat-registers only non-colliding ints ({@code
+ * 74–85}). Prefer this enum for lock codes {@code 46}/{@code 47}/{@code 53} until a composite-key
+ * registry exists. Module code is {@link AuditModule#SYS}.
+ */
+public enum DeploymentErrorCodes implements SystemErrorCode {
+
+  SERVER_VERSION_INVALID(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server version invalid: {}",
+      "Deploy server version invalid version={}"),
+
+  SERVER_RESPONSE_ELEMENT_MISSING(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server response element missing",
+      "Deploy server response element missing request={} element={}"),
+
+  SERVER_RESPONSE_ELEMENT_INVALID(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server response element invalid",
+      "Deploy server response element invalid request={} element={} detail={}"),
+
+  NOT_CONNECTED_ERROR(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Not connected to server: {}",
+      "Deploy not connected server={}"),
+
+  UNEXPECTED_ERROR(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected deployment error: {}",
+      "Deploy unexpected error detail={}"),
+
+  SERVER_RESPONSE_EMPTY(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server response empty",
+      "Deploy server response empty status={} request={}"),
+
+  SERVER_ERROR_RESPONSE(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server error response",
+      "Deploy server error response request={} status={} xml={}"),
+
+  NULL_INPUT_DOC(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Null input document",
+      "Deploy null input document"),
+
+  NULL_REPOSITORY_INFO(
+      9,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Null repository info",
+      "Deploy null repository info"),
+
+  INVALID_REQUEST_TYPE(
+      10,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid request type: {}",
+      "Deploy invalid request type type={}"),
+
+  ARCHIVE_WRITE_ERROR(
+      11,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Archive write error",
+      "Deploy archive write error file={} detail={}"),
+
+  ARCHIVE_READ_ERROR(
+      12,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Archive read error",
+      "Deploy archive read error file={} detail={}"),
+
+  CATALOG_REQD_PROP_NOT_SPECIFIED(
+      13,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Catalog required property not specified: {}",
+      "Deploy catalog required prop not specified prop={}"),
+
+  SERVER_REQUEST_MALFORMED(
+      14,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server request malformed",
+      "Deploy server request malformed element={} detail={}"),
+
+  SERVER_OBJECT_NOT_FOUND(
+      15,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server object not found",
+      "Deploy server object not found type={} name={}"),
+
+  SERVER_REQUEST_PARAM_INVALID(
+      16,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server request parameter invalid",
+      "Deploy server request param invalid name={} value={}"),
+
+  DEPENDENCY_HANDLER_INIT(
+      17,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dependency handler init failed",
+      "Deploy dependency handler init class={} detail={}"),
+
+  CHILD_DEPENDENCY_TYPE_NOT_FOUND(
+      18,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Child dependency type not found",
+      "Deploy child dependency type not found child={} parent={}"),
+
+  DEPENDENCY_MGR_INIT(
+      19,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dependency manager init failed: {}",
+      "Deploy dependency manager init detail={}"),
+
+  DEPENDENCY_DEF_NOT_FOUND(
+      20,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dependency definition not found: {}",
+      "Deploy dependency def not found type={}"),
+
+  REPOSITORY_CONNECTION_ERROR(
+      21,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Repository connection error: {}",
+      "Deploy repository connection error detail={}"),
+
+  REPOSITORY_READ_WRITE_ERROR(
+      22,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Repository read/write error: {}",
+      "Deploy repository read write error detail={}"),
+
+  INVALID_REPOSITORY_COLUMN_VALUE(
+      23,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid repository column value",
+      "Deploy invalid repository column table={} column={} value={}"),
+
+  MISSING_ID_MAPPING(
+      24,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing id mapping",
+      "Deploy missing id mapping type={} id={} server={}"),
+
+  MISSING_DEPENDENCY_FILE(
+      25,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing dependency file",
+      "Deploy missing dependency file fileType={} depType={} depId={} depName={}"),
+
+  INVALID_DEPENDENCY_FILE(
+      26,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid dependency file",
+      "Deploy invalid dependency file fileType={} depType={} depId={} depName={} detail={}"),
+
+  INVALID_SAVED_ID_MAP(
+      27,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid saved id map",
+      "Deploy invalid saved id map repository={} sourceId={} sourceName={}"),
+
+  UNEXPECTED_EXTRA_ROW(
+      28,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected extra row",
+      "Deploy unexpected extra row repository={} table={}"),
+
+  UNABLE_FIND_TABLE(
+      29,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unable to find table: {}",
+      "Deploy unable find table name={}"),
+
+  ID_TYPE_MAP_LOAD(
+      30,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Id type map load failed",
+      "Deploy id type map load key={} detail={}"),
+
+  SERVER_VERSION_MISMATCH(
+      31,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server version mismatch",
+      "Deploy server version mismatch archive={} target={}"),
+
+  SERVER_BUILD_MISMATCH(
+      32,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server build mismatch",
+      "Deploy server build mismatch archive={} target={}"),
+
+  ARCHIVE_REF_FOUND(
+      33,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Archive ref already exists: {}",
+      "Deploy archive ref found name={}"),
+
+  INCOMPLETE_ID_TYPE_MAPPING(
+      34,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Incomplete id type mapping",
+      "Deploy incomplete id type mapping depType={} depId={} value={} context={}"),
+
+  MISSING_REPOSITORY_ROW(
+      35,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing repository row",
+      "Deploy missing repository row table={} key={} value={}"),
+
+  INCOMPLETE_ID_MAPPING(
+      36,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Incomplete id mapping",
+      "Deploy incomplete id mapping type={} id={} server={}"),
+
+  INVALID_ID_MAPPING_TARGET(
+      37,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid id mapping target",
+      "Deploy invalid id mapping target type={} id={} server={} targetId={}"),
+
+  VALUE_NOT_FOUND_IN_TABLE(
+      38,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Value not found in table",
+      "Deploy value not found in table value={} table={} column={}"),
+
+  CHILD_DEP_NOT_FOUND(
+      39,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Child dependency not found",
+      "Deploy child dep not found childId={} childType={} objectId={} objectType={}"),
+
+  NO_ROWS_TO_PROCESS(
+      40,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No rows to process",
+      "Deploy no rows to process"),
+
+  WRONG_DEPENDENCY_FILE_TYPE(
+      41,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Wrong dependency file type",
+      "Deploy wrong dependency file type actual={} expected={}"),
+
+  MISSING_ID_TYPES(
+      42,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing id types",
+      "Deploy missing id types depType={} depId={}"),
+
+  DEP_OBJECT_NOT_FOUND(
+      45,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dependency object not found",
+      "Deploy dep object not found package={} id={} type={} name={}"),
+
+  LOCK_ALREADY_HELD(
+      46,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Deployment lock already held",
+      "Deploy lock already held"),
+
+  LOCK_NOT_EXTENSIBLE_TAKEN(
+      47,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Deployment lock not extensible; taken by another",
+      "Deploy lock not extensible taken"),
+
+  CANNOT_FIND_DATA(
+      49,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find data",
+      "Deploy cannot find data table={} filter={}"),
+
+  CATALOG_INVALID_DIRECTORY_SPECIFIED(
+      50,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid catalog directory: {}",
+      "Deploy catalog invalid directory path={}"),
+
+  MAX_DEP_COUNT_EXCEEDED(
+      51,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Max dependency count exceeded: {}",
+      "Deploy max dep count exceeded max={}"),
+
+  EMPTY_PACKAGE_LIST(
+      52,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Empty package list",
+      "Deploy empty package list"),
+
+  LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED(
+      53,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Deployment lock not extensible; taken and released",
+      "Deploy lock not extensible taken released lastUser={}"),
+
+  LOCK_NOT_RELEASED(
+      54,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Lock not released",
+      "Deploy lock not released server={} detail={}"),
+
+  MULTISERVER_MANAGER_DISABLED(
+      55,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Multi-server manager disabled",
+      "Deploy multi-server manager disabled"),
+
+  APP_FILE_LOAD(
+      56,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Application file load error",
+      "Deploy app file load file={} app={} detail={}"),
+
+  SERVER_RESPONSE_PARSE_ERROR(
+      57,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server response parse error",
+      "Deploy server response parse error request={} detail={}"),
+
+  SERVER_NOT_AVAILABLE(
+      58,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Server not available",
+      "Deploy server not available"),
+
+  EXTRACT_ID_FROM_KEY(
+      59,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Extract id from key failed",
+      "Deploy extract id from key component={} type={}"),
+
+  ASSIGN_NEW_KEY(
+      60,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Assign new key failed",
+      "Deploy assign new key component={} type={} detail={}"),
+
+  MISSING_REQUIRED_CACHE_DATA(
+      61,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing required cache data",
+      "Deploy missing required cache data contentId={} column={} table={}"),
+
+  FAILED_GET_NUMERIC_CACHED_DATA(
+      62,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed get numeric cached data",
+      "Deploy failed get numeric cached data contentId={} table={} detail={}"),
+
+  SLOT_DEFINITION_ALREADY_EXISTS(
+      63,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Slot definition already exists: {}",
+      "Deploy slot definition already exists slotId={}"),
+
+  APP_DEFINITION_DOESNOT_EXIST(
+      64,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Application definition does not exist: {}",
+      "Deploy app definition does not exist name={}"),
+
+  CANNOT_FIND_DEP_DEF(
+      65,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find dependency definition: {}",
+      "Deploy cannot find dep def objectType={}"),
+
+  DEP_DEF_NOT_DEPLOYABLE(
+      66,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Dependency definition not deployable: {}",
+      "Deploy dep def not deployable objectType={}"),
+
+  CANNOT_FIND_PARENT_DEP_DEF(
+      67,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find parent dependency definition: {}",
+      "Deploy cannot find parent dep def objectType={}"),
+
+  PARENT_DEP_DEF_NOT_DEPLOYABLE(
+      68,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Parent dependency definition not deployable: {}",
+      "Deploy parent dep def not deployable objectType={}"),
+
+  INCOMPLATE_ORDER_DEF(
+      69,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Incomplete order definition",
+      "Deploy incomplete order def"),
+
+  INVALID_NUM_PARENT_DEFS(
+      70,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid number of parent definitions",
+      "Deploy invalid num parent defs"),
+
+  UNEXPECTED_PARENT_TYPE(
+      71,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected parent type",
+      "Deploy unexpected parent type actual={} expected={}"),
+
+  INVALID_NUM_CHILD_DEFS(
+      72,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid number of child definitions",
+      "Deploy invalid num child defs objectType={}"),
+
+  MISSING_PKG_GUID(
+      73,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing package GUID",
+      "Deploy missing package guid"),
+
+  VERSION_LOWER_THAN_INSTALLED(
+      74,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Package version lower than installed",
+      "Deploy version lower than installed new={} installed={}"),
+
+  PKG_DEP_VALIDATION(
+      76,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Package dependency validation failed",
+      "Deploy package dep validation missing={}"),
+
+  PKG_DEP_VERSION_VALIDATION(
+      77,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Package dependency version validation failed",
+      "Deploy package dep version validation detail={}"),
+
+  CONFIG_DOES_NOT_EXIST(
+      78,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Configuration does not exist: {}",
+      "Deploy config does not exist path={}"),
+
+  PACKAGE_CREATED_ON_SYSTEM(
+      79,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Package was created on system: {}",
+      "Deploy package created on system name={}"),
+
+  CONTROL_NOT_PACKAGEABLE(
+      80,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Control not packageable: {}",
+      "Deploy control not packageable name={}"),
+
+  UNABLE_TO_CONNECT_TO_SERVER(
+      81,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unable to connect to server",
+      "Deploy unable to connect to server"),
+
+  FAILED_TO_CREATE_COMPONENT_COMMUNITY_ASSNS(
+      82,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to create component community associations: {}",
+      "Deploy failed create component community assns community={}"),
+
+  NO_TYPE_MAPPING_FOR_GUID(
+      83,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No type mapping for GUID",
+      "Deploy no type mapping for guid"),
+
+  MISSING_VALIDATION_RESULTS(
+      84,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing validation results",
+      "Deploy missing validation results package={} depId={}"),
+
+  WRONG_FORMAT_FOR_PAIRID_DEP_ID(
+      85,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Wrong format for pair id dependency id: {}",
+      "Deploy wrong format for pairid dep id pairId={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  DeploymentErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register non-colliding deployment ints in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly. Skips package-local ints {@code 1–73} that collide with workflow / assembly /
+   * webservice catalogs in the flat map.
+   */
+  public static void ensureRegistered() {
+    for (DeploymentErrorCodes code : values()) {
+      if (code.numericCode <= 73) {
+        // Preserve WF (1–10), assembly/job (11–27), webservice (28–73) ownership.
+        continue;
+      }
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/FilterServiceErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/FilterServiceErrorCodes.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Filter service error catalog bridging legacy {@code
+ * com.percussion.services.filter.IPSFilterServiceErrors} package-local ints (1–8).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: filter / authtype lookup and
+ * rule graph failures are operational publishing noise.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–8} already belong to
+ * {@link WorkflowErrorCodes}. This catalog does <strong>not</strong> flat-register any ints.
+ * Prefer this enum directly. Module code is {@link AuditModule#PUB}.
+ */
+public enum FilterServiceErrorCodes implements SystemErrorCode {
+
+  FILTER_MISSING(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Filter not found: {}",
+      "Filter missing name={}"),
+
+  AUTHTYPE_MISSING(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown authentication type: {}",
+      "Filter authtype missing value={}"),
+
+  RULE_MISSING(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Filter rule not found: {}",
+      "Filter rule missing name={}"),
+
+  DATABASE(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Filter database operation failed",
+      "Filter database error"),
+
+  RULE_ARGUMENT_MISSING(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Required rule parameter missing",
+      "Filter rule argument missing rule={} param={}"),
+
+  ARGUMENT_MISSING(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Required filter argument missing",
+      "Filter argument missing"),
+
+  PARAMS_AUTHTYPE_OR_FILTER(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing auth type or filter parameter",
+      "Filter params authtype or filter expected"),
+
+  PROBABLE_CYCLE(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Probable cycle detected in filter rules",
+      "Filter probable cycle in rule graph");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  FilterServiceErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat registry: package-local ints collide with earlier Phase 2b catalogs. Prefer
+   * this enum directly. Safe to call repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.PUB;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/LockErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/LockErrorCodes.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Object lock service error catalog bridging legacy {@code
+ * com.percussion.services.locking.IPSLockErrors} package-local ints (1–9).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: invalid session and permission denied
+ * dual-write; already-locked / not-locked operational concurrency noise does not.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–9} already belong to
+ * {@link WorkflowErrorCodes}. This catalog does <strong>not</strong> flat-register any ints.
+ * Prefer this enum directly (including {@link #PERMISSION_DENIED}). Module code is {@link
+ * AuditModule#SYS}.
+ */
+public enum LockErrorCodes implements SystemErrorCode {
+
+  OBJECT_ALREADY_LOCKED(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object is already locked",
+      "Object already locked objectId={} locker={}"),
+
+  LOCK_EXTENSION_NOT_LOCKED(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object is not locked for extension",
+      "Lock extension not locked objectId={}"),
+
+  LOCK_EXTENSION_LOCKED_BY_SOMEBODY_ELSE(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object locked by somebody else",
+      "Lock extension locked by somebody else objectId={} locker={}"),
+
+  LOCK_EXTENSION_INVALID_SESSION(
+      4,
+      true,
+      AuditEventType.AUTH_FAILURE,
+      AuditOutcome.FAILURE,
+      "Invalid session for lock extension",
+      "Lock extension invalid session objectId={}"),
+
+  OBJECT_NOT_LOCKED(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Object is not locked",
+      "Object not locked objectId={}"),
+
+  MULTI_OPERATION(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Multi-object lock operation mixed results",
+      "Lock multi-operation mixed results"),
+
+  LOCK_NOT_FOUND(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Lock not found",
+      "Lock not found"),
+
+  LOCK_EXPIRED(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Lock expired",
+      "Lock expired"),
+
+  PERMISSION_DENIED(
+      9,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "Lock permission denied",
+      "Lock permission denied");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  LockErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat registry: package-local ints collide with earlier Phase 2b catalogs. Prefer
+   * this enum directly. Safe to call repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/NavigationErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/NavigationErrorCodes.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Managed navigation error catalog bridging legacy {@code
+ * com.percussion.fastforward.managednav.IPSNavigationErrors} ints (18001–18009; category base
+ * 18000).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: navon/navtree structural
+ * failures are operational content-structure noise.
+ *
+ * <p>Numbering is globally unique in the flat {@link LegacyErrorCodeRegistry}, so all constants
+ * are registered. Module code is {@link AuditModule#CONT}.
+ */
+public enum NavigationErrorCodes implements SystemErrorCode {
+
+  NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH(
+      18001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Folder id not found for path",
+      "Nav folder id not found for path path={}"),
+
+  NAVIGATION_SERVICE_CANT_FIND_RELATED_FOLDER_FOR_NAVON(
+      18002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find related folder for navon",
+      "Nav cannot find related folder for navon"),
+
+  NAVIGATION_SERVICE_FAILED_TO_MOVE_SOURCE_NAVON_TO_TARGET(
+      18003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to move source navon to target",
+      "Nav failed to move source navon to target"),
+
+  NAVIGATION_SERVICE_FAILED_TO_MOVE_SECTION_BECAUSE_TARGET_ALREADY_HAS_ITEM(
+      18004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to move section; target already has item",
+      "Nav failed move section target has item"),
+
+  NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON(
+      18005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Navtree cannot be added to folder with navon",
+      "Nav navtree cannot add to folder with navon"),
+
+  NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE(
+      18006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Navtree cannot be added to folder with navtree",
+      "Nav navtree cannot add to folder with navtree"),
+
+  NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER(
+      18007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Error adding navtree to folder",
+      "Nav error adding navtree to folder"),
+
+  NAVIGATION_SERVICE_CANNOT_FIND_ANY_NAVONS(
+      18008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find any navons",
+      "Nav cannot find any navons"),
+
+  NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE(
+      18009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find navtree for site",
+      "Nav cannot find navtree for site");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  NavigationErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (NavigationErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.CONT;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/PublisherErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/PublisherErrorCodes.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Publisher service error catalog bridging legacy {@code
+ * com.percussion.services.publisher.IPSPublisherServiceErrors} package-local ints (10–24).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: publishing job and item publish
+ * failures dual-write as {@link AuditEventType#CONTENT_PUBLISH}; lookup / filter / repository
+ * operational noise does not.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 10–24} already belong to
+ * {@link WorkflowErrorCodes} (10), {@link JobErrorCodes} (11), and {@link AssemblyErrorCodes}
+ * (12–24) in the flat map. This catalog therefore does <strong>not</strong> flat-register any
+ * ints. Prefer this enum directly for dual-write until a composite-key registry exists. Module
+ * code is {@link AuditModule#PUB}.
+ */
+public enum PublisherErrorCodes implements SystemErrorCode {
+
+  LIST_MISSING(
+      10,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content list not found: {}",
+      "Content list missing name={}"),
+
+  BAD_QUERY(
+      11,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid query: {}",
+      "Invalid publisher query query={}"),
+
+  REPOSITORY(
+      12,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Repository access error: {}",
+      "Publisher repository error detail={}"),
+
+  SITE_LOAD(
+      13,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Site loading failed: {}",
+      "Publisher site load failed siteGuid={}"),
+
+  MISSING_EXTENSION(
+      14,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Extension not found: {}",
+      "Publisher missing extension name={} context={} iface={}"),
+
+  EXTENSION_LOOKUP(
+      15,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Extension lookup failed",
+      "Publisher extension lookup failed"),
+
+  ROW_RETRIEVAL(
+      16,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Query row retrieval failed",
+      "Publisher row retrieval failed"),
+
+  DB(
+      17,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Database operation failed",
+      "Publisher database error"),
+
+  FILTER_FAILED(
+      18,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content filter failed: {}",
+      "Publisher filter failed filter={}"),
+
+  JOB_FAILED(
+      19,
+      true,
+      AuditEventType.CONTENT_PUBLISH,
+      AuditOutcome.FAILURE,
+      "Publishing job failed: {}",
+      "Publishing job failed jobId={} detail={}"),
+
+  ITEM_PUBLISH_FAILED(
+      20,
+      true,
+      AuditEventType.CONTENT_PUBLISH,
+      AuditOutcome.FAILURE,
+      "Content item publishing failed",
+      "Content item publishing failed contentId={} siteId={} detail={}"),
+
+  RUNTIME_ERROR(
+      21,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Runtime exception during publishing: {}",
+      "Publisher runtime error detail={}"),
+
+  SITE_MISSING(
+      22,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Site not found",
+      "Publisher site missing"),
+
+  CONTEXT_MISSING(
+      23,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Publishing context missing",
+      "Publisher context missing"),
+
+  UNEXPECTED(
+      24,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected error during publishing: {}",
+      "Publisher unexpected error detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  PublisherErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat registry: package-local ints collide with earlier Phase 2b catalogs. Prefer
+   * this enum directly. Safe to call repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.PUB;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SiteManagerErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SiteManagerErrorCodes.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Site manager error catalog bridging legacy {@code
+ * com.percussion.services.sitemgr.IPSSiteManagerErrors} package-local ints (1–9).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: site/scheme/context lookup
+ * failures are operational noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–9} already belong to
+ * {@link WorkflowErrorCodes}. This catalog does <strong>not</strong> flat-register any ints.
+ * Prefer this enum directly. Module code is {@link AuditModule#PUB}.
+ */
+public enum SiteManagerErrorCodes implements SystemErrorCode {
+
+  SITE_ID_NOT_EXIST(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Site id not found: {}",
+      "Site id not found siteId={}"),
+
+  FAILED_FIND_ROOT_FOLDER_ID(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to find root folder id for site",
+      "Failed find root folder id siteId={} path={} detail={}"),
+
+  CANNOT_FIND_ROOT_FOLDER_ID(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot find root folder id for site",
+      "Cannot find root folder id siteId={} path={}"),
+
+  FAILED_GET_FOLDER_PATH(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed to get folder path",
+      "Failed get folder path folderId={} detail={}"),
+
+  NOT_SITE_FOLDER(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Folder is not under site",
+      "Not site folder folderId={} siteId={} rootPath={}"),
+
+  UNEXPECTED_ERROR(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected site manager error: {}",
+      "Site manager unexpected error detail={}"),
+
+  SITE_NAME_NOT_EXIST(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Site name not found: {}",
+      "Site name not found name={}"),
+
+  SCHEME_NOT_EXIST(
+      8,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Scheme not found: {}",
+      "Scheme not found schemeId={}"),
+
+  NO_SUCH_CONTEXT(
+      9,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Publishing context not found",
+      "No such context kind={} data={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  SiteManagerErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat registry: package-local ints collide with earlier Phase 2b catalogs. Prefer
+   * this enum directly. Safe to call repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.PUB;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/UiErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/UiErrorCodes.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * UI service error catalog bridging legacy {@code com.percussion.services.ui.IPSUiErrors}
+ * package-local ints (1–8: hierarchy nodes).
+ *
+ * <p>Every constant sets {@link #isAuditable()} explicitly: access denied dual-writes; hierarchy
+ * validation and lookup noise does not.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–8} already belong to
+ * {@link WorkflowErrorCodes}. This catalog does <strong>not</strong> flat-register any ints.
+ * Prefer this enum directly (including {@link #ACCESS_DENIED}). Module code is {@link
+ * AuditModule#SYS}.
+ */
+public enum UiErrorCodes implements SystemErrorCode {
+
+  MISSING_HIERARCHY_NODE(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing hierarchy node: {}",
+      "Missing hierarchy node id={}"),
+
+  DUPLICATE_NODE_NAME(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate node name: {}",
+      "Duplicate node name name={} parent={}"),
+
+  INVALID_HIERARCHY_OPERATION(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid hierarchy operation",
+      "Invalid hierarchy operation op={} reason={}"),
+
+  NODE_TYPE_MISMATCH(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Node type mismatch",
+      "Node type mismatch nodeId={} expected={} actual={}"),
+
+  OPERATION_FAILED(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "UI operation failed",
+      "UI operation failed op={} detail={}"),
+
+  INVALID_NODE_NAME(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid node name: {}",
+      "Invalid node name name={} rule={}"),
+
+  CIRCULAR_REFERENCE(
+      7,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Circular hierarchy reference",
+      "Circular hierarchy reference source={} target={}"),
+
+  ACCESS_DENIED(
+      8,
+      true,
+      AuditEventType.ACCESS_DENIED,
+      AuditOutcome.FAILURE,
+      "UI access denied",
+      "UI access denied operation={} resource={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  UiErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat registry: package-local ints collide with earlier Phase 2b catalogs. Prefer
+   * this enum directly. Safe to call repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints are not flat-registered.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -41,6 +41,14 @@ import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DeploymentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.FilterServiceErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.LockErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.NavigationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.PublisherErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SiteManagerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.UiErrorCodes;
 import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -845,6 +853,200 @@ class LegacyErrorCodeRegistryTest {
     assertTrue(LegacyErrorCodeRegistry.find(16311).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(1801).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(3501).isPresent());
+  }
+
+// --- Publisher / SiteMgr / Filter / Lock / Catalog / Deployment / Nav / UI residual (#2882) ---
+
+  @Test
+  void publisherPackageLocalNotFlatRegisteredButJobFailedIsAuditableViaEnum() {
+    // 19 is assembly FINDER_ERROR; flat registry does not claim publisher JOB_FAILED
+    assertSame(AssemblyErrorCodes.FINDER_ERROR, LegacyErrorCodeRegistry.find(19).orElseThrow());
+    assertTrue(PublisherErrorCodes.JOB_FAILED.isAuditable());
+    assertEquals(19, PublisherErrorCodes.JOB_FAILED.numericCode());
+    assertTrue(PublisherErrorCodes.ITEM_PUBLISH_FAILED.isAuditable());
+  }
+
+  @Test
+  void publisherAuditableViaServiceLogDualWrites() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        svc.log(
+            PublisherErrorCodes.JOB_FAILED,
+            AuditContext.builder().actor("jdoe").build(),
+            "job-9",
+            "boom");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(1, sink.records().size());
+    assertEquals(PublisherErrorCodes.JOB_FAILED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[PUB-19]-"));
+  }
+
+  @Test
+  void siteManagerAndFilterPackageLocalRemainWorkflowInFlatRegistry() {
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertEquals(1, SiteManagerErrorCodes.SITE_ID_NOT_EXIST.numericCode());
+    assertFalse(SiteManagerErrorCodes.SITE_ID_NOT_EXIST.isAuditable());
+    assertEquals(1, FilterServiceErrorCodes.FILTER_MISSING.numericCode());
+    assertFalse(FilterServiceErrorCodes.FILTER_MISSING.isAuditable());
+  }
+
+  @Test
+  void lockPermissionDeniedAuditableViaEnumNotFlatRegistered() {
+    // bare 9 remains WorkflowErrorCodes.CONFIGURATION_ERROR in the flat map
+    assertSame(
+        WorkflowErrorCodes.CONFIGURATION_ERROR, LegacyErrorCodeRegistry.find(9).orElseThrow());
+    assertTrue(LockErrorCodes.PERMISSION_DENIED.isAuditable());
+    assertEquals(9, LockErrorCodes.PERMISSION_DENIED.numericCode());
+  }
+
+  @Test
+  void lockPermissionDeniedDualWritesViaEnum() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        svc.log(
+            LockErrorCodes.PERMISSION_DENIED, AuditContext.builder().actor("jdoe").build());
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(LockErrorCodes.PERMISSION_DENIED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-9]-"));
+  }
+
+  @Test
+  void uiAccessDeniedAuditableViaEnumNotFlatRegistered() {
+    assertSame(WorkflowErrorCodes.INVALID_TRANSITION, LegacyErrorCodeRegistry.find(8).orElseThrow());
+    assertTrue(UiErrorCodes.ACCESS_DENIED.isAuditable());
+    assertEquals(8, UiErrorCodes.ACCESS_DENIED.numericCode());
+  }
+
+  @Test
+  void uiAccessDeniedDualWritesViaEnum() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        svc.log(
+            UiErrorCodes.ACCESS_DENIED,
+            AuditContext.builder().actor("jdoe").build(),
+            "delete",
+            "node-1");
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(UiErrorCodes.ACCESS_DENIED, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-8]-"));
+  }
+
+  @Test
+  void catalogDesignRangeIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(4101));
+    assertSame(
+        CatalogErrorCodes.REQD_PROP_NOT_SPECIFIED,
+        LegacyErrorCodeRegistry.find(4101).orElseThrow());
+    assertFalse(CatalogErrorCodes.REQD_PROP_NOT_SPECIFIED.isAuditable());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(4310));
+    assertSame(CatalogErrorCodes.CATALOG_ERROR, LegacyErrorCodeRegistry.find(4310).orElseThrow());
+  }
+
+  @Test
+  void catalogServicePackageLocalRemainsWorkflowInFlatRegistry() {
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertEquals(1, CatalogErrorCodes.SUMMARY_ERROR.numericCode());
+  }
+
+  @Test
+  void catalogNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc, CatalogErrorCodes.REQD_PROP_NOT_SPECIFIED.numericCode(), AuditContext.empty(), "p");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void deploymentNonCollidingVersionCodeIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(74));
+    assertSame(
+        DeploymentErrorCodes.VERSION_LOWER_THAN_INSTALLED,
+        LegacyErrorCodeRegistry.find(74).orElseThrow());
+    assertFalse(DeploymentErrorCodes.VERSION_LOWER_THAN_INSTALLED.isAuditable());
+    assertSame(
+        DeploymentErrorCodes.WRONG_FORMAT_FOR_PAIRID_DEP_ID,
+        LegacyErrorCodeRegistry.find(85).orElseThrow());
+  }
+
+  @Test
+  void deploymentLockCodesNotFlatRegisteredButAuditableViaEnum() {
+    // 46 is webservice FAILED_FIND_FOLDER_CHILDREN in the flat map
+    assertSame(
+        WebserviceErrorCodes.FAILED_FIND_FOLDER_CHILDREN,
+        LegacyErrorCodeRegistry.find(46).orElseThrow());
+    assertTrue(DeploymentErrorCodes.LOCK_ALREADY_HELD.isAuditable());
+    assertEquals(46, DeploymentErrorCodes.LOCK_ALREADY_HELD.numericCode());
+  }
+
+  @Test
+  void deploymentLockAlreadyHeldDualWritesViaEnum() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        svc.log(
+            DeploymentErrorCodes.LOCK_ALREADY_HELD,
+            AuditContext.builder().actor("jdoe").build());
+
+    assertFalse(id.value().equals(LegacyErrorCodeRegistry.SKIPPED.value()));
+    assertEquals(DeploymentErrorCodes.LOCK_ALREADY_HELD, sink.records().get(0).code());
+    assertTrue(sink.records().get(0).formattedLine().startsWith("[SYS-46]-"));
+  }
+
+  @Test
+  void navigationCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(18001));
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH,
+        LegacyErrorCodeRegistry.find(18001).orElseThrow());
+    assertFalse(
+        NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH.isAuditable());
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE,
+        LegacyErrorCodeRegistry.find(18009).orElseThrow());
+  }
+
+  @Test
+  void navigationNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "/Sites/x");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void registryCoversCatalogDeploymentAndNavigationResidual() {
+    assertTrue(LegacyErrorCodeRegistry.size() >= 370);
+    assertTrue(LegacyErrorCodeRegistry.find(4101).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(4311).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(74).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(85).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(18001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(18009).isPresent());
+    // WF ownership of package-local low ints preserved
+    assertSame(WorkflowErrorCodes.ACCESS_DENIED, LegacyErrorCodeRegistry.find(6).orElseThrow());
   }
 
 }

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/PublisherSiteLockCatalogErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/PublisherSiteLockCatalogErrorCodesTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for #2882 residual catalogs: publisher, site manager, filter, lock, catalog,
+ * deployment, navigation, UI.
+ */
+class PublisherSiteLockCatalogErrorCodesTest {
+
+  @Test
+  void publisherJobAndItemFailuresAreAuditable() {
+    assertTrue(PublisherErrorCodes.JOB_FAILED.isAuditable());
+    assertEquals(AuditEventType.CONTENT_PUBLISH, PublisherErrorCodes.JOB_FAILED.eventType());
+    assertEquals(19, PublisherErrorCodes.JOB_FAILED.numericCode());
+    assertTrue(PublisherErrorCodes.ITEM_PUBLISH_FAILED.isAuditable());
+    assertEquals(20, PublisherErrorCodes.ITEM_PUBLISH_FAILED.numericCode());
+    assertFalse(PublisherErrorCodes.LIST_MISSING.isAuditable());
+    assertNull(PublisherErrorCodes.LIST_MISSING.eventType());
+    assertEquals(AuditModule.PUB, PublisherErrorCodes.JOB_FAILED.module());
+  }
+
+  @Test
+  void publisherConstantsUniqueAndPreserveLegacyInts() {
+    assertUniqueNumeric(PublisherErrorCodes.values(), c -> c.numericCode());
+    assertEquals(10, PublisherErrorCodes.LIST_MISSING.numericCode());
+    assertEquals(24, PublisherErrorCodes.UNEXPECTED.numericCode());
+    assertEquals(15, PublisherErrorCodes.values().length);
+  }
+
+  @Test
+  void siteManagerAndFilterAreNonAuditablePubModule() {
+    for (SiteManagerErrorCodes code : SiteManagerErrorCodes.values()) {
+      assertEquals(AuditModule.PUB, code.module());
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+    assertEquals(1, SiteManagerErrorCodes.SITE_ID_NOT_EXIST.numericCode());
+    assertEquals(9, SiteManagerErrorCodes.NO_SUCH_CONTEXT.numericCode());
+
+    for (FilterServiceErrorCodes code : FilterServiceErrorCodes.values()) {
+      assertEquals(AuditModule.PUB, code.module());
+      assertFalse(code.isAuditable(), code.name());
+    }
+    assertEquals(1, FilterServiceErrorCodes.FILTER_MISSING.numericCode());
+    assertEquals(8, FilterServiceErrorCodes.PROBABLE_CYCLE.numericCode());
+  }
+
+  @Test
+  void lockPermissionAndInvalidSessionAreAuditable() {
+    assertTrue(LockErrorCodes.PERMISSION_DENIED.isAuditable());
+    assertEquals(AuditEventType.ACCESS_DENIED, LockErrorCodes.PERMISSION_DENIED.eventType());
+    assertEquals(9, LockErrorCodes.PERMISSION_DENIED.numericCode());
+    assertTrue(LockErrorCodes.LOCK_EXTENSION_INVALID_SESSION.isAuditable());
+    assertEquals(
+        AuditEventType.AUTH_FAILURE, LockErrorCodes.LOCK_EXTENSION_INVALID_SESSION.eventType());
+    assertFalse(LockErrorCodes.OBJECT_ALREADY_LOCKED.isAuditable());
+    assertEquals(AuditModule.SYS, LockErrorCodes.PERMISSION_DENIED.module());
+  }
+
+  @Test
+  void uiAccessDeniedIsAuditableOthersNot() {
+    assertTrue(UiErrorCodes.ACCESS_DENIED.isAuditable());
+    assertEquals(AuditEventType.ACCESS_DENIED, UiErrorCodes.ACCESS_DENIED.eventType());
+    assertEquals(8, UiErrorCodes.ACCESS_DENIED.numericCode());
+    assertFalse(UiErrorCodes.MISSING_HIERARCHY_NODE.isAuditable());
+    assertEquals(AuditModule.SYS, UiErrorCodes.ACCESS_DENIED.module());
+  }
+
+  @Test
+  void catalogDesignRangePreservedServiceRangeNonAuditable() {
+    assertEquals(1, CatalogErrorCodes.SUMMARY_ERROR.numericCode());
+    assertEquals(4101, CatalogErrorCodes.REQD_PROP_NOT_SPECIFIED.numericCode());
+    assertEquals(4311, CatalogErrorCodes.CATALOG_EXCEPTION.numericCode());
+    for (CatalogErrorCodes code : CatalogErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertFalse(code.isAuditable(), code.name());
+    }
+    assertUniqueNumeric(CatalogErrorCodes.values(), c -> c.numericCode());
+  }
+
+  @Test
+  void deploymentLockCodesAuditableVersionFlatRegisteredRangePreserved() {
+    assertTrue(DeploymentErrorCodes.LOCK_ALREADY_HELD.isAuditable());
+    assertEquals(46, DeploymentErrorCodes.LOCK_ALREADY_HELD.numericCode());
+    assertTrue(DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN.isAuditable());
+    assertTrue(DeploymentErrorCodes.LOCK_NOT_EXTENSIBLE_TAKEN_RELEASED.isAuditable());
+    assertFalse(DeploymentErrorCodes.NULL_INPUT_DOC.isAuditable());
+    assertEquals(8, DeploymentErrorCodes.NULL_INPUT_DOC.numericCode());
+    assertEquals(74, DeploymentErrorCodes.VERSION_LOWER_THAN_INSTALLED.numericCode());
+    assertEquals(85, DeploymentErrorCodes.WRONG_FORMAT_FOR_PAIRID_DEP_ID.numericCode());
+    assertEquals(AuditModule.SYS, DeploymentErrorCodes.LOCK_ALREADY_HELD.module());
+    assertUniqueNumeric(DeploymentErrorCodes.values(), c -> c.numericCode());
+  }
+
+  @Test
+  void navigationCodesUniqueContModuleNonAuditable() {
+    for (NavigationErrorCodes code : NavigationErrorCodes.values()) {
+      assertEquals(AuditModule.CONT, code.module());
+      assertFalse(code.isAuditable(), code.name());
+      assertTrue(code.numericCode() >= 18001 && code.numericCode() <= 18009, code.name());
+    }
+    assertEquals(
+        18001, NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH.numericCode());
+    assertEquals(
+        18009, NavigationErrorCodes.NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE.numericCode());
+    assertEquals(9, NavigationErrorCodes.values().length);
+  }
+
+  private static <T> void assertUniqueNumeric(T[] values, java.util.function.ToIntFunction<T> fn) {
+    Set<Integer> seen = new HashSet<>();
+    for (T v : values) {
+      int n = fn.applyAsInt(v);
+      assertTrue(n > 0, v.toString());
+      assertTrue(seen.add(n), "duplicate numeric: " + n);
+      assertNotNull(v);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2b residual of parent **#2616**: migrate publisher / site manager / filter / lock / catalog / deployment / navigation / UI `IPS*Errors` into `*ErrorCodes` with explicit `isAuditable`, collision-safe flat registry registration, dual-write tests, and README catalog table.

**Operator:** Grok: night-issue-prs (model grok-4.5)

### Catalogs

| Enum | Legacy source | Flat registry | Auditable subset |
|------|---------------|---------------|------------------|
| `PublisherErrorCodes` | `IPSPublisherServiceErrors` 10–24 | none (collides WF/job/assembly) | `JOB_FAILED`, `ITEM_PUBLISH_FAILED` |
| `SiteManagerErrorCodes` | `IPSSiteManagerErrors` 1–9 | none (WF) | none |
| `FilterServiceErrorCodes` | `IPSFilterServiceErrors` 1–8 | none (WF) | none |
| `LockErrorCodes` | `IPSLockErrors` 1–9 | none (WF) | `PERMISSION_DENIED`, `LOCK_EXTENSION_INVALID_SESSION` |
| `CatalogErrorCodes` | services 1–6 + design 4101–4311 | design range only | none |
| `DeploymentErrorCodes` | `IPSDeploymentErrors` 1–85 | 74–85 only | lock codes 46/47/53 (enum) |
| `NavigationErrorCodes` | `IPSNavigationErrors` 18001–18009 | full | none |
| `UiErrorCodes` | `IPSUiErrors` 1–8 | none (WF) | `ACCESS_DENIED` |

### Collision handling

Documented in enum javadoc + `LegacyErrorCodeRegistry` bootstrap order: package-local low ints that collide with Workflow (1–10), assembly/job (11–27), or webservice (28–73) are **not** flat-registered; call sites prefer the enum. Design catalog and navigation ranges are globally unique; deployment registers only 74–85.

### Residual

Utils/XML/beans/table/JBoss/SiteManage catalogs remain — filed as residual child of #2616 (see residual issue linked after open).

## Test plan

- [x] `cd modules/perc-auditlog && ../../mvnw.cmd clean install`
- [x] Tests run: **171**, Failures: 0
- [x] Dual-write tests for publisher job failure, lock permission denied, UI access denied, deploy lock held
- [x] Flat registry ownership of WF 1–10 / assembly 19 / webservice 46 preserved

### C3 build evidence

- **modules_built:** `modules/perc-auditlog`
- **build_evidence:** `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 171, Failures: 0
- **downstream_checked:** none (new enums + registry bootstrap only; no public type sealed/final or signature change to reverse-deps)

## Product documentation

- [x] N/A — internal Phase 2b error-code catalog migration; no operator/UI/REST/install surface change

## Checklist

- [x] Erlang-style self-review (auditable flags explicit; collisions documented; portable paths N/A)
- [x] Unit tests for new/changed logic
- [x] Pre-PR module clean install green
- [x] Fixes #2882
- [x] Refs #2616

> Co-Authored by Grok Build using grok-4.5 with agent main.
