### PR TITLE
fix(WebUI): Administration WorkflowSection map TypeError (#2959)

### DIFF
--- a/WebUI/src/main/ts/api/developer/workflowsApi.ts
+++ b/WebUI/src/main/ts/api/developer/workflowsApi.ts
@@ -26,8 +26,12 @@ const LIST_WRAPPER_KEYS = [
  * Parse workflowmanagement metadata list.
  * Accepts a bare JSON array or a known list wrapper object. Unknown object shapes throw
  * so the UI surfaces an error instead of a silent empty catalog.
+ *
+ * <p>Shared by Developer catalog and Admin WorkflowSection — Jackson WRAP_ROOT often
+ * returns {@code { "Workflow": [ ... ] }} (PSUiWorkflowList @JsonRootName), and treating
+ * that object as an array causes {@code TypeError: e.map is not a function} (#2959).
  */
-function parseWorkflowList(payload: unknown): WorkflowDef[] {
+export function parseWorkflowList(payload: unknown): WorkflowDef[] {
   if (payload == null) {
     return [];
   }

--- a/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowSection.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/workflow/WorkflowSection.tsx
@@ -16,10 +16,55 @@
 
 import React, { useEffect, useState } from "react";
 import { get, post, put, del } from "../../api/client";
+import { parseWorkflowList } from "../../api/developer/workflowsApi";
+import type { WorkflowDef } from "../../api/developer/types";
 import { PATHS } from "../../api/paths";
 import { message } from "../../i18n/message";
 import { WF_ADMIN_MSG } from "../messages";
 import { WorkflowDefinition, WorkflowEditor } from "./WorkflowEditor";
+import type { WorkflowStep } from "./WorkflowStepList";
+
+/**
+ * Map a workflowmanagement row (PSUiWorkflow / WorkflowDef, or legacy admin shape)
+ * into the WorkflowSection editor model.
+ */
+export function toWorkflowDefinition(
+  item: WorkflowDef | Record<string, unknown> | null | undefined,
+): WorkflowDefinition {
+  if (item == null || typeof item !== "object") {
+    return { name: "", isDefault: false, steps: [] };
+  }
+  const o = item as Record<string, unknown>;
+  const name = String(o.name ?? o.workflowName ?? "").trim();
+  const isDefault = Boolean(o.isDefault ?? o.defaultWorkflow ?? false);
+  const stagingRaw = o.stagingRoleId ?? o.stagingRoleNames;
+  const stagingRoleId =
+    typeof stagingRaw === "string" && stagingRaw.trim().length > 0
+      ? stagingRaw
+      : undefined;
+
+  let steps: WorkflowStep[] = [];
+  if (Array.isArray(o.steps)) {
+    steps = o.steps as WorkflowStep[];
+  } else if (Array.isArray(o.workflowSteps)) {
+    steps = (o.workflowSteps as Record<string, unknown>[]).map((s, i) => {
+      const roleNames = Array.isArray(s.roleNames)
+        ? (s.roleNames as string[])
+        : Array.isArray(s.stepRoles)
+          ? (s.stepRoles as { roleName?: string }[])
+              .map((r) => (typeof r?.roleName === "string" ? r.roleName : ""))
+              .filter((n) => n.length > 0)
+          : [];
+      return {
+        name: String(s.name ?? s.stepName ?? "").trim(),
+        roleNames,
+        position: typeof s.position === "number" ? s.position : i,
+      };
+    });
+  }
+
+  return { name, isDefault, stagingRoleId, steps };
+}
 
 export const WorkflowSection: React.FC = () => {
   const [workflows, setWorkflows] = useState<WorkflowDefinition[]>([]);
@@ -37,13 +82,21 @@ export const WorkflowSection: React.FC = () => {
       // role/find. POST role/find expects PSStringWrapper root "psstring"
       // ({ psstring: { value } }); a bare { name: "" } body fails Jackson with
       // "Root name ('name') does not match expected ('psstring')" (#2701).
-      const [wfList, rolesRes] = await Promise.all([
-        get<WorkflowDefinition[]>(PATHS.WORKFLOW_METADATA),
+      //
+      // Workflow metadata is often a Jackson root wrapper ({ Workflow: [...] }),
+      // not a bare array — parseWorkflowList unwraps before map (#2959).
+      const [wfPayload, rolesRes] = await Promise.all([
+        get<unknown>(PATHS.WORKFLOW_METADATA),
         get<{ RoleList: { roles: string[] } }>(PATHS.USER_ROLES).catch(() => null),
       ]);
-      setWorkflows(wfList || []);
+      const parsed = parseWorkflowList(wfPayload);
+      const list = Array.isArray(parsed)
+        ? parsed.map((row) => toWorkflowDefinition(row))
+        : [];
+      setWorkflows(list);
       setAvailableRoles(rolesRes?.RoleList?.roles || []);
     } catch (err) {
+      setWorkflows([]);
       setError(message(WF_ADMIN_MSG.ERROR_GENERIC));
     } finally {
       setIsLoading(false);

--- a/WebUI/src/test/ts/api/developer/workflowsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/workflowsApi.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseWorkflowList } from "../../../../main/ts/api/developer/workflowsApi";
+
+describe("parseWorkflowList", () => {
+  it("returns bare arrays", () => {
+    const rows = [{ workflowName: "Default Workflow" }];
+    expect(parseWorkflowList(rows)).toEqual(rows);
+  });
+
+  it("returns empty for null", () => {
+    expect(parseWorkflowList(null)).toEqual([]);
+    expect(parseWorkflowList(undefined)).toEqual([]);
+  });
+
+  it("unwraps Workflow root wrapper (PSUiWorkflowList @JsonRootName)", () => {
+    expect(
+      parseWorkflowList({
+        Workflow: [
+          { workflowName: "Default Workflow", defaultWorkflow: true },
+          { workflowName: "Simple Workflow", defaultWorkflow: false },
+        ],
+      }),
+    ).toEqual([
+      { workflowName: "Default Workflow", defaultWorkflow: true },
+      { workflowName: "Simple Workflow", defaultWorkflow: false },
+    ]);
+  });
+
+  it("unwraps single Workflow object", () => {
+    expect(
+      parseWorkflowList({
+        Workflow: { workflowName: "Only One", defaultWorkflow: true },
+      }),
+    ).toEqual([{ workflowName: "Only One", defaultWorkflow: true }]);
+  });
+
+  it("unwraps WorkflowList / entries aliases", () => {
+    expect(
+      parseWorkflowList({ WorkflowList: [{ workflowName: "A" }] }),
+    ).toEqual([{ workflowName: "A" }]);
+    expect(parseWorkflowList({ entries: [{ workflowName: "B" }] })).toEqual([
+      { workflowName: "B" },
+    ]);
+  });
+
+  it("throws on unknown object shape", () => {
+    expect(() => parseWorkflowList({ unexpected: true })).toThrow(
+      /Unexpected workflow list payload/,
+    );
+  });
+
+  it("throws on non-object non-array types", () => {
+    expect(() => parseWorkflowList("not-json-list")).toThrow(
+      /Unexpected workflow list payload type/,
+    );
+  });
+});

--- a/WebUI/src/test/ts/workflowAdmin/WorkflowSection.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/WorkflowSection.test.tsx
@@ -17,7 +17,10 @@
 import React from "react";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { WorkflowSection } from "../../../main/ts/workflowAdmin/workflow/WorkflowSection";
+import {
+  toWorkflowDefinition,
+  WorkflowSection,
+} from "../../../main/ts/workflowAdmin/workflow/WorkflowSection";
 import * as client from "../../../main/ts/api/client";
 
 vi.mock("../../../main/ts/api/client", () => ({
@@ -27,22 +30,65 @@ vi.mock("../../../main/ts/api/client", () => ({
   del: vi.fn(),
 }));
 
+function mockGets(workflowPayload: unknown, roles: string[] = ["Editor", "Publisher"]) {
+  vi.mocked(client.get).mockImplementation(async (url: string) => {
+    if (url.includes("user/roles") || url.includes("/roles")) {
+      return { RoleList: { roles } };
+    }
+    return workflowPayload;
+  });
+}
+
+describe("toWorkflowDefinition", () => {
+  it("maps admin shape fields", () => {
+    expect(
+      toWorkflowDefinition({
+        name: "Default Workflow",
+        isDefault: true,
+        stagingRoleId: "Editor",
+        steps: [],
+      }),
+    ).toEqual({
+      name: "Default Workflow",
+      isDefault: true,
+      stagingRoleId: "Editor",
+      steps: [],
+    });
+  });
+
+  it("maps PSUiWorkflow / WorkflowDef fields", () => {
+    expect(
+      toWorkflowDefinition({
+        workflowName: "Default Workflow",
+        defaultWorkflow: true,
+        stagingRoleNames: "Editor;Publisher",
+        workflowSteps: [{ stepName: "Draft", stepRoles: [{ roleName: "Author" }] }],
+      }),
+    ).toEqual({
+      name: "Default Workflow",
+      isDefault: true,
+      stagingRoleId: "Editor;Publisher",
+      steps: [{ name: "Draft", roleNames: ["Author"], position: 0 }],
+    });
+  });
+
+  it("handles null / empty", () => {
+    expect(toWorkflowDefinition(null)).toEqual({ name: "", isDefault: false, steps: [] });
+    expect(toWorkflowDefinition(undefined)).toEqual({ name: "", isDefault: false, steps: [] });
+  });
+});
+
 describe("WorkflowSection", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it("renders workflow list after loading", async () => {
+  it("renders workflow list after loading bare array", async () => {
     const mockWorkflows = [
       { name: "Default Workflow", isDefault: true, stagingRoleId: "Editor", steps: [] },
       { name: "Blog Workflow", isDefault: false, stagingRoleId: "Publisher", steps: [] },
     ];
-    vi.mocked(client.get).mockImplementation(async (url: string) => {
-      if (url.includes("user/roles") || url.includes("/roles")) {
-        return { RoleList: { roles: ["Editor", "Publisher"] } };
-      }
-      return mockWorkflows;
-    });
+    mockGets(mockWorkflows);
 
     render(<WorkflowSection />);
     expect(screen.getByText(/loading/i)).toBeTruthy();
@@ -58,13 +104,57 @@ describe("WorkflowSection", () => {
     expect(getUrls.some((u) => u.includes("user/roles") || u.endsWith("/roles"))).toBe(true);
   });
 
-  it("opens create editor when Create Workflow button is clicked", async () => {
-    vi.mocked(client.get).mockImplementation(async (url: string) => {
-      if (url.includes("user/roles") || url.includes("/roles")) {
-        return { RoleList: { roles: [] } };
-      }
-      return [];
+  it("unwraps Jackson Workflow root wrapper without throwing (#2959)", async () => {
+    mockGets({
+      Workflow: [
+        {
+          workflowName: "Default Workflow",
+          defaultWorkflow: true,
+          stagingRoleNames: "Editor",
+        },
+        {
+          workflowName: "Simple Workflow",
+          defaultWorkflow: false,
+          stagingRoleNames: "",
+        },
+      ],
     });
+
+    render(<WorkflowSection />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-workflow-section")).toBeTruthy();
+      expect(screen.getByTestId("workflow-row-Default Workflow")).toBeTruthy();
+      expect(screen.getByTestId("workflow-row-Simple Workflow")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("route-error")).toBeNull();
+  });
+
+  it("renders empty state for empty array payload", async () => {
+    mockGets([]);
+
+    render(<WorkflowSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-workflow-section")).toBeTruthy();
+      expect(screen.getByTestId("create-workflow-button")).toBeTruthy();
+    });
+    expect(screen.queryByTestId(/^workflow-row-/)).toBeNull();
+  });
+
+  it("shows error and does not crash for unexpected non-array object (#2959)", async () => {
+    mockGets({ unexpected: true, foo: 1 });
+
+    render(<WorkflowSection />);
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-workflow-section")).toBeTruthy();
+    });
+    // Generic error path — no TypeError / no workflow rows
+    expect(screen.queryByTestId(/^workflow-row-/)).toBeNull();
+    expect(screen.getByTestId("create-workflow-button")).toBeTruthy();
+  });
+
+  it("opens create editor when Create Workflow button is clicked", async () => {
+    mockGets([]);
 
     render(<WorkflowSection />);
     await waitFor(() => {
@@ -76,12 +166,10 @@ describe("WorkflowSection", () => {
   });
 
   it("loads available roles from USER_ROLES and does not post PSStringWrapper shape { name }", async () => {
-    vi.mocked(client.get).mockImplementation(async (url: string) => {
-      if (String(url).includes("user/roles")) {
-        return { RoleList: { roles: ["Admin", "Editor"] } };
-      }
-      return [{ name: "Default Workflow", isDefault: true, stagingRoleId: "Admin", steps: [] }];
-    });
+    mockGets(
+      [{ name: "Default Workflow", isDefault: true, stagingRoleId: "Admin", steps: [] }],
+      ["Admin", "Editor"],
+    );
 
     render(<WorkflowSection />);
     await waitFor(() => {

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js
@@ -1,0 +1,78 @@
+/**
+ * Regression: Admin → Administration fails with TypeError e.map is not a function (#2959).
+ *
+ * GET workflowmanagement/workflows/metadata often returns a Jackson root wrapper
+ * ({ Workflow: [...] }). WorkflowSection must unwrap before workflows.map so the
+ * Administration shell loads without RouteErrorBoundary.
+ *
+ * Tags: @workflow-admin @administration @smoke @bug-2959
+ *
+ * Surface filter:
+ *   npm run test:surface -- --path tests/bugs/bug-2959-admin-workflow-section.spec.js
+ *   npm run test:surface -- --tag bug-2959
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+test.describe("Administration WorkflowSection load (#2959)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test(
+    "perc-workflow-section loads without RouteErrorBoundary",
+    {
+      tag: ["@workflow-admin", "@administration", "@smoke", "@bug-2959"],
+    },
+    async ({ page }) => {
+      await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
+
+      const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
+      await expect(shell).toBeVisible({ timeout: 30_000 });
+
+      // Must not crash into route error boundary (Unable to load Administration)
+      await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
+      await expect(
+        page.getByText(/Unable to load Administration/i),
+      ).toHaveCount(0);
+
+      const wfSection = page.locator("[data-testid='perc-workflow-section']");
+      await expect(wfSection).toBeVisible({ timeout: 30_000 });
+      await expect(
+        page.locator("[data-testid='create-workflow-button']"),
+      ).toBeVisible();
+      await expect(page.locator("[data-testid='tab-workflow']")).toBeVisible();
+    },
+  );
+
+  test(
+    "Admin sibling Administration link reaches workflow section",
+    {
+      tag: ["@workflow-admin", "@administration", "@bug-2959"],
+    },
+    async ({ page }) => {
+      await page.goto(`${BASE_URL}/cm/app/index.jsp?view=admin`);
+
+      const adminShell = page.locator("[data-testid='perc-admin-shell']");
+      await expect(adminShell).toBeVisible({ timeout: 30_000 });
+
+      const workflowLink = page.getByTestId("admin-sibling-workflow-link");
+      if ((await workflowLink.count()) > 0) {
+        await workflowLink.click();
+      } else {
+        // Fallback deep link used by product nav when sibling chrome differs
+        await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
+      }
+
+      await expect(
+        page.locator("[data-testid='perc-workflow-admin-shell']"),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
+      await expect(
+        page.locator("[data-testid='perc-workflow-section']"),
+      ).toBeVisible({ timeout: 30_000 });
+    },
+  );
+});

--- a/modules/perc-qa-automation/frontend/tests/us1-workflow-definitions.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/us1-workflow-definitions.spec.js
@@ -6,25 +6,33 @@ test.describe("Workflow Administration - Workflow Definitions (US1)", () => {
     await loginAsAdmin(page);
   });
 
-  test("navigate to workflow admin and verify shell and list render", async ({
-    page,
-  }) => {
-    await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
+  test(
+    "navigate to workflow admin and verify shell and list render",
+    { tag: ["@workflow-admin", "@administration", "@smoke"] },
+    async ({ page }) => {
+      await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
 
-    // Verify WorkflowAdminShell container is present
-    const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
-    await expect(shell).toBeVisible();
+      // Verify WorkflowAdminShell container is present
+      const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
+      await expect(shell).toBeVisible({ timeout: 30_000 });
 
-    // Verify Workflow section table is visible
-    const wfSection = page.locator("[data-testid='perc-workflow-section']");
-    await expect(wfSection).toBeVisible();
+      // #2959: wrapper payload must not trip RouteErrorBoundary (e.map is not a function)
+      await expect(page.locator("[data-testid='route-error']")).toHaveCount(0);
+      await expect(
+        page.getByText(/Unable to load Administration/i),
+      ).toHaveCount(0);
 
-    // Verify tabs are present
-    await expect(page.locator("[data-testid='tab-workflow']")).toBeVisible();
-    await expect(page.locator("[data-testid='tab-roles']")).toBeVisible();
-    await expect(page.locator("[data-testid='tab-users']")).toBeVisible();
-    await expect(page.locator("[data-testid='tab-categories']")).toBeVisible();
-  });
+      // Verify Workflow section table is visible
+      const wfSection = page.locator("[data-testid='perc-workflow-section']");
+      await expect(wfSection).toBeVisible({ timeout: 30_000 });
+
+      // Verify tabs are present
+      await expect(page.locator("[data-testid='tab-workflow']")).toBeVisible();
+      await expect(page.locator("[data-testid='tab-roles']")).toBeVisible();
+      await expect(page.locator("[data-testid='tab-users']")).toBeVisible();
+      await expect(page.locator("[data-testid='tab-categories']")).toBeVisible();
+    },
+  );
 
   test("open create workflow form", async ({ page }) => {
     await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);


### PR DESCRIPTION
## Summary

Fixes **#2959**: Admin → Administration crashed with `TypeError: e.map is not a function` in `WorkflowSection.tsx` because `GET workflowmanagement/workflows/metadata` often returns a Jackson root wrapper (`{ "Workflow": [ ... ] }` from `PSUiWorkflowList` `@JsonRootName`), and the admin UI stored that object via `setWorkflows(wfList || [])` without unwrapping.

**Changes:**
- Export and reuse `parseWorkflowList` from `WebUI/src/main/ts/api/developer/workflowsApi.ts` in Admin `WorkflowSection.loadData`
- Map server `PSUiWorkflow` fields (`workflowName` / `defaultWorkflow` / `stagingRoleNames` / `workflowSteps`) into the admin `WorkflowDefinition` model
- `Array.isArray` guard; clear list + generic error path on unexpected payloads (no render crash)
- Vitest coverage for bare array, Jackson wrapper, empty, and unknown object payloads
- Playwright surface regression `bug-2959-admin-workflow-section.spec.js` (+ stronger `us1-workflow-definitions` RouteErrorBoundary checks)

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2959

## Test plan

1. **Vitest (WebUI):** `cd WebUI/src/main/frontend && npm run test -- --run ../../test/ts/workflowAdmin/WorkflowSection.test.tsx ../../test/ts/api/developer/workflowsApi.test.ts` → 16 passed
2. **Maven:** `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**
3. **Playwright (QA H2):** after `perc-devctl qa-up` + hot-copy modern assets (or full dist rebuild):
   ```
   TEST_CMS_URL=http://127.0.0.1:9993 ADMIN_USERNAME=Admin ADMIN_PASSWORD=…
   npm run test:surface -- --path tests/bugs/bug-2959-admin-workflow-section.spec.js
   ```
   → 2 passed (shell + perc-workflow-section visible; no `route-error`)
4. Manual: log in as Admin → Admin page → Administration sibling / `?view=workflow` → workflow list renders without "Unable to load Administration"

## Checklist

- [x] **Product documentation** — **N/A** (bugfix restoring expected Administration load; no new operator-facing options/config/API docs)
- [x] **Unit / module tests** — Vitest for `parseWorkflowList` + `WorkflowSection` wrapper/empty/array/error paths; WebUI standalone clean install green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/bugs/bug-2959-admin-workflow-section.spec.js` + `us1-workflow-definitions.spec.js` RouteErrorBoundary assertions
- [x] **Build gates** — `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS; no Java API shape / `final` changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### Build evidence (C3)

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS (2026-08-11); Vitest 16 passed (WorkflowSection + workflowsApi); Playwright surface 2 passed against H2 QA cell with hot-copied modern assets
- **downstream_checked:** none (no public Java API / `final` / signature changes; TS-only WebUI + Playwright)

> Co-Authored by Grok Build using grok-4.5 with agent main.