### PR TITLE
fix(perc-system): type IPSComponent parentComponents in design.objectstore (#2936)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
@@ -52,7 +52,7 @@ public class PSAcl extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSAcl(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSAcl(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -408,7 +408,7 @@ public class PSAcl extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXAcl
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
@@ -157,7 +157,7 @@ public class PSAclEntry extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSAclEntry(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSAclEntry(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -518,7 +518,7 @@ public class PSAclEntry extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXAclEntry
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSActionLink.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSActionLink.java
@@ -47,7 +47,7 @@ public class PSActionLink extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSActionLink(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSActionLink(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -184,7 +184,7 @@ public class PSActionLink extends PSComponent {
   }
 
   // see IPSComponent
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSActionLinkList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSActionLinkList.java
@@ -48,7 +48,7 @@ public class PSActionLinkList extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSActionLinkList(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSActionLinkList(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -122,7 +122,7 @@ public class PSActionLinkList extends PSCollectionComponent {
   }
 
   // see IPSComponent
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplicationFile.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplicationFile.java
@@ -182,7 +182,7 @@ public class PSApplicationFile extends PSFile {
    *     supported by the class.
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     String isFolderStr = sourceNode.getAttribute(ATTR_IS_FOLDER);
     setIsFolder(isFolderStr != null && isFolderStr.equals("true"));

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
@@ -71,7 +71,7 @@ public class PSApplicationFlow extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSApplicationFlow(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSApplicationFlow(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -317,7 +317,7 @@ public class PSApplicationFlow extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplyWhen.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplyWhen.java
@@ -38,7 +38,7 @@ public class PSApplyWhen extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSApplyWhen(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSApplyWhen(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -95,7 +95,7 @@ public class PSApplyWhen extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
@@ -52,7 +52,8 @@ public class PSAttribute extends PSDatabaseComponentCollection {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type or
    *     null
    */
-  public PSAttribute(Element sourceNode, IPSDocument parentDoc, List<?> parentComponents)
+  public PSAttribute(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     // This constructor takes an arraylist because of the specification
     // of fromXml() in IPSComponent
@@ -288,7 +289,7 @@ public class PSAttribute extends PSDatabaseComponentCollection {
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXRole
    * @see IPSComponent#fromXml(Element, IPSDocument, List) for the interface description
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
@@ -187,7 +187,7 @@ public class PSAttributeList extends PSDatabaseComponentCollection implements IP
    * @see IPSComponent#fromXml(Element, IPSDocument, List) for the interface description
    */
   @Override
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttributeValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttributeValue.java
@@ -44,7 +44,7 @@ public class PSAttributeValue extends PSDatabaseComponent {
    * @param parentComponents the parent objects of this object can be <code>null</code>
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  PSAttributeValue(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  PSAttributeValue(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     // Arraylist is used in this ctor because of the definition
     // of fromXml in IPSComponent
@@ -176,7 +176,7 @@ public class PSAttributeValue extends PSDatabaseComponent {
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXRole
    * @see IPSComponent#fromXml(Element, IPSDocument, List) for the interface description
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
@@ -55,7 +55,7 @@ public class PSAuthentication extends PSComponent {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSAuthentication(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents, boolean encryptPwd)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents, boolean encryptPwd)
       throws PSUnknownNodeTypeException {
     this.encryptPwd = encryptPwd;
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -346,7 +346,7 @@ public class PSAuthentication extends PSComponent {
    * @see IPSComponent
    */
   @Override
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
@@ -50,7 +50,7 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSBackEndColumn(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSBackEndColumn(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     // Private path avoids virtual fromXml (e.g. PSSortedColumn) during construction.
     fromXmlBase(sourceNode, parentDoc, parentComponents);
@@ -440,7 +440,7 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndColumn
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
@@ -449,7 +449,7 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
    * Shared load for {@link #fromXml} and the Element constructor. Avoids virtual fromXml dispatch
    * (e.g. {@link PSSortedColumn}) before subclass fields are initialized.
    */
-  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
@@ -484,7 +484,7 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
       for (int i = parentComponents.size(); i != 0; ) {
         i--; // decrement right away as arraylist's are 0-based
 
-        parent = (IPSComponent) parentComponents.get(i);
+        parent = parentComponents.get(i);
         if (parent instanceof com.percussion.design.objectstore.PSBackEndDataTank)
           dt = (PSBackEndDataTank) parent;
         else if (parent instanceof com.percussion.design.objectstore.PSPipe)

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndConnection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndConnection.java
@@ -51,7 +51,7 @@ public class PSBackEndConnection extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSBackEndConnection(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -430,7 +430,7 @@ public class PSBackEndConnection extends PSComponent {
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndConnection
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
@@ -50,7 +50,7 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSBackEndCredential(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -316,7 +316,7 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
    * @exception PSUnknownNodeTypeException if the XML element node is not of type
    *     PSXBackEndCredential
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
@@ -51,7 +51,7 @@ public class PSBackEndDataTank extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSBackEndDataTank(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -356,7 +356,7 @@ public class PSBackEndDataTank extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndDataTank
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndJoin.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndJoin.java
@@ -78,7 +78,7 @@ public class PSBackEndJoin extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSBackEndJoin(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSBackEndJoin(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -379,7 +379,7 @@ public class PSBackEndJoin extends PSComponent {
    * @param parentComponents all the parent objects of this object, may be <code>null</code>
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
@@ -81,7 +81,7 @@ public class PSBackEndTable extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSBackEndTable(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
 
@@ -296,7 +296,7 @@ public class PSBackEndTable extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndTable
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCgiVariable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCgiVariable.java
@@ -41,7 +41,7 @@ public class PSCgiVariable extends PSNamedReplacementValue {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSCgiVariable(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCgiVariable(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoiceFilter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoiceFilter.java
@@ -40,7 +40,7 @@ public class PSChoiceFilter extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSChoiceFilter(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSChoiceFilter(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -64,7 +64,7 @@ public class PSChoiceFilter extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
@@ -257,7 +257,7 @@ public class PSChoiceFilter extends PSComponent {
     /**
      * @see IPSComponent
      */
-    public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+    public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
         throws PSUnknownNodeTypeException {
       if (sourceNode == null)
         throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoiceTableInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoiceTableInfo.java
@@ -79,7 +79,7 @@ public class PSChoiceTableInfo extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSChoiceTableInfo(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSChoiceTableInfo(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -138,7 +138,7 @@ public class PSChoiceTableInfo extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
@@ -77,7 +77,7 @@ public class PSChoices extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSChoices(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSChoices(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -348,7 +348,7 @@ public class PSChoices extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfig.java
@@ -40,7 +40,7 @@ public class PSCloneHandlerConfig extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSCloneHandlerConfig(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCloneHandlerConfig(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -92,7 +92,7 @@ public class PSCloneHandlerConfig extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfigSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfigSet.java
@@ -36,7 +36,7 @@ public class PSCloneHandlerConfigSet extends PSCollectionComponent implements IP
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSCloneHandlerConfigSet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCloneHandlerConfigSet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(PSCloneHandlerConfig.class);
 
@@ -66,7 +66,7 @@ public class PSCloneHandlerConfigSet extends PSCollectionComponent implements IP
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideField.java
@@ -64,7 +64,7 @@ public class PSCloneOverrideField extends PSComponent {
    * @param parentComponents the parent objects of this object.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type.
    */
-  public PSCloneOverrideField(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCloneOverrideField(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -97,7 +97,7 @@ public class PSCloneOverrideField extends PSComponent {
   /* (non-Javadoc)
    * @see IPSComponent#fromXml(Element, IPSDocument, ArrayList)
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null.");
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideFieldList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideFieldList.java
@@ -47,7 +47,7 @@ public class PSCloneOverrideFieldList extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSCloneOverrideFieldList(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCloneOverrideFieldList(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -77,7 +77,7 @@ public class PSCloneOverrideFieldList extends PSCollectionComponent {
   /* (non-Javadoc)
    * @see com.percussion.design.objectstore.IPSComponent#fromXml(org.w3c.dom.Element, com.percussion.design.objectstore.IPSDocument, java.util.ArrayList)
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCollectionComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCollectionComponent.java
@@ -140,7 +140,7 @@ public abstract class PSCollectionComponent extends com.percussion.util.PSCollec
    * @exception PSUnknownNodeTypeException if the XML element node does not represent a type
    *     supported by the class.
    */
-  public abstract void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public abstract void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException;
 
   /**
@@ -173,7 +173,7 @@ public abstract class PSCollectionComponent extends com.percussion.util.PSCollec
    * @param parentComponents the parent list
    * @return the new parent list (in case parentComponents was null)
    */
-  protected List updateParentList(List parentComponents) {
+  protected List<IPSComponent> updateParentList(List<IPSComponent> parentComponents) {
     if (parentComponents == null) parentComponents = new ArrayList<>();
 
     parentComponents.add(this);
@@ -187,7 +187,7 @@ public abstract class PSCollectionComponent extends com.percussion.util.PSCollec
    * @param parentComponents the parent list
    * @param size the size to set the list to
    */
-  protected void resetParentList(List parentComponents, int size) {
+  protected void resetParentList(List<?> parentComponents, int size) {
     if (parentComponents == null) return;
 
     if (size == 0) parentComponents.clear();

--- a/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
@@ -72,7 +72,7 @@ public class PSCommandHandlerStylesheets extends PSComponent {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSCommandHandlerStylesheets(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -282,7 +282,7 @@ public class PSCommandHandlerStylesheets extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditional.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditional.java
@@ -149,7 +149,7 @@ public class PSConditional extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSConditional(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSConditional(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -421,7 +421,7 @@ public class PSConditional extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXConditional
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalEffect.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalEffect.java
@@ -43,7 +43,7 @@ public class PSConditionalEffect extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSConditionalEffect(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSConditionalEffect(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -116,7 +116,7 @@ public class PSConditionalEffect extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
@@ -56,7 +56,7 @@ public class PSConditionalExit extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSConditionalExit(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSConditionalExit(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -171,7 +171,7 @@ public class PSConditionalExit extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalExtension.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalExtension.java
@@ -38,7 +38,7 @@ public class PSConditionalExtension extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type.
    */
-  public PSConditionalExtension(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSConditionalExtension(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode annot be null");
 
@@ -134,7 +134,7 @@ public class PSConditionalExtension extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
@@ -71,7 +71,7 @@ public class PSConditionalRequest extends PSUrlRequest {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSConditionalRequest(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSConditionalRequest(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -156,7 +156,7 @@ public class PSConditionalRequest extends PSUrlRequest {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
@@ -64,7 +64,7 @@ public class PSConditionalStylesheet extends PSStylesheet {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSConditionalStylesheet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSConditionalStylesheet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -130,7 +130,7 @@ public class PSConditionalStylesheet extends PSStylesheet {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConfig.java
@@ -60,7 +60,7 @@ public class PSConfig extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSConfig(Element source, IPSDocument parent, List parentComponents)
+  public PSConfig(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(source, parent, parentComponents);
   }
@@ -200,7 +200,7 @@ public class PSConfig extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public void fromXml(Element source, IPSDocument parent, List parentComponents)
+  public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
@@ -53,7 +53,7 @@ public class PSContainerLocator extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSContainerLocator(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSContainerLocator(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -331,7 +331,7 @@ public class PSContainerLocator extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
@@ -122,7 +122,7 @@ public class PSContentEditor extends PSDataSet {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSContentEditor(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSContentEditor(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this(sourceNode, parentDoc, parentComponents, true);
   }
@@ -138,7 +138,7 @@ public class PSContentEditor extends PSDataSet {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSContentEditor(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents, boolean runUpdater)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents, boolean runUpdater)
       throws PSUnknownNodeTypeException {
     /*
      * This constructor has been created as kind of hack to resolve the
@@ -627,7 +627,7 @@ public class PSContentEditor extends PSDataSet {
    *      com.percussion.design.objectstore.IPSDocument, java.util.ArrayList)
    */
   @Override
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
@@ -63,7 +63,7 @@ public class PSContentEditorMapper extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSContentEditorMapper(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSContentEditorMapper(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -262,7 +262,7 @@ public class PSContentEditorMapper extends PSComponent {
    * @see IPSComponent
    */
   // $NON-NLS-1$
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
@@ -58,7 +58,7 @@ public class PSContentEditorPipe extends PSPipe {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSContentEditorPipe(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSContentEditorPipe(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -226,7 +226,7 @@ public class PSContentEditorPipe extends PSPipe {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentItemData.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentItemData.java
@@ -32,7 +32,7 @@ public class PSContentItemData extends PSNamedReplacementValue {
    * @throws IllegalArgumentException if source is <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format.
    */
-  public PSContentItemData(Element source, IPSDocument parent, List parentComponents)
+  public PSContentItemData(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(source, parent, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentItemStatus.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentItemStatus.java
@@ -34,7 +34,7 @@ public class PSContentItemStatus extends PSNamedReplacementValue {
    * @throws IllegalArgumentException if source is <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format.
    */
-  public PSContentItemStatus(Element source, IPSDocument parent, List parentComponents)
+  public PSContentItemStatus(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(source, parent, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentType.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentType.java
@@ -67,7 +67,7 @@ public class PSContentType extends PSComponent {
    * @param parentComponents ignored.
    * @throws PSUnknownNodeTypeException if an expected XML element is missing, or <code>null</code>
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
@@ -54,7 +54,7 @@ public class PSControlMeta extends PSComponent {
    * @param parentComponents ignored.
    * @throws PSUnknownNodeTypeException if an expected XML element is missing, or <code>null</code>
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
@@ -56,7 +56,7 @@ public class PSControlParameter extends PSComponent {
    * @param parentComponents ignored.
    * @throws PSUnknownNodeTypeException if an expected XML element is missing, or <code>null</code>
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
@@ -71,7 +71,7 @@ public class PSControlRef extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSControlRef(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSControlRef(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -154,7 +154,7 @@ public class PSControlRef extends PSComponent {
   }
 
   // see interface for description
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSCookie.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCookie.java
@@ -39,7 +39,7 @@ public class PSCookie extends PSNamedReplacementValue {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSCookie(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCookie(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
@@ -49,7 +49,7 @@ public class PSCustomActionGroup extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSCustomActionGroup(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCustomActionGroup(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -191,7 +191,7 @@ public class PSCustomActionGroup extends PSComponent {
   }
 
   // see IPSComponent
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomError.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomError.java
@@ -53,7 +53,7 @@ public class PSCustomError extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSCustomError(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSCustomError(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -189,7 +189,7 @@ public class PSCustomError extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXCustomError
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataEncryptor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataEncryptor.java
@@ -61,7 +61,7 @@ public class PSDataEncryptor extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSDataEncryptor(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -224,7 +224,7 @@ public class PSDataEncryptor extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXDataEncryptor
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataMapper.java
@@ -52,7 +52,7 @@ public class PSDataMapper extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDataMapper(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDataMapper(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -117,7 +117,7 @@ public class PSDataMapper extends PSCollectionComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXDataMapper
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataMapping.java
@@ -54,7 +54,7 @@ public class PSDataMapping extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDataMapping(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDataMapping(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -383,7 +383,7 @@ public class PSDataMapping extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXDataMapping
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;
@@ -626,7 +626,7 @@ public class PSDataMapping extends PSComponent {
   }
 
   private IPSComponent createMappingObject(
-      Element mappingNode, String nodeSource, IPSDocument parentDoc, List parentComponents)
+      Element mappingNode, String nodeSource, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     return (IPSComponent)
         PSReplacementValueFactory.getReplacementValueFromXml(

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSelector.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSelector.java
@@ -62,7 +62,7 @@ public class PSDataSelector extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSDataSelector(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -639,7 +639,7 @@ public class PSDataSelector extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXDataSelector
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
@@ -54,7 +54,7 @@ public class PSDataSet extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDataSet(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDataSet(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     // Private path avoids virtual fromXml (e.g. PSContentEditor) during super construction.
@@ -641,7 +641,7 @@ public class PSDataSet extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXDataSet
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
@@ -650,7 +650,7 @@ public class PSDataSet extends PSComponent {
    * Shared load for {@link #fromXml} and the Element constructor. Avoids virtual fromXml dispatch
    * (e.g. {@link PSContentEditor}) before subclass fields are initialized.
    */
-  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSynchronizer.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSynchronizer.java
@@ -51,7 +51,7 @@ public class PSDataSynchronizer extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSDataSynchronizer(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -241,7 +241,7 @@ public class PSDataSynchronizer extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of type
    *     PSXDataSynchronizer
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponentCollection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponentCollection.java
@@ -159,7 +159,7 @@ public class PSDatabaseComponentCollection extends PSDatabaseComponent implement
    * @exception PSUnknownNodeTypeException if the XML element node does not represent a type
    *     supported by the class.
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     m_components.clear();
     m_deletes.clear();

--- a/system/src/main/java/com/percussion/design/objectstore/PSDateLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDateLiteral.java
@@ -50,7 +50,7 @@ public class PSDateLiteral extends PSLiteral {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDateLiteral(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDateLiteral(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -222,7 +222,7 @@ public class PSDateLiteral extends PSLiteral {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXDateLiteral
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDefaultSelected.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDefaultSelected.java
@@ -66,7 +66,7 @@ public class PSDefaultSelected extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDefaultSelected(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDefaultSelected(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -135,7 +135,7 @@ public class PSDefaultSelected extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDependency.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDependency.java
@@ -99,7 +99,7 @@ public class PSDependency extends PSComponent {
   }
 
   // see interface for method description; see toXml for XML format
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
@@ -50,7 +50,7 @@ public class PSDirectory extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDirectory(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDirectory(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -344,7 +344,7 @@ public class PSDirectory extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
@@ -156,7 +156,7 @@ public class PSDirectorySet extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayFieldRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayFieldRef.java
@@ -48,7 +48,7 @@ public class PSDisplayFieldRef extends PSComponent implements IPSMutatableReplac
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDisplayFieldRef(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDisplayFieldRef(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -119,7 +119,7 @@ public class PSDisplayFieldRef extends PSComponent implements IPSMutatableReplac
   }
 
   // see IPSComponent for description
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
@@ -51,7 +51,7 @@ public class PSDisplayMapper extends PSCollectionComponent {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    * @throws ClassCastException if the class could be found.
    */
-  public PSDisplayMapper(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDisplayMapper(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -151,7 +151,7 @@ public class PSDisplayMapper extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
@@ -47,7 +47,7 @@ public class PSDisplayMapping extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDisplayMapping(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDisplayMapping(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -169,7 +169,7 @@ public class PSDisplayMapping extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayText.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayText.java
@@ -44,7 +44,7 @@ public class PSDisplayText extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSDisplayText(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDisplayText(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -118,7 +118,7 @@ public class PSDisplayText extends PSComponent {
    *  (non-Javadoc)
    * @see com.percussion.design.objectstore.IPSComponent#fromXml(org.w3c.dom.Element, com.percussion.design.objectstore.IPSDocument, java.util.ArrayList)
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayTextLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayTextLiteral.java
@@ -61,7 +61,7 @@ public class PSDisplayTextLiteral extends PSLiteral implements IPSMutatableRepla
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type or if
    *     sourceNode is <code>null</code>
    */
-  public PSDisplayTextLiteral(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSDisplayTextLiteral(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -85,7 +85,7 @@ public class PSDisplayTextLiteral extends PSLiteral implements IPSMutatableRepla
   }
 
   // see interface for description; see toXml() for the format
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
     m_displayValue = sourceNode.getAttribute("displayText");

--- a/system/src/main/java/com/percussion/design/objectstore/PSEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSEntry.java
@@ -58,7 +58,7 @@ public class PSEntry extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSEntry(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSEntry(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     // Private path avoids virtual fromXml dispatch before subclass fields initialize.
     fromXmlBase(sourceNode, parentDoc, parentComponents);
@@ -252,7 +252,7 @@ public class PSEntry extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
@@ -262,7 +262,7 @@ public class PSEntry extends PSComponent {
    * virtual {@code fromXml} dispatch so subclasses (e.g. {@link PSNullEntry}) can initialize
    * safely.
    */
-  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSErrorWebPages.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSErrorWebPages.java
@@ -57,7 +57,7 @@ public class PSErrorWebPages extends PSCollectionComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSErrorWebPages(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -191,7 +191,7 @@ public class PSErrorWebPages extends PSCollectionComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXErrorWebPages
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionCallSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionCallSet.java
@@ -45,7 +45,7 @@ public class PSExtensionCallSet extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSExtensionCallSet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSExtensionCallSet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -106,7 +106,7 @@ public class PSExtensionCallSet extends PSCollectionComponent {
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXExtensionCallSet
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionFile.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionFile.java
@@ -153,7 +153,7 @@ public class PSExtensionFile extends PSFile {
    * @exception PSUnknownNodeTypeException if the XML element node does not represent a type
    *     supported by the class.
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super.fromXml(sourceNode, parentDoc, parentComponents, ms_nodeType);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionParamDef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionParamDef.java
@@ -49,7 +49,7 @@ public class PSExtensionParamDef extends PSComponent implements IPSExtensionPara
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSExtensionParamDef(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -235,7 +235,7 @@ public class PSExtensionParamDef extends PSComponent implements IPSExtensionPara
    * @exception PSUnknownNodeTypeException if the XML element node is not of type
    *     PSXExtensionParamDef
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSField.java
@@ -191,7 +191,7 @@ public class PSField extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSField(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSField(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -1581,7 +1581,7 @@ public class PSField extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
@@ -78,7 +78,7 @@ public class PSFieldSet extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSFieldSet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSFieldSet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -723,7 +723,7 @@ public class PSFieldSet extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldTranslation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldTranslation.java
@@ -45,7 +45,7 @@ public class PSFieldTranslation extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSFieldTranslation(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSFieldTranslation(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -127,7 +127,7 @@ public class PSFieldTranslation extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldValidationRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldValidationRules.java
@@ -40,7 +40,7 @@ public class PSFieldValidationRules extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSFieldValidationRules(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSFieldValidationRules(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -224,7 +224,7 @@ public class PSFieldValidationRules extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFile.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFile.java
@@ -405,7 +405,7 @@ public abstract class PSFile extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node does not represent a type
    *     supported by the class.
    */
-  public abstract void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public abstract void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException;
 
   /**
@@ -421,7 +421,7 @@ public abstract class PSFile extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   protected void fromXml(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents, String nodeType)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents, String nodeType)
       throws PSUnknownNodeTypeException {
     String lastModified = null;
     try {

--- a/system/src/main/java/com/percussion/design/objectstore/PSFileDescriptor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFileDescriptor.java
@@ -56,7 +56,7 @@ public class PSFileDescriptor extends PSComponent {
    * @throws IllegalArgumentException if <code>sourceNode</code> is <code>null</code>.
    * @throws PSUnknownNodeTypeException if an expected XML element is missing, or <code>null</code>
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSFormAction.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFormAction.java
@@ -52,7 +52,7 @@ public class PSFormAction extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSFormAction(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSFormAction(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -138,7 +138,7 @@ public class PSFormAction extends PSComponent {
   }
 
   // see IPSComponent
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSGlobalLookup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSGlobalLookup.java
@@ -76,7 +76,7 @@ public class PSGlobalLookup extends PSComponent {
    * @param parentComponents ignored.
    * @throws PSUnknownNodeTypeException if an expected XML element is missing, or <code>null</code>
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSGlobalSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSGlobalSubject.java
@@ -43,7 +43,7 @@ public class PSGlobalSubject extends PSSubject {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSGlobalSubject(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSGlobalSubject(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSGroupProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSGroupProviderInstance.java
@@ -98,7 +98,7 @@ public abstract class PSGroupProviderInstance extends PSComponent
    * @throws PSUnknownNodeTypeException if the XML element node does not represent a type supported
    *     or does not contain valid attribute values.
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSHtmlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSHtmlParameter.java
@@ -59,7 +59,7 @@ public class PSHtmlParameter extends PSNamedReplacementValue {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSHtmlParameter(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSHtmlParameter(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSInputTranslations.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSInputTranslations.java
@@ -41,7 +41,7 @@ public class PSInputTranslations extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSInputTranslations(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSInputTranslations(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -96,7 +96,7 @@ public class PSInputTranslations extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSJavaPlugin.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSJavaPlugin.java
@@ -222,7 +222,7 @@ public class PSJavaPlugin implements IPSJavaPlugin {
   public void fromXml(
       Element sourceNode,
       @SuppressWarnings("unused") IPSDocument parentDoc,
-      @SuppressWarnings("unused") List parentComponents)
+      @SuppressWarnings("unused") List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode must not be null");
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSJavaPluginConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSJavaPluginConfig.java
@@ -117,7 +117,7 @@ public class PSJavaPluginConfig implements IPSJavaPluginConfig {
   // Implementation of the method defined in the intreface
   // Implementation of the interface method
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (!sourceNode.getTagName().equals(XML_NODE_NAME)) {
       String[] args = {XML_NODE_NAME, sourceNode.getTagName()};

--- a/system/src/main/java/com/percussion/design/objectstore/PSJdbcDriverConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSJdbcDriverConfig.java
@@ -120,7 +120,7 @@ public class PSJdbcDriverConfig extends PSComponent {
   public void fromXml(
       Element sourceNode,
       @SuppressWarnings("unused") IPSDocument parentDoc,
-      @SuppressWarnings("unused") List parentComponents)
+      @SuppressWarnings("unused") List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSLiteralSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLiteralSet.java
@@ -47,7 +47,7 @@ public class PSLiteralSet extends PSCollectionComponent implements IPSReplacemen
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSLiteralSet(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSLiteralSet(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this(PSLiteral.class);
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -101,7 +101,7 @@ public class PSLiteralSet extends PSCollectionComponent implements IPSReplacemen
     return buf.toString();
   }
 
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
 
     if (sourceNode == null)

--- a/system/src/main/java/com/percussion/design/objectstore/PSLocation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLocation.java
@@ -52,7 +52,7 @@ public class PSLocation extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSLocation(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSLocation(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -227,7 +227,7 @@ public class PSLocation extends PSComponent {
   }
 
   // see IPSComponent
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSLogger.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLogger.java
@@ -46,7 +46,7 @@ public class PSLogger extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSLogger(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSLogger(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -480,7 +480,7 @@ public class PSLogger extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXLogger
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
@@ -48,7 +48,7 @@ public class PSLoginWebPage extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSLoginWebPage(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -183,7 +183,7 @@ public class PSLoginWebPage extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXLoginWebPage
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSMacro.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMacro.java
@@ -35,7 +35,7 @@ public class PSMacro extends PSNamedReplacementValue {
    * @param parentComponents the parent objects of this object, may be <code>null</code> or empty.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type.
    */
-  public PSMacro(Element source, IPSDocument parent, List parentComponents)
+  public PSMacro(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(source, parent, parentComponents);
     fromXml(source, parent, parentComponents);
@@ -69,7 +69,7 @@ public class PSMacro extends PSNamedReplacementValue {
    * @param parentComponents may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format.
    */
-  public void fromXml(Element source, IPSDocument parent, List parentComponents)
+  public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super.fromXml(source, parent, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinition.java
@@ -37,7 +37,7 @@ public class PSMacroDefinition extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code> or empty.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type.
    */
-  public PSMacroDefinition(Element source, IPSDocument parent, List parentComponents)
+  public PSMacroDefinition(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(source, parent, parentComponents);
   }
@@ -141,7 +141,7 @@ public class PSMacroDefinition extends PSComponent {
    * @param parentComponents may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format.
    */
-  public void fromXml(Element source, IPSDocument parent, List parentComponents)
+  public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     PSXmlTreeWalker tree = new PSXmlTreeWalker(source);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinitionSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinitionSet.java
@@ -51,7 +51,7 @@ public class PSMacroDefinitionSet extends PSCollectionComponent {
    *
    * @see IPSComponent
    */
-  public void fromXml(Element source, IPSDocument parent, List parentComponents)
+  public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
@@ -44,7 +44,7 @@ public class PSNullEntry extends PSEntry {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSNullEntry(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSNullEntry(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -138,7 +138,7 @@ public class PSNullEntry extends PSEntry {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSNumericLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNumericLiteral.java
@@ -51,7 +51,7 @@ public class PSNumericLiteral extends PSLiteral {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSNumericLiteral(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -233,7 +233,7 @@ public class PSNumericLiteral extends PSLiteral {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXNumericLiteral
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSOriginatingRelationshipProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSOriginatingRelationshipProperty.java
@@ -38,7 +38,7 @@ public class PSOriginatingRelationshipProperty extends PSNamedReplacementValue {
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format.
    */
   public PSOriginatingRelationshipProperty(
-      Element source, IPSDocument parent, List parentComponents) throws PSUnknownNodeTypeException {
+      Element source, IPSDocument parent, List<IPSComponent> parentComponents) throws PSUnknownNodeTypeException {
     super(source, parent, parentComponents);
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSOutputTranslations.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSOutputTranslations.java
@@ -40,7 +40,7 @@ public class PSOutputTranslations extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSOutputTranslations(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSOutputTranslations(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -95,7 +95,7 @@ public class PSOutputTranslations extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
@@ -49,7 +49,7 @@ public class PSPageDataTank extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSPageDataTank(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSPageDataTank(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -226,7 +226,7 @@ public class PSPageDataTank extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXPageDataTank
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSParam.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSParam.java
@@ -44,7 +44,7 @@ public class PSParam extends PSComponent implements IPSParameter {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSParam(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSParam(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -200,7 +200,7 @@ public class PSParam extends PSComponent implements IPSParameter {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSProcessCheck.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProcessCheck.java
@@ -37,7 +37,7 @@ public class PSProcessCheck extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSProcessCheck(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSProcessCheck(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -112,7 +112,7 @@ public class PSProcessCheck extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
@@ -221,7 +221,7 @@ public class PSProperty extends PSComponent {
    * @see IPSComponent
    */
   @Override
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSPropertySet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSPropertySet.java
@@ -52,7 +52,7 @@ public class PSPropertySet extends PSCollectionComponent {
    */
   @Override
   public void fromXml(
-      Element sourceNode, @SuppressWarnings("unused") IPSDocument parentDoc, List parentComponents)
+      Element sourceNode, @SuppressWarnings("unused") IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSProvider.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProvider.java
@@ -34,7 +34,7 @@ public class PSProvider extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSProvider(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSProvider(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -134,7 +134,7 @@ public class PSProvider extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
@@ -47,7 +47,7 @@ public class PSQueryPipe extends PSPipe {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSQueryPipe(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSQueryPipe(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -234,7 +234,7 @@ public class PSQueryPipe extends PSPipe {
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXQueryPipe
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSRecipient.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRecipient.java
@@ -48,7 +48,7 @@ public class PSRecipient extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRecipient(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRecipient(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -960,7 +960,7 @@ public class PSRecipient extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXRecipient
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSReference.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSReference.java
@@ -34,7 +34,7 @@ public class PSReference extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSReference(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSReference(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -117,7 +117,7 @@ public class PSReference extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelation.java
@@ -255,7 +255,7 @@ public class PSRelation extends PSDatabaseComponent implements Cloneable {
    *     elements each with (#PCDATA) as their value.
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfig.java
@@ -55,7 +55,7 @@ public class PSRelationshipConfig extends PSComponent implements IPSCatalogSumma
    * @param parentComponents the parent objects of this object, it may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRelationshipConfig(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRelationshipConfig(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -823,7 +823,7 @@ public class PSRelationshipConfig extends PSComponent implements IPSCatalogSumma
    * @see IPSComponent
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfigSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipConfigSet.java
@@ -35,7 +35,7 @@ public class PSRelationshipConfigSet extends PSCollectionComponent implements IP
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRelationshipConfigSet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRelationshipConfigSet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
 
@@ -261,7 +261,7 @@ public class PSRelationshipConfigSet extends PSCollectionComponent implements IP
    * @see com.percussion.design.objectstore.IPSComponent#fromXml(org.w3c.dom.Element, com.percussion.design.objectstore.IPSDocument, java.util.ArrayList)
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
@@ -321,7 +321,7 @@ public class PSRelationshipConfigSet extends PSCollectionComponent implements IP
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   protected PSRelationshipConfig createMemberObject(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     return new PSRelationshipConfig(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipProperty.java
@@ -37,7 +37,7 @@ public class PSRelationshipProperty extends PSNamedReplacementValue {
    * @throws IllegalArgumentException if source is <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format.
    */
-  public PSRelationshipProperty(Element source, IPSDocument parent, List parentComponents)
+  public PSRelationshipProperty(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(source, parent, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipSet.java
@@ -56,7 +56,7 @@ public class PSRelationshipSet extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRelationshipSet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRelationshipSet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(PSRelationship.class);
 
@@ -66,7 +66,7 @@ public class PSRelationshipSet extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelativeSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelativeSubject.java
@@ -45,7 +45,7 @@ public class PSRelativeSubject extends PSSubject {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRelativeSubject(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRelativeSubject(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRequestLink.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRequestLink.java
@@ -54,7 +54,7 @@ public class PSRequestLink extends PSComponent implements IPSResults {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRequestLink(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRequestLink(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -344,7 +344,7 @@ public class PSRequestLink extends PSComponent implements IPSResults {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXRequestLink
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
@@ -55,7 +55,7 @@ public class PSRequestor extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRequestor(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRequestor(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -458,7 +458,7 @@ public class PSRequestor extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXRequestor
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
@@ -200,7 +200,7 @@ public class PSResourceCacheSettings extends PSComponent {
    *     this component. May be <code>null</code>.
    * @throws PSUnknownNodeTypeException if <code>sourceNode</code> is not in the expected format.
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
@@ -52,7 +52,7 @@ public class PSResultPage extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSResultPage(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSResultPage(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -362,7 +362,7 @@ public class PSResultPage extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXResultPage
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
@@ -47,7 +47,7 @@ public class PSResultPageSet extends PSComponent implements IPSResults {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSResultPageSet(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -158,7 +158,7 @@ public class PSResultPageSet extends PSComponent implements IPSResults {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXResults
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
@@ -47,7 +47,7 @@ public class PSResultPager extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSResultPager(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSResultPager(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -241,7 +241,7 @@ public class PSResultPager extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXResults
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRevisionEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRevisionEntry.java
@@ -224,7 +224,7 @@ public class PSRevisionEntry extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXRevisionEntry
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRevisionHistory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRevisionHistory.java
@@ -231,7 +231,7 @@ public class PSRevisionHistory extends PSComponent {
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXRevisionHistory
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRole.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRole.java
@@ -73,7 +73,7 @@ public class PSRole extends PSDatabaseComponent implements Comparable, IPSCatalo
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRole(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRole(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -363,7 +363,7 @@ public class PSRole extends PSDatabaseComponent implements Comparable, IPSCatalo
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXRole
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
@@ -38,7 +38,7 @@ public class PSRoleProvider extends PSComponent {
    * @param parentComponents the parent objects of this object, may be <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRoleProvider(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRoleProvider(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -228,7 +228,7 @@ public class PSRoleProvider extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRule.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRule.java
@@ -55,7 +55,7 @@ public class PSRule extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSRule(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSRule(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -233,7 +233,7 @@ public class PSRule extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
@@ -114,7 +114,7 @@ public class PSSearchConfig extends PSComponent {
    * @throws PSUnknownNodeTypeException if the XML element node does not conform to the required
    *     dtd.
    */
-  public PSSearchConfig(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSSearchConfig(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this(); // Setup defaults
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -233,7 +233,7 @@ public class PSSearchConfig extends PSComponent {
    *     method.
    */
   @Override
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
     String searchEnabled = sourceNode.getAttribute(SEARCH_ENABLED_ATTR);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchProperties.java
@@ -275,7 +275,7 @@ public class PSSearchProperties extends PSComponent {
    * Expects a node that conforms to the dtd specified for PSXSearchProperties in
    * sys_basicObjects.dtd. See base class for description of params.
    */
-  public final void fromXml(Element source, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element source, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSecurityProviderInstance.java
@@ -59,7 +59,7 @@ public class PSSecurityProviderInstance extends PSComponent {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSSecurityProviderInstance(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     // Private path avoids virtual fromXml dispatch before subclass fields initialize.
@@ -308,7 +308,7 @@ public class PSSecurityProviderInstance extends PSComponent {
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndConnection
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
@@ -318,7 +318,7 @@ public class PSSecurityProviderInstance extends PSComponent {
    * virtual {@code fromXml} dispatch so subclasses (e.g. legacy security provider instances) can
    * initialize safely while still overriding public {@code fromXml}.
    */
-  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSServerCacheSettings.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSServerCacheSettings.java
@@ -91,7 +91,7 @@ public class PSServerCacheSettings extends PSComponent {
    * null</code>.
    * @throws PSUnknownNodeTypeException if <code>source</code> is not in the expected format.
    */
-  public PSServerCacheSettings(Element source, IPSDocument parentDoc, List parentComponents)
+  public PSServerCacheSettings(Element source, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null) throw new IllegalArgumentException("source may not be null");
 
@@ -178,7 +178,7 @@ public class PSServerCacheSettings extends PSComponent {
    *     this component. May be <code>null</code>.
    * @throws PSUnknownNodeTypeException if <code>sourceNode</code> is not in the expected format.
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
@@ -52,7 +52,7 @@ public class PSSharedFieldGroup extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSSharedFieldGroup(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSSharedFieldGroup(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -291,7 +291,7 @@ public class PSSharedFieldGroup extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSingleHtmlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSingleHtmlParameter.java
@@ -37,7 +37,7 @@ public class PSSingleHtmlParameter extends PSHtmlParameter {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSSingleHtmlParameter(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSSingleHtmlParameter(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSSortedColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSortedColumn.java
@@ -45,7 +45,7 @@ public class PSSortedColumn extends PSBackEndColumn {
    * @throws PSUnknownNodeTypeException if the XML element node is <code>null
    * </code> or not of the appropriate type.
    */
-  public PSSortedColumn(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSSortedColumn(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     /*
        Use super's empty constructor, rather than its Element constructor,
@@ -146,7 +146,7 @@ public class PSSortedColumn extends PSBackEndColumn {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXSortedColumn
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSStylesheet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSStylesheet.java
@@ -43,7 +43,7 @@ public class PSStylesheet extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSStylesheet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSStylesheet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -105,7 +105,7 @@ public class PSStylesheet extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSubject.java
@@ -149,7 +149,7 @@ public abstract class PSSubject extends PSDatabaseComponent {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    * @throws IllegalArgumentException if sourceNode is <code>null</code>.
    */
-  public PSSubject(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSSubject(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
@@ -374,7 +374,7 @@ public abstract class PSSubject extends PSDatabaseComponent {
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXSubject
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
@@ -384,7 +384,7 @@ public abstract class PSSubject extends PSDatabaseComponent {
    * virtual {@code fromXml} dispatch so subclasses ({@link PSGlobalSubject}, {@link
    * PSRelativeSubject}) can initialize safely.
    */
-  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
@@ -55,7 +55,7 @@ public class PSTableLocator extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSTableLocator(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSTableLocator(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     // check for a converter
     IPSComponentConverter converter = getComponentConverter(this.getClass());
@@ -215,7 +215,7 @@ public class PSTableLocator extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableRef.java
@@ -54,7 +54,7 @@ public class PSTableRef extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSTableRef(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSTableRef(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -148,7 +148,7 @@ public class PSTableRef extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
@@ -61,7 +61,7 @@ public class PSTableSet extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSTableSet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSTableSet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -207,7 +207,7 @@ public class PSTableSet extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSTextLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTextLiteral.java
@@ -46,7 +46,7 @@ public class PSTextLiteral extends PSLiteral implements IPSMutatableReplacementV
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSTextLiteral(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSTextLiteral(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -156,7 +156,7 @@ public class PSTextLiteral extends PSLiteral implements IPSMutatableReplacementV
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXTextLiteral
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTraceInfo.java
@@ -44,7 +44,7 @@ public class PSTraceInfo extends PSComponent {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSTraceInfo(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSTraceInfo(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this(sourceNode, parentDoc, parentComponents, Locale.getDefault());
   }
@@ -287,7 +287,7 @@ public class PSTraceInfo extends PSComponent {
    * @throws PSUnknownNodeTypeException if the XML element node does not represent a type supported
    *     by the class.
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
 
     if (sourceNode == null) {
@@ -544,7 +544,7 @@ public class PSTraceInfo extends PSComponent {
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSTraceInfo(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents, Locale locale)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents, Locale locale)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
     createOptionsList(locale);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
@@ -57,7 +57,7 @@ public class PSUIDefinition extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSUIDefinition(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSUIDefinition(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -314,7 +314,7 @@ public class PSUIDefinition extends PSComponent {
   }
 
   // see IPSComponent
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUISet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUISet.java
@@ -38,7 +38,7 @@ public class PSUISet extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSUISet(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSUISet(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -386,7 +386,7 @@ public class PSUISet extends PSComponent {
   }
 
   // @see IPSComponent
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUpdateColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUpdateColumn.java
@@ -46,7 +46,7 @@ public class PSUpdateColumn extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSUpdateColumn(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -193,7 +193,7 @@ public class PSUpdateColumn extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXUpdateColumn
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
@@ -48,7 +48,7 @@ public class PSUpdatePipe extends PSPipe {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSUpdatePipe(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSUpdatePipe(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -211,7 +211,7 @@ public class PSUpdatePipe extends PSPipe {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXUpdatePipe
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUrlRequest.java
@@ -65,7 +65,7 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSUrlRequest(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSUrlRequest(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     // Private path avoids virtual fromXml dispatch before subclass fields initialize.
     fromXmlBase(sourceNode, parentDoc, parentComponents);
@@ -338,7 +338,7 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
@@ -347,7 +347,7 @@ public class PSUrlRequest extends PSComponent implements IPSReplacementValue {
    * Shared load for {@link #fromXml} and the Element constructor. Avoids virtual fromXml dispatch
    * during construction for subclasses such as {@link PSConditionalRequest}.
    */
-  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUserContext.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUserContext.java
@@ -39,7 +39,7 @@ public class PSUserContext extends PSNamedReplacementValue {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSUserContext(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSUserContext(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSValidationRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSValidationRules.java
@@ -41,7 +41,7 @@ public class PSValidationRules extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSValidationRules(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSValidationRules(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -121,7 +121,7 @@ public class PSValidationRules extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSVisibilityRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSVisibilityRules.java
@@ -38,7 +38,7 @@ public class PSVisibilityRules extends PSCollectionComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSVisibilityRules(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSVisibilityRules(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -98,7 +98,7 @@ public class PSVisibilityRules extends PSCollectionComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
@@ -50,7 +50,7 @@ public class PSWhereClause extends PSConditional {
    * @param parentComponents the parent objects of this object
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSWhereClause(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSWhereClause(org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -171,7 +171,7 @@ public class PSWhereClause extends PSConditional {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXWhereClause
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSWorkflow.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWorkflow.java
@@ -89,7 +89,7 @@ public class PSWorkflow extends PSComponent {
    * @param parentComponents ignored.
    * @throws PSUnknownNodeTypeException if an expected XML element is missing, or <code>null</code>
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
@@ -70,7 +70,7 @@ public class PSWorkflowInfo extends PSComponent {
    * @param parentComponents ignored.
    * @throws PSUnknownNodeTypeException if an expected XML element is missing, or <code>null</code>
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, XML_NODE_NAME);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSXmlField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSXmlField.java
@@ -39,7 +39,7 @@ public class PSXmlField extends PSNamedReplacementValue {
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSXmlField(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSXmlField(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndConnection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndConnection.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore.legacy;
 
+import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
 import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.IPSValidationContext;
@@ -56,7 +57,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSLegacyBackEndConnection(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -435,7 +436,7 @@ public class PSLegacyBackEndConnection extends PSComponent {
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndConnection
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndCredential.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndCredential.java
@@ -59,7 +59,7 @@ public class PSLegacyBackEndCredential extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSLegacyBackEndCredential(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -477,7 +477,7 @@ public class PSLegacyBackEndCredential extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of type
    *     PSXBackEndCredential
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndTable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyBackEndTable.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore.legacy;
 
+import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
 import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.IPSValidationContext;
@@ -149,7 +150,7 @@ public class PSLegacyBackEndTable extends PSComponent {
    * @exception PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSLegacyBackEndTable(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -455,7 +456,7 @@ public class PSLegacyBackEndTable extends PSComponent {
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndTable
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacySecurityProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacySecurityProviderInstance.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore.legacy;
 
+import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
 import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.PSProvider;
@@ -53,7 +54,7 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
   public PSLegacySecurityProviderInstance(
-      Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     this();
     // Private path avoids virtual fromXml dispatch during construction (this-escape).
@@ -102,7 +103,7 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
    *
    * @throws PSUnknownNodeTypeException if the XML element node is not of type PSXBackEndConnection
    */
-  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXmlBase(sourceNode, parentDoc, parentComponents);
   }
@@ -110,7 +111,7 @@ public class PSLegacySecurityProviderInstance extends PSSecurityProviderInstance
   /**
    * Shared load for {@link #fromXml} and the Element constructor (this-escape safe; non-virtual).
    */
-  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyTableLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyTableLocator.java
@@ -63,7 +63,7 @@ public class PSLegacyTableLocator extends PSComponent {
    * @param parentComponents the parent objects of this object, not <code>null</code>.
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSLegacyTableLocator(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSLegacyTableLocator(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -246,7 +246,7 @@ public class PSLegacyTableLocator extends PSComponent {
   /**
    * @see IPSComponent
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
       throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);

--- a/system/src/test/java/com/percussion/design/objectstore/PSCollectionComponentSerializationTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSCollectionComponentSerializationTest.java
@@ -95,7 +95,8 @@ public class PSCollectionComponentSerializationTest {
     }
 
     @Override
-    public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents) {
+    public void fromXml(
+        Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents) {
       throw new UnsupportedOperationException("not used in serialization test");
     }
   }

--- a/system/src/test/java/com/percussion/design/objectstore/PSComponentParentChainTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSComponentParentChainTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral coverage for typed {@code parentComponents} on {@link IPSComponent} and core
+ * design.objectstore fromXml parent-chain push/pop (#2936 / parent #2455).
+ */
+public class PSComponentParentChainTest {
+
+  @Test
+  public void testIpsComponentFromXmlUsesTypedParentList() throws Exception {
+    Method fromXml =
+        IPSComponent.class.getMethod(
+            "fromXml", Element.class, IPSDocument.class, List.class);
+    Type[] params = fromXml.getGenericParameterTypes();
+    assertTrue(params[2] instanceof ParameterizedType, "parentComponents must be parameterized");
+    ParameterizedType pt = (ParameterizedType) params[2];
+    assertEquals(List.class, pt.getRawType());
+    assertEquals(IPSComponent.class, pt.getActualTypeArguments()[0]);
+  }
+
+  @Test
+  public void testUpdateAndResetParentListPushPop() {
+    List<IPSComponent> parents = new ArrayList<>();
+    ProbeComponent sentinel = new ProbeComponent(1);
+    parents.add(sentinel);
+
+    ProbeComponent child = new ProbeComponent(2);
+    List<IPSComponent> afterPush = child.exposeUpdate(parents);
+    assertSame(parents, afterPush);
+    assertEquals(2, parents.size());
+    assertSame(sentinel, parents.get(0));
+    assertSame(child, parents.get(1));
+
+    child.exposeReset(parents, 1);
+    assertEquals(1, parents.size());
+    assertSame(sentinel, parents.get(0));
+  }
+
+  @Test
+  public void testUpdateParentListCreatesListWhenNull() {
+    ProbeComponent child = new ProbeComponent(9);
+    List<IPSComponent> created = child.exposeUpdate(null);
+    assertEquals(1, created.size());
+    assertSame(child, created.get(0));
+    child.exposeReset(created, 0);
+    assertTrue(created.isEmpty());
+  }
+
+  @Test
+  public void testDisplayTextFromXmlRestoresParentChain() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSDisplayText original = new PSDisplayText("hello-parent-chain");
+    Element elem = original.toXml(doc);
+
+    ProbeComponent sentinel = new ProbeComponent(42);
+    List<IPSComponent> parents = new ArrayList<>();
+    parents.add(sentinel);
+
+    PSDisplayText restored = new PSDisplayText();
+    restored.fromXml(elem, null, parents);
+
+    assertEquals("hello-parent-chain", restored.getText());
+    assertEquals(1, parents.size());
+    assertSame(sentinel, parents.get(0));
+  }
+
+  @Test
+  public void testEntryFromXmlRestoresParentChainAfterNestedLabel() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSEntry original = new PSEntry("v1", "Label One");
+    Element elem = original.toXml(doc);
+
+    ProbeComponent sentinel = new ProbeComponent(7);
+    List<IPSComponent> parents = new ArrayList<>();
+    parents.add(sentinel);
+
+    PSEntry restored = new PSEntry(elem, null, parents);
+
+    assertEquals("v1", restored.getValue());
+    assertEquals("Label One", restored.getLabel().getText());
+    assertEquals(1, parents.size());
+    assertSame(sentinel, parents.get(0));
+  }
+
+  @Test
+  public void testCollectionComponentFromXmlRestoresParentChain() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSActionLinkList list = new PSActionLinkList();
+    // Empty list still exercises updateParentList/resetParentList on fromXml.
+    Element elem = list.toXml(doc);
+
+    ProbeComponent sentinel = new ProbeComponent(3);
+    List<IPSComponent> parents = new ArrayList<>();
+    parents.add(sentinel);
+
+    PSActionLinkList restored = new PSActionLinkList(elem, null, parents);
+    assertEquals(0, restored.size());
+    assertEquals(1, parents.size());
+    assertSame(sentinel, parents.get(0));
+  }
+
+  /** Minimal {@link PSComponent} exposing parent-list helpers for direct push/pop tests. */
+  private static final class ProbeComponent extends PSComponent {
+    private static final long serialVersionUID = 1L;
+
+    ProbeComponent(int id) {
+      setId(id);
+    }
+
+    List<IPSComponent> exposeUpdate(List<IPSComponent> parents) {
+      return updateParentList(parents);
+    }
+
+    void exposeReset(List<?> parents, int size) {
+      resetParentList(parents, size);
+    }
+
+    @Override
+    public Element toXml(Document doc) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void fromXml(
+        Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void validate(IPSValidationContext cxt) {
+      // no-op
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/design/objectstore/PSFileTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSFileTest.java
@@ -51,7 +51,8 @@ public class PSFileTest {
     }
 
     @Override
-    public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+    public void fromXml(
+        Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
         throws PSUnknownNodeTypeException {
       throw new AssertionError();
     }


### PR DESCRIPTION
## Summary
Slice 1 of #2455 (parent #2022 / #2200): complete typed `parentComponents` for design.objectstore core.

- `IPSComponent.fromXml(..., List<IPSComponent>)` already parameterized; align **all design.objectstore implementors** (including `legacy/`) and matching Element constructors to `List<IPSComponent>`.
- Type `PSCollectionComponent` abstract `fromXml` + `updateParentList` / `resetParentList` helpers to match `PSComponent`.
- Drop redundant cast when walking the parent chain in `PSBackEndColumn`.
- Add `PSComponentParentChainTest` (interface generic signature, push/pop helpers, fromXml restore for `PSDisplayText` / `PSEntry` / `PSActionLinkList`).
- **Out of scope:** cms.objectstore wave → #2937; distant callers → #2938.

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Suite: Tests run: **1703**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] `PSComponentParentChainTest`: Tests run: **6**, Failures: 0

## Product documentation
- [x] N/A — pure generics/tech-debt signature cleanup; no operator/user-facing product behavior change

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system; ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1703, Failures: 0, Errors: 0, Skipped: 240; `PSComponentParentChainTest` 6/0
- **downstream_checked:** public `fromXml` signature change — grepped monorepo for `List parentComponents` / design overrides outside `design.objectstore`; only remaining raw overrides are in-module `cms.objectstore` (erasure-compatible, left for #2937). No external modules override design `fromXml(..., List parentComponents)`. System clean install compiles cms.objectstore reverse overrides in the same module.

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2936
Parent tracker: #2455 / Grandparent: #2022 / Tracker: #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.
