### PR TITLE
fix(perc-system): design.objectstore this-escape residual leaf finals (#2871)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2871-design-objectstore-this-escape-residual-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2871-design-objectstore-this-escape-residual-erlang.md
@@ -1,0 +1,31 @@
+# Erlang review — issue #2871 design.objectstore this-escape residual
+
+**Reviewer persona:** Erlang (strict pre-commit)  
+**Change class:** design.objectstore this-escape residual batch (final leaf classes + final parent-list helpers)  
+**Module:** `system` / perc-system  
+**Parent:** #2022 / #2200 · Prior: #2465 (never landed on main; re-applied leaf finals) · PR open thrash note: #2952
+
+## Summary
+
+PR-sized residual after #2465 inventory: make ~50 monorepo-leaf `design.objectstore` types `final`, and seal `PSComponent` / `PSCollectionComponent` parent-list helpers (`updateParentList` / `resetParentList` / `applyId`) so Element/fromXml constructors no longer trip `-Xlint:this-escape` via overridable bookkeeping.
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in new logic | None — class-final + helper-final only; no behavior change |
+| Behavioral unit tests | Extended `PSDesignObjectStoreThisEscapeTest` (+ CE/FieldSet/role/directory/auth) |
+| Cross-platform paths | N/A — no path I/O |
+| Product docs | N/A — compiler hygiene / non-operator-facing |
+| Subclass blast radius | Grep `extends <Type>` for all finalized types; zero monorepo subclasses |
+| Blanket `@SuppressWarnings("this-escape")` | Not used |
+| Thrash vs open PRs | Class-declaration-only finals minimize conflict with #2952 parentComponents retypes on same files; base helpers only sealed as `final` (no signature retype) |
+
+## Cannot-finalize (documented residual)
+
+Left non-final with external subclasses: `PSServerConfiguration` (+ legacy), `PSRelationship` (+ AA / RxFix), `PSRelationshipConfig` / `PSRelationshipConfigSet` (+ install upgrade), `PSPipe`, `PSDataSet`, `PSEntry`, `PSConditional`, `PSUrlRequest`, `PSStylesheet`, deployer `PSDependency`. Need private base-load if further this-escape remains.
+
+## Risk notes
+
+- Making types `final` is a binary-compatible change for callers that do not subclass; monorepo has no subclasses of the batch.
+- `copyFrom` now uses `applyId` so id assignment during copy is non-virtual (matches #2465 intent).

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplication.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplication.java
@@ -54,7 +54,7 @@ import org.w3c.dom.NodeList;
  * @since 1.0
  */
 @SuppressWarnings(value = {"unchecked"})
-public class PSApplication implements IPSDocument {
+public final class PSApplication implements IPSDocument {
   /**
    * Specialized wrapper class that takes a <code>PSDataSet</code> and uses only the request name
    * and parameters to determine equivalence. Used in validation to determine if two datasets in the

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Node;
  * to <code>true</code>.
  */
 @SuppressWarnings("serial")
-public class PSApplicationFlow extends PSComponent {
+public final class PSApplicationFlow extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
@@ -39,7 +39,7 @@ import org.w3c.dom.Node;
  * A component that holds one authentication definition used to connect with directory servers. See
  * the toXml(Document) method for the DTD description.
  */
-public class PSAuthentication extends PSComponent {
+public final class PSAuthentication extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
@@ -36,7 +36,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSBackEndDataTank extends PSComponent {
+public final class PSBackEndDataTank extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implements the PSXChoices DTD in BasicObjects.dtd. */
-public class PSChoices extends PSComponent {
+public final class PSChoices extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSCollectionComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCollectionComponent.java
@@ -170,10 +170,13 @@ public abstract class PSCollectionComponent extends com.percussion.util.PSCollec
    * <p>After a call to this method, the caller should keep get the size of the arraylist so that a
    * call to resetParentList can be made (with size - 1) to allow for proper reset.
    *
+   * <p>Final so Element constructors / fromXml can call this without this-escape (parallel to
+   * {@link PSComponent#updateParentList}).
+   *
    * @param parentComponents the parent list
    * @return the new parent list (in case parentComponents was null)
    */
-  protected List updateParentList(List parentComponents) {
+  protected final List updateParentList(List parentComponents) {
     if (parentComponents == null) parentComponents = new ArrayList<>();
 
     parentComponents.add(this);
@@ -182,12 +185,13 @@ public abstract class PSCollectionComponent extends com.percussion.util.PSCollec
   }
 
   /**
-   * Reset the list of parent objects in the array list to the specified size.
+   * Reset the list of parent objects in the array list to the specified size. Final so fromXml load
+   * paths can reset the parent stack without this-escape.
    *
    * @param parentComponents the parent list
    * @param size the size to set the list to
    */
-  protected void resetParentList(List parentComponents, int size) {
+  protected final void resetParentList(List parentComponents, int size) {
     if (parentComponents == null) return;
 
     if (size == 0) parentComponents.clear();

--- a/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Node;
  * evaluating to <code>true</code>.
  */
 @SuppressWarnings("serial")
-public class PSCommandHandlerStylesheets extends PSComponent {
+public final class PSCommandHandlerStylesheets extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSComponent.java
@@ -57,6 +57,15 @@ public abstract class PSComponent implements IPSComponent, Serializable {
    * @param id the to assign the component
    */
   public void setId(int id) {
+    applyId(id);
+  }
+
+  /**
+   * Non-overridable id assignment for construction and {@link #setId(int)}. Subclasses that need
+   * custom setId rules still override {@link #setId(int)}; ctors that only store the id field
+   * should assign {@link #m_id} or call this helper.
+   */
+  protected final void applyId(int id) {
     m_id = id;
   }
 
@@ -68,7 +77,7 @@ public abstract class PSComponent implements IPSComponent, Serializable {
    */
   public void copyFrom(PSComponent c) {
     if (null == c) throw new IllegalArgumentException("Invalid object for copy");
-    setId(c.getId());
+    applyId(c.getId());
   }
 
   /**
@@ -127,10 +136,13 @@ public abstract class PSComponent implements IPSComponent, Serializable {
    * <p>After a call to this method, the caller should keep get the size of the arraylist so that a
    * call to resetParentList can be made (with size - 1) to allow for proper reset.
    *
+   * <p>Final so Element constructors / private fromXmlBase helpers can call this without
+   * this-escape (no external override of parent-list bookkeeping).
+   *
    * @param parentComponents the parent list
    * @return the new parent list (in case parentComponents was null)
    */
-  protected List<IPSComponent> updateParentList(List<IPSComponent> parentComponents) {
+  protected final List<IPSComponent> updateParentList(List<IPSComponent> parentComponents) {
     if (parentComponents == null) parentComponents = new ArrayList<>();
 
     parentComponents.add(this);
@@ -139,12 +151,13 @@ public abstract class PSComponent implements IPSComponent, Serializable {
   }
 
   /**
-   * Reset the list of parent objects in the array list to the specified size.
+   * Reset the list of parent objects in the array list to the specified size. Final so fromXml load
+   * paths can reset the parent stack without this-escape.
    *
    * @param parentComponents the parent list
    * @param size the size to set the list to
    */
-  protected void resetParentList(List<?> parentComponents, int size) {
+  protected final void resetParentList(List<?> parentComponents, int size) {
     if (parentComponents == null) return;
 
     if (size == 0) parentComponents.clear();

--- a/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implements the PSXContainerLocator DTD defined in BasicObjects.dtd. */
-public class PSContainerLocator extends PSComponent {
+public final class PSContainerLocator extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
@@ -36,7 +36,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implements the PSXContentEditorLocalDef DTD defined in ContentEditorLocalDef.dtd. */
-public class PSContentEditor extends PSDataSet {
+public final class PSContentEditor extends PSDataSet {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
@@ -33,7 +33,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implements the PSXContentEditorMapper DTD defined in ContentEditorLocalDef.dtd. */
-public class PSContentEditorMapper extends PSComponent {
+public final class PSContentEditorMapper extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implements the PSXContentEditorPipe DTD defined in ContentEditorLocalDef.dtd. */
-public class PSContentEditorPipe extends PSPipe {
+public final class PSContentEditorPipe extends PSPipe {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSharedDef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSharedDef.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implements the PSXContentEditorSharedDef DTD defined in ContentEditorSharedDef.dtd. */
-public class PSContentEditorSharedDef extends PSComponent implements IPSDocument {
+public final class PSContentEditorSharedDef extends PSComponent implements IPSDocument {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /** Creates a new empty shared content editor definition. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSystemDef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSystemDef.java
@@ -37,7 +37,7 @@ import org.w3c.dom.Element;
  * This class wraps the system def xml document and provides access to the objectstore objects
  * defined within it.
  */
-public class PSContentEditorSystemDef implements IPSDocument {
+public final class PSContentEditorSystemDef implements IPSDocument {
   /**
    * Constructor for this class that takes a source document.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlMeta.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Element;
  * Represents the metadata for a content editor control, as defined by the
  * &lt;psxctl:ControlMeta&gt; node in <code>sys_LibraryControlDef.dtd</code>
  */
-public class PSControlMeta extends PSComponent {
+public final class PSControlMeta extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlParameter.java
@@ -30,7 +30,7 @@ import org.w3c.dom.NodeList;
  * &lt;psxctl:Param&gt; node in <code>
  * sys_LibraryControlDef.dtd</code>
  */
-public class PSControlParameter extends PSComponent {
+public final class PSControlParameter extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXControlRef DTD in BasicObjects.dtd. */
-public class PSControlRef extends PSComponent {
+public final class PSControlRef extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implementation for the PSCustomActionGroup DTD in BasicObjects.dtd. */
-public class PSCustomActionGroup extends PSComponent {
+public final class PSCustomActionGroup extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataMapper.java
@@ -38,7 +38,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSDataMapper extends PSCollectionComponent {
+public final class PSDataMapper extends PSCollectionComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataMapping.java
@@ -40,7 +40,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSDataMapping extends PSComponent {
+public final class PSDataMapping extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSelector.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSelector.java
@@ -47,7 +47,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSDataSelector extends PSComponent {
+public final class PSDataSelector extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSynchronizer.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSynchronizer.java
@@ -36,7 +36,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSDataSynchronizer extends PSComponent {
+public final class PSDataSynchronizer extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
@@ -34,7 +34,7 @@ import org.w3c.dom.Node;
  * A component that holds one directory definition used to catalog information from directory
  * servers.
  */
-public class PSDirectory extends PSComponent {
+public final class PSDirectory extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Element;
  * Collection container for <code>PSReference</code> objects which all reference a <code>PSDirectory
  * </code> object.
  */
-public class PSDirectorySet extends PSCollectionComponent {
+public final class PSDirectorySet extends PSCollectionComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXDisplayMapper DTD in BasicObjects.dtd. */
-public class PSDisplayMapper extends PSCollectionComponent {
+public final class PSDisplayMapper extends PSCollectionComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
@@ -24,7 +24,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXDisplayMapping DTD in BasicObjects.dtd. */
-public class PSDisplayMapping extends PSComponent {
+public final class PSDisplayMapping extends PSComponent {
   /** */
   private static final long serialVersionUID = 1L;
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSField.java
@@ -44,7 +44,7 @@ import org.w3c.dom.Node;
  * field specifies something other than PSXBackEndColumn, this field cannot be updated, it's for
  * query only.
  */
-public class PSField extends PSComponent {
+public final class PSField extends PSComponent {
   /** */
   private static final long serialVersionUID = -1837223721972561274L;
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXFieldSet DTD in BasicObjects.dtd. */
-public class PSFieldSet extends PSComponent {
+public final class PSFieldSet extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldTranslation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldTranslation.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXFieldTranslation DTD in BasicObjects.dtd. */
-public class PSFieldTranslation extends PSComponent {
+public final class PSFieldTranslation extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldValidationRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldValidationRules.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implementation for the PSXFieldValidationRules DTD in BasicObjects.dtd. */
-public class PSFieldValidationRules extends PSComponent {
+public final class PSFieldValidationRules extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinition.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** This class is used to define a macro definition. */
-public class PSMacroDefinition extends PSComponent {
+public final class PSMacroDefinition extends PSComponent {
 
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;

--- a/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
@@ -37,7 +37,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSPageDataTank extends PSComponent {
+public final class PSPageDataTank extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSQueryPipe.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSQueryPipe extends PSPipe {
+public final class PSQueryPipe extends PSPipe {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipSet.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** A collection of PSRelationship objects. See PSXRelationshipSet.dtd. */
-public class PSRelationshipSet extends PSCollectionComponent {
+public final class PSRelationshipSet extends PSCollectionComponent {
   /** Constucts an empty relationship set. */
   public PSRelationshipSet() {
     super(PSRelationship.class);

--- a/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRequestor.java
@@ -43,7 +43,7 @@ import org.w3c.dom.Node;
  * @version 1.0
  * @since 1.0
  */
-public class PSRequestor extends PSComponent {
+public final class PSRequestor extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResourceCacheSettings.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Class to represent the cache settings for a resource. */
-public class PSResourceCacheSettings extends PSComponent {
+public final class PSResourceCacheSettings extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPage.java
@@ -40,7 +40,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSResultPage extends PSComponent {
+public final class PSResultPage extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPageSet.java
@@ -34,7 +34,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSResultPageSet extends PSComponent implements IPSResults {
+public final class PSResultPageSet extends PSComponent implements IPSResults {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSResultPager.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSResultPager extends PSComponent {
+public final class PSResultPager extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSRole.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRole.java
@@ -42,7 +42,7 @@ import org.w3c.dom.Element;
  * @see com.percussion.design.objectstore.PSRelativeSubject
  * @see PSCollectionComponent
  */
-public class PSRole extends PSDatabaseComponent implements Comparable, IPSCatalogSummary {
+public final class PSRole extends PSDatabaseComponent implements Comparable, IPSCatalogSummary {
 
   private static final long serialVersionUID = 1L;
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSRoleConfiguration.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRoleConfiguration.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Element;
  * implements IPSDocument so that it can be sent to and retrieved from the administrator (and
  * administration applications i.e. PSRoleSynchronizer) by the server.
  */
-public class PSRoleConfiguration implements IPSDocument {
+public final class PSRoleConfiguration implements IPSDocument {
   private static final Logger log = LogManager.getLogger(PSRoleConfiguration.class);
 
   /** Empty ctor (for fromXml(), fromDb()) */

--- a/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRoleProvider.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Element;
  * A component that holds one directory definition used to catalog information from directory
  * servers.
  */
-public class PSRoleProvider extends PSComponent {
+public final class PSRoleProvider extends PSComponent {
   /** java serial id */
   private static final long serialVersionUID = 1L;
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSRule.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRule.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXRule DTD in BasicObjects.dtd. */
-public class PSRule extends PSComponent {
+public final class PSRule extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSearchConfig.java
@@ -38,7 +38,7 @@ import org.w3c.dom.Element;
  * world, these keys would not be here because they are implementation specific and this object
  * attempts to be unaware of the implementation.
  */
-public class PSSearchConfig extends PSComponent {
+public final class PSSearchConfig extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSharedFieldGroup.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXSharedFieldGroup DTD in ContentEditorSharedDef.dtd. */
 @SuppressWarnings("serial")
-public class PSSharedFieldGroup extends PSComponent {
+public final class PSSharedFieldGroup extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXTableLocator DTD in BasicObjects.dtd. */
-public class PSTableLocator extends PSComponent {
+public final class PSTableLocator extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableSet.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Implementation for the PSXTableSet DTD in BasicObjects.dtd. */
-public class PSTableSet extends PSComponent {
+public final class PSTableSet extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUIDefinition.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implementation for the PSXUIDefinition DTD in BasicObjects.dtd. */
-public class PSUIDefinition extends PSComponent {
+public final class PSUIDefinition extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSUISet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUISet.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Implementation for the PSXUISet DTD in BasicObjects.dtd. */
-public class PSUISet extends PSComponent {
+public final class PSUISet extends PSComponent {
   /** */
   private static final long serialVersionUID = 1L;
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUpdatePipe.java
@@ -36,7 +36,7 @@ import org.w3c.dom.Node;
  * @version 1.0
  * @since 1.0
  */
-public class PSUpdatePipe extends PSPipe {
+public final class PSUpdatePipe extends PSPipe {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWhereClause.java
@@ -38,7 +38,7 @@ import org.w3c.dom.Element;
  * @version 1.0
  * @since 1.0
  */
-public class PSWhereClause extends PSConditional {
+public final class PSWhereClause extends PSConditional {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Element;
  *
  * @see PSContentEditor
  */
-public class PSWorkflowInfo extends PSComponent {
+public final class PSWorkflowInfo extends PSComponent {
   /** Serialization id for {@link java.io.Serializable}. */
   private static final long serialVersionUID = 1L;
 

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectStoreThisEscapeTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectStoreThisEscapeTest.java
@@ -131,6 +131,95 @@ public class PSDesignObjectStoreThisEscapeTest {
   }
 
   @Test
+  public void fieldSetWithFieldElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSField field = new PSField("sys_title", null);
+    field.setType(PSField.TYPE_SYSTEM);
+    PSFieldSet original = new PSFieldSet("body", field);
+    Element elem = original.toXml(doc);
+
+    PSFieldSet restored = new PSFieldSet(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getType(), restored.getType());
+    assertNotNull(restored.get("sys_title"));
+  }
+
+  @Test
+  public void contentEditorValueCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSContentEditor original = new PSContentEditor("ceArticle", 101L, 5);
+    Element elem = original.toXml(doc);
+
+    PSContentEditor restored = new PSContentEditor(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getContentType(), restored.getContentType());
+    assertEquals(original.getWorkflowId(), restored.getWorkflowId());
+  }
+
+  @Test
+  public void roleProviderDirectoryCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSRoleProvider original =
+        new PSRoleProvider("ldapRoles", PSRoleProvider.TYPE_DIRECTORY, "dirSet1");
+    Element elem = original.toXml(doc);
+
+    PSRoleProvider restored = new PSRoleProvider(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertTrue(restored.isDirectoryRoleProvider());
+    assertNotNull(restored.getDirectoryRef());
+    assertEquals("dirSet1", restored.getDirectoryRef().getName());
+  }
+
+  @Test
+  public void directoryValueCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSDirectory original =
+        new PSDirectory(
+            "corpLdap",
+            PSDirectory.CATALOG_SHALLOW,
+            "com.sun.jndi.ldap.LdapCtxFactory",
+            "auth1",
+            "ldap://ldap.example.intsof:389/dc=example,dc=intsof",
+            null);
+    Element elem = original.toXml(doc);
+
+    PSDirectory restored = new PSDirectory(elem, null, null);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getProviderUrl(), restored.getProviderUrl());
+    assertTrue(restored.isShallowCatalogOption());
+    assertEquals(original.getFactory(), restored.getFactory());
+  }
+
+  @Test
+  public void directorySetNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSDirectorySet original = new PSDirectorySet("dirSet1", "uid");
+    Element elem = original.toXml(doc);
+
+    PSDirectorySet restored = new PSDirectorySet(elem);
+    assertEquals(original.getName(), restored.getName());
+  }
+
+  @Test
+  public void authenticationNameCtorAndElementRoundTrip() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    // name, scheme, user, userAttr, pw, filterExtension
+    PSAuthentication original =
+        new PSAuthentication(
+            "auth1",
+            PSAuthentication.SCHEME_SIMPLE,
+            "cn=admin",
+            "uid",
+            "password",
+            null);
+    Element elem = original.toXml(doc);
+
+    PSAuthentication restored = new PSAuthentication(elem, null, null, true);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getScheme(), restored.getScheme());
+  }
+
+  @Test
   public void propertyNameCtorAndElementRoundTrip() throws Exception {
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
     PSProperty original =


### PR DESCRIPTION
## Summary

PR-sized residual for **#2871** after #2465 inventory: clear most remaining `-Xlint:this-escape` in `design.objectstore` via **final leaf classes** + **final parent-list helpers** (not blanket suppress).

### Changes
- `PSComponent` / `PSCollectionComponent`: `final updateParentList` / `resetParentList`; `applyId` helper for non-virtual id assignment in `copyFrom`
- **~50 monorepo-leaf types** made `final` (grep-verified no monorepo subclasses), including:
  - Hotspots: `PSContentEditor`, `PSFieldSet`, `PSRoleProvider`, `PSDirectory`, `PSDirectorySet`, `PSAuthentication`, `PSRole`
  - #2465 never-landed leaves: Application, pipes, mappers, shared def, workflow info, result pages, etc.
  - Editor/field/UI companions: mappers, field validation/translation, choices, table set/locator, etc.
- Tests: `PSDesignObjectStoreThisEscapeTest` (+6 CE/FieldSet/role/directory/auth; **25** in class)

### Residual
After this batch, design.objectstore compile this-escape residual is **only** non-final bases with subclasses:
- `PSEntry`, `PSDataSet` (private `fromXmlBase` already present; `updateParentList` still leaks `this`)
- Follow-up: #2984

### Thrash note
Open cluster #2952 retypes `parentComponents` on many of the same files. This PR only changes class `final` and base helper `final` (minimal signature thrash vs List retypes). Union on merge: keep both `final class` and typed `List<IPSComponent>`.

Parent trackers: #2022 / #2200. Prior: #2465.

## Test plan
- [x] `cd system && ..\mvnw.cmd clean install` (JDK 21)
- [x] BUILD SUCCESS
- [x] Tests run: **1703**, Failures: **0**, Errors: **0**, Skipped: 240
- [x] `PSDesignObjectStoreThisEscapeTest`: 25 tests, 0 failures
- [x] Compile residual this-escape in design.objectstore: only PSEntry + PSDataSet (4 diagnostic lines)
- [x] Grep monorepo `extends <Type>` for all finalized types → **none**
- [x] Product documentation: **N/A** (compiler hygiene; no operator-facing behavior)

## Evidence (C3)

| Field | Value |
|-------|--------|
| modules_built | system |
| build_evidence | `cd system && ..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1703, Failures: 0, Errors: 0, Skipped: 240 |
| downstream_checked | monorepo grep `extends`/`new Type(){` for all finalized types → no reverse subclasses; no perc-toolkit/system test anonymous subclass hits |

## Checklist
- [x] Product documentation — **N/A** (javac this-escape hygiene; no operator/user-facing product behavior)
- [x] Unit tests for changed logic
- [x] Pre-PR Maven standalone clean install green
- [x] Erlang self-review (`docs/ai-generated/code-reviews/issue-2871-design-objectstore-this-escape-residual-erlang.md`)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2871  
Refs #2022 #2200 #2465 #2984

> Co-Authored by Grok Build using grok-4.5 with agent main.
