### PR TITLE
feat(rest): CT field rule expressions read-only (CD-05-07) (#2920)

### DIFF
--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -19,6 +19,7 @@
 - name, label, description, enabled, hideFromMenu, appName, editorUrl, guid
 - fields: name, label (display), origin (local/system/shared), dataType, control, searchable, fieldSet, required
 - fields **P0.2c rule flags**: readOnly, occurrence, hasValidation, hasVisibilityRules, hasInputTranslation, hasOutputTranslation
+- fields **CD-05–07 read-only expressions** (issue #2920): `validationExpression`, `visibilityExpression`, `inputTranslationExpression`, `outputTranslationExpression`, `controlPropertyNames[]` (names only; no values)
 - child field set names
 - **allowedWorkflows[]** + **defaultWorkflow** (P0.2b)
 - **allowedTemplates[]** (P0.2b)
@@ -36,8 +37,8 @@ Write (create/edit/delete keyword) not exposed yet.
 
 |                         Gap                          |    FR IDs    |                       Notes                       |
 |------------------------------------------------------|--------------|---------------------------------------------------|
-| Full field rule **expressions** / control properties | CD-05–CD-07  | Flags present (P0.2c); expressions not serialized |
-| Control property + choice configuration              | CD-07        | Only control **name** today                       |
+| Full field rule **expressions** / control properties | CD-05–CD-07  | **Read-only expressions + control property names** shipped (#2920); write/save + full catalogs still open |
+| Control property + choice configuration              | CD-07        | Control **name** + **property names** (read-only); values/choices not exposed |
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **Read-only lists available**                     |
 | Enable/disable as design action                      | CD-13        | Read `enabled` only                               |
@@ -51,10 +52,11 @@ Write (create/edit/delete keyword) not exposed yet.
 ## Recommended next API work
 
 1. ~~Optional JSON projection of field rules (read-only)~~ **Done P0.2c (flags only)**
-2. Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`
-3. Keyword create/update/delete
-4. Full rule-expression serialization + control property catalogs
-5. Templates/slots design editors
+2. ~~Read-only field rule expressions + control property names~~ **Done CD-05–07 read path (#2920)**
+3. Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`
+4. Keyword create/update/delete (partially shipped — see keyword write slice)
+5. Control property value/choice catalogs + rule write/save
+6. Templates/slots design editors
 
 ## Client behavior
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -42,6 +42,31 @@ Developer-module (Workbench replacement) endpoints should map design operations 
 endpoints chosen only because they “look REST.” See repository
 `docs/developer-module/workbench-rest-and-qa-modes.md` for the engineering contract.
 
+## Content types (design catalog)
+
+| Operation | Path | Notes |
+|-----------|------|--------|
+| List | `GET /services/contenttypes` | Name, label, description, guid |
+| Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `designGaps` |
+
+### Field rule expressions (read-only)
+
+Content type **detail** field rows include boolean rule **flags** and, when rules exist,
+human-readable **expression summaries**:
+
+| Field | Meaning |
+|-------|---------|
+| `hasValidation` / `validationExpression` | Validation rules present / summary of conditionals or extension calls |
+| `hasVisibilityRules` / `visibilityExpression` | Visibility rules present / summary |
+| `hasInputTranslation` / `inputTranslationExpression` | Input transform present / extension call summary |
+| `hasOutputTranslation` / `outputTranslationExpression` | Output transform present / extension call summary |
+| `control` | Display control name |
+| `controlPropertyNames` | Control parameter **names** only (values and full choice catalogs not exposed) |
+
+These expression fields are **null/omitted when empty** (`NON_NULL` JSON). They are **not**
+writable via `PUT` — rule write/save and full control property editors remain Workbench /
+future design APIs. `designGaps` on detail still calls out write and catalog gaps.
+
 ## Testing tips
 
 - Unit-test resources with Mockito and provide Spring test stubs for new adaptor interfaces on the

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -20,15 +20,22 @@ package com.percussion.apibridge;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSContentEditorPipe;
 import com.percussion.design.objectstore.PSControlRef;
 import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSDisplayMapping;
+import com.percussion.design.objectstore.PSExtensionCall;
+import com.percussion.design.objectstore.PSExtensionCallSet;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSFieldTranslation;
+import com.percussion.design.objectstore.PSFieldValidationRules;
+import com.percussion.design.objectstore.PSParam;
+import com.percussion.design.objectstore.PSRule;
 import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.design.objectstore.PSUISet;
+import com.percussion.design.objectstore.PSVisibilityRules;
 import com.percussion.design.objectstore.PSWorkflowInfo;
 import com.percussion.rest.Guid;
 import com.percussion.rest.contenttypes.ContentType;
@@ -172,17 +179,18 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     detail.setGuid(ApiUtils.convertGuid(new PSGuid(PSTypeEnum.NODEDEF, def.getTypeId())));
 
     Map<String, String> controlByField = new HashMap<>();
-    boolean controlsResolved = mapControls(def, controlByField);
+    Map<String, List<String>> controlPropsByField = new HashMap<>();
+    boolean controlsResolved = mapControls(def, controlByField, controlPropsByField);
     List<ContentTypeField> fields = new ArrayList<>();
     List<String> childSets = new ArrayList<>();
 
     PSFieldSet parentFs = def.getFieldSet();
     if (parentFs != null) {
-      addFieldsFromSet(parentFs, null, controlByField, fields);
+      addFieldsFromSet(parentFs, null, controlByField, controlPropsByField, fields);
       for (PSFieldSet child : def.getComplexChildren()) {
         if (child != null && StringUtils.isNotBlank(child.getName())) {
           childSets.add(child.getName());
-          addFieldsFromSet(child, child.getName(), controlByField, fields);
+          addFieldsFromSet(child, child.getName(), controlByField, controlPropsByField, fields);
         }
       }
     }
@@ -200,8 +208,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
 
     List<String> gaps = new ArrayList<>();
     gaps.add(
-        "Field rule flags are exposed (validation/visibility/transforms present); full rule"
-            + " expressions and control properties are not");
+        "Field rule expressions and control property names are read-only; rule write/save and"
+            + " full control property catalogs/values are not supported");
     gaps.add("Item-level pre/post exits not exposed");
     gaps.add(
         "Create / delete not supported; update uses design lock for label/description/enabled,"
@@ -608,6 +616,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       PSFieldSet fieldSet,
       String fieldSetName,
       Map<String, String> controlByField,
+      Map<String, List<String>> controlPropsByField,
       List<ContentTypeField> out) {
     if (fieldSet == null) {
       return;
@@ -643,6 +652,14 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
           field.getVisibilityRules() != null && !field.getVisibilityRules().isEmpty());
       f.setHasInputTranslation(hasTranslation(field.getInputTranslation()));
       f.setHasOutputTranslation(hasTranslation(field.getOutputTranslation()));
+      f.setValidationExpression(summarizeValidationRules(field.getValidationRules()));
+      f.setVisibilityExpression(summarizeVisibilityRules(field.getVisibilityRules()));
+      f.setInputTranslationExpression(summarizeTranslation(field.getInputTranslation()));
+      f.setOutputTranslationExpression(summarizeTranslation(field.getOutputTranslation()));
+      List<String> propNames = controlPropsByField.get(field.getSubmitName());
+      if (propNames != null && !propNames.isEmpty()) {
+        f.setControlPropertyNames(List.copyOf(propNames));
+      }
       out.add(f);
     }
   }
@@ -676,16 +693,147 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   /**
+   * Package-visible for unit tests. Summarizes validation rules as a human-readable expression
+   * string, or {@code null} when empty.
+   */
+  static String summarizeValidationRules(PSFieldValidationRules rules) {
+    if (rules == null) {
+      return null;
+    }
+    List<String> parts = new ArrayList<>();
+    for (Iterator<?> it = rules.getRules(); it.hasNext(); ) {
+      Object o = it.next();
+      if (o instanceof PSRule rule) {
+        String s = summarizeRule(rule);
+        if (StringUtils.isNotBlank(s)) {
+          parts.add(s);
+        }
+      }
+    }
+    for (Iterator<?> it = rules.getRuleReferences(); it.hasNext(); ) {
+      Object ref = it.next();
+      if (ref != null && StringUtils.isNotBlank(ref.toString())) {
+        parts.add("ref:" + ref.toString().trim());
+      }
+    }
+    if (parts.isEmpty()) {
+      return null;
+    }
+    return String.join("; ", parts);
+  }
+
+  /**
+   * Package-visible for unit tests. Summarizes visibility rules, or {@code null} when empty.
+   */
+  static String summarizeVisibilityRules(PSVisibilityRules rules) {
+    if (rules == null || rules.isEmpty()) {
+      return null;
+    }
+    List<String> parts = new ArrayList<>();
+    for (Object o : rules) {
+      if (o instanceof PSRule rule) {
+        String s = summarizeRule(rule);
+        if (StringUtils.isNotBlank(s)) {
+          parts.add(s);
+        }
+      }
+    }
+    if (parts.isEmpty()) {
+      return null;
+    }
+    return String.join("; ", parts);
+  }
+
+  /**
+   * Package-visible for unit tests. Summarizes translation extension calls, or {@code null} when
+   * empty.
+   */
+  static String summarizeTranslation(PSFieldTranslation translation) {
+    if (!hasTranslation(translation)) {
+      return null;
+    }
+    return summarizeExtensionCalls(translation.getTranslations());
+  }
+
+  /**
+   * Package-visible for unit tests. Summarizes a single design rule (conditionals or extension
+   * set).
+   */
+  static String summarizeRule(PSRule rule) {
+    if (rule == null) {
+      return null;
+    }
+    if (rule.isExtensionSetRule()) {
+      return summarizeExtensionCalls(rule.getExtensionRules());
+    }
+    List<String> conds = new ArrayList<>();
+    for (Iterator<?> it = rule.getConditionalRules(); it.hasNext(); ) {
+      Object o = it.next();
+      if (o instanceof PSConditional conditional) {
+        String text = conditional.toString();
+        if (StringUtils.isNotBlank(text)) {
+          conds.add(text.trim());
+        }
+      }
+    }
+    if (conds.isEmpty()) {
+      return null;
+    }
+    return String.join(" ", conds);
+  }
+
+  /** Package-visible for unit tests. Summarizes extension calls as {@code name(args)}. */
+  static String summarizeExtensionCalls(PSExtensionCallSet callSet) {
+    if (callSet == null || callSet.isEmpty()) {
+      return null;
+    }
+    List<String> calls = new ArrayList<>();
+    for (Object o : callSet) {
+      if (o instanceof PSExtensionCall call) {
+        String text = call.toString();
+        if (StringUtils.isNotBlank(text)) {
+          calls.add(text.trim());
+        }
+      }
+    }
+    if (calls.isEmpty()) {
+      return null;
+    }
+    return String.join("; ", calls);
+  }
+
+  /**
+   * Package-visible for unit tests. Collects control parameter names (not values) from a control
+   * ref.
+   */
+  static List<String> controlPropertyNames(PSControlRef control) {
+    if (control == null) {
+      return List.of();
+    }
+    List<String> names = new ArrayList<>();
+    for (Iterator<?> it = control.getParameters(); it.hasNext(); ) {
+      Object o = it.next();
+      if (o instanceof PSParam param && StringUtils.isNotBlank(param.getName())) {
+        names.add(param.getName());
+      }
+    }
+    return names;
+  }
+
+  /**
    * Walk parent display mapper for control names and labels keyed by field ref.
    *
    * @return {@code true} when the display mapper was walked successfully; {@code false} when
    *     resolution failed (caller should surface a design gap).
    */
-  private boolean mapControls(PSItemDefinition def, Map<String, String> map) {
+  private boolean mapControls(
+      PSItemDefinition def,
+      Map<String, String> map,
+      Map<String, List<String>> controlPropsByField) {
     try {
       PSContentEditorPipe pipe = (PSContentEditorPipe) def.getContentEditor().getPipe();
       PSDisplayMapper dmapper = pipe.getMapper().getUIDefinition().getDisplayMapper();
-      walkDisplayMapper(dmapper, map);
+      walkDisplayMapper(dmapper, map, controlPropsByField);
       return true;
     } catch (Exception e) {
       log.warn("Could not resolve display controls for {}: {}", def.getName(), e.getMessage(), e);
@@ -693,7 +841,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     }
   }
 
-  private void walkDisplayMapper(PSDisplayMapper dmapper, Map<String, String> map) {
+  private void walkDisplayMapper(
+      PSDisplayMapper dmapper,
+      Map<String, String> map,
+      Map<String, List<String>> controlPropsByField) {
     if (dmapper == null) {
       return;
     }
@@ -712,11 +863,15 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
           PSControlRef control = ui.getControl();
           if (control != null && StringUtils.isNotBlank(control.getName())) {
             map.put(fieldRef, control.getName());
+            List<String> propNames = controlPropertyNames(control);
+            if (!propNames.isEmpty()) {
+              controlPropsByField.put(fieldRef, propNames);
+            }
           }
         }
       }
       if (entry.getDisplayMapper() != null) {
-        walkDisplayMapper(entry.getDisplayMapper(), map);
+        walkDisplayMapper(entry.getDisplayMapper(), map, controlPropsByField);
       }
     }
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorFieldRulesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorFieldRulesTest.java
@@ -19,31 +19,57 @@ package com.percussion.apibridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.percussion.design.objectstore.PSConditional;
+import com.percussion.design.objectstore.PSControlRef;
+import com.percussion.design.objectstore.PSExtensionCall;
 import com.percussion.design.objectstore.PSExtensionCallSet;
-import com.percussion.design.objectstore.PSField;
+import com.percussion.design.objectstore.PSExtensionParamValue;
 import com.percussion.design.objectstore.PSFieldTranslation;
+import com.percussion.design.objectstore.PSFieldValidationRules;
+import com.percussion.design.objectstore.PSParam;
+import com.percussion.design.objectstore.PSRule;
+import com.percussion.design.objectstore.PSTextLiteral;
+import com.percussion.design.objectstore.PSVisibilityRules;
+import com.percussion.extension.PSExtensionRef;
+import com.percussion.util.PSCollection;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-/** Behavioral unit tests for ContentTypeAdaptor field-rule mapping helpers (P0.2c). */
+/**
+ * Behavioral unit tests for ContentTypeAdaptor field-rule mapping helpers (P0.2c flags + CD-05–07
+ * read-only expressions).
+ */
 @Tag("UnitTest")
 public class ContentTypeAdaptorFieldRulesTest {
 
   @Test
   public void mapOccurrenceCoversAllKnownDimensions() {
     assertEquals(
-        "optional", ContentTypeAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_OPTIONAL));
+        "optional",
+        ContentTypeAdaptor.mapOccurrence(
+            com.percussion.design.objectstore.PSField.OCCURRENCE_DIMENSION_OPTIONAL));
     assertEquals(
-        "required", ContentTypeAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_REQUIRED));
+        "required",
+        ContentTypeAdaptor.mapOccurrence(
+            com.percussion.design.objectstore.PSField.OCCURRENCE_DIMENSION_REQUIRED));
     assertEquals(
-        "oneOrMore", ContentTypeAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE));
+        "oneOrMore",
+        ContentTypeAdaptor.mapOccurrence(
+            com.percussion.design.objectstore.PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE));
     assertEquals(
-        "zeroOrMore", ContentTypeAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_ZERO_OR_MORE));
-    assertEquals("count", ContentTypeAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_COUNT));
+        "zeroOrMore",
+        ContentTypeAdaptor.mapOccurrence(
+            com.percussion.design.objectstore.PSField.OCCURRENCE_DIMENSION_ZERO_OR_MORE));
+    assertEquals(
+        "count",
+        ContentTypeAdaptor.mapOccurrence(
+            com.percussion.design.objectstore.PSField.OCCURRENCE_DIMENSION_COUNT));
     assertEquals("unknown", ContentTypeAdaptor.mapOccurrence(-1));
     assertEquals("unknown", ContentTypeAdaptor.mapOccurrence(99));
   }
@@ -65,5 +91,108 @@ public class ContentTypeAdaptorFieldRulesTest {
     PSFieldTranslation present = mock(PSFieldTranslation.class);
     when(present.getTranslations()).thenReturn(calls);
     assertTrue(ContentTypeAdaptor.hasTranslation(present));
+  }
+
+  @Test
+  public void summarizeValidationRulesEmptyAndNull() {
+    assertNull(ContentTypeAdaptor.summarizeValidationRules(null));
+    assertNull(ContentTypeAdaptor.summarizeValidationRules(new PSFieldValidationRules()));
+  }
+
+  @Test
+  public void summarizeValidationRulesPresentConditional() {
+    PSCollection conditionals = new PSCollection(PSConditional.class);
+    conditionals.add(
+        new PSConditional(
+            new PSTextLiteral("sys_title"),
+            PSConditional.OPTYPE_NOTEQUALS,
+            new PSTextLiteral("")));
+    PSRule rule = new PSRule(conditionals);
+
+    PSFieldValidationRules rules = new PSFieldValidationRules();
+    PSCollection ruleCol = new PSCollection(PSRule.class);
+    ruleCol.add(rule);
+    rules.setRules(ruleCol);
+
+    String summary = ContentTypeAdaptor.summarizeValidationRules(rules);
+    assertTrue(summary != null && !summary.isBlank(), "expected non-empty summary");
+    assertTrue(summary.contains("sys_title"), summary);
+    assertTrue(summary.contains("<>") || summary.contains("!="), summary);
+  }
+
+  @Test
+  public void summarizeValidationRulesWithReference() {
+    PSFieldValidationRules rules = new PSFieldValidationRules();
+    PSCollection refs = new PSCollection(String.class);
+    refs.add("sharedRequiredCheck");
+    rules.setRuleReferences(refs);
+
+    String summary = ContentTypeAdaptor.summarizeValidationRules(rules);
+    assertEquals("ref:sharedRequiredCheck", summary);
+  }
+
+  @Test
+  public void summarizeVisibilityRulesEmptyAndPresent() {
+    assertNull(ContentTypeAdaptor.summarizeVisibilityRules(null));
+    assertNull(ContentTypeAdaptor.summarizeVisibilityRules(new PSVisibilityRules()));
+
+    PSCollection conditionals = new PSCollection(PSConditional.class);
+    conditionals.add(
+        new PSConditional(
+            new PSTextLiteral("sys_communityid"),
+            PSConditional.OPTYPE_EQUALS,
+            new PSTextLiteral("1001")));
+    PSVisibilityRules visibility = new PSVisibilityRules();
+    visibility.add(new PSRule(conditionals));
+
+    String summary = ContentTypeAdaptor.summarizeVisibilityRules(visibility);
+    assertTrue(summary.contains("sys_communityid"), summary);
+    assertTrue(summary.contains("1001"), summary);
+  }
+
+  @Test
+  public void summarizeTranslationEmptyAndPresent() {
+    assertNull(ContentTypeAdaptor.summarizeTranslation(null));
+
+    PSFieldTranslation empty = new PSFieldTranslation(new PSExtensionCallSet());
+    assertNull(ContentTypeAdaptor.summarizeTranslation(empty));
+
+    PSExtensionCallSet set = new PSExtensionCallSet();
+    set.add(
+        new PSExtensionCall(
+            new PSExtensionRef("Java", "global/percussion/generic/", "sys_ToUpperCase"),
+            new PSExtensionParamValue[] {new PSExtensionParamValue(new PSTextLiteral("x"))}));
+    PSFieldTranslation present = new PSFieldTranslation(set);
+
+    String summary = ContentTypeAdaptor.summarizeTranslation(present);
+    assertTrue(summary.contains("sys_ToUpperCase"), summary);
+  }
+
+  @Test
+  public void summarizeExtensionRule() {
+    PSExtensionCallSet set = new PSExtensionCallSet();
+    set.add(
+        new PSExtensionCall(
+            new PSExtensionRef("Java", "global/percussion/generic/", "sys_ValidateDate"),
+            new PSExtensionParamValue[0]));
+    PSRule rule = new PSRule(set);
+    String summary = ContentTypeAdaptor.summarizeRule(rule);
+    assertTrue(summary.contains("sys_ValidateDate"), summary);
+  }
+
+  @Test
+  public void controlPropertyNamesEmptyAndPresent() {
+    assertTrue(ContentTypeAdaptor.controlPropertyNames(null).isEmpty());
+
+    PSControlRef bare = new PSControlRef("sys_EditBox");
+    assertTrue(ContentTypeAdaptor.controlPropertyNames(bare).isEmpty());
+
+    PSCollection params = new PSCollection(PSParam.class);
+    params.add(new PSParam("height", new PSTextLiteral("200")));
+    params.add(new PSParam("width", new PSTextLiteral("400")));
+    PSControlRef withParams = new PSControlRef("sys_TextArea");
+    withParams.setParameters(params);
+    List<String> names = ContentTypeAdaptor.controlPropertyNames(withParams);
+    assertEquals(List.of("height", "width"), names);
   }
 }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
@@ -20,6 +20,7 @@ package com.percussion.rest.contenttypes;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
 
 /** Read-only field summary for a content type (Developer module design view). */
 @XmlRootElement(name = "ContentTypeField")
@@ -67,6 +68,33 @@ public class ContentTypeField {
 
   @Schema(description = "Control name when resolved from display mapping")
   private String control;
+
+  @Schema(
+      description =
+          "Read-only summary of field validation rule expressions (conditionals / extensions)."
+              + " Null when no validation rules are defined. Not writable via PUT.")
+  private String validationExpression;
+
+  @Schema(
+      description =
+          "Read-only summary of visibility rule expressions. Null when none defined. Not writable.")
+  private String visibilityExpression;
+
+  @Schema(
+      description =
+          "Read-only summary of input translation extension calls. Null when none. Not writable.")
+  private String inputTranslationExpression;
+
+  @Schema(
+      description =
+          "Read-only summary of output translation extension calls. Null when none. Not writable.")
+  private String outputTranslationExpression;
+
+  @Schema(
+      description =
+          "Control property / parameter names from the display mapping (cheap names only;"
+              + " values and full catalogs not exposed). Null or omitted when none. Not writable.")
+  private List<String> controlPropertyNames;
 
   @Schema(description = "Child field-set name when this field is nested; null for parent fields")
   private String fieldSet;
@@ -175,6 +203,46 @@ public class ContentTypeField {
 
   public void setControl(String control) {
     this.control = control;
+  }
+
+  public String getValidationExpression() {
+    return validationExpression;
+  }
+
+  public void setValidationExpression(String validationExpression) {
+    this.validationExpression = validationExpression;
+  }
+
+  public String getVisibilityExpression() {
+    return visibilityExpression;
+  }
+
+  public void setVisibilityExpression(String visibilityExpression) {
+    this.visibilityExpression = visibilityExpression;
+  }
+
+  public String getInputTranslationExpression() {
+    return inputTranslationExpression;
+  }
+
+  public void setInputTranslationExpression(String inputTranslationExpression) {
+    this.inputTranslationExpression = inputTranslationExpression;
+  }
+
+  public String getOutputTranslationExpression() {
+    return outputTranslationExpression;
+  }
+
+  public void setOutputTranslationExpression(String outputTranslationExpression) {
+    this.outputTranslationExpression = outputTranslationExpression;
+  }
+
+  public List<String> getControlPropertyNames() {
+    return controlPropertyNames;
+  }
+
+  public void setControlPropertyNames(List<String> controlPropertyNames) {
+    this.controlPropertyNames = controlPropertyNames;
   }
 
   public String getFieldSet() {

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -96,6 +96,33 @@ public class ContentTypesResourceDetailTest {
     assertEquals("percPage", resource.getContentType("percPage").getName());
   }
 
+  @Test
+  public void fieldRuleExpressionsSerializeWhenPresentAndOmitWhenEmpty() {
+    ContentTypeField withRules = new ContentTypeField();
+    withRules.setName("sys_title");
+    withRules.setHasValidation(true);
+    withRules.setValidationExpression("sys_title <>  AND");
+    withRules.setControlPropertyNames(List.of("height", "width"));
+
+    ContentTypeField emptyRules = new ContentTypeField();
+    emptyRules.setName("page_title");
+    emptyRules.setHasValidation(false);
+
+    ContentTypeDetail d = new ContentTypeDetail();
+    d.setName("percPage");
+    d.setFields(List.of(withRules, emptyRules));
+
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentTypeDetail.class);
+    String json = mapper.writeValueAsString(d);
+
+    assertTrue(json.contains("\"validationExpression\""), json);
+    assertTrue(json.contains("sys_title <>"), json);
+    assertTrue(json.contains("\"controlPropertyNames\""), json);
+    assertTrue(json.contains("height"), json);
+    // empty expression fields must not force empty-string noise for the second field
+    assertTrue(json.contains("page_title"), json);
+  }
+
   private static ContentType sampleContentType() {
     ContentType ct = new ContentType();
     ct.setName("percPage");


### PR DESCRIPTION
## Summary

Implements **CD-05–07 read-only field rule expressions** (issue #2920, parent epic #1690).

- **Wire DTO (`rest`):** `ContentTypeField` gains `validationExpression`, `visibilityExpression`, `inputTranslationExpression`, `outputTranslationExpression`, and `controlPropertyNames[]` (names only). Null-safe / `NON_NULL` JSON.
- **Mapping (`sitemanage`):** `ContentTypeAdaptor` summarizes CE validation/visibility/transform rules from design objectstore and collects control parameter names from display mapping. **No write/save path.**
- **designGaps:** Updated honesty text (expressions read-only; write + full catalogs still open).
- **Gap map:** `content-type-api-gaps.md` marks read path done.
- **Product docs:** `product-docs/8.2/developer/rest.md` documents the detail field contract.

SPA display of expressions was **optional** for this slice and deferred (flags UI already works; no WebUI/Playwright change).

## Test plan

- [x] `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 276, Failures: 0); `ContentTypesResourceDetailTest` 9 tests incl. expression JSON
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 903, Failures: 0); `ContentTypeAdaptorFieldRulesTest` 9 tests (empty + present rules, control props)
- [x] No new public final/sealed or method signature removals — additive DTO fields only; sitemanage built against new rest SNAPSHOT

### Build evidence (C3)

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:** standalone clean install each module (commands above) — BUILD SUCCESS; rest Tests=276; sitemanage Tests=903
- **downstream_checked:** sitemanage (implements rest CT adaptor) clean install after rest install; additive DTO only (no final/sealed / no removed signatures)

## Product documentation

- [x] Updated pages under `product-docs/` — `product-docs/8.2/developer/rest.md` (CT detail field rule expressions)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Parent: #1690  
Fixes #2920

> Co-Authored by Grok Build using grok-4.5 with agent main.
