### PR TITLE
feat(auditlog): CMS/ContentExplorer/Remote/SystemService ErrorCodes (#2900)

### DIFF
--- a/modules/perc-auditlog/README.md
+++ b/modules/perc-auditlog/README.md
@@ -18,7 +18,10 @@ System-wide Percussion CMS audit logging and unified error-code support.
   `WebserviceErrorCodes` (package-local 28–73), `ServerWebServicesErrorCodes`, `WebdavErrorCodes`,
   `ServletErrorCodes`, `TransformationErrorCodes` (enum-only),
   `SearchErrorCodes` (`IPSSearchErrors`; auth failure dual-write), `LuceneErrorCodes`,
-  `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable)
+  `LocaleErrorCodes`, `MailErrorCodes` (all non-auditable),
+  `CmsErrorCodes` (residual `IPSCmsErrors` after `PathItemErrorCodes`; all non-auditable),
+  `ContentExplorerErrorCodes`, `RemoteErrorCodes` (all non-auditable),
+  `SystemServiceErrorCodes` (enum-only; WF owns bare 1/4)
   + `LegacyErrorCodeRegistry` bridge legacy `IPS*Errors` ints. Non-auditable / unregistered ints never
   dual-write. Central `PSErrorHandler.appendError` dual-writes only when the registry marks the legacy
   int auditable.
@@ -65,7 +68,9 @@ audit.log(
 ```java
 import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
@@ -75,11 +80,13 @@ import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.RemoteErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SystemServiceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
@@ -128,6 +135,10 @@ LegacyErrorCodeRegistry.logIfAuditable(audit, 16311, ctx); // Lucene index dir �
 | `LuceneErrorCodes` | 16311–16456 (`IPSLuceneErrors`) | All non-auditable index/query codes |
 | `LocaleErrorCodes` | 1801–1804 (`IPSLocaleErrors`) | All non-auditable |
 | `MailErrorCodes` | 3501–3508 (`IPSMailErrors`) | All non-auditable |
+| `CmsErrorCodes` | residual `IPSCmsErrors` 13001–14000 | All non-auditable; skips PathItem-owned ints + SQL 1002 (Server) |
+| `ContentExplorerErrorCodes` | 20001–20011 (`IPSContentExplorerErrors`) | All non-auditable UI/client codes |
+| `RemoteErrorCodes` | 15001–15002 (`IPSRemoteErrors`) | All non-auditable SOAP/transport |
+| `SystemServiceErrorCodes` | package-local 1, 4 (`IPSSystemErrors`) | Enum-only; WF owns bare 1/4 in flat registry |
 
 Non-auditable codes (`isAuditable() == false`) never create audit rows.
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistry.java
@@ -17,7 +17,9 @@
 package com.intsof.percussioncms.auditlog;
 
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
@@ -27,11 +29,13 @@ import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.RemoteErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SystemServiceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
@@ -55,9 +59,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * package-local ints, non-colliding {@link WebserviceErrorCodes} package-local ints (28–73), fully
  * unique {@link ServerWebServicesErrorCodes} / {@link WebdavErrorCodes} / {@link ServletErrorCodes},
  * fully unique {@link SearchErrorCodes} / {@link LuceneErrorCodes} / {@link LocaleErrorCodes} /
- * {@link MailErrorCodes}, and bootstrap-only {@link TransformationErrorCodes} / {@link
- * DeliveryErrorCodes} (no flat register). Residual slices may register additional catalogs via
- * {@link #register(int, SystemErrorCode)}.
+ * {@link MailErrorCodes}, residual CMS {@link CmsErrorCodes} (skips PathItem-owned ints), fully
+ * unique {@link ContentExplorerErrorCodes} / {@link RemoteErrorCodes}, bootstrap-only {@link
+ * SystemServiceErrorCodes} / {@link TransformationErrorCodes} / {@link DeliveryErrorCodes} (no flat
+ * register). Residual slices may register additional catalogs via {@link #register(int,
+ * SystemErrorCode)}.
  */
 public final class LegacyErrorCodeRegistry {
 
@@ -72,14 +78,16 @@ public final class LegacyErrorCodeRegistry {
   /**
    * Ensure Phase 2b catalogs are loaded (auth/security, content, workflow, path/item, design,
    * server, HTTP, assembly, extension, delivery, job, webservices, WebDAV, servlet, search,
-   * Lucene, locale, mail, transformation). Safe to call repeatedly; catalogs register themselves
-   * in their own static initializers. {@link AssemblyErrorCodes} and {@link JobErrorCodes} skip
-   * package-local ints {@code 1–10} that collide with {@link WorkflowErrorCodes}. {@link
-   * JobErrorCodes} is bootstrapped after assembly so flat int {@code 11} ({@code
-   * CONFIG_FILE_NOT_FOUND}) wins over assembly package-local {@code MISSING_SLOT} (prefer enum for
-   * assembly {@code 11}). {@link WebserviceErrorCodes} skips package-local ints {@code 1–27};
-   * {@link TransformationErrorCodes} and {@link DeliveryErrorCodes} do not flat-register. Search /
-   * Lucene / Locale / Mail ints are globally unique and fully registered.
+   * Lucene, locale, mail, residual CMS, Content Explorer, remote, system-service, transformation).
+   * Safe to call repeatedly; catalogs register themselves in their own static initializers. {@link
+   * AssemblyErrorCodes} and {@link JobErrorCodes} skip package-local ints {@code 1–10} that collide
+   * with {@link WorkflowErrorCodes}. {@link JobErrorCodes} is bootstrapped after assembly so flat
+   * int {@code 11} ({@code CONFIG_FILE_NOT_FOUND}) wins over assembly package-local {@code
+   * MISSING_SLOT} (prefer enum for assembly {@code 11}). {@link WebserviceErrorCodes} skips
+   * package-local ints {@code 1–27}; {@link TransformationErrorCodes}, {@link DeliveryErrorCodes},
+   * and {@link SystemServiceErrorCodes} do not flat-register. Search / Lucene / Locale / Mail /
+   * Content Explorer / Remote ints are globally unique and fully registered. {@link CmsErrorCodes}
+   * registers residual CMS ints after {@link PathItemErrorCodes} so path ownership is preserved.
    */
   public static void bootstrap() {
     if (BOOTSTRAPPED.compareAndSet(false, true)) {
@@ -109,6 +117,12 @@ public final class LegacyErrorCodeRegistry {
       LuceneErrorCodes.ensureRegistered();
       LocaleErrorCodes.ensureRegistered();
       MailErrorCodes.ensureRegistered();
+      // CMS/CX/Remote/System residual (#2900): PathItem first; residual CMS; unique CX/Remote;
+      // system-service enum-only (WF owns bare 1/4).
+      CmsErrorCodes.ensureRegistered();
+      ContentExplorerErrorCodes.ensureRegistered();
+      RemoteErrorCodes.ensureRegistered();
+      SystemServiceErrorCodes.ensureRegistered();
     }
   }
 

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/CmsErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/CmsErrorCodes.java
@@ -1,0 +1,716 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * CMS error catalog bridging residual legacy {@code com.percussion.cms.IPSCmsErrors} ints
+ * (13001–14000 general / objectstore / server-side OS handlers).
+ *
+ * <p>Path / folder / item permission codes remain owned by {@link PathItemErrorCodes} (registered
+ * first; this catalog skips those ints). Legacy {@code SQL_EXCEPTION_WRAPPER = 1002} collides with
+ * {@link ServerErrorCodes#SQL_PROBLEM} and is not re-registered here — prefer Server for flat
+ * dual-write of 1002.
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: residual CMS codes are operational
+ * objectstore / AA / relationship noise. Security dual-write for folder/community denials stays on
+ * {@link PathItemErrorCodes}. Module code is {@link AuditModule#CONT}.
+ *
+ * <p>All residual ints in the 13001–14000 range are globally unique and fully flat-registered.
+ */
+public enum CmsErrorCodes implements SystemErrorCode {
+
+  CORRUPT_DATABASE_ENTRY(
+      13001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Corrupt database entry",
+      "Corrupt database entry detail={}"),
+  INVALID_CONTENT_TYPE_ID(
+      13002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid content type id",
+      "Invalid content type id detail={}"),
+  ERROR_SEND_DATA(
+      13003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Error send data",
+      "Error send data detail={}"),
+  RECEIVED_UNKNOWN_DATA(
+      13004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Received unknown data",
+      "Received unknown data detail={}"),
+  INVALID_CONTENT_TYPE(
+      13102,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid content type",
+      "Invalid content type detail={}"),
+  CONTENT_TYPE_CANNOT_BE_OPENED(
+      13103,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content type cannot be opened",
+      "Content type cannot be opened detail={}"),
+  DATA_EXTRACTION_ERROR_NULL_DATAPIPE(
+      13106,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Data extraction error null datapipe",
+      "Data extraction error null datapipe detail={}"),
+  PSFIELDVALUE_TO_STRING_ERROR(
+      13105,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Psfieldvalue to string error",
+      "Psfieldvalue to string error detail={}"),
+  REQUIRED_DOCUMENT_MISSING_ERROR(
+      13107,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Required document missing error",
+      "Required document missing error detail={}"),
+  MALFORMED_XML_DOCUMENT_UKNOWN_NODE_TYPE(
+      13108,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Malformed xml document uknown node type",
+      "Malformed xml document uknown node type detail={}"),
+  CMS_INTERNAL_REQUEST_ERROR(
+      13109,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cms internal request error",
+      "Cms internal request error detail={}"),
+  KEY_PARTS_NOT_MATCH(
+      13110,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Key parts not match",
+      "Key parts not match detail={}"),
+  KEY_NOT_ASSIGNED(
+      13111,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Key not assigned",
+      "Key not assigned detail={}"),
+  UNSUPPORTED_COMPONENT_TYPE(
+      13112,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unsupported component type",
+      "Unsupported component type detail={}"),
+  MISSING_PROPERTY(
+      13113,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing property",
+      "Missing property detail={}"),
+  SERIALIZED_COMPONENTS_WRONG_XML_DOC(
+      13114,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Serialized components wrong xml doc",
+      "Serialized components wrong xml doc detail={}"),
+  EMPTY_XML_DOCUMENT(
+      13115,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Empty xml document",
+      "Empty xml document detail={}"),
+  REQUIRED_RESOURCE_MISSING(
+      13116,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Required resource missing",
+      "Required resource missing detail={}"),
+  PROCESSOR_CONFIG_MISSING(
+      13117,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Processor config missing",
+      "Processor config missing detail={}"),
+  XML_PARSING_ERROR(
+      13118,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Xml parsing error",
+      "Xml parsing error detail={}"),
+  DUPLICATE_PROCESSOR_PROPERTY(
+      13119,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate processor property",
+      "Duplicate processor property detail={}"),
+  DUPLICATE_PROCESSOR_ENTRY(
+      13120,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Duplicate processor entry",
+      "Duplicate processor entry detail={}"),
+  NO_PROCESSOR_ENTRY(
+      13121,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No processor entry",
+      "No processor entry detail={}"),
+  PROCESSOR_NO_SUCH_METHOD(
+      13122,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Processor no such method",
+      "Processor no such method detail={}"),
+  PROCESSOR_BAD_HERITAGE(
+      13123,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Processor bad heritage",
+      "Processor bad heritage detail={}"),
+  PROCESSOR_INSTANTIATION_ERROR(
+      13124,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Processor instantiation error",
+      "Processor instantiation error detail={}"),
+  COMPONENT_INSTANTIATION_ERROR(
+      13125,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Component instantiation error",
+      "Component instantiation error detail={}"),
+  KEY_MISMATCH(
+      13126,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Key mismatch",
+      "Key mismatch detail={}"),
+  TOO_MANY_FOREIGN_KEY_PARTS(
+      13127,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Too many foreign key parts",
+      "Too many foreign key parts detail={}"),
+  TOO_FEW_FOREIGN_KEY_PARTS(
+      13128,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Too few foreign key parts",
+      "Too few foreign key parts detail={}"),
+  LIST_ENTRY_INSTANTIATION_ERROR(
+      13129,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "List entry instantiation error",
+      "List entry instantiation error detail={}"),
+  INVALID_ENTRY_CLASSNAME(
+      13130,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid entry classname",
+      "Invalid entry classname detail={}"),
+  MISSING_LOOKUP_KEY(
+      13131,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing lookup key",
+      "Missing lookup key detail={}"),
+  MISMATCH_BETWEEN_KEY_AND_DATA(
+      13132,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Mismatch between key and data",
+      "Mismatch between key and data detail={}"),
+  COMM_ERROR_WITH_SERVER(
+      13133,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Comm error with server",
+      "Comm error with server detail={}"),
+  SAX_PROCESSING_EXCEPTION(
+      13134,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Sax processing exception",
+      "Sax processing exception detail={}"),
+  MISSING_HTML_PARAMETER(
+      13135,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing html parameter",
+      "Missing html parameter detail={}"),
+  FAIL_GET_COMPONENT_SUMMARIES(
+      13136,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Fail get component summaries",
+      "Fail get component summaries detail={}"),
+  CONTENTTYPE_DEFINITION_NOT_FOUND(
+      13140,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Contenttype definition not found",
+      "Contenttype definition not found detail={}"),
+  UNKNOWN_RELATED_TYPE(
+      13146,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown related type",
+      "Unknown related type detail={}"),
+  INVALID_RELATED_TYPE(
+      13147,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid related type",
+      "Invalid related type detail={}"),
+  FOLDERID_REF_BY_CROSS_SITE_LINK(
+      13144,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Folderid ref by cross site link",
+      "Folderid ref by cross site link detail={}"),
+  SITEID_REF_BY_CROSS_SITE_LINK(
+      13145,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Siteid ref by cross site link",
+      "Siteid ref by cross site link detail={}"),
+  INVALID_CHILD_TYPE(
+      13148,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid child type",
+      "Invalid child type detail={}"),
+  UNKNOWN_RELATIONSHIP_TYPE(
+      13201,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown relationship type",
+      "Unknown relationship type detail={}"),
+  UNEXPECTED_KEY_TYPE(
+      13202,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected key type",
+      "Unexpected key type detail={}"),
+  PERSISTED_KEY_EXPECTED(
+      13203,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Persisted key expected",
+      "Persisted key expected detail={}"),
+  INVALID_INSERT_RELATIONSHIP_TYPE(
+      13204,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid insert relationship type",
+      "Invalid insert relationship type detail={}"),
+  ID_GENERATOR_FAILED(
+      13205,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Id generator failed",
+      "Id generator failed detail={}"),
+  UNEXPECTED_ERROR(
+      13206,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected error",
+      "Unexpected error detail={}"),
+  INVALID_AA_RELATIONSHIP_TYPE(
+      13207,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid aa relationship type",
+      "Invalid aa relationship type detail={}"),
+  UNKNOWN_AA_COMMAND(
+      13208,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unknown aa command",
+      "Unknown aa command detail={}"),
+  MISSING_AA_PARAMETER(
+      13209,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing aa parameter",
+      "Missing aa parameter detail={}"),
+  PROCESSOR_CONFIG_IO_ERROR(
+      13210,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Processor config io error",
+      "Processor config io error detail={}"),
+  UNDEFINED_DEFAULT_TRANSITION(
+      13211,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Undefined default transition",
+      "Undefined default transition detail={}"),
+  FAIL_DELETE_NON_FOLDER(
+      13213,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Fail delete non folder",
+      "Fail delete non folder detail={}"),
+  GET_SUMMARIES_ERROR(
+      13214,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Get summaries error",
+      "Get summaries error detail={}"),
+  UNEXPECTED_CATALOG_ERROR(
+      13215,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unexpected catalog error",
+      "Unexpected catalog error detail={}"),
+  INVALID_RELATIONSHIP_PROP_VALUE(
+      13217,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid relationship prop value",
+      "Invalid relationship prop value detail={}"),
+  NO_ORIGINATING_RELATIONSHIP(
+      13218,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "No originating relationship",
+      "No originating relationship detail={}"),
+  VALIDATION_ERROR(
+      13219,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Validation error",
+      "Validation error detail={}"),
+  SEARCH_ERROR(
+      13220,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Search error",
+      "Search error detail={}"),
+  MODIFY_ERROR_DUPLICATED_CHILDNAME(
+      13221,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Modify error duplicated childname",
+      "Modify error duplicated childname detail={}"),
+  FAILED_GET_SUMMARY(
+      13223,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed get summary",
+      "Failed get summary detail={}"),
+  RELATIONSHIP_EXISTENCE_CHECK_FAILED(
+      13225,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Relationship existence check failed",
+      "Relationship existence check failed detail={}"),
+  NON_EXITING_OWNER(
+      13226,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Non exiting owner",
+      "Non exiting owner detail={}"),
+  NON_EXITING_DEPENDENT(
+      13227,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Non exiting dependent",
+      "Non exiting dependent detail={}"),
+  INVALID_AUTHTYPE(
+      13229,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid authtype",
+      "Invalid authtype detail={}"),
+  INVALID_AA_RELATIONSHIP(
+      13230,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid aa relationship",
+      "Invalid aa relationship detail={}"),
+  VARIANT_LOOKUP_FAILED(
+      13231,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Variant lookup failed",
+      "Variant lookup failed detail={}"),
+  INVALID_AA_RELATIONSHIP_SLOT_VARIANT(
+      13232,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid aa relationship slot variant",
+      "Invalid aa relationship slot variant detail={}"),
+  INVALID_CONTEXT_FOR_AA_PROXY(
+      13233,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid context for aa proxy",
+      "Invalid context for aa proxy detail={}"),
+  ERROR_RECURSIVEASSEMBLY(
+      13234,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Error recursiveassembly",
+      "Error recursiveassembly detail={}"),
+  FAILED_GET_REL_CONFIG_FROM_XML(
+      13236,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed get rel config from xml",
+      "Failed get rel config from xml detail={}"),
+  UNKOWN_SYS_REL_CONFIG_ID(
+      13238,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Unkown sys rel config id",
+      "Unkown sys rel config id detail={}"),
+  FAILED_DELETE_REL_CONFIG_NAME(
+      13240,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed delete rel config name",
+      "Failed delete rel config name detail={}"),
+  INVALID_REL_CONFIG_ID(
+      13241,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid rel config id",
+      "Invalid rel config id detail={}"),
+  INVALID_REL_CONFIG_NAME(
+      13242,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Invalid rel config name",
+      "Invalid rel config name detail={}"),
+  ERROR_LOADING_SITES(
+      13243,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Error loading sites",
+      "Error loading sites detail={}"),
+  CANNOT_MOVE_CHECKEDOUT_ITEMS(
+      13244,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot move checkedout items",
+      "Cannot move checkedout items detail={}"),
+  CANNOT_MOVE_PUBLIC_ITEMS(
+      13245,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Cannot move public items",
+      "Cannot move public items detail={}"),
+  FORCE_MOVE_REMOVE_REQUIED(
+      13246,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Force move remove requied",
+      "Force move remove requied detail={}"),
+  ERROR_SAVING_RELATIONSHIPS(
+      13247,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Error saving relationships",
+      "Error saving relationships detail={}"),
+  LOAD_AA_RELATIONSHIP_FAILED(
+      13248,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Load aa relationship failed",
+      "Load aa relationship failed detail={}"),
+  CROSSSITE_LINK_PROCESS_MULTI_ERROR(
+      13249,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Crosssite link process multi error",
+      "Crosssite link process multi error detail={}"),
+  FAILED_GET_NAVON_CIRCULAR_AA_RELATIONSHIP(
+      13250,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Failed get navon circular aa relationship",
+      "Failed get navon circular aa relationship detail={}");
+
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  CmsErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register residual CMS ints in {@link LegacyErrorCodeRegistry}. Safe to call repeatedly.
+   * Does not include PathItem-owned ints or SQL_EXCEPTION_WRAPPER (1002).
+   */
+  public static void ensureRegistered() {
+    for (CmsErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.CONT;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentExplorerErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/ContentExplorerErrorCodes.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Content Explorer error catalog bridging legacy {@code
+ * com.percussion.cx.error.IPSContentExplorerErrors} ints (20001–20011: options, actions, search,
+ * catalog, wizard, path, site-def).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: Content Explorer UI / client
+ * operational failures are not security dual-write events.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum ContentExplorerErrorCodes implements SystemErrorCode {
+
+  GENERAL_ERROR(
+      20001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer general error",
+      "Content explorer general error detail={}"),
+
+  PSCLASS_INSTANTIATION_ERROR(
+      20002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer class instantiation error",
+      "Content explorer class instantiation error class={} node={}"),
+
+  MISC_PROCESSING_OPTIONS_ERROR(
+      20003,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer options processing error",
+      "Content explorer options processing error detail={}"),
+
+  OPTIONS_LOAD_ERROR(
+      20004,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer options load error",
+      "Content explorer options load error detail={}"),
+
+  OPTIONS_SAVE_ERROR(
+      20005,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer options save error",
+      "Content explorer options save error detail={}"),
+
+  ACTION_GET_CHILDREN(
+      20006,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer action get children error",
+      "Content explorer action get children error detail={}"),
+
+  SEARCH_ERROR(
+      20007,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer search error",
+      "Content explorer search error detail={}"),
+
+  CATALOG_ERROR(
+      20008,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer catalog error",
+      "Content explorer catalog error detail={}"),
+
+  WIZARD_VALIDATION_ERROR(
+      20009,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer wizard validation error",
+      "Content explorer wizard validation error detail={}"),
+
+  INCOMPATIBLE_PATHS(
+      20010,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer incompatible paths",
+      "Content explorer incompatible paths root={} relative={}"),
+
+  SITEDEF_UPDATE_FAILURES(
+      20011,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Content explorer site definition update failures",
+      "Content explorer site definition update failures detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  ContentExplorerErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (ContentExplorerErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/RemoteErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/RemoteErrorCodes.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * Remote agent error catalog bridging legacy {@code
+ * com.percussion.cms.objectstore.client.IPSRemoteErrors} ints (15001–15002: SOAP response / transport
+ * failures).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: remote client transport failures
+ * are operational noise, not security dual-write events.
+ *
+ * <p>All ints are globally unique and fully flat-registered in {@link LegacyErrorCodeRegistry}.
+ * Module code is {@link AuditModule#SYS}.
+ */
+public enum RemoteErrorCodes implements SystemErrorCode {
+
+  REMOTE_WRONG_SOAP_RESP(
+      15001,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Remote wrong SOAP response",
+      "Remote wrong SOAP response expected={} actual={}"),
+
+  REMOTE_UNEXPECTED_ERROR(
+      15002,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Remote unexpected error",
+      "Remote unexpected error detail={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  RemoteErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Register (or re-register) all constants in {@link LegacyErrorCodeRegistry}. Safe to call
+   * repeatedly — used by registry bootstrap and tests after {@code clearForTests}.
+   */
+  public static void ensureRegistered() {
+    for (RemoteErrorCodes code : values()) {
+      LegacyErrorCodeRegistry.register(code.numericCode(), code);
+    }
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SystemServiceErrorCodes.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/codes/SystemServiceErrorCodes.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import com.intsof.percussioncms.auditlog.AuditEventType;
+import com.intsof.percussioncms.auditlog.AuditModule;
+import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+
+/**
+ * System service error catalog bridging legacy {@code
+ * com.percussion.services.system.IPSSystemErrors} package-local ints ({@code
+ * MISSING_SHARED_PROPERTY = 1}, {@code ERROR_DETERMINING_FOLDER_READ = 4}).
+ *
+ * <p>Every constant sets {@link #isAuditable()} to {@code false}: system-service property / folder
+ * read failures are operational noise, not security dual-write events.
+ *
+ * <p><strong>Flat registry collision:</strong> package-local ints {@code 1} and {@code 4} already
+ * belong to {@link WorkflowErrorCodes} in {@link LegacyErrorCodeRegistry}. This catalog therefore
+ * does <strong>not</strong> flat-register any ints. Call sites should prefer this enum directly
+ * until a composite-key registry exists. Module code is {@link AuditModule#SYS}.
+ */
+public enum SystemServiceErrorCodes implements SystemErrorCode {
+
+  MISSING_SHARED_PROPERTY(
+      1,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Missing shared property",
+      "Missing shared property id={}"),
+
+  ERROR_DETERMINING_FOLDER_READ(
+      4,
+      false,
+      null,
+      AuditOutcome.UNKNOWN,
+      "Error determining folder read",
+      "Error determining folder read contentId={}");
+
+  private final int numericCode;
+  private final boolean auditable;
+  private final AuditEventType eventType;
+  private final AuditOutcome defaultOutcome;
+  private final String userMessageTemplate;
+  private final String logMessageTemplate;
+
+  SystemServiceErrorCodes(
+      int numericCode,
+      boolean auditable,
+      AuditEventType eventType,
+      AuditOutcome defaultOutcome,
+      String userMessageTemplate,
+      String logMessageTemplate) {
+    this.numericCode = numericCode;
+    this.auditable = auditable;
+    this.eventType = eventType;
+    this.defaultOutcome = defaultOutcome;
+    this.userMessageTemplate = userMessageTemplate;
+    this.logMessageTemplate = logMessageTemplate;
+  }
+
+  static {
+    ensureRegistered();
+  }
+
+  /**
+   * Bootstrap / test hook. Does not flat-register package-local ints {@code 1} / {@code 4} (WF
+   * ownership). Safe to call repeatedly.
+   */
+  public static void ensureRegistered() {
+    // No-op flat register — preserve WorkflowErrorCodes ownership of bare ints 1 and 4.
+  }
+
+  @Override
+  public AuditModule module() {
+    return AuditModule.SYS;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public String userMessageTemplate() {
+    return userMessageTemplate;
+  }
+
+  @Override
+  public String logMessageTemplate() {
+    return logMessageTemplate;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return auditable;
+  }
+
+  @Override
+  public AuditEventType eventType() {
+    return eventType;
+  }
+
+  @Override
+  public AuditOutcome defaultOutcome() {
+    return defaultOutcome;
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -22,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.intsof.percussioncms.auditlog.codes.AssemblyErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ContentErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DeliveryErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.DesignErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
@@ -32,11 +34,13 @@ import com.intsof.percussioncms.auditlog.codes.LocaleErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.MailErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.RemoteErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServerWebServicesErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SystemServiceErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.TransformationErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
@@ -845,6 +849,123 @@ class LegacyErrorCodeRegistryTest {
     assertTrue(LegacyErrorCodeRegistry.find(16311).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(1801).isPresent());
     assertTrue(LegacyErrorCodeRegistry.find(3501).isPresent());
+  }
+
+  // --- CMS / ContentExplorer / Remote / SystemService residual (#2900) ---
+
+  @Test
+  void residualCmsCodeIsRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(13001));
+    assertSame(
+        CmsErrorCodes.CORRUPT_DATABASE_ENTRY, LegacyErrorCodeRegistry.find(13001).orElseThrow());
+    assertFalse(CmsErrorCodes.CORRUPT_DATABASE_ENTRY.isAuditable());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(13250));
+    assertSame(
+        CmsErrorCodes.FAILED_GET_NAVON_CIRCULAR_AA_RELATIONSHIP,
+        LegacyErrorCodeRegistry.find(13250).orElseThrow());
+  }
+
+  @Test
+  void residualCmsNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "app/resource",
+            "boom");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void pathItemStillOwnsFolderPermissionDeniedAfterCmsResidual() {
+    // PathItem registered before CmsErrorCodes; residual CMS skips 13007.
+    assertSame(
+        PathItemErrorCodes.FOLDER_PERMISSION_DENIED,
+        LegacyErrorCodeRegistry.find(13007).orElseThrow());
+    assertTrue(LegacyErrorCodeRegistry.isAuditable(13007));
+  }
+
+  @Test
+  void contentExplorerCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(20001));
+    assertSame(
+        ContentExplorerErrorCodes.GENERAL_ERROR, LegacyErrorCodeRegistry.find(20001).orElseThrow());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(20011));
+    assertSame(
+        ContentExplorerErrorCodes.SITEDEF_UPDATE_FAILURES,
+        LegacyErrorCodeRegistry.find(20011).orElseThrow());
+  }
+
+  @Test
+  void contentExplorerNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            ContentExplorerErrorCodes.SEARCH_ERROR.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "search failed");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void remoteCodesAreRegisteredButNotAuditable() {
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(15001));
+    assertSame(
+        RemoteErrorCodes.REMOTE_WRONG_SOAP_RESP, LegacyErrorCodeRegistry.find(15001).orElseThrow());
+    assertFalse(LegacyErrorCodeRegistry.isAuditable(15002));
+    assertSame(
+        RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR,
+        LegacyErrorCodeRegistry.find(15002).orElseThrow());
+  }
+
+  @Test
+  void remoteNonAuditableSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR.numericCode(),
+            AuditContext.empty(),
+            "timeout");
+
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void systemServicePackageLocalDoesNotClobberWorkflowInFlatRegistry() {
+    // SystemService ints 1 and 4 intentionally not registered; Workflow owns bare 1–10.
+    assertSame(
+        WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
+    assertEquals(1, SystemServiceErrorCodes.MISSING_SHARED_PROPERTY.numericCode());
+    assertFalse(SystemServiceErrorCodes.MISSING_SHARED_PROPERTY.isAuditable());
+    assertEquals(4, SystemServiceErrorCodes.ERROR_DETERMINING_FOLDER_READ.numericCode());
+    assertFalse(SystemServiceErrorCodes.ERROR_DETERMINING_FOLDER_READ.isAuditable());
+  }
+
+  @Test
+  void registryCoversCmsContentExplorerRemoteAndSystemService() {
+    assertTrue(LegacyErrorCodeRegistry.size() >= 470);
+    assertTrue(LegacyErrorCodeRegistry.find(13001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(13007).isPresent()); // PathItem
+    assertTrue(LegacyErrorCodeRegistry.find(15001).isPresent());
+    assertTrue(LegacyErrorCodeRegistry.find(20001).isPresent());
+    // SystemService not flat-registered:
+    assertSame(
+        WorkflowErrorCodes.WORKFLOW_NOT_FOUND, LegacyErrorCodeRegistry.find(1).orElseThrow());
   }
 
 }

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/CmsErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/CmsErrorCodesTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class CmsErrorCodesTest {
+
+  @Test
+  void everyConstantHasContModuleUniqueNumericAndTemplates() {
+    Set<Integer> seen = new HashSet<>();
+    for (CmsErrorCodes code : CmsErrorCodes.values()) {
+      assertEquals(AuditModule.CONT, code.module());
+      assertTrue(code.numericCode() >= 13001, code.name());
+      assertTrue(code.numericCode() <= 14000, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("CONT-"));
+    }
+    assertEquals(86, CmsErrorCodes.values().length);
+  }
+
+  @Test
+  void allResidualCmsCodesAreNonAuditable() {
+    for (CmsErrorCodes code : CmsErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsCmsErrorsNumericValues() {
+    assertEquals(13001, CmsErrorCodes.CORRUPT_DATABASE_ENTRY.numericCode());
+    assertEquals(13003, CmsErrorCodes.ERROR_SEND_DATA.numericCode());
+    assertEquals(13109, CmsErrorCodes.CMS_INTERNAL_REQUEST_ERROR.numericCode());
+    assertEquals(13201, CmsErrorCodes.UNKNOWN_RELATIONSHIP_TYPE.numericCode());
+    assertEquals(13250, CmsErrorCodes.FAILED_GET_NAVON_CIRCULAR_AA_RELATIONSHIP.numericCode());
+  }
+
+  @Test
+  void doesNotClaimPathItemOwnedInts() {
+    Set<Integer> cmsNums = new HashSet<>();
+    for (CmsErrorCodes code : CmsErrorCodes.values()) {
+      cmsNums.add(code.numericCode());
+    }
+    // PathItemErrorCodes owns these folder/permission dual-write ints.
+    assertFalse(cmsNums.contains(13007));
+    assertFalse(cmsNums.contains(13008));
+    assertFalse(cmsNums.contains(13138));
+    assertFalse(cmsNums.contains(13212));
+    assertFalse(cmsNums.contains(13235));
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ContentExplorerErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/ContentExplorerErrorCodesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ContentExplorerErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (ContentExplorerErrorCodes code : ContentExplorerErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 20001, code.name());
+      assertTrue(code.numericCode() <= 20011, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(11, ContentExplorerErrorCodes.values().length);
+  }
+
+  @Test
+  void allContentExplorerCodesAreNonAuditable() {
+    for (ContentExplorerErrorCodes code : ContentExplorerErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsContentExplorerErrorsNumericValues() {
+    assertEquals(20001, ContentExplorerErrorCodes.GENERAL_ERROR.numericCode());
+    assertEquals(20004, ContentExplorerErrorCodes.OPTIONS_LOAD_ERROR.numericCode());
+    assertEquals(20007, ContentExplorerErrorCodes.SEARCH_ERROR.numericCode());
+    assertEquals(20010, ContentExplorerErrorCodes.INCOMPATIBLE_PATHS.numericCode());
+    assertEquals(20011, ContentExplorerErrorCodes.SITEDEF_UPDATE_FAILURES.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/RemoteErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/RemoteErrorCodesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RemoteErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (RemoteErrorCodes code : RemoteErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() >= 15001, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(2, RemoteErrorCodes.values().length);
+  }
+
+  @Test
+  void allRemoteCodesAreNonAuditable() {
+    for (RemoteErrorCodes code : RemoteErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsRemoteErrorsNumericValues() {
+    assertEquals(15001, RemoteErrorCodes.REMOTE_WRONG_SOAP_RESP.numericCode());
+    assertEquals(15002, RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR.numericCode());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SystemServiceErrorCodesTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/codes/SystemServiceErrorCodesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog.codes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditModule;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class SystemServiceErrorCodesTest {
+
+  @Test
+  void everyConstantHasExplicitModuleSysAndUniqueNumericCode() {
+    Set<Integer> seen = new HashSet<>();
+    for (SystemServiceErrorCodes code : SystemServiceErrorCodes.values()) {
+      assertEquals(AuditModule.SYS, code.module());
+      assertTrue(code.numericCode() > 0, code.name());
+      assertTrue(seen.add(code.numericCode()), "duplicate numeric: " + code.numericCode());
+      assertNotNull(code.userMessageTemplate());
+      assertNotNull(code.logMessageTemplate());
+      assertTrue(code.qualifiedCode().startsWith("SYS-"));
+    }
+    assertEquals(2, SystemServiceErrorCodes.values().length);
+  }
+
+  @Test
+  void allSystemServiceCodesAreNonAuditable() {
+    for (SystemServiceErrorCodes code : SystemServiceErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertNull(code.eventType(), code.name());
+    }
+  }
+
+  @Test
+  void preservesLegacyIpsSystemErrorsNumericValues() {
+    assertEquals(1, SystemServiceErrorCodes.MISSING_SHARED_PROPERTY.numericCode());
+    assertEquals(4, SystemServiceErrorCodes.ERROR_DETERMINING_FOLDER_READ.numericCode());
+  }
+}

--- a/system/services/src/com/percussion/services/system/IPSSystemErrors.java
+++ b/system/services/src/com/percussion/services/system/IPSSystemErrors.java
@@ -19,6 +19,12 @@ package com.percussion.services.system;
 /**
  * Error numbers for use with the bundle
  * <code>PSSystemErrorStringBundle.properties</code>
+ *
+ * <p><strong>Phase 2b bridge:</strong> cataloged in {@code
+ * com.intsof.percussioncms.auditlog.codes.SystemServiceErrorCodes} with explicit {@code
+ * isAuditable} (all non-auditable). Package-local ints {@code 1} and {@code 4} collide with
+ * workflow service codes in the flat {@code LegacyErrorCodeRegistry}; prefer the enum directly for
+ * dual-write decisions.
  */
 public interface IPSSystemErrors
 {

--- a/system/src/main/java/com/percussion/cms/IPSCmsErrors.java
+++ b/system/src/main/java/com/percussion/cms/IPSCmsErrors.java
@@ -21,8 +21,11 @@ package com.percussion.cms;
  * error codes. Errors are in the range 13001 - 14000.
  *
  * <p><strong>Phase 2b bridge:</strong> path/folder/item subset is cataloged in {@code
- * com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes} with explicit {@code isAuditable}.
- * Prefer that enum / {@code LegacyErrorCodeRegistry} for dual-write decisions.
+ * com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes} (auditable folder/community denials);
+ * residual general/objectstore/OS-handler ints are in {@code
+ * com.intsof.percussioncms.auditlog.codes.CmsErrorCodes} (all non-auditable). Prefer those enums /
+ * {@code LegacyErrorCodeRegistry} for dual-write decisions. Legacy {@code SQL_EXCEPTION_WRAPPER =
+ * 1002} remains on {@code ServerErrorCodes} in the flat registry.
  *
  * <p>Within this range, errors are further broken down as follows:
  *

--- a/system/src/main/java/com/percussion/cms/objectstore/client/IPSRemoteErrors.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/client/IPSRemoteErrors.java
@@ -17,7 +17,13 @@
 
 package com.percussion.cms.objectstore.client;
 
-/** Error codes for the <code>PSRemoteAgent</code> class. */
+/**
+ * Error codes for the <code>PSRemoteAgent</code> class.
+ *
+ * <p><strong>Phase 2b bridge:</strong> cataloged in {@code
+ * com.intsof.percussioncms.auditlog.codes.RemoteErrorCodes} with explicit {@code isAuditable} (all
+ * non-auditable). Prefer that enum / {@code LegacyErrorCodeRegistry} for dual-write decisions.
+ */
 public interface IPSRemoteErrors {
   /**
    * Got wrong soap response while communicating with remote server

--- a/system/src/main/java/com/percussion/cx/error/IPSContentExplorerErrors.java
+++ b/system/src/main/java/com/percussion/cx/error/IPSContentExplorerErrors.java
@@ -21,6 +21,11 @@ package com.percussion.cx.error;
  * system related error codes. The error code messages are defined in the
  * PSContentExplorerErrorStringBundle.properties file.
  *
+ * <p><strong>Phase 2b bridge:</strong> cataloged in {@code
+ * com.intsof.percussioncms.auditlog.codes.ContentExplorerErrorCodes} with explicit {@code
+ * isAuditable} (all non-auditable). Prefer that enum / {@code LegacyErrorCodeRegistry} for
+ * dual-write decisions.
+ *
  * <TABLE BORDER="1"><CAPTION>Error Arguments</CAPTION>
  * <TR><TH>Range</TH><TH>Component</TH></TR>
  * <TR><TD>20001 - 21000</TD><TD>All content explorer error</TD></TR>


### PR DESCRIPTION
## Summary

Phase 2b residual for **#2900** (parent **#2616**): migrate remaining mid-size legacy catalogs into `*ErrorCodes` + explicit `isAuditable` + registry dual-write bridge.

| Catalog | Legacy | Notes |
|---------|--------|-------|
| `CmsErrorCodes` | residual `IPSCmsErrors` (86 ints) | All non-auditable; skips PathItem-owned folder/permission ints; skips SQL `1002` (Server) |
| `PathItemErrorCodes` | (existing) | Still owns folder/community dual-write ints (e.g. 13007) |
| `ContentExplorerErrorCodes` | `IPSContentExplorerErrors` 20001–20011 | Full catalog; all non-auditable |
| `RemoteErrorCodes` | `IPSRemoteErrors` 15001–15002 | Full catalog; all non-auditable |
| `SystemServiceErrorCodes` | `IPSSystemErrors` 1, 4 | Enum-only; WF owns bare 1/4 in flat registry |

Collision handling is documented in enum Javadoc, registry bootstrap, and module README.

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2616  
Fixes #2900

## Test plan

- [x] `cd modules/perc-auditlog && ../../mvnw.cmd clean install`
- [x] New unit tests for each catalog + registry dual-write / collision coverage
- [x] PathItem still owns 13007 after Cms residual bootstrap
- [x] SystemService does not clobber Workflow flat ints 1/4

## Product documentation

- [x] N/A — pure engineering Phase 2b error-code catalog / dual-write bridge; no operator-, admin-, integrator-, or end-user-facing product behavior change.

## Build evidence (C3)

- **modules_built:** `modules/perc-auditlog`
- **build_evidence:** `cd modules/perc-auditlog; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **192**, Failures: 0
- **downstream_checked:** none (new enum catalogs + javadoc bridge notes only; no `final`/`sealed` or public API signature changes)

## Checklist

- [x] Erlang-style self-review (no bugs, portable paths, change-class companions)
- [x] Unit tests for new/changed logic
- [x] Pre-PR Maven clean install green on changed module
- [x] No residual children (CMS residual complete; CX/Remote/SystemService complete)
