### PR TITLE
fix(perc-content-explorer): display table/panel/view rawtypes (#2875)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2875-display-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2875-display-rawtypes-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review: issue #2875 display table/panel/view rawtypes
+
+**Scope:** `PSDisplayFormatTableModel`, `PSMainDisplayPanel`, `PSMainView`, new `PSDisplayFormatTableModelTest`
+**Date:** 2026-08-11
+**Verdict:** PASS
+
+## Bugs
+- None found. Generics-only; `setRoot` / selection / refresh control flow preserved.
+- `convertCellValue` extracted with same String casts and NumberFormatException fall-through as historical inline logic.
+- `getData()` still uses column 0 for the bulk iterator (historic behavior; row `getData(int)` still uses `m_titleCol`).
+- `PSTableSorter.getSortingColumns()` remains raw (ServerUIComponents); call site uses annotated unchecked cast to `List<Integer>` for `PSNode.setLastSortColumns`.
+
+## Behavioral tests
+- `PSDisplayFormatTableModelTest` (10): ctor/setRoot null guards, name-column path, display-format number/text conversion + column classes, convertCellValue, getSysTitleIndex without format id, setLocale.
+- Swing-heavy `PSMainDisplayPanel` / `PSMainView` not unit-instantiated (headless ActionManager / tree); typing only.
+
+## Cross-platform
+- N/A (no path/file I/O changes).
+
+## Change-class companions
+- Unit tests for typed model; module standalone clean install green (119 tests).
+- Product docs N/A (compiler tech-debt, no operator surface).
+- No Playwright (no WebUI product screen change).
+- C2: no `final`/`sealed` on public types; method shapes unchanged for callers.
+
+## Residual
+- Scope files clean of rawtypes/unchecked under module compile.
+- Avoid #2439 PSFolderAclEditorDialog (In Progress).
+- Next PR-sized clusters: PSACLNewUserDialog (~20), PSSearchDialog, PSOptionManager / PSDisplayFormatOption, etc.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatTableModel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatTableModel.java
@@ -62,13 +62,13 @@ public class PSDisplayFormatTableModel extends PSTableModel {
 
     m_root = node;
 
-    Iterator children = node.getChildren();
+    Iterator<PSNode> children = node.getChildren();
     if (children != null && children.hasNext()) {
-      Vector columnNames = new Vector();
-      Vector columnTypes = new Vector();
+      Vector<String> columnNames = new Vector<>();
+      Vector<String> columnTypes = new Vector<>();
 
       // Get the column names
-      Iterator tableFormat = node.getChildrenDisplayFormat();
+      Iterator<Map.Entry<String, String>> tableFormat = node.getChildrenDisplayFormat();
 
       int titleIndex = -1;
       if (tableFormat != null) {
@@ -84,7 +84,7 @@ public class PSDisplayFormatTableModel extends PSTableModel {
 
       if (tableFormat != null) {
         while (tableFormat.hasNext()) {
-          Map.Entry columnDef = (Map.Entry) tableFormat.next();
+          Map.Entry<String, String> columnDef = tableFormat.next();
           columnNames.add(columnDef.getKey());
           columnTypes.add(columnDef.getValue());
         }
@@ -92,17 +92,17 @@ public class PSDisplayFormatTableModel extends PSTableModel {
 
       m_colTypes = columnTypes;
 
-      Vector tableData = new Vector();
+      Vector<Vector<Object>> tableData = new Vector<>();
       while (children.hasNext()) {
-        PSNode childNode = (PSNode) children.next();
-        Vector rowVector = new Vector();
+        PSNode childNode = children.next();
+        Vector<Object> rowVector = new Vector<>();
 
         if (tableFormat != null) {
-          Map rowData = childNode.getRowData();
+          Map<String, Object> rowData = childNode.getRowData();
           if (rowData != null) {
             // Get all dynamic column names
-            Iterator colNames = null;
-            Iterator colTypes = null;
+            Iterator<String> colNames = null;
+            Iterator<String> colTypes = null;
             if (titleIndex < 0) {
               colNames = columnNames.subList(1, columnNames.size()).iterator();
               colTypes = columnTypes.subList(1, columnTypes.size()).iterator();
@@ -119,25 +119,8 @@ public class PSDisplayFormatTableModel extends PSTableModel {
 
               Object obj = rowData.get(colNames.next());
               if (obj != null) {
-                String colType = (String) colTypes.next();
-                if (PSNode.DATA_TYPE_DATE.equals(colType)) {
-                  if (obj.toString().trim().length() > 0) {
-                    // extract a date from the raw string
-                    obj = PSDataTypeConverter.parseStringToDate((String) obj);
-                  }
-                } else if (PSNode.DATA_TYPE_NUMBER.equals(colType)) {
-                  if (((String) obj).length() > 0) {
-                    try {
-                      obj = Integer.valueOf((String) obj);
-                    } catch (NumberFormatException e) {
-                      /*
-                       * Let it be string. Some times the column type
-                       * is number but the display value could be
-                       * string.
-                       */
-                    }
-                  }
-                }
+                String colType = colTypes.next();
+                obj = convertCellValue(obj, colType);
               }
               rowVector.add(obj);
             }
@@ -156,6 +139,39 @@ public class PSDisplayFormatTableModel extends PSTableModel {
   }
 
   /**
+   * Converts a raw cell value according to the column data type. Same conversion rules as
+   * historically applied in {@link #setRoot(PSNode)}. Package-visible for unit tests.
+   *
+   * @param obj the raw value, may be <code>null</code>
+   * @param colType one of {@link PSNode#DATA_TYPE_DATE}, {@link PSNode#DATA_TYPE_NUMBER}, or other
+   *     (left unchanged)
+   * @return converted value (Date, Integer, or original), may be <code>null</code>
+   */
+  static Object convertCellValue(Object obj, String colType) {
+    if (obj == null) return null;
+
+    if (PSNode.DATA_TYPE_DATE.equals(colType)) {
+      if (obj.toString().trim().length() > 0) {
+        // extract a date from the raw string
+        return PSDataTypeConverter.parseStringToDate((String) obj);
+      }
+    } else if (PSNode.DATA_TYPE_NUMBER.equals(colType)) {
+      if (((String) obj).length() > 0) {
+        try {
+          return Integer.valueOf((String) obj);
+        } catch (NumberFormatException e) {
+          /*
+           * Let it be string. Some times the column type is number but the
+           * display value could be string.
+           */
+          return obj;
+        }
+      }
+    }
+    return obj;
+  }
+
+  /**
    * Get the last root node set on this model by {@link #setRoot(PSNode)}
    *
    * @return The root, or <code>null</code> if one has not been set.
@@ -170,13 +186,14 @@ public class PSDisplayFormatTableModel extends PSTableModel {
    * @return the class, or {@link Object#getClass()} if there is no column type defined for the
    *     supplied index. (base class behavior)
    */
-  public Class getColumnClass(int columnIndex) {
-    Class cls = Object.class;
+  @Override
+  public Class<?> getColumnClass(int columnIndex) {
+    Class<?> cls = Object.class;
 
     // title column is the PSNode itself, so let that return Object
     // image type should also return object
     if (m_colTypes != null && columnIndex < m_colTypes.size() && columnIndex != m_titleCol) {
-      String type = (String) m_colTypes.get(columnIndex);
+      String type = m_colTypes.get(columnIndex);
       if (PSNode.DATA_TYPE_DATE.equals(type)) cls = Date.class;
       else if (PSNode.DATA_TYPE_NUMBER.equals(type)) cls = Integer.class;
       else if (PSNode.DATA_TYPE_TEXT.equals(type)) cls = String.class;
@@ -207,14 +224,6 @@ public class PSDisplayFormatTableModel extends PSTableModel {
   }
 
   /**
-   * Checks supplied <code>PSNode</code>to see if the sys_title field is present in its associated
-   * <code>PSDisplayFormat</code>
-   *
-   * @param node the node in which the check will be made, is <code>null</code> <code>-1</code> will
-   *     be returned.
-   * @return the index of sys_title, <code>-1</code> if not found.
-   */
-  /**
    * Checks supplied <code>PSNode</code> to see if the sys_title field is present in its associated
    * <code>PSDisplayFormat</code>.
    *
@@ -239,11 +248,10 @@ public class PSDisplayFormatTableModel extends PSTableModel {
 
       if (format == null) return hasTitle;
 
-      Iterator it = format.getColumns();
+      Iterator<PSDisplayColumn> it = format.getColumns();
       int index = 0;
       while (it.hasNext() && hasTitle < 0) {
-        if (((PSDisplayColumn) it.next()).getSource().equalsIgnoreCase("sys_title"))
-          hasTitle = index;
+        if (it.next().getSource().equalsIgnoreCase("sys_title")) hasTitle = index;
 
         index++;
       }
@@ -261,12 +269,13 @@ public class PSDisplayFormatTableModel extends PSTableModel {
    * @return the data, an iterator over zero or more <code>PSNode</code> objects, never <code>null
    *     </code>.
    */
-  public Iterator getData() {
-    List data = new ArrayList();
+  @Override
+  public Iterator<Object> getData() {
+    List<Object> data = new ArrayList<>();
 
-    Iterator rows = getDataVector().iterator();
-    while (rows.hasNext()) {
-      Vector rowData = (Vector) rows.next();
+    for (Object rowObj : getDataVector()) {
+      @SuppressWarnings("unchecked")
+      Vector<Object> rowData = (Vector<Object>) rowObj;
       if (!rowData.isEmpty()) data.add(rowData.get(0));
     }
 
@@ -280,6 +289,7 @@ public class PSDisplayFormatTableModel extends PSTableModel {
    * @return the data node (<code>PSNode</code>), never <code>null</code>
    * @throws IllegalArgumentException if row index is invalid.
    */
+  @Override
   public Object getData(int row) {
     checkRow(row);
 
@@ -287,6 +297,7 @@ public class PSDisplayFormatTableModel extends PSTableModel {
   }
 
   // overridden to return <code>false</code> always.
+  @Override
   public boolean isCellEditable(int row, int col) {
     return false;
   }
@@ -308,7 +319,7 @@ public class PSDisplayFormatTableModel extends PSTableModel {
    * PSNode.DATA_TYPE_xxx</code> values. Modified by {@link #setRoot(PSNode)}, may be <code>null
    * </code> if that method has not been called.
    */
-  private Vector m_colTypes;
+  private Vector<String> m_colTypes;
 
   /**
    * Root node used to supply the data for this model. Modified by {@link #setRoot(PSNode)}, may be

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMainDisplayPanel.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMainDisplayPanel.java
@@ -229,7 +229,11 @@ public class PSMainDisplayPanel extends JScrollPane
               // save sorting info if we have any
               PSNode root = getDataModel().getRoot();
               if (root != null) {
-                root.setLastSortColumns(m_childViewTableModel.getSortingColumns());
+                // PSTableSorter still exposes raw List of Integer column indices
+                @SuppressWarnings("unchecked")
+                List<Integer> sortCols =
+                    (List<Integer>) m_childViewTableModel.getSortingColumns();
+                root.setLastSortColumns(sortCols);
                 root.setLastSortedAsc(m_childViewTableModel.isAscending());
               }
             }
@@ -337,7 +341,7 @@ public class PSMainDisplayPanel extends JScrollPane
     PSDisplayFormat df = null;
 
     // see if new node has sorting info saved
-    List sortingInfo = node.getLastSortColumns();
+    List<Integer> sortingInfo = node.getLastSortColumns();
     boolean sortAscending = node.getLastSortedAsc();
 
     // if no previous sort info, try to get initial sort column
@@ -377,7 +381,7 @@ public class PSMainDisplayPanel extends JScrollPane
 
     // Create a new model and set that, saving selection for later restore
     Iterator<PSNode> curSelIter = getSelectedRowNodes();
-    Collection<PSNode> curSel = new ArrayList<PSNode>();
+    Collection<PSNode> curSel = new ArrayList<>();
     while (curSelIter.hasNext()) curSel.add(curSelIter.next());
     PSDisplayFormatTableModel tableModel = new PSDisplayFormatTableModel(m_applet);
     tableModel.setLocale(m_applet.getUserInfo().getLocale());
@@ -435,7 +439,7 @@ public class PSMainDisplayPanel extends JScrollPane
   private void resetColumnWidths(PSNode node, PSDisplayFormat df) {
     if (node == null) throw new IllegalArgumentException("node must not be null");
 
-    List widths = m_actManager.getApplet().getColumnWidthsFromOptions(node);
+    List<String> widths = m_actManager.getApplet().getColumnWidthsFromOptions(node);
 
     // if no stored column widths or if the number of column widths that were
     // stored is different than the current table model, check the display
@@ -448,11 +452,11 @@ public class PSMainDisplayPanel extends JScrollPane
 
     if (widths == null || (widths.size() != numCols)) {
       if (df != null) {
-        widths = new ArrayList(numCols);
+        widths = new ArrayList<>(numCols);
         colIndex = 0;
-        Iterator cols = df.getColumns();
+        Iterator<PSDisplayColumn> cols = df.getColumns();
         while (cols.hasNext() && colIndex < numCols) {
-          PSDisplayColumn dfCol = (PSDisplayColumn) cols.next();
+          PSDisplayColumn dfCol = cols.next();
           String strColWidth = null; // will add null value if not specd
           int colWidth = dfCol.getWidth();
           if (colWidth != -1) {
@@ -476,10 +480,8 @@ public class PSMainDisplayPanel extends JScrollPane
     }
 
     colIndex = 0;
-    Iterator i = widths.iterator();
-    while (i.hasNext()) {
+    for (String width : widths) {
       int useWidth;
-      String width = (String) i.next();
       if (width == null) // using display format, no width for this col
       {
         useWidth = (defaultColWidth > MIN_COL_WIDTH) ? defaultColWidth : MIN_COL_WIDTH;
@@ -632,7 +634,7 @@ public class PSMainDisplayPanel extends JScrollPane
         for (int col = 0; col < count; col++) {
           // if any of the column widths have changed, save the widths
           if (mi_saveColWidths[col] != colModel.getColumn(col).getWidth()) {
-            List widths = new ArrayList();
+            List<String> widths = new ArrayList<>();
             for (int i = 0; i < count; i++) widths.add("" + colModel.getColumn(i).getWidth());
 
             // save the current column widths to the applet persistance
@@ -802,7 +804,7 @@ public class PSMainDisplayPanel extends JScrollPane
 
     PSDisplayFormatTableModel model = getDataModel();
 
-    List<PSNode> selNodes = new ArrayList<PSNode>();
+    List<PSNode> selNodes = new ArrayList<>();
     if (rows != null && rows.length > 0) {
       for (int i = 0; i < rows.length; i++) {
         int modelRow = m_childViewTableModel.getModelRow(rows[i]);
@@ -840,7 +842,7 @@ public class PSMainDisplayPanel extends JScrollPane
 
     PSDisplayFormatTableModel model = getDataModel();
 
-    List<PSNode> draggableNodes = new ArrayList<PSNode>();
+    List<PSNode> draggableNodes = new ArrayList<>();
     if (rows != null && rows.length > 0) {
       for (int i = 0; i < rows.length; i++) {
         int modelRow = m_childViewTableModel.getModelRow(rows[i]);
@@ -965,7 +967,7 @@ public class PSMainDisplayPanel extends JScrollPane
 
         getAccessibleContext().setAccessibleName(data.getName());
       } else {
-        Iterator cols = m_parentNode.getChildrenDisplayFormat();
+        Iterator<Map.Entry<String, String>> cols = m_parentNode.getChildrenDisplayFormat();
         String colType = null;
         // If the column is not default column (column data loaded from server)
         // check whether this represents an image data and display icon
@@ -974,7 +976,7 @@ public class PSMainDisplayPanel extends JScrollPane
           // Get list of columns and get the definition of the column
           // corresponding to the column index - 1 (reduce index because
           // default column is not in the list.
-          List colDefs = PSIteratorUtils.cloneList(cols);
+          List<Map.Entry<String, String>> colDefs = PSIteratorUtils.cloneList(cols);
 
           // this is a hack for now, what we really need to do is to
           // be sure that folders always have the display format
@@ -982,8 +984,8 @@ public class PSMainDisplayPanel extends JScrollPane
           if (PSDisplayFormatTableModel.getSysTitleIndex(m_parentNode, m_actManager) < 0
               && column > 0) column--;
 
-          Map.Entry columnDef = (Map.Entry) colDefs.get(column);
-          colType = (String) columnDef.getValue();
+          Map.Entry<String, String> columnDef = colDefs.get(column);
+          colType = columnDef.getValue();
         }
 
         // Show tool tip if there is an image to explain that image.
@@ -1537,7 +1539,7 @@ public class PSMainDisplayPanel extends JScrollPane
   private static final int MIN_COL_WIDTH = 15;
 
   /** A map of display names to icon names. Map keys and values are of type <code>String</code>. */
-  private static final Map<String, String> ms_displayNameToIconName = new HashMap<String, String>();
+  private static final Map<String, String> ms_displayNameToIconName = new HashMap<>();
 
   static {
     ms_displayNameToIconName.put(

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMainView.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSMainView.java
@@ -74,7 +74,7 @@ public class PSMainView extends JSplitPane
    * addSelectionListener(IPSSelectionListener)</code>. Never <code>null</code> after
    * initialization.
    */
-  private List m_selListeners = new ArrayList();
+  private final List<IPSSelectionListener> m_selListeners = new ArrayList<>();
 
   /**
    * The current view of UI, initialized in the constructor and never <code>
@@ -220,7 +220,7 @@ public class PSMainView extends JSplitPane
 
       PSUiMode mode = new PSUiMode(m_view, PSUiMode.TYPE_MODE_NAV);
       PSNode parent = m_navTree.getSelectedParentNode();
-      Iterator selection = PSIteratorUtils.iterator(selNode);
+      Iterator<PSNode> selection = PSIteratorUtils.iterator(selNode);
       PSNavigationalSelection sel = new PSNavigationalSelection(mode, parent, selection, path);
 
       informListeners(sel);
@@ -280,10 +280,7 @@ public class PSMainView extends JSplitPane
    * @param selection the new selection, assumed not <code>null</code>
    */
   private void informListeners(PSSelection selection) {
-    Iterator listeners = m_selListeners.iterator();
-
-    while (listeners.hasNext()) {
-      IPSSelectionListener listener = (IPSSelectionListener) listeners.next();
+    for (IPSSelectionListener listener : m_selListeners) {
       listener.selectionChanged(selection);
     }
   }
@@ -296,7 +293,7 @@ public class PSMainView extends JSplitPane
    * @param node The node whose children may need to be refreshed, assumed not <code>null</code>.
    */
   private void refreshChildNodes(TreePath treePath, PSNode node) {
-    Iterator children = node.getChildren();
+    Iterator<PSNode> children = node.getChildren();
 
     // don't check for dirty if option is not enabled in server config
     if ((children == null)
@@ -319,7 +316,7 @@ public class PSMainView extends JSplitPane
       return;
     }
 
-    Iterator selNodes = m_mainDisplayPanel.getSelectedRowNodes();
+    Iterator<PSNode> selNodes = m_mainDisplayPanel.getSelectedRowNodes();
 
     if (selNodes.hasNext()) {
       PSNode parent = m_navTree.getSelectedNode();
@@ -356,12 +353,12 @@ public class PSMainView extends JSplitPane
         m_navTree.selectNode(nodeToRefresh);
       }
     } else if (refreshHint.equals(PSActionEvent.REFRESH_NODES)) {
-      Iterator nodes = event.getRefreshNodes();
+      Iterator<?> nodes = event.getRefreshNodes();
       PSNode oldNode = null;
       PSNode newNode = null;
       boolean wasExpanded = false;
 
-      while (nodes.hasNext()) {
+      while (nodes != null && nodes.hasNext()) {
         oldNode = (PSNode) nodes.next();
         wasExpanded = oldNode.shouldExpand();
 
@@ -382,12 +379,10 @@ public class PSMainView extends JSplitPane
       // try to locate and dirty current nodes
       // if none found, insert new dirty node into each view/search/folder
       // so the new items/folders may appear on selective refresh
-      List dirtyList = PSIteratorUtils.cloneList(event.getRefreshNodes());
-      Iterator dirtyNodes = dirtyList.iterator();
-
-      while (dirtyNodes.hasNext()) {
-        PSNode node = (PSNode) dirtyNodes.next();
-        List types = new ArrayList();
+      List<?> dirtyList = PSIteratorUtils.cloneList(event.getRefreshNodes());
+      for (Object dirtyObj : dirtyList) {
+        PSNode node = (PSNode) dirtyObj;
+        List<String> types = new ArrayList<>();
         types.addAll(PSNode.getFolderTypes());
         types.addAll(PSNode.getSearchTypes());
         m_navTree.dirtyChildNodes(node, types);
@@ -455,10 +450,10 @@ public class PSMainView extends JSplitPane
           // This will always have only one entry because, double-click removes
           // the previous selection and makes the clicked row alone as selected.
           // even if multiple rows comes, take the first one.
-          Iterator selNodes = m_mainDisplayPanel.getSelectedRowNodes();
+          Iterator<PSNode> selNodes = m_mainDisplayPanel.getSelectedRowNodes();
 
           if (selNodes.hasNext()) {
-            selNode = (PSNode) selNodes.next();
+            selNode = selNodes.next();
           } else {
             return;
           }
@@ -547,4 +542,3 @@ public class PSMainView extends JSplitPane
     }
   }
 }
-;

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatTableModelTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatTableModelTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cx.objectstore.PSNode;
+import com.percussion.util.PSEntrySet;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed {@link PSDisplayFormatTableModel} after rawtypes cleanup (#2875).
+ * Uses headless applet; does not exercise live ActionManager / display-format catalog.
+ */
+public class PSDisplayFormatTableModelTest {
+
+  @Test
+  public void constructorRejectsNullApplet() {
+    assertThrows(IllegalArgumentException.class, () -> new PSDisplayFormatTableModel(null));
+  }
+
+  @Test
+  public void setRootRejectsNull() {
+    PSDisplayFormatTableModel model = newModel();
+    assertThrows(IllegalArgumentException.class, () -> model.setRoot(null));
+  }
+
+  @Test
+  public void getRootNullUntilSet() {
+    PSDisplayFormatTableModel model = newModel();
+    assertNull(model.getRoot());
+  }
+
+  @Test
+  public void getSysTitleIndexNullNode() {
+    assertEquals(-1, PSDisplayFormatTableModel.getSysTitleIndex(null, null));
+  }
+
+  @Test
+  public void getSysTitleIndexMissingDisplayFormatId() {
+    PSNode node = folder("p", "Parent");
+    assertEquals(-1, PSDisplayFormatTableModel.getSysTitleIndex(node, null));
+  }
+
+  @Test
+  public void setRootWithoutDisplayFormatUsesNameColumnAndNodeData() {
+    PSDisplayFormatTableModel model = newModel();
+    PSNode parent = folder("p", "Parent");
+    PSNode child = item("c1", "Child One");
+    parent.addChild(child);
+
+    model.setRoot(parent);
+
+    assertSame(parent, model.getRoot());
+    assertEquals(1, model.getRowCount());
+    assertEquals(1, model.getColumnCount());
+    assertSame(child, model.getData(0));
+    assertFalse(model.isCellEditable(0, 0));
+
+    Iterator<Object> data = model.getData();
+    assertTrue(data.hasNext());
+    assertSame(child, data.next());
+    assertFalse(data.hasNext());
+  }
+
+  @Test
+  public void setRootWithDisplayFormatConvertsNumberAndTextColumns() {
+    PSDisplayFormatTableModel model = newModel();
+    PSNode parent = folder("p", "Parent");
+
+    List<Map.Entry<String, String>> defs = new ArrayList<>();
+    defs.add(new PSEntrySet<>("sys_contentid", PSNode.DATA_TYPE_NUMBER));
+    defs.add(new PSEntrySet<>("sys_title", PSNode.DATA_TYPE_TEXT));
+    parent.setChildrenDisplayFormat(defs.iterator());
+
+    PSNode child = item("c1", "Child One");
+    Map<String, Object> row = new HashMap<>();
+    row.put("sys_contentid", "4242");
+    row.put("sys_title", "Hello");
+    child.setRowData(row);
+    parent.addChild(child);
+
+    model.setRoot(parent);
+
+    // default Name column + 2 display format columns
+    assertEquals(3, model.getColumnCount());
+    assertEquals(1, model.getRowCount());
+    assertSame(child, model.getData(0));
+    assertEquals(Integer.valueOf(4242), model.getValueAt(0, 1));
+    assertEquals("Hello", model.getValueAt(0, 2));
+    assertEquals(Integer.class, model.getColumnClass(1));
+    assertEquals(String.class, model.getColumnClass(2));
+  }
+
+  @Test
+  public void convertCellValueNumberAndNonNumeric() {
+    assertEquals(Integer.valueOf(7), PSDisplayFormatTableModel.convertCellValue("7", PSNode.DATA_TYPE_NUMBER));
+    assertEquals("abc", PSDisplayFormatTableModel.convertCellValue("abc", PSNode.DATA_TYPE_NUMBER));
+    assertNull(PSDisplayFormatTableModel.convertCellValue(null, PSNode.DATA_TYPE_NUMBER));
+    assertEquals("x", PSDisplayFormatTableModel.convertCellValue("x", PSNode.DATA_TYPE_TEXT));
+  }
+
+  @Test
+  public void convertCellValueDateParsesString() {
+    Object converted =
+        PSDisplayFormatTableModel.convertCellValue("2020-01-15 00:00:00.000", PSNode.DATA_TYPE_DATE);
+    assertNotNull(converted);
+    assertInstanceOf(Date.class, converted);
+  }
+
+  @Test
+  public void setLocaleEmptyUsesDefault() {
+    PSDisplayFormatTableModel model = newModel();
+    model.setLocale(null);
+    assertNotNull(model.getLocale());
+    model.setLocale("");
+    assertNotNull(model.getLocale());
+  }
+
+  private static PSDisplayFormatTableModel newModel() {
+    return new PSDisplayFormatTableModel(new PSContentExplorerApplet(true));
+  }
+
+  private static PSNode folder(String name, String label) {
+    return new PSNode(name, label, PSNode.TYPE_FOLDER, "url", null, false, 1);
+  }
+
+  private static PSNode item(String name, String label) {
+    return new PSNode(name, label, PSNode.TYPE_ITEM, "", null, false, -1);
+  }
+}


### PR DESCRIPTION
## Summary
Residual javac `-Xlint` batch for `perc-content-explorer` (#2875 / parent residual #2326 / module #2045 / monorepo #2200): clear **PSDisplayFormatTableModel**, **PSMainDisplayPanel**, and **PSMainView** rawtypes/unchecked under full inventory.

- Typed `PSDisplayFormatTableModel` Vectors/Iterators/Maps; `Class<?>` column class; package-visible `convertCellValue` (same historic String cast rules)
- `PSMainDisplayPanel`: typed column widths, sort columns (`List<Integer>`), display-format column defs
- `PSMainView`: typed selection listeners, refresh/dirty node iteration (`Iterator<?>`, `List<String>` types)
- Behavioral tests: `PSDisplayFormatTableModelTest` (10)
- Erlang pre-commit: `docs/ai-generated/code-reviews/issue-2875-display-rawtypes-erlang.md`

**Did not touch** `PSFolderAclEditorDialog` (#2439 In Progress).

**Fixes #2875.** Partial for parent residual #2326 / module #2045.

### Residual filed
- #2939 PSACLNewUserDialog rawtypes residual

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Tests run: **119**, Failures: 0 (includes 10 new `PSDisplayFormatTableModelTest`)
- [x] Module compile: zero rawtypes/unchecked warnings on the three in-scope files

## Gates
- Erlang self-review: pass
- Per-module clean install: perc-content-explorer
- Product documentation: **N/A** — compiler tech-debt / rawtypes only; no operator or UI behavior change
- Downstream (C2): no public signature / final/sealed API change; callers already use typed PSNode iterators

### C3 evidence
- **modules_built:** modules/DesktopContentExplorer
- **build_evidence:** `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 119, Failures: 0
- **downstream_checked:** none (C2 did not apply — no final/sealed, no signature change)

### Product documentation
- [x] N/A — pure generics/rawtypes tech-debt; no product behavior, config, or operator-facing surface change

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
