### PR TITLE
fix(WebUI): restore Admin tools shell title and sibling affordance (#2953)

### DIFF
--- a/WebUI/src/main/ts/admin/AdminShell.tsx
+++ b/WebUI/src/main/ts/admin/AdminShell.tsx
@@ -72,8 +72,10 @@ export const AdminShell: React.FC<AdminShellProps> = ({
     >
       <header className={styles.header}>
         <div className={styles.headerRow}>
-          <h1>{message(ADMIN_MSG.ADMIN_TITLE)}</h1>
-          {/* Top nav lands on Admin tools (#2784); keep Workflow admin reachable. */}
+          <h1 data-testid="perc-admin-shell-title">
+            {message(ADMIN_MSG.ADMIN_TITLE)}
+          </h1>
+          {/* Top nav lands on Admin tools (#2784/#2953); keep Workflow admin reachable. */}
           <Link
             to="/workflow"
             className={styles.siblingLink}

--- a/WebUI/src/main/ts/admin/messages.ts
+++ b/WebUI/src/main/ts/admin/messages.ts
@@ -15,7 +15,12 @@
  */
 
 export const ADMIN_MSG = {
-  ADMIN_TITLE: "perc.ui.admin@Administration",
+  /**
+   * Shell page title for Admin tools (#2784 / #2953).
+   * Reuses the localized dashboard modern key so operators see "Admin tools"
+   * (not "Administration") when top-nav Admin lands on {@code /admin}.
+   */
+  ADMIN_TITLE: "perc.ui.dashboard.modern@Admin tools",
   TAB_TASKS: "perc.ui.admin@Scheduled Tasks",
   TAB_LOGS: "perc.ui.admin@Execution Logs",
   TAB_NOTIFICATIONS: "perc.ui.admin@Notification Settings",

--- a/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
@@ -72,8 +72,10 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
     >
       <header className={styles.header}>
         <div className={styles.headerRow}>
-          <h1>{message(WF_ADMIN_MSG.TITLE)}</h1>
-          {/* Admin tools is top-nav landing (#2784); keep cross-link when deep-linked here. */}
+          <h1 data-testid="perc-workflow-admin-shell-title">
+            {message(WF_ADMIN_MSG.TITLE)}
+          </h1>
+          {/* Admin tools is top-nav landing (#2784/#2953); cross-link when deep-linked here. */}
           <Link
             to="/admin"
             className={styles.siblingLink}

--- a/WebUI/src/test/ts/admin/AdminShell.test.tsx
+++ b/WebUI/src/test/ts/admin/AdminShell.test.tsx
@@ -46,11 +46,19 @@ function renderShell(ui: React.ReactElement) {
 }
 
 describe("AdminShell", () => {
-  it("renders administration shell title and default active tab", () => {
+  it("renders Admin tools title and Administration sibling (#2953)", () => {
     renderShell(<AdminShell />);
     expect(screen.getByTestId("perc-admin-shell")).toBeDefined();
     expect(screen.getByTestId("mock-tasks-section")).toBeDefined();
-    expect(screen.getByTestId("admin-sibling-workflow-link")).toBeDefined();
+    // Shell title must read Admin tools (not Administration) — #2784 landing.
+    expect(screen.getByTestId("perc-admin-shell-title").textContent).toMatch(
+      /Admin tools/i,
+    );
+    const sibling = screen.getByTestId("admin-sibling-workflow-link");
+    expect(sibling).toBeDefined();
+    expect(sibling.textContent).toMatch(/Administration/i);
+    const href = sibling.getAttribute("href") || "";
+    expect(href === "/workflow" || href.endsWith("/workflow")).toBe(true);
   });
 
   it("exposes responsive tablist chrome for narrow / portrait layouts", () => {

--- a/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
@@ -46,11 +46,16 @@ function renderShell(ui: React.ReactElement) {
 }
 
 describe("WorkflowAdminShell", () => {
-  it("renders shell title and default active tab", () => {
+  it("renders shell title and Admin tools sibling (#2953)", () => {
     renderShell(<WorkflowAdminShell />);
     expect(screen.getByTestId("perc-workflow-admin-shell")).toBeTruthy();
     expect(screen.getByTestId("mock-workflow-section")).toBeTruthy();
-    expect(screen.getByTestId("admin-sibling-tools-link")).toBeTruthy();
+    expect(screen.getByTestId("perc-workflow-admin-shell-title")).toBeTruthy();
+    const sibling = screen.getByTestId("admin-sibling-tools-link");
+    expect(sibling).toBeTruthy();
+    expect(sibling.textContent).toMatch(/Admin tools/i);
+    const href = sibling.getAttribute("href") || "";
+    expect(href === "/admin" || href.endsWith("/admin")).toBe(true);
   });
 
   it("exposes responsive tablist chrome for narrow / portrait layouts", () => {

--- a/docs/ai-generated/code-reviews/issue-2953-admin-tools-nav-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2953-admin-tools-nav-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #2953 Admin tools nav
+
+**Scope:** uncommitted + branch `fix/issue-2953-admin-tools-nav` vs `origin/main`  
+**Modules:** WebUI (AdminShell title/i18n, sibling testids), perc-qa-automation (Playwright surface), product-docs/8.2/admin  
+**Date:** 2026-08-11
+
+## Summary
+
+After #2784, consolidated top-nav **Admin** correctly lands on `/admin` (Admin tools shell) with an **Administration** sibling to `/workflow`. The shell **page title** still used `perc.ui.admin@Administration`, so operators saw “Administration” as both the H1 and the sibling label and reported the Admin tools affordance as missing (#2953).
+
+Fix reuses the existing localized key `perc.ui.dashboard.modern@Admin tools` for `ADMIN_MSG.ADMIN_TITLE`, adds stable title testids, hardens Vitest sibling href/label assertions, extends Playwright bidirectional sibling navigation, and documents SPA Admin navigation in product-docs.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none
+- Behavioral tests: Vitest AdminShell + WorkflowAdminShell sibling/title; topNavConfig landing already covered; Playwright surface extended
+- Cross-platform paths: N/A (no filesystem path construction)
+- Change-class companions: WebUI unit + Playwright + product-docs present
+- May commit/push: **yes**
+
+## Issues
+
+None (blocking).
+
+### Low / nits
+
+- Issue body expected landing on Workflow Administration; product intent from #2784 is Admin tools landing — this PR follows #2784 and triage disposition. Human QA should confirm against product intent.
+- Live Playwright against QA H2 not run in this agent session (`agent_safe_only`); Vitest green; surface spec updated for CI/QA mode.
+
+## Build evidence
+
+- `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Vitest 1789 passed; Surefire Tests run: 37
+- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS

--- a/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/top-nav-restructure.spec.js
@@ -16,11 +16,12 @@
  */
 
 /**
- * Top navigation restructure (#2702 / #2784):
+ * Top navigation restructure (#2702 / #2784 / #2953):
  * - Dashboard removed from SPA top chrome
  * - Explorer immediately after Home
  * - Single consolidated Admin (no separate Administration + Admin tools)
  * - Admin lands on working Admin tools shell (/admin); Workflow via sibling
+ * - Admin tools shell title + Administration sibling; /workflow → Admin tools sibling
  *
  * Surface-filtered only:
  *   npm run test:surface -- --path tests/top-nav-restructure.spec.js
@@ -76,16 +77,28 @@ test.describe("Top nav restructure (#2702)", () => {
     });
     expect(adjacency).toBe(true);
 
-    // Consolidated Admin lands on working Admin tools shell (#2784)
+    // Consolidated Admin lands on working Admin tools shell (#2784 / #2953)
     await admin.click();
     await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
       timeout: 30_000,
     });
+    await expect(page.getByTestId("perc-admin-shell-title")).toContainText(
+      /Admin tools/i,
+    );
     // Workflow administration still reachable from Admin tools sibling link
     const workflowLink = page.getByTestId("admin-sibling-workflow-link");
     await expect(workflowLink).toBeVisible();
+    await expect(workflowLink).toContainText(/Administration/i);
     await workflowLink.click();
     await expect(page.getByTestId("perc-workflow-admin-shell")).toBeVisible({
+      timeout: 30_000,
+    });
+    // Deep-linked Administration surface must offer Admin tools sibling (#2953)
+    const toolsLink = page.getByTestId("admin-sibling-tools-link");
+    await expect(toolsLink).toBeVisible();
+    await expect(toolsLink).toContainText(/Admin tools/i);
+    await toolsLink.click();
+    await expect(page.getByTestId("perc-admin-shell")).toBeVisible({
       timeout: 30_000,
     });
   });

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -12,6 +12,19 @@ tags: [admin]
 Operator and administrator topics for Percussion CMS 8.2 — Sites, security, publishing, and
 day-two server operations.
 
+## Product Admin navigation (SPA)
+
+The top navigation exposes a **single Admin** item for administrators:
+
+1. **Admin** opens the **Admin tools** shell (scheduled tasks, execution logs, notification
+   settings, and system tools such as the security audit log and consistency checker).
+2. From Admin tools, use the **Administration** sibling link (page header, right side) to open
+   workflow / users / roles / categories administration.
+3. From Administration, use the **Admin tools** sibling link to return to the tools shell.
+
+There are no separate top-nav entries for Administration and Admin tools. Both surfaces share
+the consolidated Admin highlight in the top bar.
+
 ## Topics
 
 - [Sites & content structure](id:admin-sites)


### PR DESCRIPTION
## Summary

Restores the consolidated **Admin tools** navigation affordance reported missing in #2953 (related #2784 / #2702).

After #2784, top-nav **Admin** correctly lands on `/admin` (Admin tools shell) with an **Administration** sibling to `/workflow`. The Admin tools shell **page title** still used `perc.ui.admin@Administration`, so operators saw **Administration** as both the H1 and the sibling label and reported that the Admin tools link was missing.

### Changes

- `ADMIN_MSG.ADMIN_TITLE` → localized `perc.ui.dashboard.modern@Admin tools` (reuse existing TMX key)
- Stable title testids on Admin tools + Workflow admin shells
- Vitest asserts title text + sibling label/href on both shells
- Playwright surface: Admin → Admin tools title + Administration sibling → Administration shell + Admin tools sibling → back
- Product docs: SPA Admin navigation note under `product-docs/8.2/admin/index.md`

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2953  
Refs #2784 #2702

## Test plan

- [x] `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS
- [x] Vitest: AdminShell / WorkflowAdminShell sibling + title assertions
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
- [ ] QA mode (optional/human): `perc-devctl qa-up` → `npm run test:surface -- --path tests/top-nav-restructure.spec.js`
- [ ] Manual: Admin top-nav → title **Admin tools** → sibling **Administration** → sibling **Admin tools**

## Product documentation

- [x] Updated pages under `product-docs/` (`product-docs/8.2/admin/index.md` — SPA Admin navigation)

## Build evidence (C3)

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` → **BUILD SUCCESS**; Surefire Tests run: 37, Failures: 0; Vitest Test Files 257 passed / Tests **1789** passed
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- **downstream_checked:** none (no public Java API shape change; UI/i18n/label + docs only)

## Erlang

Approve — see `docs/ai-generated/code-reviews/issue-2953-admin-tools-nav-erlang.md`

> Co-Authored by Grok Build using grok-4.5 with agent main.
