### PR TITLE
fix(sitemanage): Xlint batch 3 — serial-field concrete collections (#2870)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2870-sitemanage-xlint-serial-field-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2870-sitemanage-xlint-serial-field-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review — issue #2870 sitemanage Xlint serial-field batch 3
+
+**Verdict:** Approve for PR.
+
+## Scope
+Main-source `serial-field` cluster on `projects/sitemanage` after #2421 batch 2 (serialVersionUID). Converted ~72 collection fields from bare `List`/`Map`/`Set`/`Collection` interfaces to concrete serializable types (`ArrayList`/`HashMap`/`HashSet`/`Vector`). Public getter return types and setter parameter types remain interfaces.
+
+## Live main-source inventory (uncapped `-Xmaxwarns`)
+| Metric | Before | After |
+|--------|--------|-------|
+| Total main WARNING lines | 227 | 165 |
+| serial-field | 86 | 14 |
+| this-escape | 55 | 55 |
+| unchecked/raw (+cast) | ~53 | ~63 |
+| other / serialVersionUID | ~33 | ~33 |
+
+## Correctness
+- Setters use **share-if-concrete** assignment: if the argument is already the concrete type, assign the same reference (required for JAXB get/set/add collection population and for tests that mutate a shared `HashMap` after `PSAsset#setFields`). Otherwise copy into a new concrete collection.
+- `@SuppressWarnings("unchecked")` on those setters for the generic cast after `instanceof`.
+- No REST contract / public API signature changes.
+- Product-docs: N/A (compiler lint tech debt).
+
+## Tests
+- Extended `PSSerializableListWrappersTest` with field-type guards and defensive-copy behavior for non-concrete inputs (`LinkedList`).
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 970, Failures: 0, Errors: 0, Skipped: 127.
+
+## Residual (next PR-sized slices)
+- Remaining **serial-field** on non-collection nested types (`Object`, `PSMapWrapper`, `PSPubInfo`, `PSObjectAcl`, widget nested types, JCR `Node`, etc.).
+- **this-escape** (~55) and remaining **unchecked/raw** packages (`pagemanagement.dao.impl`, comments, Siteimprove LinkedHashMap, etc.).
+- Test-source Xlint still separate.
+
+## Bugs found
+None blocking.

--- a/projects/sitemanage/src/main/java/com/percussion/activity/data/PSContentTrafficRequest.java
+++ b/projects/sitemanage/src/main/java/com/percussion/activity/data/PSContentTrafficRequest.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 
+import java.util.ArrayList;
 /** A request object used for getting the content traffic data from the rest service. */
 @JsonRootName(value = "ContentTrafficRequest")
 public class PSContentTrafficRequest extends PSTrafficDetailsRequest implements Serializable {
@@ -30,7 +31,7 @@ public class PSContentTrafficRequest extends PSTrafficDetailsRequest implements 
   private static final long serialVersionUID = 1L;
 
   private String granularity;
-  private List<String> trafficRequested;
+  private ArrayList<String> trafficRequested;
 
   /**
    * Get granularity of date list.
@@ -64,7 +65,14 @@ public class PSContentTrafficRequest extends PSTrafficDetailsRequest implements 
    *
    * @param trafficRequested
    */
+  @SuppressWarnings("unchecked")
   public void setTrafficRequested(List<String> trafficRequested) {
-    this.trafficRequested = trafficRequested;
+    if (trafficRequested == null) {
+      this.trafficRequested = null;
+    } else if (trafficRequested instanceof ArrayList) {
+      this.trafficRequested = (ArrayList<String>) trafficRequested;
+    } else {
+      this.trafficRequested = new ArrayList<>(trafficRequested);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/analytics/data/PSAnalyticsProviderConfig.java
+++ b/projects/sitemanage/src/main/java/com/percussion/analytics/data/PSAnalyticsProviderConfig.java
@@ -35,8 +35,8 @@ public class PSAnalyticsProviderConfig implements Serializable {
   private String password;
   private boolean isEncrypted;
   private String uid;
-  private Map<String, String> params = new HashMap<>();
-  private Map<String, String> extraParamsMap;
+  private HashMap<String, String> params = new HashMap<>();
+  private HashMap<String, String> extraParamsMap;
   private ExtraParamsClass extraParams;
 
   public PSAnalyticsProviderConfig() {
@@ -62,7 +62,13 @@ public class PSAnalyticsProviderConfig implements Serializable {
     this.userid = userid;
     this.password = password;
     this.isEncrypted = isEncrypted;
-    this.extraParamsMap = extraParamsMap;
+    if (extraParamsMap == null) {
+      this.extraParamsMap = null;
+    } else if (extraParamsMap instanceof HashMap) {
+      this.extraParamsMap = (HashMap) extraParamsMap;
+    } else {
+      this.extraParamsMap = new HashMap<>(extraParamsMap);
+    }
     this.uid = userid;
 
     // Build ExtraParamsClass from extraParamsMap
@@ -111,8 +117,15 @@ public class PSAnalyticsProviderConfig implements Serializable {
     return params;
   }
 
+  @SuppressWarnings("unchecked")
   public void setParams(Map<String, String> params) {
-    this.params = params;
+    if (params == null) {
+      this.params = null;
+    } else if (params instanceof HashMap) {
+      this.params = (HashMap<String, String>) params;
+    } else {
+      this.params = new HashMap<>(params);
+    }
   }
 
   public Map<String, String> getExtraParamsMap() {
@@ -127,8 +140,15 @@ public class PSAnalyticsProviderConfig implements Serializable {
     return map;
   }
 
+  @SuppressWarnings("unchecked")
   public void setExtraParamsMap(Map<String, String> extraParamsMap) {
-    this.extraParamsMap = extraParamsMap;
+    if (extraParamsMap == null) {
+      this.extraParamsMap = null;
+    } else if (extraParamsMap instanceof HashMap) {
+      this.extraParamsMap = (HashMap<String, String>) extraParamsMap;
+    } else {
+      this.extraParamsMap = new HashMap<>(extraParamsMap);
+    }
   }
 
   public ExtraParamsClass getExtraParams() {
@@ -142,14 +162,21 @@ public class PSAnalyticsProviderConfig implements Serializable {
   /** Holds extra parameters as a list of key-value pairs. */
   static class ExtraParamsClass implements Serializable {
     private static final long serialVersionUID = 1L;
-    private List<PSGAPairConfig> entry = new ArrayList<>();
+    private ArrayList<PSGAPairConfig> entry = new ArrayList<>();
 
     public List<PSGAPairConfig> getEntry() {
       return entry;
     }
 
+    @SuppressWarnings("unchecked")
     public void setEntry(List<PSGAPairConfig> entry) {
-      this.entry = entry;
+      if (entry == null) {
+        this.entry = null;
+      } else if (entry instanceof ArrayList) {
+        this.entry = (ArrayList<PSGAPairConfig>) entry;
+      } else {
+        this.entry = new ArrayList<>(entry);
+      }
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAsset.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSAsset.java
@@ -29,7 +29,7 @@ public class PSAsset extends PSAssetSummary implements IPSContentItem {
 
   private static final long serialVersionUID = 8252999104256582955L;
 
-  private Map<String, Object> fields = new HashMap<>();
+  private HashMap<String, Object> fields = new HashMap<>();
 
   /**
    * Gets the asset fields.
@@ -45,7 +45,14 @@ public class PSAsset extends PSAssetSummary implements IPSContentItem {
    *
    * @param fields the fields map; must not be {@code null}.
    */
+  @SuppressWarnings("unchecked")
   public void setFields(Map<String, Object> fields) {
-    this.fields = fields;
+    if (fields == null) {
+      this.fields = null;
+    } else if (fields instanceof HashMap) {
+      this.fields = (HashMap<String, Object>) fields;
+    } else {
+      this.fields = new HashMap<>(fields);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSOrphanAssetsSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/data/PSOrphanAssetsSummary.java
@@ -29,7 +29,7 @@ public class PSOrphanAssetsSummary extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;
 
-  private List<PSAssetWidgetRelationship> assetWidgetRelationship = new ArrayList<>();
+  private ArrayList<PSAssetWidgetRelationship> assetWidgetRelationship = new ArrayList<>();
 
   /**
    * @return List of PSAssetWidgetRelationship objects, may be empty but never <code>null</code>.
@@ -41,7 +41,14 @@ public class PSOrphanAssetsSummary extends PSAbstractDataObject {
   /**
    * @param assetWidgetRelationship the list of assetWidgetRelationship to set.
    */
+  @SuppressWarnings("unchecked")
   public void setAssetWidgetRelationship(List<PSAssetWidgetRelationship> assetWidgetRelationship) {
-    this.assetWidgetRelationship = assetWidgetRelationship;
+    if (assetWidgetRelationship == null) {
+      this.assetWidgetRelationship = null;
+    } else if (assetWidgetRelationship instanceof ArrayList) {
+      this.assetWidgetRelationship = (ArrayList<PSAssetWidgetRelationship>) assetWidgetRelationship;
+    } else {
+      this.assetWidgetRelationship = new ArrayList<>(assetWidgetRelationship);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategory.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategory.java
@@ -40,7 +40,7 @@ public class PSCategory extends PSAbstractDataObject implements Cloneable {
 
   @JsonProperty private String allowedSites;
 
-  private List<PSCategoryNode> topLevelNodes = new ArrayList<>();
+  private ArrayList<PSCategoryNode> topLevelNodes = new ArrayList<>();
 
   @XmlElement(name = "Children")
   @JsonProperty("topLevelNodes")
@@ -49,8 +49,15 @@ public class PSCategory extends PSAbstractDataObject implements Cloneable {
     return topLevelNodes;
   }
 
+  @SuppressWarnings("unchecked")
   public void setTopLevelNodes(List<PSCategoryNode> children) {
-    this.topLevelNodes = children;
+    if (children == null) {
+      this.topLevelNodes = null;
+    } else if (children instanceof ArrayList) {
+      this.topLevelNodes = (ArrayList<PSCategoryNode>) children;
+    } else {
+      this.topLevelNodes = new ArrayList<>(children);
+    }
   }
 
   @XmlAttribute(name = "title")

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryNode.java
@@ -80,7 +80,7 @@ public class PSCategoryNode extends PSAbstractDataObject
   @JsonProperty private boolean deleted = false;
 
   @JsonProperty("children")
-  private List<PSCategoryNode> childNodes = new ArrayList<>();
+  private ArrayList<PSCategoryNode> childNodes = new ArrayList<>();
 
   @JsonProperty private boolean selected = false;
 
@@ -97,8 +97,15 @@ public class PSCategoryNode extends PSAbstractDataObject
     return childNodes;
   }
 
+  @SuppressWarnings("unchecked")
   public void setChildNodes(List<PSCategoryNode> children) {
-    this.childNodes = children;
+    if (children == null) {
+      this.childNodes = null;
+    } else if (children instanceof ArrayList) {
+      this.childNodes = (ArrayList<PSCategoryNode>) children;
+    } else {
+      this.childNodes = new ArrayList<>(children);
+    }
   }
 
   @XmlAttribute(name = "id")

--- a/projects/sitemanage/src/main/java/com/percussion/comments/data/PSComment.java
+++ b/projects/sitemanage/src/main/java/com/percussion/comments/data/PSComment.java
@@ -30,6 +30,7 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.Set;
 
+import java.util.HashSet;
 /**
  * Represents a comment in Percussion CMS. Provides all comment metadata and supports XML
  * serialization.
@@ -47,11 +48,11 @@ public class PSComment extends PSAbstractDataObject implements IPSEditableItem {
   private String commentApprovalState;
   private Boolean commentModerated;
   private Boolean commentViewed;
-  private Set<String> commentTags;
+  private HashSet<String> commentTags;
   private Integer commentParentId;
   private String siteName;
   private String pagePath;
-  private Set<String> pageTags;
+  private HashSet<String> pageTags;
   private String userName;
   private String userLinkUrl;
   private String userEmail;
@@ -144,8 +145,15 @@ public class PSComment extends PSAbstractDataObject implements IPSEditableItem {
     return commentTags;
   }
 
+  @SuppressWarnings("unchecked")
   public void setCommentTags(Set<String> commentTags) {
-    this.commentTags = commentTags;
+    if (commentTags == null) {
+      this.commentTags = null;
+    } else if (commentTags instanceof HashSet) {
+      this.commentTags = (HashSet<String>) commentTags;
+    } else {
+      this.commentTags = new HashSet<>(commentTags);
+    }
   }
 
   @XmlElement(name = "site")
@@ -171,8 +179,15 @@ public class PSComment extends PSAbstractDataObject implements IPSEditableItem {
     return pageTags;
   }
 
+  @SuppressWarnings("unchecked")
   public void setPageTags(Set<String> pageTags) {
-    this.pageTags = pageTags;
+    if (pageTags == null) {
+      this.pageTags = null;
+    } else if (pageTags instanceof HashSet) {
+      this.pageTags = (HashSet<String>) pageTags;
+    } else {
+      this.pageTags = new HashSet<>(pageTags);
+    }
   }
 
   @XmlElement(name = "parent")

--- a/projects/sitemanage/src/main/java/com/percussion/contentmigration/service/PSContentMigrationException.java
+++ b/projects/sitemanage/src/main/java/com/percussion/contentmigration/service/PSContentMigrationException.java
@@ -23,7 +23,7 @@ import java.util.Map;
 public class PSContentMigrationException extends Exception {
   private static final long serialVersionUID = 1L;
 
-  private Map<String, String> failedItems = new HashMap<>();
+  private HashMap<String, String> failedItems = new HashMap<>();
 
   public PSContentMigrationException() {
     super();
@@ -39,7 +39,13 @@ public class PSContentMigrationException extends Exception {
 
   public void setFailedItems(Map<String, String> failedItems) {
     if (failedItems != null) {
-      this.failedItems = failedItems;
+      if (failedItems == null) {
+        this.failedItems = null;
+      } else if (failedItems instanceof HashMap) {
+        this.failedItems = (HashMap) failedItems;
+      } else {
+        this.failedItems = new HashMap<>(failedItems);
+      }
     }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSDashboard.java
+++ b/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSDashboard.java
@@ -22,10 +22,11 @@ import java.util.List;
 import net.sf.oval.constraint.NotBlank;
 import net.sf.oval.constraint.NotNull;
 
+import java.util.ArrayList;
 @XmlRootElement(name = "Dashboard")
 public class PSDashboard extends PSAbstractPersistantObject {
 
-  @NotNull @NotBlank private List<PSGadget> gadgets;
+  @NotNull @NotBlank private ArrayList<PSGadget> gadgets;
 
   private PSDashboardConfiguration config;
 
@@ -35,8 +36,15 @@ public class PSDashboard extends PSAbstractPersistantObject {
     return gadgets;
   }
 
+  @SuppressWarnings("unchecked")
   public void setGadgets(List<PSGadget> gadgets) {
-    this.gadgets = gadgets;
+    if (gadgets == null) {
+      this.gadgets = null;
+    } else if (gadgets instanceof ArrayList) {
+      this.gadgets = (ArrayList<PSGadget>) gadgets;
+    } else {
+      this.gadgets = new ArrayList<>(gadgets);
+    }
   }
 
   public PSDashboardConfiguration getDashboardConfiguration() {

--- a/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSDashboardConfiguration.java
+++ b/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSDashboardConfiguration.java
@@ -21,6 +21,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import java.util.List;
 
+import java.util.ArrayList;
 @XmlRootElement(name = "DashboardConfig")
 @XmlType(
     name = "",
@@ -28,13 +29,20 @@ import java.util.List;
 public class PSDashboardConfiguration extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
-  private List<PSGadget> gadgets;
+  private ArrayList<PSGadget> gadgets;
 
   public List<PSGadget> getGadgets() {
     return gadgets;
   }
 
+  @SuppressWarnings("unchecked")
   public void setGadgets(List<PSGadget> gadgets) {
-    this.gadgets = gadgets;
+    if (gadgets == null) {
+      this.gadgets = null;
+    } else if (gadgets instanceof ArrayList) {
+      this.gadgets = (ArrayList<PSGadget>) gadgets;
+    } else {
+      this.gadgets = new ArrayList<>(gadgets);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSGadget.java
+++ b/projects/sitemanage/src/main/java/com/percussion/dashboardmanagement/data/PSGadget.java
@@ -35,7 +35,7 @@ public class PSGadget extends PSAbstractDataObject {
 
   @XmlTransient private boolean expanded = true;
 
-  private Map<String, String> settings = new HashMap<>();
+  private HashMap<String, String> settings = new HashMap<>();
 
   public Integer getInstanceId() {
     return instanceId;
@@ -81,8 +81,15 @@ public class PSGadget extends PSAbstractDataObject {
     return settings;
   }
 
+  @SuppressWarnings("unchecked")
   public void setSettings(Map<String, String> settings) {
-    this.settings = settings;
+    if (settings == null) {
+      this.settings = null;
+    } else if (settings instanceof HashMap) {
+      this.settings = (HashMap<String, String>) settings;
+    } else {
+      this.settings = new HashMap<>(settings);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolders.java
+++ b/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSFolders.java
@@ -31,21 +31,34 @@ public class PSFolders extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
   @XmlElement(name = "child")
-  private List<PSFolderItem> children;
+  private ArrayList<PSFolderItem> children;
 
   public PSFolders() {
     // Default constructor
   }
 
   public PSFolders(List<PSFolderItem> children) {
-    this.children = children;
+    if (children == null) {
+      this.children = null;
+    } else if (children instanceof ArrayList) {
+      this.children = (ArrayList) children;
+    } else {
+      this.children = new ArrayList<>(children);
+    }
   }
 
   public List<PSFolderItem> getChildren() {
     return children == null ? new ArrayList<>() : children;
   }
 
+  @SuppressWarnings("unchecked")
   public void setChildren(List<PSFolderItem> children) {
-    this.children = children;
+    if (children == null) {
+      this.children = null;
+    } else if (children instanceof ArrayList) {
+      this.children = (ArrayList<PSFolderItem>) children;
+    } else {
+      this.children = new ArrayList<>(children);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSGetAssignedFoldersJobStatus.java
+++ b/projects/sitemanage/src/main/java/com/percussion/foldermanagement/data/PSGetAssignedFoldersJobStatus.java
@@ -21,6 +21,7 @@ import com.percussion.share.data.PSAbstractDataObject;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
+import java.util.ArrayList;
 /**
  * Status object for the async job that gets assigned folders. Sunny Sal says: "Job status
  * reporting, now with Java 11 shine!"
@@ -29,7 +30,7 @@ import java.util.List;
 public class PSGetAssignedFoldersJobStatus extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
-  private List<PSFolderItem> folderItems;
+  private ArrayList<PSFolderItem> folderItems;
   private String status;
   private String message;
   private long jobId;
@@ -38,8 +39,15 @@ public class PSGetAssignedFoldersJobStatus extends PSAbstractDataObject {
     return folderItems;
   }
 
+  @SuppressWarnings("unchecked")
   public void setFolderItems(List<PSFolderItem> folderItems) {
-    this.folderItems = folderItems;
+    if (folderItems == null) {
+      this.folderItems = null;
+    } else if (folderItems instanceof ArrayList) {
+      this.folderItems = (ArrayList<PSFolderItem>) folderItems;
+    } else {
+      this.folderItems = new ArrayList<>(folderItems);
+    }
   }
 
   public String getStatus() {

--- a/projects/sitemanage/src/main/java/com/percussion/integritymanagement/data/PSIntegrityStatus.java
+++ b/projects/sitemanage/src/main/java/com/percussion/integritymanagement/data/PSIntegrityStatus.java
@@ -76,7 +76,7 @@ public class PSIntegrityStatus extends PSAbstractDataObject {
   @JoinColumn(name = "TOKEN", nullable = false, insertable = false, updatable = false)
   @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "PSIntegrityTask")
   @Fetch(FetchMode.SUBSELECT)
-  private Set<PSIntegrityTask> tasks = new HashSet<>();
+  private HashSet<PSIntegrityTask> tasks = new HashSet<>();
 
   @Transient private long elapsedTime;
 
@@ -130,7 +130,14 @@ public class PSIntegrityStatus extends PSAbstractDataObject {
     return Collections.unmodifiableSet(tasks);
   }
 
+  @SuppressWarnings("unchecked")
   public void setTasks(Set<PSIntegrityTask> tasks) {
-    this.tasks = tasks == null ? new HashSet<>() : new HashSet<>(tasks);
+    if (tasks == null) {
+      this.tasks = new HashSet<>();
+    } else if (tasks instanceof HashSet) {
+      this.tasks = (HashSet<PSIntegrityTask>) tasks;
+    } else {
+      this.tasks = new HashSet<>(tasks);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/integritymanagement/data/PSIntegrityTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/integritymanagement/data/PSIntegrityTask.java
@@ -75,7 +75,7 @@ public class PSIntegrityTask extends PSAbstractDataObject {
   @JoinColumn(name = "TASKID", nullable = false, insertable = false, updatable = false)
   @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "PSIntegrityTaskProperty")
   @Fetch(FetchMode.SUBSELECT)
-  private Set<PSIntegrityTaskProperty> taskProperties = new HashSet<>();
+  private HashSet<PSIntegrityTaskProperty> taskProperties = new HashSet<>();
 
   public long getTaskId() {
     return taskId;
@@ -129,8 +129,15 @@ public class PSIntegrityTask extends PSAbstractDataObject {
     return taskProperties;
   }
 
+  @SuppressWarnings("unchecked")
   public void setTaskProperties(Set<PSIntegrityTaskProperty> taskProperties) {
-    this.taskProperties = taskProperties == null ? new HashSet<>() : new HashSet<>(taskProperties);
+    if (taskProperties == null) {
+      this.taskProperties = new HashSet<>();
+    } else if (taskProperties instanceof HashSet) {
+      this.taskProperties = (HashSet<PSIntegrityTaskProperty>) taskProperties;
+    } else {
+      this.taskProperties = new HashSet<>(taskProperties);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSApprovableItems.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSApprovableItems.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.ArrayList;
 /** Wrapper class to hold the list of {@link PSApprovableItem}s and their processing status. */
 @XmlRootElement(name = "ApprovableItems")
 public class PSApprovableItems extends PSAbstractDataObject {
@@ -29,13 +30,13 @@ public class PSApprovableItems extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
   /** List of approvable items associated to the gadget. */
-  private List<PSApprovableItem> approvableItems;
+  private ArrayList<PSApprovableItem> approvableItems;
 
   /** List of items that have been processed. */
-  private List<PSApprovableItem> processedItems;
+  private ArrayList<PSApprovableItem> processedItems;
 
   /** Map of errors encountered during processing. */
-  private Map<String, String> errors = new HashMap<>();
+  private HashMap<String, String> errors = new HashMap<>();
 
   public PSApprovableItems() {
     // Default constructor for JAX-RS
@@ -45,23 +46,44 @@ public class PSApprovableItems extends PSAbstractDataObject {
     return approvableItems;
   }
 
+  @SuppressWarnings("unchecked")
   public void setApprovableItems(List<PSApprovableItem> approvableItems) {
-    this.approvableItems = approvableItems;
+    if (approvableItems == null) {
+      this.approvableItems = null;
+    } else if (approvableItems instanceof ArrayList) {
+      this.approvableItems = (ArrayList<PSApprovableItem>) approvableItems;
+    } else {
+      this.approvableItems = new ArrayList<>(approvableItems);
+    }
   }
 
   public Map<String, String> getErrors() {
     return errors;
   }
 
+  @SuppressWarnings("unchecked")
   public void setErrors(Map<String, String> errors) {
-    this.errors = errors;
+    if (errors == null) {
+      this.errors = null;
+    } else if (errors instanceof HashMap) {
+      this.errors = (HashMap<String, String>) errors;
+    } else {
+      this.errors = new HashMap<>(errors);
+    }
   }
 
   public List<PSApprovableItem> getProcessedItems() {
     return processedItems;
   }
 
+  @SuppressWarnings("unchecked")
   public void setProcessedItems(List<PSApprovableItem> processedItems) {
-    this.processedItems = processedItems;
+    if (processedItems == null) {
+      this.processedItems = null;
+    } else if (processedItems instanceof ArrayList) {
+      this.processedItems = (ArrayList<PSApprovableItem>) processedItems;
+    } else {
+      this.processedItems = new ArrayList<>(processedItems);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemStateTransition.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemStateTransition.java
@@ -33,7 +33,7 @@ public class PSItemStateTransition extends PSAbstractDataObject {
   private String stateId;
   private String stateName;
   private String workflowId;
-  private List<String> transitionTriggers = new ArrayList<>();
+  private ArrayList<String> transitionTriggers = new ArrayList<>();
 
   public String getItemId() {
     return itemId;
@@ -73,7 +73,7 @@ public class PSItemStateTransition extends PSAbstractDataObject {
 
   public void setTransitionTriggers(List<String> triggers) {
     if (triggers != null) {
-      transitionTriggers = triggers;
+      transitionTriggers = new ArrayList<>(triggers);
     } else {
       transitionTriggers.clear();
     }

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemTransitionResults.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/data/PSItemTransitionResults.java
@@ -31,7 +31,7 @@ public class PSItemTransitionResults extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
   private String itemId;
-  private List<PSDataItemSummary> failedAssets = new ArrayList<>();
+  private ArrayList<PSDataItemSummary> failedAssets = new ArrayList<>();
 
   public String getItemId() {
     return itemId;
@@ -47,7 +47,7 @@ public class PSItemTransitionResults extends PSAbstractDataObject {
 
   public void setFailedAssets(List<PSDataItemSummary> assets) {
     if (assets != null) {
-      failedAssets = assets;
+      failedAssets = new ArrayList<>(assets);
     } else {
       failedAssets.clear();
     }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/impl/PSProxyAssemblyTemplate.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/impl/PSProxyAssemblyTemplate.java
@@ -41,7 +41,7 @@ public class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
 
   private PSAssemblyTemplate assemblyTemplate;
   private String template;
-  private List<PSTemplateBinding> bindings = new Vector<>();
+  private Vector<PSTemplateBinding> bindings = new Vector<>();
   private String assembler;
   private String name;
 
@@ -79,8 +79,15 @@ public class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
     return bindings;
   }
 
+  @SuppressWarnings("unchecked")
   public void setBindings(List<PSTemplateBinding> bindings) {
-    this.bindings = bindings;
+    if (bindings == null) {
+      this.bindings = null;
+    } else if (bindings instanceof Vector) {
+      this.bindings = (Vector<PSTemplateBinding>) bindings;
+    } else {
+      this.bindings = new Vector<>(bindings);
+    }
   }
 
   public void addBinding(PSTemplateBinding binding) {

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSAbstractRegion.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSAbstractRegion.java
@@ -50,8 +50,8 @@ public abstract class PSAbstractRegion extends PSRegionNode {
   /** CSS class for the region. May be {@code null}. */
   private String cssClass;
 
-  private List<PSRegionNode> children = new ArrayList<>();
-  private List<PSRegionAttribute> attributes = new ArrayList<>();
+  private ArrayList<PSRegionNode> children = new ArrayList<>();
+  private ArrayList<PSRegionAttribute> attributes = new ArrayList<>();
 
   /**
    * Gets the children of this region, which are either {@link PSRegionCode} or {@link PSRegion}.
@@ -67,8 +67,15 @@ public abstract class PSAbstractRegion extends PSRegionNode {
     return children;
   }
 
+  @SuppressWarnings("unchecked")
   public void setChildren(List<PSRegionNode> children) {
-    this.children = children;
+    if (children == null) {
+      this.children = null;
+    } else if (children instanceof ArrayList) {
+      this.children = (ArrayList<PSRegionNode>) children;
+    } else {
+      this.children = new ArrayList<>(children);
+    }
   }
 
   @NotNull
@@ -133,8 +140,15 @@ public abstract class PSAbstractRegion extends PSRegionNode {
     return attributes;
   }
 
+  @SuppressWarnings("unchecked")
   public void setAttributes(List<PSRegionAttribute> attributes) {
-    this.attributes = attributes;
+    if (attributes == null) {
+      this.attributes = null;
+    } else if (attributes instanceof ArrayList) {
+      this.attributes = (ArrayList<PSRegionAttribute>) attributes;
+    } else {
+      this.attributes = new ArrayList<>(attributes);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSMetadataDocType.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSMetadataDocType.java
@@ -36,7 +36,7 @@ public class PSMetadataDocType extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
   private String selected = "";
-  private List<PSMetadataDocTypeOptions> options = new ArrayList<>();
+  private ArrayList<PSMetadataDocTypeOptions> options = new ArrayList<>();
 
   /** Default constructor, sets default doc type to HTML5. */
   public PSMetadataDocType() {
@@ -75,8 +75,15 @@ public class PSMetadataDocType extends PSAbstractDataObject {
    *
    * @param options the doc type options
    */
+  @SuppressWarnings("unchecked")
   public void setOptions(List<PSMetadataDocTypeOptions> options) {
-    this.options = options;
+    if (options == null) {
+      this.options = null;
+    } else if (options instanceof ArrayList) {
+      this.options = (ArrayList<PSMetadataDocTypeOptions>) options;
+    } else {
+      this.options = new ArrayList<>(options);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSPageSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSPageSummary.java
@@ -21,6 +21,7 @@ import java.util.List;
 import net.sf.oval.constraint.NotBlank;
 import net.sf.oval.constraint.NotNull;
 
+import java.util.ArrayList;
 /**
  * The base class for all page-related classes. Contains summary information for a page.
  *
@@ -39,7 +40,7 @@ public class PSPageSummary extends PSDataItemSummarySingleFolderPath {
 
   private String noindex;
   private String author;
-  private List<String> tags;
+  private ArrayList<String> tags;
   private String templateContentMigrationVersion = "0";
   private boolean migrationEmptyWidgetFlag = false;
   private String description;
@@ -166,8 +167,15 @@ public class PSPageSummary extends PSDataItemSummarySingleFolderPath {
    *
    * @param tags the page tags to set
    */
+  @SuppressWarnings("unchecked")
   public void setTags(List<String> tags) {
-    this.tags = tags;
+    if (tags == null) {
+      this.tags = null;
+    } else if (tags instanceof ArrayList) {
+      this.tags = (ArrayList<String>) tags;
+    } else {
+      this.tags = new ArrayList<>(tags);
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRegionBranches.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRegionBranches.java
@@ -35,7 +35,7 @@ import org.apache.commons.beanutils.BeanUtils;
 public class PSRegionBranches extends PSRegionWidgetAssociations {
   private static final long serialVersionUID = 1L;
 
-  @AssertValid private List<PSRegion> regions = new ArrayList<>();
+  @AssertValid private ArrayList<PSRegion> regions = new ArrayList<>();
 
   @AssertValid
   @XmlElementWrapper(name = "regions")
@@ -44,8 +44,15 @@ public class PSRegionBranches extends PSRegionWidgetAssociations {
     return regions;
   }
 
+  @SuppressWarnings("unchecked")
   public void setRegions(List<PSRegion> pageRegions) {
-    this.regions = pageRegions;
+    if (pageRegions == null) {
+      this.regions = null;
+    } else if (pageRegions instanceof ArrayList) {
+      this.regions = (ArrayList<PSRegion>) pageRegions;
+    } else {
+      this.regions = new ArrayList<>(pageRegions);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRegionWidgetAssociations.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRegionWidgetAssociations.java
@@ -36,7 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 public abstract class PSRegionWidgetAssociations implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  @AssertValid private Set<PSRegionWidgets> regionWidgetAssociations = new HashSet<>();
+  @AssertValid private HashSet<PSRegionWidgets> regionWidgetAssociations = new HashSet<>();
 
   protected PSRegionWidgetAssociations() {
     super();

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRegionWidgets.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSRegionWidgets.java
@@ -43,7 +43,7 @@ public class PSRegionWidgets extends PSAbstractPersistantObject {
 
   @NotNull @NotBlank private String regionId;
 
-  @AssertValid private List<PSWidgetItem> widgetItems = new ArrayList<>();
+  @AssertValid private ArrayList<PSWidgetItem> widgetItems = new ArrayList<>();
 
   /**
    * The id of the region.
@@ -72,8 +72,15 @@ public class PSRegionWidgets extends PSAbstractPersistantObject {
     return widgetItems;
   }
 
+  @SuppressWarnings("unchecked")
   public void setWidgetItems(List<PSWidgetItem> widgetItems) {
-    this.widgetItems = widgetItems;
+    if (widgetItems == null) {
+      this.widgetItems = null;
+    } else if (widgetItems instanceof ArrayList) {
+      this.widgetItems = (ArrayList<PSWidgetItem>) widgetItems;
+    } else {
+      this.widgetItems = new ArrayList<>(widgetItems);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSResourceDefinitionGroup.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSResourceDefinitionGroup.java
@@ -35,17 +35,24 @@ import java.util.List;
 public class PSResourceDefinitionGroup extends PSAbstractPersistantObject {
 
   private String id;
-  private List<PSFileResource> fileResources;
-  private List<PSFolderResource> folderResources;
-  private List<PSAssetResource> assetResources;
+  private ArrayList<PSFileResource> fileResources;
+  private ArrayList<PSFolderResource> folderResources;
+  private ArrayList<PSAssetResource> assetResources;
 
   @XmlElement(name = "folder")
   public List<PSFolderResource> getFolderResources() {
     return folderResources;
   }
 
+  @SuppressWarnings("unchecked")
   public void setFolderResources(List<PSFolderResource> folderResources) {
-    this.folderResources = folderResources;
+    if (folderResources == null) {
+      this.folderResources = null;
+    } else if (folderResources instanceof ArrayList) {
+      this.folderResources = (ArrayList<PSFolderResource>) folderResources;
+    } else {
+      this.folderResources = new ArrayList<>(folderResources);
+    }
   }
 
   @XmlElement(name = "asset")
@@ -53,8 +60,15 @@ public class PSResourceDefinitionGroup extends PSAbstractPersistantObject {
     return assetResources;
   }
 
+  @SuppressWarnings("unchecked")
   public void setAssetResources(List<PSAssetResource> assetResources) {
-    this.assetResources = assetResources;
+    if (assetResources == null) {
+      this.assetResources = null;
+    } else if (assetResources instanceof ArrayList) {
+      this.assetResources = (ArrayList<PSAssetResource>) assetResources;
+    } else {
+      this.assetResources = new ArrayList<>(assetResources);
+    }
   }
 
   @XmlElement(name = "file")
@@ -62,8 +76,15 @@ public class PSResourceDefinitionGroup extends PSAbstractPersistantObject {
     return fileResources;
   }
 
+  @SuppressWarnings("unchecked")
   public void setFileResources(List<PSFileResource> fileResources) {
-    this.fileResources = fileResources;
+    if (fileResources == null) {
+      this.fileResources = null;
+    } else if (fileResources instanceof ArrayList) {
+      this.fileResources = (ArrayList<PSFileResource>) fileResources;
+    } else {
+      this.fileResources = new ArrayList<>(fileResources);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetDefinition.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetDefinition.java
@@ -71,16 +71,16 @@ public class PSWidgetDefinition extends PSAbstractPersistantObject {
   protected WidgetPrefs widgetPrefs;
 
   @XmlElement(name = "Resource")
-  protected List<Resource> resource;
+  protected ArrayList<Resource> resource;
 
   @XmlElement(name = "DnDPref")
-  protected List<DnDPref> dnDPref;
+  protected ArrayList<DnDPref> dnDPref;
 
   @XmlElement(name = "UserPref")
-  protected List<UserPref> userPref;
+  protected ArrayList<UserPref> userPref;
 
   @XmlElement(name = "CssPref")
-  protected List<CssPref> cssPref;
+  protected ArrayList<CssPref> cssPref;
 
   @XmlElement(name = "Content", required = true)
   protected Content content;

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSWidgetItem.java
@@ -49,8 +49,8 @@ public class PSWidgetItem extends PSAbstractPersistantObject {
 
   @NotNull @NotBlank private String definitionId;
 
-  private Map<String, Object> properties = new HashMap<>();
-  private Map<String, Object> cssProperties = new HashMap<>();
+  private HashMap<String, Object> properties = new HashMap<>();
+  private HashMap<String, Object> cssProperties = new HashMap<>();
 
   @Override
   @NotBlank
@@ -93,8 +93,15 @@ public class PSWidgetItem extends PSAbstractPersistantObject {
     return Collections.unmodifiableMap(properties);
   }
 
+  @SuppressWarnings("unchecked")
   public void setProperties(Map<String, Object> properties) {
-    this.properties = (properties == null) ? new HashMap<>() : new HashMap<>(properties);
+    if (properties == null) {
+      this.properties = new HashMap<>();
+    } else if (properties instanceof HashMap) {
+      this.properties = (HashMap<String, Object>) properties;
+    } else {
+      this.properties = new HashMap<>(properties);
+    }
   }
 
   /**
@@ -107,8 +114,15 @@ public class PSWidgetItem extends PSAbstractPersistantObject {
     return Collections.unmodifiableMap(cssProperties);
   }
 
+  @SuppressWarnings("unchecked")
   public void setCssProperties(Map<String, Object> css) {
-    this.cssProperties = (css == null) ? new HashMap<>() : new HashMap<>(css);
+    if (css == null) {
+      this.cssProperties = new HashMap<>();
+    } else if (css instanceof HashMap) {
+      this.cssProperties = (HashMap<String, Object>) css;
+    } else {
+      this.cssProperties = new HashMap<>(css);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSFolderPermission.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSFolderPermission.java
@@ -21,6 +21,7 @@ import com.percussion.share.data.PSAbstractDataObject;
 import java.util.List;
 import java.util.Objects;
 
+import java.util.ArrayList;
 /**
  * Represents the permissions of a folder.
  *
@@ -85,10 +86,10 @@ public class PSFolderPermission extends PSAbstractDataObject {
   }
 
   private Access accessLevel = Access.ADMIN;
-  private List<Principal> adminPrincipals;
-  private List<Principal> writePrincipals;
-  private List<Principal> readPrincipals;
-  private List<Principal> viewPrincipals;
+  private ArrayList<Principal> adminPrincipals;
+  private ArrayList<Principal> writePrincipals;
+  private ArrayList<Principal> readPrincipals;
+  private ArrayList<Principal> viewPrincipals;
 
   /**
    * Gets the access level applied to unspecified principals. Defaults to {@link Access#ADMIN} if
@@ -123,8 +124,15 @@ public class PSFolderPermission extends PSAbstractDataObject {
    *
    * @param principals the new list, may be null or empty
    */
+  @SuppressWarnings("unchecked")
   public void setAdminPrincipals(List<Principal> principals) {
-    this.adminPrincipals = principals;
+    if (principals == null) {
+      this.adminPrincipals = null;
+    } else if (principals instanceof ArrayList) {
+      this.adminPrincipals = (ArrayList<Principal>) principals;
+    } else {
+      this.adminPrincipals = new ArrayList<>(principals);
+    }
   }
 
   /**
@@ -141,8 +149,15 @@ public class PSFolderPermission extends PSAbstractDataObject {
    *
    * @param principals the new list, may be null or empty
    */
+  @SuppressWarnings("unchecked")
   public void setWritePrincipals(List<Principal> principals) {
-    this.writePrincipals = principals;
+    if (principals == null) {
+      this.writePrincipals = null;
+    } else if (principals instanceof ArrayList) {
+      this.writePrincipals = (ArrayList<Principal>) principals;
+    } else {
+      this.writePrincipals = new ArrayList<>(principals);
+    }
   }
 
   /**
@@ -159,8 +174,15 @@ public class PSFolderPermission extends PSAbstractDataObject {
    *
    * @param principals the new list, may be null or empty
    */
+  @SuppressWarnings("unchecked")
   public void setReadPrincipals(List<Principal> principals) {
-    this.readPrincipals = principals;
+    if (principals == null) {
+      this.readPrincipals = null;
+    } else if (principals instanceof ArrayList) {
+      this.readPrincipals = (ArrayList<Principal>) principals;
+    } else {
+      this.readPrincipals = new ArrayList<>(principals);
+    }
   }
 
   /**
@@ -177,8 +199,15 @@ public class PSFolderPermission extends PSAbstractDataObject {
    *
    * @param viewPrincipals the new list, may be null or empty
    */
+  @SuppressWarnings("unchecked")
   public void setViewPrincipals(List<Principal> viewPrincipals) {
-    this.viewPrincipals = viewPrincipals;
+    if (viewPrincipals == null) {
+      this.viewPrincipals = null;
+    } else if (viewPrincipals instanceof ArrayList) {
+      this.viewPrincipals = (ArrayList<Principal>) viewPrincipals;
+    } else {
+      this.viewPrincipals = new ArrayList<>(viewPrincipals);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/data/PSPathItem.java
@@ -52,7 +52,7 @@ public class PSPathItem extends PSDataItemSummary implements IPSItemSummary, IPS
 
   @XmlElement(name = "columnData")
   @XmlJavaTypeAdapter(PSMapAdapter.class)
-  protected Map<String, String> displayProperties = new HashMap<>();
+  protected HashMap<String, String> displayProperties = new HashMap<>();
 
   /** Used to return properties that are specific to the type of item the path item represents. */
   private PSMapWrapper typeProperties = new PSMapWrapper();
@@ -192,8 +192,15 @@ public class PSPathItem extends PSDataItemSummary implements IPSItemSummary, IPS
     return displayProperties;
   }
 
+  @SuppressWarnings("unchecked")
   public void setDisplayProperties(Map<String, String> value) {
-    this.displayProperties = value;
+    if (value == null) {
+      this.displayProperties = null;
+    } else if (value instanceof HashMap) {
+      this.displayProperties = (HashMap<String, String>) value;
+    } else {
+      this.displayProperties = new HashMap<>(value);
+    }
   }
 
   private static final long serialVersionUID = -1L;

--- a/projects/sitemanage/src/main/java/com/percussion/role/data/PSRole.java
+++ b/projects/sitemanage/src/main/java/com/percussion/role/data/PSRole.java
@@ -48,7 +48,7 @@ public class PSRole extends PSAbstractNamedObject {
   private String description;
   private String homepage;
 
-  @NotNull private List<String> users = new ArrayList<>();
+  @NotNull private ArrayList<String> users = new ArrayList<>();
 
   @Override
   @IsInvariant
@@ -86,8 +86,15 @@ public class PSRole extends PSAbstractNamedObject {
     return users == null ? List.of() : Collections.unmodifiableList(users);
   }
 
+  @SuppressWarnings("unchecked")
   public void setUsers(List<String> users) {
-    this.users = users == null ? new ArrayList<>() : new ArrayList<>(users);
+    if (users == null) {
+      this.users = new ArrayList<>();
+    } else if (users instanceof ArrayList) {
+      this.users = (ArrayList<String>) users;
+    } else {
+      this.users = new ArrayList<>(users);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItem.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class PSContentItem extends PSDataItemSummary implements IPSContentItem {
 
   /** Never null. */
-  private Map<String, Object> fields = new HashMap<>();
+  private HashMap<String, Object> fields = new HashMap<>();
 
   /** {@inheritDoc} */
   @Override
@@ -41,7 +41,13 @@ public class PSContentItem extends PSDataItemSummary implements IPSContentItem {
   @Override
   public void setFields(Map<String, Object> fields) {
     notNull(fields, "fields");
-    this.fields = fields;
+    if (fields == null) {
+      this.fields = null;
+    } else if (fields instanceof HashMap) {
+      this.fields = (HashMap) fields;
+    } else {
+      this.fields = new HashMap<>(fields);
+    }
   }
 
   /** Not safe to serialize. */

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItem.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItem.java
@@ -39,12 +39,11 @@ public class PSContentItem extends PSDataItemSummary implements IPSContentItem {
 
   /** {@inheritDoc} */
   @Override
+  @SuppressWarnings("unchecked")
   public void setFields(Map<String, Object> fields) {
     notNull(fields, "fields");
-    if (fields == null) {
-      this.fields = null;
-    } else if (fields instanceof HashMap) {
-      this.fields = (HashMap) fields;
+    if (fields instanceof HashMap) {
+      this.fields = (HashMap<String, Object>) fields;
     } else {
       this.fields = new HashMap<>(fields);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSDataItemSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSDataItemSummary.java
@@ -34,6 +34,7 @@ import net.sf.oval.constraint.NotBlank;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 
+import java.util.ArrayList;
 /**
  * Data summary for items in Percussion CMS. Sunny Sal says: "Summaries so sharp, even your boss
  * will be impressed!"
@@ -55,7 +56,7 @@ public class PSDataItemSummary extends PSAbstractPersistantObject implements IPS
 
   private String id;
   private String name;
-  private List<String> folderPaths;
+  private ArrayList<String> folderPaths;
   private String icon;
   private Category category;
   private boolean revisionable = false;
@@ -71,7 +72,7 @@ public class PSDataItemSummary extends PSAbstractPersistantObject implements IPS
    * All tags associated with the item. Historically this was called "folderPaths" and we keep the
    * same backing field for compatibility.
    */
-  private List<String> tags;
+  private ArrayList<String> tags;
 
   @Override
   public String getId() {
@@ -95,8 +96,15 @@ public class PSDataItemSummary extends PSAbstractPersistantObject implements IPS
     return folderPaths;
   }
 
+  @SuppressWarnings("unchecked")
   public void setFolderPaths(List<String> paths) {
-    this.folderPaths = paths;
+    if (paths == null) {
+      this.folderPaths = null;
+    } else if (paths instanceof ArrayList) {
+      this.folderPaths = (ArrayList<String>) paths;
+    } else {
+      this.folderPaths = new ArrayList<>(paths);
+    }
   }
 
   public String getIcon() {
@@ -195,7 +203,14 @@ public class PSDataItemSummary extends PSAbstractPersistantObject implements IPS
   }
 
   /** Helper used by JAXB &amp; legacy code that previously relied on folderPaths. */
+  @SuppressWarnings("unchecked")
   public void setTags(List<String> tags) {
-    this.tags = tags;
+    if (tags == null) {
+      this.tags = null;
+    } else if (tags instanceof ArrayList) {
+      this.tags = (ArrayList<String>) tags;
+    } else {
+      this.tags = new ArrayList<>(tags);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSEnumVals.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSEnumVals.java
@@ -37,7 +37,7 @@ public class PSEnumVals implements Serializable {
 
   private static final long serialVersionUID = 1496690238764003673L;
 
-  @NotNull private List<EnumVal> entries = new ArrayList<>();
+  @NotNull private ArrayList<EnumVal> entries = new ArrayList<>();
 
   /**
    * @return list of entry objects, never null, may be empty.
@@ -46,8 +46,15 @@ public class PSEnumVals implements Serializable {
     return entries;
   }
 
+  @SuppressWarnings("unchecked")
   public void setEntries(List<EnumVal> entries) {
-    this.entries = entries;
+    if (entries == null) {
+      this.entries = null;
+    } else if (entries instanceof ArrayList) {
+      this.entries = (ArrayList<EnumVal>) entries;
+    } else {
+      this.entries = new ArrayList<>(entries);
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSItemProperties.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSItemProperties.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import java.util.Collection;
 import net.sf.oval.constraint.NotEmpty;
 
+import java.util.ArrayList;
 /**
  * This class contains a set of known properties of an item. Sunny Sal says: "Properties—because
  * every item deserves a good story!"
@@ -41,7 +42,7 @@ public class PSItemProperties extends PSAbstractPersistantObject {
   @NotEmpty private String path;
   @NotEmpty private String summary;
   private String author;
-  private Collection<String> tags;
+  private ArrayList<String> tags;
   private int commentsCount;
   private int newCommentsCount;
   private String size;
@@ -145,8 +146,15 @@ public class PSItemProperties extends PSAbstractPersistantObject {
     return tags;
   }
 
+  @SuppressWarnings("unchecked")
   public void setTags(Collection<String> tags) {
-    this.tags = tags;
+    if (tags == null) {
+      this.tags = null;
+    } else if (tags instanceof ArrayList) {
+      this.tags = (ArrayList<String>) tags;
+    } else {
+      this.tags = new ArrayList<>(tags);
+    }
   }
 
   public int getCommentsCount() {

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSUnassignedResults.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSUnassignedResults.java
@@ -64,7 +64,7 @@ public class PSUnassignedResults extends PSAbstractDataObject {
     private static final long serialVersionUID = 1L;
     private Integer startIndex;
     private Integer childrenCount;
-    private List<UnassignedItem> childrenInPage;
+    private ArrayList<UnassignedItem> childrenInPage;
 
     public UnassignedItemList() {
       this.startIndex = 0;
@@ -76,7 +76,13 @@ public class PSUnassignedResults extends PSAbstractDataObject {
         Integer startIndex, Integer childrenCount, List<UnassignedItem> childrenInPage) {
       this.startIndex = startIndex;
       this.childrenCount = childrenCount;
-      this.childrenInPage = childrenInPage == null ? new ArrayList<>() : childrenInPage;
+      if (childrenInPage == null) {
+        this.childrenInPage = new ArrayList<>();
+      } else if (childrenInPage instanceof ArrayList) {
+        this.childrenInPage = (ArrayList) childrenInPage;
+      } else {
+        this.childrenInPage = new ArrayList<>(childrenInPage);
+      }
     }
 
     /**
@@ -111,8 +117,15 @@ public class PSUnassignedResults extends PSAbstractDataObject {
      * @see #getChildrenInPage()
      * @param childrenInPage {@code List<UnassignedItem>} assumed not null.
      */
+    @SuppressWarnings("unchecked")
     public void setChildrenInPage(List<UnassignedItem> childrenInPage) {
-      this.childrenInPage = childrenInPage;
+      if (childrenInPage == null) {
+        this.childrenInPage = null;
+      } else if (childrenInPage instanceof ArrayList) {
+        this.childrenInPage = (ArrayList<UnassignedItem>) childrenInPage;
+      } else {
+        this.childrenInPage = new ArrayList<>(childrenInPage);
+      }
     }
 
     /**

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
@@ -105,8 +105,15 @@ public class PSSectionNode extends PSAbstractPersistantObject {
    *
    * @param nodes the new list of child nodes, null treated as empty list.
    */
+  @SuppressWarnings("unchecked")
   public void setChildNodes(List<PSSectionNode> nodes) {
-    this.childNodes = nodes == null ? new ArrayList<>() : nodes == null ? null : new ArrayList<>(nodes == null ? new ArrayList<>() : nodes);
+    if (nodes == null) {
+      this.childNodes = new ArrayList<>();
+    } else if (nodes instanceof ArrayList) {
+      this.childNodes = (ArrayList<PSSectionNode>) nodes;
+    } else {
+      this.childNodes = new ArrayList<>(nodes);
+    }
   }
 
   public boolean isRequiresLogin() {

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSectionNode.java
@@ -38,7 +38,7 @@ public class PSSectionNode extends PSAbstractPersistantObject {
 
   private static final long serialVersionUID = 1L;
 
-  private List<PSSectionNode> childNodes = new ArrayList<>();
+  private ArrayList<PSSectionNode> childNodes = new ArrayList<>();
   private String title;
   private String folderPath;
   private String id;
@@ -106,7 +106,7 @@ public class PSSectionNode extends PSAbstractPersistantObject {
    * @param nodes the new list of child nodes, null treated as empty list.
    */
   public void setChildNodes(List<PSSectionNode> nodes) {
-    this.childNodes = nodes == null ? new ArrayList<>() : nodes;
+    this.childNodes = nodes == null ? new ArrayList<>() : nodes == null ? null : new ArrayList<>(nodes == null ? new ArrayList<>() : nodes);
   }
 
   public boolean isRequiresLogin() {

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteArchitecture.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteArchitecture.java
@@ -22,13 +22,14 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Optional;
 
+import java.util.ArrayList;
 @XmlRootElement(name = "SiteArchitecture")
 public class PSSiteArchitecture extends PSAbstractPersistantObject {
 
   private static final long serialVersionUID = 8249374630117416709L;
 
   private String name;
-  private List<PSSiteSection> sections;
+  private ArrayList<PSSiteSection> sections;
 
   @Override
   public String getId() {
@@ -67,7 +68,14 @@ public class PSSiteArchitecture extends PSAbstractPersistantObject {
   /**
    * @param sections sub sections of site, may be null or empty.
    */
+  @SuppressWarnings("unchecked")
   public void setSections(List<PSSiteSection> sections) {
-    this.sections = sections;
+    if (sections == null) {
+      this.sections = null;
+    } else if (sections instanceof ArrayList) {
+      this.sections = (ArrayList<PSSiteSection>) sections;
+    } else {
+      this.sections = new ArrayList<>(sections);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteBlogPosts.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteBlogPosts.java
@@ -25,6 +25,7 @@ import java.util.List;
 // Optional import removed
 import net.sf.oval.constraint.NotEmpty;
 
+import java.util.ArrayList;
 /** This class contains post information for a blog. */
 @XmlRootElement(name = "SiteBlogPosts")
 @JsonRootName("SiteBlogPosts")
@@ -36,7 +37,7 @@ public class PSSiteBlogPosts extends PSAbstractDataObject {
 
   @NotEmpty private String blogSectionPath;
 
-  private List<PSItemProperties> posts;
+  private ArrayList<PSItemProperties> posts;
 
   @NotEmpty private String blogPostTemplateId;
 
@@ -78,8 +79,15 @@ public class PSSiteBlogPosts extends PSAbstractDataObject {
   /**
    * @param posts the blog posts to set
    */
+  @SuppressWarnings("unchecked")
   public void setPosts(List<PSItemProperties> posts) {
-    this.posts = posts;
+    if (posts == null) {
+      this.posts = null;
+    } else if (posts instanceof ArrayList) {
+      this.posts = (ArrayList<PSItemProperties>) posts;
+    } else {
+      this.posts = new ArrayList<>(posts);
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSitePublishPurgeRequest.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSitePublishPurgeRequest.java
@@ -21,6 +21,7 @@ import com.percussion.share.data.PSAbstractDataObject;
 import java.util.List;
 import java.util.Optional;
 
+import java.util.ArrayList;
 /**
  * Request to purge site publish jobs.
  *
@@ -30,13 +31,20 @@ import java.util.Optional;
 public class PSSitePublishPurgeRequest extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
-  private List<Long> jobids;
+  private ArrayList<Long> jobids;
 
   public Optional<List<Long>> getJobids() {
     return Optional.ofNullable(jobids);
   }
 
+  @SuppressWarnings("unchecked")
   public void setJobids(List<Long> jobids) {
-    this.jobids = jobids;
+    if (jobids == null) {
+      this.jobids = null;
+    } else if (jobids instanceof ArrayList) {
+      this.jobids = (ArrayList<Long>) jobids;
+    } else {
+      this.jobids = new ArrayList<>(jobids);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteSection.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteSection.java
@@ -55,7 +55,7 @@ public class PSSiteSection extends PSAbstractPersistantObject implements IPSFold
   @NotNull private PSSectionTargetEnum target = PSSectionTargetEnum._self;
 
   /** The IDs of sub-sections. */
-  private List<String> childIds = new ArrayList<>();
+  private ArrayList<String> childIds = new ArrayList<>();
 
   /** Field to note if the section requires login. */
   private boolean requiresLogin;
@@ -101,8 +101,15 @@ public class PSSiteSection extends PSAbstractPersistantObject implements IPSFold
    *
    * @param ids the IDs of sub-sections, may be null or empty.
    */
+  @SuppressWarnings("unchecked")
   public void setChildIds(List<String> ids) {
-    this.childIds = (ids == null) ? Collections.emptyList() : new ArrayList<>(ids);
+    if (ids == null) {
+      this.childIds = new ArrayList<>();
+    } else if (ids instanceof ArrayList) {
+      this.childIds = (ArrayList<String>) ids;
+    } else {
+      this.childIds = new ArrayList<>(ids);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteStatisticsSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/data/PSSiteStatisticsSummary.java
@@ -35,7 +35,7 @@ public class PSSiteStatisticsSummary extends PSAbstractDataObject {
 
   private PSSiteStatistics statistics;
 
-  private List<PSSiteIssueSummary> issues = new ArrayList<>();
+  private ArrayList<PSSiteIssueSummary> issues = new ArrayList<>();
 
   private String abridgedErrorMessage;
 
@@ -67,8 +67,15 @@ public class PSSiteStatisticsSummary extends PSAbstractDataObject {
     return issues;
   }
 
+  @SuppressWarnings("unchecked")
   public void setIssues(List<PSSiteIssueSummary> issues) {
-    this.issues = issues == null ? new ArrayList<>() : issues;
+    if (issues == null) {
+      this.issues = new ArrayList<>();
+    } else if (issues instanceof ArrayList) {
+      this.issues = (ArrayList<PSSiteIssueSummary>) issues;
+    } else {
+      this.issues = new ArrayList<>(issues);
+    }
   }
 
   public void setAbridgedErrorMessage(String message) {

--- a/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCSS.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCSS.java
@@ -43,7 +43,7 @@ public class PSRegionCSS extends PSAbstractDataObject
 
   @NotBlank @NotNull private String outerRegionName;
 
-  private List<Property> properties = new ArrayList<>();
+  private ArrayList<Property> properties = new ArrayList<>();
 
   /** Represents a CSS property for a region. */
   public static class Property extends PSAbstractDataObject implements Serializable {
@@ -146,7 +146,13 @@ public class PSRegionCSS extends PSAbstractDataObject
 
   public void setProperties(List<Property> props) {
     notNull(props);
-    properties = props;
+    if (props == null) {
+      properties = null;
+    } else if (props instanceof ArrayList) {
+      properties = (ArrayList) props;
+    } else {
+      properties = new ArrayList<>(props);
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCSS.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCSS.java
@@ -144,12 +144,11 @@ public class PSRegionCSS extends PSAbstractDataObject
     return properties;
   }
 
+  @SuppressWarnings("unchecked")
   public void setProperties(List<Property> props) {
     notNull(props);
-    if (props == null) {
-      properties = null;
-    } else if (props instanceof ArrayList) {
-      properties = (ArrayList) props;
+    if (props instanceof ArrayList) {
+      properties = (ArrayList<Property>) props;
     } else {
       properties = new ArrayList<>(props);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCssList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCssList.java
@@ -36,12 +36,11 @@ public class PSRegionCssList extends PSAbstractDataObject {
     return regions;
   }
 
+  @SuppressWarnings("unchecked")
   public void setRegions(List<PSRegionCSS> regionList) {
     notNull(regionList);
-    if (regionList == null) {
-      regions = null;
-    } else if (regionList instanceof ArrayList) {
-      regions = (ArrayList) regionList;
+    if (regionList instanceof ArrayList) {
+      regions = (ArrayList<PSRegionCSS>) regionList;
     } else {
       regions = new ArrayList<>(regionList);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCssList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/data/PSRegionCssList.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class PSRegionCssList extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
-  private List<PSRegionCSS> regions = new ArrayList<>();
+  private ArrayList<PSRegionCSS> regions = new ArrayList<>();
 
   public List<PSRegionCSS> getRegions() {
     return regions;
@@ -38,6 +38,12 @@ public class PSRegionCssList extends PSAbstractDataObject {
 
   public void setRegions(List<PSRegionCSS> regionList) {
     notNull(regionList);
-    regions = regionList;
+    if (regionList == null) {
+      regions = null;
+    } else if (regionList instanceof ArrayList) {
+      regions = (ArrayList) regionList;
+    } else {
+      regions = new ArrayList<>(regionList);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSCurrentUser.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSCurrentUser.java
@@ -36,7 +36,7 @@ public class PSCurrentUser extends PSUser {
   private boolean designerUser = false;
 
   /** Role-resolved community names for the signed-in user (read-only summary). */
-  private List<String> communities = new ArrayList<>();
+  private ArrayList<String> communities = new ArrayList<>();
 
   /** Active community name for the current session, or empty when unknown. */
   private String currentCommunity = "";
@@ -81,8 +81,15 @@ public class PSCurrentUser extends PSUser {
     return communities;
   }
 
+  @SuppressWarnings("unchecked")
   public void setCommunities(List<String> communities) {
-    this.communities = communities != null ? communities : new ArrayList<>();
+    if (communities == null) {
+      this.communities = new ArrayList<>();
+    } else if (communities instanceof ArrayList) {
+      this.communities = (ArrayList<String>) communities;
+    } else {
+      this.communities = new ArrayList<>(communities);
+    }
   }
 
   public String getCurrentCommunity() {

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSLdapConfig.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSLdapConfig.java
@@ -27,6 +27,7 @@ import net.sf.oval.constraint.NotBlank;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 
+import java.util.HashSet;
 /**
  * Directory Service Configuration loaded from a configuration file.
  *
@@ -87,7 +88,7 @@ public class PSLdapConfig extends PSAbstractDataObject {
 
     private String emailAttributeName;
 
-    @NotNull @NotEmpty private Set<String> organizationalUnits;
+    @NotNull @NotEmpty private HashSet<String> organizationalUnits;
 
     private boolean secure;
 
@@ -174,8 +175,15 @@ public class PSLdapConfig extends PSAbstractDataObject {
       return organizationalUnits;
     }
 
+    @SuppressWarnings("unchecked")
     public void setOrganizationalUnits(Set<String> organizationalUnits) {
-      this.organizationalUnits = organizationalUnits;
+      if (organizationalUnits == null) {
+        this.organizationalUnits = null;
+      } else if (organizationalUnits instanceof HashSet) {
+        this.organizationalUnits = (HashSet<String>) organizationalUnits;
+      } else {
+        this.organizationalUnits = new HashSet<>(organizationalUnits);
+      }
     }
 
     public Boolean getSecure() {

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSRoleList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSRoleList.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class PSRoleList extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;
-  private List<String> roles;
+  private ArrayList<String> roles;
 
   public PSRoleList() {
     roles = new ArrayList<>();
@@ -47,7 +47,14 @@ public class PSRoleList extends PSAbstractDataObject {
   }
 
   /** Sets the roles. */
+  @SuppressWarnings("unchecked")
   public void setRoles(List<String> roles) {
-    this.roles = roles;
+    if (roles == null) {
+      this.roles = null;
+    } else if (roles instanceof ArrayList) {
+      this.roles = (ArrayList<String>) roles;
+    } else {
+      this.roles = new ArrayList<>(roles);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSUser.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSUser.java
@@ -54,7 +54,7 @@ public class PSUser extends PSAbstractNamedObject {
   private boolean isCreateUser;
 
   /** A user has to be in at least one role. */
-  @NotEmpty @NotNull private List<String> roles;
+  @NotEmpty @NotNull private ArrayList<String> roles;
 
   public PSUser() {
     roles = new ArrayList<>();
@@ -119,8 +119,15 @@ public class PSUser extends PSAbstractNamedObject {
   }
 
   /** Sets the roles. */
+  @SuppressWarnings("unchecked")
   public void setRoles(List<String> roles) {
-    this.roles = roles;
+    if (roles == null) {
+      this.roles = null;
+    } else if (roles instanceof ArrayList) {
+      this.roles = (ArrayList<String>) roles;
+    } else {
+      this.roles = new ArrayList<>(roles);
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/user/data/PSUserList.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/data/PSUserList.java
@@ -35,7 +35,7 @@ import java.util.List;
 @JsonRootName("UserList")
 public class PSUserList extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
-  private List<String> users;
+  private ArrayList<String> users;
 
   public PSUserList() {
     users = new ArrayList<>();
@@ -47,7 +47,14 @@ public class PSUserList extends PSAbstractDataObject {
   }
 
   /** Sets the users. */
+  @SuppressWarnings("unchecked")
   public void setUsers(List<String> users) {
-    this.users = users;
+    if (users == null) {
+      this.users = null;
+    } else if (users instanceof ArrayList) {
+      this.users = (ArrayList<String>) users;
+    } else {
+      this.users = new ArrayList<>(users);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderFieldsListData.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderFieldsListData.java
@@ -60,12 +60,11 @@ public class PSWidgetBuilderFieldsListData extends PSAbstractDataObject {
    *
    * @param fields The fields, not {@code null}, may be empty.
    */
+  @SuppressWarnings("unchecked")
   public void setFields(List<PSWidgetBuilderFieldData> fields) {
     Objects.requireNonNull(fields, "fields must not be null");
-    if (fields == null) {
-      this.fields = null;
-    } else if (fields instanceof ArrayList) {
-      this.fields = (ArrayList) fields;
+    if (fields instanceof ArrayList) {
+      this.fields = (ArrayList<PSWidgetBuilderFieldData>) fields;
     } else {
       this.fields = new ArrayList<>(fields);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderFieldsListData.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderFieldsListData.java
@@ -32,7 +32,7 @@ public class PSWidgetBuilderFieldsListData extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;
 
-  private List<PSWidgetBuilderFieldData> fields = new ArrayList<>();
+  private ArrayList<PSWidgetBuilderFieldData> fields = new ArrayList<>();
 
   public PSWidgetBuilderFieldsListData() {
     // Default constructor
@@ -62,7 +62,13 @@ public class PSWidgetBuilderFieldsListData extends PSAbstractDataObject {
    */
   public void setFields(List<PSWidgetBuilderFieldData> fields) {
     Objects.requireNonNull(fields, "fields must not be null");
-    this.fields = fields;
+    if (fields == null) {
+      this.fields = null;
+    } else if (fields instanceof ArrayList) {
+      this.fields = (ArrayList) fields;
+    } else {
+      this.fields = new ArrayList<>(fields);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderResourceListData.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderResourceListData.java
@@ -56,12 +56,11 @@ public class PSWidgetBuilderResourceListData extends PSAbstractDataObject {
    *
    * @param resourceList The list, not {@code null}, may be empty.
    */
+  @SuppressWarnings("unchecked")
   public void setResourceList(List<String> resourceList) {
     Objects.requireNonNull(resourceList, "resourceList must not be null");
-    if (resourceList == null) {
-      this.resourceList = null;
-    } else if (resourceList instanceof ArrayList) {
-      this.resourceList = (ArrayList) resourceList;
+    if (resourceList instanceof ArrayList) {
+      this.resourceList = (ArrayList<String>) resourceList;
     } else {
       this.resourceList = new ArrayList<>(resourceList);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderResourceListData.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderResourceListData.java
@@ -32,7 +32,7 @@ public class PSWidgetBuilderResourceListData extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;
 
-  private List<String> resourceList = new ArrayList<>();
+  private ArrayList<String> resourceList = new ArrayList<>();
 
   public static PSWidgetBuilderResourceListData fromXml(String resourceXml) {
     return PSSerializerUtils.unmarshal(resourceXml, PSWidgetBuilderResourceListData.class);
@@ -58,7 +58,13 @@ public class PSWidgetBuilderResourceListData extends PSAbstractDataObject {
    */
   public void setResourceList(List<String> resourceList) {
     Objects.requireNonNull(resourceList, "resourceList must not be null");
-    this.resourceList = resourceList;
+    if (resourceList == null) {
+      this.resourceList = null;
+    } else if (resourceList instanceof ArrayList) {
+      this.resourceList = (ArrayList) resourceList;
+    } else {
+      this.resourceList = new ArrayList<>(resourceList);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderValidationResults.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/data/PSWidgetBuilderValidationResults.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
+import java.util.ArrayList;
 /** Represents a collection of validation results for a widget builder definition. */
 @XmlRootElement(name = "WidgetBuilderValidationResults")
 @JsonRootName("WidgetBuilderValidationResults")
@@ -30,15 +31,22 @@ public class PSWidgetBuilderValidationResults implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private List<PSWidgetBuilderValidationResult> results;
+  private ArrayList<PSWidgetBuilderValidationResult> results;
   private long definitionId;
 
   public List<PSWidgetBuilderValidationResult> getResults() {
     return results;
   }
 
+  @SuppressWarnings("unchecked")
   public void setResults(List<PSWidgetBuilderValidationResult> results) {
-    this.results = results;
+    if (results == null) {
+      this.results = null;
+    } else if (results instanceof ArrayList) {
+      this.results = (ArrayList<PSWidgetBuilderValidationResult>) results;
+    } else {
+      this.results = new ArrayList<>(results);
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflow.java
+++ b/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflow.java
@@ -43,7 +43,7 @@ public class PSUiWorkflow extends PSAbstractDataObject {
   // Used for step creation/update to identify the step to update or insert after.
   private String previousStepName = "";
 
-  private List<PSUiWorkflowStep> workflowSteps = new ArrayList<>();
+  private ArrayList<PSUiWorkflowStep> workflowSteps = new ArrayList<>();
 
   public PSUiWorkflow() {
     this("", new ArrayList<>());
@@ -51,7 +51,13 @@ public class PSUiWorkflow extends PSAbstractDataObject {
 
   public PSUiWorkflow(String workflowName, List<PSUiWorkflowStep> workflowSteps) {
     this.workflowName = workflowName;
-    this.workflowSteps = workflowSteps;
+    if (workflowSteps == null) {
+      this.workflowSteps = null;
+    } else if (workflowSteps instanceof ArrayList) {
+      this.workflowSteps = (ArrayList) workflowSteps;
+    } else {
+      this.workflowSteps = new ArrayList<>(workflowSteps);
+    }
   }
 
   public String getWorkflowName() {
@@ -75,8 +81,15 @@ public class PSUiWorkflow extends PSAbstractDataObject {
     return workflowSteps;
   }
 
+  @SuppressWarnings("unchecked")
   public void setWorkflowSteps(List<PSUiWorkflowStep> workflowSteps) {
-    this.workflowSteps = workflowSteps;
+    if (workflowSteps == null) {
+      this.workflowSteps = null;
+    } else if (workflowSteps instanceof ArrayList) {
+      this.workflowSteps = (ArrayList<PSUiWorkflowStep>) workflowSteps;
+    } else {
+      this.workflowSteps = new ArrayList<>(workflowSteps);
+    }
   }
 
   public String getPreviousWorkflowName() {

--- a/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflowStep.java
+++ b/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflowStep.java
@@ -35,8 +35,8 @@ public class PSUiWorkflowStep extends PSAbstractDataObject {
   private static final long serialVersionUID = 1L;
 
   private String stepName;
-  private List<PSUiWorkflowStepRole> stepRoles = new ArrayList<>();
-  private List<String> permissionNames = new ArrayList<>();
+  private ArrayList<PSUiWorkflowStepRole> stepRoles = new ArrayList<>();
+  private ArrayList<String> permissionNames = new ArrayList<>();
 
   public PSUiWorkflowStep() {
     super();
@@ -55,8 +55,15 @@ public class PSUiWorkflowStep extends PSAbstractDataObject {
     return stepRoles;
   }
 
+  @SuppressWarnings("unchecked")
   public void setStepRoles(List<PSUiWorkflowStepRole> stepRoles) {
-    this.stepRoles = stepRoles;
+    if (stepRoles == null) {
+      this.stepRoles = null;
+    } else if (stepRoles instanceof ArrayList) {
+      this.stepRoles = (ArrayList<PSUiWorkflowStepRole>) stepRoles;
+    } else {
+      this.stepRoles = new ArrayList<>(stepRoles);
+    }
   }
 
   /** Gets the permission names. May be empty but never {@code null}. */
@@ -64,7 +71,14 @@ public class PSUiWorkflowStep extends PSAbstractDataObject {
     return permissionNames;
   }
 
+  @SuppressWarnings("unchecked")
   public void setPermissionNames(List<String> permissionNames) {
-    this.permissionNames = permissionNames;
+    if (permissionNames == null) {
+      this.permissionNames = null;
+    } else if (permissionNames instanceof ArrayList) {
+      this.permissionNames = (ArrayList<String>) permissionNames;
+    } else {
+      this.permissionNames = new ArrayList<>(permissionNames);
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflowStepRole.java
+++ b/projects/sitemanage/src/main/java/com/percussion/workflow/data/PSUiWorkflowStepRole.java
@@ -39,7 +39,7 @@ public class PSUiWorkflowStepRole extends PSAbstractDataObject {
   private String roleName;
   private Integer roleId;
   private Boolean enableNotification = false;
-  private List<PSUiWorkflowStepRoleTransition> roleTransitions = new ArrayList<>();
+  private ArrayList<PSUiWorkflowStepRoleTransition> roleTransitions = new ArrayList<>();
 
   public PSUiWorkflowStepRole() {
     super();
@@ -81,8 +81,15 @@ public class PSUiWorkflowStepRole extends PSAbstractDataObject {
   }
 
   /** Sets the transitions of the role. May be empty but never {@code null}. */
+  @SuppressWarnings("unchecked")
   public void setRoleTransitions(List<PSUiWorkflowStepRoleTransition> roleTransitions) {
-    this.roleTransitions = (roleTransitions == null) ? new ArrayList<>() : roleTransitions;
+    if (roleTransitions == null) {
+      this.roleTransitions = new ArrayList<>();
+    } else if (roleTransitions instanceof ArrayList) {
+      this.roleTransitions = (ArrayList<PSUiWorkflowStepRoleTransition>) roleTransitions;
+    } else {
+      this.roleTransitions = new ArrayList<>(roleTransitions);
+    }
   }
 
   public Boolean isEnableNotification() {

--- a/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
@@ -162,6 +162,59 @@ public class PSSerializableListWrappersTest {
     section.setChildIds(null);
     assertNotNull(section.getChildIds());
     assertTrue(section.getChildIds().isEmpty());
+
+    // PSSectionNode: null → empty; share ArrayList; copy non-ArrayList
+    var sectionNode = new com.percussion.sitemanage.data.PSSectionNode();
+    sectionNode.setChildNodes(null);
+    assertNotNull(sectionNode.getChildNodes());
+    assertTrue(sectionNode.getChildNodes().isEmpty());
+    var sharedChildren = new ArrayList<com.percussion.sitemanage.data.PSSectionNode>();
+    sectionNode.setChildNodes(sharedChildren);
+    assertTrue(
+        sectionNode.getChildNodes() == sharedChildren,
+        "setChildNodes should share concrete ArrayList");
+    List<com.percussion.sitemanage.data.PSSectionNode> linkedChildren = new LinkedList<>();
+    sectionNode.setChildNodes(linkedChildren);
+    assertTrue(sectionNode.getChildNodes() instanceof ArrayList);
+    assertTrue(sectionNode.getChildNodes() != linkedChildren);
+
+    // notNull-guarded setters: share HashMap; copy non-HashMap (no dead null branch)
+    var contentItem = new com.percussion.share.dao.impl.PSContentItem();
+    Map<String, Object> sharedMap = new HashMap<>();
+    sharedMap.put("k", "v");
+    contentItem.setFields(sharedMap);
+    assertTrue(contentItem.getFields() == sharedMap, "setFields should share concrete HashMap");
+    Map<String, Object> treeMap = new java.util.TreeMap<>();
+    treeMap.put("k", "v");
+    contentItem.setFields(treeMap);
+    assertTrue(contentItem.getFields() instanceof HashMap);
+    assertTrue(contentItem.getFields() != treeMap);
+    assertEquals("v", contentItem.getFields().get("k"));
+    treeMap.put("k2", "v2");
+    assertEquals(1, contentItem.getFields().size());
+
+    var regionCss = new com.percussion.theme.data.PSRegionCSS();
+    List<com.percussion.theme.data.PSRegionCSS.Property> props =
+        new LinkedList<>();
+    regionCss.setProperties(props);
+    assertTrue(regionCss.getProperties() instanceof ArrayList);
+    assertTrue(regionCss.getProperties() != props);
+
+    var regionList = new com.percussion.theme.data.PSRegionCssList();
+    List<com.percussion.theme.data.PSRegionCSS> regions = new LinkedList<>();
+    regionList.setRegions(regions);
+    assertTrue(regionList.getRegions() instanceof ArrayList);
+
+    var fieldsList = new com.percussion.widgetbuilder.data.PSWidgetBuilderFieldsListData();
+    List<com.percussion.widgetbuilder.data.PSWidgetBuilderFieldData> fields =
+        new LinkedList<>();
+    fieldsList.setFields(fields);
+    assertTrue(fieldsList.getFields() instanceof ArrayList);
+
+    var resourceList = new com.percussion.widgetbuilder.data.PSWidgetBuilderResourceListData();
+    List<String> resources = new LinkedList<>();
+    resourceList.setResourceList(resources);
+    assertTrue(resourceList.getResourceList() instanceof ArrayList);
   }
 
   private static void assertSerialVersionUid(Class<?> type) throws Exception {

--- a/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/data/PSSerializableListWrappersTest.java
@@ -22,17 +22,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.assetmanagement.data.PSAssetList;
 import com.percussion.assetmanagement.data.PSAssetSummaryList;
+import com.percussion.itemmanagement.data.PSItemStateTransition;
 import com.percussion.pagemanagement.data.PSWidgetContentTypeList;
 import com.percussion.pagemanagement.data.PSWidgetSummaryList;
 import com.percussion.sitemanage.data.PSPublishingActionList;
+import com.percussion.sitemanage.data.PSSiteSection;
+import com.percussion.user.data.PSUser;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
 import org.junit.jupiter.api.Test;
 
 /**
  * Guards serialVersionUID + construction for JAXB/JSON list wrappers cleaned in issue #2032 batch
- * 1.
+ * 1, residual serialVersionUID batch 2 (#2421), and serial-field concrete collection types (#2870).
  */
 public class PSSerializableListWrappersTest {
 
@@ -99,11 +112,86 @@ public class PSSerializableListWrappersTest {
     assertEquals("2", list.get(1).getId());
   }
 
+  /**
+   * Guards issue #2870 serial-field cleanup: representative DTO collection fields use concrete
+   * serializable types (ArrayList/HashMap/HashSet/Vector), not bare List/Map/Set interfaces.
+   */
+  @Test
+  public void serialFieldCollectionTypesAreConcreteAndSerializable() throws Exception {
+    assertCollectionFieldConcrete(PSUser.class, "roles", ArrayList.class);
+    assertCollectionFieldConcrete(PSItemStateTransition.class, "transitionTriggers", ArrayList.class);
+    assertCollectionFieldConcrete(PSSiteSection.class, "childIds", ArrayList.class);
+    assertCollectionFieldConcrete(PSItemProperties.class, "tags", ArrayList.class);
+    assertCollectionFieldConcrete(
+        com.percussion.pathmanagement.data.PSPathItem.class, "displayProperties", HashMap.class);
+    assertCollectionFieldConcrete(
+        com.percussion.dashboardmanagement.data.PSGadget.class, "settings", HashMap.class);
+    assertCollectionFieldConcrete(
+        com.percussion.comments.data.PSComment.class, "commentTags", HashSet.class);
+    assertCollectionFieldConcrete(
+        com.percussion.pagemanagement.assembler.impl.PSProxyAssemblyTemplate.class,
+        "bindings",
+        Vector.class);
+  }
+
+  /**
+   * Setters accepting List/Map must defensive-copy into the concrete field so callers cannot share
+   * a non-serializable collection implementation with the DTO.
+   */
+  @Test
+  public void serialFieldSettersDefensivelyCopyCollections() {
+    var user = new PSUser();
+    List<String> linked = new LinkedList<>(Arrays.asList("Editor", "Admin"));
+    user.setRoles(linked);
+    assertEquals(List.of("Editor", "Admin"), user.getRoles());
+    assertTrue(user.getRoles() instanceof ArrayList, "roles field/runtime should be ArrayList");
+    linked.add("Extra");
+    assertEquals(
+        2, user.getRoles().size(), "mutating input list must not change DTO roles after set");
+
+    var transition = new PSItemStateTransition();
+    List<String> triggers = new LinkedList<>(List.of("approve", "reject"));
+    transition.setTransitionTriggers(triggers);
+    assertEquals(List.of("approve", "reject"), transition.getTransitionTriggers());
+    triggers.clear();
+    assertEquals(2, transition.getTransitionTriggers().size());
+
+    var section = new PSSiteSection();
+    section.setChildIds(new LinkedList<>(List.of("a", "b")));
+    assertEquals(List.of("a", "b"), section.getChildIds());
+    section.setChildIds(null);
+    assertNotNull(section.getChildIds());
+    assertTrue(section.getChildIds().isEmpty());
+  }
+
   private static void assertSerialVersionUid(Class<?> type) throws Exception {
     assertTrue(Serializable.class.isAssignableFrom(type), type.getName() + " should be Serializable");
     Field f = type.getDeclaredField("serialVersionUID");
     f.setAccessible(true);
     assertNotNull(f.get(null));
     assertEquals(long.class, f.getType());
+  }
+
+  private static void assertCollectionFieldConcrete(
+      Class<?> type, String fieldName, Class<?> expectedConcrete) throws Exception {
+    Field f = type.getDeclaredField(fieldName);
+    Class<?> fieldType = f.getType();
+    assertTrue(
+        expectedConcrete.equals(fieldType),
+        type.getName()
+            + "#"
+            + fieldName
+            + " expected field type "
+            + expectedConcrete.getName()
+            + " but was "
+            + fieldType.getName());
+    assertTrue(
+        Serializable.class.isAssignableFrom(fieldType),
+        type.getName() + "#" + fieldName + " field type must be Serializable");
+    assertTrue(
+        !fieldType.isInterface(),
+        type.getName() + "#" + fieldName + " must not be a bare collection interface");
+    // keep modifiers readable for future audits
+    assertTrue(Modifier.isPrivate(f.getModifiers()) || Modifier.isProtected(f.getModifiers()));
   }
 }


### PR DESCRIPTION
## Summary

Partial Xlint cleanup for **sitemanage** residual issue **#2870** (parent module issue **#2032**, monorepo tracker **#2200**). Batch 3 clears the dominant **serial-field** cluster on main-source JAXB/JSON DTOs by using concrete serializable collection field types.

### Main changes

- Field types: `List`/`Collection` → `ArrayList`, `Map` → `HashMap`, `Set` → `HashSet`, and one `Vector` bindings field (`PSProxyAssemblyTemplate`)
- Public **getters/setters keep interface types** (`List`/`Map`/`Set`) — no REST/API contract change
- Setters **share** when the argument is already the concrete type (JAXB collection population + shared-map tests), otherwise copy into a new concrete collection
- `@SuppressWarnings("unchecked")` on share-if-concrete setters for the generic cast after `instanceof`

### Tests

- Extended `PSSerializableListWrappersTest` — concrete field-type guards + LinkedList input defensive-copy behavior

### Inventory (main-source, uncapped `-Xmaxwarns`)

| Metric | Before | After |
|--------|--------|-------|
| Total WARNING lines | ~227 | ~165 |
| serial-field | 86 | 14 |
| this-escape | 55 | 55 |

### Residual

Remaining main diagnostics: **this-escape**, **unchecked/raw**, ~14 non-collection **serial-field**. Residual child filed after this PR.

## Test plan

- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **970**, Failures: **0**, Errors: **0**, Skipped: **127**
- [x] Main-source serial-field 86 → 14
- [x] No production REST contract changes

## Product documentation

- [x] N/A — pure compiler lint tech debt; no operator/user/API surface change

## Gates / evidence (C3)

- **modules_built:** `projects/sitemanage`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 970, Failures: 0, Errors: 0, Skipped: 127
- **downstream_checked:** none (no public API signature / final / sealed changes; C2 N/A)
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2870-sitemanage-xlint-serial-field-erlang.md`
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2870  
Refs #2032 #2200 #2421

> Co-Authored by Grok Build using grok-4.5 with agent main.
