### PR TITLE
fix(webui): Display Format detail GUID normalize for Object ACL (#2951)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
@@ -26,14 +26,16 @@
 
 import { get } from "../client";
 import { PATHS } from "../paths";
-import type { DisplayFormat, DisplayFormatColumn } from "../developer/types";
+import type { DisplayFormat, DisplayFormatColumn, RestGuid } from "../developer/types";
 
 export type { DisplayFormat, DisplayFormatColumn };
 
-function asArray<T>(payload: unknown): T[] {
+function asArray(payload: unknown): DisplayFormat[] {
   if (payload == null) return [];
-  if (Array.isArray(payload)) return payload as T[];
-  if (typeof payload === "object") {
+  let rawList: unknown[] = [];
+  if (Array.isArray(payload)) {
+    rawList = payload;
+  } else if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
     const raw =
       obj.DisplayFormat ??
@@ -41,9 +43,79 @@ function asArray<T>(payload: unknown): T[] {
       obj.DisplayFormatList ??
       obj.displayFormatList;
     if (raw == null) return [];
-    return Array.isArray(raw) ? (raw as T[]) : [raw as T];
+    rawList = Array.isArray(raw) ? raw : [raw];
+  } else {
+    return [];
   }
-  return [];
+  return rawList.map((item) => unwrapDisplayFormat(item));
+}
+
+/**
+ * Extract a usable object GUID string from REST Guid wire shapes
+ * (shared behavior with developer displayFormatsApi — issues #2689 / #2951).
+ */
+export function objectGuidString(guid: unknown): string | undefined {
+  if (guid == null) {
+    return undefined;
+  }
+  if (typeof guid === "string") {
+    const trimmed = guid.trim();
+    return trimmed || undefined;
+  }
+  if (typeof guid !== "object" || Array.isArray(guid)) {
+    return undefined;
+  }
+
+  let g = guid as Record<string, unknown>;
+  const nestedGuid = g.Guid ?? g.guid;
+  if (
+    nestedGuid != null &&
+    typeof nestedGuid === "object" &&
+    !Array.isArray(nestedGuid) &&
+    g.stringValue == null &&
+    g.hostId == null &&
+    g.uuid == null
+  ) {
+    g = nestedGuid as Record<string, unknown>;
+  }
+
+  const sv = g.stringValue;
+  if (typeof sv === "string" && sv.trim()) {
+    return sv.trim();
+  }
+  if (sv != null && typeof sv === "object" && !Array.isArray(sv)) {
+    const opt = sv as Record<string, unknown>;
+    if (typeof opt.value === "string" && opt.value.trim()) {
+      return opt.value.trim();
+    }
+  }
+
+  const hostId = g.hostId;
+  const type = g.type;
+  const uuid = g.uuid;
+  const hostOk = typeof hostId === "number" || typeof hostId === "string";
+  const typeOk = typeof type === "number" || typeof type === "string";
+  const uuidOk = typeof uuid === "number" || typeof uuid === "string";
+  if (hostOk && typeOk && uuidOk) {
+    return `${hostId}-${type}-${uuid}`;
+  }
+
+  return undefined;
+}
+
+function normalizeDisplayFormatGuid(df: DisplayFormat): DisplayFormat {
+  const gs = objectGuidString(df.guid);
+  if (!gs) {
+    return df;
+  }
+  if (df.guid != null && typeof df.guid === "object" && !Array.isArray(df.guid)) {
+    const existing = df.guid as RestGuid;
+    if (existing.stringValue === gs) {
+      return df;
+    }
+    return { ...df, guid: { ...existing, stringValue: gs } };
+  }
+  return { ...df, guid: { stringValue: gs } };
 }
 
 export function normalizeDisplayFormatColumns(
@@ -76,13 +148,14 @@ export async function listDisplayFormats(
   const payload = await get<unknown>(
     `${PATHS.DISPLAY_FORMATS}${qs ? `?${qs}` : ""}`,
   );
-  return asArray<DisplayFormat>(payload);
+  return asArray(payload);
 }
 
 /**
  * Unwrap Jackson root wrap for a single display format
  * ({@code {"DisplayFormat":{…}}}) so {@code guid.stringValue} is reachable
- * (issue #2689). Flat payloads pass through.
+ * (issue #2689). Flat payloads pass through. Also synthesizes stringValue from
+ * host/type/uuid when the wire Guid omitted stringValue (#2951).
  */
 export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
   if (payload == null) {
@@ -93,16 +166,20 @@ export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
   }
   const root = payload as Record<string, unknown>;
   const nested = root.DisplayFormat ?? root.displayFormat;
+  let body: DisplayFormat;
   if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
-    return nested as DisplayFormat;
-  }
-  if (Array.isArray(nested) && nested.length > 0) {
+    body = nested as DisplayFormat;
+  } else if (Array.isArray(nested) && nested.length > 0) {
     const first = nested[0];
     if (first != null && typeof first === "object") {
-      return first as DisplayFormat;
+      body = first as DisplayFormat;
+    } else {
+      body = root as DisplayFormat;
     }
+  } else {
+    body = root as DisplayFormat;
   }
-  return root as DisplayFormat;
+  return normalizeDisplayFormatGuid(body);
 }
 
 /** GET /services/displayformats/{idOrName} */

--- a/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/displayFormatsApi.ts
@@ -22,13 +22,25 @@
  * {@code GET /Rhythmyx/rest/displayformats}. Optional query filters
  * {@code validForFolder} and {@code validForViewsAndSearches} are applied
  * server-side.</p>
+ *
+ * <p>GUID unwrap / synthesis is shared with the Developer API via
+ * {@link ../displayFormatGuid} (#2689 / #2951).</p>
  */
 
 import { get } from "../client";
+import {
+  normalizeDisplayFormatGuid,
+  objectGuidString,
+  unwrapDisplayFormat,
+} from "../displayFormatGuid";
 import { PATHS } from "../paths";
-import type { DisplayFormat, DisplayFormatColumn, RestGuid } from "../developer/types";
+import type { DisplayFormat, DisplayFormatColumn } from "../developer/types";
 
 export type { DisplayFormat, DisplayFormatColumn };
+
+// Re-export shared GUID helpers so Content Explorer callers (and tests) share
+// one implementation with the Developer API.
+export { normalizeDisplayFormatGuid, objectGuidString, unwrapDisplayFormat };
 
 function asArray(payload: unknown): DisplayFormat[] {
   if (payload == null) return [];
@@ -48,74 +60,6 @@ function asArray(payload: unknown): DisplayFormat[] {
     return [];
   }
   return rawList.map((item) => unwrapDisplayFormat(item));
-}
-
-/**
- * Extract a usable object GUID string from REST Guid wire shapes
- * (shared behavior with developer displayFormatsApi — issues #2689 / #2951).
- */
-export function objectGuidString(guid: unknown): string | undefined {
-  if (guid == null) {
-    return undefined;
-  }
-  if (typeof guid === "string") {
-    const trimmed = guid.trim();
-    return trimmed || undefined;
-  }
-  if (typeof guid !== "object" || Array.isArray(guid)) {
-    return undefined;
-  }
-
-  let g = guid as Record<string, unknown>;
-  const nestedGuid = g.Guid ?? g.guid;
-  if (
-    nestedGuid != null &&
-    typeof nestedGuid === "object" &&
-    !Array.isArray(nestedGuid) &&
-    g.stringValue == null &&
-    g.hostId == null &&
-    g.uuid == null
-  ) {
-    g = nestedGuid as Record<string, unknown>;
-  }
-
-  const sv = g.stringValue;
-  if (typeof sv === "string" && sv.trim()) {
-    return sv.trim();
-  }
-  if (sv != null && typeof sv === "object" && !Array.isArray(sv)) {
-    const opt = sv as Record<string, unknown>;
-    if (typeof opt.value === "string" && opt.value.trim()) {
-      return opt.value.trim();
-    }
-  }
-
-  const hostId = g.hostId;
-  const type = g.type;
-  const uuid = g.uuid;
-  const hostOk = typeof hostId === "number" || typeof hostId === "string";
-  const typeOk = typeof type === "number" || typeof type === "string";
-  const uuidOk = typeof uuid === "number" || typeof uuid === "string";
-  if (hostOk && typeOk && uuidOk) {
-    return `${hostId}-${type}-${uuid}`;
-  }
-
-  return undefined;
-}
-
-function normalizeDisplayFormatGuid(df: DisplayFormat): DisplayFormat {
-  const gs = objectGuidString(df.guid);
-  if (!gs) {
-    return df;
-  }
-  if (df.guid != null && typeof df.guid === "object" && !Array.isArray(df.guid)) {
-    const existing = df.guid as RestGuid;
-    if (existing.stringValue === gs) {
-      return df;
-    }
-    return { ...df, guid: { ...existing, stringValue: gs } };
-  }
-  return { ...df, guid: { stringValue: gs } };
 }
 
 export function normalizeDisplayFormatColumns(
@@ -149,37 +93,6 @@ export async function listDisplayFormats(
     `${PATHS.DISPLAY_FORMATS}${qs ? `?${qs}` : ""}`,
   );
   return asArray(payload);
-}
-
-/**
- * Unwrap Jackson root wrap for a single display format
- * ({@code {"DisplayFormat":{…}}}) so {@code guid.stringValue} is reachable
- * (issue #2689). Flat payloads pass through. Also synthesizes stringValue from
- * host/type/uuid when the wire Guid omitted stringValue (#2951).
- */
-export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
-  if (payload == null) {
-    return {};
-  }
-  if (typeof payload !== "object" || Array.isArray(payload)) {
-    return {};
-  }
-  const root = payload as Record<string, unknown>;
-  const nested = root.DisplayFormat ?? root.displayFormat;
-  let body: DisplayFormat;
-  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
-    body = nested as DisplayFormat;
-  } else if (Array.isArray(nested) && nested.length > 0) {
-    const first = nested[0];
-    if (first != null && typeof first === "object") {
-      body = first as DisplayFormat;
-    } else {
-      body = root as DisplayFormat;
-    }
-  } else {
-    body = root as DisplayFormat;
-  }
-  return normalizeDisplayFormatGuid(body);
 }
 
 /** GET /services/displayformats/{idOrName} */

--- a/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
@@ -17,12 +17,14 @@
 
 import { get } from "../client";
 import { PATHS } from "../paths";
-import type { DisplayFormat, DisplayFormatColumn } from "./types";
+import type { DisplayFormat, DisplayFormatColumn, RestGuid } from "./types";
 
-function asArray<T>(payload: unknown): T[] {
+function asArray(payload: unknown): DisplayFormat[] {
   if (payload == null) return [];
-  if (Array.isArray(payload)) return payload as T[];
-  if (typeof payload === "object") {
+  let rawList: unknown[] = [];
+  if (Array.isArray(payload)) {
+    rawList = payload;
+  } else if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
     const raw =
       obj.DisplayFormat ??
@@ -30,9 +32,89 @@ function asArray<T>(payload: unknown): T[] {
       obj.DisplayFormatList ??
       obj.displayFormatList;
     if (raw == null) return [];
-    return Array.isArray(raw) ? (raw as T[]) : [raw as T];
+    rawList = Array.isArray(raw) ? raw : [raw];
+  } else {
+    return [];
   }
-  return [];
+  // Normalize each element (Jackson may wrap list items or omit guid.stringValue).
+  return rawList.map((item) => unwrapDisplayFormat(item));
+}
+
+/**
+ * Extract a usable object GUID string from REST Guid wire shapes.
+ *
+ * <p>Handles plain strings, {@code { stringValue }}, nested {@code { Guid: … }}
+ * wraps, and synthesis from {@code hostId-type-uuid} when {@code stringValue} is
+ * missing (issue #2951 residual after #2689 root unwrap).
+ */
+export function objectGuidString(guid: unknown): string | undefined {
+  if (guid == null) {
+    return undefined;
+  }
+  if (typeof guid === "string") {
+    const trimmed = guid.trim();
+    return trimmed || undefined;
+  }
+  if (typeof guid !== "object" || Array.isArray(guid)) {
+    return undefined;
+  }
+
+  let g = guid as Record<string, unknown>;
+  // Nested root-style wrap (rare): { Guid: { stringValue / parts } }
+  const nestedGuid = g.Guid ?? g.guid;
+  if (
+    nestedGuid != null &&
+    typeof nestedGuid === "object" &&
+    !Array.isArray(nestedGuid) &&
+    g.stringValue == null &&
+    g.hostId == null &&
+    g.uuid == null
+  ) {
+    g = nestedGuid as Record<string, unknown>;
+  }
+
+  const sv = g.stringValue;
+  if (typeof sv === "string" && sv.trim()) {
+    return sv.trim();
+  }
+  // Accidental Optional-like object (defensive)
+  if (sv != null && typeof sv === "object" && !Array.isArray(sv)) {
+    const opt = sv as Record<string, unknown>;
+    if (typeof opt.value === "string" && opt.value.trim()) {
+      return opt.value.trim();
+    }
+  }
+
+  const hostId = g.hostId;
+  const type = g.type;
+  const uuid = g.uuid;
+  const hostOk = typeof hostId === "number" || typeof hostId === "string";
+  const typeOk = typeof type === "number" || typeof type === "string";
+  const uuidOk = typeof uuid === "number" || typeof uuid === "string";
+  if (hostOk && typeOk && uuidOk) {
+    return `${hostId}-${type}-${uuid}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Ensure {@link DisplayFormat.guid}.stringValue is populated when the wire
+ * Guid only carried numeric parts (or was a plain string).
+ */
+export function normalizeDisplayFormatGuid(df: DisplayFormat): DisplayFormat {
+  const gs = objectGuidString(df.guid);
+  if (!gs) {
+    return df;
+  }
+  if (df.guid != null && typeof df.guid === "object" && !Array.isArray(df.guid)) {
+    const existing = df.guid as RestGuid;
+    if (existing.stringValue === gs) {
+      return df;
+    }
+    return { ...df, guid: { ...existing, stringValue: gs } };
+  }
+  return { ...df, guid: { stringValue: gs } };
 }
 
 /**
@@ -43,6 +125,9 @@ function asArray<T>(payload: unknown): T[] {
  * {@code detail.guid} as undefined and Object ACL shows
  * "Object GUID not available" even though the server supplied a GUID
  * (issue #2689). Flat payloads (no wrap) pass through unchanged.
+ *
+ * <p>Also normalizes {@code guid.stringValue} when only host/type/uuid parts
+ * are present (#2951).
  */
 export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
   if (payload == null) {
@@ -53,17 +138,21 @@ export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
   }
   const root = payload as Record<string, unknown>;
   const nested = root.DisplayFormat ?? root.displayFormat;
+  let body: DisplayFormat;
   if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
-    return nested as DisplayFormat;
-  }
-  if (Array.isArray(nested) && nested.length > 0) {
+    body = nested as DisplayFormat;
+  } else if (Array.isArray(nested) && nested.length > 0) {
     const first = nested[0];
     if (first != null && typeof first === "object") {
-      return first as DisplayFormat;
+      body = first as DisplayFormat;
+    } else {
+      body = root as DisplayFormat;
     }
+  } else {
+    // Flat body (WRAP_ROOT_VALUE off or already unwrapped)
+    body = root as DisplayFormat;
   }
-  // Flat body (WRAP_ROOT_VALUE off or already unwrapped)
-  return root as DisplayFormat;
+  return normalizeDisplayFormatGuid(body);
 }
 
 export function normalizeColumns(
@@ -79,7 +168,7 @@ export function normalizeColumns(
 /** GET /services/displayformats */
 export async function listDisplayFormats(): Promise<DisplayFormat[]> {
   const payload = await get<unknown>(PATHS.DISPLAY_FORMATS);
-  return asArray<DisplayFormat>(payload);
+  return asArray(payload);
 }
 
 /** GET /services/displayformats/{idOrName} */

--- a/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
+++ b/WebUI/src/main/ts/api/developer/displayFormatsApi.ts
@@ -10,14 +10,21 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
 import { get } from "../client";
+import {
+  normalizeDisplayFormatGuid,
+  objectGuidString,
+  unwrapDisplayFormat,
+} from "../displayFormatGuid";
 import { PATHS } from "../paths";
-import type { DisplayFormat, DisplayFormatColumn, RestGuid } from "./types";
+import type { DisplayFormat, DisplayFormatColumn } from "./types";
+
+// Re-export shared GUID helpers so existing developer imports keep working.
+export { normalizeDisplayFormatGuid, objectGuidString, unwrapDisplayFormat };
 
 function asArray(payload: unknown): DisplayFormat[] {
   if (payload == null) return [];
@@ -38,121 +45,6 @@ function asArray(payload: unknown): DisplayFormat[] {
   }
   // Normalize each element (Jackson may wrap list items or omit guid.stringValue).
   return rawList.map((item) => unwrapDisplayFormat(item));
-}
-
-/**
- * Extract a usable object GUID string from REST Guid wire shapes.
- *
- * <p>Handles plain strings, {@code { stringValue }}, nested {@code { Guid: … }}
- * wraps, and synthesis from {@code hostId-type-uuid} when {@code stringValue} is
- * missing (issue #2951 residual after #2689 root unwrap).
- */
-export function objectGuidString(guid: unknown): string | undefined {
-  if (guid == null) {
-    return undefined;
-  }
-  if (typeof guid === "string") {
-    const trimmed = guid.trim();
-    return trimmed || undefined;
-  }
-  if (typeof guid !== "object" || Array.isArray(guid)) {
-    return undefined;
-  }
-
-  let g = guid as Record<string, unknown>;
-  // Nested root-style wrap (rare): { Guid: { stringValue / parts } }
-  const nestedGuid = g.Guid ?? g.guid;
-  if (
-    nestedGuid != null &&
-    typeof nestedGuid === "object" &&
-    !Array.isArray(nestedGuid) &&
-    g.stringValue == null &&
-    g.hostId == null &&
-    g.uuid == null
-  ) {
-    g = nestedGuid as Record<string, unknown>;
-  }
-
-  const sv = g.stringValue;
-  if (typeof sv === "string" && sv.trim()) {
-    return sv.trim();
-  }
-  // Accidental Optional-like object (defensive)
-  if (sv != null && typeof sv === "object" && !Array.isArray(sv)) {
-    const opt = sv as Record<string, unknown>;
-    if (typeof opt.value === "string" && opt.value.trim()) {
-      return opt.value.trim();
-    }
-  }
-
-  const hostId = g.hostId;
-  const type = g.type;
-  const uuid = g.uuid;
-  const hostOk = typeof hostId === "number" || typeof hostId === "string";
-  const typeOk = typeof type === "number" || typeof type === "string";
-  const uuidOk = typeof uuid === "number" || typeof uuid === "string";
-  if (hostOk && typeOk && uuidOk) {
-    return `${hostId}-${type}-${uuid}`;
-  }
-
-  return undefined;
-}
-
-/**
- * Ensure {@link DisplayFormat.guid}.stringValue is populated when the wire
- * Guid only carried numeric parts (or was a plain string).
- */
-export function normalizeDisplayFormatGuid(df: DisplayFormat): DisplayFormat {
-  const gs = objectGuidString(df.guid);
-  if (!gs) {
-    return df;
-  }
-  if (df.guid != null && typeof df.guid === "object" && !Array.isArray(df.guid)) {
-    const existing = df.guid as RestGuid;
-    if (existing.stringValue === gs) {
-      return df;
-    }
-    return { ...df, guid: { ...existing, stringValue: gs } };
-  }
-  return { ...df, guid: { stringValue: gs } };
-}
-
-/**
- * Unwrap Jackson {@code WRAP_ROOT_VALUE} envelopes for a single display format.
- *
- * <p>REST {@code JacksonContextResolver} wraps DTOs as
- * {@code {"DisplayFormat":{…}}}. Without unwrapping, detail panels read
- * {@code detail.guid} as undefined and Object ACL shows
- * "Object GUID not available" even though the server supplied a GUID
- * (issue #2689). Flat payloads (no wrap) pass through unchanged.
- *
- * <p>Also normalizes {@code guid.stringValue} when only host/type/uuid parts
- * are present (#2951).
- */
-export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
-  if (payload == null) {
-    return {};
-  }
-  if (typeof payload !== "object" || Array.isArray(payload)) {
-    return {};
-  }
-  const root = payload as Record<string, unknown>;
-  const nested = root.DisplayFormat ?? root.displayFormat;
-  let body: DisplayFormat;
-  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
-    body = nested as DisplayFormat;
-  } else if (Array.isArray(nested) && nested.length > 0) {
-    const first = nested[0];
-    if (first != null && typeof first === "object") {
-      body = first as DisplayFormat;
-    } else {
-      body = root as DisplayFormat;
-    }
-  } else {
-    // Flat body (WRAP_ROOT_VALUE off or already unwrapped)
-    body = root as DisplayFormat;
-  }
-  return normalizeDisplayFormatGuid(body);
 }
 
 export function normalizeColumns(

--- a/WebUI/src/main/ts/api/displayFormatGuid.ts
+++ b/WebUI/src/main/ts/api/displayFormatGuid.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared Display Format GUID wire helpers used by both Developer and Content
+ * Explorer {@code displayFormatsApi} modules (issues #2689 / #2951).
+ *
+ * <p>Keep a single implementation so synthesis / nested-Guid rules cannot drift
+ * between the two REST clients.
+ */
+
+import type { DisplayFormat, RestGuid } from "./developer/types";
+
+/**
+ * Extract a usable object GUID string from REST Guid wire shapes.
+ *
+ * <p>Handles plain strings, {@code { stringValue }}, nested {@code { Guid: … }}
+ * wraps, and synthesis from {@code hostId-type-uuid} when {@code stringValue} is
+ * missing (issue #2951 residual after #2689 root unwrap).
+ */
+export function objectGuidString(guid: unknown): string | undefined {
+  if (guid == null) {
+    return undefined;
+  }
+  if (typeof guid === "string") {
+    const trimmed = guid.trim();
+    return trimmed || undefined;
+  }
+  if (typeof guid !== "object" || Array.isArray(guid)) {
+    return undefined;
+  }
+
+  let g = guid as Record<string, unknown>;
+  // Nested root-style wrap (rare): { Guid: { stringValue / parts } }
+  const nestedGuid = g.Guid ?? g.guid;
+  if (
+    nestedGuid != null &&
+    typeof nestedGuid === "object" &&
+    !Array.isArray(nestedGuid) &&
+    g.stringValue == null &&
+    g.hostId == null &&
+    g.uuid == null
+  ) {
+    g = nestedGuid as Record<string, unknown>;
+  }
+
+  const sv = g.stringValue;
+  if (typeof sv === "string" && sv.trim()) {
+    return sv.trim();
+  }
+  // Accidental Optional-like object (defensive)
+  if (sv != null && typeof sv === "object" && !Array.isArray(sv)) {
+    const opt = sv as Record<string, unknown>;
+    if (typeof opt.value === "string" && opt.value.trim()) {
+      return opt.value.trim();
+    }
+  }
+
+  const hostId = g.hostId;
+  const type = g.type;
+  const uuid = g.uuid;
+  const hostOk = typeof hostId === "number" || typeof hostId === "string";
+  const typeOk = typeof type === "number" || typeof type === "string";
+  const uuidOk = typeof uuid === "number" || typeof uuid === "string";
+  if (hostOk && typeOk && uuidOk) {
+    return `${hostId}-${type}-${uuid}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Ensure {@link DisplayFormat.guid}.stringValue is populated when the wire
+ * Guid only carried numeric parts (or was a plain string).
+ */
+export function normalizeDisplayFormatGuid(df: DisplayFormat): DisplayFormat {
+  const gs = objectGuidString(df.guid);
+  if (!gs) {
+    return df;
+  }
+  if (df.guid != null && typeof df.guid === "object" && !Array.isArray(df.guid)) {
+    const existing = df.guid as RestGuid;
+    if (existing.stringValue === gs) {
+      return df;
+    }
+    return { ...df, guid: { ...existing, stringValue: gs } };
+  }
+  return { ...df, guid: { stringValue: gs } };
+}
+
+/**
+ * Unwrap Jackson {@code WRAP_ROOT_VALUE} envelopes for a single display format.
+ *
+ * <p>REST may wrap DTOs as {@code {"DisplayFormat":{…}}}. Without unwrapping,
+ * detail panels read {@code detail.guid} as undefined. Flat payloads pass
+ * through. Also normalizes {@code guid.stringValue} when only host/type/uuid
+ * parts are present (#2951).
+ */
+export function unwrapDisplayFormat(payload: unknown): DisplayFormat {
+  if (payload == null) {
+    return {};
+  }
+  if (typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+  const root = payload as Record<string, unknown>;
+  const nested = root.DisplayFormat ?? root.displayFormat;
+  let body: DisplayFormat;
+  if (nested != null && typeof nested === "object" && !Array.isArray(nested)) {
+    body = nested as DisplayFormat;
+  } else if (Array.isArray(nested) && nested.length > 0) {
+    const first = nested[0];
+    if (first != null && typeof first === "object") {
+      body = first as DisplayFormat;
+    } else {
+      body = root as DisplayFormat;
+    }
+  } else {
+    // Flat body (WRAP_ROOT_VALUE off or already unwrapped)
+    body = root as DisplayFormat;
+  }
+  return normalizeDisplayFormatGuid(body);
+}

--- a/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
@@ -19,6 +19,7 @@ import React, { useEffect, useState } from "react";
 import {
   getDisplayFormatDetail,
   normalizeColumns,
+  objectGuidString,
 } from "../api/developer/displayFormatsApi";
 import type { DisplayFormat } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
@@ -28,9 +29,12 @@ import { ObjectAclSection } from "./ObjectAclSection";
 
 export function DisplayFormatDetailPanel({
   idOrName,
+  catalogGuid,
   onBack,
 }: {
   idOrName: string;
+  /** GUID from catalog list row when detail wire omits stringValue (#2951). */
+  catalogGuid?: string | null;
   onBack: () => void;
 }): React.ReactElement {
   const [detail, setDetail] = useState<DisplayFormat | null>(null);
@@ -54,6 +58,11 @@ export function DisplayFormatDetailPanel({
 
   const columns =
     detail != null ? normalizeColumns(detail.columns) : [];
+  // Prefer detail GUID (after unwrap/normalize); fall back to catalog list GUID.
+  const objectGuid =
+    (detail != null ? objectGuidString(detail.guid) : undefined) ||
+    (catalogGuid && catalogGuid.trim() ? catalogGuid.trim() : undefined) ||
+    undefined;
 
   return (
     <div data-testid="developer-df-detail">
@@ -89,8 +98,11 @@ export function DisplayFormatDetailPanel({
               <dt>{DEV_MSG.DF_COL_NAME}</dt>
               <dd style={{ margin: 0, ...monoCell }}>{detail.name || "—"}</dd>
               <dt>{DEV_MSG.DF_COL_GUID}</dt>
-              <dd style={{ margin: 0, ...monoCell }}>
-                {detail.guid?.stringValue || "—"}
+              <dd
+                style={{ margin: 0, ...monoCell }}
+                data-testid="developer-df-detail-guid"
+              >
+                {objectGuid || "—"}
               </dd>
               <dt>{DEV_MSG.DF_COL_USAGE}</dt>
               <dd style={{ margin: 0 }}>
@@ -158,7 +170,7 @@ export function DisplayFormatDetailPanel({
           </section>
 
           <ObjectAclSection
-            objectGuid={detail.guid?.stringValue}
+            objectGuid={objectGuid}
             objectKind="display-format"
             testIdPrefix="developer-df-acl"
           />

--- a/WebUI/src/main/ts/developer/DisplayFormatsPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatsPanel.tsx
@@ -16,7 +16,11 @@
  */
 
 import React, { useEffect, useMemo, useState } from "react";
-import { listDisplayFormats, normalizeColumns } from "../api/developer/displayFormatsApi";
+import {
+  listDisplayFormats,
+  normalizeColumns,
+  objectGuidString,
+} from "../api/developer/displayFormatsApi";
 import type { DisplayFormat } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
 import { monoCell, mutedCell, openButtonStyle } from "./catalogStyles";
@@ -24,13 +28,19 @@ import { panelErrMsg } from "./errors";
 import { DisplayFormatDetailPanel } from "./DisplayFormatDetailPanel";
 import { DEV_MSG } from "./messages";
 
+type SelectedFormat = {
+  idOrName: string;
+  /** List-row GUID fallback when detail payload omits stringValue (#2951). */
+  catalogGuid?: string;
+};
+
 /**
  * P0.11 — display format catalog + read-only detail (UI-05 read).
  */
 export function DisplayFormatsPanel(): React.ReactElement {
   const [items, setItems] = useState<DisplayFormat[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<SelectedFormat | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,9 +69,22 @@ export function DisplayFormatsPanel(): React.ReactElement {
     );
   }, [items]);
 
+  const openFormat = (f: DisplayFormat) => {
+    const idOrName = f.name || f.internalName || objectGuidString(f.guid) || "";
+    if (!idOrName) return;
+    setSelected({
+      idOrName,
+      catalogGuid: objectGuidString(f.guid),
+    });
+  };
+
   if (selected) {
     return (
-      <DisplayFormatDetailPanel idOrName={selected} onBack={() => setSelected(null)} />
+      <DisplayFormatDetailPanel
+        idOrName={selected.idOrName}
+        catalogGuid={selected.catalogGuid}
+        onBack={() => setSelected(null)}
+      />
     );
   }
 
@@ -92,7 +115,8 @@ export function DisplayFormatsPanel(): React.ReactElement {
           DEV_MSG.DF_COL_DESCRIPTION,
         ]}
         rows={sorted.map((f, index) => {
-          const openKey = f.name || f.internalName || f.guid?.stringValue || "";
+          const openKey =
+            f.name || f.internalName || objectGuidString(f.guid) || "";
           const interactive = openKey.length > 0;
           const colCount = normalizeColumns(f.columns).length;
           const usage: string[] = [];
@@ -100,8 +124,8 @@ export function DisplayFormatsPanel(): React.ReactElement {
           if (f.validForViewsAndSearches) usage.push(DEV_MSG.DF_USAGE_VIEWS);
           if (f.validForRelatedContent) usage.push(DEV_MSG.DF_USAGE_RELATED);
           return {
-            key: f.guid?.stringValue || f.name || `df-${index}`,
-            onClick: interactive ? () => setSelected(openKey) : undefined,
+            key: objectGuidString(f.guid) || f.name || `df-${index}`,
+            onClick: interactive ? () => openFormat(f) : undefined,
             cells: [
               interactive ? (
                 <button
@@ -111,7 +135,7 @@ export function DisplayFormatsPanel(): React.ReactElement {
                   aria-label={`Open ${f.name || openKey}`}
                   onClick={(e) => {
                     e.stopPropagation();
-                    setSelected(openKey);
+                    openFormat(f);
                   }}
                   style={{ ...openButtonStyle, fontFamily: "monospace" }}
                 >

--- a/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/displayFormatsApi.test.ts
@@ -17,8 +17,39 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getDisplayFormatDetail,
+  listDisplayFormats,
+  objectGuidString,
   unwrapDisplayFormat,
 } from "../../../../main/ts/api/developer/displayFormatsApi";
+
+describe("objectGuidString", () => {
+  it("reads stringValue when present", () => {
+    expect(objectGuidString({ stringValue: "0-11-5" })).toBe("0-11-5");
+  });
+
+  it("accepts plain string GUID", () => {
+    expect(objectGuidString(" 0-11-7 ")).toBe("0-11-7");
+  });
+
+  it("synthesizes host-type-uuid when stringValue missing (#2951)", () => {
+    expect(
+      objectGuidString({ hostId: 0, type: 11, uuid: 5, longValue: 5 }),
+    ).toBe("0-11-5");
+  });
+
+  it("unwraps nested Guid envelope", () => {
+    expect(
+      objectGuidString({ Guid: { stringValue: "0-11-9", type: 11, uuid: 9 } }),
+    ).toBe("0-11-9");
+  });
+
+  it("returns undefined for empty payloads", () => {
+    expect(objectGuidString(null)).toBeUndefined();
+    expect(objectGuidString(undefined)).toBeUndefined();
+    expect(objectGuidString({})).toBeUndefined();
+    expect(objectGuidString("")).toBeUndefined();
+  });
+});
 
 describe("unwrapDisplayFormat", () => {
   it("unwraps Jackson DisplayFormat root envelope so guid is reachable (#2689)", () => {
@@ -33,6 +64,17 @@ describe("unwrapDisplayFormat", () => {
     expect(unwrapped.name).toBe("By_Author");
     expect(unwrapped.guid?.stringValue).toBe("0-11-5");
     expect(unwrapped.columns).toHaveLength(1);
+  });
+
+  it("synthesizes guid.stringValue from numeric parts under root wrap (#2951)", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: {
+        name: "By_Author",
+        guid: { hostId: 0, type: 11, uuid: 301, longValue: 301 },
+      },
+    });
+    expect(unwrapped.name).toBe("By_Author");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-301");
   });
 
   it("unwraps camelCase displayFormat envelope", () => {
@@ -98,5 +140,52 @@ describe("getDisplayFormatDetail", () => {
     const calledUrl = String((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]);
     expect(calledUrl).toContain("/displayformats/");
     expect(calledUrl).toContain("By_Author");
+  });
+
+  it("fills stringValue when detail guid has only parts (#2951)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            DisplayFormat: {
+              name: "By_Author",
+              guid: { hostId: 0, type: 11, uuid: 5 },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    const detail = await getDisplayFormatDetail("By_Author");
+    expect(detail.guid?.stringValue).toBe("0-11-5");
+  });
+});
+
+describe("listDisplayFormats", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes guid on each list item", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            DisplayFormat: [
+              { name: "By_Author", guid: { hostId: 0, type: 11, uuid: 5 } },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
+    const list = await listDisplayFormats();
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe("By_Author");
+    expect(list[0].guid?.stringValue).toBe("0-11-5");
   });
 });

--- a/WebUI/src/test/ts/api/displayFormatGuid.test.ts
+++ b/WebUI/src/test/ts/api/displayFormatGuid.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  normalizeDisplayFormatGuid,
+  objectGuidString,
+  unwrapDisplayFormat,
+} from "../../../main/ts/api/displayFormatGuid";
+
+describe("objectGuidString", () => {
+  it("reads stringValue when present", () => {
+    expect(objectGuidString({ stringValue: "0-11-5" })).toBe("0-11-5");
+  });
+
+  it("accepts plain string GUID", () => {
+    expect(objectGuidString(" 0-11-7 ")).toBe("0-11-7");
+  });
+
+  it("synthesizes host-type-uuid when stringValue missing (#2951)", () => {
+    expect(
+      objectGuidString({ hostId: 0, type: 11, uuid: 5, longValue: 5 }),
+    ).toBe("0-11-5");
+  });
+
+  it("unwraps nested Guid envelope", () => {
+    expect(
+      objectGuidString({ Guid: { stringValue: "0-11-9", type: 11, uuid: 9 } }),
+    ).toBe("0-11-9");
+  });
+
+  it("returns undefined for empty payloads", () => {
+    expect(objectGuidString(null)).toBeUndefined();
+    expect(objectGuidString(undefined)).toBeUndefined();
+    expect(objectGuidString({})).toBeUndefined();
+    expect(objectGuidString("")).toBeUndefined();
+  });
+});
+
+describe("normalizeDisplayFormatGuid", () => {
+  it("fills stringValue from parts without dropping other fields", () => {
+    const out = normalizeDisplayFormatGuid({
+      name: "By_Author",
+      guid: { hostId: 0, type: 11, uuid: 301 },
+    });
+    expect(out.guid?.stringValue).toBe("0-11-301");
+    expect(out.guid?.hostId).toBe(0);
+    expect(out.guid?.type).toBe(11);
+    expect(out.guid?.uuid).toBe(301);
+  });
+
+  it("returns same reference when stringValue already matches", () => {
+    const df = { name: "x", guid: { stringValue: "0-11-1", uuid: 1 } };
+    expect(normalizeDisplayFormatGuid(df)).toBe(df);
+  });
+});
+
+describe("unwrapDisplayFormat", () => {
+  it("unwraps Jackson DisplayFormat root envelope so guid is reachable (#2689)", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: {
+        name: "By_Author",
+        label: "By Author",
+        guid: { stringValue: "0-11-5", type: 11, uuid: 5 },
+        columns: [{ source: "sys_title" }],
+      },
+    });
+    expect(unwrapped.name).toBe("By_Author");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-5");
+    expect(unwrapped.columns).toHaveLength(1);
+  });
+
+  it("synthesizes guid.stringValue from numeric parts under root wrap (#2951)", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: {
+        name: "By_Author",
+        guid: { hostId: 0, type: 11, uuid: 301, longValue: 301 },
+      },
+    });
+    expect(unwrapped.name).toBe("By_Author");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-301");
+  });
+
+  it("unwraps camelCase displayFormat envelope", () => {
+    const unwrapped = unwrapDisplayFormat({
+      displayFormat: {
+        name: "Default",
+        guid: { stringValue: "0-11-1" },
+      },
+    });
+    expect(unwrapped.name).toBe("Default");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-1");
+  });
+
+  it("passes through flat payloads without wrap", () => {
+    const flat = {
+      name: "FolderList",
+      guid: { stringValue: "0-11-2" },
+    };
+    expect(unwrapDisplayFormat(flat)).toEqual(flat);
+  });
+
+  it("takes first element when envelope holds a singleton array", () => {
+    const unwrapped = unwrapDisplayFormat({
+      DisplayFormat: [{ name: "only", guid: { stringValue: "0-11-9" } }],
+    });
+    expect(unwrapped.name).toBe("only");
+    expect(unwrapped.guid?.stringValue).toBe("0-11-9");
+  });
+
+  it("returns empty object for null/non-object payloads", () => {
+    expect(unwrapDisplayFormat(null)).toEqual({});
+    expect(unwrapDisplayFormat(undefined)).toEqual({});
+    expect(unwrapDisplayFormat("x")).toEqual({});
+    expect(unwrapDisplayFormat([])).toEqual({});
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
@@ -63,6 +63,16 @@ describe("displayFormatsApi", () => {
     expect(df.guid?.stringValue).toBe("0-11-5");
   });
 
+  it("unwrapDisplayFormat synthesizes stringValue from guid parts (#2951)", () => {
+    const df = unwrapDisplayFormat({
+      DisplayFormat: {
+        name: "By_Author",
+        guid: { hostId: 0, type: 11, uuid: 5 },
+      },
+    });
+    expect(df.guid?.stringValue).toBe("0-11-5");
+  });
+
   it("getDisplayFormatDetail unwraps wrapped body", async () => {
     mockFetch(async (input) => {
       const url = typeof input === "string" ? input : (input as Request).url;

--- a/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/displayFormatsApi.test.ts
@@ -19,9 +19,43 @@ import {
   getDisplayFormatDetail,
   listDisplayFormats,
   normalizeDisplayFormatColumns,
+  objectGuidString,
   unwrapDisplayFormat,
 } from "../../../main/ts/api/contentExplorer/displayFormatsApi";
 import { mockFetch } from "./setup";
+
+/**
+ * Content Explorer re-exports the shared GUID helpers — keep a dedicated
+ * describe so CE and Developer cannot diverge without a red test (#2951 review).
+ */
+describe("objectGuidString (contentExplorer re-export)", () => {
+  it("reads stringValue when present", () => {
+    expect(objectGuidString({ stringValue: "0-11-5" })).toBe("0-11-5");
+  });
+
+  it("accepts plain string GUID", () => {
+    expect(objectGuidString(" 0-11-7 ")).toBe("0-11-7");
+  });
+
+  it("synthesizes host-type-uuid when stringValue missing (#2951)", () => {
+    expect(
+      objectGuidString({ hostId: 0, type: 11, uuid: 5, longValue: 5 }),
+    ).toBe("0-11-5");
+  });
+
+  it("unwraps nested Guid envelope", () => {
+    expect(
+      objectGuidString({ Guid: { stringValue: "0-11-9", type: 11, uuid: 9 } }),
+    ).toBe("0-11-9");
+  });
+
+  it("returns undefined for empty payloads", () => {
+    expect(objectGuidString(null)).toBeUndefined();
+    expect(objectGuidString(undefined)).toBeUndefined();
+    expect(objectGuidString({})).toBeUndefined();
+    expect(objectGuidString("")).toBeUndefined();
+  });
+});
 
 describe("displayFormatsApi", () => {
   it("listDisplayFormats unwraps array envelope and passes filters", async () => {

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -406,6 +406,7 @@ vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
     columns: [],
   }),
   normalizeColumns: () => [],
+  objectGuidString: () => undefined,
 }));
 
 vi.mock("../../../main/ts/api/developer/actionMenusApi", () => ({

--- a/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
@@ -14,6 +14,22 @@ vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
   listDisplayFormats: vi.fn(),
   getDisplayFormatDetail: vi.fn(),
   normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
+  objectGuidString: (guid: unknown) => {
+    if (guid == null) return undefined;
+    if (typeof guid === "string") {
+      const t = guid.trim();
+      return t || undefined;
+    }
+    if (typeof guid !== "object" || Array.isArray(guid)) return undefined;
+    const g = guid as { stringValue?: string; hostId?: number; type?: number; uuid?: number };
+    if (typeof g.stringValue === "string" && g.stringValue.trim()) {
+      return g.stringValue.trim();
+    }
+    if (g.hostId != null && g.type != null && g.uuid != null) {
+      return `${g.hostId}-${g.type}-${g.uuid}`;
+    }
+    return undefined;
+  },
 }));
 
 // ObjectAclSection loads ACL via separate API; stub to isolate detail load + assert wiring.
@@ -80,6 +96,43 @@ describe("DisplayFormatDetailPanel", () => {
     const acl = screen.getByTestId("developer-df-acl-stub");
     expect(acl.getAttribute("data-object-kind")).toBe("display-format");
     expect(acl.getAttribute("data-object-guid")).toBe("0-1-100");
+    expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-1-100");
+  });
+
+  it("uses catalogGuid fallback when detail guid has no stringValue (#2951)", async () => {
+    getDisplayFormatDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: undefined,
+    });
+    render(
+      <DisplayFormatDetailPanel
+        idOrName="By_Author"
+        catalogGuid="0-11-5"
+        onBack={() => undefined}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-11-5");
+    expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-11-5",
+    );
+  });
+
+  it("synthesizes object guid from host/type/uuid parts on detail (#2951)", async () => {
+    getDisplayFormatDetail.mockResolvedValue({
+      ...sampleDetail,
+      guid: { hostId: 0, type: 11, uuid: 301 },
+    });
+    render(<DisplayFormatDetailPanel idOrName="By_Author" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-acl-stub")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-guid").textContent).toBe("0-11-301");
+    expect(screen.getByTestId("developer-df-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-11-301",
+    );
   });
 
   it("shows empty columns section when detail has none", async () => {

--- a/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
@@ -14,6 +14,19 @@ vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
   listDisplayFormats: vi.fn(),
   getDisplayFormatDetail: vi.fn(),
   normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
+  objectGuidString: (guid: unknown) => {
+    if (guid == null) return undefined;
+    if (typeof guid === "string") {
+      const t = guid.trim();
+      return t || undefined;
+    }
+    if (typeof guid !== "object" || Array.isArray(guid)) return undefined;
+    const g = guid as { stringValue?: string };
+    if (typeof g.stringValue === "string" && g.stringValue.trim()) {
+      return g.stringValue.trim();
+    }
+    return undefined;
+  },
 }));
 
 const listDisplayFormats = displayFormatsApi.listDisplayFormats as ReturnType<typeof vi.fn>;

--- a/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-object-acl-product-path.spec.js
@@ -361,6 +361,18 @@ test.describe("Developer Object ACL product path (#2642 / #2605 B5) @object-acl-
     });
     if (!opened) return;
 
+    // Issue #2951: detail header must render a real GUID (not em-dash) so
+    // ObjectAclSection receives objectGuid — catalog fallback + wire normalize.
+    const guidCell = page.locator('[data-testid="developer-df-detail-guid"]');
+    await expect(guidCell).toBeVisible({ timeout: 15_000 });
+    const guidText = (await guidCell.innerText()).trim();
+    expect(
+      guidText && guidText !== "—" && guidText !== "-",
+      `display-format detail GUID must be synthesized/normalized (got "${guidText}")`,
+    ).toBeTruthy();
+    // host-type-uuid wire form or other non-empty string from REST
+    expect(guidText.length).toBeGreaterThan(2);
+
     const mode = await assertLayeredObjectAcl(
       page,
       "developer-df-acl",

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -114,7 +114,8 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     ret.setDescription(f.getDescription());
     ret.setDisplayName(f.getDisplayName());
     // Always map GUID so Developer detail / Object ACL can bind objectGuid
-    // (issues #2689 / #2951). PSDisplayFormat#getGUID never returns null.
+    // (issues #2689 / #2951). PSDisplayFormat#getGUID is expected non-null for
+    // persisted formats; copyGuid still accepts null defensively.
     ret.setGuid(copyGuid(f.getGUID()));
     return ret;
   }
@@ -122,9 +123,13 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
   /**
    * Copy a design-object GUID into the REST {@link Guid} DTO with a guaranteed
    * {@code stringValue} ({@code host-type-uuid}) for SPA Object ACL binding.
+   *
+   * @param guid design GUID; may be null only in defensive/edge cases
+   * @return REST Guid DTO, or {@code null} when {@code guid} is null
    */
   private Guid copyGuid(IPSGuid guid) {
     if (guid == null) {
+      // Defensive: interface type does not prove non-null at compile time.
       return null;
     }
     var g = new Guid();

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -113,18 +113,36 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     ret.setLabel(f.getLabel());
     ret.setDescription(f.getDescription());
     ret.setDisplayName(f.getDisplayName());
+    // Always map GUID so Developer detail / Object ACL can bind objectGuid
+    // (issues #2689 / #2951). PSDisplayFormat#getGUID never returns null.
     ret.setGuid(copyGuid(f.getGUID()));
     return ret;
   }
 
+  /**
+   * Copy a design-object GUID into the REST {@link Guid} DTO with a guaranteed
+   * {@code stringValue} ({@code host-type-uuid}) for SPA Object ACL binding.
+   */
   private Guid copyGuid(IPSGuid guid) {
+    if (guid == null) {
+      return null;
+    }
     var g = new Guid();
     g.setHostId(guid.getHostId());
     g.setLongValue(guid.longValue());
-    g.setStringValue(guid.toString());
     g.setType(guid.getType());
     g.setUuid(guid.getUUID());
-    g.setUntypedString(guid.toStringUntyped());
+    String asString = guid.toString();
+    if (asString == null || asString.isBlank()) {
+      // Defensive: synthesize the same wire form PSGuid#toString uses.
+      asString = guid.getHostId() + "-" + guid.getType() + "-" + guid.getUUID();
+    }
+    g.setStringValue(asString);
+    try {
+      g.setUntypedString(guid.toStringUntyped());
+    } catch (RuntimeException e) {
+      log.debug("Could not copy untyped GUID string: {}", e.toString());
+    }
     return g;
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
@@ -4,9 +4,20 @@
 
 package com.percussion.apibridge;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.percussion.cms.objectstore.PSDbComponent;
+import com.percussion.cms.objectstore.PSDisplayFormat;
+import com.percussion.cms.objectstore.PSKey;
+import com.percussion.rest.displayformat.DisplayFormat;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -24,5 +35,37 @@ class DisplayFormatAdaptorSafeKeyTest {
     assertFalse(DisplayFormatAdaptor.isSafeDisplayFormatKey("   "));
     assertFalse(DisplayFormatAdaptor.isSafeDisplayFormatKey("a\u0000b"));
     assertFalse(DisplayFormatAdaptor.isSafeDisplayFormatKey(null));
+  }
+
+  /**
+   * Detail mapping must always set REST {@code guid.stringValue} so Developer Object ACL can load
+   * (issues #2689 / #2951).
+   */
+  @Test
+  void findDisplayFormatByKey_mapsGuidStringValue() throws Exception {
+    IPSUiDesignWs designWs = mock(IPSUiDesignWs.class);
+    PSDisplayFormat nativeDf = new PSDisplayFormat();
+    // Unpersisted formats have displayId -1; assign a real DISPLAYID so getGUID() is valid.
+    PSKey key = PSDisplayFormat.createKey(new String[] {"301"});
+    Method setKey = PSDbComponent.class.getDeclaredMethod("setKey", PSKey.class);
+    setKey.setAccessible(true);
+    setKey.invoke(nativeDf, key);
+    assertEquals(301, nativeDf.getDisplayId());
+
+    when(designWs.findDisplayFormat(eq("By_Author"))).thenReturn(nativeDf);
+
+    DisplayFormatAdaptor adaptor = new DisplayFormatAdaptor(designWs);
+    DisplayFormat out = adaptor.findDisplayFormatByKey("By_Author");
+
+    assertNotNull(out, "adaptor should return a REST DisplayFormat");
+    assertNotNull(out.getGuid(), "guid must be mapped for Object ACL");
+    assertTrue(
+        out.getGuid().getStringValue().isPresent(),
+        "guid.stringValue must be present for SPA binding");
+    String sv = out.getGuid().getStringValue().get();
+    assertFalse(sv.isBlank(), "guid.stringValue must not be blank");
+    // PSGuid#toString form host-type-uuid; uuid part is display id 301
+    assertTrue(sv.endsWith("-301"), "unexpected guid form: " + sv);
+    assertEquals(301, out.getGuid().getUuid());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
@@ -50,7 +50,7 @@ public class TestDisplayFormat {
 
   /**
    * Developer SPA reads {@code detail.guid.stringValue} for Object ACL. REST Jackson mapper must
-   * emit {@code stringValue} under the DisplayFormat root wrap (issue #2689).
+   * emit {@code stringValue} under the DisplayFormat root wrap (issue #2689 / #2951).
    */
   @Test
   public void jacksonContextResolver_serializesGuidStringValueUnderRootWrap() {
@@ -66,5 +66,30 @@ public class TestDisplayFormat {
     assertTrue(json.contains("\"stringValue\""), json);
     assertTrue(json.contains("0-11-5"), json);
     assertTrue(json.contains("By_Author"), json);
+    // Nested Guid must not re-wrap under WRAP_ROOT_VALUE (would hide stringValue from SPA)
+    assertTrue(
+        json.contains("\"guid\":{") || json.contains("\"guid\" : {"),
+        "guid should be a nested object, not re-wrapped: " + json);
+  }
+
+  @Test
+  public void jacksonContextResolver_serializesGuidPartsAndStringValue() {
+    Guid g = new Guid();
+    g.setHostId(0);
+    g.setType((short) 11);
+    g.setUuid(301);
+    g.setLongValue(301L);
+    g.setStringValue("0-11-301");
+
+    DisplayFormat f = new DisplayFormat();
+    f.setName("By_Author");
+    f.setGuid(g);
+
+    ObjectMapper mapper = new JacksonContextResolver().getContext(DisplayFormat.class);
+    String json = mapper.writeValueAsString(f);
+
+    assertTrue(json.contains("\"stringValue\""), json);
+    assertTrue(json.contains("0-11-301"), json);
+    assertTrue(json.contains("\"uuid\""), json);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #2951 (QA residual after #2689 / PR #2725): Display Format detail still showed **GUID —** and Object ACL **Object GUID not available** for formats such as By_Author.

**Hardening beyond root unwrap (#2689):**
1. **Client `objectGuidString`** — accepts plain string, `{ stringValue }`, nested `{ Guid: … }`, and **synthesizes** `hostId-type-uuid` when wire Guid omits `stringValue`.
2. **`unwrapDisplayFormat` / list `asArray`** — normalize every list/detail item so `guid.stringValue` is always populated when parts exist.
3. **Catalog → detail fallback** — `DisplayFormatsPanel` passes list-row GUID as `catalogGuid` so Object ACL can load even if detail omits GUID.
4. **Server** — `DisplayFormatAdaptor.copyGuid` always sets non-blank `stringValue`; unit test maps By_Author-style key.

## Test plan
1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Vitest includes displayFormatsApi + DetailPanel)
2. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (`TestDisplayFormat` GUID wire tests)
3. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (`DisplayFormatAdaptorSafeKeyTest` maps guid.stringValue)
4. Focused Vitest: 23 tests pass (displayFormatsApi 14 + DetailPanel 9)
5. Manual/QA: System Definition → Display Formats → By_Author → header GUID not em-dash; Object ACL not no-guid shell

## Product documentation
- [x] N/A — bug fix for existing Developer Display Format detail GUID / Object ACL binding; no new operator procedure or config surface. product-docs already describe the Object ACL section when GUID is available.

## Pre-PR Maven evidence (C3)
- **modules_built:** WebUI, rest, projects/sitemanage
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS
  - `cd rest; ../mvnw.cmd clean install` → BUILD SUCCESS
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 969, Failures: 0, Errors: 0 after fix)
  - Focused Vitest: Tests 23 passed
- **downstream_checked:** none required for C2 (no public type made final; private copyGuid + client helpers). Built reverse path sitemanage (adaptor) + rest (DTO tests) as changed modules.

## Gates
- Erlang-style self-review: no path I/O; residual root-cause at Guid wire normalization + catalog fallback
- Behavioral unit tests for objectGuidString, unwrap parts, catalogGuid fallback, adaptor mapping
- No new product-docs required

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2951 (related prior: #2689 / QA #2726)

> Co-Authored by Grok Build using grok-4.5 with agent main.
