### PR TITLE
fix(deployer): Xlint residual — DataObject/Cms/AuthType/community handlers (#2861)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/PSDependencyValidator.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDependencyValidator.java
@@ -103,16 +103,16 @@ public class PSDependencyValidator {
     // validate local dependencies of any referenced elements at the end to
     // ensure that if the same dependency occurs elsewhere in the tree, it
     // is properly validated first.
-    Iterator deps = m_depElem.getDependencies();
+    Iterator<PSDependency> deps = m_depElem.getDependencies();
     if (deps != null) {
       while (deps.hasNext() && !m_ctx.getJobHandle().isCancelled()) {
-        validateDependency((PSDependency) deps.next());
+        validateDependency(deps.next());
       }
     }
 
-    Iterator locals = m_localDeps.iterator();
+    Iterator<PSDependency> locals = m_localDeps.iterator();
     while (locals.hasNext() && !m_ctx.getJobHandle().isCancelled()) {
-      validateDependency((PSDependency) locals.next());
+      validateDependency(locals.next());
     }
 
     return m_results;
@@ -220,10 +220,10 @@ public class PSDependencyValidator {
    */
   private void validateChildDependencies(PSDependency dep)
       throws PSDeployException, PSNotFoundException {
-    Iterator deps = dep.getDependencies();
+    Iterator<PSDependency> deps = dep.getDependencies();
     if (deps != null) {
       while (deps.hasNext() && !m_ctx.getJobHandle().isCancelled()) {
-        validateDependency((PSDependency) deps.next());
+        validateDependency(deps.next());
       }
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/PSExportJob.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSExportJob.java
@@ -115,7 +115,7 @@ public class PSExportJob extends PSDeployJob {
       var treeCtx = new PSDependencyTreeContext();
       m_descriptor
           .getPackages()
-          .forEachRemaining(de -> treeCtx.addPackage((PSDeployableElement) de, true));
+          .forEachRemaining(de -> treeCtx.addPackage(de, true));
 
       // add suppression filter from descriptor to context
       if (m_descriptor.getDepKeysToExclude() != null) {
@@ -132,7 +132,7 @@ public class PSExportJob extends PSDeployJob {
               MessageFormat.format(bundle.getString("analyzingDeps"), de.getDisplayIdentifier());
           setStatusMessage(msg);
           try {
-            dm.addMissingDependencies(getSecurityToken(), (PSDeployableElement) de, treeCtx, this);
+            dm.addMissingDependencies(getSecurityToken(), de, treeCtx, this);
           } catch (PSDeployException e) {
             // wrap checked exception so we can handle it in the outer catch
             throw new RuntimeException(e);
@@ -177,7 +177,7 @@ public class PSExportJob extends PSDeployJob {
           var msg = MessageFormat.format(bundle.getString("processing"), de.getDisplayIdentifier());
           setStatusMessage(msg);
           try {
-            dm.addToArchive(getSecurityToken(), (PSDeployableElement) de, ah, this);
+            dm.addToArchive(getSecurityToken(), de, ah, this);
           } catch (PSDeployException e) {
             throw new RuntimeException(e);
           }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAclDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAclDefDependencyHandler.java
@@ -256,12 +256,12 @@ public class PSAclDefDependencyHandler extends PSDependencyHandler {
    * @throws PSDeployException if there is no dependency file in the archive for the specified
    *     dependency object, or any other error occurs.
    */
-  protected static Iterator getAclDependencyFilesFromArchive(
+  protected static Iterator<PSDependencyFile> getAclDependencyFilesFromArchive(
       PSArchiveHandler archive, PSDependency dep) throws PSDeployException {
     if (archive == null) throw new IllegalArgumentException("archive may not be null");
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
 
     if (!files.hasNext()) {
       Object[] args = {
@@ -375,9 +375,9 @@ public class PSAclDefDependencyHandler extends PSDependencyHandler {
     if (ctx == null) throw new IllegalArgumentException("ctx may not be null");
 
     // retrieve datas, acl data
-    Iterator files = getAclDependencyFilesFromArchive(archive, dep);
+    Iterator<PSDependencyFile> files = getAclDependencyFilesFromArchive(archive, dep);
     while (files.hasNext()) {
-      PSDependencyFile depFile = (PSDependencyFile) files.next();
+      PSDependencyFile depFile = files.next();
       PSAclImpl tmp = generateAclFromFile(archive, depFile);
       doTransforms(tok, archive, dep, ctx, tmp);
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAuthTypeDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSAuthTypeDependencyHandler.java
@@ -19,6 +19,7 @@ package com.percussion.deployer.server.dependencies;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSChoiceBuilder;
 import com.percussion.deployer.objectstore.PSDependency;
+import com.percussion.deployer.objectstore.PSDependencyFile;
 import com.percussion.deployer.objectstore.PSDeployComponentUtils;
 import com.percussion.deployer.server.PSArchiveHandler;
 import com.percussion.deployer.server.PSDependencyDef;
@@ -135,7 +136,7 @@ public class PSAuthTypeDependencyHandler extends PSDependencyHandler {
     Properties props = getAuthTypesProps();
     String propKey = getPropKey(id);
     if (props.containsKey(propKey)) {
-      String name = (String) getAuthtypeNames().get(id);
+      String name = getAuthtypeNames().get(id);
       dep = createDependency(m_def, id, (name != null ? name : id));
       PSDependency appDep = getAppDep(tok, props.getProperty(propKey));
       if (appDep != null) dep.setDependencyType(appDep.getDependencyType());
@@ -154,7 +155,7 @@ public class PSAuthTypeDependencyHandler extends PSDependencyHandler {
   private Map<String, String> getAuthtypeNames() throws PSDeployException {
     try {
       Map<String, String> result = new HashMap<>();
-      Iterator entries =
+      Iterator<?> entries =
           PSChoiceBuilder.getGlobalLookupEntries(
               AUTH_TYPE_LOOKUP_ID, PSRequest.getContextForRequest());
       while (entries.hasNext()) {
@@ -249,23 +250,27 @@ public class PSAuthTypeDependencyHandler extends PSDependencyHandler {
    * @return An iterator over zero or more types as <code>String</code> objects, never <code>null
    *     </code>, does not contain <code>null</code> or empty entries.
    */
-  public Iterator getChildTypes() {
+  @Override
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
   // see base class
+  @Override
   public String getType() {
     return DEPENDENCY_TYPE;
   }
 
   // see base class
+  @Override
   public boolean doesDependencyExist(PSSecurityToken tok, String id)
       throws PSDeployException, PSNotFoundException {
     return (getDependency(tok, id) != null);
   }
 
   // see base class
-  public Iterator getDependencyFiles(PSSecurityToken tok, PSDependency dep)
+  @Override
+  public Iterator<PSDependencyFile> getDependencyFiles(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -300,7 +305,7 @@ public class PSAuthTypeDependencyHandler extends PSDependencyHandler {
   private static final String AUTH_TYPE_LOOKUP_ID = "10";
 
   /** List of child types supported by this handler, it will never be <code>null</code> or empty. */
-  private static List ms_childTypes = new ArrayList();
+  private static final List<String> ms_childTypes = new ArrayList<>();
 
   static {
     ms_childTypes.add(PSKeywordDependencyHandler.DEPENDENCY_TYPE);

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCEDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCEDependencyHandler.java
@@ -49,7 +49,8 @@ public class PSCEDependencyHandler extends PSElementDependencyHandler {
    * @return An iterator over zero or more types as <code>String</code> objects, never <code>null
    *     </code>, does not contain <code>null</code> or empty entries.
    */
-  public Iterator getChildTypes() {
+  @Override
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCmsObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCmsObjectDependencyHandler.java
@@ -196,12 +196,12 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
    * @throws PSDeployException if there is no dependency file in the archive for the specified
    *     dependency object, or any other error occurs.
    */
-  protected Iterator getDependencyFilesFromArchive(PSArchiveHandler archive, PSDependency dep)
-      throws PSDeployException {
+  protected Iterator<PSDependencyFile> getDependencyFilesFromArchive(
+      PSArchiveHandler archive, PSDependency dep) throws PSDeployException {
     if (archive == null) throw new IllegalArgumentException("archive may not be null");
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
 
     if (!files.hasNext()) {
       Object[] args = {
@@ -281,7 +281,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
     var deps = new ArrayList<PSDependency>();
     var propIter = prop.iterator();
     while (propIter.hasNext()) {
-      var dep = handler.getDependency(tok, (String) propIter.next());
+      var dep = handler.getDependency(tok, propIter.next());
       Optional.ofNullable(dep).ifPresent(deps::add);
     }
     return deps;
@@ -307,10 +307,10 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
     boolean isMapped = true;
 
     // get each value and transform it.
-    List newIds = new ArrayList();
-    Iterator vals = prop.iterator();
+    List<String> newIds = new ArrayList<>();
+    Iterator<String> vals = prop.iterator();
     while (vals.hasNext() && isMapped) {
-      String val = (String) vals.next();
+      String val = vals.next();
       PSIdMapping idMapping = getIdMapping(ctx, val, type);
       if (idMapping != null) newIds.add(idMapping.getTargetId());
       else isMapped = false;
@@ -318,7 +318,7 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
 
     if (isMapped) {
       prop.clear();
-      prop.add((String[]) newIds.toArray(new String[newIds.size()]));
+      prop.add(newIds.toArray(new String[0]));
     }
   }
 
@@ -384,10 +384,12 @@ public abstract class PSCmsObjectDependencyHandler extends PSIdTypeDependencyHan
    * @throws IllegalArgumentException if <code>tok</code> is <code>null</code>.
    * @throws PSDeployException if the processor cannot be created.
    */
-  protected PSRelationshipProcessor getRelationshipProcessor(PSSecurityToken tok, Map params)
-      throws PSDeployException {
+  protected PSRelationshipProcessor getRelationshipProcessor(
+      PSSecurityToken tok, Map<String, ?> params) throws PSDeployException {
     PSRequest req = new PSRequest(tok);
-    if (params != null) req.setParameters(new HashMap(params));
+    if (params != null) {
+      req.setParameters(new HashMap<String, Object>(params));
+    }
 
     return getRelationshipProcessor(req);
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCommunityDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCommunityDefDependencyHandler.java
@@ -209,8 +209,8 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
       PSSecurityToken tok, PSArchiveHandler archive, PSDependency dep, PSImportCtx ctx)
       throws PSDeployException {
     // get the community data first
-    Iterator files = getDependecyDataFiles(archive, dep);
-    PSDependencyFile file = (PSDependencyFile) files.next();
+    Iterator<PSDependencyFile> files = getDependecyDataFiles(archive, dep);
+    PSDependencyFile file = files.next();
     PSDependencyData depData = getDepDataFromFile(archive, file);
 
     Integer version = null;
@@ -249,12 +249,12 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
 
     // retrieve the files and install them
     while (files.hasNext()) {
-      file = (PSDependencyFile) files.next();
+      file = files.next();
       depData = getDepDataFromFile(archive, file);
       PSJdbcTableData data = depData.getData();
       String table = data.getName();
       if (table.equalsIgnoreCase(COMM_RL_TABLE)) data = transferIdsForRLData(data, dep, ctx, tok);
-      else data = transferIdsForChildData(data, (String) columnMap.get(table), dep, ctx, tok);
+      else data = transferIdsForChildData(data, columnMap.get(table), dep, ctx, tok);
 
       installDependencyData(
           depData.getSchema(), data, dep, ctx, PSTransactionSummary.ACTION_CREATED, null);
@@ -351,20 +351,20 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
 
     // get the source row
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
-    Iterator rows = data.getRows();
+    Iterator<PSJdbcRowData> rows = data.getRows();
     if (!rows.hasNext()) {
       throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
     }
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the COMM_RL_ID to its
       // corresponding ROLE_NAME in ROLE_TABLE
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(COMM_RL_ID)) {
           // query the database based on the role id, colume value
@@ -375,8 +375,7 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
           pdata = getDepDataFromTable(ROLE_TABLE, filter, true);
 
           // get the role name from the result set
-          PSJdbcRowData row;
-          row = (PSJdbcRowData) pdata.getData().getRows().next();
+          PSJdbcRowData row = pdata.getData().getRows().next();
           String roleName = PSDbmsHelper.getInstance().getColumnString(ROLE_TABLE, ROLE_NAME, row);
 
           col.setValue(roleName);
@@ -417,20 +416,20 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
 
     // get the source row
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
-    Iterator rows = data.getRows();
+    Iterator<PSJdbcRowData> rows = data.getRows();
     if (!rows.hasNext()) {
       throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
     }
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the id for
       // COMMUNITY_ID, convert role-name to role-id for COMM_RL_ID
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(COMMUNITY_ID)) {
           if (commMapping != null) col.setValue(commMapping.getTargetId());
@@ -447,8 +446,7 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
           pdata = getDepDataFromTable(ROLE_TABLE, filter, true);
 
           // get the role id from the result set
-          PSJdbcRowData row;
-          row = (PSJdbcRowData) pdata.getData().getRows().next();
+          PSJdbcRowData row = pdata.getData().getRows().next();
           String roleId = PSDbmsHelper.getInstance().getColumnString(ROLE_TABLE, ROLE_ID, row);
 
           col.setValue(roleId);
@@ -489,21 +487,21 @@ public class PSCommunityDefDependencyHandler extends PSDataObjectDependencyHandl
 
     // get the source row
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
-    Iterator rows = data.getRows();
+    Iterator<PSJdbcRowData> rows = data.getRows();
     if (!rows.hasNext()) {
       throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
     }
 
     while (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for COMMUNITY_ID, COMM_CP_ID, COMM_CT_ID,
       // COMM_ST_ID, COMM_VR_ID and COMM_WF_ID
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(COMMUNITY_ID)) {
           if (commMapping != null) col.setValue(commMapping.getTargetId());

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCommunityDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSCommunityDependencyHandler.java
@@ -78,7 +78,7 @@ public class PSCommunityDependencyHandler extends PSElementDependencyHandler {
   private PSDependencyHandler m_cdHandler = null;
 
   /** List of child types supported by this handler, it will never be <code>null</code> or empty. */
-  private static List ms_childTypes = new ArrayList();
+  private static final List<String> ms_childTypes = new ArrayList<>();
 
   static {
     ms_childTypes.add(PSCommunityDefDependencyHandler.DEPENDENCY_TYPE);

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSComponentDefDependencyHandler.java
@@ -77,7 +77,7 @@ public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandl
     var ids =
         getChildIdsFromTable(COMPONENT_TABLE, COMPONENT_URL, COMPONENT_ID, dep.getDependencyId());
     if (ids.hasNext()) {
-      var url = (String) ids.next();
+      var url = ids.next();
       var appName = PSDeployComponentUtils.getAppName(url);
       if (appName != null && !appName.isBlank()) {
         var handler = getDependencyHandler(PSApplicationDependencyHandler.DEPENDENCY_TYPE);
@@ -107,7 +107,8 @@ public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandl
   }
 
   // see base class
-  public Iterator getDependencies(PSSecurityToken tok) throws PSDeployException {
+  @Override
+  public Iterator<PSDependency> getDependencies(PSSecurityToken tok) throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
     return getDependencies(tok, COMPONENT_TABLE, COMPONENT_ID, COMPONENT_NAME);
@@ -159,7 +160,8 @@ public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandl
   }
 
   // see base class
-  public Iterator getDependencyFiles(PSSecurityToken tok, PSDependency dep)
+  @Override
+  public Iterator<PSDependencyFile> getDependencyFiles(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -193,13 +195,13 @@ public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandl
     if (ctx == null) throw new IllegalArgumentException("ctx may not be null");
 
     // retrieve the data from the archive, 1st component, 2nd property
-    Iterator files = getDependecyDataFiles(archive, dep);
-    PSDependencyFile file = (PSDependencyFile) files.next();
+    Iterator<PSDependencyFile> files = getDependecyDataFiles(archive, dep);
+    PSDependencyFile file = files.next();
     PSDependencyData compData = getDepDataFromFile(archive, file);
 
     PSDependencyData propData = null;
     if (files.hasNext()) {
-      file = (PSDependencyFile) files.next();
+      file = files.next();
       propData = getDepDataFromFile(archive, file);
     }
 
@@ -233,7 +235,7 @@ public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandl
       PSJdbcTableData srcData, PSDependency compDep, PSImportCtx ctx, PSSecurityToken tok)
       throws PSDeployException {
     // reserve ids for the COMPPROP_ID
-    List rows = PSDeployComponentUtils.cloneList(srcData.getRows());
+    List<PSJdbcRowData> rows = PSDeployComponentUtils.cloneList(srcData.getRows());
 
     if (rows.isEmpty()) // not expecting no rows
     throw new PSDeployException(IPSDeploymentErrors.NO_ROWS_TO_PROCESS);
@@ -246,14 +248,14 @@ public class PSComponentDefDependencyHandler extends PSDataObjectDependencyHandl
     // get the source row
     List<PSJdbcRowData> tgtRowList = new ArrayList<>();
     for (int i = 0; i < rows.size(); i++) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.get(i);
+      PSJdbcRowData srcRow = rows.get(i);
 
       // walk the columns and build a new row, xform the ids as we go
       // xform the ids for COMPPROP_ID and COMPONENT_ID
       List<PSJdbcColumnData> tgtColList = new ArrayList<>();
-      Iterator srcCols = srcRow.getColumns();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         String colName = col.getName();
         if (colName.equalsIgnoreCase(COMPONENT_ID)) {
           if (compMapping != null) col.setValue(compMapping.getTargetId());

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataObjectDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSDataObjectDependencyHandler.java
@@ -196,7 +196,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     PSDependencyHandler handler = getDependencyHandler(dependencyType);
     String id;
     while (ids.hasNext()) {
-      id = (String) ids.next();
+      id = ids.next();
       PSDependency dep = handler.getDependency(tok, id);
       if (dep != null) {
         if (depType != -1) dep.setDependencyType(depType);
@@ -258,8 +258,8 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
    * @throws IllegalArgumentException if any param is invalid.
    * @throws PSDeployException if any other error occurs.
    */
-  protected Iterator getAppNamesFromTableData(PSJdbcTableData data, String table, String col)
-      throws PSDeployException {
+  protected Iterator<String> getAppNamesFromTableData(
+      PSJdbcTableData data, String table, String col) throws PSDeployException {
     if (table == null || table.trim().length() == 0)
       throw new IllegalArgumentException("table may not be null or empty");
 
@@ -270,11 +270,11 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     Set<String> appNames = new HashSet<>();
 
     if (data != null && data.getRows().hasNext()) {
-      Iterator rows = data.getRows();
+      Iterator<PSJdbcRowData> rows = data.getRows();
       PSDbmsHelper dbmsHelper = PSDbmsHelper.getInstance();
 
       while (rows.hasNext()) {
-        PSJdbcRowData row = (PSJdbcRowData) rows.next();
+        PSJdbcRowData row = rows.next();
         String url = getColumnValueNullable(table, col, row);
         if (url != null && url.trim().length() != 0) {
           String appName = dbmsHelper.getColumnAppName(table, col, row);
@@ -893,16 +893,16 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
       PSJdbcTableData data, String tableName, String idColumn, PSIdMapping mapping)
       throws PSDeployException {
     // get the source row
-    List tgtRowList = new ArrayList();
-    Iterator rows = data.getRows();
+    List<PSJdbcRowData> tgtRowList = new ArrayList<>();
+    Iterator<PSJdbcRowData> rows = data.getRows();
     if (rows.hasNext()) {
-      PSJdbcRowData srcRow = (PSJdbcRowData) rows.next();
+      PSJdbcRowData srcRow = rows.next();
 
       // walk the columns and build a new row, xform the id as we go
-      List tgtColList = new ArrayList();
-      Iterator srcCols = srcRow.getColumns();
+      List<PSJdbcColumnData> tgtColList = new ArrayList<>();
+      Iterator<PSJdbcColumnData> srcCols = srcRow.getColumns();
       while (srcCols.hasNext()) {
-        PSJdbcColumnData col = (PSJdbcColumnData) srcCols.next();
+        PSJdbcColumnData col = srcCols.next();
         if (mapping == null) {
           tgtColList.add(col);
         } else {
@@ -936,12 +936,12 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
    * @throws PSDeployException if there is no dependency file in the archive for the specified
    *     dependency object, or any other error occurs.
    */
-  protected Iterator getDependecyDataFiles(PSArchiveHandler archive, PSDependency dep)
-      throws PSDeployException {
+  protected Iterator<PSDependencyFile> getDependecyDataFiles(
+      PSArchiveHandler archive, PSDependency dep) throws PSDeployException {
     if (archive == null) throw new IllegalArgumentException("archive may not be null");
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
 
     if (!files.hasNext()) {
       Object[] args = {
@@ -1211,15 +1211,14 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     if (childDepType == null || childDepType.trim().length() == 0)
       throw new IllegalArgumentException("childDepType may not be null or empty");
 
-    Iterator childIDs = getChildPairIdsFromTable(table, childIdCol, parentIdCol, parentId);
+    Iterator<String> childIDs =
+        getChildPairIdsFromTable(table, childIdCol, parentIdCol, parentId);
 
     List<PSDependency> childDeps = getDepsFromIds(childIDs, childDepType, tok);
 
     // set dependency scope if needed
     if (childDepScope != -1) {
-      Iterator deps = childDeps.iterator();
-      while (deps.hasNext()) {
-        PSDependency dep = (PSDependency) deps.next();
+      for (PSDependency dep : childDeps) {
         dep.setDependencyType(childDepScope);
       }
     }
@@ -1242,7 +1241,7 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
    *     null</code>, but may be empty.
    * @throws PSDeployException if any error occurs.
    */
-  protected Iterator getChildPairIdsFromTable(
+  protected Iterator<String> getChildPairIdsFromTable(
       String table, String childIdCol, String parentIdCol, String parentId)
       throws PSDeployException {
     if (table == null || table.trim().length() == 0)
@@ -1265,12 +1264,12 @@ public abstract class PSDataObjectDependencyHandler extends PSDependencyHandler 
     Set<String> ids = new HashSet<>();
 
     if (data != null && data.getRows().hasNext()) {
-      Iterator rows = data.getRows();
+      Iterator<PSJdbcRowData> rows = data.getRows();
       String childId;
       String depId;
       PSJdbcRowData row;
       while (rows.hasNext()) {
-        row = (PSJdbcRowData) rows.next();
+        row = rows.next();
         childId = dbmsHelper.getColumnString(table, childIdCol, row);
         parentId = dbmsHelper.getColumnString(table, parentIdCol, row);
         depId = PSPairDependencyId.getPairDependencyId(parentId, childId);

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPairIdDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSPairIdDependencyHandler.java
@@ -129,8 +129,8 @@ public abstract class PSPairIdDependencyHandler extends PSDataObjectDependencyHa
 
     // should only get back one, take the first if found
     if (data != null && data.getRows().hasNext()) {
-      Iterator rows = data.getRows();
-      PSJdbcRowData row = (PSJdbcRowData) rows.next();
+      Iterator<PSJdbcRowData> rows = data.getRows();
+      PSJdbcRowData row = rows.next();
       String name = dbmsHelper.getColumnString(table, childNameCol, row);
 
       dep = createDependency(m_def, id, name);
@@ -244,16 +244,17 @@ public abstract class PSPairIdDependencyHandler extends PSDataObjectDependencyHa
     if (data != null && data.getRows().hasNext()) // if there is things
     { // exist in the table
       // prepare to be deleted row
-      List cols = new ArrayList();
-      cols.add(new PSJdbcColumnData(parentIdCol, newParentId));
-      cols.add(new PSJdbcColumnData(childNameCol, pairId.getChildId()));
-      PSJdbcRowData rowData = new PSJdbcRowData(cols.iterator(), PSJdbcRowData.ACTION_DELETE);
+      List<PSJdbcColumnData> colDataList = new ArrayList<>();
+      colDataList.add(new PSJdbcColumnData(parentIdCol, newParentId));
+      colDataList.add(new PSJdbcColumnData(childNameCol, pairId.getChildId()));
+      PSJdbcRowData rowData =
+          new PSJdbcRowData(colDataList.iterator(), PSJdbcRowData.ACTION_DELETE);
 
       // set the update key: WHERE PARENT_ID=parentId and CHILD_NAME=childId
-      cols.clear();
-      cols.add(parentIdCol);
-      cols.add(childNameCol);
-      dbmsHelper.setUpdateKeyForSchema(cols.iterator(), schema);
+      List<String> keyCols = new ArrayList<>();
+      keyCols.add(parentIdCol);
+      keyCols.add(childNameCol);
+      dbmsHelper.setUpdateKeyForSchema(keyCols.iterator(), schema);
 
       // do the delete
       dbmsHelper.processTable(schema, table, rowData);

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSDataObjectHandlersTypedTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSDataObjectHandlersTypedTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.server.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.deployer.objectstore.PSDependency;
+import com.percussion.deployer.objectstore.PSDependencyFile;
+import com.percussion.deployer.server.PSArchiveHandler;
+import com.percussion.security.PSSecurityToken;
+import com.percussion.tablefactory.PSJdbcTableData;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Iterator;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Signature smoke for typed DataObject / CmsObject / AuthType / Community / Component dependency
+ * handler surfaces (issue #2861 Xlint residual after #2847). Runtime paths require a live CMS;
+ * these tests lock compile-time API shapes that cleared rawtypes diagnostics.
+ */
+public class PSDataObjectHandlersTypedTest {
+
+  @Test
+  public void dataObjectHelperMethodsReturnTypedIterators() throws Exception {
+    Method getAppNames =
+        PSDataObjectDependencyHandler.class.getDeclaredMethod(
+            "getAppNamesFromTableData", PSJdbcTableData.class, String.class, String.class);
+    assertTypedIterator(getAppNames.getGenericReturnType(), String.class);
+
+    Method getDepDataFiles =
+        PSDataObjectDependencyHandler.class.getDeclaredMethod(
+            "getDependecyDataFiles", PSArchiveHandler.class, PSDependency.class);
+    assertTypedIterator(getDepDataFiles.getGenericReturnType(), PSDependencyFile.class);
+
+    Method getChildPairIds =
+        PSDataObjectDependencyHandler.class.getDeclaredMethod(
+            "getChildPairIdsFromTable", String.class, String.class, String.class, String.class);
+    assertTypedIterator(getChildPairIds.getGenericReturnType(), String.class);
+  }
+
+  @Test
+  public void cmsObjectArchiveAndProcessorSurfacesAreTyped() throws Exception {
+    Method getFiles =
+        PSCmsObjectDependencyHandler.class.getDeclaredMethod(
+            "getDependencyFilesFromArchive", PSArchiveHandler.class, PSDependency.class);
+    assertTypedIterator(getFiles.getGenericReturnType(), PSDependencyFile.class);
+
+    Method relProc =
+        PSCmsObjectDependencyHandler.class.getDeclaredMethod(
+            "getRelationshipProcessor", PSSecurityToken.class, Map.class);
+    Type[] params = relProc.getGenericParameterTypes();
+    assertEquals(2, params.length);
+    assertTrue(params[1] instanceof ParameterizedType);
+    ParameterizedType mapType = (ParameterizedType) params[1];
+    assertEquals(Map.class, mapType.getRawType());
+    Type[] mapArgs = mapType.getActualTypeArguments();
+    assertEquals(String.class, mapArgs[0]);
+    assertTrue(
+        mapArgs[1] instanceof WildcardType,
+        "second map type arg should be wildcard (?), was " + mapArgs[1]);
+  }
+
+  @Test
+  public void authTypeChildTypesAndDependencyFilesAreTyped() throws Exception {
+    Method getChildTypes = PSAuthTypeDependencyHandler.class.getMethod("getChildTypes");
+    assertTypedIterator(getChildTypes.getGenericReturnType(), String.class);
+
+    Method getDepFiles =
+        PSAuthTypeDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class);
+    assertTypedIterator(getDepFiles.getGenericReturnType(), PSDependencyFile.class);
+
+    assertEquals("AuthType", PSAuthTypeDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void communityAndComponentHandlerSurfacesAreTyped() throws Exception {
+    Method communityChildTypes = PSCommunityDependencyHandler.class.getMethod("getChildTypes");
+    assertTypedIterator(communityChildTypes.getGenericReturnType(), String.class);
+
+    Method ceChildTypes = PSCEDependencyHandler.class.getMethod("getChildTypes");
+    assertTypedIterator(ceChildTypes.getGenericReturnType(), String.class);
+
+    Method compDeps =
+        PSComponentDefDependencyHandler.class.getMethod("getDependencies", PSSecurityToken.class);
+    assertTypedIterator(compDeps.getGenericReturnType(), PSDependency.class);
+
+    Method compFiles =
+        PSComponentDefDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class);
+    assertTypedIterator(compFiles.getGenericReturnType(), PSDependencyFile.class);
+
+    Method aclFiles =
+        PSAclDefDependencyHandler.class.getDeclaredMethod(
+            "getAclDependencyFilesFromArchive", PSArchiveHandler.class, PSDependency.class);
+    assertTypedIterator(aclFiles.getGenericReturnType(), PSDependencyFile.class);
+  }
+
+  private static void assertTypedIterator(Type genericReturn, Class<?> elementType) {
+    assertTrue(genericReturn instanceof ParameterizedType, "expected ParameterizedType, got " + genericReturn);
+    ParameterizedType pt = (ParameterizedType) genericReturn;
+    assertEquals(Iterator.class, pt.getRawType());
+    Type[] args = pt.getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(elementType, args[0]);
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-2861-deployer-xlint-handlers-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2861-deployer-xlint-handlers-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — issue #2861 perc-deployer Xlint residual (handlers batch)
+
+**Reviewer persona:** independent Erlang-style gate  
+**Scope:** deployer dependency-handler generics cleanup (no behavior change)  
+**Verdict:** **PASS**
+
+## Checklist
+
+| Gate | Result | Notes |
+|------|--------|-------|
+| Bugs / behavior change | PASS | Real generics on locals/returns; drop redundant casts after typed APIs; no control-flow changes |
+| Unit tests for new/changed logic | PASS | `PSDataObjectHandlersTypedTest` locks generic return/param shapes (4 tests) |
+| Cross-platform paths | PASS | No new path/file I/O; existing AuthType path string unchanged |
+| Change-class companions | PASS | Mirrors #2847 Application/AppObject typed surfaces + signature smoke tests |
+| Module clean install | PASS | `cd deployer && ../mvnw.cmd clean install` BUILD SUCCESS; Tests run: 224, Failures: 0, Errors: 0, Skipped: 19 |
+| C2 API blast | PASS | No final/sealed; public overrides only add type params; protected helpers return typed iterators. Grep not required for reverse modules (deployer-internal) |
+| Product docs | N/A | Pure tech-debt Xlint; no operator/user surface |
+
+## Files
+
+- PSDataObjectDependencyHandler, PSCmsObjectDependencyHandler, PSAuthTypeDependencyHandler
+- PSCommunityDefDependencyHandler, PSComponentDefDependencyHandler, PSCommunityDependencyHandler
+- PSCEDependencyHandler, PSAclDefDependencyHandler, PSPairIdDependencyHandler
+- PSExportJob, PSDependencyValidator
+- PSDataObjectHandlersTypedTest
+
+## Residual
+
+Maven still reports 100 (cap). Next composition dominated by PSComponentSlotDependencyHandler / PSContentDefDependencyHandler / file handlers — file residual under #2028/#2200.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.


### PR DESCRIPTION
## Summary
Partial Xlint cleanup for **perc-deployer** (issue #2861, residual of #2847 / PR #2860, slice of #2028, parent tracker #2200).

### Main changes
- **PSDataObjectDependencyHandler** (~25): typed `Iterator`/`List` for app-names, dep data files, pair-ids, row/column transfer helpers; drop redundant casts
- **PSCmsObjectDependencyHandler** (~13): typed archive file iterator; typed multi-value property transform; `getRelationshipProcessor(tok, Map<String, ?>)`
- **PSAuthTypeDependencyHandler** (~12): typed `getChildTypes` / `getDependencyFiles`; `List<String>` child types; drop redundant cast
- **Community / Component / CE / ACL / PairId**: real generics on handlers dominating the post-#2847 cap report
- **PSExportJob** / **PSDependencyValidator**: drop redundant casts after typed package/dependency iterators

### Tests
- `PSDataObjectHandlersTypedTest` — signature smoke for typed helper/override surfaces (4 tests)

## Residual
Maven still reports 100 (cap). Post-batch composition is dominated by **PSComponentSlotDependencyHandler** (~36), **PSContentDefDependencyHandler** (~33), file/config handlers. Residual child filed under #2028/#2200.

## Test plan
- [x] `cd deployer && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **224**, Failures: **0**, Errors: **0**, Skipped: **19**
- [x] Target-file rawtypes for DataObject/Cms/AuthType/Community/Component/ACL/CE/PairId/ExportJob/Validator cleared from report
- [x] C2: no final/sealed; overrides only add type parameters; protected helpers deployer-internal — **downstream_checked=none** (C2 did not apply beyond typed overrides)
- [x] No monorepo-wide reformat

## Gates
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2861-deployer-xlint-handlers-erlang.md` — PASS
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

### C3 evidence
- **modules_built:** deployer
- **build_evidence:** `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 224, Failures: 0, Errors: 0, Skipped: 19
- **downstream_checked:** none (C2 not required — no final/sealed or breaking signature changes)

### Product documentation
- [x] N/A — pure tech-debt Xlint generics; no operator/user/API surface change

Fixes #2861
Refs #2028 #2200 #2847
Partial of #2028 (Xlint residual remains for ComponentSlot/ContentDef/file handlers)

> Co-Authored by Grok Build using grok-4.5 with agent main.
