### PR TITLE
fix(utils): batch 6 this-escape redesign cluster (#2414)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2414-utils-this-escape-batch6-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2414-utils-this-escape-batch6-erlang.md
@@ -1,0 +1,77 @@
+# Erlang review: fix/issue-2414-utils-javac-residual-batch6
+
+## Summary
+
+Batch 6 residual after utils batch 5 (#2382 / PR #2413). Clears a **coherent this-escape cluster** with real redesigns (final classes/methods, direct field init, Exception cause via `super(cause)` instead of post-construction `initCause`). Does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map API. Module `mvnw clean install` green; project-Xlint compile shows **0** this-escape warnings on changed sources.
+
+## Scope
+
+- Branch: `fix/issue-2414-utils-javac-residual-batch6`
+- Module: `modules/utils` only
+- Parent tracker: #2200 / module #2016 / residual #2414
+- Prior: batch 5 #2382 / PR #2413
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+May commit/push: **yes**
+
+## Cross-platform path review
+
+- New tests use `Path` / `@TempDir` / `Files` — portable.
+- `PSTomcatConnectors` resolves OS via `System.getProperty("os.name")` (not hardcoded path separators).
+- No new `".../" +` filesystem joins introduced.
+
+## Change map
+
+| Area | Fix |
+|------|-----|
+| `PSFileFilter` | `final` class; strip this-escape (setters already final) |
+| `PSHtmlParamDocument` | `final` class; strip this-escape |
+| `PSDatasourceConfig` | `final` class + final mutators/`fromXml`/`copyFrom`; direct field init in members ctor |
+| `PSProperties` | `final` class; `final` `load`/`put` |
+| `PSBrandCodeElement` / `List` / `MapVersion` | `final` classes; strip this-escape |
+| `Code` | `final` class; strip this-escape |
+| `PSAbstractConnectors` | `final` `setConnectors` / `mergeConnectors` / http(s) getters |
+| `PSJettyConnectors` / `PSJBossConnectors` | `final` classes; strip this-escape on copy ctors |
+| `PSTomcatConnectors` | OS via `System` property; `final` getter; strip this-escape |
+| `HttpsBuilder` | direct `scheme` assign instead of overridable `setHttps()` |
+| `PSBaseException` / `ConnectorConfigurationException` | `super(cause)` / `super(message, cause)`; drop post-`initCause` this-escape |
+| `PSGuid` | `final` `getHostId`/`getType`/`getUUID`; strip class this-escape |
+
+## Behavioral tests
+
+- `PSFileFilterTest` (3)
+- `PSHtmlParamDocumentTest` (3)
+- `PSPropertiesTest` (3)
+- `PSDatasourceConfigTest` (4)
+- `PSBaseExceptionCauseTest` (2)
+- `ConnectorConfigurationExceptionTest` (2)
+- `PSGuidTest` (3)
+
+## Residual (intentional — file child if desired)
+
+| Area | Notes |
+|------|-------|
+| `PSWorkflowUtilsBase` raw List/Map API | Source-compat; do not reparameterize without policy |
+| `PSCollection` raw/this-escape | Legacy collection |
+| `PSJexlEvaluator` / `PSXmlSerializationHelper` | Scripting/serialization surfaces |
+| `PSException` this-escape | Deep exception hierarchy; many subclasses |
+| `PSJBossJndiDatasource` / `PSJettyJndiDatasource` | BeanUtils.copyProperties / props ctor this-escape |
+| `ConfigurationContextAbstract` CRTP | `(T) this` / BeanUtils.cloneBean |
+| `PSItemIterator` / `PSCopier` | Documented inherent unchecked casts |
+| `PSConcurrentList.readObject` | Serialization unchecked |
+
+## Verification
+
+- `cd modules/utils && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**
+- Tests: **346** run, **0** failures, **9** skips
+- Main compile: **no** `possible 'this' escape` warnings on changed files
+- Grep: no monorepo `extends` of newly-final leaf types
+
+## Issues
+
+None (bug).

--- a/modules/utils/src/main/java/com/percussion/install/Code.java
+++ b/modules/utils/src/main/java/com/percussion/install/Code.java
@@ -47,9 +47,11 @@ import org.w3c.dom.Element;
  * The Code class handles Rhythmyx Installer's brand code issue. This class should not use any
  * com.percussion classes in order to avoid circular dependencies. This is the first class to be
  * build during the build procedure.
+ *
+ * <p>Final so constructors may call private {@code init()} / {@code fromString} without {@code
+ * this-escape}.
  */
-@SuppressWarnings("this-escape")
-public class Code {
+public final class Code {
 
   private static final Logger log = LogManager.getLogger(Code.class);
 

--- a/modules/utils/src/main/java/com/percussion/install/PSBrandCodeElement.java
+++ b/modules/utils/src/main/java/com/percussion/install/PSBrandCodeElement.java
@@ -28,9 +28,10 @@ import org.w3c.dom.Element;
 /**
  * This class stores the tag name of the wrapped element and the name and value of all the attribute
  * of this element defined in the component map xml.
+ *
+ * <p>Final so the XML constructor may call {@link #fromXml(Element)} without {@code this-escape}.
  */
-@SuppressWarnings("this-escape")
-public class PSBrandCodeElement {
+public final class PSBrandCodeElement {
   /**
    * Constructor.
    *

--- a/modules/utils/src/main/java/com/percussion/install/PSBrandCodeElementList.java
+++ b/modules/utils/src/main/java/com/percussion/install/PSBrandCodeElementList.java
@@ -25,9 +25,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-/** This class stores an array of <code>PSBrandCodeElement</code> objects. */
-@SuppressWarnings("this-escape")
-public class PSBrandCodeElementList {
+/**
+ * This class stores an array of <code>PSBrandCodeElement</code> objects.
+ *
+ * <p>Final so the XML constructor may call {@link #fromXml(Element)} without {@code this-escape}.
+ */
+public final class PSBrandCodeElementList {
   /**
    * Constructor.
    *

--- a/modules/utils/src/main/java/com/percussion/install/PSBrandCodeMapVersion.java
+++ b/modules/utils/src/main/java/com/percussion/install/PSBrandCodeMapVersion.java
@@ -28,9 +28,12 @@ import java.util.Set;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-/** This class represents a single version of the brand code map. */
-@SuppressWarnings("this-escape")
-public class PSBrandCodeMapVersion {
+/**
+ * This class represents a single version of the brand code map.
+ *
+ * <p>Final so the XML constructor may call {@link #fromXml(Element)} without {@code this-escape}.
+ */
+public final class PSBrandCodeMapVersion {
   /**
    * Constructor
    *

--- a/modules/utils/src/main/java/com/percussion/services/guidmgr/data/PSGuid.java
+++ b/modules/utils/src/main/java/com/percussion/services/guidmgr/data/PSGuid.java
@@ -63,7 +63,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  *
  * @author dougrand
  */
-@SuppressWarnings("this-escape")
 public class PSGuid extends Number implements IPSGuid {
   /** */
   private static final long serialVersionUID = 3134898757562243271L;
@@ -320,7 +319,7 @@ public class PSGuid extends Number implements IPSGuid {
    *
    * @see com.percussion.utils.guid.IPSGuid#getHostId()
    */
-  public long getHostId() {
+  public final long getHostId() {
     return doGetHostId(m_guid);
   }
 
@@ -344,7 +343,7 @@ public class PSGuid extends Number implements IPSGuid {
    *
    * @see com.percussion.utils.guid.IPSGuid#getType()
    */
-  public short getType() {
+  public final short getType() {
     return doGetType(m_guid);
   }
 
@@ -367,7 +366,7 @@ public class PSGuid extends Number implements IPSGuid {
    *
    * @see com.percussion.utils.guid.IPSGuid#getUUID()
    */
-  public int getUUID() {
+  public final int getUUID() {
     return doGetUUID(m_guid);
   }
 

--- a/modules/utils/src/main/java/com/percussion/util/PSFileFilter.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSFileFilter.java
@@ -22,10 +22,12 @@ import java.util.Date;
 
 /**
  * A file filter that allows filtering on attributes, length, last modified, and name pattern
- * matching
+ * matching.
+ *
+ * <p>Final so constructors may call the {@code final} configuration setters without {@code
+ * this-escape} diagnostics.
  */
-@SuppressWarnings("this-escape")
-public class PSFileFilter implements java.io.FileFilter, java.io.FilenameFilter {
+public final class PSFileFilter implements java.io.FileFilter, java.io.FilenameFilter {
   /** Bit fields for allowable attributes */
   public static final int IS_DIRECTORY = 1;
 

--- a/modules/utils/src/main/java/com/percussion/util/PSHtmlParamDocument.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSHtmlParamDocument.java
@@ -39,9 +39,10 @@ import org.w3c.dom.Text;
  * element name will be the parameter name and the value of the element is the value of the
  * parameter. There can be multiple elelements with the same name so that multi-valued HTML
  * parameter is supported.
+ *
+ * <p>Final so the map constructor may call {@link #setParams(Map)} without {@code this-escape}.
  */
-@SuppressWarnings("this-escape")
-public class PSHtmlParamDocument {
+public final class PSHtmlParamDocument {
   private static final Logger log = LogManager.getLogger(PSHtmlParamDocument.class);
 
   /** Default Constructor. */

--- a/modules/utils/src/main/java/com/percussion/util/PSProperties.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSProperties.java
@@ -41,9 +41,11 @@ import org.apache.logging.log4j.Logger;
  * https://www.dreamincode.net/forums/topic/53734-java-code-to-modify-properties-file-and-preserve-comments/
  *
  * <p>Written for Java version 1.4
+ *
+ * <p>Final so the file constructor may call {@link #load(InputStream)} (and thereby {@link
+ * #put(Object, Object)}) without {@code this-escape}.
  */
-@SuppressWarnings("this-escape")
-public class PSProperties extends java.util.Properties {
+public final class PSProperties extends java.util.Properties {
 
   private static final Logger log = LogManager.getLogger(PSProperties.class);
   private static final long serialVersionUID = 1L;
@@ -152,7 +154,8 @@ public class PSProperties extends java.util.Properties {
    *
    * @param inStream The InputStream to read.
    */
-  public void load(InputStream inStream) throws IOException {
+  @Override
+  public final void load(InputStream inStream) throws IOException {
     // The spec says that the file must be encoded using ISO-8859-1.
     try (BufferedReader reader =
         new BufferedReader(new InputStreamReader(inStream, "ISO-8859-1"))) {
@@ -384,7 +387,7 @@ public class PSProperties extends java.util.Properties {
    * @param value The value of this Property.
    */
   @Override
-  public synchronized Object put(Object keyString, Object value) {
+  public final synchronized Object put(Object keyString, Object value) {
     // add new entries at end but just update existing entries.
     if (!this.containsKey(keyString)) {
       lineData.add("");

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSAbstractConnector.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSAbstractConnector.java
@@ -338,10 +338,10 @@ public abstract class PSAbstractConnector implements IPSConnector, XMLEnabled {
       super();
     }
 
-    @SuppressWarnings("this-escape")
     public HttpsBuilder(Builder connectorBuilder) {
       super(connectorBuilder);
-      setHttps();
+      // Direct field assign — avoid overridable setHttps() during construction (this-escape)
+      this.scheme = PSAbstractConnector.SCHEME_HTTPS;
       this.connectorFileContext = connectorBuilder.connectorFileContext;
     }
 

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSAbstractConnectors.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSAbstractConnectors.java
@@ -108,19 +108,23 @@ public class PSAbstractConnectors implements IPSConnectorInfo<IPSConnector>, Con
   }
 
   @Override
-  public void setConnectors(List<IPSConnector> connectors) {
+  public final void setConnectors(List<IPSConnector> connectors) {
     this.connectors = connectors;
   }
 
-  public Optional<IPSConnector> getHttpsConnector() {
+  public final Optional<IPSConnector> getHttpsConnector() {
     return this.connectors.stream().filter(IPSConnector::isHttps).findFirst();
   }
 
-  public Optional<IPSConnector> getHttpConnector() {
+  public final Optional<IPSConnector> getHttpConnector() {
     return this.connectors.stream().filter(IPSConnector::isHttp).findFirst();
   }
 
-  protected void mergeConnectors(List<IPSConnector> existingConnectors) {
+  /**
+   * Merge existing connectors into this list. Final so subclass constructors may call without
+   * {@code this-escape}.
+   */
+  protected final void mergeConnectors(List<IPSConnector> existingConnectors) {
     List<IPSConnector> newConnectors = new ArrayList<>();
     for (IPSConnector connector : existingConnectors) {
       IPSConnector connectorToAdd = connector;

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSJBossConnectors.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSJBossConnectors.java
@@ -32,7 +32,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.xml.sax.SAXException;
 
-public class PSJBossConnectors extends PSAbstractXmlConnectors {
+/** Final so copy ctor may call {@code setConnectors} without {@code this-escape}. */
+public final class PSJBossConnectors extends PSAbstractXmlConnectors {
 
   private static final Path JBOSS_APPSERVER_PATH = Paths.get("AppServer");
   private static final Path JBOSS_SERVER_XML_PATH =
@@ -52,7 +53,6 @@ public class PSJBossConnectors extends PSAbstractXmlConnectors {
     this.laxFile = rxRootDir.resolve(CM1_LEGACY_LAX_FILE);
   }
 
-  @SuppressWarnings("this-escape")
   public PSJBossConnectors(File rxDir, PSAbstractConnectors connectorInfo) {
     this(rxDir);
     setConnectors(connectorInfo.getConnectors());

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSJettyConnectors.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSJettyConnectors.java
@@ -33,7 +33,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.math.NumberUtils;
 
-public class PSJettyConnectors extends PSAbstractConnectors {
+/** Final so copy ctor may call {@code mergeConnectors} without {@code this-escape}. */
+public final class PSJettyConnectors extends PSAbstractConnectors {
 
   public static final String KEYSTORE_FILE_ATTR = "jetty.sslContext.keyStorePath";
   public static final String KEYSTORE_PASS_ATTR = "jetty.sslContext.keyStorePassword";
@@ -61,7 +62,6 @@ public class PSJettyConnectors extends PSAbstractConnectors {
     rxRootDir = rxDir;
   }
 
-  @SuppressWarnings("this-escape")
   public PSJettyConnectors(Path rxDir, PSAbstractConnectors connectorInfo) {
     this(rxDir);
     mergeConnectors(connectorInfo.getConnectors());

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSTomcatConnectors.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSTomcatConnectors.java
@@ -44,14 +44,15 @@ public class PSTomcatConnectors extends PSAbstractXmlConnectors {
 
   private Path dtsRoot;
 
-  @SuppressWarnings("this-escape")
   public PSTomcatConnectors(Path rxDir, Path dtsRoot) {
     super(rxDir.resolve(dtsRoot.resolve("Server")));
     // dtsRoot = rxDir.resolve(dtsRoot);
     rxRootDir = rxDir;
     this.serverFile = dtsRoot.resolve(SERVER_XML_PATH);
 
-    if (getOperatingSystem().toUpperCase().contains("WINDOWS")) {
+    // Resolve OS name via System property (not an overridable instance method) to avoid this-escape
+    String osName = System.getProperty("os.name");
+    if (osName != null && osName.toUpperCase().contains("WINDOWS")) {
       this.laxFile = rxDir.resolve(CM1_LEGACY_LAX_FILE);
     } else {
       this.laxFile = rxDir.resolve(CM1_LEGACY_LAX_FILE_LINUX);
@@ -61,7 +62,7 @@ public class PSTomcatConnectors extends PSAbstractXmlConnectors {
     PSLogger.logInfo("Perc-Catalina properties file*********" + this.propertiesFile);
   }
 
-  public String getOperatingSystem() {
+  public final String getOperatingSystem() {
     String os = System.getProperty("os.name");
     return os;
   }

--- a/modules/utils/src/main/java/com/percussion/utils/exceptions/ConnectorConfigurationException.java
+++ b/modules/utils/src/main/java/com/percussion/utils/exceptions/ConnectorConfigurationException.java
@@ -67,11 +67,14 @@ public class ConnectorConfigurationException extends Exception {
    * @param arrayArgs The array of arguments to use as the arguments in the error message. May be
    *     <code>null</code>, and may contain <code>null</code> elements.
    */
-  @SuppressWarnings("this-escape")
   public ConnectorConfigurationException(int msgCode, Throwable cause, Object... arrayArgs) {
-    this(msgCode, arrayArgs);
-    fillInStackTrace();
-    initCause(cause);
+    // Pass cause to Exception super first (no post-construction initCause / this-escape)
+    super(cause);
+    for (int i = 0; arrayArgs != null && i < arrayArgs.length; i++) {
+      if (arrayArgs[i] == null) arrayArgs[i] = "";
+    }
+    m_code = msgCode;
+    m_args = arrayArgs;
   }
 
   /**

--- a/modules/utils/src/main/java/com/percussion/utils/exceptions/PSBaseException.java
+++ b/modules/utils/src/main/java/com/percussion/utils/exceptions/PSBaseException.java
@@ -68,11 +68,14 @@ public abstract class PSBaseException extends Exception {
    * @param arrayArgs The array of arguments to use as the arguments in the error message. May be
    *     <code>null</code>, and may contain <code>null</code> elements.
    */
-  @SuppressWarnings("this-escape")
   public PSBaseException(int msgCode, Throwable cause, Object... arrayArgs) {
-    this(msgCode, arrayArgs);
-    fillInStackTrace();
-    initCause(cause);
+    // Pass cause to Exception super first (no post-construction initCause / this-escape)
+    super(cause);
+    for (int i = 0; arrayArgs != null && i < arrayArgs.length; i++) {
+      if (arrayArgs[i] == null) arrayArgs[i] = "";
+    }
+    m_code = msgCode;
+    m_args = arrayArgs;
   }
 
   /**
@@ -96,12 +99,12 @@ public abstract class PSBaseException extends Exception {
    * @param message the exception message
    * @param cause the causing throwable
    */
-  @SuppressWarnings("this-escape")
   public PSBaseException(String message, Throwable cause) {
+    // super already installs the cause — do not call initCause afterward (IllegalStateException +
+    // this-escape)
     super(message, cause);
     this.m_code = 0;
     this.m_args = new Object[] {message};
-    initCause(cause);
   }
 
   /**

--- a/modules/utils/src/main/java/com/percussion/utils/jdbc/PSDatasourceConfig.java
+++ b/modules/utils/src/main/java/com/percussion/utils/jdbc/PSDatasourceConfig.java
@@ -24,13 +24,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-/** Class to describe the configuration used to obtain and use a database connection. */
-public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, Cloneable {
+/**
+ * Class to describe the configuration used to obtain and use a database connection.
+ *
+ * <p>Final so constructors may call {@link #fromXml(Element)} / {@link
+ * #copyFrom(IPSDatasourceConfig)} / mutators without {@code this-escape}.
+ */
+public final class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, Cloneable {
   /**
    * Empty ctor only for use by Spring framework. If used, an invalid object may result if all
    * required members are not subsequently set on this object before its first use.
    */
-  @SuppressWarnings("this-escape")
   public PSDatasourceConfig() {}
 
   /**
@@ -45,7 +49,6 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    * @param database The database name to use when qualifying statements against this datasource,
    *     may be <code>null</code> or empty.
    */
-  @SuppressWarnings("this-escape")
   public PSDatasourceConfig(String name, String dsName, String origin, String database) {
     if (StringUtils.isEmpty(name))
       throw new IllegalArgumentException("name may not be null or empty");
@@ -55,8 +58,9 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
 
     m_name = name;
     m_dsName = dsName;
-    setOrigin(origin);
-    setDatabase(database);
+    // Direct field init (avoid overridable mutators during construction)
+    m_origin = origin == null ? "" : origin.trim();
+    m_database = database == null ? "" : database.trim();
   }
 
   /**
@@ -66,7 +70,6 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    * @param sourceNode The source element, may not be <code>null</code>.
    * @throws PSInvalidXmlException if the supplied element does not conform to the expected DTD.
    */
-  @SuppressWarnings("this-escape")
   public PSDatasourceConfig(Element sourceNode) throws PSInvalidXmlException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode may not be null");
 
@@ -79,7 +82,6 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    *
    * @param config The config, may not be <code>null</code>.
    */
-  @SuppressWarnings("this-escape")
   public PSDatasourceConfig(IPSDatasourceConfig config) {
     if (config == null) throw new IllegalArgumentException("config may not be null");
 
@@ -111,7 +113,7 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    *
    * @param name The name, may not be <code>null</code> or empty.
    */
-  public void setName(String name) {
+  public final void setName(String name) {
     if (StringUtils.isBlank(name))
       throw new IllegalArgumentException("name may not be null or empty");
 
@@ -123,7 +125,7 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    *
    * @param dataSource The datasource name, may not be <code>null</code> or empty.
    */
-  public void setDataSource(String dataSource) {
+  public final void setDataSource(String dataSource) {
     if (StringUtils.isBlank(dataSource))
       throw new IllegalArgumentException("dataSource may not be null or empty");
 
@@ -135,7 +137,7 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    *
    * @param origin The origin or schema name, may be <code>null</code> or empty.
    */
-  public void setOrigin(String origin) {
+  public final void setOrigin(String origin) {
     m_origin = origin == null ? "" : origin.trim();
   }
 
@@ -144,7 +146,7 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    *
    * @param database The database name, may be <code>null</code> or empty.
    */
-  public void setDatabase(String database) {
+  public final void setDatabase(String database) {
     m_database = database == null ? "" : database.trim();
   }
 
@@ -154,7 +156,7 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
    *
    * @param config Config to copy, must never be <code>null</code>
    */
-  public void copyFrom(IPSDatasourceConfig config) {
+  public final void copyFrom(IPSDatasourceConfig config) {
     if (config == null) {
       throw new IllegalArgumentException("config must never be null");
     }
@@ -180,7 +182,7 @@ public class PSDatasourceConfig implements IPSDatasourceConfig, IPSBeanConfig, C
   }
 
   // see IPSBeanConfig interface
-  public void fromXml(Element source) throws PSInvalidXmlException {
+  public final void fromXml(Element source) throws PSInvalidXmlException {
     if (source == null) throw new IllegalArgumentException("source may not be null");
 
     // need to get name first

--- a/modules/utils/src/test/java/com/percussion/services/guidmgr/data/PSGuidTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/guidmgr/data/PSGuidTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.guidmgr.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class PSGuidTest {
+
+  @Test
+  public void assembleFromHostTypeUuid() {
+    PSGuid guid = new PSGuid(1001L, PSTypeEnum.INTERNAL, 42L);
+    assertEquals(1001L, guid.getHostId());
+    assertEquals(PSTypeEnum.INTERNAL.getOrdinal(), guid.getType());
+    assertEquals(42, guid.getUUID());
+    assertEquals("1001-0-42", guid.toString());
+  }
+
+  @Test
+  public void stringCtorWithType() {
+    PSGuid guid = new PSGuid(PSTypeEnum.INTERNAL, "1001-0-7");
+    assertEquals(1001L, guid.getHostId());
+    assertEquals(7, guid.getUUID());
+  }
+
+  @Test
+  public void typeMismatchRejected() {
+    // INTERNAL ordinal is 0 (treated as "unset"); use a non-zero type so mismatch is detectable
+    PSGuid typed = new PSGuid(5L, PSTypeEnum.NODEDEF, 1L);
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSGuid(PSTypeEnum.TEMPLATE, typed.longValue()));
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/util/PSFileFilterTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSFileFilterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.utils.tools.PSPatternMatcher;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+public class PSFileFilterTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  public void attributeCtorAcceptsFilesOnly() throws Exception {
+    Path file = Files.createFile(tempDir.resolve("a.txt"));
+    Path dir = Files.createDirectory(tempDir.resolve("subdir"));
+
+    PSFileFilter filter = new PSFileFilter(PSFileFilter.IS_FILE);
+    assertTrue(filter.accept(file.toFile()));
+    assertFalse(filter.accept(dir.toFile()));
+  }
+
+  @Test
+  public void namePatternCtorMatchesPattern() throws Exception {
+    Path match = Files.createFile(tempDir.resolve("note.txt"));
+    Path other = Files.createFile(tempDir.resolve("note.md"));
+
+    PSPatternMatcher matcher = new PSPatternMatcher('?', '*', "*.txt", false);
+    PSFileFilter filter = new PSFileFilter(matcher);
+    assertTrue(filter.accept(match.toFile()));
+    assertFalse(filter.accept(other.toFile()));
+  }
+
+  @Test
+  public void filenameFilterDelegateUsesSameRules() throws Exception {
+    Files.createFile(tempDir.resolve("keep.log"));
+    PSFileFilter filter = new PSFileFilter(PSFileFilter.IS_FILE);
+    File dir = tempDir.toFile();
+    assertTrue(filter.accept(dir, "keep.log"));
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/util/PSHtmlParamDocumentTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSHtmlParamDocumentTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class PSHtmlParamDocumentTest {
+
+  @Test
+  public void mapCtorCopiesParamsAndBuildsXml() {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put("a", "1");
+    params.put("b", List.of("x", "y"));
+
+    PSHtmlParamDocument doc = new PSHtmlParamDocument(params);
+    String xml = doc.getXmlString();
+    assertTrue(xml.contains("<a>1</a>"));
+    assertTrue(xml.contains("<b>x</b>"));
+    assertTrue(xml.contains("<b>y</b>"));
+  }
+
+  @Test
+  public void setParamReplacesAndRemoves() {
+    PSHtmlParamDocument doc = new PSHtmlParamDocument();
+    doc.setParam("k", "v");
+    assertTrue(doc.getXmlString().contains("<k>v</k>"));
+    doc.setParam("k", "v2");
+    assertTrue(doc.getXmlString().contains("<k>v2</k>"));
+    doc.setParam("k", null);
+    assertEquals(
+        true,
+        !doc.getXmlString().contains("<k>"),
+        "null value removes existing param");
+  }
+
+  @Test
+  public void setParamsRejectsNull() {
+    PSHtmlParamDocument doc = new PSHtmlParamDocument();
+    assertThrows(IllegalArgumentException.class, () -> doc.setParams(null));
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/util/PSPropertiesTest.java
+++ b/modules/utils/src/test/java/com/percussion/util/PSPropertiesTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+public class PSPropertiesTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  public void fileCtorLoadsProperties() throws Exception {
+    Path propsFile = tempDir.resolve("sample.properties");
+    Files.writeString(propsFile, "alpha=1\n# comment\nbeta=two\n", StandardCharsets.ISO_8859_1);
+
+    PSProperties props = new PSProperties(propsFile.toString());
+    assertEquals("1", props.getProperty("alpha"));
+    assertEquals("two", props.getProperty("beta"));
+    assertEquals(1, props.getInt("alpha"));
+  }
+
+  @Test
+  public void loadRecordsCommentLinesInLineData() throws Exception {
+    String input = "# keep me\nalpha=1\n";
+    PSProperties props = new PSProperties();
+    props.load(new ByteArrayInputStream(input.getBytes(StandardCharsets.ISO_8859_1)));
+    assertEquals("1", props.getProperty("alpha"));
+    // Comment rows are captured in lineData (paired with empty keyData entries)
+    assertTrue(props.lineData.stream().anyMatch(l -> l.contains("# keep me")));
+    assertTrue(props.keyData.contains("alpha"));
+  }
+
+  @Test
+  public void putUpdatesExistingWithoutDuplicatingKeyData() {
+    PSProperties props = new PSProperties();
+    props.put("k", "v1");
+    props.put("k", "v2");
+    assertEquals("v2", props.getProperty("k"));
+    long keyCount = props.keyData.stream().filter("k"::equals).count();
+    assertEquals(1, keyCount);
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/utils/exceptions/ConnectorConfigurationExceptionTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/exceptions/ConnectorConfigurationExceptionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class ConnectorConfigurationExceptionTest {
+
+  @Test
+  public void causeCtorWiresCauseAndCode() {
+    Throwable cause = new IllegalArgumentException("dup");
+    ConnectorConfigurationException ex =
+        new ConnectorConfigurationException(
+            ConnectorConfigurationException.Errors.DUPLICATE_PORT, cause, "8080");
+    assertSame(cause, ex.getCause());
+    assertEquals(ConnectorConfigurationException.Errors.DUPLICATE_PORT, ex.getErrorCode());
+  }
+
+  @Test
+  public void noArgCtorUsesCodeOnly() {
+    ConnectorConfigurationException ex =
+        new ConnectorConfigurationException(ConnectorConfigurationException.Errors.DUPLICATE_PORT);
+    assertEquals(ConnectorConfigurationException.Errors.DUPLICATE_PORT, ex.getErrorCode());
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/utils/exceptions/PSBaseExceptionCauseTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/exceptions/PSBaseExceptionCauseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class PSBaseExceptionCauseTest {
+
+  /** Minimal concrete subclass for constructor coverage. */
+  private static final class TestBaseException extends PSBaseException {
+    private static final long serialVersionUID = 1L;
+
+    TestBaseException(int msgCode, Throwable cause, Object... args) {
+      super(msgCode, cause, args);
+    }
+
+    TestBaseException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    @Override
+    protected String getResourceBundleBaseName() {
+      return "com.percussion.utils.xml.PSXmlErrorStringBundle";
+    }
+  }
+
+  @Test
+  public void msgCodeCauseCtorInstallsCauseWithoutInitCause() {
+    RuntimeException cause = new RuntimeException("root");
+    TestBaseException ex = new TestBaseException(1, cause, "arg");
+    assertSame(cause, ex.getCause());
+    assertEquals(1, ex.getErrorCode());
+  }
+
+  @Test
+  public void messageCauseCtorInstallsCauseAndArgs() {
+    IllegalStateException cause = new IllegalStateException("boom");
+    TestBaseException ex = new TestBaseException("hello", cause);
+    assertSame(cause, ex.getCause());
+    assertEquals(0, ex.getErrorCode());
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/utils/jdbc/PSDatasourceConfigTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/jdbc/PSDatasourceConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class PSDatasourceConfigTest {
+
+  @Test
+  public void membersCtorTrimsOriginAndDatabase() {
+    PSDatasourceConfig cfg = new PSDatasourceConfig("cfg", "jdbc/rx", "  dbo  ", "  rxdb  ");
+    assertEquals("cfg", cfg.getName());
+    assertEquals("jdbc/rx", cfg.getDataSource());
+    assertEquals("dbo", cfg.getOrigin());
+    assertEquals("rxdb", cfg.getDatabase());
+  }
+
+  @Test
+  public void copyCtorShallowCopiesFields() {
+    PSDatasourceConfig source = new PSDatasourceConfig("a", "ds", "o", "db");
+    PSDatasourceConfig copy = new PSDatasourceConfig(source);
+    assertEquals(source, copy);
+    copy.setName("b");
+    assertNotEquals(source.getName(), copy.getName());
+  }
+
+  @Test
+  public void membersCtorRejectsBlankName() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSDatasourceConfig("", "ds", null, null));
+  }
+
+  @Test
+  public void setOriginNullBecomesEmpty() {
+    PSDatasourceConfig cfg = new PSDatasourceConfig("a", "ds", "o", "db");
+    cfg.setOrigin(null);
+    assertEquals("", cfg.getOrigin());
+  }
+}


### PR DESCRIPTION
## Summary

Partial implement for **#2414** (modules/utils javac residual after batch 5) — **batch 6** real **this-escape redesign** cluster (no new blanket suppressions; does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map API).

| Area | Fix |
|------|-----|
| `PSFileFilter` / `PSHtmlParamDocument` / `PSDatasourceConfig` / `PSProperties` | `final` classes (+ final mutators/`load`/`put` where needed) |
| Brand-code (`Code`, `PSBrandCodeElement*`) | `final` classes; strip this-escape |
| Connectors (`PSAbstractConnectors`, Jetty/JBoss/Tomcat) | final helpers / final classes; OS via `System.getProperty` |
| `HttpsBuilder` | direct `scheme` field assign (no overridable `setHttps()` in ctor) |
| `PSBaseException` / `ConnectorConfigurationException` | `super(cause)` instead of post-construction `initCause` |
| `PSGuid` | final accessors; strip class this-escape |

**Not changed (by design):** `PSWorkflowUtilsBase` raw public API; `PSCollection` / `PSJexlEvaluator` / `PSXmlSerializationHelper`; `PSException` hierarchy this-escape; JNDI datasource BeanUtils this-escape; CRTP / ItemIterator / Copier residuals.

Parent module: **#2016**. Tracker: **#2200**. Residual after this batch: **#2969**.

## Test plan

- [x] Standalone `modules/utils`: `cd modules/utils && ..\..\mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Suite: **346** tests, **0** failures (9 pre-existing skips)
- [x] Project-Xlint: **0** `possible 'this' escape` warnings on changed sources
- [x] New tests: FileFilter, HtmlParamDocument, Properties, DatasourceConfig, BaseException cause, ConnectorConfigurationException, PSGuid

## Product documentation

- [x] N/A — pure compiler hygiene / non-product-facing tech-debt (no operator, admin, integrator, or end-user behavior change)

## Gates evidence (C3)

- **modules_built:** `modules/utils`
- **build_evidence:** `cd modules/utils && ..\..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 346, Failures: 0, Errors: 0, Skipped: 9
- **downstream_checked:** grepped monorepo for `extends` of newly-final types (`PSFileFilter`, `PSHtmlParamDocument`, `PSDatasourceConfig`, `PSProperties`, brand-code leafs, `PSJettyConnectors`, `PSJBossConnectors`) — none; `PSGuid` class not finalized (subclasses keep working); final accessors not overridden by `PSLegacyGuid`/`PSDesignGuid`
- Erlang-style self-review: approve — `docs/ai-generated/code-reviews/issue-2414-utils-this-escape-batch6-erlang.md`

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2414. Fixes #2414 is deferred until residual #2969 lands (or close #2414 when residual is accepted as the open tracker). Refs #2016 #2200. Residual: #2969.

> Co-Authored by Grok Build using grok-4.5 with agent main.
