### PR TITLE
feat(auditlog): Utils/XML/Beans/Table/JBoss/SiteManage ErrorCodes (#2889)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -18,7 +18,11 @@ System-wide Percussion CMS audit logging and unified error-code support.
   `WebserviceErrorCodes` (package-local 28–73), `ServerWebServicesErrorCodes`, `WebdavErrorCodes`,
   `ServletErrorCodes`, `TransformationErrorCodes` (enum-only),
   `SearchErrorCodes` (`IPSSearchErrors`; auth failure dual-write), `LuceneErrorCodes`,
-  `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable)
+  `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable),
+  `UtilErrorCodes` (`IPSUtilErrors`), system `XmlErrorCodes` (`com.percussion.xml.IPSXmlErrors`),
+  `SiteManageErrorCodes` (flat-registered; non-auditable),
+  `BeansErrorCodes` / `TableFactoryErrorCodes` / `JBossErrorCodes` / utils-local `XmlErrorCodes`
+  (enum-only — Server/WF collisions)
   + `LegacyErrorCodeRegistry` bridge legacy `IPS*Errors` ints. Non-auditable / unregistered ints never
   dual-write. Central `PSErrorHandler.appendError` dual-writes only when the registry marks the legacy
   int auditable.
@@ -65,11 +69,13 @@ audit.log(
 ```java
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.BeansErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.JBossErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
@@ -80,10 +86,14 @@ import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SiteManageErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.UtilErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
 
 // Prefer enum when available:
 audit.log(SecurityErrorCodes.AUTHENTICATION_FAILED, ctx, "Directory", "ldap1", "jdoe");
@@ -102,7 +112,12 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 1001, ctx); // SYS native — non-
 LegacyErrorCodeRegistry.logIfAuditable(audit, 401, ctx); // HTTP status — non-auditable skip
 LegacyErrorCodeRegistry.logIfAuditable(audit, 16052, ctx); // search auth failed — dual-write
 LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir — non-auditable skip
+LegacyErrorCodeRegistry.logIfAuditable(audit, 10001, ctx); // util Base64 — non-auditable skip
+LegacyErrorCodeRegistry.logIfAuditable(audit, 6001, ctx); // system XML dump — non-auditable skip
+LegacyErrorCodeRegistry.logIfAuditable(audit, 18252, ctx); // site manage bad site — non-auditable skip
 // Prefer JobErrorCodes enum for job ints 1–10 (flat registry keeps WF ownership of 1–10)
+// Prefer BeansErrorCodes / TableFactoryErrorCodes / JBossErrorCodes / XmlErrorCodes package-local
+// enums directly (flat ints collide with Server/WF)
 // Provider/config/conversion/path/design/server/http/job/assembly/extension/webservice noise (isAuditable=false) and unknown ints → no dual-write
 ```
 
@@ -128,6 +143,12 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir �
 | `LuceneErrorCodes` | 16311–16456 (`IPSLuceneErrors`) | All non-auditable index/query codes |
 | `LocaleErrorCodes` | 1801–1804 (`IPSLocaleErrors`) | All non-auditable |
 | `MailErrorCodes` | 3501–3508 (`IPSMailErrors`) | All non-auditable |
+| `UtilErrorCodes` | 10001–10203 (`IPSUtilErrors`) | All non-auditable util/encode/HTTP |
+| `XmlErrorCodes` | utils 1–6 (enum-only) + system 6001–6028 | Flat-registers system only; WF owns 1–6 |
+| `BeansErrorCodes` | package-local 1001 (no flat register) | Server owns flat 1001; all non-auditable |
+| `TableFactoryErrorCodes` | package-local 1001–1310 (no flat register) | Server range collision; prefer enum |
+| `JBossErrorCodes` | package-local 1 (no flat register) | Legacy JBoss container; WF owns bare 1 |
+| `SiteManageErrorCodes` | 18252 (`IPSSiteManageErrors`) | All non-auditable site-service noise |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -17,11 +17,13 @@
 package com.intsof.percussioncms.auditlog;
 
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.BeansErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.JBossErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
@@ -32,10 +34,14 @@ import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SiteManageErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.UtilErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,9 +61,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * package-local ints, non-colliding {@link WebserviceErrorCodes} package-local ints (28–73), fully
  * unique {@link ServerWebServicesErrorCodes} / {@link WebdavErrorCodes} / {@link ServletErrorCodes},
  * fully unique {@link SearchErrorCodes} / {@link LuceneErrorCodes} / {@link LocaleErrorCodes} /
- * {@link MailErrorCodes}, and bootstrap-only {@link TransformationErrorCodes} / {@link
- * DeliveryErrorCodes} (no flat register). Residual slices may register additional catalogs via
- * {@link #register(int, SystemErrorCode)}.
+ * {@link MailErrorCodes}, fully unique {@link UtilErrorCodes} / system {@link XmlErrorCodes} /
+ * {@link SiteManageErrorCodes}, and bootstrap-only {@link TransformationErrorCodes} / {@link
+ * DeliveryErrorCodes} / {@link BeansErrorCodes} / {@link TableFactoryErrorCodes} / {@link
+ * JBossErrorCodes} / utils-local {@link XmlErrorCodes} (no flat register). Residual slices may
+ * register additional catalogs via {@link #register(int, SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -72,14 +80,17 @@ public final class LegacyErrorCodeRegistry {
   /**
    * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design,
    * server, HTTP, assembly, extension, delivery, job, webservices, WebDAV, servlet, search,
-   * Lucene, locale, mail, transformation). Safe to call repeatedly; catalogs register themselves
-   * in their own static initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip
-   * package-local ints {@code 1–10} that collide with {@link WorkflowErrorCodes}. {@link
-   * JobErrorCodes} is bootstrapped after assembly so flat int {@code 11} ({@code
-   * CONFIG_FILE_NOT_FOUND}) wins over assembly package-local {@code MISSING_SLOT} (prefer enum for
-   * assembly {@code 11}). {@link WebserviceErrorCodes} skips package-local ints {@code 1–27};
-   * {@link TransformationErrorCodes} and {@link DeliveryErrorCodes} do not flat-register. Search /
-   * Lucene / Locale / Mail ints are globally unique and fully registered.
+   * Lucene, locale, mail, transformation, util, XML, beans, table factory, JBoss, site manage).
+   * Safe to call repeatedly; catalogs register themselves in their own static initializers.
+   * {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip package-local ints {@code 1–10}
+   * that collide with {@link WorkflowErrorCodes}. {@link JobErrorCodes} is bootstrapped after
+   * assembly so flat int {@code 11} ({@code CONFIG_FILE_NOT_FOUND}) wins over assembly
+   * package-local {@code MISSING_SLOT} (prefer enum for assembly {@code 11}). {@link
+   * WebserviceErrorCodes} skips package-local ints {@code 1–27}; {@link TransformationErrorCodes},
+   * {@link DeliveryErrorCodes}, {@link BeansErrorCodes}, {@link TableFactoryErrorCodes}, {@link
+   * JBossErrorCodes}, and utils-local {@link XmlErrorCodes} ({@code 1–6}) do not flat-register.
+   * Search / Lucene / Locale / Mail / Util / system XML / SiteManage ints are globally unique and
+   * fully registered.
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
@@ -109,6 +120,15 @@ public final class LegacyErrorCodeRegistry {
       LuceneErrorCodes.ensureRegistered();
       LocaleErrorCodes.ensureRegistered();
       MailErrorCodes.ensureRegistered();
+      // Utils/XML/Beans/Table/JBoss/SiteManage residual (#2889).
+      UtilErrorCodes.ensureRegistered();
+      // Xml: only system range 6001+ flat-registers; package-local 1–6 stay enum-only.
+      XmlErrorCodes.ensureRegistered();
+      // Beans/Table/JBoss: no-op flat register (Server/WF collisions); enums still loadable.
+      BeansErrorCodes.ensureRegistered();
+      TableFactoryErrorCodes.ensureRegistered();
+      JBossErrorCodes.ensureRegistered();
+      SiteManageErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/BeansErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/BeansErrorCodes.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Beans error catalog bridging legacy {@code com.percussion.error.IPSBeansErrors} ints (only
+ * {@code XML_PROCESSING_ERROR = 1001}).
+ *
+ * <p>All constants set {@link #isAuditable()} to {@code false}: beans XML processing failures are
+ * operational noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local int {@code 1001} already belongs to
+ * {@link ServerErrorCodes#NATIVE_ERROR}. This catalog therefore does <strong>not</strong>
+ * flat-register any ints. Prefer this enum directly until a composite-key registry exists. Module
+ * code is {@link AuditModule#SYS}.
+ */
+public enum BeansErrorCodes implements SystemErrorCode {
+
+  XML_PROCESSING_ERROR(
+      1001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Beans XML processing error",
+      "Beans XML processing error detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  BeansErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat {@link com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry}: int
+   * {@code 1001} collides with {@link ServerErrorCodes}. Prefer this enum directly. Safe to call
+   * repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local int collides with ServerErrorCodes.NATIVE_ERROR.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/JBossErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/JBossErrorCodes.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Legacy JBoss container error catalog bridging {@code
+ * com.percussion.utils.container.jboss.IPSJBossErrors} (only {@code APP_POLICY_ELEMENT_MISSING =
+ * 1}).
+ *
+ * <p><strong>Retired-container note:</strong> JBoss is no longer the product runtime (Jetty is).
+ * This catalog exists so residual legacy ints remain type-safe and explicitly non-auditable if
+ * any install/upgrade path still loads JBoss error bundles.
+ *
+ * <p>All constants set {@link #isAuditable()} to {@code false}.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local int {@code 1} already belongs to
+ * {@link WorkflowErrorCodes}. This catalog therefore does <strong>not</strong> flat-register any
+ * ints. Prefer this enum directly. Module code is {@link AuditModule#CFG}.
+ */
+public enum JBossErrorCodes implements SystemErrorCode {
+
+  APP_POLICY_ELEMENT_MISSING(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "JBoss app policy element missing",
+      "JBoss app policy element missing policy={} file={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  JBossErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat {@link com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry}: package-local
+   * int {@code 1} collides with {@link WorkflowErrorCodes}. Prefer this enum directly. Safe to call
+   * repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local int collides with WorkflowErrorCodes.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.CFG;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SiteManageErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SiteManageErrorCodes.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Site management service error catalog bridging legacy {@code
+ * com.percussion.sitemanage.error.IPSSiteManageErrors} ints (category {@code 18251}+; currently
+ * only {@code SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD = 18252}).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: bad-site cleanup noise is
+ * operational, not a security dual-write event. Call sites that need site lifecycle audits should
+ * use content/design catalogs instead.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#CFG}.
+ */
+public enum SiteManageErrorCodes implements SystemErrorCode {
+
+  SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD(
+      18252,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Deleting bad site record",
+      "Site manage service deleting bad site record");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  SiteManageErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (SiteManageErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.CFG;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/TableFactoryErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/TableFactoryErrorCodes.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Table factory error catalog bridging legacy {@code
+ * com.percussion.tablefactory.IPSTableFactoryErrors} ints (1001–1310: XML schema, object store,
+ * SQL processing, schema/data process).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: schema/SQL factory failures are
+ * operational install/upgrade noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> the entire package-local range overlaps {@link
+ * ServerErrorCodes} (1001–1709). This catalog therefore does <strong>not</strong> flat-register
+ * any ints. Prefer this enum directly until a composite-key registry exists. Module code is {@link
+ * AuditModule#CFG}.
+ */
+public enum TableFactoryErrorCodes implements SystemErrorCode {
+
+  XML_ELEMENT_NULL(
+      1001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory XML element null",
+      "Table factory XML element null expected={}"),
+
+  XML_ELEMENT_WRONG_TYPE(
+      1002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory XML element wrong type",
+      "Table factory XML element wrong type expected={} actual={}"),
+
+  XML_ELEMENT_INVALID_ATTR(
+      1003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory XML element invalid attr",
+      "Table factory XML element invalid attr tag={} attr={} value={}"),
+
+  XML_ELEMENT_INVALID_CHILD(
+      1004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory XML element invalid child",
+      "Table factory XML element invalid child tag={} child={} value={}"),
+
+  STYLESHEET_NOT_FOUND(
+      1005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory stylesheet not found",
+      "Table factory stylesheet not found name={}"),
+
+  TRANSFORMATION_ERROR(
+      1006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory transform error",
+      "Table factory transform error stylesheet={} detail={}"),
+
+  LOG_FILE_CONF_ERROR(
+      1007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory log file config error",
+      "Table factory log file config error"),
+
+  LOG_FILE_WRITE_ERROR(
+      1008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory log file write error",
+      "Table factory log file write error"),
+
+  DATA_TYPE_MAP_NOT_FOUND(
+      1101,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory data type map not found",
+      "Table factory data type map not found db={} driver={} os={}"),
+
+  INVALID_DATA_TYPE_MAPPING(
+      1102,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory invalid data type mapping",
+      "Table factory invalid data type mapping jdbc={} native={}"),
+
+  JDBC_INT_DATA_TYPE_CONVERSION(
+      1103,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory JDBC int data type conversion",
+      "Table factory JDBC int data type conversion jdbc={}"),
+
+  JDBC_STRING_DATA_TYPE_CONVERSION(
+      1104,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory JDBC string data type conversion",
+      "Table factory JDBC string data type conversion jdbc={}"),
+
+  PW_DECRYPTION_ERROR(
+      1105,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory password decryption error",
+      "Table factory password decryption error password={} detail={}"),
+
+  DUPLICATE_COLUMN(
+      1106,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory duplicate column",
+      "Table factory duplicate column container={} column={}"),
+
+  INVALID_COLUMN_NAME(
+      1107,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory invalid column name",
+      "Table factory invalid column name container={}"),
+
+  REMOVE_LAST_COLUMN(
+      1108,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory remove last column",
+      "Table factory remove last column"),
+
+  TABLE_SCHEMA_NOT_FOUND(
+      1109,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory table schema not found",
+      "Table factory table schema not found table={}"),
+
+  COLUMN_NOT_FOUND(
+      1110,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory column not found",
+      "Table factory column not found table={} column={}"),
+
+  ALTER_TABLE_SET_DATA(
+      1111,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory alter table set data",
+      "Table factory alter table set data table={}"),
+
+  MISSING_COLUMN(
+      1112,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory missing column",
+      "Table factory missing column table={} container={} columns={}"),
+
+  LOAD_DEFAULT_DATATYPE_MAP(
+      1113,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory load default datatype map",
+      "Table factory load default datatype map detail={}"),
+
+  INVALID_ENCODING(
+      1114,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory invalid encoding",
+      "Table factory invalid encoding container={} encoding={}"),
+
+  SQL_TABLE_META_DATA(
+      1201,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory SQL table meta data",
+      "Table factory SQL table meta data table={} detail={}"),
+
+  SQL_CONNECTION_FAILED(
+      1202,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory SQL connection failed",
+      "Table factory SQL connection failed detail={}"),
+
+  SQL_CATALOG_TABLE_FAILED(
+      1203,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory SQL catalog table failed",
+      "Table factory SQL catalog table failed table={} detail={}"),
+
+  SQL_BIND_PARAMETER(
+      1204,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory SQL bind parameter",
+      "Table factory SQL bind parameter value={} type={} detail={}"),
+
+  SQL_CATALOG_DATA(
+      1205,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory SQL catalog data",
+      "Table factory SQL catalog data table={} detail={}"),
+
+  SCHEMA_PROCESS_ERROR(
+      1301,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory schema process error",
+      "Table factory schema process error table={} detail={}"),
+
+  CHECK_EXISTING_DATA(
+      1302,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory check existing data",
+      "Table factory check existing data table={} detail={}"),
+
+  SCHEMA_COLL_PROCESS_ERROR(
+      1303,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory schema collection process error",
+      "Table factory schema collection process error detail={}"),
+
+  ALTER_NO_TABLE(
+      1304,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory alter no table",
+      "Table factory alter no table table={}"),
+
+  UPDATE_DATA_NO_KEYS(
+      1305,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory update data no keys",
+      "Table factory update data no keys table={}"),
+
+  UPDATE_DATA_NO_KEY_VALUE(
+      1306,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory update data no key value",
+      "Table factory update data no key value table={} column={}"),
+
+  DATA_PROCESS_ERROR(
+      1307,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory data process error",
+      "Table factory data process error table={} detail={}"),
+
+  UPDATE_DATA_NO_KEY_VALUE_IN_DB(
+      1308,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory update data no key value in db",
+      "Table factory update data no key value in db table={} column={}"),
+
+  ALTER_VIEW_NOT_SUPPORTED(
+      1309,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory alter view not supported",
+      "Table factory alter view not supported view={}"),
+
+  DATA_HANDLER_CLASS_NOT_FOUND(
+      1310,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Table factory data handler class not found",
+      "Table factory data handler class not found class={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  TableFactoryErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * No-op for the flat {@link com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry}: the full
+   * range collides with {@link ServerErrorCodes}. Prefer this enum directly. Safe to call
+   * repeatedly for bootstrap symmetry.
+   */
+  public static void ensureRegistered() {
+    // Intentionally empty — package-local ints collide with ServerErrorCodes.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.CFG;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/UtilErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/UtilErrorCodes.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Util error catalog bridging legacy {@code com.percussion.util.IPSUtilErrors} ints (10001–10203:
+ * Base64 encode/decode, collection class load, purgable temp dir, HTTP receive/post).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: util encode / I/O failures are
+ * operational noise, not security dual-write events.
+ *
+ * <p>All ints are globally unique (distinct from {@link ServletErrorCodes} 10151+) and fully
+ * flat-registered in {@link LegacyErrorCodeRegistry}. Module code is {@link AuditModule#SYS}.
+ */
+public enum UtilErrorCodes implements SystemErrorCode {
+
+  BASE64_ENCODING_EXCEPTION(
+      10001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Base64 encoding exception",
+      "Base64 encoding exception input={} detail={}"),
+
+  BASE64_DECODING_EXCEPTION(
+      10002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Base64 decoding exception",
+      "Base64 decoding exception input={} detail={}"),
+
+  COLLECTION_CLASS_NOT_FOUND(
+      10051,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Collection class not found",
+      "Collection class not found class={}"),
+
+  PURGABLE_TEMP_DIR_IS_FILE(
+      10101,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Purgable temp dir is a file",
+      "Purgable temp dir is a file"),
+
+  RECEIVE_DATA_ERROR(
+      10202,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Receive data error",
+      "Receive data error received={} expected={}"),
+
+  POST_DATA_ERROR(
+      10203,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Post data error",
+      "Post data error code={} message={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  UtilErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (UtilErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/XmlErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/XmlErrorCodes.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * XML error catalog bridging two legacy {@code IPSXmlErrors} sources:
+ *
+ * <ul>
+ *   <li>{@code com.percussion.utils.xml.IPSXmlErrors} package-local ints {@code 1–6} (element /
+ *       attribute restore noise)
+ *   <li>{@code com.percussion.xml.IPSXmlErrors} ints {@code 6001–6028} (raw dump, processing, DTD)
+ * </ul>
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: XML parse / DTD / restore
+ * failures are operational noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1–6} already belong to
+ * {@link WorkflowErrorCodes}. Only the unique system range ({@code 6001+}) is flat-registered.
+ * Prefer this enum directly for utils package-local codes. Module code is {@link
+ * AuditModule#SYS}.
+ */
+public enum XmlErrorCodes implements SystemErrorCode {
+
+  // --- utils package-local (com.percussion.utils.xml.IPSXmlErrors) — not flat-registered ---
+
+  XML_ELEMENT_MISSING(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "XML element missing",
+      "XML element missing tag={}"),
+
+  XML_ELEMENT_INVALID_VALUE(
+      2,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "XML element invalid value",
+      "XML element invalid value tag={} value={}"),
+
+  XML_TWO_ROOT_ELEMENTS(
+      3,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "XML two root elements",
+      "XML two root elements first={} second={}"),
+
+  XML_ELEMENT_INVALID_ATTR(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "XML element invalid attribute",
+      "XML element invalid attribute tag={} attr={} value={}"),
+
+  XML_ELEMENT_ATTR_INVALID_VAL(
+      5,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "XML element attribute invalid value",
+      "XML element attribute invalid value tag={} attr={} attrValue={} elementValue={}"),
+
+  XML_RESTORE_ERROR(
+      6,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "XML restore error",
+      "XML restore error class={} detail={} xml={}"),
+
+  // --- system (com.percussion.xml.IPSXmlErrors) — flat-registered ---
+
+  RAW_XML_DUMP(
+      6001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Raw XML dump",
+      "Raw XML dump data={}"),
+
+  XML_PROCESSING_ERROR(
+      6002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "XML processing error",
+      "XML processing error session={}"),
+
+  DTD_IO_ERROR(
+      6025,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "DTD IO error",
+      "DTD IO error detail={}"),
+
+  DTD_ROOTNOTFOUND_ERROR(
+      6026,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "DTD root not found",
+      "DTD root not found root={}"),
+
+  DTD_MULTIPLE_OCCURRENCE_NOTSUPPORTED_ERROR(
+      6027,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "DTD multiple occurrence not supported",
+      "DTD multiple occurrence not supported first={} second={}"),
+
+  DTD_ELEMENT_NOTFOUND_ERROR(
+      6028,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "DTD element not found",
+      "DTD element not found element={}");
+
+  /** Lowest flat-registered system XML int ({@code com.percussion.xml.IPSXmlErrors}). */
+  private static final int SYSTEM_XML_RANGE_START = 6001;
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  XmlErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register unique system XML ints ({@code 6001+}) only. Package-local {@code 1–6} are skipped so
+   * {@link WorkflowErrorCodes} keeps ownership of bare low ints. Safe to call repeatedly.
+   */
+  public static void ensureRegistered() {
+    for (XmlErrorCodes code : values()) {
+      if (code.numericCode() >= SYSTEM_XML_RANGE_START) {
+        LegacyErrorCodeRegistry.register(code.numericCode(), code);
+      }
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -22,11 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.BeansErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.JBossErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
@@ -37,10 +39,14 @@ import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SiteManageErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.UtilErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WorkflowErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
 import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -845,6 +851,124 @@ class LegacyErrorCodeRegistryTest {
     assertTrue(LegacyErrorCodeRegistry.find(16311).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(1801).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(3501).isPresent());
+  }
+
+  // --- Utils / XML / Beans / Table / JBoss / SiteManage residual (#2889) ---
+
+  @Test
+  void utilCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(10001));
+    assertSame(
+        UtilErrorCodes.BASE64_ENCODING_EXCEPTION,
+        LegacyErrorCodeRegistry.find(10001).orElseThrow());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(10203));
+    assertSame(UtilErrorCodes.POST_DATA_ERROR, LegacyErrorCodeRegistry.find(10203).orElseThrow());
+  }
+
+  @Test
+  void utilNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            UtilErrorCodes.BASE64_DECODING_EXCEPTION.numericCode(),
+            AuditContext.empty(),
+            "input",
+            "detail");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void systemXmlCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(6001));
+    assertSame(XmlErrorCodes.RAW_XML_DUMP, LegacyErrorCodeRegistry.find(6001).orElseThrow());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(6028));
+    assertSame(
+        XmlErrorCodes.DTD_ELEMENT_NOTFOUND_ERROR,
+        LegacyErrorCodeRegistry.find(6028).orElseThrow());
+  }
+
+  @Test
+  void systemXmlNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc, XmlErrorCodes.XML_PROCESSING_ERROR.numericCode(), AuditContext.empty(), "sess");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void utilsXmlPackageLocalOneRemainsWorkflowInFlatRegistry() {
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertEquals(1, XmlErrorCodes.XML_ELEMENT_MISSING.numericCode());
+    assertFalse(XmlErrorCodes.XML_ELEMENT_MISSING.isAuditable());
+    assertEquals(6, XmlErrorCodes.XML_RESTORE_ERROR.numericCode());
+    assertSame(WorkflowErrorCodes.ACCESS_DENIED, LegacyErrorCodeRegistry.find(6).orElseThrow());
+  }
+
+  @Test
+  void beansNotFlatRegisteredButEnumIsNonAuditable() {
+    assertSame(ServerErrorCodes.NATIVE_ERROR, LegacyErrorCodeRegistry.find(1001).orElseThrow());
+    assertFalse(BeansErrorCodes.XML_PROCESSING_ERROR.isAuditable());
+    assertEquals(1001, BeansErrorCodes.XML_PROCESSING_ERROR.numericCode());
+  }
+
+  @Test
+  void tableFactoryNotFlatRegisteredButEnumIsNonAuditable() {
+    // Server owns flat 1001/1101/1201/1301 ranges
+    assertSame(ServerErrorCodes.NATIVE_ERROR, LegacyErrorCodeRegistry.find(1001).orElseThrow());
+    assertSame(
+        ServerErrorCodes.AUTHORIZATION_ERROR, LegacyErrorCodeRegistry.find(1101).orElseThrow());
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_NULL.isAuditable());
+    assertEquals(1001, TableFactoryErrorCodes.XML_ELEMENT_NULL.numericCode());
+    assertEquals(1310, TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND.numericCode());
+  }
+
+  @Test
+  void jbossNotFlatRegisteredButEnumIsNonAuditable() {
+    assertSame(WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertFalse(JBossErrorCodes.APP_POLICY_ELEMENT_MISSING.isAuditable());
+    assertEquals(1, JBossErrorCodes.APP_POLICY_ELEMENT_MISSING.numericCode());
+  }
+
+  @Test
+  void siteManageCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(18252));
+    assertSame(
+        SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD,
+        LegacyErrorCodeRegistry.find(18252).orElseThrow());
+    assertFalse(SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD.isAuditable());
+  }
+
+  @Test
+  void siteManageNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD.numericCode(),
+            AuditContext.empty());
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void registryCoversUtilXmlAndSiteManage() {
+    assertTrue(LegacyErrorCodeRegistry.size() >= 390);
+    assertTrue(LegacyErrorCodeRegistry.find(10001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(6001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(18252).isPresent());
   }
 
 }

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/BeansErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/BeansErrorCodesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import org.junit.jupiter.api.Test;
+
+class BeansErrorCodesTest {
+
+  @Test
+  void singleConstantIsNonAuditableSysModule() {
+    assertEquals(1, BeansErrorCodes.values().length);
+    BeansErrorCodes code = BeansErrorCodes.XML_PROCESSING_ERROR;
+    assertEquals(AuditModule.SYS, code.module());
+    assertEquals(1001, code.numericCode());
+    assertFalse(code.isAuditable());
+    assertNull(code.eventType());
+    assertNotNull(code.userMessageTemplate());
+    assertNotNull(code.logMessageTemplate());
+    assertTrue(code.qualifiedCode().startsWith("SYS-"));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/JBossErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/JBossErrorCodesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import org.junit.jupiter.api.Test;
+
+class JBossErrorCodesTest {
+
+  @Test
+  void singleLegacyContainerCodeIsNonAuditableCfgModule() {
+    assertEquals(1, JBossErrorCodes.values().length);
+    JBossErrorCodes code = JBossErrorCodes.APP_POLICY_ELEMENT_MISSING;
+    assertEquals(AuditModule.CFG, code.module());
+    assertEquals(1, code.numericCode());
+    assertFalse(code.isAuditable());
+    assertNull(code.eventType());
+    assertNotNull(code.userMessageTemplate());
+    assertNotNull(code.logMessageTemplate());
+    assertTrue(code.qualifiedCode().startsWith("CFG-"));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SiteManageErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SiteManageErrorCodesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import org.junit.jupiter.api.Test;
+
+class SiteManageErrorCodesTest {
+
+  @Test
+  void singleConstantIsNonAuditableCfgModule() {
+    assertEquals(1, SiteManageErrorCodes.values().length);
+    SiteManageErrorCodes code = SiteManageErrorCodes.SITE_MANAGE_SERVICE_DELETING_BAD_SITE_RECORD;
+    assertEquals(AuditModule.CFG, code.module());
+    assertEquals(18252, code.numericCode());
+    assertFalse(code.isAuditable());
+    assertNull(code.eventType());
+    assertNotNull(code.userMessageTemplate());
+    assertNotNull(code.logMessageTemplate());
+    assertTrue(code.qualifiedCode().startsWith("CFG-"));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/TableFactoryErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/TableFactoryErrorCodesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class TableFactoryErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleCfgAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (TableFactoryErrorCodes code : TableFactoryErrorCodes.values()) {
+      assertEquals(AuditModule.CFG, code.module());
+      assertTrue(code.numericCode() >= 1001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("CFG-"));
+    }
+    assertEquals(37, TableFactoryErrorCodes.values().length);
+  }
+
+  @Test
+  void allTableFactoryCodesAreNonAuditable() {
+    for (TableFactoryErrorCodes code : TableFactoryErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsTableFactoryErrorsNumericValues() {
+    assertEquals(1001, TableFactoryErrorCodes.XML_ELEMENT_NULL.numericCode());
+    assertEquals(1008, TableFactoryErrorCodes.LOG_FILE_WRITE_ERROR.numericCode());
+    assertEquals(1101, TableFactoryErrorCodes.DATA_TYPE_MAP_NOT_FOUND.numericCode());
+    assertEquals(1114, TableFactoryErrorCodes.INVALID_ENCODING.numericCode());
+    assertEquals(1201, TableFactoryErrorCodes.SQL_TABLE_META_DATA.numericCode());
+    assertEquals(1205, TableFactoryErrorCodes.SQL_CATALOG_DATA.numericCode());
+    assertEquals(1301, TableFactoryErrorCodes.SCHEMA_PROCESS_ERROR.numericCode());
+    assertEquals(1310, TableFactoryErrorCodes.DATA_HANDLER_CLASS_NOT_FOUND.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/UtilErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/UtilErrorCodesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class UtilErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (UtilErrorCodes code : UtilErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 10001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(6, UtilErrorCodes.values().length);
+  }
+
+  @Test
+  void allUtilCodesAreNonAuditable() {
+    for (UtilErrorCodes code : UtilErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsUtilErrorsNumericValues() {
+    assertEquals(10001, UtilErrorCodes.BASE64_ENCODING_EXCEPTION.numericCode());
+    assertEquals(10002, UtilErrorCodes.BASE64_DECODING_EXCEPTION.numericCode());
+    assertEquals(10051, UtilErrorCodes.COLLECTION_CLASS_NOT_FOUND.numericCode());
+    assertEquals(10101, UtilErrorCodes.PURGABLE_TEMP_DIR_IS_FILE.numericCode());
+    assertEquals(10202, UtilErrorCodes.RECEIVE_DATA_ERROR.numericCode());
+    assertEquals(10203, UtilErrorCodes.POST_DATA_ERROR.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/XmlErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/XmlErrorCodesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class XmlErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (XmlErrorCodes code : XmlErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 1, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(12, XmlErrorCodes.values().length);
+  }
+
+  @Test
+  void allXmlCodesAreNonAuditable() {
+    for (XmlErrorCodes code : XmlErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsXmlErrorsNumericValues() {
+    // utils package-local
+    assertEquals(1, XmlErrorCodes.XML_ELEMENT_MISSING.numericCode());
+    assertEquals(6, XmlErrorCodes.XML_RESTORE_ERROR.numericCode());
+    // system
+    assertEquals(6001, XmlErrorCodes.RAW_XML_DUMP.numericCode());
+    assertEquals(6002, XmlErrorCodes.XML_PROCESSING_ERROR.numericCode());
+    assertEquals(6025, XmlErrorCodes.DTD_IO_ERROR.numericCode());
+    assertEquals(6028, XmlErrorCodes.DTD_ELEMENT_NOTFOUND_ERROR.numericCode());
+  }
+}


### PR DESCRIPTION
## Summary
Parent epic: **#2616** (system audit log Phase 2b residual). Implements free residual **#2889** after #2882/#2880 peers.

Migrates remaining **utils / XML / beans / table factory / JBoss / SiteManage** legacy `IPS*Errors` ints into package `*ErrorCodes` enums with explicit `isAuditable`, collision-safe `LegacyErrorCodeRegistry` registration, dual-write skip tests, and README collision notes.

### Catalogs
| Enum | Legacy source | Flat registry | Auditable |
|------|---------------|---------------|-----------|
| `UtilErrorCodes` | `IPSUtilErrors` 10001–10203 | full | all `false` |
| `XmlErrorCodes` | utils `IPSXmlErrors` 1–6 + system 6001–6028 | system only (6001+) | all `false` |
| `BeansErrorCodes` | `IPSBeansErrors` 1001 | none (Server owns 1001) | `false` |
| `TableFactoryErrorCodes` | `IPSTableFactoryErrors` 1001–1310 | none (Server range) | all `false` |
| `JBossErrorCodes` | `IPSJBossErrors` 1 (legacy container) | none (WF owns 1) | `false` |
| `SiteManageErrorCodes` | `IPSSiteManageErrors` 18252 | full | `false` |

**Out of scope (as issue directed):** Data/BackEnd/Publisher catalogs owned by open #2887/#2888. Further ObjectStore/CMS residuals already filed as #2898–#2900.

## Test plan
- [x] `cd modules/perc-auditlog && ../../mvnw.cmd clean install`
- [x] BUILD SUCCESS — Tests run: **193**, Failures: 0, Errors: 0, Skipped: 0
- [x] Dual-write skip tests for flat-registered non-auditable util/xml/site-manage ints
- [x] Collision assertions: WF keeps bare 1–6; Server keeps 1001/1101; beans/table/jboss enum-only

## Product documentation
- [x] N/A — pure auditlog tech-debt / ErrorCodes catalog migration; no operator-, admin-, integrator-, or end-user-facing product surface change

## Build evidence (C3)
- **modules_built:** `modules/perc-auditlog`
- **build_evidence:** `cd modules/perc-auditlog; ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 193, Failures: 0
- **downstream_checked:** none — no `final`/`sealed` API shape change; additive enums + registry bootstrap only; reverse-dep compile surface unchanged

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2889
Parent: #2616

> Co-Authored by Grok Build using grok-4.5 with agent main.
