### PR TITLE
fix(perc-toolkit): clear test-source Xlint residual 46→0 (#2030)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2030-perc-toolkit-xlint-test-source-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2030-perc-toolkit-xlint-test-source-erlang.md
@@ -1,0 +1,62 @@
+# Erlang review: issue #2030 perc-toolkit test-source Xlint
+
+**Date:** 2026-08-11  
+**Branch:** `fix/issue-2030-perc-toolkit-xlint-residual`  
+**Scope:** Uncommitted changes in `modules/perc-toolkit` test sources only  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+Clears remaining **test-source** project `-Xlint` diagnostics for `perc-toolkit` after main-source was already at 0 (#2658 / #2419). Real generics / typed matchers / static-method qualification — no blanket `@SuppressWarnings`.
+
+**Diagnostic inventory (project `-Xlint`):**
+
+| Phase | Before | After |
+|-------|--------|-------|
+| main compile | 0 | 0 |
+| test compile | 46 | 0 |
+| javadoc | ~100 (capped report) | unchanged (out of this PR) |
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none
+- Behavioral tests: existing suite exercises the typed call sites; tests still green (245 run, 0 fail, 16 skipped)
+- Cross-platform paths: N/A (no path/file I/O in diff)
+- **May commit/push: yes**
+
+## Issues
+
+None blocking.
+
+### Nits (non-blocking)
+
+- Residual **Javadoc** (~100 warnings) remains for a follow-up residual under #2030 acceptance (javac+javadoc zero). Not introduced by this PR.
+- Deprecation still surfaces as compiler **INFO** (`-Xlint:-deprecation` in parent); not project WARNING under current `-Xlint` set.
+
+## Files reviewed
+
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/jexl/PSOListToolsTest.java`
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/imageedit/data/MasterImageMetaDataTest.java`
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/preview/SiteFolderFinderImplTest.java`
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/preview/ActionPreviewControllerTest.java`
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/preview/ConfigurableSiteLoaderImplTest.java`
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/utils/MutableHttpServletRequestWrapperTest.java`
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/utils/SimplifyParameterMapTest.java`
+- `modules/perc-toolkit/src/test/java/test/percussion/pso/validation/PSOUniqueFieldWithInFoldersValidatorTest.java`
+
+## Build evidence
+
+```text
+cd modules/perc-toolkit && ../../mvnw.cmd clean install
+BUILD SUCCESS
+Tests run: 245, Failures: 0, Errors: 0, Skipped: 16
+testCompile primary file:line [WARNING]: 0
+```
+
+Memory patterns hit: prefer real generics over suppress; typed Mockito matchers (`anyList` / typed `any()`); qualify static setters by type name.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/imageedit/data/MasterImageMetaDataTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/imageedit/data/MasterImageMetaDataTest.java
@@ -52,7 +52,7 @@ public class MasterImageMetaDataTest {
       cut.setSysTitle("sys title");
       cut.setDisplayTitle("display title");
       cut.setDescription("This is the description");
-      Map description = BeanUtils.describe(cut);
+      Map<?, ?> description = BeanUtils.describe(cut);
       assertTrue(description.size() > 0);
       log.info("Master Image Metadata : " + description);
 

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/jexl/PSOListToolsTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/jexl/PSOListToolsTest.java
@@ -33,40 +33,40 @@ import org.junit.jupiter.api.Test;
 
 public class PSOListToolsTest {
 
-  private Collection emptyList;
-  private Collection nullCollection = null;
+  private Collection<String> emptyList;
+  private Collection<String> nullCollection = null;
   private Collection<String> stringVectorSingle;
   private Collection<String> stringVectorThree;
   private String[] stringArrayThree;
   private Vector<String> stringVectorTen;
   private Set<Integer> integerSetFour;
-  private Object[] nullArray;
+  private String[] nullArray;
   // private Object[] emptyArray;
   private PSOListTools listTools;
 
   @BeforeEach
   protected void setUp() throws Exception {
     listTools = new PSOListTools();
-    emptyList = new ArrayList();
+    emptyList = new ArrayList<>();
     nullArray = null;
     // emptyArray = new Object[] {};
-    stringVectorSingle = new Vector<String>();
+    stringVectorSingle = new Vector<>();
     stringVectorSingle.add("one");
-    stringVectorThree = new Vector<String>();
+    stringVectorThree = new Vector<>();
     stringVectorThree.add("a");
     stringVectorThree.add("b");
     stringVectorThree.add("c");
 
     stringArrayThree = new String[] {"a", "b", "c"};
 
-    stringVectorTen = new Vector<String>();
+    stringVectorTen = new Vector<>();
     String[] tenArray =
         new String[] {
           "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"
         };
     Collection<String> tenList = Arrays.asList(tenArray);
     stringVectorTen.addAll(tenList);
-    integerSetFour = new HashSet<Integer>();
+    integerSetFour = new HashSet<>();
     integerSetFour.add(0);
     integerSetFour.add(1);
     integerSetFour.add(2);
@@ -108,9 +108,9 @@ public class PSOListToolsTest {
      *  sublist(["a","b","c"], -2, -1) = ["b"]
      *  sublist(["a","b","c"], -4, 2)  = ["a","b"]
      */
-    List ab = Arrays.asList("a", "b");
-    List c = Arrays.asList("c");
-    List b = Arrays.asList("b");
+    List<String> ab = Arrays.asList("a", "b");
+    List<String> c = Arrays.asList("c");
+    List<String> b = Arrays.asList("b");
     assertNotNull(listTools.sublist(emptyList, 5, 6), "Empty collection should not be null");
     assertNotNull(
         listTools.sublist(nullCollection, 3, 4),
@@ -118,19 +118,19 @@ public class PSOListToolsTest {
     assertTrue(listTools.sublist(emptyList, 5, 6).size() == 0, "List should be empty");
 
     //// sublist(["a","b","c"], 0, 3)   = ["a","b","c"]
-    List abcTest = listTools.sublist(stringVectorThree, 0, 3);
+    List<String> abcTest = listTools.sublist(stringVectorThree, 0, 3);
     assertTrue(ListUtils.isEqualList(abcTest, stringVectorThree), "List should be equal");
 
     // sublist(["a","b","c"], 2, 4)   = ["c"]
-    List cTest = listTools.sublist(stringVectorThree, 2, 4);
+    List<String> cTest = listTools.sublist(stringVectorThree, 2, 4);
     assertTrue(ListUtils.isEqualList(cTest, c), "List should be equal to [\"c\"] but is " + cTest);
 
     // sublist(["a","b","c"], 0, 2)   = ["a","b"]
-    List abTest = listTools.sublist(stringVectorThree, 0, 2);
+    List<String> abTest = listTools.sublist(stringVectorThree, 0, 2);
     assertTrue(ListUtils.isEqualList(abTest, ab), "List should be equal to ['a','b'] ");
 
     // sublist(["a","b","c"], -2, -1) = ["b"]
-    List bTest = listTools.sublist(stringVectorThree, -2, -1);
+    List<String> bTest = listTools.sublist(stringVectorThree, -2, -1);
     assertTrue(ListUtils.isEqualList(bTest, b), "List should be equal to ['b'] ");
 
     // sublist(["a","b","c"], -4, 2)  = ["a","b"]
@@ -143,14 +143,14 @@ public class PSOListToolsTest {
    */
   @Test
   public void testSublistCollectionStringString() {
-    List ab = Arrays.asList("a", "b");
-    List b = Arrays.asList("b");
+    List<String> ab = Arrays.asList("a", "b");
+    List<String> b = Arrays.asList("b");
     // sublist(["a","b","c"], -2, -1) = ["b"]
-    List bTest = listTools.sublist(stringVectorThree, "-2", "-1");
+    List<String> bTest = listTools.sublist(stringVectorThree, "-2", "-1");
     assertTrue(ListUtils.isEqualList(bTest, b), "List should be equal to ['b'] ");
 
     // sublist(["a","b","c"], -4, 2)  = ["a","b"]
-    List abTest = listTools.sublist(stringVectorThree, "-4", "2");
+    List<String> abTest = listTools.sublist(stringVectorThree, "-4", "2");
     assertTrue(ListUtils.isEqualList(abTest, ab), "List should be equal to ['a','b']");
     try {
       listTools.sublist(stringVectorThree, "wef", "");
@@ -164,10 +164,10 @@ public class PSOListToolsTest {
    */
   @Test
   public void testSublistObjectArrayIntInt() {
-    List abc = Arrays.asList("a", "b", "c");
-    List ab = Arrays.asList("a", "b");
-    List c = Arrays.asList("c");
-    List b = Arrays.asList("b");
+    List<String> abc = Arrays.asList("a", "b", "c");
+    List<String> ab = Arrays.asList("a", "b");
+    List<String> c = Arrays.asList("c");
+    List<String> b = Arrays.asList("b");
 
     assertNotNull(listTools.sublist(emptyList, 5, 6), "Empty collection should not be null");
     assertNotNull(
@@ -176,19 +176,19 @@ public class PSOListToolsTest {
     assertTrue(listTools.sublist(nullArray, 5, 6).size() == 0, "List should be empty");
 
     //// sublist(["a","b","c"], 0, 3)   = ["a","b","c"]
-    List abcTest = listTools.sublist(stringArrayThree, 0, 3);
+    List<String> abcTest = listTools.sublist(stringArrayThree, 0, 3);
     assertTrue(ListUtils.isEqualList(abcTest, abc), "List should be equal");
 
     // sublist(["a","b","c"], 2, 4)   = ["c"]
-    List cTest = listTools.sublist(stringArrayThree, 2, 4);
+    List<String> cTest = listTools.sublist(stringArrayThree, 2, 4);
     assertTrue(ListUtils.isEqualList(cTest, c), "List should be equal to [\"c\"] but is " + cTest);
 
     // sublist(["a","b","c"], 0, 2)   = ["a","b"]
-    List abTest = listTools.sublist(stringArrayThree, 0, 2);
+    List<String> abTest = listTools.sublist(stringArrayThree, 0, 2);
     assertTrue(ListUtils.isEqualList(abTest, ab), "List should be equal to ['a','b'] ");
 
     // sublist(["a","b","c"], -2, -1) = ["b"]
-    List bTest = listTools.sublist(stringArrayThree, -2, -1);
+    List<String> bTest = listTools.sublist(stringArrayThree, -2, -1);
     assertTrue(ListUtils.isEqualList(bTest, b), "List should be equal to ['b'] ");
 
     // sublist(["a","b","c"], -4, 2)  = ["a","b"]
@@ -201,14 +201,14 @@ public class PSOListToolsTest {
    */
   @Test
   public void testSublistObjectArrayStringString() {
-    List ab = Arrays.asList("a", "b");
-    List b = Arrays.asList("b");
+    List<String> ab = Arrays.asList("a", "b");
+    List<String> b = Arrays.asList("b");
     // sublist(["a","b","c"], -2, -1) = ["b"]
-    List bTest = listTools.sublist(stringArrayThree, "-2", "-1");
+    List<String> bTest = listTools.sublist(stringArrayThree, "-2", "-1");
     assertTrue(ListUtils.isEqualList(bTest, b), "List should be equal to ['b'] ");
 
     // sublist(["a","b","c"], -4, 2)  = ["a","b"]
-    List abTest = listTools.sublist(stringArrayThree, "-4", "2");
+    List<String> abTest = listTools.sublist(stringArrayThree, "-4", "2");
     assertTrue(ListUtils.isEqualList(abTest, ab), "List should be equal to ['a','b']");
     try {
       listTools.sublist(stringArrayThree, "wef", "");

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/preview/ActionPreviewControllerTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/preview/ActionPreviewControllerTest.java
@@ -118,7 +118,7 @@ public class ActionPreviewControllerTest {
       Mockito.when(
               urlbuilder.buildUrl(
                   Mockito.any(IPSAssemblyTemplate.class),
-                  Mockito.any(Map.class),
+                  Mockito.<Map<String, Object>>any(),
                   Mockito.any(SiteFolderLocation.class),
                   Mockito.any(Boolean.class)))
           .thenReturn("http://localhost/foo/bar/baz");

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/preview/ConfigurableSiteLoaderImplTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/preview/ConfigurableSiteLoaderImplTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
+import com.percussion.pso.preview.CachingSiteLoaderImpl;
 import com.percussion.pso.preview.ConfigurableSiteLoaderImpl;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.sitemgr.IPSSiteManager;
@@ -46,7 +47,7 @@ public class ConfigurableSiteLoaderImplTest {
   @BeforeEach
   public void setUp() {
     cut = new ConfigurableSiteLoaderImpl();
-    cut.setSiteMgr(siteMgr);
+    CachingSiteLoaderImpl.setSiteMgr(siteMgr);
   }
 
   @Test

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/preview/SiteFolderFinderImplTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/preview/SiteFolderFinderImplTest.java
@@ -198,7 +198,7 @@ public class SiteFolderFinderImplTest {
       when(mySite.getFolderRoot()).thenReturn("//Sites/foo");
       when(mySite.getName()).thenReturn("foo");
       when(mySite.getGUID()).thenReturn(new PSLegacyGuid(300, 1));
-      when(secws.filterByRuntimeVisibility(any(List.class)))
+      when(secws.filterByRuntimeVisibility(anyList()))
           .thenReturn(Collections.singletonList(new PSLegacyGuid(300, 1)));
 
       List<SiteFolderLocation> locs = cut.findSiteFolderLocations("1", "2", null);
@@ -209,7 +209,7 @@ public class SiteFolderFinderImplTest {
       SiteFolderLocation rloc = locs.get(0);
       assertEquals("//Sites/foo/bar/baz/foo", rloc.getFolderPath());
       verify(gmgr).makeGuid(any(PSLocator.class));
-      verify(secws).filterByRuntimeVisibility(any(List.class));
+      verify(secws).filterByRuntimeVisibility(anyList());
     } catch (Exception ex) {
       log.error("Unexpected Exception " + ex, ex);
       fail("Exception caught");

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/MutableHttpServletRequestWrapperTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/MutableHttpServletRequestWrapperTest.java
@@ -101,19 +101,19 @@ public class MutableHttpServletRequestWrapperTest {
     assertNotNull(h1);
     assertEquals("bat", h1);
 
-    Enumeration e = cut.getHeaders("baz");
-    List<String> s = new ArrayList<String>();
+    Enumeration<String> e = cut.getHeaders("baz");
+    List<String> s = new ArrayList<>();
     while (e.hasMoreElements()) {
-      s.add((String) e.nextElement());
+      s.add(e.nextElement());
     }
     assertEquals(2, s.size());
     assertTrue(s.contains("bat"));
     assertTrue(s.contains("ball"));
 
     e = cut.getHeaders("foo");
-    s = new ArrayList<String>();
+    s = new ArrayList<>();
     while (e.hasMoreElements()) {
-      s.add((String) e.nextElement());
+      s.add(e.nextElement());
     }
     assertEquals(1, s.size());
     assertTrue(s.contains("bar"));
@@ -123,8 +123,8 @@ public class MutableHttpServletRequestWrapperTest {
   public final void testGetHeaderNames() {
     cut.setHeader("baz", "bat");
 
-    Enumeration e = cut.getHeaderNames();
-    List<String> s = new ArrayList<String>();
+    Enumeration<String> e = cut.getHeaderNames();
+    List<String> s = new ArrayList<>();
     addAll(s, e);
     assertEquals(2, s.size());
     /*

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/SimplifyParameterMapTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/utils/SimplifyParameterMapTest.java
@@ -93,7 +93,7 @@ public class SimplifyParameterMapTest {
     assertEquals("fee", result.get(0));
     assertEquals("fum", result.get(2));
 
-    List in = Arrays.asList(arr);
+    List<String> in = Arrays.asList(arr);
     result = SimplifyParameters.getValueAsList(in);
     assertEquals(3, result.size());
     assertEquals("fee", result.get(0));

--- a/modules/perc-toolkit/src/test/java/test/percussion/pso/validation/PSOUniqueFieldWithInFoldersValidatorTest.java
+++ b/modules/perc-toolkit/src/test/java/test/percussion/pso/validation/PSOUniqueFieldWithInFoldersValidatorTest.java
@@ -269,7 +269,7 @@ public class PSOUniqueFieldWithInFoldersValidatorTest {
   public void testIsPromotable() {
     final IPSSystemWs systemWs = mock(IPSSystemWs.class);
     validator.setSystemWs(systemWs);
-    final List<PSRelationship> emptyRels = Collections.EMPTY_LIST;
+    final List<PSRelationship> emptyRels = Collections.emptyList();
     final PSRelationship rel1 = mock(PSRelationship.class);
     final List<PSRelationship> oneRels = Collections.<PSRelationship>singletonList(rel1);
 


### PR DESCRIPTION
## Summary

Clears remaining **test-source** project `-Xlint` diagnostics for **perc-toolkit** after main-source was already at **0** (PR #2658 / #2419).

**Live project `-Xlint` inventory:**

| Phase | Before this PR | After |
|-------|----------------|-------|
| main compile | 0 | 0 |
| test compile | **46** | **0** |

Parent tracker: #2200  
Module tracker: #2030  
Prior batches: #2169, #2420, #2658 / #2419

### Approach (prefer real patterns)

| Area | Fix |
|------|-----|
| `PSOListToolsTest` | Parameterize `Collection`/`List`/`ArrayList`/`nullArray` |
| `MasterImageMetaDataTest` | `Map<?, ?>` for `BeanUtils.describe` |
| `SiteFolderFinderImplTest` | `anyList()` matchers for `filterByRuntimeVisibility` |
| `ActionPreviewControllerTest` | typed `Mockito.<Map<String, Object>>any()` |
| `ConfigurableSiteLoaderImplTest` | `CachingSiteLoaderImpl.setSiteMgr(...)` (static) |
| `MutableHttpServletRequestWrapperTest` | `Enumeration<String>` |
| `SimplifyParameterMapTest` | `List<String>` for `Arrays.asList` |
| `PSOUniqueFieldWithInFoldersValidatorTest` | `Collections.emptyList()` |

No blanket `@SuppressWarnings`. No production API changes.

## Test plan

- [x] `cd modules/perc-toolkit && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **245**, Failures: **0**, Errors: **0**, Skipped: **16**
- [x] testCompile primary `*.java:[` WARNING count **0** (was 46)
- [x] Erlang: `docs/ai-generated/code-reviews/issue-2030-perc-toolkit-xlint-test-source-erlang.md` — **approve**

### C3 evidence

- **modules_built:** `modules/perc-toolkit`
- **build_evidence:** `cd modules/perc-toolkit && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 245, Failures: 0, Errors: 0, Skipped: 16; main Xlint 0; test Xlint 46→0
- **downstream_checked:** none (test-only changes; C2 final/API shape N/A)

## Product documentation

- [x] N/A — pure tech-debt test-source Xlint cleanup; no operator/user/API/product surface change

## Residual

- **Javadoc:** ~100 warnings remain under maven-javadoc-plugin (separate residual child for #2030 full acceptance).
- Main-source project `-Xlint`: already 0 (prior #2658).

## Partial / Fixes

Partial for #2030 (javac Xlint now zero main+test; javadoc residual remains).  
Refs #2030 #2200 #2419 #2420

## Gates

- Erlang pre-commit: PASS (approve)
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
