### PR TITLE
fix(WebUI): make Explorer Server actions toolbar identifiable (#2972)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
@@ -34,29 +34,26 @@
  * align types to the live DTOs per constitution II (Evidence Over
  * Invention).</p>
  *
- * <p><strong>Wire-format notes (verified 2026-07-20 against the live
- * docker dev CMS at {@code http://localhost:9992}):</strong></p>
+ * <p><strong>Wire-format notes (verified 2026-07-20 / rechecked 2026-08-11
+ * on QA H2):</strong></p>
  * <ul>
- *   <li>{@code /actions/find} returns {@code {"ActionMenu": [...]}}.
- *     The resource method signature is {@code List<ActionMenu>} but
- *     Jackson honors {@code @XmlRootElement(name = "ActionMenu")} on
- *     the {@code ActionMenu} DTO and wraps the array under that key.</li>
+ *   <li>{@code /actions/find} typically returns {@code {"ActionMenu": [...]}}
+ *     (Jackson honors {@code @XmlRootElement(name = "ActionMenu")} on the
+ *     DTO). Some serializers may emit a raw array — both are accepted.</li>
  *   <li>{@code /actions/find/types} and {@code /actions/find/templates/{id}}
- *     both return {@code {"ActionMenuList": [...]}}. Their resource
- *     methods return the explicit {@code ActionMenuList} type (extends
- *     {@code ArrayList<ActionMenu>}, carries
- *     {@code @XmlRootElement(name = "ActionMenuList")}).</li>
+ *     typically return {@code {"ActionMenuList": [...]}} (explicit
+ *     {@code ActionMenuList} type). Raw arrays and the {@code ActionMenu}
+ *     key are also accepted so the Explorer toolbar does not go empty on
+ *     wire-shape drift (#2972).</li>
  * </ul>
- * <p>The functions below unwrap these envelopes so callers receive the
- * typed {@link ActionMenu[]} surface. The wrapper keys derive from the
- * server DTOs (no invented field names).</p>
+ * <p>Use {@link unwrapActionMenuListPayload} for all list endpoints so
+ * callers always receive a typed {@link ActionMenu[]} surface.</p>
  */
 
 import { get, post } from "../client";
 import { PATHS } from "../paths";
 import type {
   ActionMenu,
-  ActionMenuListEnvelope,
   AllowedContentTypeMenusRequest,
   MenuAction,
 } from "./types";
@@ -64,19 +61,40 @@ import type {
 // ---------- Wire envelopes (internal) ----------
 
 /**
- * Wire shape for {@code findActions} (path {@code /actions/find}). The
- * returned list is wrapped under the {@code ActionMenu} key by Jackson
- * honoring the DTO's {@code @XmlRootElement}.
+ * Normalize Jackson list wire shapes for action-menu endpoints.
+ *
+ * <p>Live CMS ({@code GET /actions/find}) wraps under {@code ActionMenu}.
+ * {@code ActionMenuList} subclasses and some serializers emit a raw array
+ * or the {@code ActionMenuList} key. Accept all forms so the Explorer
+ * toolbar never silently goes empty on a wire-shape drift (#2972).</p>
  */
-interface ActionMenuListResponse {
-  ActionMenu?: ActionMenu[];
+export function unwrapActionMenuListPayload(payload: unknown): ActionMenu[] {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload as ActionMenu[];
+  }
+  if (typeof payload === "object") {
+    const obj = payload as Record<string, unknown>;
+    const raw =
+      obj.ActionMenu ??
+      obj.ActionMenuList ??
+      obj.actionMenu ??
+      obj.actionMenuList;
+    if (raw == null) {
+      return [];
+    }
+    if (Array.isArray(raw)) {
+      return raw as ActionMenu[];
+    }
+    // Single object under the envelope key.
+    if (typeof raw === "object") {
+      return [raw as ActionMenu];
+    }
+  }
+  return [];
 }
-
-/** Internal alias for the {@code ActionMenuList} wire envelope. */
-interface ActionMenuListEnvelopeResponse extends ActionMenuListEnvelope {}
-
-/** Internal alias matching the {@code POST /actions/find/types} envelope. */
-interface AllowedContentTypeMenusResponse extends ActionMenuListEnvelope {}
 
 // ---------- Public API ----------
 
@@ -106,10 +124,10 @@ export async function findActions(
   if (params.cascading !== undefined)
     q.set("cascading", String(params.cascading));
   const qs = q.toString();
-  const res = await get<ActionMenuListResponse>(
+  const res = await get<unknown>(
     `${PATHS.ACTIONS_ROOT}/find${qs ? `?${qs}` : ""}`,
   );
-  return res?.ActionMenu ?? [];
+  return unwrapActionMenuListPayload(res);
 }
 
 /**
@@ -124,11 +142,8 @@ export async function findAllowedContentTypeMenus(
   contentIds: number[],
 ): Promise<ActionMenu[]> {
   const body: AllowedContentTypeMenusRequest = { contentIds };
-  const res = await post<AllowedContentTypeMenusResponse>(
-    `${PATHS.ACTIONS_ROOT}/find/types`,
-    body,
-  );
-  return res?.ActionMenuList ?? [];
+  const res = await post<unknown>(`${PATHS.ACTIONS_ROOT}/find/types`, body);
+  return unwrapActionMenuListPayload(res);
 }
 
 /**
@@ -142,12 +157,12 @@ export async function findAllowedTemplateMenus(
   contentId: number,
   isAA = false,
 ): Promise<ActionMenu[]> {
-  const res = await get<ActionMenuListEnvelopeResponse>(
+  const res = await get<unknown>(
     `${PATHS.ACTIONS_ROOT}/find/templates/${encodeURIComponent(
       String(contentId),
     )}?isAA=${String(isAA)}`,
   );
-  return res?.ActionMenuList ?? [];
+  return unwrapActionMenuListPayload(res);
 }
 
 // ---------- Client-side mapping ----------

--- a/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
@@ -77,6 +77,10 @@ export function unwrapActionMenuListPayload(payload: unknown): ActionMenu[] {
   }
   if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
+    // Observed Jackson/@XmlRootElement keys are PascalCase (ActionMenu /
+    // ActionMenuList). Lowercase keys are accepted only as a defensive
+    // unwrap for accidental camelCase serializers or proxies — not as a
+    // documented wire contract. Prefer the uppercase keys first.
     const raw =
       obj.ActionMenu ??
       obj.ActionMenuList ??

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -276,7 +276,7 @@ function isWorkflowEligibleItem(item: PSPathItem | null | undefined): boolean {
  * <p>Desktop-only / surface enablement is applied by the shell after load
  * via {@link filterToolbarActions} / {@link filterContextMenuActions}.</p>
  */
-export async function defaultLoadMenuActions(
+async function defaultLoadMenuActions(
   item: PSPathItem | null,
 ): Promise<MenuAction[]> {
   const contentId = parseContentId(item?.id);
@@ -884,6 +884,7 @@ export function ContentExplorerShell({
                 <div
                   data-testid="explorer-server-actions-error"
                   role="status"
+                  aria-live="polite"
                   style={{ color: "#b00020", fontSize: "0.85rem", padding: "4px 0" }}
                 >
                   {message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR)}

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -222,6 +222,33 @@ const toolRowStyle: React.CSSProperties = {
   marginTop: 6,
 };
 
+/**
+ * Labeled chrome for the server-driven action catalog (#2972).
+ * Always visible (even when empty / load-error) so test plans and operators
+ * can identify the region next to Display format / reduced actions.
+ */
+const serverActionsRegionStyle: React.CSSProperties = {
+  ...toolRowStyle,
+  alignItems: "flex-start",
+  border: "1px solid #e2e8f0",
+  borderRadius: 4,
+  padding: "6px 8px",
+  background: "#f8fafc",
+  maxHeight: 140,
+  overflowY: "auto",
+};
+
+const serverActionsLabelStyle: React.CSSProperties = {
+  flex: "0 0 auto",
+  fontSize: 11,
+  fontWeight: 600,
+  color: "#475569",
+  textTransform: "uppercase",
+  letterSpacing: "0.03em",
+  paddingTop: 6,
+  minWidth: 96,
+};
+
 function parseContentId(id: string | undefined): number | null {
   if (!id) return null;
   const n = Number(id);
@@ -237,25 +264,34 @@ function isWorkflowEligibleItem(item: PSPathItem | null | undefined): boolean {
 }
 
 /**
- * Load the server action catalog for the current selection (#2849).
+ * Load the server action catalog for the current selection (#2849 / #2972).
  *
  * <p>When a content item is selected, prefer per-content-type menus from
- * {@code POST /actions/find/types}. Otherwise load the full cascading tree
- * from {@code GET /actions/find} (no {@code item=true} filter) so toolbar
- * dropdown parents ({@code MENU}) remain available — {@code item=true}
- * would keep only flat {@code MENUITEM} roots and drop nested chrome.</p>
+ * {@code POST /actions/find/types}. Failures or empty type menus fall back to
+ * the full cascading tree from {@code GET /actions/find} (no
+ * {@code item=true} filter) so toolbar dropdown parents ({@code MENU}) remain
+ * available — {@code item=true} would keep only flat {@code MENUITEM} roots
+ * and drop nested chrome. Folder-only selection always uses {@code find}.</p>
  *
  * <p>Desktop-only / surface enablement is applied by the shell after load
  * via {@link filterToolbarActions} / {@link filterContextMenuActions}.</p>
  */
-async function defaultLoadMenuActions(
+export async function defaultLoadMenuActions(
   item: PSPathItem | null,
 ): Promise<MenuAction[]> {
   const contentId = parseContentId(item?.id);
   if (contentId != null) {
-    const menus = await findAllowedContentTypeMenus([contentId]);
-    if (menus.length > 0) {
-      return mapActionMenusToMenuActions(menus);
+    try {
+      const menus = await findAllowedContentTypeMenus([contentId]);
+      if (menus.length > 0) {
+        return mapActionMenusToMenuActions(menus);
+      }
+    } catch (err: unknown) {
+      // Non-fatal: fall through to the full catalog so the toolbar is not wiped.
+      console.warn(
+        "[ContentExplorerShell] content-type menus load failed; falling back to findActions",
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
   const menus = await findActions({});
@@ -363,6 +399,8 @@ export function ContentExplorerShell({
   const [displayFormats, setDisplayFormats] = useState<DisplayFormat[]>([]);
   const [selectedFormatKey, setSelectedFormatKey] = useState<string>("");
   const [menuActions, setMenuActions] = useState<MenuAction[]>([]);
+  /** Non-fatal catalog load failure — chrome stays mounted (#2972). */
+  const [menuLoadError, setMenuLoadError] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   /**
    * Monotonic generation for context-menu loads. Rapid right-clicks on
@@ -446,8 +484,20 @@ export function ContentExplorerShell({
         // Toolbar surface: drop desktop-only URLs and CONTEXTMENU roots (#2849).
         const merged = mergeWorkflowMenuActions(base ?? [], workflow);
         setMenuActions(filterToolbarActions(merged));
-      } catch {
-        if (!cancelled) setMenuActions([]);
+        setMenuLoadError(null);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        // Keep toolbar chrome mounted; surface a non-fatal message (#2972).
+        setMenuActions([]);
+        setMenuLoadError(
+          err instanceof Error && err.message
+            ? err.message
+            : message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR),
+        );
+        console.warn(
+          "[ContentExplorerShell] server actions load failed",
+          err instanceof Error ? err.message : String(err),
+        );
       }
     }
     void loadMenus();
@@ -818,16 +868,37 @@ export function ContentExplorerShell({
             />
           </div>
           <div
-            style={toolRowStyle}
+            style={serverActionsRegionStyle}
             data-testid="explorer-server-actions"
             role="group"
             aria-label={message(EXPLORER_MSG.SERVER_ACTIONS_ARIA)}
           >
-            <ActionToolbar
-              actions={menuActions}
-              ariaLabel={message(EXPLORER_MSG.SERVER_ACTIONS_ARIA)}
-              onInvoke={handleMenuInvoke}
-            />
+            <span
+              data-testid="explorer-server-actions-label"
+              style={serverActionsLabelStyle}
+            >
+              {message(EXPLORER_MSG.SERVER_ACTIONS_LABEL)}
+            </span>
+            <div style={{ flex: "1 1 auto", minWidth: 0 }}>
+              {menuLoadError ? (
+                <div
+                  data-testid="explorer-server-actions-error"
+                  role="status"
+                  style={{ color: "#b00020", fontSize: "0.85rem", padding: "4px 0" }}
+                >
+                  {message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR)}
+                  {menuLoadError &&
+                  menuLoadError !== message(EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR)
+                    ? `: ${menuLoadError}`
+                    : null}
+                </div>
+              ) : null}
+              <ActionToolbar
+                actions={menuActions}
+                ariaLabel={message(EXPLORER_MSG.SERVER_ACTIONS_ARIA)}
+                onInvoke={handleMenuInvoke}
+              />
+            </div>
           </div>
           {/* Always-visible refresh residual (#2733); View menu also has Refresh (#2731). */}
           <div

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -158,8 +158,13 @@ export const EXPLORER_MSG = {
     "perc.ui.explorer@Custom URL searches cannot be run from Explorer",
   DISPLAY_FORMAT_LABEL: "perc.ui.explorer@Display format",
   DISPLAY_FORMAT_DEFAULT: "perc.ui.explorer@Default columns",
-  /** Product shell: server-driven action toolbar (US3 / #2400). */
+  /** Product shell: server-driven action toolbar (US3 / #2400 / #2972). */
   SERVER_ACTIONS_ARIA: "perc.ui.explorer@Server actions",
+  /** Visible chrome label so QA/operators can identify the toolbar region. */
+  SERVER_ACTIONS_LABEL: "perc.ui.explorer@Server actions",
+  /** Non-fatal load failure for the server action catalog. */
+  SERVER_ACTIONS_LOAD_ERROR:
+    "perc.ui.explorer@Could not load server actions",
   /** Product shell: view tools row (search / security / display format). */
   VIEW_TOOLS_ARIA: "perc.ui.explorer@Explorer view tools",
   /** DCE-style top menu bar (#2731 / ContentExplorerMenu.xml groups). */

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -178,7 +178,7 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       throw new Error("actions down");
     });
 
-    renderShell(
+    const { container } = renderShell(
       <ContentExplorerShell
         loadDisplayFormats={async () => []}
         loadMenuActions={loadMenuActions}
@@ -201,6 +201,8 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     // Empty toolbar placeholder still mounts under the labeled region.
     expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
     expect(screen.getByTestId("action-toolbar-empty")).toBeInTheDocument();
+    // T082a: new load-error DOM (status region) must pass axe serious/critical.
+    await renderA11yGate(container);
   });
 
   it("discards stale context-menu loads when right-clicking rows rapidly (#2732 race)", async () => {

--- a/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ContentExplorerShell.test.tsx
@@ -123,6 +123,12 @@ describe("ContentExplorerShell product composition (#2400)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
     });
+    // #2972: labeled Server actions chrome is always mounted for QA/operators.
+    expect(screen.getByTestId("explorer-server-actions")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("explorer-server-actions-label"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("action-toolbar-item-open")).toBeInTheDocument();
 
     const searchToggle = screen.getByTestId("explorer-toggle-search");
     expect(searchToggle.getAttribute("aria-expanded")).toBe("false");
@@ -164,6 +170,37 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       expect(loadMenuActions).toHaveBeenCalled();
       expect(loadWorkflowMenuActions).toHaveBeenCalled();
     });
+  });
+
+  it("keeps server-actions chrome and surfaces load error without wiping region (#2972)", async () => {
+    stubPathFetch();
+    const loadMenuActions = vi.fn(async () => {
+      throw new Error("actions down");
+    });
+
+    renderShell(
+      <ContentExplorerShell
+        loadDisplayFormats={async () => []}
+        loadMenuActions={loadMenuActions}
+        loadWorkflowMenuActions={async () => null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(loadMenuActions).toHaveBeenCalled();
+      expect(
+        screen.getByTestId("explorer-server-actions"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("explorer-server-actions-label"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("explorer-server-actions-error"),
+      ).toBeInTheDocument();
+    });
+    // Empty toolbar placeholder still mounts under the labeled region.
+    expect(screen.getByTestId("action-toolbar")).toBeInTheDocument();
+    expect(screen.getByTestId("action-toolbar-empty")).toBeInTheDocument();
   });
 
   it("discards stale context-menu loads when right-clicking rows rapidly (#2732 race)", async () => {
@@ -469,6 +506,8 @@ describe("ContentExplorerShell product composition (#2400)", () => {
       EXPLORER_MSG.DISPLAY_FORMAT_LABEL,
       EXPLORER_MSG.DISPLAY_FORMAT_DEFAULT,
       EXPLORER_MSG.SERVER_ACTIONS_ARIA,
+      EXPLORER_MSG.SERVER_ACTIONS_LABEL,
+      EXPLORER_MSG.SERVER_ACTIONS_LOAD_ERROR,
       EXPLORER_MSG.VIEW_TOOLS_ARIA,
       EXPLORER_MSG.MENU_BAR_ARIA,
       EXPLORER_MSG.MENU_CONTENT,

--- a/WebUI/src/test/ts/contentExplorer/actionMenuApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionMenuApi.test.ts
@@ -22,6 +22,7 @@ import {
   findAllowedTemplateMenus,
   mapActionMenusToMenuActions,
   unwrapActionMenuChildren,
+  unwrapActionMenuListPayload,
 } from "../../../main/ts/api/contentExplorer/actionMenuApi";
 import { PATHS } from "../../../main/ts/api/paths";
 
@@ -182,6 +183,37 @@ describe("actionMenuApi REST wrappers", () => {
     );
     const result = await findActions();
     expect(result).toEqual([]);
+  });
+
+  it("findActions unwraps a raw JSON array wire shape (#2972)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          makeMenu({ name: "open", sortRank: 1 }),
+          makeMenu({ name: "rename", sortRank: 2 }),
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const result = await findActions();
+    expect(result.map((m) => m.name)).toEqual(["open", "rename"]);
+  });
+
+  it("unwrapActionMenuListPayload accepts ActionMenu / ActionMenuList / raw array", () => {
+    expect(unwrapActionMenuListPayload(null)).toEqual([]);
+    expect(
+      unwrapActionMenuListPayload([makeMenu({ name: "a" })]).map((m) => m.name),
+    ).toEqual(["a"]);
+    expect(
+      unwrapActionMenuListPayload({
+        ActionMenu: [makeMenu({ name: "b" })],
+      }).map((m) => m.name),
+    ).toEqual(["b"]);
+    expect(
+      unwrapActionMenuListPayload({
+        ActionMenuList: [makeMenu({ name: "c" })],
+      }).map((m) => m.name),
+    ).toEqual(["c"]);
   });
 
   it("findAllowedContentTypeMenus posts the {contentIds} body and unwraps ActionMenuList", async () => {

--- a/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-action-toolbar-menus.spec.js
@@ -55,12 +55,32 @@ test.describe("modern React Content Explorer — nested ActionToolbar menus (#27
       await expect(
         page.locator(`[data-testid="${TEST_IDS.menuBar}"]`),
       ).toBeVisible();
+      // #2972: labeled Server actions chrome is always visible product chrome.
       await expect(
         page.locator('[data-testid="explorer-server-actions"]'),
       ).toBeVisible({ timeout: 15_000 });
       await expect(
+        page.locator('[data-testid="explorer-server-actions-label"]'),
+      ).toBeVisible();
+      await expect(
         page.locator(`[data-testid="${TEST_IDS.actionToolbar}"]`),
       ).toBeVisible();
+      // Either at least one server action button OR the empty-state placeholder.
+      const items = page.locator(
+        `[data-testid="${TEST_IDS.actionToolbar}"] [data-testid^="action-toolbar-item-"]`,
+      );
+      const empty = page.locator('[data-testid="action-toolbar-empty"]');
+      const loadError = page.locator(
+        '[data-testid="explorer-server-actions-error"]',
+      );
+      await expect
+        .poll(async () => {
+          const n = await items.count();
+          const e = await empty.count();
+          const err = await loadError.count();
+          return n > 0 || e > 0 || err > 0;
+        })
+        .toBe(true);
     },
   );
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-menu-bar.js
@@ -24,6 +24,10 @@ const TEST_IDS = Object.freeze({
   actionToolbar: "action-toolbar",
   /** Shell region wrapping ActionToolbar under ExplorerMenuBar. */
   serverActions: "explorer-server-actions",
+  /** Visible chrome label for the server-actions region (#2972). */
+  serverActionsLabel: "explorer-server-actions-label",
+  /** Non-fatal load error under the server-actions region (#2972). */
+  serverActionsError: "explorer-server-actions-error",
   // display-format lives on shell chrome only — see explorer-shell-chrome.js
 });
 

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-action-toolbar-menus.test.js
@@ -28,5 +28,13 @@ describe("explorer-action-toolbar-menus helpers (#2730)", () => {
   it("exports action toolbar + server-actions region test ids", () => {
     assert.equal(TEST_IDS.actionToolbar, "action-toolbar");
     assert.equal(TEST_IDS.serverActions, "explorer-server-actions");
+    assert.equal(
+      TEST_IDS.serverActionsLabel,
+      "explorer-server-actions-label",
+    );
+    assert.equal(
+      TEST_IDS.serverActionsError,
+      "explorer-server-actions-error",
+    );
   });
 });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -20,7 +20,7 @@ and assets without launching Desktop Content Explorer (DCE). Open it from the SP
 | **Menu bar** (Content / View / Help) | Product commands: search, clipboard, site/subfolder copy, view tools |
 | **Display format** | Column layout for the folder list (`validForFolder` formats) |
 | **Reduced actions** | Always-available open / preview / create folder / rename / move / copy / delete |
-| **Server action toolbar** | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection |
+| **Server actions** (labeled toolbar) | Configuration-driven actions from the CMS action catalog (`rest/actions`) for the current selection. Always shown as a labeled chrome region under the reduced actions row — even when the catalog is empty or temporarily fails to load |
 | **Tree + detail list** | Folder navigation and list of children; optional display-format columns |
 | **Context menu** | Right-click an item or folder row for the same catalog filtered for the popup surface |
 
@@ -54,9 +54,14 @@ the selected columns.
 
 ## Server actions and context menu
 
+The **Server actions** toolbar is the labeled product chrome under Open / Preview / Create Folder
+(and related reduced actions). It is always present on the Explorer page so you can tell the
+catalog region apart from the Content / View / Help menu bar and the display-format selector.
+
 Menus and toolbar buttons come from the server action catalog used by Content Explorer:
 
-- When you select a content item, the shell loads allowed menus for that content type.
+- When you select a content item, the shell loads allowed menus for that content type and
+  falls back to the full action catalog when type menus are empty or unavailable.
 - When only a folder is active, the shell loads the cascading action tree for the Explorer UI.
 - **Desktop-only** actions (for example custom application protocols that only DCE can run)
   are **hidden** in the web shell so operators are not offered controls that cannot succeed
@@ -64,6 +69,8 @@ Menus and toolbar buttons come from the server action catalog used by Content Ex
 - Actions of type **context menu** appear on right-click, not as permanent toolbar buttons.
 - Workflow transition triggers (when available for the selected item) appear as a labeled
   group on the toolbar and in the context menu.
+- If the catalog cannot be loaded, the **Server actions** region stays visible with a short
+  error message (and an empty-action placeholder) rather than disappearing from the page.
 
 Selecting a server action either navigates to a product-safe same-origin URL or refreshes the
 list after a client-handled command (for example a workflow transition).


### PR DESCRIPTION
## Summary

Fixes **#2972** — Modern Explorer Server actions toolbar appeared "missing" to QA because the region had no visible **Server actions** label (ActionToolbar was mounted and often populated). This PR makes the product chrome unmistakable, keeps it mounted on load failure, and hardens the menu load path.

### Changes
- **Labeled chrome** on `data-testid="explorer-server-actions"` with `explorer-server-actions-label` (always visible).
- **Load error UX**: catalog failures set `explorer-server-actions-error` and keep empty ActionToolbar chrome (no silent wipe).
- **`defaultLoadMenuActions`**: content-type menus failure falls back to `GET /actions/find` (folder + item selection).
- **`unwrapActionMenuListPayload`**: accepts raw array, `ActionMenu`, and `ActionMenuList` wire shapes.
- **Vitest** + **Playwright** surface (`explorer-action-toolbar-menus.spec.js`).
- **product-docs** `product-docs/8.2/admin/content-explorer.md` updated.

### Parent tracker
Parent: #2972 (self)

## Test plan
1. `perc-devctl qa-up` H2 (or existing QA CMS).
2. Login as Admin → `/Rhythmyx/cm/app/spa.jsp?entry=explorer`.
3. Confirm **Server actions** labeled region is visible under reduced actions.
4. Confirm toolbar has action buttons and/or empty placeholder (not missing region).
5. Right-click a row: context menu still mounts when actions exist.
6. Optional: block `/actions/find*` → region stays with load-error status.

### Agent evidence
- WebUI: `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest **1874** passed (265 files); Surefire Java **37** passed.
- perc-qa-automation: `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**.
- `npm run test:unit` → **218** passed.
- Hot-copy modern assets into QA H2 docker; `npm run test:surface -- --path tests/explorer-action-toolbar-menus.spec.js` → **2 passed**.

## Product documentation
- [x] Updated pages under `product-docs/` (`product-docs/8.2/admin/content-explorer.md`)

## Build evidence (C3)
- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 37 (Java); Vitest Tests 1874 passed
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
- **downstream_checked:** none (no public Java API signature / final / sealed change)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2972

> Co-Authored by Grok Build using grok-4.5 with agent main.
