### PR TITLE
docs(keywords): product-docs + gap map for CD-17 keyword write REST (#2919)

### DIFF
--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -30,7 +30,9 @@
 |------------------------------------|----------------------------------------------|
 | List keywords (+ optional choices) | `GET /services/keywords?includeChoices=true` |
 | Get one keyword (+ choices)        | `GET /services/keywords/{idOrValue}`         |
-| Create / update / delete           | `POST` / `PUT` / `DELETE` `/services/keywords[/{id}]` |
+| Create keyword                     | `POST /services/keywords`                             |
+| Update keyword                     | `PUT /services/keywords/{id}`                         |
+| Delete keyword                     | `DELETE /services/keywords/{id}`                      |
 
 **CD-17 Keyword write shipped** (PR #1612 SPA+REST; design-WS path PR #1701; product-docs #2919).
 Adaptor: `IKeywordsAdaptor` → `KeywordsAdaptor` via `IPSContentDesignWs` (create/save/delete with

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -29,8 +29,13 @@
 |              Surface               |                     Path                     |
 |------------------------------------|----------------------------------------------|
 | List keywords (+ optional choices) | `GET /services/keywords?includeChoices=true` |
+| Get one keyword (+ choices)        | `GET /services/keywords/{idOrValue}`         |
+| Create / update / delete           | `POST` / `PUT` / `DELETE` `/services/keywords[/{id}]` |
 
-Write (create/edit/delete keyword) not exposed yet.
+**CD-17 Keyword write shipped** (PR #1612 SPA+REST; design-WS path PR #1701; product-docs #2919).
+Adaptor: `IKeywordsAdaptor` → `KeywordsAdaptor` via `IPSContentDesignWs` (create/save/delete with
+design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
+`KeywordsAdaptorDesignWsTest`, Spring `TestKeywordsAdaptor` stub.
 
 ## Explicit gaps vs Workbench Content Type editor
 
@@ -46,13 +51,13 @@ Write (create/edit/delete keyword) not exposed yet.
 | Create / rename / delete / lock                      | CD-01, §5.2  | SOAP design only                                  |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
 | ACL                                                  | CD-19, §5.4  | Existing ACL REST may help later                  |
-| Keyword write                                        | CD-17        | List only                                         |
+| ~~Keyword write~~                                    | CD-17        | **Done** — REST + SPA + design WS (#1612/#1701)   |
 
 ## Recommended next API work
 
 1. ~~Optional JSON projection of field rules (read-only)~~ **Done P0.2c (flags only)**
 2. Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`
-3. Keyword create/update/delete
+3. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
 4. Full rule-expression serialization + control property catalogs
 5. Templates/slots design editors
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -42,6 +42,65 @@ Developer-module (Workbench replacement) endpoints should map design operations 
 endpoints chosen only because they “look REST.” See repository
 `docs/developer-module/workbench-rest-and-qa-modes.md` for the engineering contract.
 
+## Keywords (design catalog)
+
+Keyword definitions (Workbench **Keywords** / content design) are exposed under `/services/keywords`.
+The REST layer is a thin contract over the content **design** web service (`IPSContentDesignWs`) —
+create, update, and delete use the same design locks and session identity classic tools used.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/keywords?includeChoices=false\|true` | List keyword definitions; optionally embed choices |
+| `GET` | `/services/keywords/{idOrValue}` | Load one keyword by uuid (or numeric id) **or** by value/label (choices included) |
+| `POST` | `/services/keywords` | Create a keyword (`label` required, must be unique); optional description, sequence, choices |
+| `PUT` | `/services/keywords/{id}` | Update label / description / sequence / choices by uuid |
+| `DELETE` | `/services/keywords/{id}` | Delete keyword and its choices by uuid (`204` on success) |
+
+### Request / response shape
+
+JSON objects use the `Keyword` wire type (fields include `guid`, `label`, `value`, `description`,
+`sequence`, and `choices[]` with `label` / `value` / `description` / `sequence`). Prefer the
+generated OpenAPI schema as the integration source of truth.
+
+Example create body:
+
+```json
+{
+  "label": "Priority",
+  "description": "Item priority",
+  "sequence": 1,
+  "choices": [
+    { "label": "High", "value": "high", "sequence": 1 },
+    { "label": "Low", "value": "low", "sequence": 2 }
+  ]
+}
+```
+
+### Status codes and authorization
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List / get / create / update success |
+| `204` | Delete success |
+| `400` | Invalid input (missing label, duplicate label, invalid id) |
+| `404` | Keyword not found |
+| `500` | Design service or server failure |
+| `503` | Keywords adaptor not configured (deployment miswire) |
+
+- Callers must be authenticated; write operations require a request session and user identity for
+  the design web service (same pattern as other design catalog writes).
+- Design ACL / design-session rules of the underlying content design service still apply — REST does
+  not introduce a separate admin-only bypass.
+
+### Integrator notes
+
+- After create/update the server reloads the keyword so the response includes the assigned `guid`
+  and normalized choices.
+- Prefer uuid (or the `guid` string form) for update/delete; value/label lookup on `GET` is for
+  convenience in tooling.
+- The Developer SPA Keyword editor uses these endpoints; integrators can call the same surface
+  without the UI.
+
 ## Testing tips
 
 - Unit-test resources with Mockito and provide Spring test stubs for new adaptor interfaces on the

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -46,7 +46,7 @@ endpoints chosen only because they “look REST.” See repository
 
 Keyword definitions (Workbench **Keywords** / content design) are exposed under `/services/keywords`.
 The REST layer is a thin contract over the content **design** web service (`IPSContentDesignWs`) —
-create, update, and delete use the same design locks and session identity classic tools used.
+create, update, and delete use the same design locks and session identity classic tools use.
 
 | Method | Path | Purpose |
 |--------|------|---------|


### PR DESCRIPTION
## Summary

Issue #2919 asked for **keyword create / update / delete** on public REST (CD-17). Implementation was **already on `main`**:

| Piece | Status |
|-------|--------|
| REST resource POST/PUT/DELETE | Shipped PR #1612 (`KeywordsResource`) |
| `IKeywordsAdaptor` + Spring test stub | Shipped (`TestKeywordsAdaptor`) |
| sitemanage `KeywordsAdaptor` via `IPSContentDesignWs` | Shipped #1612; design-WS path #1701 |
| Mockito resource tests | `KeywordsResourceCrudTest` (27 tests) |
| Adaptor design-WS unit tests | `KeywordsAdaptorDesignWsTest` (22 tests) |
| Developer SPA editor | Shipped #1612 (`KeywordEditorPanel`) |

This PR closes the remaining **product-docs / gap-map** acceptance for the slice:

1. **`product-docs/8.2/developer/rest.md`** — Keywords design catalog section (paths, status codes, auth notes, sample create body)
2. **`docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md`** — mark CD-17 Keyword write **Done** (was stale “list only”)

AuthZ is consistent with design peers: authenticated session/user required for write; design locks + design ACL via `IPSContentDesignWs` (no separate admin bypass).

**Parent:** #1690  
**Fixes:** #2919  
**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Confirmed production code already present on `main` (no Java churn this PR)
- [x] `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; `KeywordsResourceCrudTest` Tests run: 27, Failures: 0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; `KeywordsAdaptorDesignWsTest` Tests run: 22, Failures: 0
- [x] Product-docs page `id: developer-rest` extended (stable id preserved)
- [ ] Reviewer: skim REST section for accuracy vs OpenAPI / live Swagger if desired

## Product documentation

- [x] Updated pages under `product-docs/` (`product-docs/8.2/developer/rest.md` Keywords section)

## Build evidence (C3)

- **modules_built:** none (docs-only PR; code modules verified green on `main` without source changes)
- **build_evidence:**  
  - `cd rest; ../mvnw.cmd clean install` → BUILD SUCCESS; KeywordsResourceCrudTest 27/27  
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS; KeywordsAdaptorDesignWsTest 22/22; Tests run: 968, Failures: 0, Errors: 0, Skipped: 127
- **downstream_checked:** none (no public API signature change in this PR; C2 N/A)

## Residual / QA

- No residual implement slices (feature already complete)
- No human QA issue (docs-only; write path already live since #1612)

> Co-Authored by Grok Build using grok-4.5 with agent main.
