### PR TITLE
fix(search): Explorer free-text search HTTP 400 missing formatId (#2950)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/searchApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/searchApi.ts
@@ -66,6 +66,51 @@ interface PSSearchCriteriaRequest {
 }
 
 /**
+ * Classic finder / Home use system list display format id {@code 9} when
+ * the active format is not yet resolved. {@code PSSearchService.searchForIds}
+ * rejects a missing {@code formatId} with IllegalArgumentException → HTTP 400
+ * (see GH-2950 Explorer Search).
+ */
+export const DEFAULT_SEARCH_FORMAT_ID = 9;
+
+/**
+ * Normalize client criteria to the shape {@code PSSearchRestService} /
+ * {@code PSSearchService} accept for a minimal free-text search.
+ *
+ * <ul>
+ *   <li>{@code formatId} defaults to {@link DEFAULT_SEARCH_FORMAT_ID} (required server-side)</li>
+ *   <li>{@code startIndex} coerced to ≥ 1 (1-based paging; server also treats &lt;1 as 1)</li>
+ *   <li>{@code maxResults} left as provided (panel/home set their own defaults)</li>
+ *   <li>Does not mutate the caller's object</li>
+ *   <li>Omits non-wire client-only fields such as {@code caseSensitive}</li>
+ * </ul>
+ */
+export function normalizeSearchCriteria(
+  criteria: PSSearchCriteria,
+): PSSearchCriteria {
+  const startRaw =
+    typeof criteria.startIndex === "number" ? criteria.startIndex : 1;
+  const startIndex = startRaw >= 1 ? startRaw : 1;
+  const formatId =
+    typeof criteria.formatId === "number" && Number.isFinite(criteria.formatId)
+      ? criteria.formatId
+      : DEFAULT_SEARCH_FORMAT_ID;
+
+  const out: PSSearchCriteria = {
+    query: criteria.query,
+    searchType: criteria.searchType,
+    startIndex,
+    maxResults: criteria.maxResults,
+    sortColumn: criteria.sortColumn,
+    sortOrder: criteria.sortOrder,
+    formatId,
+    searchFields: criteria.searchFields,
+    folderPath: criteria.folderPath,
+  };
+  return out;
+}
+
+/**
  * Server-backed extended search. Wraps the {@link PSSearchCriteria}
  * body in the {@code {"SearchCriteria": ...}} envelope, hits the
  * sitemanage search endpoint, and unwraps the response into the
@@ -78,11 +123,15 @@ interface PSSearchCriteriaRequest {
  * ({@code SecureStringUtils.removeInvalidSQLObjectNameCharacters})
  * before searching; this is documented behavior per the server
  * {@code sanitizeCriteria} method.</p>
+ *
+ * <p>GH-2950: callers often omit {@code formatId}; {@link normalizeSearchCriteria}
+ * supplies the classic default so the server does not 400 on valid text queries.</p>
  */
 export async function searchExtended(
   criteria: PSSearchCriteria,
 ): Promise<PSSearchResults> {
-  const body: PSSearchCriteriaRequest = { SearchCriteria: criteria };
+  const normalized = normalizeSearchCriteria(criteria);
+  const body: PSSearchCriteriaRequest = { SearchCriteria: normalized };
   const res = await post<PSPagedItemPropertiesListEnvelope>(
     PATHS.FINDER_SEARCH_EXTENDED,
     body,
@@ -93,13 +142,13 @@ export async function searchExtended(
     return {
       children: [],
       totalCount: 0,
-      startIndex: criteria.startIndex ?? 1,
+      startIndex: normalized.startIndex ?? 1,
     };
   }
   return {
     children: envelope.childrenInPage ?? [],
     totalCount: envelope.childrenCount,
-    startIndex: envelope.startIndex ?? criteria.startIndex ?? 1,
+    startIndex: envelope.startIndex ?? normalized.startIndex ?? 1,
   };
 }
 

--- a/WebUI/src/main/ts/api/contentExplorer/types.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/types.ts
@@ -309,8 +309,13 @@ export interface NodeRelationshipSummary {
  * <p>Mirrors {@code com.percussion.searchmanagement.data.PSSearchCriteria}.
  * The wire is wrapped under `SearchCriteria` (the DTO's
  * {@code @XmlRootElement(name = "SearchCriteria")} triggers Jackson's
- * root-name wrapping); the helper {@code searchExtended} unwraps the
- * envelope before sending the request.</p>
+ * root-name wrapping); the helper {@code searchExtended} wraps the
+ * envelope after {@code normalizeSearchCriteria}.</p>
+ *
+ * <p><strong>Required for a successful free-text search:</strong>
+ * {@code formatId} (classic system list format {@code 9} when omitted —
+ * enforced by {@code normalizeSearchCriteria} / server {@code sanitizeCriteria};
+ * missing value was HTTP 400 GH-2950). {@code startIndex} is 1-based.</p>
  */
 export interface PSSearchCriteria {
   query?: string;
@@ -319,10 +324,19 @@ export interface PSSearchCriteria {
   maxResults?: number;
   sortColumn?: string;
   sortOrder?: string;
+  /**
+   * Display format id. Required by {@code PSSearchService.searchForIds}.
+   * Prefer omitting and letting {@code searchExtended} default to 9, or set
+   * explicitly when a finder display format is known.
+   */
   formatId?: number;
   /** Per-field constraint map; matches `PSSearchCriteria.searchFields`. */
   searchFields?: Record<string, string>;
   folderPath?: string;
+  /**
+   * Client-only hint — not present on the Java DTO. Stripped by
+   * {@code normalizeSearchCriteria} before POST (do not send on the wire).
+   */
   caseSensitive?: boolean;
 }
 

--- a/WebUI/src/test/ts/contentExplorer/searchApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/searchApi.test.ts
@@ -16,6 +16,8 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_SEARCH_FORMAT_ID,
+  normalizeSearchCriteria,
   sanitizeQuery,
   searchExtended,
 } from "../../../main/ts/api/contentExplorer/searchApi";
@@ -23,6 +25,38 @@ import { PATHS } from "../../../main/ts/api/paths";
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("normalizeSearchCriteria (GH-2950)", () => {
+  it("defaults formatId and coerces startIndex < 1 for minimal free-text criteria", () => {
+    const out = normalizeSearchCriteria({ query: "a", maxResults: 25 });
+    expect(out.formatId).toBe(DEFAULT_SEARCH_FORMAT_ID);
+    expect(out.startIndex).toBe(1);
+    expect(out.query).toBe("a");
+    expect(out.maxResults).toBe(25);
+  });
+
+  it("preserves explicit formatId and valid startIndex", () => {
+    const out = normalizeSearchCriteria({
+      query: "x",
+      formatId: 12,
+      startIndex: 5,
+    });
+    expect(out.formatId).toBe(12);
+    expect(out.startIndex).toBe(5);
+  });
+
+  it("does not mutate the input object and omits client-only caseSensitive", () => {
+    const input = {
+      query: "Original",
+      startIndex: 0,
+      caseSensitive: true,
+    };
+    const out = normalizeSearchCriteria(input);
+    expect(input.startIndex).toBe(0);
+    expect(out.startIndex).toBe(1);
+    expect(out).not.toHaveProperty("caseSensitive");
+  });
 });
 
 describe("searchExtended wire shape", () => {
@@ -34,7 +68,7 @@ describe("searchExtended wire shape", () => {
           JSON.stringify({
             PagedItemPropertiesList: {
               childrenCount: 1,
-              startIndex: 0,
+              startIndex: 1,
               childrenInPage: [
                 {
                   id: "1",
@@ -58,17 +92,19 @@ describe("searchExtended wire shape", () => {
     expect(typeof url).toBe("string");
     expect(String(url)).toBe(PATHS.FINDER_SEARCH_EXTENDED);
     expect(init?.method).toBe("POST");
+    // GH-2950: formatId required server-side; startIndex 0 coerced to 1
     expect(JSON.parse(String(init?.body))).toEqual({
       SearchCriteria: {
         query: "Test",
-        startIndex: 0,
+        startIndex: 1,
         maxResults: 10,
+        formatId: DEFAULT_SEARCH_FORMAT_ID,
       },
     });
     expect(result.children).toHaveLength(1);
     expect(result.children[0]?.title).toBe("Test Page");
     expect(result.totalCount).toBe(1);
-    expect(result.startIndex).toBe(0);
+    expect(result.startIndex).toBe(1);
   });
 
   it("returns empty shape on envelope miss / empty body", async () => {
@@ -126,11 +162,34 @@ describe("searchExtended wire shape", () => {
     };
     await searchExtended(criteria);
     expect(criteria.query).toBe("Original");
-    // Fetch was called with a wrapped body but our local `criteria` is
-    // untouched (sanity check; the wrapper is a fresh object).
+    expect(criteria.startIndex).toBe(0);
+    // Fetch was called with a wrapped + normalized body; local criteria untouched.
     const init = fetchMock.mock.calls[0]?.[1];
     const body = JSON.parse(String(init?.body));
     expect(body.SearchCriteria.query).toBe("Original");
+    expect(body.SearchCriteria.formatId).toBe(DEFAULT_SEARCH_FORMAT_ID);
+    expect(body.SearchCriteria.startIndex).toBe(1);
+  });
+
+  it("sends formatId on a simple query-only search (Explorer GH-2950 shape)", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          PagedItemPropertiesList: { childrenCount: 0, childrenInPage: [] },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await searchExtended({ query: "a", startIndex: 1, maxResults: 25 });
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body).toEqual({
+      SearchCriteria: {
+        query: "a",
+        startIndex: 1,
+        maxResults: 25,
+        formatId: DEFAULT_SEARCH_FORMAT_ID,
+      },
+    });
   });
 });
 

--- a/modules/perc-qa-automation/frontend/tests/explorer-shell-chrome.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-shell-chrome.spec.js
@@ -209,4 +209,66 @@ test.describe("Explorer shell chrome composition (#2850 / #2407)", () => {
       });
     },
   );
+
+  /**
+   * GH-2950: free-text Search must not 400. Minimal criteria (query only)
+   * previously omitted formatId → IllegalArgumentException → HTTP 400.
+   * Assert the extendedresults POST is 2xx/non-400 and the panel reaches a
+   * terminal ready/empty state (not the HTTP 400 error chrome).
+   */
+  test(
+    "free-text Search POST extendedresults is not HTTP 400 (GH-2950)",
+    {
+      tag: [
+        "@explorer-shell-chrome",
+        "@explorer",
+        "@search",
+        "@smoke",
+        "@issue-2950",
+      ],
+    },
+    async ({ page }) => {
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.shell}"]`),
+      ).toBeVisible({ timeout: 20_000 });
+
+      await openViewMenu(page);
+      await page.locator(`[data-testid="${TEST_IDS.toggleSearch}"]`).click();
+      await expect(
+        page.locator(`[data-testid="${TEST_IDS.searchPanel}"]`),
+      ).toBeVisible({ timeout: 10_000 });
+
+      const responsePromise = page.waitForResponse(
+        (res) =>
+          res.request().method() === "POST" &&
+          res.url().includes("/searchmanagement/search/get/extendedresults"),
+        { timeout: 30_000 },
+      );
+
+      const input = page.locator(`[data-testid="${TEST_IDS.searchInput}"]`);
+      await input.fill("a");
+      await page.locator(`[data-testid="${TEST_IDS.searchSubmit}"]`).click();
+
+      const response = await responsePromise;
+      expect(
+        response.status(),
+        `extendedresults must not be 400 (body shape / formatId); got ${response.status()}`,
+      ).not.toBe(400);
+      expect(
+        response.ok(),
+        `extendedresults expected 2xx for simple query "a"; got ${response.status()}`,
+      ).toBeTruthy();
+
+      // Terminal UI: results, empty, or (non-400) error — never "HTTP 400 Bad Request"
+      await expect(
+        page.locator(
+          `[data-testid="search-panel-results"], [data-testid="search-panel-empty"], [data-testid="search-panel-error"]`,
+        ),
+      ).toBeVisible({ timeout: 15_000 });
+      const err = page.locator(`[data-testid="search-panel-error"]`);
+      if ((await err.count()) > 0 && (await err.isVisible())) {
+        await expect(err).not.toContainText(/HTTP 400/i);
+      }
+    },
+  );
 });

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
@@ -55,6 +55,14 @@ public class PSSearchRestService {
   private static final String SEARCH_TYPE_MY_PAGES = "MyPages";
   private static final Logger log = LogManager.getLogger(PSSearchRestService.class);
 
+  /**
+   * Default display-format id used by classic finder / Home when the active format is not
+   * resolved. Matches WebUI {@code DEFAULT_SEARCH_FORMAT_ID} and integration tests (format id 9).
+   * Required by {@code PSSearchService.searchForIds} — missing value → IllegalArgumentException →
+   * HTTP 400 (GH-2950).
+   */
+  static final int DEFAULT_SEARCH_FORMAT_ID = 9;
+
   private final IPSSearchService searchService;
   private final IPSItemService itemService;
   private final IPSSystemService systemService;
@@ -95,6 +103,14 @@ public class PSSearchRestService {
           && !SecureStringUtils.isValidCMSPathString(
               criteria.getFolderPath(), PSOperationContext.SEARCH)) {
         criteria.setFolderPath(null);
+      }
+
+      // Minimal free-text criteria (query + paging only) is valid; supply classic default format.
+      if (criteria.getFormatId() == null) {
+        criteria.setFormatId(DEFAULT_SEARCH_FORMAT_ID);
+      }
+      if (criteria.getStartIndex() == null || criteria.getStartIndex() < 1) {
+        criteria.setStartIndex(1);
       }
     }
   }

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
@@ -121,7 +121,7 @@ public class PSSearchService implements IPSSearchService {
 
   private List<Integer> getContentIdsForSearchByStatus(PSSearchCriteria criteria) {
     if (criteria.getFormatId() == null) {
-      throw new IllegalArgumentException("format Id cannot be blank.");
+      criteria.setFormatId(DEFAULT_SEARCH_FORMAT_ID);
     }
     try {
       var searchHandler = new PSSearchHandler();
@@ -201,7 +201,7 @@ public class PSSearchService implements IPSSearchService {
           PSNotFoundException,
           IPSDataService.DataServiceLoadException {
     if (criteria.getFormatId() == null) {
-      throw new IllegalArgumentException("format Id cannot be blank.");
+      criteria.setFormatId(DEFAULT_SEARCH_FORMAT_ID);
     }
     var allItemEntries = getSortedEntries(criteria, contentIdList);
     return formatResults(criteria, allItemEntries);
@@ -214,7 +214,7 @@ public class PSSearchService implements IPSSearchService {
           PSNotFoundException,
           IPSDataService.DataServiceLoadException {
     if (criteria.getFormatId() == null) {
-      throw new IllegalArgumentException("format Id cannot be blank.");
+      criteria.setFormatId(DEFAULT_SEARCH_FORMAT_ID);
     }
     // ensure we have a List since helper may return a generic Collection
     List<Integer> finalContentIdList =
@@ -224,8 +224,9 @@ public class PSSearchService implements IPSSearchService {
   }
 
   private List<Integer> searchForIds(PSSearchCriteria criteria) {
+    // GH-2950: minimal free-text criteria is valid; default format instead of 400.
     if (criteria.getFormatId() == null) {
-      throw new IllegalArgumentException("format Id cannot be blank.");
+      criteria.setFormatId(DEFAULT_SEARCH_FORMAT_ID);
     }
     try {
       var searchHandler = new PSSearchHandler();
@@ -244,7 +245,10 @@ public class PSSearchService implements IPSSearchService {
       }
 
       // Decode the URL-encoded query, workaround for jQuery bug http://bugs.jquery.com/ticket/8417
-      // Then escape it for Lucene
+      // Then escape it for Lucene. Null/blank query is not a valid FTS request.
+      if (criteria.getQuery() == null) {
+        throw new IllegalArgumentException("query cannot be blank.");
+      }
       var urlDecodedQuery = URLDecoder.decode(criteria.getQuery(), "UTF-8");
       var query = escapeLuceneQuery(urlDecodedQuery);
 
@@ -463,6 +467,13 @@ public class PSSearchService implements IPSSearchService {
   private static final String WORKFLOW_NAME = "sys_workflow";
   private static final String WORKFLOW_ID = "sys_workflowid";
   private static final String EXCLUDE_WORKFLOW = " NOT " + WORKFLOW_ID + ":";
+
+  /**
+   * Classic system list display format id (same as finder Home default / GH-2950). Used when
+   * callers omit formatId; extended-results path does not use the format for row projection but
+   * historically required a non-null id.
+   */
+  static final int DEFAULT_SEARCH_FORMAT_ID = 9;
 
   @Override
   public PSSearchCriteria validateSearchCriteria(PSSearchCriteria criteria) {

--- a/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
@@ -67,6 +67,48 @@ class PSSearchRestServiceTest {
   }
 
   /**
+   * GH-2950: Explorer free-text search posts minimal criteria (query + paging). Server must accept
+   * that shape by defaulting {@code formatId} / {@code startIndex} so {@code searchForIds} does not
+   * throw IllegalArgumentException → HTTP 400.
+   */
+  @Test
+  void sanitizeCriteriaDefaultsFormatIdAndStartIndexForMinimalQuery() {
+    PSSearchRestService restService = new PSSearchRestService(null, null, null);
+    PSSearchCriteria criteria = new PSSearchCriteria();
+    criteria.setQuery("a");
+    criteria.setMaxResults(25);
+    restService.sanitizeCriteria(criteria);
+    assertEquals(Integer.valueOf(PSSearchRestService.DEFAULT_SEARCH_FORMAT_ID), criteria.getFormatId());
+    assertEquals(Integer.valueOf(1), criteria.getStartIndex());
+    assertEquals("a", criteria.getQuery());
+  }
+
+  @Test
+  void sanitizeCriteriaPreservesExplicitFormatIdAndStartIndex() {
+    PSSearchRestService restService = new PSSearchRestService(null, null, null);
+    PSSearchCriteria criteria = new PSSearchCriteria();
+    criteria.setQuery("hello");
+    criteria.setFormatId(12);
+    criteria.setStartIndex(10);
+    restService.sanitizeCriteria(criteria);
+    assertEquals(Integer.valueOf(12), criteria.getFormatId());
+    assertEquals(Integer.valueOf(10), criteria.getStartIndex());
+  }
+
+  @Test
+  void sanitizeCriteriaCoercesNonPositiveStartIndexToOne() {
+    PSSearchRestService restService = new PSSearchRestService(null, null, null);
+    PSSearchCriteria criteria = new PSSearchCriteria();
+    criteria.setQuery("x");
+    criteria.setStartIndex(0);
+    restService.sanitizeCriteria(criteria);
+    assertEquals(Integer.valueOf(1), criteria.getStartIndex());
+    criteria.setStartIndex(-3);
+    restService.sanitizeCriteria(criteria);
+    assertEquals(Integer.valueOf(1), criteria.getStartIndex());
+  }
+
+  /**
    * Exercises {@link PSLuceneQueryEscaper#escape(String)} mid-query slash escaping used on the
    * urlDecodedQuery search path in {@code PSSearchService} (GH-878 / #889 / #914).
    */


### PR DESCRIPTION
## Summary

Fixes Explorer Content Search **HTTP 400 Bad Request** on free-text query (`POST …/searchmanagement/search/get/extendedresults`).

**Root cause:** Modern `SearchPanel` / `searchExtended` sent minimal `SearchCriteria` (query + paging) without `formatId`. `PSSearchService.searchForIds` required a non-null format id and threw `IllegalArgumentException("format Id cannot be blank.")`, mapped to **HTTP 400** by `PSRuntimeExceptionMapper`. Classic finder always injects the active display format id; Home already defaulted to system list format **9**.

**Fix:**
- **WebUI** `searchApi.normalizeSearchCriteria`: default `formatId=9`, coerce `startIndex ≥ 1`, keep `{SearchCriteria: …}` envelope, omit client-only `caseSensitive`.
- **sitemanage** `PSSearchRestService.sanitizeCriteria` + `PSSearchService` search paths: default missing `formatId`/`startIndex` so valid minimal criteria is accepted server-side too.
- Unit tests for wire shape and sanitize defaults; Playwright free-text non-400 assertion on explorer-shell-chrome surface.

Fixes #2950

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. Standalone Maven (agent):
   - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Tests run: 899, Failures: 0; `PSSearchRestServiceTest` 9/0)
   - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Vitest 1793 passed; `searchApi.test.ts` 12 tests)
2. Manual / QA H2 docker:
   - Open Explorer → Search → type `a` → Search
   - Expect results or empty state; **not** `Search failed (HTTP 400 Bad Request)`
   - Network: `POST …/extendedresults` is 2xx; body includes `formatId: 9` when client omits it
3. Optional surface Playwright (QA mode):
   - `npm run test:surface -- --path tests/explorer-shell-chrome.spec.js` (tag `@issue-2950`)

## Checklist

- [x] **Product documentation** — **N/A** (pure bugfix restoring expected free-text search; no new operator-facing options/config/API contract beyond accepting minimal criteria)
- [x] **Unit / module tests** — WebUI Vitest + sitemanage JUnit for normalize/sanitize; both modules standalone clean install green
- [x] **WebUI + Playwright** — extended `explorer-shell-chrome.spec.js` free-text extendedresults non-400 case (live CMS not exercised this run; companion for QA mode)
- [x] **Build gates** — modules_built=`projects/sitemanage,WebUI`; no public API signature breakage requiring reverse-dep rebuild
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### Build evidence (C3)

- **modules_built:** `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 899, Failures: 0, Errors: 0, Skipped: 127; `PSSearchRestServiceTest` Tests run: 9, Failures: 0
  - `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS; Java surefire 37 tests; Vitest Test Files 257 passed, Tests 1793 passed (`searchApi.test.ts` 12 tests)
- **downstream_checked:** none (no final/sealed/public signature change; internal defaults only)

> Co-Authored by Grok Build using grok-4.5 with agent main.
