### PR TITLE
fix(system): Virtual Site property validation + product-docs (#2954)

### DIFF
--- a/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-properties.md
+++ b/docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-properties.md
@@ -4,11 +4,13 @@ Used on `IPSSite` / `PSSiteProperty` without requiring new `RXSITES` columns in 
 
 | Key | Required for Virtual | Values |
 |-----|----------------------|--------|
-| `virtual.sourceKind` | Yes | `git-filesystem` (Phase 1). Other kinds later. Blank or `repository` ⇒ traditional repository Site. |
-| `virtual.rootPath` | Yes | Filesystem path to Virtual Site root (`product-docs` checkout). Prefer absolute; blank is treated as unset. |
-| `virtual.configFile` | No | Default `_config.yaml`. |
+| `virtual.sourceKind` | Yes | **Allow-list (Phase 1):** `git-filesystem` only. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `validate`. |
+| `virtual.rootPath` | Yes | Filesystem path to Virtual Site root (`product-docs` checkout). Prefer absolute; blank is treated as unset and fails validation when virtual. NIO `Path.normalize()`; reject empty / remaining `..` segments. |
+| `virtual.configFile` | No | Default `_config.yaml`. Simple file name only (no path separators or `..`). |
 | `virtual.siteKey` | No | Key for participant registry; default site name, else `default`. |
 
-Helper: `com.percussion.services.virtualsite.PSVirtualSiteHelper`.
+Helper: `com.percussion.services.virtualsite.PSVirtualSiteHelper` — call `validate(IPSSite)` before treating a Site as a safe Virtual source.
+
+Product docs peers: `product-docs/8.2/admin/sites.md`, `product-docs/8.2/developer/virtual-sites.md`, `product-docs/8.2/reference/site-config.md`.
 
 Operator workflow (build + link report): [../operator-build-and-link-report.md](../operator-build-and-link-report.md).

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -27,11 +27,23 @@ A **Virtual Site** is a Site whose content originates **outside** the traditiona
 (for example Git/filesystem Markdown under `product-docs/`). Virtual items are discovered and
 assembled without ingesting them as ordinary CMS content items.
 
-Operators configure Virtual Sites through Site properties (source kind, root path, config file).
+Operators configure Virtual Sites through **Site properties** (not new database columns in Phase 1).
 Authors of Virtual content use Git and Markdown tooling, not the classic page editor.
 
+### Property keys operators set
+
+| Property | Required | Example | Notes |
+|----------|----------|---------|-------|
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Phase 1 allow-list: **`git-filesystem` only**. Blank or `repository` = traditional Site. |
+| `virtual.rootPath` | Yes (when virtual) | absolute path to `product-docs` | Must be non-blank for Virtual Sites. Prefer absolute paths; use portable paths (Windows/Linux/macOS). Paths with `..` after normalize are rejected. |
+| `virtual.configFile` | No | `_config.yaml` | Default `_config.yaml`. Simple file name under the root (no `..` or directory separators). |
+| `virtual.siteKey` | No | `product-docs` | Optional participant key; defaults to the Site name. |
+
+Invalid combinations (unknown source kind, missing root, unsafe path, config path traversal) are
+rejected by server validation with clear error messages.
+
 See [Virtual Sites (developer)](id:developer-virtual-sites) and
-[Site configuration reference](id:reference-site-config).
+[Site configuration reference](id:reference-site-config) for full contract and offline build steps.
 
 ## Folders, pages, and assets
 

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -53,15 +53,31 @@ Details: [Frontmatter reference](id:reference-frontmatter).
 
 ## Site properties (CMS)
 
-When a Percussion Site is configured as virtual:
+When a Percussion Site is configured as virtual (Phase 1 property contract — no new `RXSITES`
+columns), set these Site properties. The server helper
+`com.percussion.services.virtualsite.PSVirtualSiteHelper` validates the contract before a Site is
+treated as a safe Virtual Site source.
 
-| Property | Example | Meaning |
-|----------|---------|---------|
-| `virtual.sourceKind` | `git-filesystem` | Non-blank ⇒ Virtual Site |
-| `virtual.rootPath` | path to tree | Source root |
-| `virtual.configFile` | `_config.yaml` | Optional; default `_config.yaml` |
+| Property | Required | Example | Meaning |
+|----------|----------|---------|---------|
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Adapter wire name. **Allow-list (Phase 1):** `git-filesystem` only. Blank or `repository` ⇒ traditional repository Site. Unknown values are rejected. |
+| `virtual.rootPath` | Yes (when virtual) | absolute path to `product-docs` (or install-relative) | Filesystem root of the Virtual Site tree. Non-blank required when virtual. Resolved with NIO `Path` (cross-platform). |
+| `virtual.configFile` | No | `_config.yaml` | Config file name under the root; default `_config.yaml`. Must be a simple file name (no path separators or `..`). |
+| `virtual.siteKey` | No | `product-docs` | Participant registry key; default = Site name, else `default`. |
 
-Empty / missing `virtual.sourceKind` means a traditional repository Site.
+Empty / missing `virtual.sourceKind` (or value `repository`) means a traditional repository Site.
+
+### Validation rules
+
+- **Source kind allow-list** — only registered adapter wire names are accepted for Virtual Sites
+  (Phase 1: `git-filesystem`). Values such as future `sql` / `api` kinds are rejected until
+  implemented.
+- **Required root** — when `virtual.sourceKind` is virtual, `virtual.rootPath` must be non-blank.
+- **Safe paths** — `virtual.rootPath` is normalized with `java.nio.file.Path`. After normalize, empty
+  paths and any remaining `..` segments are rejected (path traversal). Prefer absolute paths on
+  Windows (`C:\…`) and Unix (`/opt/…`); relative paths under the install are allowed when they do not
+  escape via `..`.
+- **Config file name** — when set, `virtual.configFile` must not contain `/`, `\`, or `..`.
 
 ## Offline build
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -47,15 +47,20 @@ theme:
 
 ## CMS Site properties (Virtual)
 
-When a Percussion Site is configured as virtual:
+When a Percussion Site is configured as virtual (Phase 1 — no new `RXSITES` columns):
 
-| Property name | Example | Meaning |
-|---------------|---------|---------|
-| `virtual.sourceKind` | `git-filesystem` | Non-blank ⇒ Virtual Site |
-| `virtual.rootPath` | absolute or install-relative path to tree | Source root |
-| `virtual.configFile` | `_config.yaml` | Optional; default `_config.yaml` |
+| Property name | Required | Example | Meaning |
+|---------------|----------|---------|---------|
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem` | Adapter wire name. **Allow-list (Phase 1):** `git-filesystem`. Blank or `repository` ⇒ traditional repository Site. Unknown values rejected by `PSVirtualSiteHelper.validate`. |
+| `virtual.rootPath` | Yes (when virtual) | absolute or install-relative path to tree | Filesystem source root. Non-blank when virtual. NIO `Path` normalize; no empty path / remaining `..` segments. |
+| `virtual.configFile` | No | `_config.yaml` | Optional; default `_config.yaml`. Simple file name only (no separators / `..`). |
+| `virtual.siteKey` | No | `product-docs` | Participant registry key; default Site name, else `default`. |
 
 Empty / missing `virtual.sourceKind` means traditional **repository** site.
+
+Cross-platform notes: prefer absolute paths (`C:\…` on Windows, `/opt/…` on Linux/macOS). Operators
+should not hardcode OS path separators in scripts — use the repo `scripts/build-cms-docs.*` wrappers
+or NIO/`Path` APIs.
 
 ## Related
 

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteHelper.java
@@ -19,11 +19,16 @@ package com.percussion.services.virtualsite;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.sitemgr.data.PSSite;
 import com.percussion.services.sitemgr.data.PSSiteProperty;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -32,11 +37,15 @@ import org.apache.commons.lang3.StringUtils;
  * <p>Property keys:
  *
  * <ul>
- *   <li>{@code virtual.sourceKind} — e.g. {@code git-filesystem}; blank ⇒ repository
- *   <li>{@code virtual.rootPath} — filesystem path to Virtual Site root
- *   <li>{@code virtual.configFile} — optional; default {@code _config.yaml}
+ *   <li>{@code virtual.sourceKind} — allow-listed adapter wire name (e.g. {@code git-filesystem});
+ *       blank or {@code repository} ⇒ traditional repository Site
+ *   <li>{@code virtual.rootPath} — filesystem path to Virtual Site root (required when virtual)
+ *   <li>{@code virtual.configFile} — optional; default {@code _config.yaml}; simple file name only
  *   <li>{@code virtual.siteKey} — optional participant key; default site name
  * </ul>
+ *
+ * <p>Use {@link #validate(IPSSite)} before treating a Site as a safe Virtual Site source. Path
+ * handling uses {@link Path} (NIO) for cross-platform Windows / Linux / macOS behavior.
  */
 public final class PSVirtualSiteHelper {
 
@@ -45,11 +54,28 @@ public final class PSVirtualSiteHelper {
   public static final String PROP_CONFIG_FILE = "virtual.configFile";
   public static final String PROP_SITE_KEY = "virtual.siteKey";
 
+  /** Wire name for traditional repository-backed Sites. */
+  public static final String SOURCE_KIND_REPOSITORY = "repository";
+
   private PSVirtualSiteHelper() {}
+
+  /**
+   * Allow-listed {@link #PROP_SOURCE_KIND} wire names for Virtual adapters (Phase 1:
+   * {@code git-filesystem} only). Does not include {@link #SOURCE_KIND_REPOSITORY}.
+   *
+   * @return unmodifiable list of wire names in enum declaration order
+   */
+  public static List<String> allowedSourceKindWireNames() {
+    List<String> names = new ArrayList<>();
+    for (VirtualSiteSourceType t : VirtualSiteSourceType.values()) {
+      names.add(t.wireName());
+    }
+    return Collections.unmodifiableList(names);
+  }
 
   public static SourceKind sourceKind(IPSSite site) {
     String kind = findProperty(site, PROP_SOURCE_KIND).orElse("");
-    if (StringUtils.isBlank(kind) || "repository".equalsIgnoreCase(kind.trim())) {
+    if (StringUtils.isBlank(kind) || SOURCE_KIND_REPOSITORY.equalsIgnoreCase(kind.trim())) {
       return SourceKind.REPOSITORY;
     }
     return SourceKind.VIRTUAL;
@@ -63,8 +89,18 @@ public final class PSVirtualSiteHelper {
     return findProperty(site, PROP_SOURCE_KIND).map(VirtualSiteSourceType::fromWireName);
   }
 
+  /**
+   * Resolved Virtual Site root as a normalized NIO path when the property is non-blank.
+   *
+   * <p>Does not validate safety; call {@link #validate(IPSSite)} for contract checks.
+   *
+   * @param site may be null
+   * @return normalized path if property present and non-blank
+   */
   public static Optional<Path> rootPath(IPSSite site) {
-    return findProperty(site, PROP_ROOT_PATH).filter(StringUtils::isNotBlank).map(Path::of);
+    return findProperty(site, PROP_ROOT_PATH)
+        .filter(StringUtils::isNotBlank)
+        .map(raw -> Path.of(raw).normalize());
   }
 
   public static String configFile(IPSSite site) {
@@ -82,6 +118,108 @@ public final class PSVirtualSiteHelper {
       return site.getName();
     }
     return "default";
+  }
+
+  /**
+   * Validates the Virtual Site property contract.
+   *
+   * <p>Traditional repository Sites (missing/blank {@code virtual.sourceKind} or value {@code
+   * repository}) always pass. Virtual Sites must:
+   *
+   * <ul>
+   *   <li>use an allow-listed {@code virtual.sourceKind} (see {@link #allowedSourceKindWireNames()})
+   *   <li>provide a non-blank {@code virtual.rootPath}
+   *   <li>use a safe root path after NIO {@link Path#normalize()} (no empty path; no remaining {@code
+   *       ..} segments)
+   *   <li>when set, use a simple {@code virtual.configFile} name (no directory separators or {@code
+   *       ..})
+   * </ul>
+   *
+   * @param site may be null (treated as a valid repository Site)
+   * @throws VirtualSiteException when the virtual property contract is violated
+   */
+  public static void validate(IPSSite site) throws VirtualSiteException {
+    String kindRaw = findProperty(site, PROP_SOURCE_KIND).orElse("");
+    if (StringUtils.isBlank(kindRaw)
+        || SOURCE_KIND_REPOSITORY.equalsIgnoreCase(kindRaw.trim())) {
+      return;
+    }
+
+    String kind = kindRaw.trim();
+    VirtualSiteSourceType type = VirtualSiteSourceType.fromWireName(kind);
+    if (type == null) {
+      throw new VirtualSiteException(
+          "Unsupported "
+              + PROP_SOURCE_KIND
+              + " value '"
+              + kind
+              + "'. Allowed: "
+              + allowedSourceKindsDescription()
+              + " (or blank/"
+              + SOURCE_KIND_REPOSITORY
+              + " for traditional Sites).");
+    }
+
+    Optional<String> rootRaw = findProperty(site, PROP_ROOT_PATH);
+    if (rootRaw.isEmpty()) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH + " is required when " + PROP_SOURCE_KIND + " is '" + kind + "'.");
+    }
+
+    Path root;
+    try {
+      root = Path.of(rootRaw.get()).normalize();
+    } catch (InvalidPathException e) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH + " is not a valid filesystem path: '" + rootRaw.get() + "'.", e);
+    }
+
+    if (!isSafeRootPath(root)) {
+      throw new VirtualSiteException(
+          PROP_ROOT_PATH
+              + " must be a non-empty path with no '..' segments after normalize (cross-platform NIO"
+              + " Path). Rejected: '"
+              + rootRaw.get()
+              + "'.");
+    }
+
+    Optional<String> configRaw = findProperty(site, PROP_CONFIG_FILE);
+    if (configRaw.isPresent()) {
+      validateConfigFileName(configRaw.get());
+    }
+  }
+
+  /**
+   * Whether {@code path} is acceptable as a Virtual Site root after normalize.
+   *
+   * <ul>
+   *   <li>Rejects empty / relative-current-only paths ({@code ""}, {@code .})
+   *   <li>Rejects any remaining {@code ..} name element (path traversal after normalize)
+   *   <li>Allows absolute roots ({@code /}, {@code C:\} on Windows) and normal absolute/relative
+   *       trees
+   * </ul>
+   *
+   * @param path may be null
+   * @return true if safe for use as virtual root
+   */
+  public static boolean isSafeRootPath(Path path) {
+    if (path == null) {
+      return false;
+    }
+    Path normalized = path.normalize();
+    // Path.of("") / Path.of(".").normalize() yield an empty relative path — not a usable root.
+    // Absolute filesystem roots ("/", "C:\") are non-empty as strings and remain absolute.
+    String text = normalized.toString();
+    if (text.isEmpty() || ".".equals(text)) {
+      return false;
+    }
+    for (Path part : normalized) {
+      String name = part.toString();
+      if (name.isEmpty() || "..".equals(name)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -108,6 +246,30 @@ public final class PSVirtualSiteHelper {
       }
     }
     return Optional.empty();
+  }
+
+  private static void validateConfigFileName(String configFile) throws VirtualSiteException {
+    String name = configFile.trim();
+    if (name.isEmpty()) {
+      throw new VirtualSiteException(PROP_CONFIG_FILE + " must not be blank when set.");
+    }
+    // Config is resolved under rootPath; reject directory traversal and separators.
+    if (name.contains("..")
+        || name.indexOf('/') >= 0
+        || name.indexOf('\\') >= 0) {
+      throw new VirtualSiteException(
+          PROP_CONFIG_FILE
+              + " must be a simple file name under the Virtual Site root (no path separators or"
+              + " '..'). Rejected: '"
+              + configFile
+              + "'.");
+    }
+  }
+
+  private static String allowedSourceKindsDescription() {
+    return Stream.of(VirtualSiteSourceType.values())
+        .map(VirtualSiteSourceType::wireName)
+        .collect(Collectors.joining(", "));
   }
 
   private static Set<PSSiteProperty> propertiesOf(IPSSite site) {

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteHelperTest.java
@@ -16,17 +16,23 @@
  */
 package com.percussion.services.virtualsite;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.percussion.services.sitemgr.data.PSSite;
 import com.percussion.services.sitemgr.data.PSSiteProperty;
+import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class PSVirtualSiteHelperTest {
 
@@ -112,5 +118,154 @@ class PSVirtualSiteHelperTest {
     root.setValue("   ");
     when(site.getProperties()).thenReturn(Set.of(root));
     assertTrue(PSVirtualSiteHelper.rootPath(site).isEmpty());
+  }
+
+  @Test
+  void rootPathNormalizesViaNio() {
+    PSSite site = siteWith(
+        prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "docs/product-docs/./pages/../"));
+    Path root = PSVirtualSiteHelper.rootPath(site).orElseThrow();
+    assertEquals(Path.of("docs", "product-docs").normalize(), root);
+  }
+
+  @Test
+  void allowedSourceKindsIncludeGitFilesystemOnlyInPhase1() {
+    List<String> allowed = PSVirtualSiteHelper.allowedSourceKindWireNames();
+    assertEquals(List.of("git-filesystem"), allowed);
+  }
+
+  @Test
+  void validatePassesForNullAndRepositorySites() {
+    assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(null));
+
+    PSSite bare = mock(PSSite.class);
+    when(bare.getProperties()).thenReturn(Set.of());
+    assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(bare));
+
+    PSSite repo = siteWith(prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "repository"));
+    assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(repo));
+  }
+
+  @Test
+  void validatePassesForAllowListedVirtualWithSafeRoot() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs"),
+            prop(PSVirtualSiteHelper.PROP_CONFIG_FILE, "_config.yaml"));
+    assertDoesNotThrow(() -> PSVirtualSiteHelper.validate(site));
+  }
+
+  @Test
+  void validateRejectsUnknownSourceKind() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "sql-api"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_SOURCE_KIND));
+    assertTrue(ex.getMessage().contains("sql-api"));
+    assertTrue(ex.getMessage().contains("git-filesystem"));
+  }
+
+  @Test
+  void validateRejectsMissingRootPathWhenVirtual() {
+    PSSite site = siteWith(prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_ROOT_PATH));
+    assertTrue(ex.getMessage().contains("required"));
+  }
+
+  @Test
+  void validateRejectsBlankRootPathWhenVirtual() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "   "));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_ROOT_PATH));
+  }
+
+  @Test
+  void validateRejectsPathTraversalInRootPath() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "../outside"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_ROOT_PATH));
+    assertTrue(ex.getMessage().contains(".."));
+  }
+
+  @Test
+  void validateRejectsRelativeParentSegmentsAfterNormalize() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "docs/../../etc"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_ROOT_PATH));
+  }
+
+  @Test
+  void validateRejectsConfigFileWithPathSeparators() {
+    PSSite site =
+        siteWith(
+            prop(PSVirtualSiteHelper.PROP_SOURCE_KIND, "git-filesystem"),
+            prop(PSVirtualSiteHelper.PROP_ROOT_PATH, "product-docs"),
+            prop(PSVirtualSiteHelper.PROP_CONFIG_FILE, "../evil.yaml"));
+    VirtualSiteException ex =
+        assertThrows(VirtualSiteException.class, () -> PSVirtualSiteHelper.validate(site));
+    assertTrue(ex.getMessage().contains(PSVirtualSiteHelper.PROP_CONFIG_FILE));
+  }
+
+  @Test
+  void isSafeRootPathRejectsEmptyAndDotAndParent() {
+    assertFalse(PSVirtualSiteHelper.isSafeRootPath(null));
+    assertFalse(PSVirtualSiteHelper.isSafeRootPath(Path.of("").normalize()));
+    assertFalse(PSVirtualSiteHelper.isSafeRootPath(Path.of(".").normalize()));
+    assertFalse(PSVirtualSiteHelper.isSafeRootPath(Path.of("..").normalize()));
+    assertFalse(PSVirtualSiteHelper.isSafeRootPath(Path.of("a", "..", "..", "b").normalize()));
+    assertTrue(PSVirtualSiteHelper.isSafeRootPath(Path.of("product-docs").normalize()));
+    assertTrue(PSVirtualSiteHelper.isSafeRootPath(Path.of("docs", "product-docs").normalize()));
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void isSafeRootPathAllowsWindowsAbsolute() {
+    assertTrue(PSVirtualSiteHelper.isSafeRootPath(Path.of("C:\\docs\\product-docs").normalize()));
+    // Absolute path whose normalize removes ".." is still absolute and has no remaining ".."
+    assertTrue(
+        PSVirtualSiteHelper.isSafeRootPath(Path.of("C:\\docs\\product-docs\\..\\help").normalize()));
+  }
+
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  void isSafeRootPathAllowsUnixAbsolute() {
+    assertTrue(PSVirtualSiteHelper.isSafeRootPath(Path.of("/opt/product-docs").normalize()));
+    assertTrue(
+        PSVirtualSiteHelper.isSafeRootPath(Path.of("/opt/product-docs/../help").normalize()));
+  }
+
+  private static PSSiteProperty prop(String name, String value) {
+    PSSiteProperty p = new PSSiteProperty();
+    p.setName(name);
+    p.setValue(value);
+    return p;
+  }
+
+  private static PSSite siteWith(PSSiteProperty... properties) {
+    PSSite site = mock(PSSite.class);
+    Set<PSSiteProperty> props = new HashSet<>();
+    for (PSSiteProperty p : properties) {
+      props.add(p);
+    }
+    when(site.getProperties()).thenReturn(props);
+    return site;
   }
 }


### PR DESCRIPTION
## Summary

Slice 1 of parent epic **#2678** (Virtual Sites Phase 3 residual).

Hardens the Phase 1 **Virtual Site property contract** on `PSVirtualSiteHelper` so sites can be configured safely without Site Manager UI yet:

- **Allow-list** `virtual.sourceKind` (Phase 1: `git-filesystem` only; blank/`repository` = traditional Site)
- **Required** non-blank `virtual.rootPath` when virtual
- **Safe path** handling via NIO `Path.normalize()` — reject empty paths and remaining `..` segments (cross-platform)
- **Config file** must be a simple file name (no separators / `..`)
- Expanded unit tests in `PSVirtualSiteHelperTest`
- Product docs updated for `virtual.*` keys (admin / developer / reference)

Out of scope (siblings): Site Manager UI (#2956), REST wiring (#2955).

**Parent tracker:** #2678  
**Fixes:** #2954

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] `PSVirtualSiteHelperTest`: 19 tests, 0 failures (1 OS-skipped absolute-path case on non-Windows)
- [x] Full system suite: **Tests run: 1710, Failures: 0, Errors: 0, Skipped: 241**
- [x] No new public API breakage (additive `validate` / helpers only; `rootPath` still returns normalized `Optional<Path>`)

### C3 build evidence

| Field | Value |
|-------|--------|
| `modules_built` | `system` |
| `build_evidence` | `cd system; ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1710, Failures: 0, Errors: 0, Skipped: 241; PSVirtualSiteHelperTest 19/0/0 (1 skipped OS) |
| `downstream_checked` | none (C2 N/A — no final/sealed change; no breaking signature change; additive validation API only) |

## Product documentation

- [x] Updated pages under `product-docs/`:
  - `product-docs/8.2/admin/sites.md` — operator property table + validation notes
  - `product-docs/8.2/developer/virtual-sites.md` — full virtual.* contract + validation rules
  - `product-docs/8.2/reference/site-config.md` — CMS Site properties table + cross-platform notes
- Engineering contract peer: `docs/ai-generated/tasks/virtual-sites-git-docs/contracts/site-properties.md`

## Checklist

- [x] Behavioral unit tests for new validation
- [x] Cross-platform NIO path handling
- [x] Pre-PR module clean install green
- [x] Product documentation updated
- [x] No Site Manager UI / REST in this PR

> Co-Authored by Grok Build using grok-4.5 with agent main.
