### PR TITLE
fix(perc-system): type install package RxUpgrade/pre-upgrade rawtypes (#2933)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2933-install-xlint-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2933-install-xlint-erlang.md
@@ -1,0 +1,44 @@
+# Erlang review — issue #2933 install package Xlint residual (slice 1)
+
+**Branch:** `fix/issue-2933-install-xlint-residual`  
+**Scope:** `com.percussion.install` core RxUpgrade/pre-upgrade/small plugins rawtypes  
+**Date:** 2026-08-11  
+**Reviewer persona:** Erlang (implementer self-review)
+
+## Summary
+
+PR-sized batch types install/upgrade framework and smaller helpers with real generics
+(`ArrayList<PSPluginResponse>`, `Set<String>`, `List<PSKeyword>`, `Map<String,String>`,
+`List<String>` query helpers). Behavioral unit tests cover plugin response storage,
+name-clash utility, deprecated-app set, and `constructNewValue`. No product behavior
+change intended.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found  
+- Behavioral tests: present (`PSInstallPackageTypedTest`, 6 tests green)  
+- Cross-platform path checklist: N/A for new path I/O  
+- **May commit/push: yes**
+
+## Issues
+
+None.
+
+## Notes
+
+- Left large residual clusters: `PSUpgradePluginRelationship`,
+  `PSUpgradePluginConvertCommunityVisibility`, slot-name upgrade, Ora LONG tool,
+  CleanLocationSchemes, UpdateExtensions, SpringBeans, Publishing, etc. (~183 raw
+  hits remaining) for a follow-up residual issue.
+- Public/package API tightenings are source-compatible for typical callers
+  (`Set<?>` / `List<String>` / `ArrayList<PSPluginResponse>`).
+- Stayed out of services (#2934) and xml/extension (#2935) siblings.
+
+## Build evidence
+
+- `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**  
+- Tests run: **1703**, Failures: **0**, Errors: **0**, Skipped: **240**

--- a/system/src/main/java/com/percussion/install/PSJdbcTableMapper.java
+++ b/system/src/main/java/com/percussion/install/PSJdbcTableMapper.java
@@ -31,7 +31,6 @@ import com.percussion.tablefactory.PSJdbcTableSchema;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -119,12 +118,10 @@ public class PSJdbcTableMapper implements IPSJdbcTableDataHandler {
       PSJdbcRowData srcRow = step.next();
       while (srcRow != null) {
         // process the row mappings
-        List rowList = tableMapping.processRow(conn, srcRow);
+        List<PSJdbcRowData> rowList = tableMapping.processRow(conn, srcRow);
         if (rowList != null) {
-          Iterator it = rowList.iterator();
-          while (it.hasNext()) {
+          for (PSJdbcRowData destRow : rowList) {
             // create the insert statement
-            PSJdbcRowData destRow = (PSJdbcRowData) it.next();
             PSJdbcExecutionStep insertStep =
                 PSJdbcStatementFactory.getInsertStatement(m_dbmsDef, destSchema, destRow);
             insertStep.execute(conn);

--- a/system/src/main/java/com/percussion/install/PSJdbcTransitionRoles.java
+++ b/system/src/main/java/com/percussion/install/PSJdbcTransitionRoles.java
@@ -186,9 +186,9 @@ public class PSJdbcTransitionRoles implements IPSJdbcTableDataHandler {
                   rolesTblFilter,
                   PSJdbcRowData.ACTION_INSERT);
           if (roleTblData != null) {
-            Iterator it = roleTblData.getRows();
+            Iterator<PSJdbcRowData> it = roleTblData.getRows();
             if (it.hasNext()) {
-              PSJdbcRowData insertRow = (PSJdbcRowData) it.next();
+              PSJdbcRowData insertRow = it.next();
               String roleId = getRequiredColumnValue(insertRow, TBL_ROLES, COL_ROLEID);
 
               // create "TRANSITIONROLEID" column

--- a/system/src/main/java/com/percussion/install/PSJdbcUniqueColumn.java
+++ b/system/src/main/java/com/percussion/install/PSJdbcUniqueColumn.java
@@ -254,7 +254,7 @@ public class PSJdbcUniqueColumn implements IPSJdbcTableDataHandler {
    * </code> passed as argument to the <code>execute()</code> method. Column values are stored as
    * <code>String</code> objects in UPPERCASE. This list is never <code>null</code>, may be empty.
    */
-  private Set m_colValues = new HashSet();
+  private Set<String> m_colValues = new HashSet<>();
 
   // Xml elements and attributes
   protected static final String COLUMN_EL = "column";

--- a/system/src/main/java/com/percussion/install/PSNameSpacesUtil.java
+++ b/system/src/main/java/com/percussion/install/PSNameSpacesUtil.java
@@ -36,7 +36,7 @@ public class PSNameSpacesUtil {
    * @param names all existing names to check for clash against. Never <code>null</code>.
    * @return the corrected name. If this name is applied caller should add it to the names set.
    */
-  public static String removeWhitespacesFromName(final String name, Set names) {
+  public static String removeWhitespacesFromName(final String name, Set<?> names) {
     final StringBuilder buf = new StringBuilder();
     for (int i = 0; i < name.length(); i++) {
       final char ch = name.charAt(i);

--- a/system/src/main/java/com/percussion/install/PSPreUpgradePluginCustomProperty.java
+++ b/system/src/main/java/com/percussion/install/PSPreUpgradePluginCustomProperty.java
@@ -24,7 +24,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import org.w3c.dom.Element;
 
@@ -60,12 +59,11 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
 
     for (int i = 0; i < m_actionProps.length; i++) m_nonCustomProps.add(m_actionProps[i]);
 
-    Set results = new HashSet();
+    Set<String> results = new HashSet<>();
     int respType = PSPluginResponse.SUCCESS;
     String respMessage = "The following Server Objects use custom properties:" + "\n\n";
     String endMessage = "\nPlease remove these properties.\n\n";
     String bodyMessage = "";
-    Iterator iter;
     String log = config.getLogFile();
 
     try {
@@ -81,10 +79,8 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
 
       if (results.size() > 0) {
         bodyMessage += "Views/Searches:\n\n";
-        iter = results.iterator();
-
-        while (iter.hasNext()) {
-          bodyMessage += (String) iter.next() + "\n";
+        for (String name : results) {
+          bodyMessage += name + "\n";
         }
       }
 
@@ -100,10 +96,8 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
 
       if (results.size() > 0) {
         bodyMessage += "\nDisplay Formats:\n\n";
-        iter = results.iterator();
-
-        while (iter.hasNext()) {
-          bodyMessage += (String) iter.next() + "\n";
+        for (String name : results) {
+          bodyMessage += name + "\n";
         }
       }
 
@@ -119,10 +113,8 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
 
       if (results.size() > 0) {
         bodyMessage += "\nActions:\n\n";
-        iter = results.iterator();
-
-        while (iter.hasNext()) {
-          bodyMessage += (String) iter.next() + "\n";
+        for (String name : results) {
+          bodyMessage += name + "\n";
         }
       }
 
@@ -159,7 +151,7 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
    * @return set containing names of any objects which use custom properties, empty if none are
    *     found.
    */
-  private Set checkCustomProps(
+  private Set<String> checkCustomProps(
       String propTable,
       String propColumn,
       String propIdColumn,
@@ -167,8 +159,8 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
       String nameColumn,
       String idColumn)
       throws Exception {
-    Set ids = new HashSet();
-    Set names = new HashSet();
+    Set<Integer> ids = new HashSet<>();
+    Set<String> names = new HashSet<>();
     Connection conn = RxUpgrade.getJdbcConnection();
     PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(RxUpgrade.getRxRepositoryProps());
 
@@ -210,10 +202,8 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
         PSSqlHelper.qualifyTableName(
             table, dbmsDef.getDataBase(), dbmsDef.getSchema(), dbmsDef.getDriver());
 
-    Iterator iter = ids.iterator();
-
-    while (iter.hasNext()) {
-      int id = ((Integer) iter.next()).intValue();
+    for (Integer idObj : ids) {
+      int id = idObj.intValue();
       queryStmt =
           "SELECT "
               + qualTableName
@@ -278,5 +268,5 @@ public class PSPreUpgradePluginCustomProperty implements IPSUpgradePlugin {
       };
 
   /** Set of all non-custom properties */
-  private Set m_nonCustomProps = new HashSet();
+  private Set<String> m_nonCustomProps = new HashSet<>();
 }

--- a/system/src/main/java/com/percussion/install/PSPreUpgradePluginDeprecatedSysApps.java
+++ b/system/src/main/java/com/percussion/install/PSPreUpgradePluginDeprecatedSysApps.java
@@ -35,11 +35,11 @@ public class PSPreUpgradePluginDeprecatedSysApps implements IPSUpgradePlugin {
   public PSPreUpgradePluginDeprecatedSysApps() {}
 
   private static void staticInit() {
-    ms_sysApps = new HashSet();
+    ms_sysApps = new HashSet<>();
 
     for (int i = 0; i < SYS_APPS.length; i++) ms_sysApps.add(SYS_APPS[i]);
 
-    ms_deprecatedSysApps = new HashSet();
+    ms_deprecatedSysApps = new HashSet<>();
   }
 
   /**
@@ -89,7 +89,7 @@ public class PSPreUpgradePluginDeprecatedSysApps implements IPSUpgradePlugin {
   }
 
   /** Returns the deprecated system applications found in the current installation. */
-  public static Set getDeprecatedSysApps() {
+  public static Set<String> getDeprecatedSysApps() {
     if (ms_deprecatedSysApps == null || ms_deprecatedSysApps.size() == 0) staticInit();
     return ms_deprecatedSysApps;
   }
@@ -101,13 +101,13 @@ public class PSPreUpgradePluginDeprecatedSysApps implements IPSUpgradePlugin {
    * Set of 6.0 system application names. Initialized in ctor, never <code>null</code> or empty
    * after that.
    */
-  private static Set ms_sysApps = null;
+  private static Set<String> ms_sysApps = null;
 
   /**
    * Deprecated system applications which exist in the current installation. Always initialized in
    * static block, never <code>null</code>, may be empty.
    */
-  private static Set ms_deprecatedSysApps = null;
+  private static Set<String> ms_deprecatedSysApps = null;
 
   /** Array containing the current 6.0 system application names. */
   public static final String[] SYS_APPS =

--- a/system/src/main/java/com/percussion/install/PSPreUpgradePluginRelationship.java
+++ b/system/src/main/java/com/percussion/install/PSPreUpgradePluginRelationship.java
@@ -130,10 +130,9 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
       throws Exception {
     boolean isValidated = true;
 
-    Iterator configs = configSet.iterator();
+    Iterator<PSRelationshipConfig> configs = configSet.iterator();
     while (configs.hasNext()) {
-      if (!validateUnknownRelationshipProperties(
-          logger, (PSRelationshipConfig) configs.next(), conn, util)) {
+      if (!validateUnknownRelationshipProperties(logger, configs.next(), conn, util)) {
         isValidated = false;
       }
     }
@@ -152,7 +151,7 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
       PSUpgradePluginRelationship util)
       throws Exception {
     // collect all property names, both system and user
-    Collection pnames = getPropertyNames(config.getSysProperties());
+    Collection<String> pnames = getPropertyNames(config.getSysProperties());
     pnames.addAll(getPropertyNames(config.getUserDefProperties()));
 
     // query the database, see if there is additional property names
@@ -160,11 +159,11 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
 
     // build the name IN clause
     StringBuilder buf = new StringBuilder();
-    Iterator pnamesIt = pnames.iterator();
+    Iterator<String> pnamesIt = pnames.iterator();
     while (pnamesIt.hasNext()) {
       if (buf.length() != 0) buf.append(",");
       buf.append("'");
-      buf.append((String) pnamesIt.next());
+      buf.append(pnamesIt.next());
       buf.append("'");
     }
 
@@ -181,7 +180,7 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
             + buf.toString()
             + ")";
 
-    List unknownNames = util.queryStringList(logger, conn, sqlStmt);
+    List<String> unknownNames = util.queryStringList(logger, conn, sqlStmt);
 
     // remove all required property names for Active Assembly config
     if ((!unknownNames.isEmpty())
@@ -198,11 +197,10 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
               + "the unknown properties are not used; otherwise they must be "
               + "specified in the relationship configuration before the "
               + "upgrade. The unknown properties are: ");
-      Iterator names = unknownNames.iterator();
       boolean firstTime = true;
-      while (names.hasNext()) {
+      for (String name : unknownNames) {
         if (!firstTime) msgBuffer.append(",");
-        msgBuffer.append("'" + (String) names.next() + "'");
+        msgBuffer.append("'" + name + "'");
         firstTime = false;
       }
       msgBuffer.append("");
@@ -222,11 +220,10 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
    *     may be empty.
    * @return the property names, never <code>null</code>.
    */
-  private Collection getPropertyNames(Iterator props) {
-    List names = new ArrayList();
-    PSProperty prop;
+  private Collection<String> getPropertyNames(Iterator<?> props) {
+    List<String> names = new ArrayList<>();
     while (props.hasNext()) {
-      prop = (PSProperty) props.next();
+      PSProperty prop = (PSProperty) props.next();
       names.add(prop.getName());
     }
     return names;
@@ -333,10 +330,9 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
   private boolean validateEmptyExpiretime(PrintStream logger, PSRelationshipConfigSet configSet) {
     boolean emptyExpiretime = true;
 
-    Iterator configs = configSet.iterator();
-    PSRelationshipConfig config;
+    Iterator<PSRelationshipConfig> configs = configSet.iterator();
     while (configs.hasNext()) {
-      config = (PSRelationshipConfig) configs.next();
+      PSRelationshipConfig config = configs.next();
       PSProperty prop = config.getSysProperty("rs_expirationtime");
       if (prop != null) {
         String value = (String) prop.getValue();
@@ -381,10 +377,8 @@ public class PSPreUpgradePluginRelationship implements IPSUpgradePlugin {
     boolean isValidated = true;
     String sqlStmt = "SELECT DISTINCT CONFIG FROM " + util.getOldRelMainTable();
 
-    List rs = util.queryStringList(logger, conn, sqlStmt);
-    Iterator names = rs.iterator();
-    while (names.hasNext()) {
-      String name = (String) names.next();
+    List<String> rs = util.queryStringList(logger, conn, sqlStmt);
+    for (String name : rs) {
       if (configs.getConfig(name) == null) {
         logWarningMsg(
             logger,

--- a/system/src/main/java/com/percussion/install/PSUpgradeConfig.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradeConfig.java
@@ -859,7 +859,7 @@ public class PSUpgradeConfig implements IPSUpgradeConfig {
    *
    * @return module iterator
    */
-  public Iterator getModuleList() {
+  public Iterator<?> getModuleList() {
     return m_modules.iterator();
   }
 
@@ -867,7 +867,7 @@ public class PSUpgradeConfig implements IPSUpgradeConfig {
    * Arraylist intended to hold the valid modules. When initialized must be empty but never be
    * <code>null</code>.
    */
-  private ArrayList m_modules = new ArrayList();
+  private ArrayList<IPSUpgradeModule> m_modules = new ArrayList<>();
 
   private static boolean ms_isUpgrade;
 

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginCheckDuplicateKeysInTables.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginCheckDuplicateKeysInTables.java
@@ -136,14 +136,14 @@ public class PSUpgradePluginCheckDuplicateKeysInTables implements IPSUpgradePlug
     PSJdbcTableData cvData = cvSchema.getTableData();
 
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
-    Iterator rows = cvData.getRows();
+    Iterator<PSJdbcRowData> rows = cvData.getRows();
     PSJdbcRowData tRow = null;
-    Set cvKeys = new HashSet();
-    Set dupKeys = new HashSet();
+    Set<String> cvKeys = new HashSet<>();
+    Set<String> dupKeys = new HashSet<>();
 
     // Since a Set forbids dups we can catch if primary key violations occur
     while (rows.hasNext()) {
-      tRow = (PSJdbcRowData) rows.next();
+      tRow = rows.next();
       String value = tRow.getColumn(getTableColumn()).getValue();
       // collect all the dup keys
       if (cvKeys.add(value) == false) dupKeys.add(value);
@@ -161,16 +161,16 @@ public class PSUpgradePluginCheckDuplicateKeysInTables implements IPSUpgradePlug
    *
    * @param set, list of duplicate keys found in the table
    */
-  private void displayErrorMessage(Set dupKeys) {
+  private void displayErrorMessage(Set<String> dupKeys) {
     String msg = "Primary key constraint violation occurred: duplicate \n";
     msg += "keys were found in table: " + getTableName() + ", in the ";
     msg += "column: " + getTableColumn();
 
     String dupMsg;
-    Iterator iter = dupKeys.iterator();
-    dupMsg = (String) iter.next();
+    Iterator<String> iter = dupKeys.iterator();
+    dupMsg = iter.next();
     while (iter.hasNext()) {
-      dupMsg += ", " + (String) iter.next();
+      dupMsg += ", " + iter.next();
     }
 
     msg += "\nDuplicate keys found are: {" + dupMsg + "}\n";

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginFixGlobalTemplateNames.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginFixGlobalTemplateNames.java
@@ -23,7 +23,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.w3c.dom.Element;
 
@@ -55,7 +54,7 @@ public class PSUpgradePluginFixGlobalTemplateNames implements IPSUpgradePlugin {
               + " FROM "
               + qualTableName;
 
-      Map gtMap = new HashMap();
+      Map<String, String> gtMap = new HashMap<>();
 
       Statement selStmt = conn.createStatement();
       ResultSet resultSet = null;
@@ -72,10 +71,9 @@ public class PSUpgradePluginFixGlobalTemplateNames implements IPSUpgradePlugin {
             Integer.toString(resultSet.getInt("SITEID")), resultSet.getString("GLOBALTEMPLATE"));
       }
 
-      Iterator iter = gtMap.keySet().iterator();
-      while (iter.hasNext()) {
-        String siteid = (String) iter.next();
-        String gtName = (String) gtMap.get(siteid);
+      for (Map.Entry<String, String> entry : gtMap.entrySet()) {
+        String siteid = entry.getKey();
+        String gtName = entry.getValue();
         if (gtName != null && gtName.toLowerCase().endsWith(".xsl")) {
           String newGtName = gtName.substring(0, gtName.length() - 4);
           String upSqlSt =

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginItemFilters.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginItemFilters.java
@@ -22,7 +22,6 @@ import com.percussion.services.filter.IPSItemFilterRuleDef;
 import com.percussion.services.filter.PSFilterException;
 import com.percussion.services.filter.PSFilterServiceLocator;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
 import org.w3c.dom.Element;
 
@@ -60,8 +59,8 @@ public class PSUpgradePluginItemFilters implements IPSUpgradePlugin {
     String respMsg = "";
 
     try {
-      checkAndAddRule(PREVIEW_FILTER, PREVIEW_FILTER_RULE, Collections.EMPTY_MAP);
-      checkAndAddRule(PUBLIC_FILTER, PUBLIC_FILTER_RULE, Collections.EMPTY_MAP);
+      checkAndAddRule(PREVIEW_FILTER, PREVIEW_FILTER_RULE, Collections.emptyMap());
+      checkAndAddRule(PUBLIC_FILTER, PUBLIC_FILTER_RULE, Collections.emptyMap());
     } catch (Exception e) {
       respType = PSPluginResponse.EXCEPTION;
       respMsg = e.getMessage();
@@ -79,13 +78,11 @@ public class PSUpgradePluginItemFilters implements IPSUpgradePlugin {
    * @param rulename the name of the rule, assumed never <code>null</code> or empty.
    * @param params the parameters, may be <code>null</code>.
    */
-  private void checkAndAddRule(String filtername, String rulename, Map params) {
+  private void checkAndAddRule(String filtername, String rulename, Map<String, String> params) {
     try {
       IPSItemFilter filter = fsvc.findFilterByName(filtername);
       boolean found = false;
-      Iterator fiter = filter.getRuleDefs().iterator();
-      while (fiter.hasNext()) {
-        IPSItemFilterRuleDef def = (IPSItemFilterRuleDef) fiter.next();
+      for (IPSItemFilterRuleDef def : filter.getRuleDefs()) {
         if (def.getRuleName().equals(rulename)) {
           found = true;
           break;

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginModifyColumnBase.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginModifyColumnBase.java
@@ -133,7 +133,7 @@ public abstract class PSUpgradePluginModifyColumnBase implements IPSUpgradePlugi
    * @param value current value.
    * @param allValues all the existing values.
    */
-  protected String constructNewValue(final String value, final Set allValues) {
+  protected String constructNewValue(final String value, final Set<String> allValues) {
     String newValue = value;
     int idx = 1;
     while (allValues.contains(newValue)) {
@@ -182,9 +182,9 @@ public abstract class PSUpgradePluginModifyColumnBase implements IPSUpgradePlugi
   }
 
   /** Loads all the names from the database. */
-  protected Set loadValues(final Connection conn, String column, final String valuesQuery)
+  protected Set<String> loadValues(final Connection conn, String column, final String valuesQuery)
       throws SQLException {
-    final Set allValues = new HashSet();
+    final Set<String> allValues = new HashSet<>();
     final Statement statement = conn.createStatement();
     try {
       final ResultSet resultSet = statement.executeQuery(valuesQuery);

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginMoveCatalogerConfigs.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginMoveCatalogerConfigs.java
@@ -82,7 +82,7 @@ public class PSUpgradePluginMoveCatalogerConfigs implements IPSUpgradePlugin {
       Element subCatEl =
           PSSpringBeanUtils.getNextPropertyElement(roleMgrEl, null, "subjectCatalogers");
 
-      List configs = new ArrayList();
+      List<PSCatalogerConfig> configs = new ArrayList<>();
       configs.addAll(getCatalogerList(subCatEl, ConfigTypes.SUBJECT));
 
       // copy subject catalogers to cataloger beans
@@ -119,9 +119,9 @@ public class PSUpgradePluginMoveCatalogerConfigs implements IPSUpgradePlugin {
    * @throws PSInvalidXmlException If the supplied element does not represent a list of beans that
    *     can be represented by a {@link PSCatalogerConfig}.
    */
-  private Collection getCatalogerList(Element source, ConfigTypes type)
+  private Collection<PSCatalogerConfig> getCatalogerList(Element source, ConfigTypes type)
       throws PSInvalidXmlException {
-    List configs = new ArrayList();
+    List<PSCatalogerConfig> configs = new ArrayList<>();
 
     Element catEl = PSSpringBeanUtils.getNextPropertyListElement(source, null);
     while (catEl != null) {

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginRelationship.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginRelationship.java
@@ -1192,8 +1192,9 @@ public class PSUpgradePluginRelationship implements IPSUpgradePlugin {
    *     empty.
    * @throws Exception if error occurs.
    */
-  List queryStringList(PrintStream logger, Connection conn, String sqlStmt) throws Exception {
-    List result = new ArrayList();
+  List<String> queryStringList(PrintStream logger, Connection conn, String sqlStmt)
+      throws Exception {
+    List<String> result = new ArrayList<>();
     Statement stmt = null;
     ResultSet rs = null;
     try {

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginRemoveDocTypeFromDTDs.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginRemoveDocTypeFromDTDs.java
@@ -31,7 +31,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.Iterator;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -56,7 +55,7 @@ public class PSUpgradePluginRemoveDocTypeFromDTDs implements IPSUpgradePlugin {
     FileInputStream fis = null;
 
     try {
-      List fileList = null;
+      List<File> fileList = null;
 
       File root = new File(RxUpgrade.getRxRoot());
 
@@ -68,10 +67,7 @@ public class PSUpgradePluginRemoveDocTypeFromDTDs implements IPSUpgradePlugin {
       PSFilteredFileList lister = new PSFilteredFileList(filter);
       fileList = lister.getFiles(root);
 
-      Iterator iter = fileList.iterator();
-      while (iter.hasNext()) {
-        File dtdFile = (File) iter.next();
-
+      for (File dtdFile : fileList) {
         String fileName = dtdFile.getName();
 
         // check if this DTD has a DOCTYPE that we want to remove

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginUniqueNames.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginUniqueNames.java
@@ -74,9 +74,9 @@ public class PSUpgradePluginUniqueNames extends PSUpgradePluginModifyColumnBase 
     int rowsModified = 0;
 
     try {
-      final Set allValues = loadValues(conn, column, valuesQuery);
+      final Set<String> allValues = loadValues(conn, column, valuesQuery);
       {
-        final Set valuesSoFar = new HashSet();
+        final Set<String> valuesSoFar = new HashSet<>();
         final Statement statement =
             conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_UPDATABLE);
         try {

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginUpgradeKeywords.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginUpgradeKeywords.java
@@ -21,7 +21,6 @@ import com.percussion.services.content.PSContentServiceLocator;
 import com.percussion.services.content.data.PSKeyword;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -40,12 +39,11 @@ public class PSUpgradePluginUpgradeKeywords extends PSSpringUpgradePluginBase
     m_config = config;
     log("Fixing Keyword Names");
 
-    final List keywords = getContentService().findKeywordsByLabel(null, null);
-    final List keywordsToFixNames = findKeywordsToFixNames(keywords);
-    final Set keywordNames = getKeywordNames(keywords);
+    final List<PSKeyword> keywords = getContentService().findKeywordsByLabel(null, null);
+    final List<PSKeyword> keywordsToFixNames = findKeywordsToFixNames(keywords);
+    final Set<String> keywordNames = getKeywordNames(keywords);
 
-    for (Iterator i = keywordsToFixNames.iterator(); i.hasNext(); ) {
-      final PSKeyword keyword = (PSKeyword) i.next();
+    for (PSKeyword keyword : keywordsToFixNames) {
       keyword.setName(PSNameSpacesUtil.removeWhitespacesFromName(keyword.getName(), keywordNames));
       keywordNames.add(keyword.getName());
       getContentService().saveKeyword(keyword);
@@ -55,10 +53,9 @@ public class PSUpgradePluginUpgradeKeywords extends PSSpringUpgradePluginBase
   }
 
   /** Selects keywords from the list which need their names to be fixed. */
-  private List findKeywordsToFixNames(final List keywords) {
-    final List keywordsToFixNames = new ArrayList();
-    for (Iterator i = keywords.iterator(); i.hasNext(); ) {
-      final PSKeyword keyword = (PSKeyword) i.next();
+  private List<PSKeyword> findKeywordsToFixNames(final List<PSKeyword> keywords) {
+    final List<PSKeyword> keywordsToFixNames = new ArrayList<>();
+    for (PSKeyword keyword : keywords) {
       final String name = keyword.getName();
       if (!name.equals(StringUtils.deleteWhitespace(name))) {
         keywordsToFixNames.add(keyword);
@@ -68,10 +65,9 @@ public class PSUpgradePluginUpgradeKeywords extends PSSpringUpgradePluginBase
   }
 
   /** Set of keyword names extracted from the provided keywords. */
-  private Set getKeywordNames(final List keywords) {
-    final Set names = new HashSet();
-    for (Iterator i = keywords.iterator(); i.hasNext(); ) {
-      final PSKeyword keyword = (PSKeyword) i.next();
+  private Set<String> getKeywordNames(final List<PSKeyword> keywords) {
+    final Set<String> names = new HashSet<>();
+    for (PSKeyword keyword : keywords) {
       names.add(keyword.getName());
     }
     return names;

--- a/system/src/main/java/com/percussion/install/RxUpgrade.java
+++ b/system/src/main/java/com/percussion/install/RxUpgrade.java
@@ -143,7 +143,7 @@ public class RxUpgrade {
    *
    * @return the pre-upgrade plugin response objects
    */
-  public static ArrayList getResponses() {
+  public static ArrayList<PSPluginResponse> getResponses() {
     return ms_pluginResponses;
   }
 
@@ -156,9 +156,9 @@ public class RxUpgrade {
     if (upgradeConfig == null) throw new IllegalArgumentException("upgradeConfig may not be null");
 
     // initialize plugin response object store
-    ms_pluginResponses = new ArrayList();
+    ms_pluginResponses = new ArrayList<>();
 
-    Iterator iter = null;
+    Iterator<?> iter = null;
     IPSUpgradeModule moduleConfig = null;
     try {
       iter = upgradeConfig.getModuleList();
@@ -393,13 +393,13 @@ public class RxUpgrade {
           String dtd = elemFile.getAttribute("DTD");
           String xslTransform = getUpgradeRoot() + elemFile.getAttribute("transformxsl");
 
-          Iterator it =
+          Iterator<String> it =
               getXmlFiles(
                   elemFile.getAttribute("path"),
                   elemFile.getAttribute("type"),
                   config.getLogStream());
           while (it.hasNext()) {
-            String xmlFile = (String) it.next();
+            String xmlFile = it.next();
             config.getLogStream().println("Processing file: " + xmlFile + "...");
             Document newDoc = transformXML(xmlFile, xslTransform);
             config.getLogStream().println("Saving the transformed file: " + xmlFile + "...");
@@ -428,7 +428,7 @@ public class RxUpgrade {
    *     be empty
    * @throws IllegalArgumentException if any param is invalid
    */
-  private Iterator getXmlFiles(String file, String type, PrintStream ps) {
+  private Iterator<String> getXmlFiles(String file, String type, PrintStream ps) {
     if ((file == null) || (file.trim().length() < 1))
       throw new IllegalArgumentException("file may not be null or empty");
 
@@ -438,7 +438,7 @@ public class RxUpgrade {
       else throw new IllegalArgumentException("invalid type specified");
     }
 
-    List xmlFiles = new ArrayList();
+    List<String> xmlFiles = new ArrayList<>();
     File f = new File(m_RxRootDir, file);
     File[] files = new File[] {f};
 
@@ -883,7 +883,7 @@ public class RxUpgrade {
   public static boolean ms_bPreUpgrade = false;
 
   /** Pre-upgrade plugin response object storage */
-  public static ArrayList ms_pluginResponses = new ArrayList();
+  public static ArrayList<PSPluginResponse> ms_pluginResponses = new ArrayList<>();
 
   /** The objectstore property name in server.properties */
   private static final String PROPS_OBJECT_STORE_VAR = "objectStoreProperties";

--- a/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
+++ b/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
@@ -44,6 +44,11 @@ class PSInstallPackageTypedTest {
   @AfterEach
   void clearPluginResponses() {
     RxUpgrade.ms_pluginResponses = new ArrayList<>();
+    // Defense-in-depth: drop test probe if a prior test aborted mid-mutation.
+    Set<String> apps = PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps();
+    if (apps != null) {
+      apps.remove("sys_testOnly.xml");
+    }
   }
 
   @Test
@@ -111,9 +116,14 @@ class PSInstallPackageTypedTest {
     Set<String> apps = PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps();
     assertNotNull(apps);
     // empty until process() scans ObjectStore; still a live mutable String set
-    apps.add("sys_testOnly.xml");
-    assertTrue(PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps().contains("sys_testOnly.xml"));
-    apps.remove("sys_testOnly.xml");
+    final String probe = "sys_testOnly.xml";
+    try {
+      apps.add(probe);
+      assertTrue(
+          PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps().contains(probe));
+    } finally {
+      apps.remove(probe);
+    }
   }
 
   @Test

--- a/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
+++ b/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.tablefactory.PSJdbcDbmsDef;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for typed install/upgrade helpers after install-package rawtypes cleanup (#2933
+ * / #2877 slice 1).
+ */
+@Tag("UnitTest")
+@DisplayName("install package generics")
+class PSInstallPackageTypedTest {
+
+  @AfterEach
+  void clearPluginResponses() {
+    RxUpgrade.ms_pluginResponses = new ArrayList<>();
+  }
+
+  @Test
+  @DisplayName("RxUpgrade stores typed PSPluginResponse list")
+  void pluginResponsesAreTyped() {
+    PSPluginResponse r1 = new PSPluginResponse(PSPluginResponse.SUCCESS, "ok");
+    PSPluginResponse r2 = new PSPluginResponse(PSPluginResponse.WARNING, "warn");
+    RxUpgrade.addResponse(r1);
+    RxUpgrade.addResponse(r2);
+
+    ArrayList<PSPluginResponse> responses = RxUpgrade.getResponses();
+    assertEquals(2, responses.size());
+    assertSame(r1, responses.get(0));
+    assertSame(r2, responses.get(1));
+    assertEquals(PSPluginResponse.SUCCESS, responses.get(0).getType());
+    assertEquals("warn", responses.get(1).getMessage());
+  }
+
+  @Test
+  @DisplayName("PSNameSpacesUtil accepts typed Set and avoids name clashes")
+  void nameSpacesUtilTypedSet() {
+    Set<String> names = new HashSet<>();
+    names.add("a_b");
+    names.add("a_b1");
+    assertEquals("a_b2", PSNameSpacesUtil.removeWhitespacesFromName("a b", names));
+    assertEquals("plain", PSNameSpacesUtil.removeWhitespacesFromName("plain", names));
+  }
+
+  @Test
+  @DisplayName("deprecated sys apps set is typed String set")
+  void deprecatedSysAppsTyped() {
+    Set<String> apps = PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps();
+    assertNotNull(apps);
+    String sample = PSPreUpgradePluginDeprecatedSysApps.SYS_APPS[0];
+    assertTrue(sample.endsWith(".xml"));
+  }
+
+  @Test
+  @DisplayName("ModifyColumnBase constructNewValue disambiguates with typed set")
+  void constructNewValueTyped() {
+    PSUpgradePluginModifyColumnBase plugin =
+        new PSUpgradePluginModifyColumnBase() {
+          @Override
+          protected boolean modifyColumnValues(
+              Connection conn,
+              PSJdbcDbmsDef dbmsDef,
+              String table,
+              String column,
+              String idcolumn) {
+            return false;
+          }
+        };
+
+    Set<String> existing = new HashSet<>();
+    existing.add("Article");
+    existing.add("Article1");
+    // same package: protected constructNewValue
+    assertEquals("Article2", plugin.constructNewValue("Article", existing));
+    assertEquals("Fresh", plugin.constructNewValue("Fresh", existing));
+  }
+
+  @Test
+  @DisplayName("getDeprecatedSysApps returns non-null typed set")
+  void deprecatedSysAppsNonNull() {
+    Set<String> apps = PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps();
+    assertNotNull(apps);
+    // empty until process() scans ObjectStore; still a live mutable String set
+    apps.add("sys_testOnly.xml");
+    assertTrue(PSPreUpgradePluginDeprecatedSysApps.getDeprecatedSysApps().contains("sys_testOnly.xml"));
+    apps.remove("sys_testOnly.xml");
+  }
+
+  @Test
+  @DisplayName("empty plugin response list after reassignment")
+  void emptyResponsesAfterClear() {
+    RxUpgrade.addResponse(new PSPluginResponse(PSPluginResponse.SUCCESS, "x"));
+    assertFalse(RxUpgrade.getResponses().isEmpty());
+    RxUpgrade.ms_pluginResponses = new ArrayList<>();
+    assertTrue(RxUpgrade.getResponses().isEmpty());
+    Iterator<PSPluginResponse> it = RxUpgrade.getResponses().iterator();
+    assertFalse(it.hasNext());
+  }
+}


### PR DESCRIPTION
## Summary
PR-sized `-Xlint` residual for **install** package surfaces in `perc-system` (Parent #2877 / #2022 slice 1 / issue #2933).

Types core upgrade framework and smaller helpers with real generics:

- `RxUpgrade` — `ArrayList<PSPluginResponse>`, typed XML file iterator
- `PSUpgradeConfig` — `ArrayList<IPSUpgradeModule>`, `Iterator<?>` module list
- Pre-upgrade: CustomProperty, DeprecatedSysApps, Relationship validators
- JDBC helpers: UniqueColumn, TableMapper, TransitionRoles
- Smaller plugins: ModifyColumnBase/UniqueNames, UpgradeKeywords, CheckDuplicateKeys, FixGlobalTemplateNames, MoveCatalogerConfigs, RemoveDocTypeFromDTDs, ItemFilters
- `queryStringList` → `List<String>` (package helper)

Out of scope / residual (~183 raw hits remaining in larger upgrade plugins): Relationship (main plugin), ConvertCommunityVisibility, slot-name upgrade, Ora LONG tool, CleanLocationSchemes, UpdateExtensions, SpringBeans, Publishing, etc.

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **1703**, Failures: **0**, Errors: **0**, Skipped: **240**
- [x] New `PSInstallPackageTypedTest` (6 tests) — responses, name util, deprecated apps, constructNewValue

## Product documentation
- [x] N/A — pure tech-debt generics/Xlint cleanup; no operator/user-facing behavior change

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1703, Failures: 0, Errors: 0, Skipped: 240
- **downstream_checked:** none — no `final`/`sealed` types; public signature tightenings are source-compatible (`ArrayList<PSPluginResponse>`, `Set<String>`, `Set<?>`, `List<String>`); grep: `getResponses` only used in RxUpgrade; `getDeprecatedSysApps` caller in perc-ant uses `Set<?>`

## Links
- Fixes #2933
- Parent residual tracker: #2877
- Epic: #2022 / tracker #2200
- Related prior: process package #2299 / PR #2878

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
