### PR TITLE
fix(sitemanage): persist Runtime visibility on Default ACL template load (#2948)

### DIFF
--- a/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperPreferencesPanel.test.tsx
@@ -158,6 +158,51 @@ describe("DeveloperPreferencesPanel", () => {
     });
   });
 
+  /**
+   * #2948 — after Save, a full remount (reload Preferences) must rehydrate
+   * RUNTIME_VISIBLE from the preference payload, not fall back to system default
+   * without Visible on Default.
+   */
+  it("reload shows RUNTIME_VISIBLE on Default after save→load round-trip (#2948)", async () => {
+    renderPanel();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-prefs-acl-table")).toBeTruthy();
+    });
+
+    const runtimeOnDefault = screen.getByTestId(
+      "developer-prefs-acl-perm-row:0:Default:USER-RUNTIME_VISIBLE",
+    ) as HTMLInputElement;
+    expect(runtimeOnDefault.checked).toBe(false);
+    fireEvent.click(runtimeOnDefault);
+
+    fireEvent.click(screen.getByTestId("developer-prefs-acl-save"));
+    await waitFor(() => {
+      expect(saveDefaultAclTemplate).toHaveBeenCalled();
+    });
+    const [savedTemplate] = vi.mocked(saveDefaultAclTemplate).mock.calls[0];
+    expect(savedTemplate.entries[0].permissions).toContain("RUNTIME_VISIBLE");
+
+    cleanup();
+
+    // Simulate remount after page reload: load returns the saved preference value.
+    vi.mocked(loadDefaultAclTemplate).mockResolvedValue({
+      template: savedTemplate,
+      fromPreference: true,
+    });
+
+    renderPanel();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-prefs-acl-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-prefs-acl-source").textContent).toMatch(
+      /saved/i,
+    );
+    const reloaded = screen.getByTestId(
+      "developer-prefs-acl-perm-row:0:Default:USER-RUNTIME_VISIBLE",
+    ) as HTMLInputElement;
+    expect(reloaded.checked).toBe(true);
+  });
+
   it("adds a template entry from the add form", async () => {
     renderPanel();
     await waitFor(() => {

--- a/WebUI/src/test/ts/developer/defaultAclTemplate.test.ts
+++ b/WebUI/src/test/ts/developer/defaultAclTemplate.test.ts
@@ -62,6 +62,34 @@ describe("defaultAclTemplate helpers", () => {
     expect(defaultAclTemplatesEqual(parsed!, sys)).toBe(true);
   });
 
+  /**
+   * #2948 — Runtime visibility on Default must survive serialize → parse
+   * (preference store round-trip). Client helpers already preserve the token;
+   * this guards against accidental allowlist filtering of RUNTIME_VISIBLE.
+   */
+  it("round-trips RUNTIME_VISIBLE on Default USER entry (#2948)", () => {
+    const template = cloneDefaultAclTemplate(systemDefaultAclTemplate());
+    expect(template.entries[0].permissions).not.toContain("RUNTIME_VISIBLE");
+    template.entries[0].permissions.push("RUNTIME_VISIBLE");
+
+    const raw = serializeDefaultAclTemplate(template);
+    expect(raw).toContain("RUNTIME_VISIBLE");
+
+    const parsed = parseDefaultAclTemplate(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.entries[0].name).toBe("Default");
+    expect(parsed!.entries[0].permissions).toEqual(
+      expect.arrayContaining([
+        "READ",
+        "UPDATE",
+        "DELETE",
+        "OWNER",
+        "RUNTIME_VISIBLE",
+      ]),
+    );
+    expect(defaultAclTemplatesEqual(parsed!, template)).toBe(true);
+  });
+
   it("parse returns null for empty or invalid payloads", () => {
     expect(parseDefaultAclTemplate(null)).toBeNull();
     expect(parseDefaultAclTemplate("")).toBeNull();

--- a/docs/ai-generated/code-reviews/issue-2948-runtime-visibility-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2948-runtime-visibility-erlang.md
@@ -1,0 +1,41 @@
+# Erlang review — #2948 Runtime visibility not persisted
+
+**Branch:** `fix/issue-2948-runtime-visibility-persist`  
+**Scope:** uncommitted changes for issue #2948  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**  
+**Memory patterns hit:** preference/DTO convert must copy all wire fields; load vs save converter drift
+
+## Summary
+
+Developer Preferences Default ACL Template Runtime visibility (`RUNTIME_VISIBLE`) was lost after reload because `ApiUtils.convertUserProperty` (used by `PreferencesAdaptor.loadPreference` for `GET /preferences/{name}`) never copied `PROPERTYVALUE` onto the REST `UserPreference`. Save path used `convertPSPersistentProperty` (which does set value), so PUT appeared to succeed and local UI state looked correct until remount/reload fell back to system default without Visible on Default.
+
+## Findings
+
+| Severity | Issue | Status |
+|----------|--------|--------|
+| (none blocking) | — | — |
+
+### Notes (non-blocking)
+
+- Fix delegates `convertUserProperty` → `convertPSPersistentProperty` to prevent future field drift.
+- Client serialize/parse already preserved `RUNTIME_VISIBLE`; extra Vitest round-trip tests lock that contract.
+- No public method signature change; no path/file I/O in the diff.
+- Product-docs N/A (bugfix restoring documented intent; no operator procedure change).
+- Playwright not required (no UI surface change; server conversion bug).
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction or assertions in this change.
+
+## Tests
+
+- `ApiUtilsUserPreferenceConvertTest` — value preserved; parity with save converter; empty value → `""`
+- `defaultAclTemplate.test.ts` — serialize/parse keeps `RUNTIME_VISIBLE` on Default
+- `DeveloperPreferencesPanel.test.tsx` — save→remount load shows Visible checked
+
+## Build evidence (pre-PR)
+
+- `cd projects/sitemanage && ../../mvnw clean install` → BUILD SUCCESS (incl. new UnitTest)
+- `cd WebUI && ../mvnw clean install` → BUILD SUCCESS
+- Focused Vitest: 18 tests passed (defaultAclTemplate + DeveloperPreferencesPanel)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -713,14 +713,17 @@ public class ApiUtils {
     return ret;
   }
 
+  /**
+   * Convert a persisted property to a REST {@link UserPreference}.
+   *
+   * <p>Must include {@code value} — {@link PreferencesAdaptor#loadPreference} uses this path for
+   * {@code GET /preferences/{name}}. Dropping value caused Developer default ACL template
+   * {@code RUNTIME_VISIBLE} (and any other stored payload) to be lost on reload (#2948).
+   *
+   * <p>Delegates to {@link #convertPSPersistentProperty} so list/get/save converters stay aligned.
+   */
   public static UserPreference convertUserProperty(PSPersistentProperty p) {
-    UserPreference u = new UserPreference();
-    u.setCategory(p.getCategory());
-    u.setContext(p.getContext());
-    u.setExtraParam(p.getExtraParam());
-    u.setName(p.getName());
-    u.setUserName(p.getUserName());
-    return u;
+    return convertPSPersistentProperty(p);
   }
 
   public static IPSTypedPrincipal convertPrincipalType(TypedPrincipal owner) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PreferencesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PreferencesAdaptor.java
@@ -69,6 +69,9 @@ public class PreferencesAdaptor implements IPreferenceAdaptor {
     var session = getSession();
     var userPrefs =
         objectMgr.findPersistentPropertiesByName(session.getRealAuthenticatedUserEntry());
+    // convertPSPersistentProperty (via convertUserProperty) must copy PROPERTYVALUE —
+    // omitting value made GET /preferences/{name} return empty payloads and dropped
+    // Developer default ACL RUNTIME_VISIBLE on reload (#2948).
     return userPrefs.stream()
         .filter(p -> p.getName().equalsIgnoreCase(preference))
         .findFirst()

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsUserPreferenceConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsUserPreferenceConvertTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.preferences.UserPreference;
+import com.percussion.server.PSPersistentProperty;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral unit tests for {@link ApiUtils} user-preference conversion used by {@link
+ * PreferencesAdaptor#loadPreference} / save (#2948).
+ *
+ * <p>Regression: {@code convertUserProperty} historically omitted {@code value}, so GET
+ * {@code /preferences/{name}} returned empty payloads and Developer default ACL {@code
+ * RUNTIME_VISIBLE} did not survive reload.
+ */
+@Tag("UnitTest")
+public class ApiUtilsUserPreferenceConvertTest {
+
+  /** Sample default ACL template JSON with RUNTIME_VISIBLE on Default (issue #2948). */
+  private static final String DEFAULT_ACL_TEMPLATE_WITH_RUNTIME =
+      "{\"version\":1,\"entries\":["
+          + "{\"name\":\"Default\",\"type\":\"USER\",\"permissions\":"
+          + "[\"READ\",\"UPDATE\",\"DELETE\",\"OWNER\",\"RUNTIME_VISIBLE\"]},"
+          + "{\"name\":\"AnyCommunity\",\"type\":\"COMMUNITY\",\"permissions\":[\"RUNTIME_VISIBLE\"]}"
+          + "]}";
+
+  @Test
+  public void convertUserPropertyPreservesValue() {
+    PSPersistentProperty prop =
+        new PSPersistentProperty(
+            "admin",
+            "developer.defaultObjectAclTemplate",
+            "sys_preferences",
+            "private",
+            DEFAULT_ACL_TEMPLATE_WITH_RUNTIME);
+
+    UserPreference up = ApiUtils.convertUserProperty(prop);
+
+    assertNotNull(up);
+    assertEquals("developer.defaultObjectAclTemplate", up.getName());
+    assertEquals("admin", up.getUserName());
+    assertEquals("sys_preferences", up.getCategory());
+    assertEquals("private", up.getContext());
+    assertEquals(DEFAULT_ACL_TEMPLATE_WITH_RUNTIME, up.getValue());
+    assertTrue(
+        up.getValue().contains("RUNTIME_VISIBLE"),
+        "preference value must retain RUNTIME_VISIBLE for Default ACL template reload");
+  }
+
+  @Test
+  public void convertUserPropertyMatchesConvertPSPersistentProperty() {
+    PSPersistentProperty prop =
+        new PSPersistentProperty(
+            "editor",
+            "some.pref",
+            "sys_preferences",
+            "private",
+            "{\"flag\":true,\"nested\":\"value\"}");
+
+    UserPreference viaLoad = ApiUtils.convertUserProperty(prop);
+    UserPreference viaSave = ApiUtils.convertPSPersistentProperty(prop);
+
+    assertEquals(viaSave.getName(), viaLoad.getName());
+    assertEquals(viaSave.getUserName(), viaLoad.getUserName());
+    assertEquals(viaSave.getCategory(), viaLoad.getCategory());
+    assertEquals(viaSave.getContext(), viaLoad.getContext());
+    assertEquals(viaSave.getValue(), viaLoad.getValue());
+    assertEquals(viaSave.getExtraParam(), viaLoad.getExtraParam());
+  }
+
+  @Test
+  public void convertUserPropertyEmptyValueIsEmptyStringNotNull() {
+    PSPersistentProperty prop =
+        new PSPersistentProperty("admin", "empty.pref", "sys_preferences", "private", null);
+
+    UserPreference up = ApiUtils.convertUserProperty(prop);
+
+    assertNotNull(up.getValue());
+    assertEquals("", up.getValue());
+  }
+}


### PR DESCRIPTION
## Summary

Fixes Developer → Preferences → Security: **Runtime visibility (Visible / `RUNTIME_VISIBLE`)** not surviving **Save default ACL template** → reload.

**Root cause:** `PreferencesAdaptor.loadPreference` (`GET /services/preferences/{name}`) converted via `ApiUtils.convertUserProperty`, which never copied `PROPERTYVALUE` onto the REST `UserPreference`. Save used `convertPSPersistentProperty` (which does set value), so PUT succeeded and in-session UI looked fine, but reload saw an empty preference value and fell back to the system default (Default USER without `RUNTIME_VISIBLE`).

**Fix:** Delegate `convertUserProperty` → `convertPSPersistentProperty` so list/get/save converters stay aligned.

**Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #2948

## Test plan

- [x] Unit: `ApiUtilsUserPreferenceConvertTest` — value preserved; parity with save converter; empty → `""`
- [x] Vitest: `defaultAclTemplate` serialize/parse keeps `RUNTIME_VISIBLE` on Default
- [x] Vitest: `DeveloperPreferencesPanel` save → remount load shows Visible checked on Default
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS
- [x] `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS
- [ ] Human QA: Developer Preferences — check Visible on Default, Save, reload, confirm still checked

### modules_built

`projects/sitemanage`, `WebUI`

### build_evidence

```
cd projects/sitemanage && ../../mvnw.cmd clean install
→ BUILD SUCCESS (ApiUtilsUserPreferenceConvertTest: Tests run: 3, Failures: 0)
  sitemanage suite: Tests run: 899, Failures: 0, Errors: 0 (Skipped: 127)

cd WebUI && ../mvnw.cmd clean install
→ BUILD SUCCESS (Surefire Java tests + frontend vitest run via npm-test)

npx vitest run defaultAclTemplate.test.ts DeveloperPreferencesPanel.test.tsx
→ Test Files 2 passed; Tests 18 passed
```

### downstream_checked

none — no public/protected signature change; conversion method body only (same return type). Reverse-dep API shape unchanged. Stale local `rest` SNAPSHOT reinstalled from worktree only to compile sitemanage (unrelated interface drift on machine).

## Product documentation

- [x] N/A — bug fix restoring intended persistence of an existing Developer Preferences control; no new operator procedure or config surface. Product docs already describe default ACL template preferences.

## Erlang

Approve — report: `docs/ai-generated/code-reviews/issue-2948-runtime-visibility-erlang.md`

## Checklist

- [x] Behavioral unit tests for changed logic
- [x] Pre-PR module clean install (standalone)
- [x] No new public API signature / final/sealed changes
- [x] Cross-platform paths N/A
