### PR TITLE
fix(perc-toolkit): clear maven-javadoc residual 943→0 (#2983)

### DIFF
--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/assembler/PSValidatingVelocityAssembler.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/assembler/PSValidatingVelocityAssembler.java
@@ -33,6 +33,9 @@ import org.apache.logging.log4j.Logger;
  * re-form content based on the supplied tidy properties file. Located in
  * @author NateChadwick
  */
+/**
+ * PSValidatingVelocityAssembler class.
+ */
 public class PSValidatingVelocityAssembler extends PSVelocityAssembler implements IPSAssembler {
 
   private IPSExtensionDef m_def = null;
@@ -40,14 +43,23 @@ public class PSValidatingVelocityAssembler extends PSVelocityAssembler implement
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSValidatingVelocityAssembler.class);
 
-  /** Constructor */
+  /**
+   * Constructor
+   * Creates a new PSValidatingVelocityAssembler.
+   *
+   */
   public PSValidatingVelocityAssembler() {
     super();
   }
 
   /**
+   * doAssembleSingle operation.
+   *
    * @see
    *     com.percussion.services.assembly.impl.plugin.PSAssemblerBase#doAssembleSingle(com.percussion.services.assembly.IPSAssemblyItem)
+   * @param item the item
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   protected IPSAssemblyResult doAssembleSingle(IPSAssemblyItem item) throws Exception {
@@ -57,8 +69,13 @@ public class PSValidatingVelocityAssembler extends PSVelocityAssembler implement
   }
 
   /**
+   * init operation.
+   *
    * @see
    *     com.percussion.services.assembly.impl.plugin.PSAssemblerBase#doAssembleSingle(com.percussion.services.assembly.IPSAssemblyItem)
+   * @param arg0 the arg0
+   * @param arg1 the arg1
+   * @throws PSExtensionException if an error occurs
    */
   @Override
   public void init(IPSExtensionDef arg0, File arg1) throws PSExtensionException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/assembler/ValidatingContentAssemblerMerge.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/assembler/ValidatingContentAssemblerMerge.java
@@ -46,6 +46,10 @@ public class ValidatingContentAssemblerMerge {
 
   /*
    * Handles merging the assembled content and pushing them through JTIDY
+   * @param def the def
+   * @param result the result
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public static IPSAssemblyResult merge(IPSExtensionDef def, IPSAssemblyResult result)
       throws Exception {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/exception/SiteLookUpException.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/exception/SiteLookUpException.java
@@ -17,23 +17,44 @@
 
 package com.percussion.pso.demandpreview.exception;
 
+/**
+ * SiteLookUpException class.
+ */
 public class SiteLookUpException extends RuntimeException {
 
-  /** */
-  private static final long serialVersionUID = -13455678L;
+    private static final long serialVersionUID = -13455678L;
 
+  /**
+   * Creates a new SiteLookUpException.
+   */
   public SiteLookUpException() {
     super();
   }
 
+  /**
+   * Creates a new SiteLookUpException.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public SiteLookUpException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates a new SiteLookUpException.
+   *
+   * @param message the message
+   */
   public SiteLookUpException(String message) {
     super(message);
   }
 
+  /**
+   * Creates a new SiteLookUpException.
+   *
+   * @param cause the cause
+   */
   public SiteLookUpException(Throwable cause) {
     super(cause);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/LinkBuilderService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/LinkBuilderService.java
@@ -42,6 +42,7 @@ public interface LinkBuilderService {
    * @param context the assembly context that is being used for the content generation
    * @param contextVar the context variable that contains the URL root for the context.
    *
+   * @return the result
    */
   public String buildLinkUrl(
       IPSSite site,

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/PreviewServiceLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/PreviewServiceLocator.java
@@ -25,6 +25,13 @@ import com.percussion.services.PSBaseServiceLocator;
  * @author davidbenua
  */
 public class PreviewServiceLocator extends PSBaseServiceLocator {
+  /**
+   * Creates a new PreviewServiceLocator.
+   */
+  public PreviewServiceLocator() {
+    // default
+  }
+
 
   /**
    * Gets the Site Edition lookup service.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/SiteEditionConfig.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/SiteEditionConfig.java
@@ -31,7 +31,11 @@ public class SiteEditionConfig {
   private String contextURLRootVar;
   private int assemblyContext;
 
-  /** Default Constructor. */
+  /**
+   * Default Constructor.
+   * Creates a new SiteEditionConfig.
+   *
+   */
   public SiteEditionConfig() {}
 
   /**

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/SiteEditionHolder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/SiteEditionHolder.java
@@ -33,7 +33,11 @@ public class SiteEditionHolder {
   private IPSPublishingContext context;
   private String contextURLRootVar;
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new SiteEditionHolder.
+   *
+   */
   public SiteEditionHolder() {}
 
   /**
@@ -91,6 +95,7 @@ public class SiteEditionHolder {
   }
 
   /**
+   * Returns the contextURLRootVar.
    * @return the contextURLRootVar
    */
   public String getContextURLRootVar() {
@@ -98,6 +103,7 @@ public class SiteEditionHolder {
   }
 
   /**
+   * Sets the contextURLRootVar.
    * @param contextURLRootVar the contextURLRootVar to set
    */
   public void setContextURLRootVar(String contextURLRootVar) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/DefaultPageTemplateBean.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/DefaultPageTemplateBean.java
@@ -41,11 +41,26 @@ import org.apache.logging.log4j.Logger;
  */
 public class DefaultPageTemplateBean implements ItemTemplateService {
 
+  /**
+   * Creates a new DefaultPageTemplateBean.
+   */
+  public DefaultPageTemplateBean() {
+    // default
+  }
+
   private static final Logger log = LogManager.getLogger(DefaultPageTemplateBean.class);
 
   private IPSTemplateService tempSvc = null;
   private IPSOObjectFinder objFinder = null;
 
+  /**
+   * init operation.
+   */
+  /**
+   * Initializes dependencies.
+   *
+   * @throws Exception if initialization fails
+   */
   public void init() throws Exception {
     if (tempSvc == null) {
       tempSvc = PSAssemblyServiceLocator.getAssemblyService();
@@ -108,6 +123,17 @@ public class DefaultPageTemplateBean implements ItemTemplateService {
     }
   }
 
+  /**
+   * Returns the SiteTemplates.
+   *
+   * @return the value
+   */
+  /**
+   * Returns template GUIDs associated with the site.
+   *
+   * @param site the site
+   * @return the template GUIDs
+   */
   protected Set<IPSGuid> getSiteTemplates(IPSSite site) {
     Set<IPSGuid> results = new HashSet<IPSGuid>();
     for (IPSAssemblyTemplate tp : site.getAssociatedTemplates()) {
@@ -118,12 +144,21 @@ public class DefaultPageTemplateBean implements ItemTemplateService {
   }
 
   /**
+   * Sets the tempSvc.
    * @param tempSvc the tempSvc to set
    */
   protected void setTempSvc(IPSTemplateService tempSvc) {
     this.tempSvc = tempSvc;
   }
 
+  /**
+   * Sets the ObjFinder.
+   */
+  /**
+   * Sets the object finder used for testing.
+   *
+   * @param objFinder the object finder
+   */
   protected void setObjFinder(IPSOObjectFinder objFinder) {
     this.objFinder = objFinder;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/DemandPublisherBean.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/DemandPublisherBean.java
@@ -37,6 +37,13 @@ import org.apache.logging.log4j.Logger;
  * @author davidbenua
  */
 public class DemandPublisherBean implements DemandPublisherService {
+
+  /**
+   * Creates a new DemandPublisherBean.
+   */
+  public DemandPublisherBean() {
+    // default
+  }
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(DemandPublisherBean.class);
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/LinkBuilderBean.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/LinkBuilderBean.java
@@ -36,10 +36,21 @@ import org.apache.commons.lang3.StringUtils;
 public class LinkBuilderBean implements LinkBuilderService {
   String linkSuffix = null;
 
+  /**
+   * Creates a new LinkBuilderBean.
+   */
   public LinkBuilderBean() {}
 
   /***
+   * buildLinkUrl operation.
+   *
    * @see LinkBuilderService
+   * @param site the site
+   * @param template the template
+   * @param content the content
+   * @param folder the folder
+   * @param context the context
+   * @return the result
    */
   public String buildLinkUrl(
       IPSSite site,
@@ -68,6 +79,17 @@ public class LinkBuilderBean implements LinkBuilderService {
     this.linkSuffix = linkSuffix;
   }
 
+  /**
+   * buildLinkUrl operation.
+   *
+   * @param site the site
+   * @param template the template
+   * @param content the content
+   * @param folder the folder
+   * @param context the context
+   * @param contextVar the context var
+   * @return the result
+   */
   public String buildLinkUrl(
       IPSSite site,
       IPSAssemblyTemplate template,

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/SiteEditionLookUpServiceImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/service/impl/SiteEditionLookUpServiceImpl.java
@@ -60,13 +60,17 @@ public class SiteEditionLookUpServiceImpl implements SiteEditionLookUpService {
   private IPSAssemblyService asm = null;
   private Map<String, SiteEditionConfig> siteLookUpMap;
 
-  /** Default Constructor */
+  /**
+   * Default Constructor
+   * Creates a new SiteEditionLookUpServiceImpl.
+   *
+   */
   public SiteEditionLookUpServiceImpl() {}
 
   /**
    * Initialize the service bean. Must be called from Spring before any of the service methods.
    *
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   public void init() throws Exception {
     if (siteManager == null) {
@@ -104,6 +108,13 @@ public class SiteEditionLookUpServiceImpl implements SiteEditionLookUpService {
     return LookUpSiteEdition(siteGuid);
   }
 
+  /**
+   * LookUpSiteEdition operation.
+   *
+   * @param siteId the site id
+   * @return the result
+   * @throws SiteLookUpException if an error occurs
+   */
   public SiteEditionHolder LookUpSiteEdition(IPSGuid siteId) throws SiteLookUpException {
     String emsg;
     String pSiteName = null;
@@ -190,9 +201,9 @@ public class SiteEditionLookUpServiceImpl implements SiteEditionLookUpService {
   /**
    * Gets the edition
    *
-   * @param editionName
+   * @param editionName the edition name
    * @return the edition. Never <code>null</code>
-   * @throws SiteLookUpException
+   * @throws SiteLookUpException if an error occurs
    */
   protected IPSEdition getEdition(String editionName) throws SiteLookUpException {
     String emsg;
@@ -218,7 +229,7 @@ public class SiteEditionLookUpServiceImpl implements SiteEditionLookUpService {
   /**
    * Sets the site look up map instance.
    *
-   * @param siteLookUpMap
+   * @param siteLookUpMap the site look up map
    */
   public void setSiteLookUpMap(Map<String, SiteEditionConfig> siteLookUpMap) {
     this.siteLookUpMap = siteLookUpMap;
@@ -227,7 +238,7 @@ public class SiteEditionLookUpServiceImpl implements SiteEditionLookUpService {
   /**
    * This method is only for testing purpose.
    *
-   * @param siteManager
+   * @param siteManager the site manager
    */
   protected void setSiteManager(IPSSiteManager siteManager) {
     this.siteManager = siteManager;
@@ -236,7 +247,7 @@ public class SiteEditionLookUpServiceImpl implements SiteEditionLookUpService {
   /**
    * Sets the publisher service. This method is only for testing purpose.
    *
-   * @param publisherService
+   * @param publisherService the publisher service
    */
   protected void setPubisherService(IPSPublisherService publisherService) {
     this.publisherService = publisherService;
@@ -245,7 +256,7 @@ public class SiteEditionLookUpServiceImpl implements SiteEditionLookUpService {
   /**
    * This method is only for testing purpose.
    *
-   * @param guidManager
+   * @param guidManager the guid manager
    */
   protected void setGuidManager(IPSGuidManager guidManager) {
     this.guidManager = guidManager;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/servlet/DemandPreviewController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/servlet/DemandPreviewController.java
@@ -50,6 +50,13 @@ import org.springframework.web.servlet.mvc.ParameterizableViewController;
  */
 public class DemandPreviewController extends ParameterizableViewController implements Controller {
 
+  /**
+   * Creates a new DemandPreviewController.
+   */
+  public DemandPreviewController() {
+    // default
+  }
+
   private static final Logger log = LogManager.getLogger(DemandPreviewController.class);
 
   private String errorViewName = "error";
@@ -61,6 +68,11 @@ public class DemandPreviewController extends ParameterizableViewController imple
 
   private IPSGuidManager gmgr = null;
 
+  /**
+   * Initializes service dependencies if they have not been injected.
+   *
+   * @throws Exception if initialization fails
+   */
   public void init() throws Exception {
     if (gmgr == null) {
       gmgr = PSGuidManagerLocator.getGuidMgr();
@@ -71,6 +83,13 @@ public class DemandPreviewController extends ParameterizableViewController imple
   }
 
   @Override
+  /**
+   * handleRequestInternal operation.
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected ModelAndView handleRequestInternal(
       HttpServletRequest request, HttpServletResponse response) throws Exception {
     String emsg;
@@ -101,6 +120,17 @@ public class DemandPreviewController extends ParameterizableViewController imple
     return mav;
   }
 
+  /**
+   * Publishes the item for on-demand preview and returns the preview URL.
+   *
+   * @param contentId the content id to publish
+   * @param folderId the folder id context
+   * @param siteId the site id for edition lookup
+   * @return the preview redirect URL
+   * @throws PSAssemblyException if template assembly fails
+   * @throws TimeoutException if the publish wait times out
+   * @throws PSException if content lookup fails
+   */
   protected String doPublishForPreview(String contentId, String folderId, String siteId)
       throws PSAssemblyException, TimeoutException, PSException {
     String redirectTo = null;
@@ -130,50 +160,110 @@ public class DemandPreviewController extends ParameterizableViewController imple
     return redirectTo;
   }
 
+  /**
+   * Returns the ErrorViewName.
+   *
+   * @return the value
+   */
   public String getErrorViewName() {
     return errorViewName;
   }
 
+  /**
+   * Sets the ErrorViewName.
+   *
+   * @param errorViewName the errorViewName
+   */
   public void setErrorViewName(String errorViewName) {
     this.errorViewName = errorViewName;
   }
 
+  /**
+   * Returns the DemandPublisherService.
+   *
+   * @return the value
+   */
   public DemandPublisherService getDemandPublisherService() {
     return demandPublisherService;
   }
 
+  /**
+   * Sets the DemandPublisherService.
+   *
+   * @param demandPublisherService the demandPublisherService
+   */
   public void setDemandPublisherService(DemandPublisherService demandPublisherService) {
     this.demandPublisherService = demandPublisherService;
   }
 
+  /**
+   * Returns the ItemTemplateService.
+   *
+   * @return the value
+   */
   public ItemTemplateService getItemTemplateService() {
     return itemTemplateService;
   }
 
+  /**
+   * Sets the ItemTemplateService.
+   *
+   * @param itemTemplateService the itemTemplateService
+   */
   public void setItemTemplateService(ItemTemplateService itemTemplateService) {
     this.itemTemplateService = itemTemplateService;
   }
 
+  /**
+   * Returns the LinkBuilderService.
+   *
+   * @return the value
+   */
   public LinkBuilderService getLinkBuilderService() {
     return linkBuilderService;
   }
 
+  /**
+   * Sets the LinkBuilderService.
+   *
+   * @param linkBuilderService the linkBuilderService
+   */
   public void setLinkBuilderService(LinkBuilderService linkBuilderService) {
     this.linkBuilderService = linkBuilderService;
   }
 
+  /**
+   * Returns the SiteEditionLookUpService.
+   *
+   * @return the value
+   */
   public SiteEditionLookUpService getSiteEditionLookUpService() {
     return siteEditionLookUpService;
   }
 
+  /**
+   * Sets the SiteEditionLookUpService.
+   *
+   * @param siteEditionLookUpService the siteEditionLookUpService
+   */
   public void setSiteEditionLookUpService(SiteEditionLookUpService siteEditionLookUpService) {
     this.siteEditionLookUpService = siteEditionLookUpService;
   }
 
+  /**
+   * Sets the Gmgr.
+   *
+   * @param gmgr the gmgr
+   */
   protected void setGmgr(IPSGuidManager gmgr) {
     this.gmgr = gmgr;
   }
 
+  /**
+   * Sets the IsFinder.
+   *
+   * @param isFinder the isFinder
+   */
   protected void setIsFinder(IPSOItemSummaryFinder isFinder) {
     this.isFinder = isFinder;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/servlet/DemandPreviewController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/servlet/DemandPreviewController.java
@@ -81,8 +81,6 @@ public class DemandPreviewController extends ParameterizableViewController imple
       isFinder = new PSOItemSummaryFinderWrapper();
     }
   }
-
-  @Override
   /**
    * handleRequestInternal operation.
    * @param request the request
@@ -90,6 +88,8 @@ public class DemandPreviewController extends ParameterizableViewController imple
    * @return the result
    * @throws Exception if an error occurs
    */
+
+  @Override
   protected ModelAndView handleRequestInternal(
       HttpServletRequest request, HttpServletResponse response) throws Exception {
     String emsg;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/editiontasks/PSExampleEditionTask.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/editiontasks/PSExampleEditionTask.java
@@ -31,18 +31,53 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSExampleEditionTask class.
+ */
 public class PSExampleEditionTask implements IPSEditionTask {
+  /**
+   * Creates a new PSExampleEditionTask.
+   */
+  public PSExampleEditionTask() {
+    // default
+  }
+
 
   private static final Logger logger = LogManager.getLogger(PSExampleEditionTask.class);
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param codeRoot the code root
+   */
   public void init(IPSExtensionDef def, File codeRoot) {
     // No initialization required
   }
 
+  /**
+   * Returns the type.
+   *
+   * @return the result
+   */
   public TaskType getType() {
     return TaskType.POSTEDITION;
   }
 
+  /**
+   * perform operation.
+   *
+   * @param edition the edition
+   * @param site the site
+   * @param starTime the star time
+   * @param endTime the end time
+   * @param jobId the job id
+   * @param duration the duration
+   * @param success the success
+   * @param params the params
+   * @param status the status
+   * @throws Exception if an error occurs
+   */
   public void perform(
       IPSEdition edition,
       IPSSite site,

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSAbstractFolderEffect.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSAbstractFolderEffect.java
@@ -45,11 +45,18 @@ public abstract class PSAbstractFolderEffect implements IPSEffect {
   /** Logger for this class */
   protected static final Logger log = LogManager.getLogger(PSFolderFollowerEffect.class);
 
+  /** sws. */
   protected static IPSSystemWs sws = null;
+  /** gmgr. */
   protected static IPSGuidManager gmgr = null;
+  /** cws. */
   protected static IPSContentWs cws = null;
 
-  /** Initialize service pointers. */
+  /**
+   * Initialize service pointers.
+   * initServices operation.
+   *
+   */
   protected static void initServices() {
     if (sws == null) {
       sws = PSSystemWsLocator.getSystemWebservice();
@@ -58,6 +65,16 @@ public abstract class PSAbstractFolderEffect implements IPSEffect {
     }
   }
 
+  /**
+   * recover operation.
+   *
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param ex the ex
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public void recover(
       Object[] params,
       IPSRequestContext req,
@@ -68,16 +85,37 @@ public abstract class PSAbstractFolderEffect implements IPSEffect {
     result.setSuccess();
   }
 
+  /**
+   * test operation.
+   *
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   */
   public void test(
       Object[] params, IPSRequestContext req, IPSExecutionContext exCtx, PSEffectResult result)
       throws PSExtensionProcessingException, PSParameterMismatchException { // nothing to do here
     result.setSuccess();
   }
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSAbstractFolderEffect.
+   *
+   */
   public PSAbstractFolderEffect() {
     super();
   }
 
+  /**
+   * init operation.
+   *
+   * @param arg0 the arg0
+   * @param arg1 the arg1
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef arg0, File arg1) throws PSExtensionException {}
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSEffectLoggingEffect.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSEffectLoggingEffect.java
@@ -43,6 +43,9 @@ import org.apache.logging.log4j.Logger;
 
 @PSHandlesEffectContext()
 // REFACTORED: CP-JAVA11
+/**
+ * PSEffectLoggingEffect class.
+ */
 public class PSEffectLoggingEffect implements IPSEffect {
 
   /**
@@ -66,11 +69,18 @@ public class PSEffectLoggingEffect implements IPSEffect {
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSEffectLoggingEffect.class);
 
+  /** sws. */
   protected static IPSSystemWs sws = null;
+  /** gmgr. */
   protected static IPSGuidManager gmgr = null;
+  /** cws. */
   protected static IPSContentWs cws = null;
 
-  /** Initialize service pointers. */
+  /**
+   * Initialize service pointers.
+   * initServices operation.
+   *
+   */
   protected static void initServices() {
     if (sws == null) {
       sws = PSSystemWsLocator.getSystemWebservice();
@@ -79,7 +89,11 @@ public class PSEffectLoggingEffect implements IPSEffect {
     }
   }
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSEffectLoggingEffect.
+   *
+   */
   public PSEffectLoggingEffect() {
     super();
   }
@@ -89,6 +103,9 @@ public class PSEffectLoggingEffect implements IPSEffect {
    * the effect implementation.
    *
    * <p>See <code>IPSExtension</code> for description.
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
    */
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     if (def == null || codeRoot == null)
@@ -99,6 +116,16 @@ public class PSEffectLoggingEffect implements IPSEffect {
     m_name = def.getRef().toString();
   }
 
+  /**
+   * recover operation.
+   *
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param ex the ex
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public void recover(
       Object[] params,
       IPSRequestContext req,
@@ -109,6 +136,16 @@ public class PSEffectLoggingEffect implements IPSEffect {
     result.setSuccess();
   }
 
+  /**
+   * test operation.
+   *
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   */
   public void test(
       Object[] params, IPSRequestContext req, IPSExecutionContext exCtx, PSEffectResult result)
       throws PSExtensionProcessingException, PSParameterMismatchException {
@@ -176,7 +213,15 @@ public class PSEffectLoggingEffect implements IPSEffect {
   }
 
   /**
+   * attempt operation.
+   *
    * @see IPSEffect#attempt(Object[], IPSRequestContext, IPSExecutionContext, PSEffectResult)
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
    */
   public void attempt(
       Object[] params, IPSRequestContext req, IPSExecutionContext exCtx, PSEffectResult result)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSFolderFollowerEffect.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSFolderFollowerEffect.java
@@ -39,9 +39,16 @@ import java.util.List;
       PSEffectContext.PRE_DESTRUCTION,
       PSEffectContext.PRE_UPDATE
     })
+/**
+ * PSFolderFollowerEffect class.
+ */
 public class PSFolderFollowerEffect extends PSAbstractFolderEffect implements IPSEffect {
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSFolderFollowerEffect.
+   *
+   */
   public PSFolderFollowerEffect() {}
 
   /**
@@ -50,7 +57,7 @@ public class PSFolderFollowerEffect extends PSAbstractFolderEffect implements IP
    * @param loc the item locator
    * @return the List of relationships to parent folders. Never <code>null</code> but may be <code>
    *     empty</code>
-   * @throws PSErrorException
+   * @throws PSErrorException if an error occurs
    */
   protected List<PSRelationship> getFolderParents(PSLocator loc) throws PSErrorException {
     initServices();
@@ -69,7 +76,7 @@ public class PSFolderFollowerEffect extends PSAbstractFolderEffect implements IP
    * where the owner resides (and removed from folders the owner does not reside).
    *
    * @param current the current relationship.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   public void processRelations(PSRelationship current) throws Exception {
     List<PSRelationship> ownerFolders = getFolderParents(current.getOwner());
@@ -86,7 +93,7 @@ public class PSFolderFollowerEffect extends PSAbstractFolderEffect implements IP
    *
    * @param item the locator for the item.
    * @param missingList the list of relationships where the item is missing from the folder.
-   * @throws PSErrorException
+   * @throws PSErrorException if an error occurs
    */
   protected void addMissing(PSLocator item, List<PSRelationship> missingList)
       throws PSErrorException {
@@ -102,8 +109,8 @@ public class PSFolderFollowerEffect extends PSAbstractFolderEffect implements IP
    * Removes extra items from a folder
    *
    * @param extras the extra relationships
-   * @throws PSErrorsException
-   * @throws PSErrorException
+   * @throws PSErrorsException if an error occurs
+   * @throws PSErrorException if an error occurs
    */
   protected void removeExtra(List<PSRelationship> extras)
       throws PSErrorsException, PSErrorException {
@@ -142,7 +149,15 @@ public class PSFolderFollowerEffect extends PSAbstractFolderEffect implements IP
   }
 
   /**
+   * attempt operation.
+   *
    * @see IPSEffect#attempt(Object[], IPSRequestContext, IPSExecutionContext, PSEffectResult)
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
    */
   public void attempt(
       Object[] params, IPSRequestContext req, IPSExecutionContext exCtx, PSEffectResult result)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSFolderOwnerSubfolderEffect.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSFolderOwnerSubfolderEffect.java
@@ -45,8 +45,15 @@ import org.apache.commons.lang3.StringUtils;
  */
 @PSHandlesEffectContext(required = {PSEffectContext.PRE_CONSTRUCTION, PSEffectContext.PRE_UPDATE})
 // REFACTORED: CP-JAVA11
+/**
+ * PSFolderOwnerSubfolderEffect class.
+ */
 public class PSFolderOwnerSubfolderEffect extends PSAbstractFolderEffect {
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSFolderOwnerSubfolderEffect.
+   *
+   */
   public PSFolderOwnerSubfolderEffect() {
     super();
   }
@@ -57,7 +64,7 @@ public class PSFolderOwnerSubfolderEffect extends PSAbstractFolderEffect {
    * @param current the current relationship.
    * @param subfolderPath the desired subfolder path.
    * @param userName the user name who caused this event.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   protected void processRelations(PSRelationship current, String subfolderPath, String userName)
       throws Exception {
@@ -86,7 +93,7 @@ public class PSFolderOwnerSubfolderEffect extends PSAbstractFolderEffect {
    * @param contentId the content id of the dependent item.
    * @param userName the user name
    * @return the set of folder paths.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   protected Set<String> getFolderPaths(int contentId, String userName) throws Exception {
     IPSGuid guid = gmgr.makeGuid(new PSLocator(contentId));
@@ -103,7 +110,7 @@ public class PSFolderOwnerSubfolderEffect extends PSAbstractFolderEffect {
    * @param subfolderPath the subfolder path.
    * @param userName the user name
    * @return the path of the subfolder.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   protected String findOrCreateChildFolder(String folderPath, String subfolderPath, String userName)
       throws Exception {
@@ -122,7 +129,15 @@ public class PSFolderOwnerSubfolderEffect extends PSAbstractFolderEffect {
   }
 
   /**
+   * attempt operation.
+   *
    * @see IPSEffect#attempt(Object[], IPSRequestContext, IPSExecutionContext, PSEffectResult)
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
    */
   public void attempt(
       Object[] params, IPSRequestContext req, IPSExecutionContext exCtx, PSEffectResult result)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSNavLandingPageGeneratorEffect.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSNavLandingPageGeneratorEffect.java
@@ -80,8 +80,17 @@ import org.apache.logging.log4j.Logger;
  */
 @PSHandlesEffectContext(required = PSEffectContext.PRE_CONSTRUCTION)
 public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
+  /**
+   * Creates a new PSNavLandingPageGeneratorEffect.
+   */
+  public PSNavLandingPageGeneratorEffect() {
+    // default
+  }
 
+
+  /** default landing contenttype. */
   public static String DEFAULT_LANDING_CONTENTTYPE = "navon.landingpage.default.ct";
+  /** default landing title template. */
   public static String DEFAULT_LANDING_TITLE_TEMPLATE = "navon.landingpage.default.title.template";
   public static String DEFAULT_LANDING_DISPLAYTITLE_FIELD =
       "navon.landingpage.default.displaytitle.field";
@@ -91,6 +100,7 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
       "navon.landingpage.default.required.fields.names";
   public static String DEFAULT_LANDING_REQUIRED_FIELD_VALUES =
       "navon.landingpage.default.required.fields.values";
+  /** default landing communityid. */
   public static String DEFAULT_LANDING_COMMUNITYID = "navon.landingpage.default.communityid";
 
   private static final Logger log = LogManager.getLogger(PSNavLandingPageGeneratorEffect.class);
@@ -104,6 +114,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   private long m_contentTypeId = 0;
 
   /**
+   * Returns the default landing community id.
+   *
    * @return the m_defaultLandingCommunityId
    */
   public Integer getDefaultLandingCommunityId() {
@@ -111,6 +123,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Sets the default landing community id.
+   *
    * @param m_defaultLandingCommunityId the m_defaultLandingCommunityId to set
    */
   public void setDefaultLandingCommunityId(Integer m_defaultLandingCommunityId) {
@@ -118,6 +132,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Returns the default landing required values.
+   *
    * @return the m_defaultLandingRequiredValues
    */
   public String[] getDefaultLandingRequiredValues() {
@@ -125,6 +141,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Sets the default landing required values.
+   *
    * @param m_defaultLandingRequiredValues the m_defaultLandingRequiredValues to set
    */
   public void setDefaultLandingRequiredValues(String[] m_defaultLandingRequiredValues) {
@@ -132,6 +150,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Returns the default landing required fields.
+   *
    * @return the m_defaultLandingRequiredFields
    */
   public String[] getDefaultLandingRequiredFields() {
@@ -139,6 +159,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Sets the default landing required fields.
+   *
    * @param m_defaultLandingRequiredFields the m_defaultLandingRequiredFields to set
    */
   public void setDefaultLandingRequiredFields(String[] m_defaultLandingRequiredFields) {
@@ -146,6 +168,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Returns the default landing display title format.
+   *
    * @return the m_defaultLandingDisplayTitleFormat
    */
   public String getDefaultLandingDisplayTitleFormat() {
@@ -153,6 +177,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Sets the default landing display title format.
+   *
    * @param m_defaultLandingDisplayTitleFormat the m_defaultLandingDisplayTitleFormat to set
    */
   public void setDefaultLandingDisplayTitleFormat(String m_defaultLandingDisplayTitleFormat) {
@@ -160,6 +186,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Returns the default landing display title field.
+   *
    * @return the m_defaultLandingDisplayTitleField
    */
   public String getDefaultLandingDisplayTitleField() {
@@ -167,6 +195,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Sets the default landing display title field.
+   *
    * @param m_defaultLandingDisplayTitleField the m_defaultLandingDisplayTitleField to set
    */
   public void setDefaultLandingDisplayTitleField(String m_defaultLandingDisplayTitleField) {
@@ -174,6 +204,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Returns the default landing title template.
+   *
    * @return the m_defaultLandingTitleTemplate
    */
   public String getDefaultLandingTitleTemplate() {
@@ -181,6 +213,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Sets the default landing title template.
+   *
    * @param m_defaultLandingTitleTemplate the m_defaultLandingTitleTemplate to set
    */
   public void setDefaultLandingTitleTemplate(String m_defaultLandingTitleTemplate) {
@@ -188,6 +222,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Returns the default content type.
+   *
    * @return the m_defaultContentType
    */
   public String getDefaultContentType() {
@@ -195,6 +231,8 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   }
 
   /**
+   * Sets the default content type.
+   *
    * @param m_defaultContentType the m_defaultContentType to set
    */
   public void setDefaultContentType(String m_defaultContentType) {
@@ -205,6 +243,9 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
    * Handle initilization parameters.  The Content Type configured
    * as the
    *
+   * @param extDef the ext def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
    */
   @Override
   public void init(com.percussion.extension.IPSExtensionDef extDef, java.io.File codeRoot)
@@ -212,6 +253,16 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
     super.init(extDef, codeRoot);
   }
 
+  /**
+   * attempt operation.
+   *
+   * @param params the params
+   * @param req the req
+   * @param excontext the excontext
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   */
   @Override
   public void attempt(
       Object[] params, IPSRequestContext req, IPSExecutionContext excontext, PSEffectResult result)
@@ -341,7 +392,7 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
   /***
    * Responsible for creating the landing page and adding it to
    * the same Folder as the NavOn.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   private PSLocator createLandingPage(
       IPSRequestContext req, PSComponentSummary folder, PSComponentSummary navon, int communityId)
@@ -454,7 +505,7 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
    * @param navon  Locator for the NavOn
    * @param lp Locator for the Landing Page
    * @param landingSlotName Name of the NavOn Landing Page slot
-   * @throws PSNavException
+   * @throws PSNavException if an error occurs
    */
   private void createNavOnLandingPageRelationship(
       IPSRequestContext req, PSComponentSummary navon, PSLocator lp, String landingSlotName)
@@ -551,7 +602,7 @@ public class PSNavLandingPageGeneratorEffect extends PSNavAbstractEffect {
 
   /***
    * Attempts a simple parse of the specified string to return CSV string represented as an array.
-   * @param arg
+   * @param arg the arg
    * @return Returns an array of strings holding the parameters. If no params are found, returns null.
    */
   public String[] getCSVList(String arg) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSOPreventDeepCloneUDF.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSOPreventDeepCloneUDF.java
@@ -55,7 +55,9 @@ public class PSOPreventDeepCloneUDF extends PSSimpleJavaUdfExtension implements 
     }
   }
 
-  /** */
+  /**
+   * Creates a new PSOPreventDeepCloneUDF.
+   */
   public PSOPreventDeepCloneUDF() {
     super();
   }
@@ -68,6 +70,8 @@ public class PSOPreventDeepCloneUDF extends PSSimpleJavaUdfExtension implements 
    * @param request the callers request context
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[],
    *     com.percussion.server.IPSRequestContext)
+   * @return the result
+   * @throws PSConversionException if an error occurs
    */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSOPreventOnTranslatedItem.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSOPreventOnTranslatedItem.java
@@ -63,16 +63,33 @@ import org.apache.logging.log4j.Logger;
       PSEffectContext.PRE_CLONE,
       PSEffectContext.PRE_WORKFLOW
     })
+/**
+ * PSOPreventOnTranslatedItem class.
+ */
 public class PSOPreventOnTranslatedItem implements IPSEffect {
+  /**
+   * Creates a new PSOPreventOnTranslatedItem.
+   */
+  public PSOPreventOnTranslatedItem() {
+    // default
+  }
+
 
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOPreventOnTranslatedItem.class);
 
+  /** cws. */
   protected static IPSContentWs cws = null;
+  /** sws. */
   protected static IPSSystemWs sws = null;
+  /** gmgr. */
   protected static IPSGuidManager gmgr = null;
 
-  /** Initialize service pointers. */
+  /**
+   * Initialize service pointers.
+   * initServices operation.
+   *
+   */
   protected static void initServices() {
     if (cws == null) {
       cws = PSContentWsLocator.getContentWebservice();
@@ -81,7 +98,17 @@ public class PSOPreventOnTranslatedItem implements IPSEffect {
     }
   }
 
-  /** Tests if this relationship owner is a translation of some other item. */
+  /**
+   * Tests if this relationship owner is a translation of some other item.
+   * test operation.
+   * @param params the params
+   * @param req the req
+   * @param exCtx the ex ctx
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   *
+   */
   public void test(
       Object[] params, IPSRequestContext req, IPSExecutionContext exCtx, PSEffectResult result)
       throws PSExtensionProcessingException, PSParameterMismatchException {
@@ -109,6 +136,16 @@ public class PSOPreventOnTranslatedItem implements IPSEffect {
   private static final String MSG_TRANSLATED_ITEM =
       "This operation is not valid on translated items";
 
+  /**
+   * attempt operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @param context the context
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   */
   public void attempt(
       Object[] params,
       IPSRequestContext request,
@@ -118,6 +155,16 @@ public class PSOPreventOnTranslatedItem implements IPSEffect {
     result.setSuccess();
   }
 
+  /**
+   * recover operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @param exCtx the ex ctx
+   * @param e the e
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   @Override
   public void recover(
       Object[] params,
@@ -129,8 +176,22 @@ public class PSOPreventOnTranslatedItem implements IPSEffect {
     result.setSuccess();
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {}
 
+  /**
+   * findTranslationOwner operation.
+   *
+   * @param id the id
+   * @return the result
+   * @throws PSErrorException if an error occurs
+   */
   public int findTranslationOwner(int id) throws PSErrorException {
 
     var filter = new PSRelationshipFilter();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSOSetFieldOnSlottedItemEffect.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/effects/PSOSetFieldOnSlottedItemEffect.java
@@ -69,6 +69,13 @@ import org.apache.logging.log4j.Logger;
  */
 @PSHandlesEffectContext(required = PSEffectContext.ALL)
 public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
+  /**
+   * Creates a new PSOSetFieldOnSlottedItemEffect.
+   */
+  public PSOSetFieldOnSlottedItemEffect() {
+    // default
+  }
+
 
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOSetFieldOnSlottedItemEffect.class);
@@ -79,6 +86,7 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
   /***
    * Returns a valid ContentWS instance
    *
+   * @return the result
    */
   protected static IPSContentWs getContentService() {
     if (mCws == null) mCws = PSContentWsLocator.getContentWebservice();
@@ -89,6 +97,7 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
   /***
    * Returns a valid Guid Manager instance.
    *
+   * @return the result
    */
   protected static IPSGuidManager getGuidManager() {
     if (mGmgr == null) mGmgr = PSGuidManagerLocator.getGuidMgr();
@@ -102,15 +111,21 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
    */
   private class ConfiguredParams {
 
+    /** field name. */
     protected String fieldName;
+    /** value if empty. */
     protected String valueIfEmpty;
+    /** value if not empty. */
     protected String valueIfNotEmpty;
+    /** slot name. */
     protected String slotName;
+    /** slot id. */
     protected int slotId;
 
     /***
      * Constructor to initialize a new parameter object
-     * @param params
+     * @param params the params
+     * @return the result
      */
     protected ConfiguredParams(Object[] params) {
 
@@ -270,7 +285,8 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
 
     /***
      * Convenience constructor
-     * @param props
+     * @param props the props
+     * @return the result
      */
     protected RelationshipParams(Map<String, String> props) {
 
@@ -286,6 +302,13 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
     }
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param f the f
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef def, File f) throws PSExtensionException {
     log.debug("Initializing...");
 
@@ -299,6 +322,12 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
   /***
    * This is called when the Effect is being executed.  Note, this will be called for every item in a slot
    * during a save request.
+   * @param params the params
+   * @param request the request
+   * @param context the context
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
    */
   public void attempt(
       Object[] params,
@@ -413,6 +442,16 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
     result.setSuccess();
   }
 
+  /**
+   * recover operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @param context the context
+   * @param e the e
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   @Override
   public void recover(
       Object[] params,
@@ -424,6 +463,16 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
     // TODO: Implement me
   }
 
+  /**
+   * test operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @param context the context
+   * @param result the result
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   */
   public void test(
       Object[] params,
       IPSRequestContext request,
@@ -479,6 +528,7 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
     return newValue;
   }
 
+  /** processed flag. */
   public static String PROCESSED_FLAG = "PSOSetFieldOnSlottedItemProcessedFlag";
 
   /***
@@ -486,7 +536,7 @@ public class PSOSetFieldOnSlottedItemEffect implements IPSEffect {
    * input transform doesn't overwrite the output of the effect when running
    * in non Content Editor contexts.
    *
-   * @param ctx
+   * @param  the ctx
    */
   private void setProcessedFlag(IPSRequestContext ctx) {
     ctx.setParameter(PROCESSED_FLAG, true);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSOAncestorFolderSlotContentFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSOAncestorFolderSlotContentFinder.java
@@ -61,12 +61,17 @@ public class PSOAncestorFolderSlotContentFinder extends PSBaseSlotContentFinder 
   private PSOFolderTools folderTools;
   private IPSContentWs contentWs;
 
+  /** param contenttype. */
   public static final String PARAM_CONTENTTYPE = "contenttype";
 
   /** The log instance to use for this class, never <code>null</code>. */
   private static final Logger log = LogManager.getLogger(PSOAncestorFolderSlotContentFinder.class);
 
-  /** Constructor for Extensions Manager. */
+  /**
+   * Constructor for Extensions Manager.
+   * Creates a new PSOAncestorFolderSlotContentFinder.
+   *
+   */
   public PSOAncestorFolderSlotContentFinder() {}
 
   /**
@@ -80,11 +85,28 @@ public class PSOAncestorFolderSlotContentFinder extends PSBaseSlotContentFinder 
     init(contentWs, folderTools);
   }
 
+  /**
+   * init operation.
+   *
+   * @param contentWs the content ws
+   * @param folderTools the folder tools
+   */
   protected final void init(IPSContentWs contentWs, PSOFolderTools folderTools) {
     this.contentWs = contentWs;
     this.folderTools = folderTools;
   }
 
+  /**
+   * Returns the slot items.
+   *
+   * @param assemblyItem the assembly item
+   * @param slot the slot
+   * @param params the params
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   * @throws PSFilterException if an error occurs
+   * @throws PSAssemblyException if an error occurs
+   */
   @Override
   public Set<SlotItem> getSlotItems(
       IPSAssemblyItem assemblyItem, IPSTemplateSlot slot, Map<String, Object> params)
@@ -140,10 +162,22 @@ public class PSOAncestorFolderSlotContentFinder extends PSBaseSlotContentFinder 
     return null;
   }
 
+  /**
+   * Returns the type.
+   *
+   * @return the result
+   */
   public Type getType() {
     return Type.AUTOSLOT;
   }
 
+  /**
+   * init operation.
+   *
+   * @param extDef the ext def
+   * @param file the file
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef extDef, File file) throws PSExtensionException {
     super.init(extDef, file);
     IPSContentWs cws = PSContentWsLocator.getContentWebservice();
@@ -153,18 +187,38 @@ public class PSOAncestorFolderSlotContentFinder extends PSBaseSlotContentFinder 
     init(cws, ft);
   }
 
+  /**
+   * Returns the folder tools.
+   *
+   * @return the result
+   */
   public PSOFolderTools getFolderTools() {
     return folderTools;
   }
 
+  /**
+   * Sets the folder tools.
+   *
+   * @param folderTools the folder tools
+   */
   public void setFolderTools(PSOFolderTools folderTools) {
     this.folderTools = folderTools;
   }
 
+  /**
+   * Returns the content ws.
+   *
+   * @return the result
+   */
   public IPSContentWs getContentWs() {
     return contentWs;
   }
 
+  /**
+   * Sets the content ws.
+   *
+   * @param contentWs the content ws
+   */
   public void setContentWs(IPSContentWs contentWs) {
     this.contentWs = contentWs;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSOReverseSlotContentFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSOReverseSlotContentFinder.java
@@ -85,15 +85,28 @@ public class PSOReverseSlotContentFinder extends PSBaseSlotContentFinder
     }
   }
 
-  /** Default Constructor. */
+  /**
+   * Default Constructor.
+   * Creates a new PSOReverseSlotContentFinder.
+   *
+   */
   public PSOReverseSlotContentFinder() {
     super();
   }
 
   /**
+   * Returns the slot items.
+   *
    * @see
    *     com.percussion.services.assembly.impl.finder.PSBaseSlotContentFinder#getSlotItems(com.percussion.services.assembly.IPSAssemblyItem,
    *     com.percussion.services.assembly.IPSTemplateSlot, java.util.Map)
+   * @param sourceItem the source item
+   * @param slot the slot
+   * @param selectors the selectors
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   * @throws PSFilterException if an error occurs
+   * @throws PSAssemblyException if an error occurs
    */
   @Override
   protected Set<SlotItem> getSlotItems(
@@ -195,6 +208,7 @@ public class PSOReverseSlotContentFinder extends PSBaseSlotContentFinder
    * Returns the slot type. Reverse slots are Computed slots.
    *
    * @see com.percussion.services.assembly.IPSSlotContentFinder#getType()
+   * @return the result
    */
   public Type getType() {
     return com.percussion.services.assembly.IPSSlotContentFinder.Type.COMPUTED;
@@ -213,6 +227,8 @@ public class PSOReverseSlotContentFinder extends PSBaseSlotContentFinder
   public static final String PARAM_LIMITPUBLIC = "limit_public";
 
   /**
+   * Sets the asm.
+   *
    * @param asm The asm to set. Only for use in Unit Tests
    */
   public static void setAsm(IPSAssemblyService asm) {
@@ -220,6 +236,8 @@ public class PSOReverseSlotContentFinder extends PSBaseSlotContentFinder
   }
 
   /**
+   * Sets the gmgr.
+   *
    * @param gmgr The gmgr to set. Only for use in Unit Tests
    */
   public static void setGmgr(IPSGuidManager gmgr) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSOSQLContentFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSOSQLContentFinder.java
@@ -132,15 +132,28 @@ public class PSOSQLContentFinder extends PSBaseSlotContentFinder implements IPSS
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOSQLContentFinder.class);
 
-  /** Default Constructor */
+  /**
+   * Default Constructor
+   * Creates a new PSOSQLContentFinder.
+   *
+   */
   public PSOSQLContentFinder() {
     super();
   }
 
   /**
+   * Returns the slot items.
+   *
    * @see
    *     com.percussion.services.assembly.impl.finder.PSBaseSlotContentFinder#getSlotItems(com.percussion.services.assembly.IPSAssemblyItem,
    *     com.percussion.services.assembly.IPSTemplateSlot, java.util.Map)
+   * @param sourceItem the source item
+   * @param slot the slot
+   * @param selectors the selectors
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   * @throws PSFilterException if an error occurs
+   * @throws PSAssemblyException if an error occurs
    */
   @Override
   protected Set<SlotItem> getSlotItems(
@@ -237,6 +250,7 @@ public class PSOSQLContentFinder extends PSBaseSlotContentFinder implements IPSS
    * This finder is an AUTOSLOT finder.
    *
    * @see com.percussion.services.assembly.IPSSlotContentFinder#getType()
+   * @return the result
    */
   public Type getType() {
     return IPSSlotContentFinder.Type.AUTOSLOT;
@@ -249,7 +263,7 @@ public class PSOSQLContentFinder extends PSBaseSlotContentFinder implements IPSS
    *
    * @param template the template name or id.
    * @return the template GUID or <code>null</code> if the template was not found.
-   * @throws PSAssemblyException
+   * @throws PSAssemblyException if an error occurs
    */
   protected IPSGuid findTemplateFromIdOrName(Object template) throws PSAssemblyException {
 
@@ -279,6 +293,7 @@ public class PSOSQLContentFinder extends PSBaseSlotContentFinder implements IPSS
     }
   }
 
+  /** param sqlparams. */
   public static final String PARAM_SQLPARAMS = "sqlparams";
 
   private static final String PARAM_MAY_HAVE_CROSS_SITE_LINKS = "mayHaveCrossSiteLinks";

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSParameterizedLegacyAutoSlotContentFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/finder/PSParameterizedLegacyAutoSlotContentFinder.java
@@ -57,6 +57,13 @@ import org.w3c.dom.NodeList;
  */
 public class PSParameterizedLegacyAutoSlotContentFinder extends PSBaseSlotContentFinder
     implements IPSSlotContentFinder {
+  /**
+   * Creates a new PSParameterizedLegacyAutoSlotContentFinder.
+   */
+  public PSParameterizedLegacyAutoSlotContentFinder() {
+    // default
+  }
+
   private static final Logger log =
       LogManager.getLogger(PSParameterizedLegacyAutoSlotContentFinder.class.getName());
 
@@ -64,6 +71,12 @@ public class PSParameterizedLegacyAutoSlotContentFinder extends PSBaseSlotConten
    * This method returns a set of SlotItems retrieved from a legacy XML query resource. The resource
    * output should conform to sys_AssemblerInfo.dtd, but only the content ID (linkurl/@contentid)
    * and the template ID (linkurl/@variantid) are of import to this routine.
+   * @param item the item
+   * @param slot the slot
+   * @param params the params
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   * @throws PSFilterException if an error occurs
    */
   protected Set<SlotItem> getSlotItems(
       IPSAssemblyItem item, IPSTemplateSlot slot, Map<String, Object> params)
@@ -149,6 +162,11 @@ public class PSParameterizedLegacyAutoSlotContentFinder extends PSBaseSlotConten
     return hits;
   }
 
+  /**
+   * Returns the type.
+   *
+   * @return the result
+   */
   public Type getType() {
     return com.percussion.services.assembly.IPSSlotContentFinder.Type.AUTOSLOT;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/fop/FopAssembler.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/fop/FopAssembler.java
@@ -98,7 +98,9 @@ public class FopAssembler extends PSVelocityAssembler implements IPSAssembler {
   private final TransformerFactory xfactory;
   private FopFactory fopFactory = null;
 
-  /** */
+  /**
+   * Creates a new FopAssembler.
+   */
   public FopAssembler() {
     super();
     xfactory = PSSecureXMLUtils.getSecuredTransformerFactory();
@@ -125,7 +127,12 @@ public class FopAssembler extends PSVelocityAssembler implements IPSAssembler {
   }
 
   /**
+   * init operation.
+   *
    * @see PSVelocityAssembler#init(IPSExtensionDef, File)
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
    */
   @Override
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
@@ -135,8 +142,13 @@ public class FopAssembler extends PSVelocityAssembler implements IPSAssembler {
   }
 
   /**
+   * doAssembleSingle operation.
+   *
    * @see
    *     com.percussion.services.assembly.impl.plugin.PSAssemblerBase#doAssembleSingle(IPSAssemblyItem)
+   * @param item the item
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   protected IPSAssemblyResult doAssembleSingle(IPSAssemblyItem item) throws Exception {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/AbstractImageMetaData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/AbstractImageMetaData.java
@@ -16,37 +16,53 @@
  */
 package com.percussion.pso.imageedit.data;
 
+/**
+ * Base holder for image editor session key and image metadata.
+ */
 public class AbstractImageMetaData {
+  /** Session or cache key for the image being edited. */
   private String imageKey;
+  /** Associated image metadata. */
   private ImageMetaData metaData;
 
+  /**
+   * Creates an empty metadata holder.
+   */
   public AbstractImageMetaData() {
     super();
   }
 
   /**
-   * @return the imageKey
+   * Returns the image session key.
+   *
+   * @return the image key
    */
   public String getImageKey() {
     return imageKey;
   }
 
   /**
-   * @param imageKey the imageKey to set
+   * Sets the image session key.
+   *
+   * @param imageKey the image key to set
    */
   public void setImageKey(String imageKey) {
     this.imageKey = imageKey;
   }
 
   /**
-   * @return the metaData
+   * Returns the image metadata.
+   *
+   * @return the metadata
    */
   public ImageMetaData getMetaData() {
     return metaData;
   }
 
   /**
-   * @param metaData the metaData to set
+   * Sets the image metadata.
+   *
+   * @param metaData the metadata to set
    */
   public void setMetaData(ImageMetaData metaData) {
     this.metaData = metaData;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ByteArrayDataSource.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ByteArrayDataSource.java
@@ -34,31 +34,57 @@ public class ByteArrayDataSource implements DataSource {
   String name;
   String contentType;
 
-  /** */
-  public ByteArrayDataSource() {
+        /**
+     * Creates a new ByteArrayDataSource.
+     */
+    public ByteArrayDataSource() {
     store = new ByteArrayOutputStream();
   }
 
+  /**
+   * Creates a new ByteArrayDataSource.
+   */
+  /**
+   * Creates a data source for the given name and content type.
+   *
+   * @param name the data source name
+   * @param contentType the MIME content type
+   */
   public ByteArrayDataSource(String name, String contentType) {
     this();
     this.name = name;
     this.contentType = contentType;
   }
 
+  /**
+   * Creates a new ByteArrayDataSource.
+   */
+  /**
+   * Creates a data source with an initial buffer size.
+   *
+   * @param name the data source name
+   * @param contentType the MIME content type
+   * @param size the initial buffer size
+   */
   public ByteArrayDataSource(String name, String contentType, int size) {
     this(name, contentType);
     store = new ByteArrayOutputStream(size);
   }
 
   /**
+   * See referenced member.
    * @see DataSource#getContentType()
+   * @return the result
    */
   public String getContentType() {
     return contentType;
   }
 
   /**
+   * See referenced member.
    * @see DataSource#getInputStream()
+   * @return the result
+   * @throws IOException if an error occurs
    */
   public InputStream getInputStream() throws IOException {
     ByteArrayInputStream bis = new ByteArrayInputStream(store.toByteArray());
@@ -66,14 +92,19 @@ public class ByteArrayDataSource implements DataSource {
   }
 
   /**
+   * See referenced member.
    * @see DataSource#getName()
+   * @return the result
    */
   public String getName() {
     return name;
   }
 
   /**
+   * See referenced member.
    * @see DataSource#getOutputStream()
+   * @return the result
+   * @throws IOException if an error occurs
    */
   public OutputStream getOutputStream() throws IOException {
     return store;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageBean.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageBean.java
@@ -16,21 +16,42 @@
  */
 package com.percussion.pso.imageedit.data;
 
+/**
+ * Form/backing bean for image editor UI properties (title, crop, sizes).
+ */
 public class ImageBean {
+  /** System title of the image item. */
   private String sysTitle;
+  /** Display title shown in the UI. */
   private String displayTitle;
+  /** Long description of the image. */
   private String description;
+  /** Alternate text for accessibility. */
   private String alt;
+  /** Encoded list of sized image variants. */
   private String sizedImages;
+  /** Image width in pixels. */
   private int width;
+  /** Image height in pixels. */
   private int height;
+  /** Crop origin X coordinate. */
   private int x;
+  /** Crop origin Y coordinate. */
   private int y;
+  /** Whether aspect ratio is constrained. */
   private Boolean constraint = true;
+  /** Whether the bean has unsaved edits. */
   private boolean dirty = false;
 
   /**
-   * is the item dirty?
+   * Creates an empty image bean.
+   */
+  public ImageBean() {
+    super();
+  }
+
+  /**
+   * Returns whether the item is dirty.
    *
    * @return the dirty flag
    */
@@ -47,86 +68,182 @@ public class ImageBean {
     this.dirty = dirty;
   }
 
+  /**
+   * Returns whether aspect ratio is constrained.
+   *
+   * @return {@code true} if constrained
+   */
   public Boolean isConstraint() {
     return constraint;
   }
 
+  /**
+   * Sets whether aspect ratio is constrained.
+   *
+   * @param constraint the constraint flag
+   */
   public void setConstraint(Boolean constraint) {
     this.constraint = constraint;
   }
 
-  public ImageBean() {
-    super();
-  }
-
+  /**
+   * Returns the system title.
+   *
+   * @return the system title
+   */
   public String getSysTitle() {
     return sysTitle;
   }
 
+  /**
+   * Sets the system title.
+   *
+   * @param sysTitle the system title
+   */
   public void setSysTitle(String sysTitle) {
     this.sysTitle = sysTitle;
   }
 
+  /**
+   * Returns the display title.
+   *
+   * @return the display title
+   */
   public String getDisplayTitle() {
     return displayTitle;
   }
 
+  /**
+   * Sets the display title.
+   *
+   * @param displayTitle the display title
+   */
   public void setDisplayTitle(String displayTitle) {
     this.displayTitle = displayTitle;
   }
 
+  /**
+   * Returns the description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the description.
+   *
+   * @param description the description
+   */
   public void setDescription(String description) {
     this.description = description;
   }
 
+  /**
+   * Returns the alternate text.
+   *
+   * @return the alt text
+   */
   public String getAlt() {
     return alt;
   }
 
+  /**
+   * Sets the alternate text.
+   *
+   * @param alt the alt text
+   */
   public void setAlt(String alt) {
     this.alt = alt;
   }
 
+  /**
+   * Returns the sized-images payload.
+   *
+   * @return the sized images value
+   */
   public String getSizedImages() {
     return sizedImages;
   }
 
+  /**
+   * Sets the sized-images payload.
+   *
+   * @param sizedImages the sized images value
+   */
   public void setSizedImages(String sizedImages) {
     this.sizedImages = sizedImages;
   }
 
+  /**
+   * Returns the image width.
+   *
+   * @return width in pixels
+   */
   public int getWidth() {
     return width;
   }
 
+  /**
+   * Sets the image width.
+   *
+   * @param width width in pixels
+   */
   public void setWidth(int width) {
     this.width = width;
   }
 
+  /**
+   * Returns the image height.
+   *
+   * @return height in pixels
+   */
   public int getHeight() {
     return height;
   }
 
+  /**
+   * Sets the image height.
+   *
+   * @param height height in pixels
+   */
   public void setHeight(int height) {
     this.height = height;
   }
 
+  /**
+   * Returns the crop origin X coordinate.
+   *
+   * @return the X coordinate
+   */
   public int getX() {
     return x;
   }
 
+  /**
+   * Sets the crop origin X coordinate.
+   *
+   * @param x the X coordinate
+   */
   public void setX(int x) {
     this.x = x;
   }
 
+  /**
+   * Returns the crop origin Y coordinate.
+   *
+   * @return the Y coordinate
+   */
   public int getY() {
     return y;
   }
 
+  /**
+   * Sets the crop origin Y coordinate.
+   *
+   * @param y the Y coordinate
+   */
   public void setY(int y) {
     this.y = y;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageData.java
@@ -29,12 +29,15 @@ public class ImageData extends ImageMetaData implements Serializable {
   private static final long serialVersionUID = -135423469L;
   private byte[] binary;
 
-  /** */
-  public ImageData() {
+    /**
+     * Creates a new ImageData.
+     */
+    public ImageData() {
     super();
   }
 
   /**
+   * Returns the binary.
    * @return the binary
    */
   public byte[] getBinary() {
@@ -42,12 +45,18 @@ public class ImageData extends ImageMetaData implements Serializable {
   }
 
   /**
+   * Sets the binary.
    * @param binary the binary to set
    */
   public void setBinary(byte[] binary) {
     this.binary = binary;
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   @Override
   public String toString() {
     return super.toString();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageEditorException.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageEditorException.java
@@ -22,28 +22,33 @@ package com.percussion.pso.imageedit.data;
  * @author DavidBenua
  */
 public class ImageEditorException extends RuntimeException {
-  /** */
-  private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
+  /**
+   * Creates a new ImageEditorException.
+   */
   public ImageEditorException() {}
 
   /**
-   * @param message
+   * Sets the message.
+   * @param message the message
    */
   public ImageEditorException(String message) {
     super(message);
   }
 
   /**
-   * @param cause
+   * Sets the cause.
+   * @param cause the cause
    */
   public ImageEditorException(Throwable cause) {
     super(cause);
   }
 
   /**
-   * @param message
-   * @param cause
+   * Sets the message.
+   * @param message the message
+   * @param cause the cause
    */
   public ImageEditorException(String message, Throwable cause) {
     super(message, cause);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageMetaData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageMetaData.java
@@ -19,6 +19,9 @@ package com.percussion.pso.imageedit.data;
 import java.io.Serializable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+/**
+ * ImageMetaData class.
+ */
 public class ImageMetaData implements Serializable {
 
   private static final long serialVersionUID = -13542359L;
@@ -31,7 +34,11 @@ public class ImageMetaData implements Serializable {
   private int width = 0;
   private int height = 0;
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new ImageMetaData.
+   *
+   */
   public ImageMetaData() {
     super();
   }
@@ -51,6 +58,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Returns the mimeType.
    * @return the mimeType
    */
   public String getMimeType() {
@@ -58,6 +66,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Sets the mimeType.
    * @param mimeType the mimeType to set
    */
   public void setMimeType(String mimeType) {
@@ -65,6 +74,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Returns the ext.
    * @return the ext
    */
   public String getExt() {
@@ -72,6 +82,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Sets the ext.
    * @param ext the ext to set
    */
   public void setExt(String ext) {
@@ -79,6 +90,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Returns the filename.
    * @return the filename
    */
   public String getFilename() {
@@ -86,6 +98,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Sets the filename.
    * @param filename the filename to set
    */
   public void setFilename(String filename) {
@@ -93,6 +106,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Returns the size.
    * @return the size
    */
   public long getSize() {
@@ -100,6 +114,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Sets the size.
    * @param size the size to set
    */
   public void setSize(long size) {
@@ -107,6 +122,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Returns the width.
    * @return the width
    */
   public int getWidth() {
@@ -114,6 +130,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Sets the width.
    * @param width the width to set
    */
   public void setWidth(int width) {
@@ -121,6 +138,7 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Returns the height.
    * @return the height
    */
   public int getHeight() {
@@ -128,12 +146,18 @@ public class ImageMetaData implements Serializable {
   }
 
   /**
+   * Sets the height.
    * @param height the height to set
    */
   public void setHeight(int height) {
     this.height = height;
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   public String toString() {
     return new ToStringBuilder(this)
         .append("filename", filename)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageSizeDefinition.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageSizeDefinition.java
@@ -23,6 +23,13 @@ package com.percussion.pso.imageedit.data;
  * @author DavidBenua
  */
 public class ImageSizeDefinition {
+  /**
+   * Creates a new ImageSizeDefinition.
+   */
+  public ImageSizeDefinition() {
+    // default
+  }
+
   private String code;
   private String label;
   private int height;
@@ -31,6 +38,7 @@ public class ImageSizeDefinition {
   private String binaryTemplate;
 
   /**
+   * Returns the code.
    * @return the code
    */
   public String getCode() {
@@ -38,6 +46,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Sets the code.
    * @param code the code to set
    */
   public void setCode(String code) {
@@ -45,6 +54,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Returns the label.
    * @return the label
    */
   public String getLabel() {
@@ -52,6 +62,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Sets the label.
    * @param label the label to set
    */
   public void setLabel(String label) {
@@ -59,6 +70,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Returns the height.
    * @return the height
    */
   public int getHeight() {
@@ -66,6 +78,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Sets the height.
    * @param height the height to set
    */
   public void setHeight(int height) {
@@ -73,6 +86,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Returns the width.
    * @return the width
    */
   public int getWidth() {
@@ -80,6 +94,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Sets the width.
    * @param width the width to set
    */
   public void setWidth(int width) {
@@ -87,6 +102,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Returns the snippetTemplate.
    * @return the snippetTemplate
    */
   public String getSnippetTemplate() {
@@ -94,6 +110,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Sets the snippetTemplate.
    * @param snippetTemplate the snippetTemplate to set
    */
   public void setSnippetTemplate(String snippetTemplate) {
@@ -101,6 +118,7 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Returns the binaryTemplate.
    * @return the binaryTemplate
    */
   public String getBinaryTemplate() {
@@ -108,12 +126,18 @@ public class ImageSizeDefinition {
   }
 
   /**
+   * Sets the binaryTemplate.
    * @param binaryTemplate the binaryTemplate to set
    */
   public void setBinaryTemplate(String binaryTemplate) {
     this.binaryTemplate = binaryTemplate;
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   @Override
   public String toString() {
     final StringBuffer sb = new StringBuffer("ImageSizeDefinition{");

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/MasterImageMetaData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/MasterImageMetaData.java
@@ -19,6 +19,9 @@ package com.percussion.pso.imageedit.data;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * MasterImageMetaData class.
+ */
 public class MasterImageMetaData extends AbstractImageMetaData {
   private String sysTitle;
   private String displayTitle;
@@ -26,12 +29,16 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   private String alt;
   private Map<String, SizedImageMetaData> sizedImages;
 
+  /**
+   * Creates a new MasterImageMetaData.
+   */
   public MasterImageMetaData() {
     super();
     sizedImages = new LinkedHashMap<String, SizedImageMetaData>();
   }
 
   /**
+   * Returns the sysTitle.
    * @return the sysTitle
    */
   public String getSysTitle() {
@@ -39,6 +46,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Sets the sysTitle.
    * @param sysTitle the sysTitle to set
    */
   public void setSysTitle(String sysTitle) {
@@ -46,6 +54,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Returns the displayTitle.
    * @return the displayTitle
    */
   public String getDisplayTitle() {
@@ -53,6 +62,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Sets the displayTitle.
    * @param displayTitle the displayTitle to set
    */
   public void setDisplayTitle(String displayTitle) {
@@ -60,6 +70,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Returns the description.
    * @return the description
    */
   public String getDescription() {
@@ -67,6 +78,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Sets the description.
    * @param description the description to set
    */
   public void setDescription(String description) {
@@ -74,6 +86,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Returns the alt.
    * @return the alt
    */
   public String getAlt() {
@@ -81,6 +94,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Sets the alt.
    * @param alt the alt to set
    */
   public void setAlt(String alt) {
@@ -97,6 +111,7 @@ public class MasterImageMetaData extends AbstractImageMetaData {
   }
 
   /**
+   * Sets the sizedImages.
    * @param sizedImages the sizedImages to set
    */
   public void setSizedImages(Map<String, SizedImageMetaData> sizedImages) {
@@ -113,10 +128,18 @@ public class MasterImageMetaData extends AbstractImageMetaData {
     this.sizedImages.put(key, sizedImage);
   }
 
+  /**
+   * clearSizedImages operation.
+   */
   public void clearSizedImages() {
     this.sizedImages = new LinkedHashMap<String, SizedImageMetaData>();
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   @Override
   public String toString() {
     final StringBuffer sb = new StringBuffer("MasterImageMetaData{");

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/OpenImageResult.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/OpenImageResult.java
@@ -27,8 +27,17 @@ public class OpenImageResult {
   private MasterImageMetaData masterImage;
   private PSItemStatus itemStatus;
 
+  /**
+   * Creates a new OpenImageResult.
+   */
   public OpenImageResult() {}
 
+  /**
+   * Creates a new OpenImageResult.
+   *
+   * @param masterImage the master image
+   * @param itemStatus the item status
+   */
   public OpenImageResult(MasterImageMetaData masterImage, PSItemStatus itemStatus) {
     this();
     this.masterImage = masterImage;
@@ -36,6 +45,7 @@ public class OpenImageResult {
   }
 
   /**
+   * Returns the masterImage.
    * @return the masterImage
    */
   public MasterImageMetaData getMasterImage() {
@@ -43,6 +53,7 @@ public class OpenImageResult {
   }
 
   /**
+   * Returns the itemStatus.
    * @return the itemStatus
    */
   public PSItemStatus getItemStatus() {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/SimpleImageMetaData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/SimpleImageMetaData.java
@@ -29,7 +29,11 @@ public class SimpleImageMetaData extends AbstractImageMetaData {
   /** height in pixels. */
   private int height = 0;
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new SimpleImageMetaData.
+   *
+   */
   public SimpleImageMetaData() {}
 
   /**
@@ -40,6 +44,11 @@ public class SimpleImageMetaData extends AbstractImageMetaData {
   @SuppressWarnings("this-escape")
   // Safe because setImageKey and setMetaData are final in practice (not overridden in this class)
   // and only set superclass fields, not accessing subclass state.
+  /**
+   * Creates a new SimpleImageMetaData.
+   *
+   * @param data the data
+   */
   public SimpleImageMetaData(AbstractImageMetaData data) {
     this.setImageKey(data.getImageKey());
     this.setMetaData(data.getMetaData());

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/SizedImageMetaData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/SizedImageMetaData.java
@@ -22,29 +22,57 @@ package com.percussion.pso.imageedit.data;
  * @author DavidBenua
  */
 public class SizedImageMetaData extends SimpleImageMetaData {
+  /**
+   * Creates a new SizedImageMetaData.
+   */
+  public SizedImageMetaData() {
+    // default
+  }
+
   private ImageSizeDefinition sizeDefinition;
 
   private int x = 0;
   private int y = 0;
   private Boolean constraint = true;
 
+  /**
+   * Returns the x.
+   *
+   * @return the result
+   */
   public int getX() {
     return x;
   }
 
+  /**
+   * Sets the x.
+   *
+   * @param x the x
+   */
   public void setX(int x) {
     this.x = x;
   }
 
+  /**
+   * Returns the y.
+   *
+   * @return the result
+   */
   public int getY() {
     return y;
   }
 
+  /**
+   * Sets the y.
+   *
+   * @param y the y
+   */
   public void setY(int y) {
     this.y = y;
   }
 
   /**
+   * Returns the sizeDefinition.
    * @return the sizeDefinition
    */
   public ImageSizeDefinition getSizeDefinition() {
@@ -52,12 +80,18 @@ public class SizedImageMetaData extends SimpleImageMetaData {
   }
 
   /**
+   * Sets the sizeDefinition.
    * @param sizeDefinition the sizeDefinition to set
    */
   public void setSizeDefinition(ImageSizeDefinition sizeDefinition) {
     this.sizeDefinition = sizeDefinition;
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   @Override
   public String toString() {
     final StringBuffer sb = new StringBuffer("SizedImageMetaData{");
@@ -69,10 +103,20 @@ public class SizedImageMetaData extends SimpleImageMetaData {
     return sb.toString();
   }
 
+  /**
+   * Returns whether constraint.
+   *
+   * @return the result
+   */
   public Boolean isConstraint() {
     return constraint;
   }
 
+  /**
+   * Sets the constraint.
+   *
+   * @param constraint the constraint
+   */
   public void setConstraint(Boolean constraint) {
     this.constraint = constraint;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/UserSessionData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/UserSessionData.java
@@ -16,7 +16,17 @@
  */
 package com.percussion.pso.imageedit.data;
 
+/**
+ * UserSessionData class.
+ */
 public class UserSessionData {
+  /**
+   * Creates a new UserSessionData.
+   */
+  public UserSessionData() {
+    // default
+  }
+
 
   MasterImageMetaData mimd = null;
   String[] pages = null;
@@ -29,23 +39,44 @@ public class UserSessionData {
 
   // Map<String, Dimension> resizeDetails = new HashMap<String, Dimension>();
 
+  /**
+   * Returns the mimd.
+   *
+   * @return the result
+   */
   public MasterImageMetaData getMimd() {
     return mimd;
   }
 
+  /**
+   * Sets the mimd.
+   *
+   * @param mimd the mimd
+   */
   public void setMimd(MasterImageMetaData mimd) {
     this.mimd = mimd;
   }
 
+  /**
+   * Returns the pages.
+   *
+   * @return the result
+   */
   public String[] getPages() {
     return pages;
   }
 
+  /**
+   * Sets the pages.
+   *
+   * @param pages the pages
+   */
   public void setPages(String[] pages) {
     this.pages = pages;
   }
 
   /**
+   * Returns the scaleFactor.
    * @return the scaleFactor
    */
   public double getScaleFactor() {
@@ -53,6 +84,7 @@ public class UserSessionData {
   }
 
   /**
+   * Sets the scaleFactor.
    * @param scaleFactor the scaleFactor to set
    */
   public void setScaleFactor(double scaleFactor) {
@@ -60,6 +92,7 @@ public class UserSessionData {
   }
 
   /**
+   * Returns the displayImage.
    * @return the displayImage
    */
   public SimpleImageMetaData getDisplayImage() {
@@ -67,16 +100,27 @@ public class UserSessionData {
   }
 
   /**
+   * Sets the displayImage.
    * @param displayImage the displayImage to set
    */
   public void setDisplayImage(SimpleImageMetaData displayImage) {
     this.displayImage = displayImage;
   }
 
+  /**
+   * Returns whether dirty.
+   *
+   * @return the result
+   */
   public boolean isDirty() {
     return dirty;
   }
 
+  /**
+   * Sets the dirty.
+   *
+   * @param dirty the dirty
+   */
   public void setDirty(boolean dirty) {
     this.dirty = dirty;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/AbstractTemplateExpanderAdaptor.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/AbstractTemplateExpanderAdaptor.java
@@ -67,6 +67,13 @@ import org.apache.logging.log4j.Logger;
 public abstract class AbstractTemplateExpanderAdaptor implements IPSTemplateExpander {
   private static final Logger log = LogManager.getLogger(AbstractTemplateExpanderAdaptor.class);
 
+  /**
+   * Creates a template expander with default settings.
+   */
+  protected AbstractTemplateExpanderAdaptor() {
+    // default
+  }
+
   private boolean NeedsContentNode = false;
 
   private static IPSGuidManager gmgr = null;
@@ -82,12 +89,22 @@ public abstract class AbstractTemplateExpanderAdaptor implements IPSTemplateExpa
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.extension.IPSExtension#init(IPSExtensionDef, File)
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
    */
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {}
 
   /**
+   * See referenced member.
    * @see IPSTemplateExpander#expand(QueryResult, Map, Map)
+   * @param results the results
+   * @param parameters the parameters
+   * @param summaryMap the summary map
+   * @return the result
+   * @throws PSPublisherException if an error occurs
    */
   public List<PSContentListItem> expand(
       QueryResult results,
@@ -225,7 +242,7 @@ public abstract class AbstractTemplateExpanderAdaptor implements IPSTemplateExpa
    * @param summaryMap the map of component summaries. Never <code>null</code>. This map is
    *     guaranteed to contain all items referenced in the query result.
    * @return the map of Nodes.
-   * @throws RepositoryException
+   * @throws RepositoryException if content nodes cannot be loaded
    */
   protected Map<IPSGuid, Node> buildNodeMap(
       QueryResult result, Map<Integer, PSComponentSummary> summaryMap) throws RepositoryException {
@@ -265,28 +282,36 @@ public abstract class AbstractTemplateExpanderAdaptor implements IPSTemplateExpa
   }
 
   /**
-   * @return the needsContentNode
+   * Returns whether content nodes must be loaded for template selection.
+   *
+   * @return {@code true} if content nodes are required
    */
   protected boolean isNeedsContentNode() {
     return NeedsContentNode;
   }
 
   /**
-   * @param needsContentNode the needsContentNode to set
+   * Sets whether content nodes must be loaded for template selection.
+   *
+   * @param needsContentNode {@code true} if content nodes are required
    */
   protected void setNeedsContentNode(boolean needsContentNode) {
     NeedsContentNode = needsContentNode;
   }
 
   /**
-   * @param gmgr the gmgr to set
+   * Sets the GUID manager. Used for unit testing.
+   *
+   * @param gmgr the GUID manager to set
    */
   public static void setGmgr(IPSGuidManager gmgr) {
     AbstractTemplateExpanderAdaptor.gmgr = gmgr;
   }
 
   /**
-   * @param cmgr the cmgr to set
+   * Sets the content manager. Used for unit testing.
+   *
+   * @param cmgr the content manager to set
    */
   public static void setCmgr(IPSContentMgr cmgr) {
     AbstractTemplateExpanderAdaptor.cmgr = cmgr;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeDefinitionManagerLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeDefinitionManagerLocator.java
@@ -28,6 +28,11 @@ public class ImageSizeDefinitionManagerLocator extends PSBaseServiceLocator {
   /** Static methods only */
   private ImageSizeDefinitionManagerLocator() {}
 
+  /**
+   * Returns the image size definition manager.
+   *
+   * @return the result
+   */
   public static ImageSizeDefinitionManager getImageSizeDefinitionManager() {
     return (ImageSizeDefinitionManager) getBean(IMAGE_SIZE_DEFINITION_MANAGER_BEAN);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeTemplateExpander.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeTemplateExpander.java
@@ -49,9 +49,6 @@ public class ImageSizeTemplateExpander extends AbstractTemplateExpanderAdaptor
   /** Default constructor. */
   @SuppressWarnings("this-escape")
   // Safe because setNeedsContentNode is final or not overridden in subclasses
-  /**
-   * Creates a new ImageSizeTemplateExpander.
-   */
   public ImageSizeTemplateExpander() {
     super.setNeedsContentNode(true);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeTemplateExpander.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeTemplateExpander.java
@@ -49,6 +49,9 @@ public class ImageSizeTemplateExpander extends AbstractTemplateExpanderAdaptor
   /** Default constructor. */
   @SuppressWarnings("this-escape")
   // Safe because setNeedsContentNode is final or not overridden in subclasses
+  /**
+   * Creates a new ImageSizeTemplateExpander.
+   */
   public ImageSizeTemplateExpander() {
     super.setNeedsContentNode(true);
   }
@@ -68,6 +71,14 @@ public class ImageSizeTemplateExpander extends AbstractTemplateExpanderAdaptor
    *
    * @see AbstractTemplateExpanderAdaptor#findTemplates(IPSGuid, IPSGuid, IPSGuid, int,
    *     PSComponentSummary, Node, Map)
+   * @param itemGuid the item guid
+   * @param folderGuid the folder guid
+   * @param siteGuid the site guid
+   * @param context the context
+   * @param summary the summary
+   * @param contentNode the content node
+   * @param parameters the parameters
+   * @return the result
    */
   @Override
   protected List<IPSGuid> findTemplates(

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/ImageCacheManager.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/ImageCacheManager.java
@@ -19,6 +19,9 @@ package com.percussion.pso.imageedit.services.cache;
 import com.percussion.pso.imageedit.data.ImageData;
 import com.percussion.pso.imageedit.data.ImageMetaData;
 
+/**
+ * ImageCacheManager interface.
+ */
 public interface ImageCacheManager {
   /**
    * Adds an image to the cache.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/ImageCacheManagerLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/ImageCacheManagerLocator.java
@@ -25,8 +25,20 @@ import com.percussion.services.PSBaseServiceLocator;
  * @author DavidBenua
  */
 public class ImageCacheManagerLocator extends PSBaseServiceLocator {
+  /**
+   * Creates a new ImageCacheManagerLocator.
+   */
+  public ImageCacheManagerLocator() {
+    // default
+  }
+
   private static final String IMAGE_CACHE_BEAN = "imedImageMetaDataCacheImpl";
 
+  /**
+   * Returns the image cache manager.
+   *
+   * @return the result
+   */
   public static ImageCacheManager getImageCacheManager() {
     return (ImageCacheManager) getBean(IMAGE_CACHE_BEAN);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/impl/ImageCacheManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/impl/ImageCacheManagerImpl.java
@@ -24,16 +24,28 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ehcache.Cache;
 
+/**
+ * ImageCacheManagerImpl class.
+ */
 public class ImageCacheManagerImpl implements ImageCacheManager {
   private static final Logger log = LogManager.getLogger(ImageCacheManagerImpl.class);
   private long counter;
 
   private Cache<String, ImageData> cache;
 
+  /**
+   * Creates a new ImageCacheManagerImpl.
+   */
   public ImageCacheManagerImpl() {
     counter = 1;
   }
 
+  /**
+   * addImage operation.
+   *
+   * @param data the data
+   * @return the result
+   */
   public String addImage(ImageData data) {
     String imageKey = generateKey(data);
     log.debug("new image key is {}", imageKey);
@@ -43,12 +55,21 @@ public class ImageCacheManagerImpl implements ImageCacheManager {
   }
 
   /**
+   * See referenced member.
    * @see ImageCacheManager#getImage(String)
+   * @param imageKey the image key
+   * @return the result
    */
   public ImageData getImage(String imageKey) {
     return cache.get(imageKey);
   }
 
+  /**
+   * Returns the image meta data.
+   *
+   * @param imageKey the image key
+   * @return the result
+   */
   public ImageMetaData getImageMetaData(String imageKey) {
     ImageData data = getImage(imageKey);
     if (data != null) {
@@ -57,17 +78,31 @@ public class ImageCacheManagerImpl implements ImageCacheManager {
     return null;
   }
 
+  /**
+   * hasImage operation.
+   *
+   * @param imageKey the image key
+   * @return the result
+   */
   public boolean hasImage(String imageKey) {
     return cache.containsKey(imageKey);
   }
 
   /**
+   * See referenced member.
    * @see ImageCacheManager#removeImage(String)
+   * @param imageKey the image key
    */
   public void removeImage(String imageKey) {
     cache.remove(imageKey);
   }
 
+  /**
+   * generateKey operation.
+   *
+   * @param data the data
+   * @return the result
+   */
   protected String generateKey(ImageMetaData data) {
     long value = data.getSize() + data.getHeight() * 2;
     String fname = data.getFilename();
@@ -81,6 +116,7 @@ public class ImageCacheManagerImpl implements ImageCacheManager {
   }
 
   /**
+   * Returns the cache.
    * @return the cache
    */
   public Cache<String, ImageData> getCache() {
@@ -88,6 +124,7 @@ public class ImageCacheManagerImpl implements ImageCacheManager {
   }
 
   /**
+   * Sets the cache.
    * @param cache the cache to set
    */
   public void setCache(Cache<String, ImageData> cache) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/impl/ImageSizeDefinitionManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/impl/ImageSizeDefinitionManagerImpl.java
@@ -42,20 +42,27 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   /** The path name of the image to be displayed when there is no image. */
   private String failureImagePath;
 
-  /** */
-  public ImageSizeDefinitionManagerImpl() {
+    /**
+     * Creates a new ImageSizeDefinitionManagerImpl.
+     */
+    public ImageSizeDefinitionManagerImpl() {
     sizes = new ArrayList<ImageSizeDefinition>();
   }
 
   /**
+   * See referenced member.
    * @see ImageSizeDefinitionManager#getAllImageSizes()
+   * @return the result
    */
   public List<ImageSizeDefinition> getAllImageSizes() {
     return sizes;
   }
 
   /**
+   * See referenced member.
    * @see ImageSizeDefinitionManager#getImageSize(String)
+   * @param code the code
+   * @return the result
    */
   public ImageSizeDefinition getImageSize(String code) {
     if (StringUtils.isEmpty(code)) {
@@ -71,6 +78,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Returns the sizes.
    * @return the sizes
    */
   public List<ImageSizeDefinition> getSizes() {
@@ -78,6 +86,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Sets the sizes.
    * @param sizes the sizes to set
    */
   public void setSizes(List<ImageSizeDefinition> sizes) {
@@ -85,6 +94,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Returns the sizedImageNodeName.
    * @return the sizedImageNodeName
    */
   public String getSizedImageNodeName() {
@@ -92,6 +102,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Sets the sizedImageNodeName.
    * @param sizedImageNodeName the sizedImageNodeName to set
    */
   public void setSizedImageNodeName(String sizedImageNodeName) {
@@ -99,6 +110,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Returns the sizedImagePropertyName.
    * @return the sizedImagePropertyName
    */
   public String getSizedImagePropertyName() {
@@ -106,6 +118,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Sets the sizedImagePropertyName.
    * @param sizedImagePropertyName the sizedImagePropertyName to set
    */
   public void setSizedImagePropertyName(String sizedImagePropertyName) {
@@ -113,6 +126,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Returns the failureImagePath.
    * @return the failureImagePath
    */
   public String getFailureImagePath() {
@@ -120,6 +134,7 @@ public class ImageSizeDefinitionManagerImpl implements ImageSizeDefinitionManage
   }
 
   /**
+   * Sets the failureImagePath.
    * @param failureImagePath the failureImagePath to set
    */
   public void setFailureImagePath(String failureImagePath) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/jexl/ImageEditorTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/jexl/ImageEditorTools.java
@@ -46,6 +46,13 @@ import org.apache.logging.log4j.Logger;
  * @author DavidBenua
  */
 public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpression {
+  /**
+   * Creates a new ImageEditorTools.
+   */
+  public ImageEditorTools() {
+    // default
+  }
+
 
   private static final Logger log = LogManager.getLogger(ImageEditorTools.class);
   private ImageSizeDefinitionManager isdm = null;
@@ -66,6 +73,12 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
   @IPSJexlMethod(
       description = "get image size definition by code",
       params = {@IPSJexlParam(name = "code", description = "size code")})
+  /**
+   * Returns the image size definition.
+   *
+   * @param code the code
+   * @return the result
+   */
   public ImageSizeDefinition getImageSizeDefinition(String code) {
     initServices();
     return isdm.getImageSize(code);
@@ -79,7 +92,7 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
    * @param sizeCode the desired size code. Must not be <code>null</code>.
    * @return the image child node of the desired size. May be <code>null</code> if the child node
    *     does not exist in this item.
-   * @throws RepositoryException
+   * @throws RepositoryException if an error occurs
    */
   @IPSJexlMethod(
       description = "gets a child node of the appropriate size",
@@ -87,6 +100,14 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
         @IPSJexlParam(name = "itemNode", type = "javax.jcr.Node", description = "item node"),
         @IPSJexlParam(name = "sizeCode", description = "desired size code")
       })
+  /**
+   * Returns the sized node.
+   *
+   * @param itemNode the item node
+   * @param sizeCode the size code
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   */
   public Object getSizedNode(Node itemNode, String sizeCode) throws RepositoryException {
     String emsg;
     initServices();
@@ -132,6 +153,14 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
             type = "java.lang.String",
             description = "desired size code")
       })
+  /**
+   * hasSizedNode operation.
+   *
+   * @param itemNode the item node
+   * @param sizeCode the size code
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   */
   public boolean hasSizedNode(Node itemNode, String sizeCode) throws RepositoryException {
     Node child = (Node) getSizedNode(itemNode, sizeCode);
     if (child != null) {
@@ -144,6 +173,11 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
       description =
           "gets the URL of the failure image defined in the image editor configuration file.",
       params = {})
+  /**
+   * Returns the failure image url.
+   *
+   * @return the result
+   */
   public String getFailureImageURL() {
     initServices();
     String path = isdm.getFailureImagePath();
@@ -153,6 +187,12 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
   @IPSJexlMethod(
       description = "gets the failure image as a stream.",
       params = {})
+  /**
+   * Returns the failure image stream.
+   *
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public InputStream getFailureImageStream() throws Exception {
     initServices();
     InputStream stream = null;
@@ -170,6 +210,12 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
   @IPSJexlMethod(
       description = "gets the failure image as a byte array.",
       params = {})
+  /**
+   * Returns the failure image binary.
+   *
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public byte[] getFailureImageBinary() throws Exception {
     InputStream stream = this.getFailureImageStream();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -177,6 +223,12 @@ public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpressio
     return baos.toByteArray();
   }
 
+  /**
+   * logRequestAttributes operation.
+   *
+   * @param request the request
+   * @param message the message
+   */
   public static void logRequestAttributes(HttpServletRequest request, String message) {
     if (!log.isDebugEnabled()) return;
     log.debug("logging request attributes for " + message);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/BinaryImageController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/BinaryImageController.java
@@ -29,6 +29,9 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
 import org.springframework.web.servlet.mvc.Controller;
 
+/**
+ * Controller that streams binary image data for the image editor.
+ */
 @org.springframework.stereotype.Controller
 public class BinaryImageController extends AbstractController implements Controller {
   private static final Logger log = LogManager.getLogger(BinaryImageController.class);
@@ -37,6 +40,9 @@ public class BinaryImageController extends AbstractController implements Control
 
   private ImageCacheManager cacheMgr = null;
 
+    /**
+   * Creates a new BinaryImageController.
+   */
   public BinaryImageController() {}
 
   private void initServices() {
@@ -46,6 +52,13 @@ public class BinaryImageController extends AbstractController implements Control
   }
 
   @Override
+  /**
+   * handleRequestInternal operation.
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected ModelAndView handleRequestInternal(
       HttpServletRequest request, HttpServletResponse response) throws Exception {
     String emsg;
@@ -88,6 +101,7 @@ public class BinaryImageController extends AbstractController implements Control
   }
 
   /**
+   * Returns the urlBuilder.
    * @return the urlBuilder
    */
   public ImageUrlBuilder getUrlBuilder() {
@@ -95,6 +109,7 @@ public class BinaryImageController extends AbstractController implements Control
   }
 
   /**
+   * Sets the urlBuilder.
    * @param urlBuilder the urlBuilder to set
    */
   public void setUrlBuilder(ImageUrlBuilder urlBuilder) {
@@ -102,6 +117,7 @@ public class BinaryImageController extends AbstractController implements Control
   }
 
   /**
+   * Sets the cacheMgr.
    * @param cacheMgr the cacheMgr to set
    */
   public void setCacheMgr(ImageCacheManager cacheMgr) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/BinaryImageController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/BinaryImageController.java
@@ -50,8 +50,6 @@ public class BinaryImageController extends AbstractController implements Control
       cacheMgr = ImageCacheManagerLocator.getImageCacheManager();
     }
   }
-
-  @Override
   /**
    * handleRequestInternal operation.
    * @param request the request
@@ -59,6 +57,8 @@ public class BinaryImageController extends AbstractController implements Control
    * @return the result
    * @throws Exception if an error occurs
    */
+
+  @Override
   protected ModelAndView handleRequestInternal(
       HttpServletRequest request, HttpServletResponse response) throws Exception {
     String emsg;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageEditorWizard.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageEditorWizard.java
@@ -56,6 +56,9 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
+/**
+ * ImageEditorWizard class.
+ */
 public class ImageEditorWizard {
   private static final Logger log = LogManager.getLogger(ImageEditorWizard.class);
   private ImageCacheManager imageCacheManager = null;
@@ -67,8 +70,16 @@ public class ImageEditorWizard {
   private int maxDisplayHeight = 1500;
   private int maxDisplayWidth = 2000;
 
+  /**
+   * Creates a new ImageEditorWizard.
+   */
   public ImageEditorWizard() {}
 
+  /**
+   * init operation.
+   *
+   * @throws Exception if an error occurs
+   */
   public void init() throws Exception {
     if (imageCacheManager == null) {
       imageCacheManager = ImageCacheManagerLocator.getImageCacheManager();
@@ -110,6 +121,16 @@ public class ImageEditorWizard {
             + "  ----------------------------");
   }
 
+  /**
+   * processFinish operation.
+   *
+   * @param command the command
+   * @param errors the errors
+   * @param modelMap the model map
+   * @param status the status
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   @RequestMapping(params = "_finish")
   protected ModelAndView processFinish(
       final @ModelAttribute("command") Object command,
@@ -173,6 +194,12 @@ public class ImageEditorWizard {
     return null;
   }
 
+  /**
+   * cleanEmptySizedImages operation.
+   *
+   * @param inmap the inmap
+   * @return the result
+   */
   protected Map<String, SizedImageMetaData> cleanEmptySizedImages(
       Map<String, SizedImageMetaData> inmap) {
     Map<String, SizedImageMetaData> outmap = new LinkedHashMap<String, SizedImageMetaData>();
@@ -190,6 +217,15 @@ public class ImageEditorWizard {
     return outmap;
   }
 
+  /**
+   * processCancel operation.
+   *
+   * @param request the request
+   * @param response the response
+   * @param status the status
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   @RequestMapping(params = "_cancel")
   protected ModelAndView processCancel(
       final HttpServletRequest request,
@@ -212,6 +248,14 @@ public class ImageEditorWizard {
     return new ModelAndView(new RedirectView("imageeditor?openImed=true" + folderParam));
   }
 
+  /**
+   * onBind operation.
+   *
+   * @param request the request
+   * @param command the command
+   * @param errors the errors
+   * @throws Exception if an error occurs
+   */
   protected void onBind(HttpServletRequest request, Object command, BindException errors)
       throws Exception {
     /*
@@ -350,6 +394,13 @@ public class ImageEditorWizard {
 
   }
 
+  /**
+   * Sets the up display image.
+   *
+   * @param mimd the mimd
+   * @param usd the usd
+   * @throws Exception if an error occurs
+   */
   protected void setupDisplayImage(MasterImageMetaData mimd, UserSessionData usd) throws Exception {
     log.debug(
         "height is {} width is {}", mimd.getMetaData().getHeight(), mimd.getMetaData().getWidth());
@@ -367,6 +418,15 @@ public class ImageEditorWizard {
     usd.setDisplayImage(displayImage);
   }
 
+  /**
+   * resizeSimpleImage operation.
+   *
+   * @param image the image
+   * @param imageKey the image key
+   * @param cropBox the crop box
+   * @param size the size
+   * @throws Exception if an error occurs
+   */
   protected void resizeSimpleImage(
       SimpleImageMetaData image, String imageKey, Rectangle cropBox, Dimension size)
       throws Exception {
@@ -380,6 +440,14 @@ public class ImageEditorWizard {
     image.setMetaData(imd);
   }
 
+  /**
+   * createScaledImage operation.
+   *
+   * @param mimd the mimd
+   * @param scaleFactor the scale factor
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected SimpleImageMetaData createScaledImage(MasterImageMetaData mimd, double scaleFactor)
       throws Exception {
     ImageMetaData imageData = mimd.getMetaData();
@@ -391,6 +459,14 @@ public class ImageEditorWizard {
     return output;
   }
 
+  /**
+   * scaledRectangle operation.
+   *
+   * @param rect the rect
+   * @param scaleFactor the scale factor
+   * @param imageSize the image size
+   * @return the result
+   */
   protected Rectangle scaledRectangle(Rectangle rect, double scaleFactor, Dimension imageSize) {
     long x = Math.max(Math.round(rect.getX() * scaleFactor), 0l);
     long y = Math.max(Math.round(rect.getY() * scaleFactor), 0l);
@@ -400,6 +476,13 @@ public class ImageEditorWizard {
     return out;
   }
 
+  /**
+   * Sets the up sized images.
+   *
+   * @param request the request
+   * @param sizedImages the sized images
+   * @param mimd the mimd
+   */
   public void setupSizedImages(
       HttpServletRequest request, String sizedImages, MasterImageMetaData mimd) {
     Collection<SizedImageMetaData> simds = mimd.getSizedImages().values();
@@ -470,6 +553,14 @@ public class ImageEditorWizard {
     }
   }
 
+  /**
+   * postProcessPage operation.
+   *
+   * @param currentPage the current page
+   * @param command the command
+   * @param response the response
+   * @throws Exception if an error occurs
+   */
   @RequestMapping(method = RequestMethod.POST)
   protected void postProcessPage(
       @RequestParam("_page") final int currentPage,
@@ -500,6 +591,9 @@ public class ImageEditorWizard {
    * Gets the target page number. Overridden to limit the target page to those pages that actually
    * exist. If the target is "off the end", this routine returns the last page, which should be the
    * confirm page.
+   * @param request the request
+   * @param currentPage the current page
+   * @return the result
    */
   protected int getTargetPage(HttpServletRequest request, int currentPage) {
     /*
@@ -521,6 +615,13 @@ public class ImageEditorWizard {
     return -1;
   }
 
+  /**
+   * Returns the page count.
+   *
+   * @param request the request
+   * @param command the command
+   * @return the result
+   */
   protected int getPageCount(HttpServletRequest request, Object command) {
     /*
     int pageCount;
@@ -538,6 +639,12 @@ public class ImageEditorWizard {
     return -1;
   }
 
+  /**
+   * Sets the pages dynamically.
+   *
+   * @param request the request
+   * @param sizedImages the sized images
+   */
   public void setPagesDynamically(HttpServletRequest request, String sizedImages) {
     int maxSize = 2;
     String[] wizardPages = new String[maxSize];
@@ -575,6 +682,12 @@ public class ImageEditorWizard {
     usd.setPages(wizardPages);
   }
 
+  /**
+   * storeImage operation.
+   *
+   * @param mimd the mimd
+   * @param mpFile the mp file
+   */
   protected void storeImage(MasterImageMetaData mimd, MultipartFile mpFile) {
     try {
       InputStream imageStream = mpFile.getInputStream();
@@ -604,6 +717,13 @@ public class ImageEditorWizard {
     }
   }
 
+  /**
+   * Returns the current sized image.
+   *
+   * @param mimd the mimd
+   * @param currPage the curr page
+   * @return the result
+   */
   protected SizedImageMetaData getCurrentSizedImage(MasterImageMetaData mimd, int currPage) {
     log.debug("getCurrentSizedImage: creating array of size: " + mimd.getSizedImages().size());
     List<SizedImageMetaData> simds =
@@ -611,6 +731,14 @@ public class ImageEditorWizard {
     return simds.get(currPage);
   }
 
+  /**
+   * Returns the view name.
+   *
+   * @param request the request
+   * @param command the command
+   * @param page the page
+   * @return the result
+   */
   protected String getViewName(HttpServletRequest request, Object command, int page) {
     UserSessionData usd = getUserSessionData(request);
     log.debug("getViewName: got usd: {}", usd);
@@ -633,6 +761,13 @@ public class ImageEditorWizard {
     return MAIN_PAGE;
   }
 
+  /**
+   * validatePage operation.
+   *
+   * @param command the command
+   * @param errors the errors
+   * @param page the page
+   */
   protected void validatePage(Object command, Errors errors, int page) {
     log.debug("validatePage: doing validatePage...");
     ImageBean ib = (ImageBean) command;
@@ -668,6 +803,14 @@ public class ImageEditorWizard {
         "validatePage: Looking at page {} nothing needs to be validated here (yet)... ", page);
   }
 
+  /**
+   * ValidateFieldLength operation.
+   *
+   * @param errors the errors
+   * @param fieldName the field name
+   * @param length the length
+   * @param fieldValue the field value
+   */
   protected void ValidateFieldLength(
       Errors errors, String fieldName, int length, String fieldValue) {
     if (StringUtils.isBlank(fieldValue)) { // field is null or empty
@@ -680,6 +823,13 @@ public class ImageEditorWizard {
     }
   }
 
+  /**
+   * formBackingObject operation.
+   *
+   * @param request the request
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected Object formBackingObject(HttpServletRequest request) throws Exception {
     /*
     Object cmd = "Exists";
@@ -786,6 +936,16 @@ public class ImageEditorWizard {
     return null;
   }
 
+  /**
+   * referenceData operation.
+   *
+   * @param request the request
+   * @param command the command
+   * @param errors the errors
+   * @param page the page
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected Map<String, Object> referenceData(
       HttpServletRequest request, Object command, Errors errors, int page) throws Exception {
     /*
@@ -856,6 +1016,12 @@ public class ImageEditorWizard {
     return null;
   }
 
+  /**
+   * buildAllSizesList operation.
+   *
+   * @param mimd the mimd
+   * @return the result
+   */
   protected List<Map<String, String>> buildAllSizesList(MasterImageMetaData mimd) {
     List<Map<String, String>> allSizes = new ArrayList<Map<String, String>>();
     Map<String, SizedImageMetaData> sizedImages = mimd.getSizedImages();
@@ -873,6 +1039,12 @@ public class ImageEditorWizard {
     return allSizes;
   }
 
+  /**
+   * buildMasterImageDisplay operation.
+   *
+   * @param mimd the mimd
+   * @return the result
+   */
   protected Map<String, String> buildMasterImageDisplay(MasterImageMetaData mimd) {
     ImageMetaData md = mimd.getMetaData();
     Map<String, String> masterData = new HashMap<String, String>();
@@ -888,6 +1060,12 @@ public class ImageEditorWizard {
     return masterData;
   }
 
+  /**
+   * buildCropBox operation.
+   *
+   * @param simd the simd
+   * @return the result
+   */
   protected Map<String, String> buildCropBox(SizedImageMetaData simd) {
     Map<String, String> box = new HashMap<String, String>();
     ImageSizeDefinition size = simd.getSizeDefinition();
@@ -909,6 +1087,12 @@ public class ImageEditorWizard {
     return box;
   }
 
+  /**
+   * buildDisplayImage operation.
+   *
+   * @param usd the usd
+   * @return the result
+   */
   protected Map<String, String> buildDisplayImage(UserSessionData usd) {
     MasterImageMetaData mimd = usd.getMimd();
     Map<String, String> displayImage = new HashMap<String, String>();
@@ -930,6 +1114,12 @@ public class ImageEditorWizard {
     return displayImage;
   }
 
+  /**
+   * buildAllSizedImagesDisplay operation.
+   *
+   * @param sizedImages the sized images
+   * @return the result
+   */
   protected List<Map<String, String>> buildAllSizedImagesDisplay(
       Map<String, SizedImageMetaData> sizedImages) {
     List<Map<String, String>> l = new ArrayList<Map<String, String>>();
@@ -950,6 +1140,13 @@ public class ImageEditorWizard {
     return l;
   }
 
+  /**
+   * computeScaleFactor operation.
+   *
+   * @param height the height
+   * @param width the width
+   * @return the result
+   */
   protected double computeScaleFactor(int height, int width) {
     if (height <= maxDisplayHeight
         && width < maxDisplayWidth) { // image is small enough that we don't need to scale it.
@@ -960,6 +1157,12 @@ public class ImageEditorWizard {
     return Math.max(hr, wr);
   }
 
+  /**
+   * Returns the user session data.
+   *
+   * @param request the request
+   * @return the result
+   */
   public UserSessionData getUserSessionData(HttpServletRequest request) {
     UserSessionData usd = (UserSessionData) request.getSession().getAttribute("userData");
     if (usd == null) {
@@ -979,43 +1182,90 @@ public class ImageEditorWizard {
     return usd;
   }
 
+  /**
+   * Sets the user session data.
+   *
+   * @param request the request
+   * @param usd the usd
+   */
   public void setUserSessionData(HttpServletRequest request, UserSessionData usd) {
     request.getSession().setAttribute("userData", usd);
   }
 
+  /**
+   * Returns the file upload field.
+   *
+   * @return the result
+   */
   public String getFILE_UPLOAD_FIELD() {
     return FILE_UPLOAD_FIELD;
   }
 
+  /**
+   * Sets the file upload field.
+   *
+   * @param file_upload_field the file upload field
+   */
   public void setFILE_UPLOAD_FIELD(String file_upload_field) {
     FILE_UPLOAD_FIELD = file_upload_field;
   }
 
+  /**
+   * Returns the main page.
+   *
+   * @return the result
+   */
   public String getMAIN_PAGE() {
     return MAIN_PAGE;
   }
 
+  /**
+   * Sets the main page.
+   *
+   * @param main_page the main page
+   */
   public void setMAIN_PAGE(String main_page) {
     MAIN_PAGE = main_page;
   }
 
+  /**
+   * Returns the confirm page.
+   *
+   * @return the result
+   */
   public String getCONFIRM_PAGE() {
     return CONFIRM_PAGE;
   }
 
+  /**
+   * Sets the confirm page.
+   *
+   * @param confirm_page the confirm page
+   */
   public void setCONFIRM_PAGE(String confirm_page) {
     CONFIRM_PAGE = confirm_page;
   }
 
+  /**
+   * Returns the size page.
+   *
+   * @return the result
+   */
   public String getSIZE_PAGE() {
     return SIZE_PAGE;
   }
 
+  /**
+   * Sets the size page.
+   *
+   * @param size_page the size page
+   */
   public void setSIZE_PAGE(String size_page) {
     SIZE_PAGE = size_page;
   }
 
   /**
+   * Returns the maxDisplayHeight.
    * @return the maxDisplayHeight
    */
   public int getMaxDisplayHeight() {
@@ -1023,6 +1273,7 @@ public class ImageEditorWizard {
   }
 
   /**
+   * Sets the maxDisplayHeight.
    * @param maxDisplayHeight the maxDisplayHeight to set
    */
   public void setMaxDisplayHeight(int maxDisplayHeight) {
@@ -1030,6 +1281,7 @@ public class ImageEditorWizard {
   }
 
   /**
+   * Returns the maxDisplayWidth.
    * @return the maxDisplayWidth
    */
   public int getMaxDisplayWidth() {
@@ -1037,16 +1289,27 @@ public class ImageEditorWizard {
   }
 
   /**
+   * Sets the maxDisplayWidth.
    * @param maxDisplayWidth the maxDisplayWidth to set
    */
   public void setMaxDisplayWidth(int maxDisplayWidth) {
     this.maxDisplayWidth = maxDisplayWidth;
   }
 
+  /**
+   * Returns the url builder.
+   *
+   * @return the result
+   */
   public ImageUrlBuilder getUrlBuilder() {
     return urlBuilder;
   }
 
+  /**
+   * Sets the url builder.
+   *
+   * @param urlBuilder the url builder
+   */
   public void setUrlBuilder(ImageUrlBuilder urlBuilder) {
     this.urlBuilder = urlBuilder;
   }
@@ -1057,6 +1320,7 @@ public class ImageEditorWizard {
   private String SIZE_PAGE = "sizeimage";
 
   /**
+   * Returns the imageResizeMgr.
    * @return the imageResizeMgr
    */
   public ImageResizeManager getImageResizeMgr() {
@@ -1064,21 +1328,33 @@ public class ImageEditorWizard {
   }
 
   /**
+   * Sets the imageResizeMgr.
    * @param imageResizeMgr the imageResizeMgr to set
    */
   public void setImageResizeMgr(ImageResizeManager imageResizeMgr) {
     this.imageResizeMgr = imageResizeMgr;
   }
 
+  /**
+   * Returns the image persistence manager.
+   *
+   * @return the result
+   */
   public ImagePersistenceManager getImagePersistenceManager() {
     return imagePersistenceManager;
   }
 
+  /**
+   * Sets the image persistence manager.
+   *
+   * @param imagePersistenceManager the image persistence manager
+   */
   public void setImagePersistenceManager(ImagePersistenceManager imagePersistenceManager) {
     this.imagePersistenceManager = imagePersistenceManager;
   }
 
   /**
+   * Sets the imageCacheManager.
    * @param imageCacheManager the imageCacheManager to set
    */
   protected void setImageCacheManager(ImageCacheManager imageCacheManager) {
@@ -1086,6 +1362,7 @@ public class ImageEditorWizard {
   }
 
   /**
+   * Sets the imageSizeDefMgr.
    * @param imageSizeDefMgr the imageSizeDefMgr to set
    */
   protected void setImageSizeDefMgr(ImageSizeDefinitionManager imageSizeDefMgr) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageResizeManager.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageResizeManager.java
@@ -37,7 +37,7 @@ public interface ImageResizeManager {
    * @param size the desired image size. If <code>null</code> the image size will be the size of the
    *     crop box (or the original image size if the crop box is also <code>null</code>
    * @return the resulting image metadata.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   public ImageData generateImage(InputStream input, Rectangle cropBox, Dimension size)
       throws Exception;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageSizeDefinitionLookupController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageSizeDefinitionLookupController.java
@@ -48,8 +48,10 @@ public class ImageSizeDefinitionLookupController extends ParameterizableViewCont
 
   private ImageSizeDefinitionManager defmgr = null;
 
-  /** */
-  public ImageSizeDefinitionLookupController() {}
+    /**
+     * Creates a new ImageSizeDefinitionLookupController.
+     */
+    public ImageSizeDefinitionLookupController() {}
 
   private void initServices() {
     if (defmgr == null) {
@@ -58,8 +60,14 @@ public class ImageSizeDefinitionLookupController extends ParameterizableViewCont
   }
 
   /**
+   * handleRequestInternal operation.
+   *
    * @see ParameterizableViewController#handleRequestInternal(HttpServletRequest,
    *     HttpServletResponse)
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   protected ModelAndView handleRequestInternal(

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageUrlBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageUrlBuilder.java
@@ -16,8 +16,23 @@
  */
 package com.percussion.pso.imageedit.web;
 
+/**
+ * ImageUrlBuilder interface.
+ */
 public interface ImageUrlBuilder {
+  /**
+   * buildUrl operation.
+   *
+   * @param imageKey the image key
+   * @return the result
+   */
   public String buildUrl(String imageKey);
 
+  /**
+   * extractKey operation.
+   *
+   * @param url the url
+   * @return the result
+   */
   public String extractKey(String url);
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/SimpleXmlView.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/SimpleXmlView.java
@@ -45,11 +45,20 @@ public class SimpleXmlView extends AbstractView implements View {
 
   private String resultKey = "result";
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new SimpleXmlView.
+   *
+   */
   public SimpleXmlView() {}
 
   /**
+   * See referenced member.
    * @see AbstractView#renderMergedOutputModel(Map, HttpServletRequest, HttpServletResponse)
+   * @param model the model
+   * @param request the request
+   * @param response the response
+   * @throws Exception if an error occurs
    */
   @Override
   protected void renderMergedOutputModel(
@@ -112,6 +121,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Returns the encoding.
    * @return the encoding
    */
   public String getEncoding() {
@@ -119,6 +129,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Sets the encoding.
    * @param encoding the encoding to set
    */
   public void setEncoding(String encoding) {
@@ -126,6 +137,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Returns the resultKey.
    * @return the resultKey
    */
   public String getResultKey() {
@@ -133,6 +145,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Sets the resultKey.
    * @param resultKey the resultKey to set
    */
   public void setResultKey(String resultKey) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageEditorTestPageController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageEditorTestPageController.java
@@ -45,13 +45,23 @@ public class ImageEditorTestPageController extends ParameterizableViewController
 
   private ImageUrlBuilder urlBuilder;
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new ImageEditorTestPageController.
+   *
+   */
   public ImageEditorTestPageController() {}
 
   /**
+   * handleRequestInternal operation.
+   *
    * @see
    *     org.springframework.web.servlet.mvc.AbstractController#handleRequestInternal(HttpServletRequest,
    *     HttpServletResponse)
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   protected ModelAndView handleRequestInternal(
@@ -77,6 +87,7 @@ public class ImageEditorTestPageController extends ParameterizableViewController
   }
 
   /**
+   * Returns the imagePersistenceManager.
    * @return the imagePersistenceManager
    */
   public ImagePersistenceManager getImagePersistenceManager() {
@@ -84,6 +95,7 @@ public class ImageEditorTestPageController extends ParameterizableViewController
   }
 
   /**
+   * Sets the imagePersistenceManager.
    * @param imagePersistenceManager the imagePersistenceManager to set
    */
   public void setImagePersistenceManager(ImagePersistenceManager imagePersistenceManager) {
@@ -91,6 +103,7 @@ public class ImageEditorTestPageController extends ParameterizableViewController
   }
 
   /**
+   * Returns the urlBuilder.
    * @return the urlBuilder
    */
   public ImageUrlBuilder getUrlBuilder() {
@@ -98,6 +111,7 @@ public class ImageEditorTestPageController extends ParameterizableViewController
   }
 
   /**
+   * Sets the urlBuilder.
    * @param urlBuilder the urlBuilder to set
    */
   public void setUrlBuilder(ImageUrlBuilder urlBuilder) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageItemSupport.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageItemSupport.java
@@ -50,7 +50,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * ImageItemSupport class.
+ */
 public class ImageItemSupport {
+  /**
+   * Creates a new ImageItemSupport.
+   */
+  public ImageItemSupport() {
+    // default
+  }
+
   private static final String _WIDTH = "_width";
 
   private static final String _HEIGHT = "_height";
@@ -65,11 +75,18 @@ public class ImageItemSupport {
 
   private static final Logger log = LogManager.getLogger(ImageItemSupport.class);
 
+  /** cws. */
   protected IPSContentWs cws = null;
+  /** gmgr. */
   protected IPSGuidManager gmgr = null;
+  /** isdm. */
   protected ImageSizeDefinitionManager isdm = null;
+  /** cache. */
   protected ImageCacheManager cache = null;
 
+  /**
+   * initServices operation.
+   */
   protected void initServices() {
     if (cws == null) {
       isdm = ImageSizeDefinitionManagerLocator.getImageSizeDefinitionManager();
@@ -97,6 +114,12 @@ public class ImageItemSupport {
     return clist.get(0);
   }
 
+  /**
+   * Returns the child.
+   *
+   * @param item the item
+   * @return the result
+   */
   protected PSItemChild getChild(PSCoreItem item) {
     initServices();
     String emsg;
@@ -115,6 +138,11 @@ public class ImageItemSupport {
     return child;
   }
 
+  /**
+   * Returns the child name.
+   *
+   * @return the result
+   */
   protected String getChildName() {
     log.debug("getChildName: getting child name...");
     log.debug("getChildName: isdm: " + isdm);
@@ -123,11 +151,25 @@ public class ImageItemSupport {
     return childName;
   }
 
+  /**
+   * Returns the child entries.
+   *
+   * @param contentid the contentid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected List<PSItemChildEntry> getChildEntries(String contentid) throws Exception {
     IPSGuid itemGuid = gmgr.makeGuid(new PSLocator(contentid));
     return getChildEntries(itemGuid);
   }
 
+  /**
+   * Returns the child entries.
+   *
+   * @param itemGuid the item guid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected List<PSItemChildEntry> getChildEntries(IPSGuid itemGuid) throws Exception {
     initServices();
     String childName = getChildName();
@@ -135,11 +177,25 @@ public class ImageItemSupport {
     return children;
   }
 
+  /**
+   * createChildEntry operation.
+   *
+   * @param contentid the contentid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected PSItemChildEntry createChildEntry(String contentid) throws Exception {
     IPSGuid itemGuid = gmgr.makeGuid(new PSLocator(contentid));
     return createChildEntry(itemGuid);
   }
 
+  /**
+   * createChildEntry operation.
+   *
+   * @param itemGuid the item guid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected PSItemChildEntry createChildEntry(IPSGuid itemGuid) throws Exception {
     List<PSItemChildEntry> elist = cws.createChildEntries(itemGuid, getChildName(), 1);
     PSItemChildEntry entry = elist.get(0);
@@ -180,6 +236,12 @@ public class ImageItemSupport {
     return null;
   }
 
+  /**
+   * buildGuidList operation.
+   *
+   * @param entries the entries
+   * @return the result
+   */
   protected List<IPSGuid> buildGuidList(List<PSItemChildEntry> entries) {
     List<IPSGuid> glist = new ArrayList<IPSGuid>();
     for (PSItemChildEntry entry : entries) {
@@ -188,6 +250,14 @@ public class ImageItemSupport {
     return glist;
   }
 
+  /**
+   * readMetaData operation.
+   *
+   * @param item the item
+   * @param bean the bean
+   * @param fieldMap the field map
+   * @throws Exception if an error occurs
+   */
   protected void readMetaData(IPSItemAccessor item, Object bean, Map<String, String> fieldMap)
       throws Exception {
     for (Map.Entry<String, String> entry : fieldMap.entrySet()) {
@@ -238,6 +308,14 @@ public class ImageItemSupport {
     }
   }
 
+  /**
+   * writeMetaData operation.
+   *
+   * @param item the item
+   * @param bean the bean
+   * @param fieldMap the field map
+   * @throws Exception if an error occurs
+   */
   protected void writeMetaData(IPSItemAccessor item, Object bean, Map<String, String> fieldMap)
       throws Exception {
     String emsg;
@@ -292,6 +370,14 @@ public class ImageItemSupport {
     }
   }
 
+  /**
+   * readBinaryMetaData operation.
+   *
+   * @param item the item
+   * @param image the image
+   * @param fieldName the field name
+   * @throws Exception if an error occurs
+   */
   protected void readBinaryMetaData(IPSItemAccessor item, ImageMetaData image, String fieldName)
       throws Exception {
     log.debug("reading binary metadata");
@@ -303,6 +389,14 @@ public class ImageItemSupport {
     image.setWidth(RxItemUtils.getFieldNumeric(item, fieldName + _WIDTH).intValue());
   }
 
+  /**
+   * writeBinaryMetaData operation.
+   *
+   * @param item the item
+   * @param image the image
+   * @param fieldName the field name
+   * @throws Exception if an error occurs
+   */
   protected void writeBinaryMetaData(IPSItemAccessor item, ImageMetaData image, String fieldName)
       throws Exception {
     log.debug(
@@ -316,6 +410,7 @@ public class ImageItemSupport {
   }
 
   /**
+   * Sets the cws.
    * @param cws the cws to set
    */
   public void setCws(IPSContentWs cws) {
@@ -323,17 +418,24 @@ public class ImageItemSupport {
   }
 
   /**
+   * Sets the isdm.
    * @param isdm the isdm to set
    */
   public void setIsdm(ImageSizeDefinitionManager isdm) {
     this.isdm = isdm;
   }
 
+  /**
+   * Sets the gmgr.
+   *
+   * @param gmgr the gmgr
+   */
   public void setGmgr(IPSGuidManager gmgr) {
     this.gmgr = gmgr;
   }
 
   /**
+   * Sets the cache.
    * @param cache the cache to set
    */
   public void setCache(ImageCacheManager cache) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImagePersistenceManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImagePersistenceManagerImpl.java
@@ -55,10 +55,19 @@ public class ImagePersistenceManagerImpl extends ImageItemSupport
   private Map<String, String> masterFieldMap;
   private Map<String, String> childFieldMap;
 
+  /**
+   * Creates a new ImagePersistenceManagerImpl.
+   */
   public ImagePersistenceManagerImpl() {}
 
   /**
+   * See referenced member.
    * @see ImagePersistenceManager#CreateImage(MasterImageMetaData, String, boolean)
+   * @param master the master
+   * @param folderid the folderid
+   * @param checkin the checkin
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public String CreateImage(MasterImageMetaData master, String folderid, boolean checkin)
       throws Exception {
@@ -95,7 +104,12 @@ public class ImagePersistenceManagerImpl extends ImageItemSupport
   }
 
   /**
+   * See referenced member.
    * @see ImagePersistenceManager#validateSystemTitleUnique(String, String)
+   * @param sysTitle the sys title
+   * @param folderId the folder id
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public boolean validateSystemTitleUnique(String sysTitle, String folderId) throws Exception {
     initServices();
@@ -121,7 +135,11 @@ public class ImagePersistenceManagerImpl extends ImageItemSupport
   }
 
   /**
+   * See referenced member.
    * @see ImagePersistenceManager#OpenImage(String)
+   * @param contentid the contentid
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public OpenImageResult OpenImage(String contentid) throws Exception {
     log.debug("OpenImage: Starting to open image");
@@ -149,7 +167,12 @@ public class ImagePersistenceManagerImpl extends ImageItemSupport
   }
 
   /**
+   * See referenced member.
    * @see ImagePersistenceManager#UpdateImage(MasterImageMetaData, String, PSItemStatus)
+   * @param image the image
+   * @param contentid the contentid
+   * @param itemStatus the item status
+   * @throws Exception if an error occurs
    */
   public void UpdateImage(MasterImageMetaData image, String contentid, PSItemStatus itemStatus)
       throws Exception {
@@ -248,6 +271,7 @@ public class ImagePersistenceManagerImpl extends ImageItemSupport
   }
 
   /**
+   * Returns the imageContentType.
    * @return the imageContentType
    */
   public String getImageContentType() {
@@ -255,24 +279,45 @@ public class ImagePersistenceManagerImpl extends ImageItemSupport
   }
 
   /**
+   * Sets the imageContentType.
    * @param imageContentType the imageContentType to set
    */
   public void setImageContentType(String imageContentType) {
     this.imageContentType = imageContentType;
   }
 
+  /**
+   * Returns the master field map.
+   *
+   * @return the result
+   */
   public Map<String, String> getMasterFieldMap() {
     return masterFieldMap;
   }
 
+  /**
+   * Sets the master field map.
+   *
+   * @param masterFieldMap the master field map
+   */
   public void setMasterFieldMap(Map<String, String> masterFieldMap) {
     this.masterFieldMap = masterFieldMap;
   }
 
+  /**
+   * Returns the child field map.
+   *
+   * @return the result
+   */
   public Map<String, String> getChildFieldMap() {
     return childFieldMap;
   }
 
+  /**
+   * Sets the child field map.
+   *
+   * @param childFieldMap the child field map
+   */
   public void setChildFieldMap(Map<String, String> childFieldMap) {
     this.childFieldMap = childFieldMap;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
@@ -40,6 +40,13 @@ import org.apache.logging.log4j.Logger;
  * @author DavidBenua
  */
 public class ImageResizeManagerImpl implements ImageResizeManager {
+  /**
+   * Creates a new ImageResizeManagerImpl.
+   */
+  public ImageResizeManagerImpl() {
+    // default
+  }
+
   private static final Logger log = LogManager.getLogger(ImageResizeManagerImpl.class);
 
   private String imageFormat = "jpeg";
@@ -63,7 +70,13 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   private int maxInterpolationSize = 1000000;
 
   /**
+   * See referenced member.
    * @see ImageResizeManager#generateImage(InputStream, Rectangle, Dimension)
+   * @param input the input
+   * @param cropBox the crop box
+   * @param size the size
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public ImageData generateImage(InputStream input, Rectangle cropBox, Dimension size)
       throws Exception {
@@ -142,6 +155,14 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
     }
   }
 
+  /**
+   * scaleImage3 operation.
+   *
+   * @param inImage the in image
+   * @param sourceBox the source box
+   * @param outsize the outsize
+   * @return the result
+   */
   protected BufferedImage scaleImage3(
       BufferedImage inImage, Rectangle sourceBox, Dimension outsize) {
     log.debug("Scale image method 3");
@@ -167,6 +188,14 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
     return outImage;
   }
 
+  /**
+   * scaleImage operation.
+   *
+   * @param inImage the in image
+   * @param sourceBox the source box
+   * @param outSize the out size
+   * @return the result
+   */
   protected BufferedImage scaleImage(
       BufferedImage inImage, Rectangle sourceBox, Dimension outSize) {
     log.debug("Scaling image");
@@ -205,6 +234,12 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
     return outImage;
   }
 
+  /**
+   * halfImage operation.
+   *
+   * @param inImage the in image
+   * @return the result
+   */
   protected BufferedImage halfImage(BufferedImage inImage) {
     long timer = System.currentTimeMillis();
     int height = inImage.getHeight() / stepFactor;
@@ -236,6 +271,13 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
     return halfImage;
   }
 
+  /**
+   * computeSizeFromAspectRatio operation.
+   *
+   * @param box the box
+   * @param size the size
+   * @return the result
+   */
   public Dimension computeSizeFromAspectRatio(Rectangle box, Dimension size) {
     // Validate.isTrue(box.height > 0 && box.width > 0);
     Validate.isTrue(size.height > 0 || size.width > 0);
@@ -269,6 +311,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Returns the imageFormat.
    * @return the imageFormat
    */
   public String getImageFormat() {
@@ -276,6 +319,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Sets the imageFormat.
    * @param imageFormat the imageFormat to set
    */
   public void setImageFormat(String imageFormat) {
@@ -283,6 +327,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Returns the extension.
    * @return the extension
    */
   public String getExtension() {
@@ -290,6 +335,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Sets the extension.
    * @param extension the extension to set
    */
   public void setExtension(String extension) {
@@ -297,6 +343,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Returns the contentType.
    * @return the contentType
    */
   public String getContentType() {
@@ -304,6 +351,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Sets the contentType.
    * @param contentType the contentType to set
    */
   public void setContentType(String contentType) {
@@ -311,6 +359,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Returns the compression.
    * @return the compression
    */
   public float getCompression() {
@@ -318,6 +367,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Sets the compression.
    * @param compression the compression to set
    */
   public void setCompression(float compression) {
@@ -325,6 +375,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Returns the stepFactor.
    * @return the stepFactor
    */
   public int getStepFactor() {
@@ -332,6 +383,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Sets the stepFactor.
    * @param stepFactor the stepFactor to set
    */
   public void setStepFactor(int stepFactor) {
@@ -339,6 +391,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Returns the maxInterpolationSize.
    * @return the maxInterpolationSize
    */
   public int getMaxInterpolationSize() {
@@ -346,6 +399,7 @@ public class ImageResizeManagerImpl implements ImageResizeManager {
   }
 
   /**
+   * Sets the maxInterpolationSize.
    * @param maxInterpolationSize the maxInterpolationSize to set
    */
   public void setMaxInterpolationSize(int maxInterpolationSize) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageUrlBuilderImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageUrlBuilderImpl.java
@@ -21,14 +21,27 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * ImageUrlBuilderImpl class.
+ */
 public class ImageUrlBuilderImpl implements ImageUrlBuilder {
+  /**
+   * Creates a new ImageUrlBuilderImpl.
+   */
+  public ImageUrlBuilderImpl() {
+    // default
+  }
+
   private static final Logger log = LogManager.getLogger(ImageUrlBuilderImpl.class);
 
   private String baseUrl;
   private String suffix = "jpg";
 
   /**
+   * See referenced member.
    * @see ImageUrlBuilder#buildUrl(String)
+   * @param imageKey the image key
+   * @return the result
    */
   public String buildUrl(String imageKey) {
     StringBuilder sb = new StringBuilder();
@@ -44,7 +57,10 @@ public class ImageUrlBuilderImpl implements ImageUrlBuilder {
   }
 
   /**
+   * See referenced member.
    * @see ImageUrlBuilder#extractKey(String)
+   * @param url the url
+   * @return the result
    */
   public String extractKey(String url) {
     String emsg;
@@ -61,6 +77,7 @@ public class ImageUrlBuilderImpl implements ImageUrlBuilder {
   }
 
   /**
+   * Returns the baseUrl.
    * @return the baseUrl
    */
   public String getBaseUrl() {
@@ -68,6 +85,7 @@ public class ImageUrlBuilderImpl implements ImageUrlBuilder {
   }
 
   /**
+   * Sets the baseUrl.
    * @param baseUrl the baseUrl to set
    */
   public void setBaseUrl(String baseUrl) {
@@ -75,6 +93,7 @@ public class ImageUrlBuilderImpl implements ImageUrlBuilder {
   }
 
   /**
+   * Returns the suffix.
    * @return the suffix
    */
   public String getSuffix() {
@@ -82,6 +101,7 @@ public class ImageUrlBuilderImpl implements ImageUrlBuilder {
   }
 
   /**
+   * Sets the suffix.
    * @param suffix the suffix to set
    */
   public void setSuffix(String suffix) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imp/assembler/ImportContentAssemblerMerge.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imp/assembler/ImportContentAssemblerMerge.java
@@ -53,7 +53,7 @@ public class ImportContentAssemblerMerge {
    * @param def IPSExtensionDef
    * @param result IPSAssemblyResult
    * @return IPSAssemblyResult
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   public static IPSAssemblyResult merge(IPSExtensionDef def, IPSAssemblyResult result)
       throws Exception {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imp/assembler/PSImportVelocityAssembler.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imp/assembler/PSImportVelocityAssembler.java
@@ -33,7 +33,9 @@ import org.apache.logging.log4j.Logger;
  * re-form content based on the supplied tidy properties file. Located in
  * @author NateChadwick
  */
-/** */
+/**
+ * Velocity-based assembler used during content import.
+ */
 public class PSImportVelocityAssembler extends PSVelocityAssembler implements IPSAssembler {
 
   /** Field m_def. */
@@ -42,15 +44,21 @@ public class PSImportVelocityAssembler extends PSVelocityAssembler implements IP
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSImportVelocityAssembler.class);
 
-  /** Constructor */
+  /**
+   * Constructor
+   * Creates a new PSImportVelocityAssembler.
+   *
+   */
   public PSImportVelocityAssembler() {
     super();
   }
 
   /**
+   * doAssembleSingle operation.
+   *
    * @param item IPSAssemblyItem
    * @return IPSAssemblyResult
-   * @throws Exception
+   * @throws Exception if an error occurs
    * @see
    *     com.percussion.services.assembly.impl.plugin.PSAssemblerBase#doAssembleSingle(IPSAssemblyItem)
    */
@@ -62,9 +70,11 @@ public class PSImportVelocityAssembler extends PSVelocityAssembler implements IP
   }
 
   /**
+   * init operation.
+   *
    * @param arg0 IPSExtensionDef
    * @param arg1 File
-   * @throws PSExtensionException
+   * @throws PSExtensionException if an error occurs
    * @see
    *     com.percussion.services.assembly.impl.plugin.PSAssemblerBase#doAssembleSingle(IPSAssemblyItem)
    */

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/itemfilter/PSORevisionCorrectingItemFilter.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/itemfilter/PSORevisionCorrectingItemFilter.java
@@ -56,13 +56,23 @@ public class PSORevisionCorrectingItemFilter extends PSBaseFilter implements IPS
   private static IPSGuidManager gmgr = null;
   private static IPSCmsContentSummaries summ = null;
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new PSORevisionCorrectingItemFilter.
+   *
+   */
   public PSORevisionCorrectingItemFilter() {
     super();
   }
 
   /**
+   * filter operation.
+   *
    * @see com.percussion.services.filter.IPSItemFilterRule#filter(java.util.List, java.util.Map)
+   * @param items the items
+   * @param params the params
+   * @return the result
+   * @throws PSFilterException if an error occurs
    */
   public List<IPSFilterItem> filter(List<IPSFilterItem> items, Map<String, String> params)
       throws PSFilterException {
@@ -123,6 +133,8 @@ public class PSORevisionCorrectingItemFilter extends PSBaseFilter implements IPS
   public static final String WORKFLOW_STATES = "workflow_states";
 
   /**
+   * Sets the gmgr.
+   *
    * @param gmgr The gmgr to set. Used only in unit tests.
    */
   public static void setGmgr(IPSGuidManager gmgr) {
@@ -130,6 +142,8 @@ public class PSORevisionCorrectingItemFilter extends PSBaseFilter implements IPS
   }
 
   /**
+   * Sets the summ.
+   *
    * @param summ The summ to set.
    */
   public static void setSumm(IPSCmsContentSummaries summ) {
@@ -137,6 +151,8 @@ public class PSORevisionCorrectingItemFilter extends PSBaseFilter implements IPS
   }
 
   /**
+   * Sets the work.
+   *
    * @param work The work to set.
    */
   public static void setWork(IPSWorkflowService work) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/IPSOObjectFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/IPSOObjectFinder.java
@@ -25,6 +25,9 @@ import com.percussion.services.contentmgr.IPSNode;
 import com.percussion.utils.guid.IPSGuid;
 import javax.jcr.RepositoryException;
 
+/**
+ * IPSOObjectFinder interface.
+ */
 public interface IPSOObjectFinder {
   /**
    * Gets the Legacy Component Summary for an item by GUID.
@@ -36,6 +39,13 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the Legacy Component Summary for an item",
       params = {@IPSJexlParam(name = "guid", description = "the item GUID")})
+  /**
+   * Returns the component summary.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSComponentSummary getComponentSummary(IPSGuid guid) throws PSException;
 
   /**
@@ -43,11 +53,18 @@ public interface IPSOObjectFinder {
    *
    * @param contentid the content id
    * @return the Component Summary for the item. Never <code>null</code>
-   * @throws PSException
+   * @throws PSException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the Legacy Component Summary for an item",
       params = {@IPSJexlParam(name = "content", description = "the content id")})
+  /**
+   * Returns the component summary by id.
+   *
+   * @param contentid the contentid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSComponentSummary getComponentSummaryById(String contentid) throws PSException;
 
   /**
@@ -59,6 +76,12 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the content type summary for a specified type",
       params = {@IPSJexlParam(name = "guid", description = "the content type GUID")})
+  /**
+   * Returns the content type summary.
+   *
+   * @param guid the guid
+   * @return the result
+   */
   public PSContentTypeSummary getContentTypeSummary(IPSGuid guid);
 
   /**
@@ -71,6 +94,11 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "Get the JSESSIONID value for the current request",
       params = {})
+  /**
+   * Returns the jsession id.
+   *
+   * @return the result
+   */
   public String getJSessionId();
 
   /**
@@ -81,6 +109,11 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "Get the PSSESSIONID value for the current request",
       params = {})
+  /**
+   * Returns the pssession id.
+   *
+   * @return the result
+   */
   public String getPSSessionId();
 
   /**
@@ -91,6 +124,11 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the users current locale",
       params = {})
+  /**
+   * Returns the user locale.
+   *
+   * @return the result
+   */
   public String getUserLocale();
 
   /**
@@ -101,6 +139,11 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the users current community name",
       params = {})
+  /**
+   * Returns the user community.
+   *
+   * @return the result
+   */
   public String getUserCommunity();
 
   /**
@@ -111,6 +154,11 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the users current community id",
       params = {})
+  /**
+   * Returns the user community id.
+   *
+   * @return the result
+   */
   public String getUserCommunityId();
 
   /**
@@ -126,6 +174,13 @@ public interface IPSOObjectFinder {
         @IPSJexlParam(name = "contentid", description = "the content id"),
         @IPSJexlParam(name = "revision", description = "the revision")
       })
+  /**
+   * Returns the guid by id.
+   *
+   * @param contentid the contentid
+   * @param revision the revision
+   * @return the result
+   */
   public IPSGuid getGuidById(String contentid, String revision);
 
   /**
@@ -137,6 +192,12 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the GUID by Content Id",
       params = {@IPSJexlParam(name = "contentid", description = "the content id")})
+  /**
+   * Returns the guid by id.
+   *
+   * @param contentid the contentid
+   * @return the result
+   */
   public IPSGuid getGuidById(String contentid);
 
   /**
@@ -144,11 +205,18 @@ public interface IPSOObjectFinder {
    *
    * @param guid the content item GUID
    * @return the Node, or <code>null</code> if the node was not found.
-   * @throws RepositoryException
+   * @throws RepositoryException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the node for a particular guid",
       params = {@IPSJexlParam(name = "guid", description = "the GUID for the item")})
+  /**
+   * Returns the node by guid.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   */
   public IPSNode getNodeByGuid(IPSGuid guid) throws RepositoryException;
 
   /**
@@ -160,6 +228,12 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the site guid for a given id",
       params = {@IPSJexlParam(name = "siteid", description = "the id for the site")})
+  /**
+   * Returns the site guid.
+   *
+   * @param siteid the siteid
+   * @return the result
+   */
   public IPSGuid getSiteGuid(int siteid);
 
   /**
@@ -171,6 +245,12 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the template guid for a given id",
       params = {@IPSJexlParam(name = "template", description = "the id for the template")})
+  /**
+   * Returns the template guid.
+   *
+   * @param templateid the templateid
+   * @return the result
+   */
   public IPSGuid getTemplateGuid(int templateid);
 
   /**
@@ -182,5 +262,11 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the community name for a  given community id",
       params = {@IPSJexlParam(name = "communityId", description = "the id for the community")})
+  /**
+   * Returns the community name.
+   *
+   * @param communityId the community id
+   * @return the result
+   */
   public String getCommunityName(int communityId);
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/IPSOObjectFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/IPSOObjectFinder.java
@@ -39,13 +39,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the Legacy Component Summary for an item",
       params = {@IPSJexlParam(name = "guid", description = "the item GUID")})
-  /**
-   * Returns the component summary.
-   *
-   * @param guid the guid
-   * @return the result
-   * @throws PSException if an error occurs
-   */
   public PSComponentSummary getComponentSummary(IPSGuid guid) throws PSException;
 
   /**
@@ -58,13 +51,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the Legacy Component Summary for an item",
       params = {@IPSJexlParam(name = "content", description = "the content id")})
-  /**
-   * Returns the component summary by id.
-   *
-   * @param contentid the contentid
-   * @return the result
-   * @throws PSException if an error occurs
-   */
   public PSComponentSummary getComponentSummaryById(String contentid) throws PSException;
 
   /**
@@ -76,12 +62,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the content type summary for a specified type",
       params = {@IPSJexlParam(name = "guid", description = "the content type GUID")})
-  /**
-   * Returns the content type summary.
-   *
-   * @param guid the guid
-   * @return the result
-   */
   public PSContentTypeSummary getContentTypeSummary(IPSGuid guid);
 
   /**
@@ -94,11 +74,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "Get the JSESSIONID value for the current request",
       params = {})
-  /**
-   * Returns the jsession id.
-   *
-   * @return the result
-   */
   public String getJSessionId();
 
   /**
@@ -109,11 +84,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "Get the PSSESSIONID value for the current request",
       params = {})
-  /**
-   * Returns the pssession id.
-   *
-   * @return the result
-   */
   public String getPSSessionId();
 
   /**
@@ -124,11 +94,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the users current locale",
       params = {})
-  /**
-   * Returns the user locale.
-   *
-   * @return the result
-   */
   public String getUserLocale();
 
   /**
@@ -139,11 +104,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the users current community name",
       params = {})
-  /**
-   * Returns the user community.
-   *
-   * @return the result
-   */
   public String getUserCommunity();
 
   /**
@@ -154,11 +114,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the users current community id",
       params = {})
-  /**
-   * Returns the user community id.
-   *
-   * @return the result
-   */
   public String getUserCommunityId();
 
   /**
@@ -174,13 +129,6 @@ public interface IPSOObjectFinder {
         @IPSJexlParam(name = "contentid", description = "the content id"),
         @IPSJexlParam(name = "revision", description = "the revision")
       })
-  /**
-   * Returns the guid by id.
-   *
-   * @param contentid the contentid
-   * @param revision the revision
-   * @return the result
-   */
   public IPSGuid getGuidById(String contentid, String revision);
 
   /**
@@ -192,12 +140,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the GUID by Content Id",
       params = {@IPSJexlParam(name = "contentid", description = "the content id")})
-  /**
-   * Returns the guid by id.
-   *
-   * @param contentid the contentid
-   * @return the result
-   */
   public IPSGuid getGuidById(String contentid);
 
   /**
@@ -210,13 +152,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the node for a particular guid",
       params = {@IPSJexlParam(name = "guid", description = "the GUID for the item")})
-  /**
-   * Returns the node by guid.
-   *
-   * @param guid the guid
-   * @return the result
-   * @throws RepositoryException if an error occurs
-   */
   public IPSNode getNodeByGuid(IPSGuid guid) throws RepositoryException;
 
   /**
@@ -228,12 +163,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the site guid for a given id",
       params = {@IPSJexlParam(name = "siteid", description = "the id for the site")})
-  /**
-   * Returns the site guid.
-   *
-   * @param siteid the siteid
-   * @return the result
-   */
   public IPSGuid getSiteGuid(int siteid);
 
   /**
@@ -245,12 +174,6 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the template guid for a given id",
       params = {@IPSJexlParam(name = "template", description = "the id for the template")})
-  /**
-   * Returns the template guid.
-   *
-   * @param templateid the templateid
-   * @return the result
-   */
   public IPSGuid getTemplateGuid(int templateid);
 
   /**
@@ -262,11 +185,5 @@ public interface IPSOObjectFinder {
   @IPSJexlMethod(
       description = "get the community name for a  given community id",
       params = {@IPSJexlParam(name = "communityId", description = "the id for the community")})
-  /**
-   * Returns the community name.
-   *
-   * @param communityId the community id
-   * @return the result
-   */
   public String getCommunityName(int communityId);
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOBase64Codec.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOBase64Codec.java
@@ -33,14 +33,18 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * JEXL helper for Base64 encoding and decoding of content values.
+ *
  * @author DavidBenua
  */
 public class PSOBase64Codec extends PSJexlUtilBase implements IPSJexlExpression {
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOBase64Codec.class);
 
-  /** */
-  public PSOBase64Codec() {
+    /**
+     * Creates a new PSOBase64Codec.
+     */
+    public PSOBase64Codec() {
     super();
   }
 
@@ -49,14 +53,24 @@ public class PSOBase64Codec extends PSJexlUtilBase implements IPSJexlExpression 
    *
    * @param jcrProperty the property to encode
    * @return a base 64 encoded String representing the property value.
-   * @throws ValueFormatException
-   * @throws RepositoryException
-   * @throws IOException
-   * @throws UnsupportedEncodingException
+   * @throws ValueFormatException if an error occurs
+   * @throws RepositoryException if an error occurs
+   * @throws IOException if an error occurs
+   * @throws UnsupportedEncodingException if an error occurs
    */
   @IPSJexlMethod(
       description = "Encode a binary property",
       params = {@IPSJexlParam(name = "source", description = "binary property to encode")})
+  /**
+   * encode operation.
+   *
+   * @param jcrProperty the jcr property
+   * @return the result
+   * @throws ValueFormatException if an error occurs
+   * @throws RepositoryException if an error occurs
+   * @throws UnsupportedEncodingException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public String encode(Property jcrProperty)
       throws ValueFormatException, RepositoryException, UnsupportedEncodingException, IOException {
     if (jcrProperty == null) {
@@ -71,12 +85,20 @@ public class PSOBase64Codec extends PSJexlUtilBase implements IPSJexlExpression 
    *
    * @param stream the byte stream to be encoded.
    * @return a base 64 encoded String representing the binary value.
-   * @throws IOException
-   * @throws UnsupportedEncodingException
+   * @throws IOException if an error occurs
+   * @throws UnsupportedEncodingException if an error occurs
    */
   @IPSJexlMethod(
       description = "Encode a binary stream",
       params = {@IPSJexlParam(name = "source", description = "binary stream to encode")})
+  /**
+   * encode operation.
+   *
+   * @param stream the stream
+   * @return the result
+   * @throws UnsupportedEncodingException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public String encode(InputStream stream) throws UnsupportedEncodingException, IOException {
     return encode(streamToBytes(stream));
   }
@@ -91,6 +113,13 @@ public class PSOBase64Codec extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "copy a binary stream to a byte array",
       params = {@IPSJexlParam(name = "stream", description = "binary stream to copy")})
+  /**
+   * streamToBytes operation.
+   *
+   * @param stream the stream
+   * @return the result
+   * @throws IOException if an error occurs
+   */
   public byte[] streamToBytes(InputStream stream) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try {
@@ -119,6 +148,13 @@ public class PSOBase64Codec extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "Encode a binary byte array",
       params = {@IPSJexlParam(name = "source", description = "binary byte array to encode")})
+  /**
+   * encode operation.
+   *
+   * @param bytes the bytes
+   * @return the result
+   * @throws UnsupportedEncodingException if an error occurs
+   */
   public String encode(byte[] bytes) throws UnsupportedEncodingException {
     byte[] out = Base64.encodeBase64(bytes);
     try {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSODateTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSODateTools.java
@@ -38,6 +38,9 @@ public class PSODateTools extends PSJexlUtilBase implements IPSJexlExpression {
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSODateTools.class);
 
+  /**
+   * Creates a new PSODateTools.
+   */
   public PSODateTools() {}
 
   @IPSJexlMethod(
@@ -47,6 +50,14 @@ public class PSODateTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "format", description = "format string"),
         @IPSJexlParam(name = "date_value", description = "the date value")
       })
+  /**
+   * formatDate operation.
+   *
+   * @param format the format
+   * @param date_value the date value
+   * @return the result
+   * @throws ParseException if an error occurs
+   */
   public String formatDate(String format, Object date_value) throws ParseException {
     SimpleDateFormat fmt = new SimpleDateFormat(format);
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOFeedTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOFeedTools.java
@@ -45,6 +45,9 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOFeedTools.class);
 
+  /**
+   * Creates a new PSOFeedTools.
+   */
   public PSOFeedTools() {
     super();
   }
@@ -55,6 +58,13 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
               + " url: 'http://rss.news.yahoo.com/rss/yahoonewsroom', targetFolder:"
               + " '//Sites/EnterpriseInvestments/News'",
       params = {@IPSJexlParam(name = "params", description = "The feed parameters")})
+  /**
+   * Returns the feed parameters.
+   *
+   * @param params the params
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   */
   public Map<String, String> getFeedParameters(String params) throws IllegalArgumentException {
 
     log.debug(params);
@@ -80,6 +90,15 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Returns a ROME SyndFeed instance for the given URL",
       params = {@IPSJexlParam(name = "url", description = "The URL of the feed to download.")})
+  /**
+   * Returns the feed.
+   *
+   * @param urlString the url string
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws FeedException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public PSSynFeedProxy getFeed(String urlString)
       throws IllegalArgumentException, FeedException, IOException {
     return new PSSynFeedProxy(urlString);
@@ -96,6 +115,17 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
             name = "lastModified",
             description = "A cached HTTP LastModified Header for the feed. ")
       })
+  /**
+   * Returns the feed.
+   *
+   * @param urlString the url string
+   * @param eTag the e tag
+   * @param lastModified the last modified
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws FeedException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public PSSynFeedProxy getFeed(String urlString, String eTag, String lastModified)
       throws IllegalArgumentException, FeedException, IOException {
 
@@ -105,6 +135,12 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Does a little cleanup of the sys_title.  URL encoding it if possible.",
       params = {@IPSJexlParam(name = "title", description = "The sys_title to cleanup")})
+  /**
+   * cleanupItemTitle operation.
+   *
+   * @param title the title
+   * @return the result
+   */
   public String cleanupItemTitle(String title) {
     String ret = title;
     URLCodec codec = new URLCodec();
@@ -122,6 +158,12 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Returns a ROME MediaEntryModule to handle Media RSS content.",
       params = {@IPSJexlParam(name = "entry", description = "A ROME SyndEntry instance.")})
+  /**
+   * Returns the media rssmodule content.
+   *
+   * @param entry the entry
+   * @return the result
+   */
   public List<MediaContent> getMediaRSSModuleContent(Object entry) {
     SyndEntry item = (SyndEntry) entry;
     List<MediaContent> contents = new ArrayList<MediaContent>();
@@ -142,6 +184,12 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Returns a boolean if the specified module is available.",
       params = {@IPSJexlParam(name = "entry", description = "A ROME SyndEntry instance.")})
+  /**
+   * Returns whether media rsscontent available.
+   *
+   * @param entry the entry
+   * @return the result
+   */
   public boolean isMediaRSSContentAvailable(Object entry) {
     boolean ret = false;
     SyndEntry e = (SyndEntry) entry;
@@ -174,6 +222,12 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Returns the base filename portion for a given url.",
       params = {@IPSJexlParam(name = "entry", description = "A valid url")})
+  /**
+   * Returns the base filename.
+   *
+   * @param url the url
+   * @return the result
+   */
   public String getBaseFilename(String url) {
     String ret = "";
 
@@ -191,6 +245,12 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Returns a folder name of the right length.",
       params = {@IPSJexlParam(name = "folder", description = "Folder name")})
+  /**
+   * Returns the clean foldername.
+   *
+   * @param folder the folder
+   * @return the result
+   */
   public String getCleanFoldername(String folder) {
     if (folder.length() > 100) {
       return folder.substring(0, 100);
@@ -219,6 +279,16 @@ public class PSOFeedTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "subject", description = "The subject of the message."),
         @IPSJexlParam(name = "body", description = "The text of the message.")
       })
+  /**
+   * sendEmail operation.
+   *
+   * @param from_line the from line
+   * @param to_line the to line
+   * @param cc_line the cc line
+   * @param bcc_line the bcc line
+   * @param subject the subject
+   * @param body the body
+   */
   public void sendEmail(
       String from_line,
       String to_line,

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOFolderTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOFolderTools.java
@@ -67,7 +67,11 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
   private IPSContentWs contentWs;
   private IPSGuidManager guidManager;
 
-  /** Extensions manager will use this constructor. */
+  /**
+   * Extensions manager will use this constructor.
+   * Creates a new PSOFolderTools.
+   *
+   */
   public PSOFolderTools() {
     super();
   }
@@ -83,6 +87,12 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
     init(contentWs, guidManager);
   }
 
+  /**
+   * init operation.
+   *
+   * @param contentWs the content ws
+   * @param guidManager the guid manager
+   */
   protected final void init(IPSContentWs contentWs, IPSGuidManager guidManager) {
     this.contentWs = contentWs;
     this.guidManager = guidManager;
@@ -100,6 +110,14 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "get the folder path for this item",
       params = {@IPSJexlParam(name = "itemId", description = "the item GUID")})
+  /**
+   * Returns the parent folder path.
+   *
+   * @param itemId the item id
+   * @return the result
+   * @throws PSErrorException if an error occurs
+   * @throws PSCmsException if an error occurs
+   */
   public String getParentFolderPath(IPSGuid itemId) throws PSErrorException, PSCmsException {
     String errmsg;
 
@@ -117,6 +135,12 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
     return paths.get(0);
   }
 
+  /**
+   * Returns the folder.
+   *
+   * @param path the path
+   * @return the result
+   */
   public PSFolder getFolder(String path) {
     PSFolder folder = null;
     try {
@@ -150,15 +174,25 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
    *
    * @param assemblyItem the assembly item whose parent folder will be fetched.
    * @return the folder path of the containing folder.
-   * @throws PSErrorResultsException
-   * @throws PSExtensionProcessingException
-   * @throws PSErrorException
-   * @throws PSCmsException
+   * @throws PSErrorResultsException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSErrorException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the folder path for this item",
       params = {@IPSJexlParam(name = "assemblyItem", description = "$sys.assemblyItem")},
       returns = "the path of the folder that contains this item")
+  /**
+   * Returns the parent folder path.
+   *
+   * @param assemblyItem the assembly item
+   * @return the result
+   * @throws PSErrorResultsException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSErrorException if an error occurs
+   * @throws PSCmsException if an error occurs
+   */
   public String getParentFolderPath(IPSAssemblyItem assemblyItem)
       throws PSErrorResultsException,
           PSExtensionProcessingException,
@@ -224,6 +258,12 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
       description = "Gets the folder properties of a folder.",
       params = {@IPSJexlParam(name = "path", description = "folder path")},
       returns = "The folder properties (Map)")
+  /**
+   * Returns the folder properties.
+   *
+   * @param path the path
+   * @return the result
+   */
   @SuppressWarnings("unchecked")
   public Map<String, String> getFolderProperties(String path) {
     try {
@@ -246,12 +286,19 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
    *
    * @param id the id of the folder
    * @return the folder path.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   @IPSJexlMethod(
       description = "Gets the folder path given a Folder ID",
       params = {@IPSJexlParam(name = "id", description = "folder id")},
       returns = "The folder path (String)")
+  /**
+   * Returns the folder path.
+   *
+   * @param id the id
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   */
   public String getFolderPath(int id) throws PSCmsException {
     try {
       return PSOItemFolderUtilities.getFolderPath(id);
@@ -268,11 +315,18 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
    * @param guid the GUID for the item
    * @return the parent folder path. If there are multiple paths, the first one will be returned.
    *     Will be return empty list if the item is not in any folders.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the folder path for this item",
       params = {@IPSJexlParam(name = "itemId", description = "the item GUID")})
+  /**
+   * Returns the parent folder paths.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   */
   public List<String> getParentFolderPaths(IPSGuid guid) throws PSCmsException {
     return PSOItemFolderUtilities.getFolderPathsForItem(guid);
   }
@@ -283,6 +337,14 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "get the child folders & items for this item",
       params = {@IPSJexlParam(name = "folderId", description = "the folderid")})
+  /**
+   * Returns the child folders.
+   *
+   * @param folderId the folder id
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   * @throws PSErrorException if an error occurs
+   */
   public List<PSItemSummary> getChildFolders(int folderId) throws PSCmsException, PSErrorException {
 
     List<PSItemSummary> ret = new ArrayList<PSItemSummary>();
@@ -309,6 +371,13 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "get the folder id for this folder path",
       params = {@IPSJexlParam(name = "path", description = "The path to get the id for")})
+  /**
+   * Returns the id for path.
+   *
+   * @param path the path
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   */
   public int getIdForPath(String path) throws PSCmsException {
     PSServerFolderProcessor folderproc = PSServerFolderProcessor.getInstance();
     return folderproc.getIdByPath(path);
@@ -326,6 +395,13 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
       params = {
         @IPSJexlParam(name = "itemId", description = "The item id to find the folder id for")
       })
+  /**
+   * Returns the parent folder id.
+   *
+   * @param itemId the item id
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   */
   public int getParentFolderId(int itemId) throws PSCmsException {
     try {
       return PSOItemFolderUtilities.getParentFolderId(itemId);
@@ -334,6 +410,13 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
     }
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   */
   @Override
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     super.init(def, codeRoot);
@@ -342,18 +425,38 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
     init(contentWs, guidManager);
   }
 
+  /**
+   * Returns the content ws.
+   *
+   * @return the result
+   */
   public IPSContentWs getContentWs() {
     return contentWs;
   }
 
+  /**
+   * Sets the content ws.
+   *
+   * @param contentWs the content ws
+   */
   public void setContentWs(IPSContentWs contentWs) {
     this.contentWs = contentWs;
   }
 
+  /**
+   * Returns the guid manager.
+   *
+   * @return the result
+   */
   public IPSGuidManager getGuidManager() {
     return guidManager;
   }
 
+  /**
+   * Sets the guid manager.
+   *
+   * @param guidManager the guid manager
+   */
   public void setGuidManager(IPSGuidManager guidManager) {
     this.guidManager = guidManager;
   }
@@ -362,6 +465,12 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
       description = "Add a folder tree for the fully qualified path. ",
       params = {@IPSJexlParam(name = "path", description = "folder path")},
       returns = "The newly added folders")
+  /**
+   * addFolderTree operation.
+   *
+   * @param path the path
+   * @return the result
+   */
   public PSFolder addFolderTree(String path) {
     PSFolder folder = null;
     String[] stringArr = new String[1];
@@ -391,6 +500,13 @@ public class PSOFolderTools extends PSJexlUtilBase implements IPSJexlExpression 
         @IPSJexlParam(name = "parent", description = "folder path to create new folder in")
       },
       returns = "The newly added folder")
+  /**
+   * addFolder operation.
+   *
+   * @param folderName the folder name
+   * @param parent the parent
+   * @return the result
+   */
   public PSFolder addFolder(String folderName, String parent) {
     PSFolder folder = null;
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOListTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOListTools.java
@@ -47,6 +47,9 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOListTools.class);
 
+  /**
+   * Creates a new PSOListTools.
+   */
   public PSOListTools() {
     super();
   }
@@ -124,6 +127,14 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "end", description = "the end index (exclusive)")
       },
       returns = "a subset of collection as a list")
+  /**
+   * sublist operation.
+   *
+   * @param c the c
+   * @param start the start
+   * @param end the end
+   * @return the result
+   */
   public <T> List<T> sublist(Collection<T> c, int start, int end) {
     log.debug("processing sublist(Collection c, int start, int end)");
     List<T> rvalue = new ArrayList<>();
@@ -164,10 +175,11 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * See referenced member.
    * @see #sublist(Collection, int, int)
-   * @param c
-   * @param start
-   * @param end
+   * @param c the c
+   * @param start the start
+   * @param end the end
    * @return a subset of the collection never <code>null</code>
    */
   public <T> List<T> sublist(Collection<T> c, String start, String end) {
@@ -177,10 +189,11 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * See referenced member.
    * @see #sublist(Collection, int, int)
-   * @param c
-   * @param start
-   * @param end
+   * @param c the c
+   * @param start the start
+   * @param end the end
    * @return a subset of the collection never <code>null</code>.
    */
   public <T> List<T> sublist(Collection<T> c, Number start, Number end) {
@@ -190,10 +203,11 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * See referenced member.
    * @see #sublist(Collection, int, int)
-   * @param c
-   * @param start
-   * @param end
+   * @param c the c
+   * @param start the start
+   * @param end the end
    * @return a subset of the collection never <code>null</code>.
    */
   public <T> List<T> sublist(T[] c, int start, int end) {
@@ -209,9 +223,10 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
-   * @param c
-   * @param start
-   * @param end
+   * Sets the c.
+   * @param c the c
+   * @param start the start
+   * @param end the end
    * @return a subset of the collection never <code>null</code>.
    * @see #sublist(Collection, int, int)
    */
@@ -235,6 +250,12 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
               + " the item.",
       params = {@IPSJexlParam(name = "value", description = "value ")},
       returns = "a list")
+  /**
+   * asList operation.
+   *
+   * @param single the single
+   * @return the result
+   */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public List<Object> asList(Object single) {
     if (single == null) {
@@ -268,6 +289,13 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "size", description = "size of the array to return")
       },
       returns = "T[]")
+  /**
+   * asList operation.
+   *
+   * @param value the value
+   * @param size the size
+   * @return the result
+   */
   public <T> List<T> asList(T value, int size) {
     List<T> rvalue = new ArrayList<T>();
     for (int i = 0; i < size; i++) {
@@ -293,6 +321,13 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "second", description = "second object")
       },
       returns = "a list")
+  /**
+   * asPair operation.
+   *
+   * @param first the first
+   * @param second the second
+   * @return the result
+   */
   public <A, B> PSPair<A, B> asPair(A first, B second) {
     PSPair<A, B> pair = new PSPair<A, B>(first, second);
     return pair;
@@ -301,8 +336,8 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
   /**
    * Validates and converts start and end to integers.
    *
-   * @param start
-   * @param end
+   * @param start the start
+   * @param end the end
    * @return an two index (length = 2) integer array with start first and end last.
    */
   private int[] convertIndexs(String start, String end) {
@@ -322,8 +357,8 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
   /**
    * Validates and converts start and end to integers.
    *
-   * @param start
-   * @param end
+   * @param start the start
+   * @param end the end
    * @return an two index (length = 2) integer array with start first and end last.
    */
   private int[] convertIndexs(Number start, Number end) {
@@ -343,12 +378,18 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
       params = {
         @IPSJexlParam(name = "list", description = "the list whose elements are to be reversed.")
       })
+  /**
+   * reverse operation.
+   *
+   * @param list the list
+   */
   public void reverse(List<?> list) {
     Collections.reverse(list);
   }
 
   /* (non-Javadoc)
    * @see java.lang.Object#toString()
+   * @return the result
    */
   @Override
   public String toString() {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOMapTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOMapTools.java
@@ -32,7 +32,17 @@ import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSOMapTools class.
+ */
 public class PSOMapTools extends PSJexlUtilBase {
+  /**
+   * Creates a new PSOMapTools.
+   */
+  public PSOMapTools() {
+    // default
+  }
+
 
   @IPSJexlMethod(
       description = "creates a map from a default map with a custom map overlayed",
@@ -43,6 +53,13 @@ public class PSOMapTools extends PSJexlUtilBase {
             description = "the map to overlay on top of the previous argument")
       },
       returns = "an overlayed map")
+  /**
+   * overlay operation.
+   *
+   * @param defaultOptions the default options
+   * @param customOptions the custom options
+   * @return the result
+   */
   public Map<String, Object> overlay(
       Map<String, Object> defaultOptions, Map<String, Object> customOptions) {
     Map<String, Object> m = new HashMap<String, Object>();
@@ -55,11 +72,27 @@ public class PSOMapTools extends PSJexlUtilBase {
     return m;
   }
 
+  /**
+   * get operation.
+   *
+   * @param m the m
+   * @param key the key
+   * @param d the d
+   * @return the result
+   */
   public Object get(Map<String, Object> m, String key, Object d) {
     Object rvalue = m.get(key);
     return rvalue == null ? d : rvalue;
   }
 
+  /**
+   * Returns the first defined.
+   *
+   * @param m the m
+   * @param keys the keys
+   * @param d the d
+   * @return the result
+   */
   public Object getFirstDefined(Map<String, Object> m, List<String> keys, Object d) {
     for (String k : keys) {
       Object rvalue = m.get(k);
@@ -70,6 +103,14 @@ public class PSOMapTools extends PSJexlUtilBase {
     return d;
   }
 
+  /**
+   * Returns the first defined.
+   *
+   * @param m the m
+   * @param keys the keys
+   * @param d the d
+   * @return the result
+   */
   public Object getFirstDefined(Map<String, Object> m, String keys, Object d) {
     return getFirstDefined(m, asList(keys.split(",")), d);
   }
@@ -78,6 +119,14 @@ public class PSOMapTools extends PSJexlUtilBase {
       description = "loads properties from a properties file.",
       params = {@IPSJexlParam(name = "file", description = "location of properties file.")},
       returns = "java.util.properties")
+  /**
+   * loadPropertiesFile operation.
+   *
+   * @param file the file
+   * @return the result
+   * @throws FileNotFoundException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Properties loadPropertiesFile(String file) throws FileNotFoundException, IOException {
     File f = new File(file);
     log.debug("Trying to load properties file: " + f.toURI().toString());
@@ -93,6 +142,13 @@ public class PSOMapTools extends PSJexlUtilBase {
         @IPSJexlParam(name = "values", description = "list of objects")
       },
       returns = "map")
+  /**
+   * create operation.
+   *
+   * @param keys the keys
+   * @param values the values
+   * @return the result
+   */
   public Map<String, Object> create(List<String> keys, List<? extends Object> values) {
     if (keys == null) {
       throw new IllegalArgumentException("Keys cannot be null");
@@ -113,6 +169,11 @@ public class PSOMapTools extends PSJexlUtilBase {
 
   // @IPSJexlMethod(description = "creates a map from a default map with a custom map overlayed",
   // params = {}, returns = "a new map.")
+  /**
+   * create operation.
+   *
+   * @return the result
+   */
   public Map<String, Object> create() {
     return new HashMap<String, Object>();
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSONavTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSONavTools.java
@@ -67,8 +67,10 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   private static IPSOParentFinder parFinder = null;
   private static PSRelationshipProcessorProxy proxy = null;
 
-  /** */
-  public PSONavTools() {
+    /**
+     * Creates a new PSONavTools.
+     */
+    public PSONavTools() {
     super();
   }
 
@@ -119,11 +121,18 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param selfNode the self node, usually <code>$nav.self</code>
    * @return The list of ancestors, including the self node. Never <code>null</code> or <code>empty
    *     </code>.
-   * @throws PSExtensionProcessingException
+   * @throws PSExtensionProcessingException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the ancestors for this node",
       params = {@IPSJexlParam(name = "selfNode", description = "the current item")})
+  /**
+   * Returns the ancestors.
+   *
+   * @param selfNode the self node
+   * @return the result
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public List<Node> getAncestors(Node selfNode) throws PSExtensionProcessingException {
     if (selfNode == null) {
       String emsg = "Self Node cannot be null";
@@ -167,11 +176,18 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
    *
    * @param folderid the folder id
    * @return the navon as a node. Will return <code>null</code> if the navon cannot be found.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "find the navon node based on the folder id",
       params = {@IPSJexlParam(name = "folderid", description = "folder id")})
+  /**
+   * findNavNodeForFolder operation.
+   *
+   * @param folderid the folderid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public IPSNode findNavNodeForFolder(String folderid) throws Exception {
     initServices();
     PSRelationshipFilter filter = new PSRelationshipFilter();
@@ -207,11 +223,18 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
    *
    * @param navonId the content id of the current navon
    * @return the parent navon node, or <code>null</code> if the navon has no parent.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "finds the parent of a Navon",
       params = {@IPSJexlParam(name = "navonId", description = "Content id of current navon")})
+  /**
+   * findParentNavonNode operation.
+   *
+   * @param navonId the navon id
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public IPSNode findParentNavonNode(String navonId) throws Exception {
     PSLocator loc = new PSLocator(navonId);
     return findParentNavonNode(loc);
@@ -224,11 +247,18 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
    *
    * @param navonGuid the GUID of the current navon.
    * @return the parent navon node, or <code>null</code> if the navon has no parent.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "finds the parent of a Navon",
       params = {@IPSJexlParam(name = "navonGuid", description = "Guid of current navon")})
+  /**
+   * findParentNavonNode operation.
+   *
+   * @param navonGuid the navon guid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public IPSNode findParentNavonNode(IPSGuid navonGuid) throws Exception {
     PSLocator loc = gmgr.makeLocator(navonGuid);
     return findParentNavonNode(loc);
@@ -240,11 +270,18 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
    *
    * @param navonLoc the locator for the current navon.
    * @return the parent navon node, or <code>null</code> if the navon has no parent.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "finds the parent of a Navon",
       params = {@IPSJexlParam(name = "navonLoc", description = "Locator of current navon")})
+  /**
+   * findParentNavonNode operation.
+   *
+   * @param navonLoc the navon loc
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public IPSNode findParentNavonNode(PSLocator navonLoc) throws Exception {
     initServices();
     Set<PSLocator> parents = new HashSet<>();
@@ -275,7 +312,7 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param folderid the folder id where the current navon is located.
    * @param propertyName the property name.
    * @return the nearest value, or <code>null</code> if no values can be located.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "finds the nearest non-empty value for a property",
@@ -283,6 +320,14 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "folderid", description = "content id of folder"),
         @IPSJexlParam(name = "propertyName", description = "name of property")
       })
+  /**
+   * findNearestNavonPropertyValue operation.
+   *
+   * @param folderid the folderid
+   * @param propertyName the property name
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public Value findNearestNavonPropertyValue(String folderid, String propertyName)
       throws Exception {
     IPSNode navonNode = findNavNodeForFolder(folderid);
@@ -299,6 +344,7 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * Sets the gmgr.
    * @param gmgr the gmgr to set
    */
   public static void setGmgr(IPSGuidManager gmgr) {
@@ -306,6 +352,7 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * Sets the navConfig.
    * @param navConfig the navConfig to set
    */
   public static void setNavConfig(PSNavConfig navConfig) {
@@ -313,6 +360,7 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * Sets the objFinder.
    * @param objFinder the objFinder to set
    */
   public static void setObjFinder(IPSOObjectFinder objFinder) {
@@ -320,6 +368,7 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * Sets the parFinder.
    * @param parFinder the parFinder to set
    */
   public static void setParFinder(IPSOParentFinder parFinder) {
@@ -327,6 +376,7 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   }
 
   /**
+   * Sets the proxy.
    * @param proxy the proxy to set
    */
   public static void setProxy(PSRelationshipProcessorProxy proxy) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSONavTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSONavTools.java
@@ -126,13 +126,6 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "get the ancestors for this node",
       params = {@IPSJexlParam(name = "selfNode", description = "the current item")})
-  /**
-   * Returns the ancestors.
-   *
-   * @param selfNode the self node
-   * @return the result
-   * @throws PSExtensionProcessingException if an error occurs
-   */
   public List<Node> getAncestors(Node selfNode) throws PSExtensionProcessingException {
     if (selfNode == null) {
       String emsg = "Self Node cannot be null";
@@ -181,13 +174,6 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "find the navon node based on the folder id",
       params = {@IPSJexlParam(name = "folderid", description = "folder id")})
-  /**
-   * findNavNodeForFolder operation.
-   *
-   * @param folderid the folderid
-   * @return the result
-   * @throws Exception if an error occurs
-   */
   public IPSNode findNavNodeForFolder(String folderid) throws Exception {
     initServices();
     PSRelationshipFilter filter = new PSRelationshipFilter();
@@ -228,13 +214,6 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "finds the parent of a Navon",
       params = {@IPSJexlParam(name = "navonId", description = "Content id of current navon")})
-  /**
-   * findParentNavonNode operation.
-   *
-   * @param navonId the navon id
-   * @return the result
-   * @throws Exception if an error occurs
-   */
   public IPSNode findParentNavonNode(String navonId) throws Exception {
     PSLocator loc = new PSLocator(navonId);
     return findParentNavonNode(loc);
@@ -252,13 +231,6 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "finds the parent of a Navon",
       params = {@IPSJexlParam(name = "navonGuid", description = "Guid of current navon")})
-  /**
-   * findParentNavonNode operation.
-   *
-   * @param navonGuid the navon guid
-   * @return the result
-   * @throws Exception if an error occurs
-   */
   public IPSNode findParentNavonNode(IPSGuid navonGuid) throws Exception {
     PSLocator loc = gmgr.makeLocator(navonGuid);
     return findParentNavonNode(loc);
@@ -275,13 +247,6 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "finds the parent of a Navon",
       params = {@IPSJexlParam(name = "navonLoc", description = "Locator of current navon")})
-  /**
-   * findParentNavonNode operation.
-   *
-   * @param navonLoc the navon loc
-   * @return the result
-   * @throws Exception if an error occurs
-   */
   public IPSNode findParentNavonNode(PSLocator navonLoc) throws Exception {
     initServices();
     Set<PSLocator> parents = new HashSet<>();
@@ -320,14 +285,6 @@ public class PSONavTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "folderid", description = "content id of folder"),
         @IPSJexlParam(name = "propertyName", description = "name of property")
       })
-  /**
-   * findNearestNavonPropertyValue operation.
-   *
-   * @param folderid the folderid
-   * @param propertyName the property name
-   * @return the result
-   * @throws Exception if an error occurs
-   */
   public Value findNearestNavonPropertyValue(String folderid, String propertyName)
       throws Exception {
     IPSNode navonNode = findNavNodeForFolder(folderid);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOObjectFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOObjectFinder.java
@@ -77,8 +77,10 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
 
   private static IPSWorkflowService wf = null;
 
-  /** */
-  public PSOObjectFinder() {
+    /**
+     * Creates a new PSOObjectFinder.
+     */
+    public PSOObjectFinder() {
     super();
   }
 
@@ -112,16 +114,31 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   @IPSJexlMethod(
       description = "get the Legacy Component Summary for an item",
       params = {@IPSJexlParam(name = "guid", description = "the item GUID")})
+  /**
+   * Returns the component summary.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSComponentSummary getComponentSummary(IPSGuid guid) throws PSException {
     return PSOItemSummaryFinder.getSummary(guid);
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getComponentSummaryById(java.lang.String)
    */
   @IPSJexlMethod(
       description = "get the Legacy Component Summary for an item",
       params = {@IPSJexlParam(name = "content", description = "the content id")})
+  /**
+   * Returns the component summary by id.
+   *
+   * @param contentid the contentid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSComponentSummary getComponentSummaryById(String contentid) throws PSException {
     return PSOItemSummaryFinder.getSummary(contentid);
   }
@@ -133,6 +150,12 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   @IPSJexlMethod(
       description = "get the content type summary for a specified type",
       params = {@IPSJexlParam(name = "guid", description = "the content type GUID")})
+  /**
+   * Returns the content type summary.
+   *
+   * @param guid the guid
+   * @return the result
+   */
   public PSContentTypeSummary getContentTypeSummary(IPSGuid guid) {
     initServices();
     List<PSContentTypeSummary> ctypes = cws.loadContentTypes(null);
@@ -146,11 +169,17 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getJSessionId()
    */
   @IPSJexlMethod(
       description = "Get the JSESSIONID value for the current request",
       params = {})
+  /**
+   * Returns the jsession id.
+   *
+   * @return the result
+   */
   public String getJSessionId() {
     String jsession = PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID).toString();
     log.debug("JSESSIONID= {}", jsession);
@@ -158,11 +187,17 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getPSSessionId()
    */
   @IPSJexlMethod(
       description = "Get the PSSESSIONID value for the current request",
       params = {})
+  /**
+   * Returns the pssession id.
+   *
+   * @return the result
+   */
   public String getPSSessionId() {
     PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
     String sessionid = req.getUserSessionId();
@@ -171,11 +206,17 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getUserLocale()
    */
   @IPSJexlMethod(
       description = "get the users current locale",
       params = {})
+  /**
+   * Returns the user locale.
+   *
+   * @return the result
+   */
   public String getUserLocale() {
     PSUserSession session = getSession();
     Object obj = session.getPrivateObject(IPSHtmlParameters.SYS_LANG);
@@ -186,22 +227,34 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getUserCommunity()
    */
   @IPSJexlMethod(
       description = "get the users current community name",
       params = {})
+  /**
+   * Returns the user community.
+   *
+   * @return the result
+   */
   public String getUserCommunity() {
     PSUserSession session = getSession();
     return session.getUserCurrentCommunity();
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getUserCommunityId()
    */
   @IPSJexlMethod(
       description = "get the users current community id",
       params = {})
+  /**
+   * Returns the user community id.
+   *
+   * @return the result
+   */
   public String getUserCommunityId() {
     PSUserSession session = getSession();
     Object obj = session.getPrivateObject(IPSHtmlParameters.SYS_COMMUNITY);
@@ -212,6 +265,7 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getGuidById(java.lang.String, java.lang.String)
    */
   @IPSJexlMethod(
@@ -220,6 +274,13 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
         @IPSJexlParam(name = "contentid", description = "the content id"),
         @IPSJexlParam(name = "revision", description = "the revision")
       })
+  /**
+   * Returns the guid by id.
+   *
+   * @param contentid the contentid
+   * @param revision the revision
+   * @return the result
+   */
   public IPSGuid getGuidById(String contentid, String revision) {
     initServices();
     PSLocator loc = new PSLocator(contentid, revision);
@@ -227,11 +288,18 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getGuidById(java.lang.String)
    */
   @IPSJexlMethod(
       description = "get the GUID by Content Id",
       params = {@IPSJexlParam(name = "contentid", description = "the content id")})
+  /**
+   * Returns the guid by id.
+   *
+   * @param contentid the contentid
+   * @return the result
+   */
   public IPSGuid getGuidById(String contentid) {
     initServices();
     PSLocator loc = new PSLocator(contentid);
@@ -239,11 +307,19 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getNodeByGuid(com.percussion.utils.guid.IPSGuid)
    */
   @IPSJexlMethod(
       description = "get the node for a particular guid",
       params = {@IPSJexlParam(name = "guid", description = "the GUID for the item")})
+  /**
+   * Returns the node by guid.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   */
   public IPSNode getNodeByGuid(IPSGuid guid) throws RepositoryException {
     initServices();
     List<Node> nodes = cmgr.findItemsByGUID(Collections.<IPSGuid>singletonList(guid), null);
@@ -254,11 +330,18 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getSiteGuid(int)
    */
   @IPSJexlMethod(
       description = "get the site guid for a given id",
       params = {@IPSJexlParam(name = "siteid", description = "the id for the site")})
+  /**
+   * Returns the site guid.
+   *
+   * @param siteid the siteid
+   * @return the result
+   */
   public IPSGuid getSiteGuid(int siteid) {
     initServices();
     IPSGuid guid = gmgr.makeGuid(siteid, PSTypeEnum.SITE);
@@ -267,11 +350,18 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.jexl.IPSOObjectFinder#getTemplateGuid(int)
    */
   @IPSJexlMethod(
       description = "get the template guid for a given id",
       params = {@IPSJexlParam(name = "template", description = "the id for the template")})
+  /**
+   * Returns the template guid.
+   *
+   * @param templateid the templateid
+   * @return the result
+   */
   public IPSGuid getTemplateGuid(int templateid) {
     initServices();
     IPSGuid guid = gmgr.makeGuid(templateid, PSTypeEnum.TEMPLATE);
@@ -282,6 +372,12 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   @IPSJexlMethod(
       description = "get the community name for a  given community id",
       params = {@IPSJexlParam(name = "communityId", description = "the id for the community")})
+  /**
+   * Returns the community name.
+   *
+   * @param communityId the community id
+   * @return the result
+   */
   public String getCommunityName(int communityId) {
     initServices();
     List<PSCommunity> communities = sws.loadCommunities(null);
@@ -306,8 +402,8 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
    *
    * &lt;h1&gt;STATE CURRENT VALUE=${state.getContentValidValue()}&lt;/h1&gt;
    *
-   * @param stateId
-   * @param workflowAppId
+   * @param stateId the state id
+   * @param workflowAppId the workflow app id
    *
    */
   @IPSJexlMethod(
@@ -318,6 +414,13 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
             name = "workflowAppId",
             description = "Returns the State definition for the specified workflow state.")
       })
+  /**
+   * Returns the workflow state.
+   *
+   * @param stateId the state id
+   * @param workflowAppId the workflow app id
+   * @return the result
+   */
   public PSState getWorkflowState(int stateId, int workflowAppId) {
     initServices();
     PSState state =
@@ -339,6 +442,7 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * Sets the cws.
    * @param cws The cws to set. This routine should only be used for unit testing.
    */
   public static void setCws(IPSContentWs cws) {
@@ -346,6 +450,7 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * Sets the gmgr.
    * @param gmgr the gmgr to set
    */
   public static void setGmgr(IPSGuidManager gmgr) {
@@ -353,6 +458,7 @@ public class PSOObjectFinder extends PSJexlUtilBase implements IPSJexlExpression
   }
 
   /**
+   * Sets the cmgr.
    * @param cmgr the cmgr to set
    */
   public static void setCmgr(IPSContentMgr cmgr) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOQueryTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOQueryTools.java
@@ -49,8 +49,10 @@ public class PSOQueryTools extends PSJexlUtilBase implements IPSJexlExpression {
 
   private static IPSContentMgr cmgr = null;
 
-  /** */
-  public PSOQueryTools() {}
+    /**
+     * Creates a new PSOQueryTools.
+     */
+    public PSOQueryTools() {}
 
   /**
    * Executes a JCR Query. The results are returned as a List. Each element of the list is a Map
@@ -62,8 +64,8 @@ public class PSOQueryTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param locale the locale used for sorting results.
    * @return a list of result rows. Each Row is a map of name and value pairs. never <code>null
    *     </code> but may be <code>empty</code>.
-   * @throws InvalidQueryException
-   * @throws RepositoryException
+   * @throws InvalidQueryException if an error occurs
+   * @throws RepositoryException if an error occurs
    */
   @IPSJexlMethod(
       description = "executes a JCR Query",
@@ -73,6 +75,17 @@ public class PSOQueryTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "params", description = "parameters for query"),
         @IPSJexlParam(name = "locale", description = "locale for collating results")
       })
+  /**
+   * executeQuery operation.
+   *
+   * @param query the query
+   * @param maxRows the max rows
+   * @param params the params
+   * @param locale the locale
+   * @return the result
+   * @throws InvalidQueryException if an error occurs
+   * @throws RepositoryException if an error occurs
+   */
   public List<Map<String, Value>> executeQuery(
       String query, int maxRows, Map<String, ? extends Object> params, String locale)
       throws InvalidQueryException, RepositoryException {
@@ -104,7 +117,7 @@ public class PSOQueryTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param params the the parameters to pass to the query.
    * @param locale the locale. Defaults to the JVM system locale if not present.
    * @return the Nodes from the query. Never <code>null</code> but may be <code>empty</code>.
-   * @throws RepositoryException
+   * @throws RepositoryException if an error occurs
    */
   @IPSJexlMethod(
       description = "executes a JCR Query and returns the Nodes",
@@ -114,6 +127,16 @@ public class PSOQueryTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "params", description = "parameters for query"),
         @IPSJexlParam(name = "locale", description = "locale for collating results")
       })
+  /**
+   * executeQueryNodes operation.
+   *
+   * @param query the query
+   * @param maxRows the max rows
+   * @param params the params
+   * @param locale the locale
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   */
   public NodeIterator executeQueryNodes(
       String query, int maxRows, Map<String, ? extends Object> params, String locale)
       throws RepositoryException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSORelationshipTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSORelationshipTools.java
@@ -48,6 +48,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * JEXL tools for inspecting and manipulating content relationships.
+ *
  * @author MikeStarck
  */
 public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpression {
@@ -56,8 +58,10 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
 
   private static IPSGuidManager gmgr = null;
 
-  /** */
-  public PSORelationshipTools() {
+    /**
+     * Creates a new PSORelationshipTools.
+     */
+    public PSORelationshipTools() {
     super();
   }
 
@@ -80,6 +84,16 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
             type = "String",
             description = "the userName with which to make the request")
       })
+  /**
+   * Returns the relationships.
+   *
+   * @param itemId the item id
+   * @param contenttypename the contenttypename
+   * @param userName the user name
+   * @return the result
+   * @throws PSErrorException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public List<PSItemSummary> getRelationships(
       IPSGuid itemId, String contenttypename, String userName)
       throws PSErrorException, PSExtensionProcessingException {
@@ -130,6 +144,14 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "slotName", description = "the slot name")
       },
       returns = "a list of all parent GUIDs")
+  /**
+   * findAllParentIds operation.
+   *
+   * @param guid the guid
+   * @param slotName the slot name
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public List<IPSGuid> findAllParentIds(IPSGuid guid, String slotName) throws Exception {
     initServices();
     String id = gmgr.makeLocator(guid).getPart(PSLocator.KEY_ID);
@@ -143,6 +165,14 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "slotName", description = "the slot name")
       },
       returns = "a list of all parent GUIDs")
+  /**
+   * findAllParentIds operation.
+   *
+   * @param contentid the contentid
+   * @param slotName the slot name
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public List<IPSGuid> findAllParentIds(String contentid, String slotName) throws Exception {
     initServices();
 
@@ -163,6 +193,15 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "usePublic", description = "use last public revision?")
       },
       returns = "a list of all parent GUIDs")
+  /**
+   * findParentIds operation.
+   *
+   * @param guid the guid
+   * @param slotName the slot name
+   * @param usePublic the use public
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public List<IPSGuid> findParentIds(IPSGuid guid, String slotName, boolean usePublic)
       throws Exception {
     initServices();
@@ -178,6 +217,15 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "usePublic", description = "use last public revision?")
       },
       returns = "a list of all parent GUIDs")
+  /**
+   * findParentIds operation.
+   *
+   * @param contentid the contentid
+   * @param slotName the slot name
+   * @param usePublic the use public
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public List<IPSGuid> findParentIds(String contentid, String slotName, boolean usePublic)
       throws Exception {
     initServices();
@@ -199,13 +247,20 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
    *
    * @param contentid the content id
    * @return <code>true</code> if this page has a public navon parent in the landing page slot.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "is this page referenced in the landing page slot",
       params = {
         @IPSJexlParam(name = "contentid", description = "the content id of the current page")
       })
+  /**
+   * Returns whether landing page.
+   *
+   * @param contentid the contentid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public boolean isLandingPage(String contentid) throws Exception {
     IPSOParentFinder relFinder = new PSOParentFinder();
     PSNavConfig nc = PSNavConfig.getInstance();
@@ -231,6 +286,14 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "contentid", description = "the content id of the current page"),
         @IPSJexlParam(name = "folderid", description = "the folder id of the current folder")
       })
+  /**
+   * Returns whether landing page in folder.
+   *
+   * @param contentid the contentid
+   * @param folderid the folderid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public boolean isLandingPageInFolder(String contentid, String folderid) throws Exception {
     initServices();
     IPSOParentFinder relFinder = new PSOParentFinder();
@@ -271,6 +334,13 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
   @IPSJexlMethod(
       description = "is this page referenced in the landing page slot",
       params = {@IPSJexlParam(name = "guid", description = "the current item guid")})
+  /**
+   * Returns whether landing page guid.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public boolean isLandingPageGuid(IPSGuid guid) throws Exception {
     initServices();
     String id = gmgr.makeLocator(guid).getPart(PSLocator.KEY_ID);
@@ -291,6 +361,14 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "contentGuid", description = "the current item guid"),
         @IPSJexlParam(name = "folderGuid", description = "the folder guid")
       })
+  /**
+   * Returns whether landing page in folder guid.
+   *
+   * @param contentGuid the content guid
+   * @param folderGuid the folder guid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public boolean isLandingPageInFolderGuid(IPSGuid contentGuid, IPSGuid folderGuid)
       throws Exception {
     initServices();
@@ -305,6 +383,14 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "contentid", description = "the current item id"),
         @IPSJexlParam(name = "folderid", description = "the folder id")
       })
+  /**
+   * Returns whether landing page in folder int.
+   *
+   * @param contentid the contentid
+   * @param folderid the folderid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public boolean isLandingPageInFolderInt(int contentid, int folderid) throws Exception {
     String cid = String.valueOf(contentid);
     String fid = String.valueOf(folderid);
@@ -318,7 +404,7 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
    * @param guid the current content item guid.
    * @param slotName the slot name
    * @return <code>true</code> if all ancestors in the slot are public.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "Does this item have any non-public ancestors",
@@ -326,6 +412,14 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
         @IPSJexlParam(name = "guid", description = "the content item GUID"),
         @IPSJexlParam(name = "slotName", description = "slotName")
       })
+  /**
+   * hasOnlyPublicAncestors operation.
+   *
+   * @param guid the guid
+   * @param slotName the slot name
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public boolean hasOnlyPublicAncestors(IPSGuid guid, String slotName) throws Exception {
     initServices();
     String contentid = gmgr.makeLocator(guid).getPart(PSLocator.KEY_ID);
@@ -343,7 +437,7 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
    * @param validFlags the validity flags considered public as a comma separated list. Defaults to
    *     &quot;y,i&quot;
    * @return <code>true</code> if all ancestors in the slot are public.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   @IPSJexlMethod(
       description = "Does this item have any non-public ancestors",
@@ -354,6 +448,15 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
             name = "validFlags",
             description = "validity flags considered public. Defaults to y,i")
       })
+  /**
+   * hasOnlyPublicAncestors operation.
+   *
+   * @param contentId the content id
+   * @param slotName the slot name
+   * @param validFlags the valid flags
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public boolean hasOnlyPublicAncestors(String contentId, String slotName, String validFlags)
       throws Exception {
     if (StringUtils.isBlank(validFlags)) {
@@ -368,6 +471,12 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
   @IPSJexlMethod(
       description = "Return a list of slots that are populated for this item",
       params = {@IPSJexlParam(name = "owner", description = "guid for this item")})
+  /**
+   * Returns the item slots.
+   *
+   * @param owner the owner
+   * @return the result
+   */
   public List<String> getItemSlots(IPSGuid owner) {
     initServices();
     PSRelationshipFilter filter = new PSRelationshipFilter();
@@ -384,6 +493,7 @@ public class PSORelationshipTools extends PSJexlUtilBase implements IPSJexlExpre
   }
 
   /**
+   * Sets the gmgr.
    * @param gmgr the gmgr to set
    */
   public static void setGmgr(IPSGuidManager gmgr) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSORemoteContentTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSORemoteContentTools.java
@@ -52,6 +52,9 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
       HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
   private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
+  /**
+   * Creates a new PSORemoteContentTools.
+   */
   public PSORemoteContentTools() {
     super();
   }
@@ -59,10 +62,10 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote JSON content and returns a JSONobject.
    *
-   * @param urlString
+   * @param urlString the url string
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   // TODO: Remove me @SuppressFBWarnings("HTTP_PARAMETER_POLLUTION") //Is an api specifically for
   // pulling remote content
@@ -74,6 +77,14 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
             description = "url to pull content from, include query params if desired")
       },
       returns = "Returns an integer status code")
+  /**
+   * Returns the httpstatus code.
+   *
+   * @param urlString the url string
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public int getHTTPStatusCode(String urlString) throws IllegalArgumentException, IOException {
     return executeGet(urlString, null, null, null).statusCode();
   }
@@ -81,12 +92,12 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote JSON content and returns a JSONobject.
    *
-   * @param urlString
-   * @param username
-   * @param password
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns a status code for a url",
@@ -98,6 +109,16 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns a integer status code")
+  /**
+   * Returns the httpstatus code.
+   *
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public int getHTTPStatusCode(String urlString, String username, String password)
       throws IllegalArgumentException, IOException {
     return executeGet(urlString, null, username, password).statusCode();
@@ -106,11 +127,11 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote JSON content and returns a JSONobject.
    *
-   * @param urlString
-   * @param headers
+   * @param urlString the url string
+   * @param headers the headers
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns status code based on url",
@@ -121,6 +142,15 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "headers", description = "map of headers to set")
       },
       returns = "Returns a integer status code")
+  /**
+   * Returns the httpstatus code.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public int getHTTPStatusCode(String urlString, Map<String, String> headers)
       throws IllegalArgumentException, IOException {
     return executeGet(urlString, headers, null, null).statusCode();
@@ -129,13 +159,13 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets a status code for a url.
    *
-   * @param urlString
-   * @param headers
-   * @param username
-   * @param password
+   * @param urlString the url string
+   * @param headers the headers
+   * @param username the username
+   * @param password the password
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns status code based on a URL.",
@@ -148,6 +178,17 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns a integer status code")
+  /**
+   * Returns the httpstatus code.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public int getHTTPStatusCode(
       String urlString, Map<String, String> headers, String username, String password)
       throws IllegalArgumentException, IOException {
@@ -157,10 +198,10 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote JSON content and returns a JSONobject.
    *
-   * @param urlString
+   * @param urlString the url string
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   // TODO: Remove me @SuppressFBWarnings("HTTP_PARAMETER_POLLUTION") //Is an API method for
   // returning remote JSON content in a template.
@@ -172,6 +213,14 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
             description = "url to pull content from, include query params if desired")
       },
       returns = "Returns parsed JSON as Object (Map for objects, List for arrays)")
+  /**
+   * Returns the remote jsoncontent.
+   *
+   * @param urlString the url string
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Object getRemoteJSONContent(String urlString)
       throws IllegalArgumentException, IOException {
     HttpResponse<String> response = executeGet(urlString, null, null, null);
@@ -188,12 +237,12 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote JSON content and returns a JSONobject.
    *
-   * @param urlString
-   * @param username
-   * @param password
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   // TODO: Remove me @SuppressFBWarnings("HTTP_PARAMETER_POLLUTION") //Is an API
   @IPSJexlMethod(
@@ -206,6 +255,16 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns parsed JSON as Object (Map for objects, List for arrays)")
+  /**
+   * Returns the remote jsoncontent.
+   *
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Object getRemoteJSONContent(String urlString, String username, String password)
       throws IllegalArgumentException, IOException {
     HttpResponse<String> response = executeGet(urlString, null, username, password);
@@ -222,11 +281,11 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote JSON content and returns a JSONobject.
    *
-   * @param urlString
-   * @param headers
+   * @param urlString the url string
+   * @param headers the headers
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns parsed JSON content (object or array) from a URL with headers.",
@@ -237,6 +296,15 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "headers", description = "map of headers to set")
       },
       returns = "Returns parsed JSON as Object (Map for objects, List for arrays)")
+  /**
+   * Returns the remote jsoncontent.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Object getRemoteJSONContent(String urlString, Map<String, String> headers)
       throws IllegalArgumentException, IOException {
     HttpResponse<String> response = executeGet(urlString, headers, null, null);
@@ -249,13 +317,13 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote JSON content and returns a JSONobject.
    *
-   * @param urlString
-   * @param headers
-   * @param username
-   * @param password
+   * @param urlString the url string
+   * @param headers the headers
+   * @param username the username
+   * @param password the password
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   // TODO: Remove me @SuppressFBWarnings("HTTP_PARAMETER_POLLUTION") // Is an api method for getting
   // remote data by url
@@ -271,6 +339,17 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns parsed JSON as Object (Map for objects, List for arrays)")
+  /**
+   * Returns the remote jsoncontent.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Object getRemoteJSONContent(
       String urlString, Map<String, String> headers, String username, String password)
       throws IllegalArgumentException, IOException {
@@ -317,10 +396,10 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote XML content and returns a JSOUP Document object.
    *
-   * @param urlString
+   * @param urlString the url string
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns JSOUP document with xml content, returns a JSoup Document element.",
@@ -330,6 +409,14 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
             description = "url to pull content from, include query params if desired")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote xmlcontent.
+   *
+   * @param urlString the url string
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Document getRemoteXMLContent(String urlString)
       throws IllegalArgumentException, IOException {
 
@@ -339,12 +426,12 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote XML content with basic authentication and returns a JSOUP Document object.
    *
-   * @param urlString
-   * @param username
-   * @param password
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns JSOUP document with xml content, returns a JSoup Document element.",
@@ -356,6 +443,16 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote xmlcontent.
+   *
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public org.jsoup.nodes.Document getRemoteXMLContent(
       String urlString, String username, String password)
       throws IllegalArgumentException, IOException {
@@ -368,11 +465,11 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This gets remote XML content with map of headers and returns a JSOUP Document object.
    *
-   * @param urlString
-   * @param headers
+   * @param urlString the url string
+   * @param headers the headers
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns JSOUP document with xml content, returns a JSoup Document element.",
@@ -383,6 +480,15 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "headers", description = "Map of headers")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote xmlcontent.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Document getRemoteXMLContent(String urlString, Map<String, String> headers)
       throws IllegalArgumentException, IOException {
     Connection connection = Jsoup.connect(urlString);
@@ -396,11 +502,11 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
    * This gets remote XML content with map of headers, username, and password then returns a JSOUP
    * Document object.
    *
-   * @param urlString
-   * @param headers
+   * @param urlString the url string
+   * @param headers the headers
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns JSOUP document with xml content, returns a JSoup Document element.",
@@ -413,6 +519,17 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote xmlcontent.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Document getRemoteXMLContent(
       String urlString, Map<String, String> headers, String username, String password)
       throws IllegalArgumentException, IOException {
@@ -430,10 +547,10 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This is an aliased method for getRemoteXMLContent
    *
-   * @param urlString
+   * @param urlString the url string
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description =
@@ -445,6 +562,14 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
             description = "url to pull content from, include query params if desired")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote htmlcontent.
+   *
+   * @param urlString the url string
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Document getRemoteHTMLContent(String urlString)
       throws IllegalArgumentException, IOException {
     return getRemoteXMLContent(urlString);
@@ -453,12 +578,12 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This is an aliased method for getRemoteXMLContent, with basic authorization
    *
-   * @param urlString
-   * @param username
-   * @param password
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns JSOUP document with xml content, returns a JSoup Document element.",
@@ -470,6 +595,16 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote htmlcontent.
+   *
+   * @param urlString the url string
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Document getRemoteHTMLContent(String urlString, String username, String password)
       throws IllegalArgumentException, IOException {
     return getRemoteXMLContent(urlString, username, password);
@@ -478,11 +613,11 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   /**
    * This is an aliased method for getRemoteXMLContent, with headers
    *
-   * @param urlString
-   * @param headers
+   * @param urlString the url string
+   * @param headers the headers
    * @return org.jsoup.nodes.Document
-   * @throws IllegalArgumentException
-   * @throws IOException
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Returns JSOUP document with xml content, returns a JSoup Document element.",
@@ -493,6 +628,15 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "headers", description = "Map of headers")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote htmlcontent.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Document getRemoteHTMLContent(String urlString, Map<String, String> headers)
       throws IllegalArgumentException, IOException {
     return getRemoteXMLContent(urlString, headers);
@@ -520,6 +664,17 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
         @IPSJexlParam(name = "password", description = "password")
       },
       returns = "Returns a JSOUP document")
+  /**
+   * Returns the remote htmlcontent.
+   *
+   * @param urlString the url string
+   * @param headers the headers
+   * @param username the username
+   * @param password the password
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public Document getRemoteHTMLContent(
       String urlString, Map<String, String> headers, String username, String password)
       throws IllegalArgumentException, IOException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOSlotTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOSlotTools.java
@@ -79,15 +79,6 @@ public class PSOSlotTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "params", description = "extra parameters to the process")
       },
       returns = "list of assembly items")
-  /**
-   * Returns the slot contents.
-   *
-   * @param item the item
-   * @param slotName the slot name
-   * @param params the params
-   * @return the result
-   * @throws Throwable if an error occurs
-   */
   public List<IPSAssemblyItem> getSlotContents(
       IPSAssemblyItem item, String slotName, Map<String, Object> params) throws Throwable {
     try {
@@ -155,14 +146,6 @@ public class PSOSlotTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "slotcontent", description = "contents of the slot"),
         @IPSJexlParam(name = "propertyName", description = "name of the property to fetch")
       })
-  /**
-   * Returns the slot property values.
-   *
-   * @param slotcontents the slotcontents
-   * @param propertyName the property name
-   * @return the result
-   * @throws RepositoryException if an error occurs
-   */
   public List<String> getSlotPropertyValues(List<IPSAssemblyItem> slotcontents, String propertyName)
       throws RepositoryException {
     Validate.notEmpty(propertyName, "the property name must be specified.");

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOSlotTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOSlotTools.java
@@ -52,7 +52,11 @@ public class PSOSlotTools extends PSJexlUtilBase implements IPSJexlExpression {
 
   private static final Logger ms_log = LogManager.getLogger(PSOListTools.class);
 
-  /** Ctor. */
+  /**
+   * Ctor.
+   * Creates a new PSOSlotTools.
+   *
+   */
   public PSOSlotTools() {
     super();
   }
@@ -65,7 +69,7 @@ public class PSOSlotTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param params the combined map of parameters to pass to the slot finder. Never <code>null
    *     </code> may be <code>empty</code>
    * @return a list of results
-   * @throws Throwable
+   * @throws Throwable if an error occurs
    */
   @IPSJexlMethod(
       description = "Get the contents of a slot as a list of assembly items",
@@ -75,6 +79,15 @@ public class PSOSlotTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "params", description = "extra parameters to the process")
       },
       returns = "list of assembly items")
+  /**
+   * Returns the slot contents.
+   *
+   * @param item the item
+   * @param slotName the slot name
+   * @param params the params
+   * @return the result
+   * @throws Throwable if an error occurs
+   */
   public List<IPSAssemblyItem> getSlotContents(
       IPSAssemblyItem item, String slotName, Map<String, Object> params) throws Throwable {
     try {
@@ -134,7 +147,7 @@ public class PSOSlotTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param propertyName the name of the desired property. Must not be <code>null</code> or <code>
    *     blank</code>
    * @return a list of String values. Never <code>null</code> but may be <code>empty</code>
-   * @throws RepositoryException
+   * @throws RepositoryException if an error occurs
    */
   @IPSJexlMethod(
       description = "gets all property values across the contents of a slot",
@@ -142,6 +155,14 @@ public class PSOSlotTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "slotcontent", description = "contents of the slot"),
         @IPSJexlParam(name = "propertyName", description = "name of the property to fetch")
       })
+  /**
+   * Returns the slot property values.
+   *
+   * @param slotcontents the slotcontents
+   * @param propertyName the property name
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   */
   public List<String> getSlotPropertyValues(List<IPSAssemblyItem> slotcontents, String propertyName)
       throws RepositoryException {
     Validate.notEmpty(propertyName, "the property name must be specified.");

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOStringTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOStringTools.java
@@ -43,7 +43,11 @@ public class PSOStringTools extends PSJexlUtilBase implements IPSJexlExpression 
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOStringTools.class);
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSOStringTools.
+   *
+   */
   public PSOStringTools() {}
 
   /**
@@ -56,6 +60,12 @@ public class PSOStringTools extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "gets a StringBuilder for concatenating strings",
       params = {@IPSJexlParam(name = "value", description = "initial value")})
+  /**
+   * Returns the string builder.
+   *
+   * @param value the value
+   * @return the result
+   */
   public StringBuilder getStringBuilder(String value) {
     return new StringBuilder(value);
   }
@@ -69,6 +79,11 @@ public class PSOStringTools extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "gets a StringBuilder for concatenating strings",
       params = {})
+  /**
+   * Returns the string builder.
+   *
+   * @return the result
+   */
   public StringBuilder getStringBuilder() {
     return new StringBuilder();
   }
@@ -83,6 +98,12 @@ public class PSOStringTools extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "gets a java.util.Locale based on the String representation",
       params = {@IPSJexlParam(name = "locString", description = "locale as a String")})
+  /**
+   * Returns the locale.
+   *
+   * @param locString the loc string
+   * @return the result
+   */
   public Locale getLocale(String locString) {
     return PSI18nUtils.getLocaleFromString(locString);
   }
@@ -90,6 +111,14 @@ public class PSOStringTools extends PSJexlUtilBase implements IPSJexlExpression 
   @IPSJexlMethod(
       description = "Removes XML markup from a string.",
       params = {@IPSJexlParam(name = "body", description = "A string with xml markup.")})
+  /**
+   * removeXml operation.
+   *
+   * @param body the body
+   * @return the result
+   * @throws IOException if an error occurs
+   * @throws SAXException if an error occurs
+   */
   public String removeXml(String body) throws IOException, SAXException {
     String wrapper = "<wrapper>" + body + "</wrapper>";
     StringReader reader = new StringReader(wrapper);
@@ -107,6 +136,13 @@ public class PSOStringTools extends PSJexlUtilBase implements IPSJexlExpression 
         @IPSJexlParam(name = "body", description = "the string to truncate"),
         @IPSJexlParam(name = "maxWords", description = "The maximum number of words")
       })
+  /**
+   * truncateByWords operation.
+   *
+   * @param body the body
+   * @param maxWords the max words
+   * @return the result
+   */
   public String truncateByWords(String body, Number maxWords) {
     int size = body.length();
     int words = 0;
@@ -144,6 +180,18 @@ public class PSOStringTools extends PSJexlUtilBase implements IPSJexlExpression 
             name = "forceExtension",
             description = "Add or replace extension with this value")
       })
+  /**
+   * cleanupPath operation.
+   *
+   * @param path the path
+   * @param forceLower the force lower
+   * @param includesExtension the includes extension
+   * @param stripExtension the strip extension
+   * @param prefix the prefix
+   * @param suffix the suffix
+   * @param forceExtension the force extension
+   * @return the result
+   */
   public String cleanupPath(
       String path,
       boolean forceLower,

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOTransform.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOTransform.java
@@ -44,8 +44,10 @@ public class PSOTransform extends PSJexlUtilBase implements IPSJexlExpression {
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOTransform.class);
 
-  /** */
-  public PSOTransform() {
+    /**
+     * Creates a new PSOTransform.
+     */
+    public PSOTransform() {
     super();
   }
 
@@ -65,6 +67,13 @@ public class PSOTransform extends PSJexlUtilBase implements IPSJexlExpression {
             type = "String",
             description = "the URI of the stylesheet to apply")
       })
+  /**
+   * transform operation.
+   *
+   * @param source the source
+   * @param stylesheetName the stylesheet name
+   * @return the result
+   */
   public String transform(String source, String stylesheetName) {
     Map<String, Object> params = new HashMap<String, Object>();
     return transform(source, stylesheetName, params);
@@ -95,6 +104,14 @@ public class PSOTransform extends PSJexlUtilBase implements IPSJexlExpression {
             description = "the file: URL of the stylesheet to apply"),
         @IPSJexlParam(name = "params", description = "XSLT parameters for stylesheet")
       })
+  /**
+   * transform operation.
+   *
+   * @param source the source
+   * @param stylesheetName the stylesheet name
+   * @param params the params
+   * @return the result
+   */
   public String transform(String source, String stylesheetName, Map<String, Object> params) {
     URL styleFile;
     PSCachedStylesheet styleCached = null;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOJexlEvaluatorUDF.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOJexlEvaluatorUDF.java
@@ -45,7 +45,22 @@ import java.util.Map;
  * @author DavidBenua
  */
 public class PSOJexlEvaluatorUDF extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /**
+   * Creates a new PSOJexlEvaluatorUDF.
+   */
+  public PSOJexlEvaluatorUDF() {
+    // default
+  }
 
+
+  /**
+   * processUdf operation.
+   *
+   * @param params the params
+   * @param req the req
+   * @return the result
+   * @throws PSConversionException if an error occurs
+   */
   public Object processUdf(Object[] params, IPSRequestContext req) throws PSConversionException {
     PSExtensionParams ep = new PSExtensionParams(params);
     String expression = ep.getStringParam(0, null, true);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSONextNumberUDF.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSONextNumberUDF.java
@@ -36,7 +36,9 @@ public class PSONextNumberUDF extends PSSimpleJavaUdfExtension implements IPSUdf
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSONextNumberUDF.class);
 
-  /** */
+  /**
+   * Creates a new PSONextNumberUDF.
+   */
   public PSONextNumberUDF() {
     super();
   }
@@ -49,6 +51,8 @@ public class PSONextNumberUDF extends PSSimpleJavaUdfExtension implements IPSUdf
    * @param request the callers request context
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[],
    *     com.percussion.server.IPSRequestContext)
+   * @return the result
+   * @throws PSConversionException if an error occurs
    */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOProxyQueryResource.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOProxyQueryResource.java
@@ -57,6 +57,13 @@ import org.xml.sax.SAXException;
  */
 public class PSOProxyQueryResource extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /**
+   * Creates a new PSOProxyQueryResource.
+   */
+  public PSOProxyQueryResource() {
+    // default
+  }
+
 
   private static final String PARAM_PASSWORD = "password";
   private static final String PARAM_USER = "user";
@@ -65,10 +72,25 @@ public class PSOProxyQueryResource extends PSDefaultExtension
   /** The log instance to use for this class, never <code>null</code>. */
   private static final Logger log = LogManager.getLogger(PSOProxyQueryResource.class);
 
+  /**
+   * canModifyStyleSheet operation.
+   *
+   * @return the result
+   */
   public boolean canModifyStyleSheet() {
     return false;
   }
 
+  /**
+   * processResultDocument operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @param resultDoc the result doc
+   * @return the result
+   * @throws PSParameterMismatchException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public Document processResultDocument(
       Object[] params, IPSRequestContext request, Document resultDoc)
       throws PSParameterMismatchException, PSExtensionProcessingException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOUserCommunityUDF.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/legacy/PSOUserCommunityUDF.java
@@ -30,10 +30,21 @@ import com.percussion.server.IPSRequestContext;
  */
 public class PSOUserCommunityUDF extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /**
+   * Creates a new PSOUserCommunityUDF.
+   */
+  public PSOUserCommunityUDF() {
+    // default
+  }
+
+  /**
    * Gets the user community from user session.
    *
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[],
    *     com.percussion.server.IPSRequestContext)
+   * @param arg0 the arg0
+   * @param arg1 the arg1
+   * @return the result
+   * @throws PSConversionException if an error occurs
    */
   public Object processUdf(Object[] arg0, IPSRequestContext arg1) throws PSConversionException {
     PSOObjectFinder finder = new PSOObjectFinder();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/AbstractMenuController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/AbstractMenuController.java
@@ -54,17 +54,35 @@ import org.springframework.web.servlet.mvc.ParameterizableViewController;
  */
 public abstract class AbstractMenuController extends ParameterizableViewController
     implements Controller {
+  /** Logger for menu controller subclasses. */
   private static final Logger log = LogManager.getLogger(AbstractMenuController.class);
+  /** Finds site-folder locations for content items. */
   protected SiteFolderFinder siteFolderFinder = null;
+  /** Assembly service used to resolve templates. */
   protected static IPSAssemblyService asm = null;
+  /** Security web service used for community visibility checks. */
   protected static IPSSecurityWs secws = null;
 
+  /** Object finder used to load component summaries. */
   protected static PSOObjectFinder objectFinder = null;
   private boolean testCommunityVisibility = true;
 
   /**
+   * Creates a menu controller with default community-visibility filtering enabled.
+   */
+  protected AbstractMenuController() {
+    // default
+  }
+
+  /**
+   * handleRequestInternal operation.
+   *
    * @see ParameterizableViewController#handleRequestInternal(HttpServletRequest,
    *     HttpServletResponse)
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
    */
   protected ModelAndView handleRequestInternal(
       HttpServletRequest request, HttpServletResponse response) throws Exception {
@@ -74,11 +92,11 @@ public abstract class AbstractMenuController extends ParameterizableViewControll
   /**
    * Find the visible templates for a given item
    *
-   * @param contentid
-   * @param sites
+   * @param contentid the content id of the item
+   * @param sites the sites used to filter visible templates
    * @return the list of templates. Never <code>null</code> but may be <code>empty</code>
-   * @throws PSException
-   * @throws PSAssemblyException
+   * @throws PSException if the item summary cannot be loaded
+   * @throws PSAssemblyException if templates cannot be resolved
    */
   protected List<IPSAssemblyTemplate> findVisibleTemplates(String contentid, Set<IPSSite> sites)
       throws PSException, PSAssemblyException {
@@ -183,7 +201,11 @@ public abstract class AbstractMenuController extends ParameterizableViewControll
     return siteFolderFinder;
   }
 
-  /** Initialize the service pointers. */
+  /**
+   * Initialize the service pointers.
+   * initServices operation.
+   *
+   */
   protected static void initServices() {
     if (asm == null) {
       secws = PSSecurityWsLocator.getSecurityWebservice();
@@ -193,6 +215,8 @@ public abstract class AbstractMenuController extends ParameterizableViewControll
   }
 
   /**
+   * Sets the site folder finder used by this controller.
+   *
    * @param siteFolderFinder the siteFolderFinder to set
    */
   public void setSiteFolderFinder(SiteFolderFinder siteFolderFinder) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionActiveAssemblyController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionActiveAssemblyController.java
@@ -28,6 +28,8 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.web.servlet.mvc.Controller;
 
 /**
+ * Spring MVC controller for Active Assembly menu actions in preview.
+ *
  * @author DavidBenua
  */
 public class ActionActiveAssemblyController extends ActionPreviewController implements Controller {
@@ -36,7 +38,9 @@ public class ActionActiveAssemblyController extends ActionPreviewController impl
 
   private boolean showSnippets = true;
 
-  /** */
+    /**
+   * Creates an Active Assembly menu controller.
+   */
   public ActionActiveAssemblyController() {}
 
   /**
@@ -45,6 +49,11 @@ public class ActionActiveAssemblyController extends ActionPreviewController impl
    * in the Active Assembly menu. The default is <code>true</code>.
    *
    * @see ActionPreviewController#findVisibleTemplates(String, Set)
+   * @param contentid the contentid
+   * @param sites the sites
+   * @return the result
+   * @throws PSException if an error occurs
+   * @throws PSAssemblyException if an error occurs
    */
   @Override
   protected List<IPSAssemblyTemplate> findVisibleTemplates(String contentid, Set<IPSSite> sites)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionPreviewController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionPreviewController.java
@@ -41,6 +41,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /**
+ * Spring MVC controller that builds preview menu actions for content items.
+ *
  * @author DavidBenua
  */
 public class ActionPreviewController extends AbstractMenuController implements Controller {
@@ -51,15 +53,25 @@ public class ActionPreviewController extends AbstractMenuController implements C
 
   private UrlBuilder urlBuilder = null;
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new ActionPreviewController.
+   *
+   */
   public ActionPreviewController() {
     super();
   }
 
   /**
+   * handleRequestInternal operation.
+   *
    * @see
    *     org.springframework.web.servlet.mvc.AbstractController#handleRequestInternal(HttpServletRequest,
    *     HttpServletResponse)
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   protected ModelAndView handleRequestInternal(
@@ -145,6 +157,18 @@ public class ActionPreviewController extends AbstractMenuController implements C
     return mav;
   }
 
+  /**
+   * Builds menu actions from the given assembly templates.
+   *
+   * @param actions destination list that receives new actions
+   * @param templates templates to convert into actions
+   * @param properties base action properties
+   * @param urlParams URL parameters for the preview link
+   * @param location site-folder location for the item
+   * @param useMulti whether multi-site URL building is enabled
+   * @return the actions list (same instance as {@code actions})
+   * @throws Exception if a URL cannot be built
+   */
   protected List<PSOAction> makeActionsFromTemplates(
       List<PSOAction> actions,
       List<IPSAssemblyTemplate> templates,
@@ -183,6 +207,12 @@ public class ActionPreviewController extends AbstractMenuController implements C
     return actions;
   }
 
+  /**
+   * Serializes the action list to an XML document for the menu response.
+   *
+   * @param actions actions to include
+   * @return XML document with an {@code ActionList} root
+   */
   protected Document buildActionListXml(List<PSOAction> actions) {
     Document output = PSXmlDocumentBuilder.createXmlDocument();
     Element root = PSXmlDocumentBuilder.createRoot(output, "ActionList");
@@ -194,28 +224,36 @@ public class ActionPreviewController extends AbstractMenuController implements C
   }
 
   /**
-   * @return the snippetTargetStyle
+   * Returns the target style applied to snippet previews.
+   *
+   * @return the snippet target style
    */
   public String getSnippetTargetStyle() {
     return snippetTargetStyle;
   }
 
   /**
-   * @param snippetTargetStyle the snippetTargetStyle to set
+   * Sets the target style applied to snippet previews.
+   *
+   * @param snippetTargetStyle the snippet target style to set
    */
   public void setSnippetTargetStyle(String snippetTargetStyle) {
     this.snippetTargetStyle = snippetTargetStyle;
   }
 
   /**
-   * @return the urlBuilder
+   * Returns the URL builder used for preview links.
+   *
+   * @return the URL builder
    */
   public UrlBuilder getUrlBuilder() {
     return urlBuilder;
   }
 
   /**
-   * @param urlBuilder the urlBuilder to set
+   * Sets the URL builder used for preview links.
+   *
+   * @param urlBuilder the URL builder to set
    */
   public void setUrlBuilder(UrlBuilder urlBuilder) {
     this.urlBuilder = urlBuilder;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionSiteForwardingController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionSiteForwardingController.java
@@ -52,6 +52,13 @@ public class ActionSiteForwardingController extends AbstractMenuController imple
 
   private static final Logger log = LogManager.getLogger(ActionSiteForwardingController.class);
 
+  /**
+   * Creates a site-forwarding menu controller.
+   */
+  public ActionSiteForwardingController() {
+    // default
+  }
+
   private String baseUrl = null;
 
   private String contentIdParam = IPSHtmlParameters.SYS_CONTENTID;
@@ -63,7 +70,12 @@ public class ActionSiteForwardingController extends AbstractMenuController imple
   private String siteIdParam = IPSHtmlParameters.SYS_SITEID;
 
   /**
+   * See referenced member.
    * @see AbstractMenuController#handleRequestInternal(HttpServletRequest, HttpServletResponse)
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   protected ModelAndView handleRequestInternal(
@@ -113,7 +125,7 @@ public class ActionSiteForwardingController extends AbstractMenuController imple
    *
    * @param pmap the HTML parameters that define the item.
    * @return the sites that this item appears on.
-   * @throws Exception
+   * @throws Exception if site folder locations cannot be resolved
    */
   protected Set<IPSSite> findSitesForItem(Map<String, String> pmap) throws Exception {
     String contentid = StringUtils.defaultString(pmap.get(contentIdParam));

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActiveAssemblyUrlBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActiveAssemblyUrlBuilder.java
@@ -33,12 +33,25 @@ import org.apache.logging.log4j.Logger;
  */
 public class ActiveAssemblyUrlBuilder extends PreviewUrlBuilder implements UrlBuilder, Cloneable {
 
+  /**
+   * Creates a new ActiveAssemblyUrlBuilder.
+   */
+  public ActiveAssemblyUrlBuilder() {
+    // default
+  }
+
   private static final Logger log = LogManager.getLogger(ActiveAssemblyUrlBuilder.class);
 
   /**
    * Builds the active assembly URL.
    *
    * @see PreviewUrlBuilder#buildUrl(IPSAssemblyTemplate, Map, SiteFolderLocation, boolean)
+   * @param template the template
+   * @param urlParams the url params
+   * @param location the location
+   * @param useMultiple the use multiple
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   public String buildUrl(
@@ -76,5 +89,6 @@ public class ActiveAssemblyUrlBuilder extends PreviewUrlBuilder implements UrlBu
     return url.toString();
   }
 
+  /** BASE_AA_URL field. */
   protected static final String BASE_AA_URL = "/Rhythmyx/sys_action/checkoutaapage.xml";
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/CachingSiteLoaderImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/CachingSiteLoaderImpl.java
@@ -46,6 +46,7 @@ public class CachingSiteLoaderImpl implements InitializingBean, SiteLoader {
 
   private static IPSSiteManager siteMgr = null;
 
+  /** allSites field. */
   protected List<IPSSite> allSites = null;
 
   /**
@@ -54,6 +55,9 @@ public class CachingSiteLoaderImpl implements InitializingBean, SiteLoader {
    */
   private long siteReloadDelay = 0;
 
+    /**
+   * Creates a new CachingSiteLoaderImpl.
+   */
   public CachingSiteLoaderImpl() {}
 
   private static void initServices() {
@@ -63,7 +67,9 @@ public class CachingSiteLoaderImpl implements InitializingBean, SiteLoader {
   }
 
   /**
+   * See referenced member.
    * @see InitializingBean#afterPropertiesSet()
+   * @throws Exception if an error occurs
    */
   public void afterPropertiesSet() throws Exception {
     allSites = loadAllSites();
@@ -74,6 +80,15 @@ public class CachingSiteLoaderImpl implements InitializingBean, SiteLoader {
     }
   }
 
+  /**
+   * loadAllSites operation.
+   */
+  /**
+   * Loads all sites from the site manager.
+   *
+   * @return the list of sites
+   * @throws PSSiteManagerException if sites cannot be loaded
+   */
   protected List<IPSSite> loadAllSites() throws PSSiteManagerException {
     initServices();
     log.debug("Loading all sites");
@@ -86,7 +101,10 @@ public class CachingSiteLoaderImpl implements InitializingBean, SiteLoader {
   }
 
   /**
+   * See referenced member.
    * @see SiteLoader#findAllSites()
+   * @return the result
+   * @throws PSSiteManagerException if an error occurs
    */
   public synchronized List<IPSSite> findAllSites() throws PSSiteManagerException {
     if (allSites == null || siteReloadDelay < 0) {
@@ -122,10 +140,23 @@ public class CachingSiteLoaderImpl implements InitializingBean, SiteLoader {
     CachingSiteLoaderImpl.siteMgr = siteMgr;
   }
 
+  /**
+   * Returns the AllSites.
+   *
+   * @return the value
+   */
   protected synchronized List<IPSSite> getAllSites() {
     return allSites;
   }
 
+  /**
+   * Sets the AllSites.
+   */
+  /**
+   * Sets the cached site list.
+   *
+   * @param allSites the sites to cache
+   */
   protected synchronized void setAllSites(List<IPSSite> allSites) {
     this.allSites = allSites;
   }
@@ -133,6 +164,7 @@ public class CachingSiteLoaderImpl implements InitializingBean, SiteLoader {
   private class SiteReloader implements Runnable {
 
     /**
+     * See referenced member.
      * @see Runnable#run()
      */
     public void run() {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ConfigurableSiteLoaderImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ConfigurableSiteLoaderImpl.java
@@ -24,6 +24,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Site loader implementation that loads sites from configuration.
+ *
  * @author DavidBenua
  */
 public class ConfigurableSiteLoaderImpl extends CachingSiteLoaderImpl implements SiteLoader {
@@ -32,13 +34,20 @@ public class ConfigurableSiteLoaderImpl extends CachingSiteLoaderImpl implements
 
   private List<String> allowedSites;
 
-  /** */
-  public ConfigurableSiteLoaderImpl() {
+        /**
+     * Creates a new ConfigurableSiteLoaderImpl.
+     */
+    public ConfigurableSiteLoaderImpl() {
     super();
     allowedSites = new ArrayList<String>();
   }
 
   @Override
+  /**
+   * loadAllSites operation.
+   * @return the result
+   * @throws PSSiteManagerException if an error occurs
+   */
   public synchronized List<IPSSite> loadAllSites() throws PSSiteManagerException {
     List<IPSSite> allSites = super.loadAllSites();
     List<IPSSite> mySites = new ArrayList<IPSSite>();
@@ -55,10 +64,23 @@ public class ConfigurableSiteLoaderImpl extends CachingSiteLoaderImpl implements
     return mySites;
   }
 
+  /**
+   * Returns the AllowedSites.
+   *
+   * @return the value
+   */
   public List<String> getAllowedSites() {
     return allowedSites;
   }
 
+  /**
+   * Sets the AllowedSites.
+   */
+  /**
+   * Sets the list of allowed site names.
+   *
+   * @param allowedSites the allowed site names
+   */
   public void setAllowedSites(List<String> allowedSites) {
     this.allowedSites = allowedSites;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ConfigurableSiteLoaderImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ConfigurableSiteLoaderImpl.java
@@ -41,13 +41,13 @@ public class ConfigurableSiteLoaderImpl extends CachingSiteLoaderImpl implements
     super();
     allowedSites = new ArrayList<String>();
   }
-
-  @Override
   /**
    * loadAllSites operation.
    * @return the result
    * @throws PSSiteManagerException if an error occurs
    */
+
+  @Override
   public synchronized List<IPSSite> loadAllSites() throws PSSiteManagerException {
     List<IPSSite> allSites = super.loadAllSites();
     List<IPSSite> mySites = new ArrayList<IPSSite>();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ContentTypeLoggingInterceptor.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ContentTypeLoggingInterceptor.java
@@ -36,20 +36,36 @@ public class ContentTypeLoggingInterceptor implements HandlerInterceptor {
 
   private static final Logger log = LogManager.getLogger(ContentTypeLoggingInterceptor.class);
 
-  /** */
-  public ContentTypeLoggingInterceptor() {}
+    /**
+     * Creates a new ContentTypeLoggingInterceptor.
+     */
+    public ContentTypeLoggingInterceptor() {}
 
   /**
+   * afterCompletion operation.
+   *
    * @see HandlerInterceptor#afterCompletion(HttpServletRequest, HttpServletResponse, Object,
    *     Exception)
+   * @param request the request
+   * @param response the response
+   * @param handler the handler
+   * @param ex the ex
+   * @throws Exception if an error occurs
    */
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
       throws Exception {}
 
   /**
+   * postHandle operation.
+   *
    * @see HandlerInterceptor#postHandle(HttpServletRequest, HttpServletResponse, Object,
    *     ModelAndView)
+   * @param request the request
+   * @param response the response
+   * @param handler the handler
+   * @param modelAndView the model and view
+   * @throws Exception if an error occurs
    */
   public void postHandle(
       HttpServletRequest request,
@@ -59,7 +75,13 @@ public class ContentTypeLoggingInterceptor implements HandlerInterceptor {
       throws Exception {}
 
   /**
+   * See referenced member.
    * @see HandlerInterceptor#preHandle(HttpServletRequest, HttpServletResponse, Object)
+   * @param request the request
+   * @param response the response
+   * @param handler the handler
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/MultiSiteResolutionController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/MultiSiteResolutionController.java
@@ -40,6 +40,8 @@ import org.springframework.web.servlet.mvc.Controller;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
 /**
+ * Controller that resolves multi-site preview locations for a content item.
+ *
  * @author DavidBenua
  */
 public class MultiSiteResolutionController extends ParameterizableViewController
@@ -53,8 +55,10 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   private static IPSGuidManager gmgr = null;
   private static IPSAssemblyService asm = null;
 
-  /** */
-  public MultiSiteResolutionController() {}
+    /**
+     * Creates a new MultiSiteResolutionController.
+     */
+    public MultiSiteResolutionController() {}
 
   private static void initServices() {
     if (asm == null) {
@@ -64,9 +68,15 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * handleRequestInternal operation.
+   *
    * @see
    *     org.springframework.web.servlet.mvc.AbstractController#handleRequestInternal(HttpServletRequest,
    *     HttpServletResponse)
+   * @param request the request
+   * @param response the response
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -113,6 +123,13 @@ public class MultiSiteResolutionController extends ParameterizableViewController
     return mav;
   }
 
+  /**
+   * findTemplate operation.
+   *
+   * @param templateid the templateid
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   */
   protected IPSAssemblyTemplate findTemplate(String templateid) throws PSAssemblyException {
     initServices();
     long tid = Long.parseLong(templateid);
@@ -123,6 +140,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Returns the siteFolderFinder.
    * @return the siteFolderFinder
    */
   public SiteFolderFinder getSiteFolderFinder() {
@@ -130,6 +148,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Sets the siteFolderFinder.
    * @param siteFolderFinder the siteFolderFinder to set
    */
   public void setSiteFolderFinder(SiteFolderFinder siteFolderFinder) {
@@ -137,6 +156,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Returns the gmgr.
    * @return the gmgr
    */
   public static IPSGuidManager getGmgr() {
@@ -144,6 +164,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Sets the gmgr.
    * @param gmgr the gmgr to set
    */
   public static void setGmgr(IPSGuidManager gmgr) {
@@ -151,6 +172,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Returns the asm.
    * @return the asm
    */
   public static IPSAssemblyService getAsm() {
@@ -158,6 +180,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Sets the asm.
    * @param asm the asm to set
    */
   public static void setAsm(IPSAssemblyService asm) {
@@ -165,6 +188,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Returns the urlBuilder.
    * @return the urlBuilder
    */
   public UrlBuilder getUrlBuilder() {
@@ -172,6 +196,7 @@ public class MultiSiteResolutionController extends ParameterizableViewController
   }
 
   /**
+   * Sets the urlBuilder.
    * @param urlBuilder the urlBuilder to set
    */
   public void setUrlBuilder(UrlBuilder urlBuilder) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/MultipartResolverEncoding.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/MultipartResolverEncoding.java
@@ -33,6 +33,13 @@ import org.springframework.web.multipart.support.StandardServletMultipartResolve
  * @author DavidBenua
  */
 public class MultipartResolverEncoding extends StandardServletMultipartResolver {
+  /**
+   * Creates a new MultipartResolverEncoding.
+   */
+  public MultipartResolverEncoding() {
+    // default
+  }
+
 
   private static final Logger log = LogManager.getLogger(MultipartResolverEncoding.class);
 
@@ -61,17 +68,30 @@ public class MultipartResolverEncoding extends StandardServletMultipartResolver 
    * Override resolveMultipart so we can clean up any malformed charset values sent by the Content
    * Explorer applet. The standard resolver does not expose determineEncoding, so we wrap the
    * request and sanitize the values before delegating.
+   * @param request the request
+   * @return the result
+   * @throws MultipartException if an error occurs
    */
   @Override
   public MultipartHttpServletRequest resolveMultipart(HttpServletRequest request)
       throws MultipartException {
     HttpServletRequestWrapper cleaned =
         new HttpServletRequestWrapper(request) {
+          /**
+           * Returns the character encoding.
+           *
+           * @return the result
+           */
           @Override
           public String getCharacterEncoding() {
             return determineEncoding(this);
           }
 
+          /**
+           * Returns the content type.
+           *
+           * @return the result
+           */
           @Override
           public String getContentType() {
             String type = super.getContentType();
@@ -84,6 +104,11 @@ public class MultipartResolverEncoding extends StandardServletMultipartResolver 
     return super.resolveMultipart(cleaned);
   }
 
+  /**
+   * cleanupMultipart operation.
+   *
+   * @param request the request
+   */
   @Override
   public void cleanupMultipart(MultipartHttpServletRequest request) {
     super.cleanupMultipart(request);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PSOAction.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PSOAction.java
@@ -39,11 +39,18 @@ public class PSOAction implements Comparable<PSOAction> {
   private String description;
   private Properties properties;
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new PSOAction.
+   *
+   */
   public PSOAction() {}
 
   /**
+   * See referenced member.
    * @see Comparable#compareTo(Object)
+   * @param other the other
+   * @return the result
    */
   public int compareTo(PSOAction other) {
     if (this == other) return 0;
@@ -51,18 +58,32 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * See referenced member.
    * @see Object#equals(Object)
+   * @param obj the obj
+   * @return the result
    */
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj);
   }
 
+  /**
+   * hashCode operation.
+   *
+   * @return the result
+   */
   @Override
   public int hashCode() {
     return super.hashCode();
   }
 
+  /**
+   * toXml operation.
+   *
+   * @param doc the doc
+   * @return the result
+   */
   @SuppressWarnings("unused")
   public Element toXml(Document doc) {
     Element root = doc.createElement("Action");
@@ -95,6 +116,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the handler.
    * @return the handler
    */
   public String getHandler() {
@@ -102,6 +124,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the handler.
    * @param handler the handler to set
    */
   public void setHandler(String handler) {
@@ -109,6 +132,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the label.
    * @return the label
    */
   public String getLabel() {
@@ -116,6 +140,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the label.
    * @param label the label to set
    */
   public void setLabel(String label) {
@@ -123,6 +148,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the name.
    * @return the name
    */
   public String getName() {
@@ -130,6 +156,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the name.
    * @param name the name to set
    */
   public void setName(String name) {
@@ -137,6 +164,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the url.
    * @return the url
    */
   public String getUrl() {
@@ -144,6 +172,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the url.
    * @param url the url to set
    */
   public void setUrl(String url) {
@@ -151,6 +180,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the type.
    * @return the type
    */
   public String getType() {
@@ -158,6 +188,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the type.
    * @param type the type to set
    */
   public void setType(String type) {
@@ -165,6 +196,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the sortrank.
    * @return the sortrank
    */
   public int getSortrank() {
@@ -172,6 +204,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the sortrank.
    * @param sortrank the sortrank to set
    */
   public void setSortrank(int sortrank) {
@@ -179,6 +212,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the description.
    * @return the description
    */
   public String getDescription() {
@@ -186,6 +220,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the description.
    * @param description the description to set
    */
   public void setDescription(String description) {
@@ -193,6 +228,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Returns the properties.
    * @return the properties
    */
   public Properties getProperties() {
@@ -200,6 +236,7 @@ public class PSOAction implements Comparable<PSOAction> {
   }
 
   /**
+   * Sets the properties.
    * @param properties the properties to set
    */
   public void setProperties(Properties properties) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PreviewLocation.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PreviewLocation.java
@@ -28,10 +28,16 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
   String path;
   String url;
 
+  /**
+   * Creates a new PreviewLocation.
+   */
   public PreviewLocation() {}
 
   /**
+   * See referenced member.
    * @see Comparable#compareTo(Object)
+   * @param other the other
+   * @return the result
    */
   public int compareTo(PreviewLocation other) {
     if (this == other) return 0;
@@ -44,19 +50,28 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
   }
 
   /**
+   * See referenced member.
    * @see Object#equals(Object)
+   * @param obj the obj
+   * @return the result
    */
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj);
   }
 
+  /**
+   * hashCode operation.
+   *
+   * @return the result
+   */
   @Override
   public int hashCode() {
     return super.hashCode();
   }
 
   /**
+   * Returns the siteName.
    * @return the siteName
    */
   public String getSiteName() {
@@ -64,6 +79,7 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
   }
 
   /**
+   * Sets the siteName.
    * @param siteName the siteName to set
    */
   public void setSiteName(String siteName) {
@@ -71,6 +87,7 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
   }
 
   /**
+   * Returns the path.
    * @return the path
    */
   public String getPath() {
@@ -78,6 +95,7 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
   }
 
   /**
+   * Sets the path.
    * @param path the path to set
    */
   public void setPath(String path) {
@@ -85,6 +103,7 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
   }
 
   /**
+   * Returns the url.
    * @return the url
    */
   public String getUrl() {
@@ -92,6 +111,7 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
   }
 
   /**
+   * Sets the url.
    * @param url the url to set
    */
   public void setUrl(String url) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PreviewUrlBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PreviewUrlBuilder.java
@@ -37,11 +37,20 @@ public class PreviewUrlBuilder implements UrlBuilder, Cloneable {
 
   private String multipleLocationUrl;
 
-  /** */
-  public PreviewUrlBuilder() {}
+        /**
+     * Creates a new PreviewUrlBuilder.
+     */
+    public PreviewUrlBuilder() {}
 
   /**
+   * See referenced member.
    * @see UrlBuilder#buildUrl(IPSAssemblyTemplate, Map, SiteFolderLocation, boolean)
+   * @param template the template
+   * @param urlParams the url params
+   * @param location the location
+   * @param useMultiple the use multiple
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public String buildUrl(
       IPSAssemblyTemplate template,
@@ -77,7 +86,7 @@ public class PreviewUrlBuilder implements UrlBuilder, Cloneable {
   /**
    * Find the template id for the given template.
    *
-   * @param template
+   * @param template the template
    * @return the template id.
    */
   protected String findTemplateId(IPSAssemblyTemplate template) {
@@ -103,6 +112,7 @@ public class PreviewUrlBuilder implements UrlBuilder, Cloneable {
   protected static final String DEFAULT_ASSY_URL = "/Rhythmyx/assembler/render";
 
   /**
+   * Returns the defaultLocationUrl.
    * @return the defaultLocationUrl
    */
   public String getDefaultLocationUrl() {
@@ -110,6 +120,7 @@ public class PreviewUrlBuilder implements UrlBuilder, Cloneable {
   }
 
   /**
+   * Sets the defaultLocationUrl.
    * @param defaultLocationUrl the defaultLocationUrl to set
    */
   public void setDefaultLocationUrl(String defaultLocationUrl) {
@@ -117,6 +128,7 @@ public class PreviewUrlBuilder implements UrlBuilder, Cloneable {
   }
 
   /**
+   * Returns the multipleLocationUrl.
    * @return the multipleLocationUrl
    */
   public String getMultipleLocationUrl() {
@@ -124,6 +136,7 @@ public class PreviewUrlBuilder implements UrlBuilder, Cloneable {
   }
 
   /**
+   * Sets the multipleLocationUrl.
    * @param multipleLocationUrl the multipleLocationUrl to set
    */
   public void setMultipleLocationUrl(String multipleLocationUrl) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SimpleXmlView.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SimpleXmlView.java
@@ -46,11 +46,20 @@ public class SimpleXmlView extends AbstractView implements View {
 
   private String resultKey = "result";
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new SimpleXmlView.
+   *
+   */
   public SimpleXmlView() {}
 
   /**
+   * See referenced member.
    * @see AbstractView#renderMergedOutputModel(Map, HttpServletRequest, HttpServletResponse)
+   * @param model the model
+   * @param request the request
+   * @param response the response
+   * @throws Exception if an error occurs
    */
   @Override
   @SuppressWarnings({"rawtypes"})
@@ -114,6 +123,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Returns the encoding.
    * @return the encoding
    */
   public String getEncoding() {
@@ -121,6 +131,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Sets the encoding.
    * @param encoding the encoding to set
    */
   public void setEncoding(String encoding) {
@@ -128,6 +139,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Returns the resultKey.
    * @return the resultKey
    */
   public String getResultKey() {
@@ -135,6 +147,7 @@ public class SimpleXmlView extends AbstractView implements View {
   }
 
   /**
+   * Sets the resultKey.
    * @param resultKey the resultKey to set
    */
   public void setResultKey(String resultKey) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteFolderFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteFolderFinder.java
@@ -18,6 +18,9 @@ package com.percussion.pso.preview;
 
 import java.util.List;
 
+/**
+ * SiteFolderFinder interface.
+ */
 public interface SiteFolderFinder {
   /**
    * Find the possible site folder previews for an item. The set of possible site id / folder id
@@ -27,9 +30,9 @@ public interface SiteFolderFinder {
    *
    * @param contentid the content id of the selected item. Must not be null or empty.
    * @param folderid the folder id, if known. Leave this blank if you do not know the folder id.
-   * @param siteid
+   * @param siteid the siteid
    * @return the List of possible site folders.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   public List<SiteFolderLocation> findSiteFolderLocations(
       String contentid, String folderid, String siteid) throws Exception;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteFolderFinderImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteFolderFinderImpl.java
@@ -52,7 +52,11 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
 
   private boolean testCommunityVisibility = true;
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new SiteFolderFinderImpl.
+   *
+   */
   public SiteFolderFinderImpl() {
     super();
   }
@@ -68,7 +72,13 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
   }
 
   /**
+   * See referenced member.
    * @see SiteFolderFinder#findSiteFolderLocations(String, String, String)
+   * @param contentid the contentid
+   * @param folderid the folderid
+   * @param siteid the siteid
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public List<SiteFolderLocation> findSiteFolderLocations(
       String contentid, String folderid, String siteid) throws Exception {
@@ -184,20 +194,38 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
     return visible;
   }
 
+  /**
+   * findFolderTitle operation.
+   *
+   * @param folderid the folderid
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public String findFolderTitle(String folderid) throws Exception {
     PSComponentSummary summ = finder.getComponentSummaryById(folderid);
     return summ.getName();
   }
 
+  /**
+   * Sets the gmgr.
+   *
+   * @param gmgr the gmgr
+   */
   public static void setGmgr(IPSGuidManager gmgr) {
     SiteFolderFinderImpl.gmgr = gmgr;
   }
 
+  /**
+   * Sets the cws.
+   *
+   * @param cws the cws
+   */
   public static void setCws(IPSContentWs cws) {
     SiteFolderFinderImpl.cws = cws;
   }
 
   /**
+   * Sets the secws.
    * @param secws the secws to set
    */
   public static void setSecws(IPSSecurityWs secws) {
@@ -205,6 +233,7 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
   }
 
   /**
+   * Returns the testCommunityVisibility.
    * @return the testCommunityVisibility
    */
   public boolean isTestCommunityVisibility() {
@@ -212,6 +241,7 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
   }
 
   /**
+   * Sets the testCommunityVisibility.
    * @param testCommunityVisibility the testCommunityVisibility to set
    */
   public void setTestCommunityVisibility(boolean testCommunityVisibility) {
@@ -219,6 +249,7 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
   }
 
   /**
+   * Returns the siteLoader.
    * @return the siteLoader
    */
   public SiteLoader getSiteLoader() {
@@ -226,6 +257,7 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
   }
 
   /**
+   * Sets the siteLoader.
    * @param siteLoader the siteLoader to set
    */
   public void setSiteLoader(SiteLoader siteLoader) {
@@ -233,6 +265,7 @@ public class SiteFolderFinderImpl implements SiteFolderFinder {
   }
 
   /**
+   * Sets the finder.
    * @param finder the finder to set
    */
   public static void setFinder(PSOObjectFinder finder) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteFolderLocation.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteFolderLocation.java
@@ -33,7 +33,11 @@ public class SiteFolderLocation {
   private int folderid;
   private IPSSite site;
 
-  /** Default Constructor */
+  /**
+   * Default Constructor
+   * Creates a new SiteFolderLocation.
+   *
+   */
   public SiteFolderLocation() {}
 
   /**
@@ -51,9 +55,9 @@ public class SiteFolderLocation {
   /**
    * Fixes a URL by applying the parameters in the map
    *
-   * @param baseUrl
+   * @param baseUrl the base url
    * @return the url with the parameters added.
-   * @throws PSRequestParsingException
+   * @throws PSRequestParsingException if an error occurs
    */
   public String fixUrl(String baseUrl) throws PSRequestParsingException {
     PSOMutableUrl url = new PSOMutableUrl(baseUrl);
@@ -62,6 +66,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Returns the siteName.
    * @return the siteName
    */
   public String getSiteName() {
@@ -69,6 +74,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Returns the folderPath.
    * @return the folderPath
    */
   public String getFolderPath() {
@@ -76,6 +82,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Sets the folderPath.
    * @param folderPath the folderPath to set
    */
   public void setFolderPath(String folderPath) {
@@ -83,6 +90,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Returns the siteid.
    * @return the siteid
    */
   public long getSiteid() {
@@ -90,6 +98,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Returns the folderid.
    * @return the folderid
    */
   public int getFolderid() {
@@ -97,6 +106,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Sets the folderid.
    * @param folderid the folderid to set
    */
   public void setFolderid(int folderid) {
@@ -104,6 +114,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Returns the site.
    * @return the site
    */
   public IPSSite getSite() {
@@ -111,6 +122,7 @@ public class SiteFolderLocation {
   }
 
   /**
+   * Sets the site.
    * @param site the site to set
    */
   public void setSite(IPSSite site) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteLoader.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/SiteLoader.java
@@ -30,7 +30,7 @@ public interface SiteLoader {
    * Finds all sites defined in the system.
    *
    * @return the list of sites. Never <code>null</code> but may be <code>empty</code>
-   * @throws PSSiteManagerException
+   * @throws PSSiteManagerException if an error occurs
    */
   public List<IPSSite> findAllSites() throws PSSiteManagerException;
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/UrlBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/UrlBuilder.java
@@ -34,7 +34,7 @@ public interface UrlBuilder {
    * @param location the site folder location
    * @param useMultiple does this URL point to the appropriate multisiteresolver?
    * @return the URL. Never <code>null</code>
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   public String buildUrl(
       IPSAssemblyTemplate template,

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/IPSRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/IPSRelationshipBuilder.java
@@ -23,6 +23,9 @@ import com.percussion.services.assembly.PSAssemblyException;
 import java.util.Collection;
 import java.util.Set;
 
+/**
+ * IPSRelationshipBuilder interface.
+ */
 public interface IPSRelationshipBuilder {
 
   /**
@@ -36,6 +39,7 @@ public interface IPSRelationshipBuilder {
    *     slot
    * @throws PSCmsException propagated from relationship API, if there are problems querying
    *     relationships
+   * @throws PSException if an error occurs
    */
   public abstract Collection<Integer> retrieve(int sourceId)
       throws PSAssemblyException, PSException;
@@ -51,9 +55,17 @@ public interface IPSRelationshipBuilder {
    * @param targetIds items that should be related to sourceId
    * @throws PSCmsException propagated from relationship api errors
    * @throws PSAssemblyException if the slot or template cannot be found by assembly service.
+   * @throws PSException if an error occurs
    */
   public abstract void synchronize(int sourceId, Set<Integer> targetIds)
       throws PSAssemblyException, PSException;
 
+  /**
+   * addRelationships operation.
+   *
+   * @param ids the ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   public void addRelationships(Collection<Integer> ids) throws PSAssemblyException, PSException;
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/IPSRelationshipHelperService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/IPSRelationshipHelperService.java
@@ -22,6 +22,9 @@ import com.percussion.services.assembly.PSAssemblyException;
 import java.util.Collection;
 
 // TODO JAVADOC
+/**
+ * IPSRelationshipHelperService interface.
+ */
 public interface IPSRelationshipHelperService {
 
   /**
@@ -34,12 +37,39 @@ public interface IPSRelationshipHelperService {
    */
   public abstract Collection<Integer> getFolders(int itemId, String jcrQuery);
 
+  /**
+   * Returns the owners.
+   *
+   * @param dependentId the dependent id
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public abstract Collection<Integer> getOwners(
       int dependentId, String slotName, String templateName) throws PSException;
 
+  /**
+   * Returns the dependents.
+   *
+   * @param ownerId the owner id
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public abstract Collection<Integer> getDependents(
       int ownerId, String slotName, String templateName) throws PSException;
 
+  /**
+   * deleteRelationships operation.
+   *
+   * @param owners the owners
+   * @param dependents the dependents
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @throws PSException if an error occurs
+   */
   public abstract void deleteRelationships(
       Collection<Integer> owners,
       Collection<Integer> dependents,
@@ -47,9 +77,26 @@ public interface IPSRelationshipHelperService {
       String templateName)
       throws PSException;
 
+  /**
+   * deleteFolderRelationships operation.
+   *
+   * @param folderIds the folder ids
+   * @param itemIds the item ids
+   * @throws PSException if an error occurs
+   */
   public abstract void deleteFolderRelationships(
       Collection<Integer> folderIds, Collection<Integer> itemIds) throws PSException;
 
+  /**
+   * addRelationships operation.
+   *
+   * @param ownerIds the owner ids
+   * @param dependentIds the dependent ids
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   public abstract void addRelationships(
       Collection<Integer> ownerIds,
       Collection<Integer> dependentIds,
@@ -57,6 +104,13 @@ public interface IPSRelationshipHelperService {
       String templateName)
       throws PSAssemblyException, PSException;
 
+  /**
+   * addFolderRelationships operation.
+   *
+   * @param folderIds the folder ids
+   * @param itemIds the item ids
+   * @throws PSException if an error occurs
+   */
   public abstract void addFolderRelationships(
       Collection<Integer> folderIds, Collection<Integer> itemIds) throws PSException;
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaDependentRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaDependentRelationshipBuilder.java
@@ -29,6 +29,9 @@ package com.percussion.pso.relationshipbuilder;
  */
 public final class PSAaDependentRelationshipBuilder extends PSActiveAssemblyRelationshipBuilder {
 
+  /**
+   * Creates a new PSAaDependentRelationshipBuilder.
+   */
   public PSAaDependentRelationshipBuilder() {
     super(false);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaOwnerRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAaOwnerRelationshipBuilder.java
@@ -29,6 +29,9 @@ package com.percussion.pso.relationshipbuilder;
  */
 public final class PSAaOwnerRelationshipBuilder extends PSActiveAssemblyRelationshipBuilder {
 
+  /**
+   * Creates a new PSAaOwnerRelationshipBuilder.
+   */
   public PSAaOwnerRelationshipBuilder() {
     super(true);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAbstractRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSAbstractRelationshipBuilder.java
@@ -32,6 +32,13 @@ import org.apache.logging.log4j.Logger;
  * @since 6.0
  */
 public abstract class PSAbstractRelationshipBuilder implements IPSRelationshipBuilder {
+  /**
+   * Creates a new PSAbstractRelationshipBuilder.
+   */
+  protected PSAbstractRelationshipBuilder() {
+    // default
+  }
+
 
   /**
    * Creates a new list of the elements in <code>retain</code> that are not in <code>suppress</code>
@@ -55,7 +62,15 @@ public abstract class PSAbstractRelationshipBuilder implements IPSRelationshipBu
     return complement;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   * synchronize operation.
+   * @param sourceId the source id
+   * @param targetIds the target ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   *
+   */
   public void synchronize(int sourceId, Set<Integer> targetIds)
       throws PSAssemblyException, PSException {
     log.debug("\tdesired ids: {}", targetIds);
@@ -88,8 +103,8 @@ public abstract class PSAbstractRelationshipBuilder implements IPSRelationshipBu
    * @see IPSRelationshipBuilder#synchronize(int, Set)
    * @param sourceId the id to be related from.
    * @param targetIds the ids to be related to.
-   * @throws PSAssemblyException
-   * @throws PSException
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
    */
   public abstract void add(int sourceId, Collection<Integer> targetIds)
       throws PSAssemblyException, PSException;
@@ -100,22 +115,40 @@ public abstract class PSAbstractRelationshipBuilder implements IPSRelationshipBu
    *
    * @param sourceId the id to be related from.
    * @param targetIds the ids to be related.
-   * @throws PSAssemblyException
-   * @throws PSException
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
    */
   public abstract void delete(int sourceId, Collection<Integer> targetIds)
       throws PSAssemblyException, PSException;
 
+  /** m relationship helper service. */
   protected IPSRelationshipHelperService m_relationshipHelperService;
 
+  /**
+   * Returns the relationship helper service.
+   *
+   * @return the result
+   */
   public IPSRelationshipHelperService getRelationshipHelperService() {
     return m_relationshipHelperService;
   }
 
+  /**
+   * Sets the relationship helper service.
+   *
+   * @param relationshipHelper the relationship helper
+   */
   public void setRelationshipHelperService(IPSRelationshipHelperService relationshipHelper) {
     m_relationshipHelperService = relationshipHelper;
   }
 
+  /**
+   * addRelationships operation.
+   *
+   * @param ids the ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   public void addRelationships(Collection<Integer> ids) throws PSAssemblyException, PSException {
     log.debug("addRelationships in PSAbstractRelationshipBuilder does nothing");
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSActiveAssemblyRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSActiveAssemblyRelationshipBuilder.java
@@ -34,6 +34,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSActiveAssemblyRelationshipBuilder class.
+ */
 public abstract class PSActiveAssemblyRelationshipBuilder extends PSRelationshipBuilder {
 
   /** The log instance to use for this class, never <code>null</code>. */
@@ -44,9 +47,14 @@ public abstract class PSActiveAssemblyRelationshipBuilder extends PSRelationship
 
   private IPSAssemblyService m_assemblyService;
 
+  /**
+   * Creates a new PSActiveAssemblyRelationshipBuilder.
+   */
   public PSActiveAssemblyRelationshipBuilder() {}
 
   /**
+   * Creates a new PSActiveAssemblyRelationshipBuilder.
+   *
    * @param isParent {@code true} when the updated item is the relationship owner
    * @see PSRelationshipBuilder#PSRelationshipBuilder(boolean)
    */
@@ -54,6 +62,9 @@ public abstract class PSActiveAssemblyRelationshipBuilder extends PSRelationship
     super(isParent);
   }
 
+  /**
+   * init operation.
+   */
   public void init() {
     if (m_assemblyService == null) {
       m_assemblyService = PSAssemblyServiceLocator.getAssemblyService();
@@ -61,6 +72,12 @@ public abstract class PSActiveAssemblyRelationshipBuilder extends PSRelationship
     super.init();
   }
 
+  /**
+   * Sets the up filter.
+   *
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   protected void setupFilter() throws PSAssemblyException, PSException {
     if (slotName != null) {
       IPSTemplateSlot slot = findSlot(slotName);
@@ -77,22 +94,49 @@ public abstract class PSActiveAssemblyRelationshipBuilder extends PSRelationship
     super.setupFilter();
   }
 
+  /**
+   * Returns the slot name.
+   *
+   * @return the result
+   */
   public String getSlotName() {
     return slotName;
   }
 
+  /**
+   * Sets the slot name.
+   *
+   * @param slotName the slot name
+   */
   public void setSlotName(String slotName) {
     this.slotName = slotName;
   }
 
+  /**
+   * Returns the template name.
+   *
+   * @return the result
+   */
   public String getTemplateName() {
     return templateName;
   }
 
+  /**
+   * Sets the template name.
+   *
+   * @param templateName the template name
+   */
   public void setTemplateName(String templateName) {
     this.templateName = templateName;
   }
 
+  /**
+   * addRelationships operation.
+   *
+   * @param ids the ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   public void addRelationships(Collection<Integer> ids) throws PSAssemblyException, PSException {
     IPSAssemblyTemplate template = findTemplate(templateName);
     IPSTemplateSlot slot = findSlot(slotName);
@@ -127,7 +171,7 @@ public abstract class PSActiveAssemblyRelationshipBuilder extends PSRelationship
    * Validates that the slot is setup correctly to add relationships to. Emits log messages to help
    * the user find errors.
    *
-   * @param slot
+   * @param  the slot
    * @return 0 if successful, non-zero otherwise.
    */
   private int validateSlot(IPSTemplateSlot slot) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSFolderRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSFolderRelationshipBuilder.java
@@ -23,30 +23,74 @@ import com.percussion.error.PSException;
 import com.percussion.services.assembly.PSAssemblyException;
 import java.util.Collection;
 
+/**
+ * PSFolderRelationshipBuilder class.
+ */
 public class PSFolderRelationshipBuilder extends PSAbstractRelationshipBuilder {
+  /**
+   * Creates a new PSFolderRelationshipBuilder.
+   */
+  public PSFolderRelationshipBuilder() {
+    // default
+  }
+
 
   private String m_jcrQuery;
 
+  /**
+   * add operation.
+   *
+   * @param sourceId the source id
+   * @param targetIds the target ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   @Override
   public void add(int sourceId, Collection<Integer> targetIds)
       throws PSAssemblyException, PSException {
     m_relationshipHelperService.addFolderRelationships(targetIds, asList(sourceId));
   }
 
+  /**
+   * delete operation.
+   *
+   * @param sourceId the source id
+   * @param targetIds the target ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   @Override
   public void delete(int sourceId, Collection<Integer> targetIds)
       throws PSAssemblyException, PSException {
     m_relationshipHelperService.deleteFolderRelationships(targetIds, asList(sourceId));
   }
 
+  /**
+   * retrieve operation.
+   *
+   * @param sourceId the source id
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   public Collection<Integer> retrieve(int sourceId) throws PSAssemblyException, PSException {
     return m_relationshipHelperService.getFolders(sourceId, m_jcrQuery);
   }
 
+  /**
+   * Returns the jcr query.
+   *
+   * @return the result
+   */
   public String getJcrQuery() {
     return m_jcrQuery;
   }
 
+  /**
+   * Sets the jcr query.
+   *
+   * @param jcrQuery the jcr query
+   */
   public void setJcrQuery(String jcrQuery) {
     m_jcrQuery = jcrQuery;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipBuilder.java
@@ -42,6 +42,9 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSRelationshipBuilder class.
+ */
 public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
 
   private boolean isParent = true;
@@ -56,7 +59,11 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
   private boolean init = false;
   private PSRelationshipFilter filter;
 
-  /** Wires up all the service components when in Rhythmyx. */
+  /**
+   * Wires up all the service components when in Rhythmyx.
+   * init operation.
+   *
+   */
   public void init() {
     if (m_assemblyService == null)
       m_assemblyService = PSAssemblyServiceLocator.getAssemblyService();
@@ -66,6 +73,9 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     init = true;
   }
 
+  /**
+   * Creates a new PSRelationshipBuilder.
+   */
   public PSRelationshipBuilder() {
     filter = new PSRelationshipFilter();
   }
@@ -81,6 +91,11 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     this.isParent = isParent;
   }
 
+  /**
+   * Returns whether parent.
+   *
+   * @return the result
+   */
   public boolean isParent() {
     return isParent;
   }
@@ -94,6 +109,12 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     this.isParent = isParent;
   }
 
+  /**
+   * Sets the up filter.
+   *
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   protected void setupFilter() throws PSAssemblyException, PSException {
     return;
   }
@@ -125,7 +146,9 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
   }
 
   /**
-   * @param relationships
+   * saveRelationships operation.
+   *
+   * @param relationships the relationships
    */
   private Collection<PSRelationship> filterRelationships(Collection<PSRelationship> relationships)
       throws PSAssemblyException, PSException {
@@ -209,6 +232,14 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     }
 
     return filteredRelationships;
+  /**
+   * retrieve operation.
+   *
+   * @param sourceId the source id
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   }
 
   public Collection<Integer> retrieve(int sourceId) throws PSAssemblyException, PSException {
@@ -217,6 +248,14 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     log.debug("Set id to {}", sourceId);
     populateRelationships();
     return resultIds;
+  /**
+   * synchronize operation.
+   *
+   * @param sourceId the source id
+   * @param targetIds the target ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   }
 
   public void synchronize(int sourceId, Set<Integer> targetIds)
@@ -225,14 +264,29 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     populateRelationships();
     deleteRelationships(relationships);
     addRelationships(targetIds);
+  /**
+   * Returns the id.
+   *
+   * @return the result
+   */
   }
 
   public int getId() {
     return id;
+  /**
+   * Sets the id.
+   *
+   * @param id the id
+   */
   }
 
   public void setId(int id) {
     this.id = id;
+  /**
+   * Returns the cms object manager.
+   *
+   * @return the result
+   */
   }
 
   public IPSCmsObjectMgr getCmsObjectManager() {
@@ -246,6 +300,13 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     if (toBeDeleted.size() > 0) {
       m_relationshipService.deleteRelationship(toBeDeleted);
     }
+  /**
+   * addRelationships operation.
+   *
+   * @param ids the ids
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   }
 
   public void addRelationships(Collection<Integer> ids) throws PSAssemblyException, PSException {
@@ -255,6 +316,7 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
 
   /* (non-Javadoc)
    * @see com.percussion.pso.relationshipbuilder.IPSRelationshipHelperService#createEmptyRelationshipCollection()
+   * @return the result
    */
 
   @SuppressWarnings("unchecked")
@@ -265,6 +327,8 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
 
   /* (non-Javadoc)
    * @see com.percussion.pso.relationshipbuilder.IPSRelationshipHelperService#saveRelationships(java.util.Collection)
+   * @param toBeSaved the to be saved
+   * @throws PSException if an error occurs
    */
   public void saveRelationships(Collection<PSRelationship> toBeSaved) throws PSException {
     if (!init) init();
@@ -273,6 +337,12 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     }
   }
 
+  /**
+   * asLocators operation.
+   *
+   * @param ids the ids
+   * @return the result
+   */
   protected List<PSLocator> asLocators(Collection<Integer> ids) {
     if (!init) init();
     List<PSLocator> idLocators = new ArrayList<PSLocator>(ids.size());
@@ -285,6 +355,12 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
     return idLocators;
   }
 
+  /**
+   * asLocatorsNoRev operation.
+   *
+   * @param ids the ids
+   * @return the result
+   */
   protected List<PSLocator> asLocatorsNoRev(Collection<Integer> ids) {
     List<PSLocator> idLocators = new ArrayList<PSLocator>(ids.size());
     for (Integer id : ids) {
@@ -297,46 +373,101 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
   /** The log instance to use for this class, never <code>null</code>. */
   private static final Logger log = LogManager.getLogger(PSRelationshipBuilder.class);
 
+  /**
+   * Returns the relationships.
+   *
+   * @return the result
+   */
   public Collection<PSRelationship> getRelationships() {
     return relationships;
   }
 
+  /**
+   * Sets the relationships.
+   *
+   * @param relationships the relationships
+   */
   public void setRelationships(Collection<PSRelationship> relationships) {
     this.relationships = relationships;
   }
 
+  /**
+   * Returns the result ids.
+   *
+   * @return the result
+   */
   public Collection<Integer> getResultIds() {
     return resultIds;
   }
 
+  /**
+   * Sets the result ids.
+   *
+   * @param resultIds the result ids
+   */
   public void setResultIds(Collection<Integer> resultIds) {
     this.resultIds = resultIds;
   }
 
+  /**
+   * Returns whether cleanup broken rels.
+   *
+   * @return the result
+   */
   public boolean isCleanupBrokenRels() {
     return cleanupBrokenRels;
   }
 
+  /**
+   * Sets the cleanup broken rels.
+   *
+   * @param cleanupBrokenRels the cleanup broken rels
+   */
   public void setCleanupBrokenRels(boolean cleanupBrokenRels) {
     this.cleanupBrokenRels = cleanupBrokenRels;
   }
 
+  /**
+   * Returns the m assembly service.
+   *
+   * @return the result
+   */
   public IPSAssemblyService getM_assemblyService() {
     return m_assemblyService;
   }
 
+  /**
+   * Sets the m assembly service.
+   *
+   * @param service the service
+   */
   public void setM_assemblyService(IPSAssemblyService service) {
     m_assemblyService = service;
   }
 
+  /**
+   * Sets the relationship service.
+   *
+   * @param service the service
+   */
   public void setRelationshipService(IPSRelationshipService service) {
     m_relationshipService = service;
   }
 
+  /**
+   * Sets the cms object manager.
+   *
+   * @param objectManager the object manager
+   */
   public void setCmsObjectManager(IPSCmsObjectMgr objectManager) {
     m_cmsObjectManager = objectManager;
   }
 
+  /**
+   * Returns the filter.
+   *
+   * @return the result
+   */
   public PSRelationshipFilter getFilter() {
     return filter;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipHelperService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipHelperService.java
@@ -65,7 +65,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSRelationshipHelperService class.
+ */
 public class PSRelationshipHelperService implements IPSRelationshipHelperService {
+  /**
+   * Creates a new PSRelationshipHelperService.
+   */
+  public PSRelationshipHelperService() {
+    // default
+  }
+
 
   private IPSRelationshipService m_relationshipService;
   private IPSAssemblyService m_assemblyService;
@@ -76,7 +86,11 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
   /** Content manager service */
   private IPSContentMgr m_contentManager;
 
-  /** Wires up all the service components when in Rhythmyx. */
+  /**
+   * Wires up all the service components when in Rhythmyx.
+   * init operation.
+   *
+   */
   public void init() {
 
     if (m_cmsObjectManager == null) m_cmsObjectManager = PSCmsObjectMgrLocator.getObjectManager();
@@ -133,6 +147,13 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     }
   }
 
+  /**
+   * deleteFolderRelationships operation.
+   *
+   * @param folderIds the folder ids
+   * @param itemIds the item ids
+   * @throws PSException if an error occurs
+   */
   public void deleteFolderRelationships(Collection<Integer> folderIds, Collection<Integer> itemIds)
       throws PSException {
     Collection<IPSGuid> folderGuids = asGuids(folderIds);
@@ -169,6 +190,8 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
 
   /* (non-Javadoc)
    * @see com.percussion.pso.relationshipbuilder.IPSRelationshipHelperService#saveRelationships(java.util.Collection)
+   * @param toBeSaved the to be saved
+   * @throws PSException if an error occurs
    */
   public void saveRelationships(Collection<PSRelationship> toBeSaved) throws PSException {
     if (toBeSaved.size() > 0) {
@@ -234,6 +257,12 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
 
   /* (non-Javadoc)
    * @see com.percussion.pso.relationshipbuilder.IPSRelationshipHelperService#addRelationships(java.util.Collection, java.util.Collection, java.util.Collection, java.lang.String, java.lang.String)
+   * @param ownerIds the owner ids
+   * @param dependentIds the dependent ids
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
    */
   public void addRelationships(
       Collection<Integer> ownerIds,
@@ -268,6 +297,13 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     saveRelationships(relationshipSet);
   }
 
+  /**
+   * addFolderRelationships operation.
+   *
+   * @param folderIds the folder ids
+   * @param itemIds the item ids
+   * @throws PSException if an error occurs
+   */
   public void addFolderRelationships(Collection<Integer> folderIds, Collection<Integer> itemIds)
       throws PSException {
     List<IPSGuid> folderGuids = asGuids(folderIds);
@@ -282,10 +318,20 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     }
   }
 
+  /**
+   * Returns the assembly service.
+   *
+   * @return the result
+   */
   public IPSAssemblyService getAssemblyService() {
     return m_assemblyService;
   }
 
+  /**
+   * Sets the assembly service.
+   *
+   * @param assemblyService the assembly service
+   */
   public void setAssemblyService(IPSAssemblyService assemblyService) {
     m_assemblyService = assemblyService;
   }
@@ -316,7 +362,7 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
    * Validates that the slot is setup correctly to add relationships to. Emits log messages to help
    * the user find errors.
    *
-   * @param slot
+   * @param  the slot
    * @return 0 if successful, non-zero otherwise.
    */
   private int validateSlot(IPSTemplateSlot slot) {
@@ -354,10 +400,22 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     return idLocators;
   }
 
+  /**
+   * asLocators operation.
+   *
+   * @param ids the ids
+   * @return the result
+   */
   protected List<PSLocator> asLocators(Integer... ids) {
     return asLocators(Arrays.asList(ids));
   }
 
+  /**
+   * asLocatorsNoRev operation.
+   *
+   * @param ids the ids
+   * @return the result
+   */
   protected List<PSLocator> asLocatorsNoRev(Collection<Integer> ids) {
     List<PSLocator> idLocators = new ArrayList<PSLocator>(ids.size());
     for (Integer id : ids) {
@@ -367,10 +425,22 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     return idLocators;
   }
 
+  /**
+   * asLocatorsNoRev operation.
+   *
+   * @param ids the ids
+   * @return the result
+   */
   protected List<PSLocator> asLocatorsNoRev(Integer... ids) {
     return asLocatorsNoRev(Arrays.asList(ids));
   }
 
+  /**
+   * asGuids operation.
+   *
+   * @param ids the ids
+   * @return the result
+   */
   protected List<IPSGuid> asGuids(Collection<Integer> ids) {
     List<IPSGuid> guids = new ArrayList<IPSGuid>(ids.size());
     Collection<PSLocator> locators = asLocators(ids);
@@ -381,10 +451,10 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
   }
 
   /**
-   * @param relationships
-   * @param ids
-   * @param trueKeepOnlyIdsFalseRemoveOnlyIds
-   * @param trueOwnerIdsFalseDependentIds
+   * @param  the relationships
+   * @param  the ids
+   * @param  the true keep only ids false remove only ids
+   * @param  the true owner ids false dependent ids
    */
   private void filterRelationships(
       Collection<PSRelationship> relationships,
@@ -417,22 +487,53 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
   /** The log instance to use for this class, never <code>null</code>. */
   private static final Logger log = LogManager.getLogger(PSRelationshipHelperService.class);
 
+  /**
+   * Returns the cms object manager.
+   *
+   * @return the result
+   */
   public IPSCmsObjectMgr getCmsObjectManager() {
     return m_cmsObjectManager;
   }
 
+  /**
+   * Sets the cms object manager.
+   *
+   * @param cmsObjectManager the cms object manager
+   */
   public void setCmsObjectManager(IPSCmsObjectMgr cmsObjectManager) {
     m_cmsObjectManager = cmsObjectManager;
   }
 
+  /**
+   * Returns the relationship service.
+   *
+   * @return the result
+   */
   public IPSRelationshipService getRelationshipService() {
     return m_relationshipService;
   }
 
+  /**
+   * Sets the relationship service.
+   *
+   * @param relationshipService the relationship service
+   */
   public void setRelationshipService(IPSRelationshipService relationshipService) {
     m_relationshipService = relationshipService;
   }
 
+  /**
+   * Returns the relationships.
+   *
+   * @param owners the owners
+   * @param dependents the dependents
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   protected Collection<PSRelationship> getRelationships(
       Collection<Integer> owners,
       Collection<Integer> dependents,
@@ -466,6 +567,15 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     return relationships;
   }
 
+  /**
+   * deleteRelationships operation.
+   *
+   * @param owners the owners
+   * @param dependents the dependents
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @throws PSException if an error occurs
+   */
   public void deleteRelationships(
       Collection<Integer> owners,
       Collection<Integer> dependents,
@@ -503,6 +613,15 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     return message;
   }
 
+  /**
+   * Returns the dependents.
+   *
+   * @param ownerId the owner id
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public Collection<Integer> getDependents(int ownerId, String slotName, String templateName)
       throws PSException {
     log.debug(
@@ -523,6 +642,15 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
     return extractDependentIds(relationships);
   }
 
+  /**
+   * Returns the owners.
+   *
+   * @param dependentId the dependent id
+   * @param slotName the slot name
+   * @param templateName the template name
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public Collection<Integer> getOwners(int dependentId, String slotName, String templateName)
       throws PSException {
     log.debug(

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSAbstractBuildRelationshipsExtension.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSAbstractBuildRelationshipsExtension.java
@@ -42,25 +42,49 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 
+/**
+ * Abstract exit that builds or selects relationships for content items based on extension mode.
+ */
 public abstract class PSAbstractBuildRelationshipsExtension extends PSDefaultExtension
     implements IPSUdfProcessor,
         IPSFieldOutputTransformer,
         IPSResultDocumentProcessor,
         IPSItemOutputTransformer {
 
+  /** Init-parameter name that selects BUILD vs SELECT mode. */
   private static final String MODE_INIT_PARAM = "com.percussion.extension.relationshipbuilder.mode";
   // private static IPSRelationshipHelperService m_relationshipHelperService;
+  /** Current operating mode for this extension instance. */
   private Mode m_mode;
 
   /** The log instance to use for this class, never <code>null</code>. */
   private static final Logger log =
       LogManager.getLogger(PSAbstractBuildRelationshipsExtension.class);
 
+  /**
+   * Operating modes for relationship-builder exits.
+   */
   public enum Mode {
+    /** Build relationships from field data. */
     BUILD,
+    /** Select relationships for display. */
     SELECT
-  };
+  }
 
+  /**
+   * Creates a relationship-builder exit instance.
+   */
+  protected PSAbstractBuildRelationshipsExtension() {
+    // default
+  }
+
+  /**
+   * Initializes the extension and resolves BUILD/SELECT mode from init parameters.
+   *
+   * @param def the extension definition
+   * @param codeRoot the extension code root
+   * @throws PSExtensionException if required init parameters are missing or invalid
+   */
   @Override
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     super.init(def, codeRoot);
@@ -108,11 +132,27 @@ public abstract class PSAbstractBuildRelationshipsExtension extends PSDefaultExt
       m_relationshipHelperService = relationshipHelperService;
   }
   */
+
+  /**
+   * Returns whether this exit can modify the stylesheet.
+   *
+   * @return {@code false}; this exit does not modify stylesheets
+   */
   public boolean canModifyStyleSheet() {
     // TODO Auto-generated method stub
     return false;
   }
 
+  /**
+   * Builds or selects relationships and updates the result document when appropriate.
+   *
+   * @param params extension parameters
+   * @param request the request context
+   * @param resultDoc the result document to update
+   * @return the (possibly updated) result document
+   * @throws PSParameterMismatchException if parameters are invalid
+   * @throws PSExtensionProcessingException if processing fails
+   */
   public final Document processResultDocument(
       Object[] params, IPSRequestContext request, Document resultDoc)
       throws PSParameterMismatchException, PSExtensionProcessingException {
@@ -141,6 +181,14 @@ public abstract class PSAbstractBuildRelationshipsExtension extends PSDefaultExt
     return resultDoc;
   }
 
+  /**
+   * UDF entry that retrieves related ids for selection mode.
+   *
+   * @param params UDF parameters
+   * @param request the request context
+   * @return related id payload
+   * @throws PSConversionException if builder creation fails
+   */
   public final Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSBuildAaRelationshipsExit.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSBuildAaRelationshipsExit.java
@@ -36,6 +36,13 @@ import org.apache.logging.log4j.Logger;
  * @since 6.0
  */
 public class PSBuildAaRelationshipsExit extends PSAbstractBuildRelationshipsExtension {
+  /**
+   * Creates a new PSBuildAaRelationshipsExit.
+   */
+  public PSBuildAaRelationshipsExit() {
+    // default
+  }
+
   private static final String SOURCE_ITEM_TYPE_PARAM_DEPENDENT = "DEPENDENT";
   private static final String SOURCE_ITEM_TYPE_PARAM_OWNER = "OWNER";
   private static final String SOURCE_ITEM_TYPE_PARAM = "sourceItemType";
@@ -55,6 +62,8 @@ public class PSBuildAaRelationshipsExit extends PSAbstractBuildRelationshipsExte
    *
    * @param request the current request context, not <code>null</code>..
    * @return a {@link IPSRelationshipBuilder}
+   * @param paramMap the param map
+   * @param mode the mode
    */
   @Override
   public IPSRelationshipBuilder createRelationshipBuilder(

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSBuildFolderRelationshipsExit.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSBuildFolderRelationshipsExit.java
@@ -26,12 +26,31 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSBuildFolderRelationshipsExit class.
+ */
 public class PSBuildFolderRelationshipsExit extends PSAbstractBuildRelationshipsExtension
     implements IPSResultDocumentProcessor {
+  /**
+   * Creates a new PSBuildFolderRelationshipsExit.
+   */
+  public PSBuildFolderRelationshipsExit() {
+    // default
+  }
+
 
   /** The log instance to use for this class, never <code>null</code>. */
   private static final Logger log = LogManager.getLogger(PSBuildFolderRelationshipsExit.class);
 
+  /**
+   * createRelationshipBuilder operation.
+   *
+   * @param paramMap the param map
+   * @param request the request
+   * @param mode the mode
+   * @return the result
+   * @throws IllegalArgumentException if an error occurs
+   */
   @Override
   public IPSRelationshipBuilder createRelationshipBuilder(
       Map<String, String> paramMap, IPSRequestContext request, Mode mode)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSExtensionHelper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSExtensionHelper.java
@@ -54,6 +54,7 @@ import org.w3c.dom.NodeList;
  */
 public class PSExtensionHelper {
 
+  /** ids field name. */
   public static final String IDS_FIELD_NAME = "fieldName";
 
   private static final String DEFAULT_OUTPUT = "";
@@ -64,8 +65,16 @@ public class PSExtensionHelper {
 
   private final transient IPSRequestContext m_request;
 
+  /** array delimeter. */
   public static final String ARRAY_DELIMETER = ";";
 
+  /**
+   * Creates a new PSExtensionHelper.
+   *
+   * @param builder the builder
+   * @param parameters the parameters
+   * @param m_request the m request
+   */
   public PSExtensionHelper(
       IPSRelationshipBuilder builder, Map<String, String> parameters, IPSRequestContext m_request) {
     super();
@@ -80,9 +89,9 @@ public class PSExtensionHelper {
    * but rather our sys_Lookup query resource we need to set all the display choices that it returns
    * selected to "yes".
    *
-   * @param resultDoc
-   * @param selectAll
-   * @throws PSExtensionProcessingException
+   * @param resultDoc the result doc
+   * @param selectAll the select all
+   * @throws PSExtensionProcessingException if an error occurs
    */
   public void updateDisplayChoices(Document resultDoc, boolean selectAll)
       throws PSExtensionProcessingException {
@@ -308,6 +317,16 @@ public class PSExtensionHelper {
     }
   }
 
+  /**
+   * buildFromFieldValues operation.
+   *
+   * @param m_builder the m builder
+   * @param cid the cid
+   * @param fieldName the field name
+   * @param fieldValues the field values
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
+   */
   public void buildFromFieldValues(
       IPSRelationshipBuilder m_builder, int cid, String fieldName, Object[] fieldValues)
       throws PSAssemblyException, PSException {
@@ -333,6 +352,11 @@ public class PSExtensionHelper {
     }
   }
 
+  /**
+   * logRequestCommand operation.
+   *
+   * @param request the request
+   */
   public static void logRequestCommand(IPSRequestContext request) {
     String command = request.getParameter(IPSHtmlParameters.SYS_COMMAND);
     String page = request.getParameter(PSContentEditorHandler.PAGE_ID_PARAM_NAME);
@@ -342,6 +366,12 @@ public class PSExtensionHelper {
         "Command is: {}, page is: {}, processInlineLink is: {}", command, page, processInlineLink);
   }
 
+  /**
+   * Returns whether request to be processed for building.
+   *
+   * @param request the request
+   * @return the result
+   */
   public static boolean isRequestToBeProcessedForBuilding(IPSRequestContext request) {
     Map<String, String> noParams = new HashMap<String, String>();
     PSOExtensionParamsHelper helper = new PSOExtensionParamsHelper(noParams, request, null);
@@ -357,6 +387,12 @@ public class PSExtensionHelper {
         && (processInlineLink == null || !processInlineLink.equals("yes")));
   }
 
+  /**
+   * Returns whether request to be processed for selecting.
+   *
+   * @param request the request
+   * @return the result
+   */
   public static boolean isRequestToBeProcessedForSelecting(IPSRequestContext request) {
     Map<String, String> noParams = new HashMap<String, String>();
     PSOExtensionParamsHelper helper = new PSOExtensionParamsHelper(noParams, request, null);
@@ -371,6 +407,12 @@ public class PSExtensionHelper {
         && (processInlineLink == null || !processInlineLink.equals("yes")));
   }
 
+  /**
+   * convertToFieldValue operation.
+   *
+   * @param ids the ids
+   * @return the result
+   */
   public static String convertToFieldValue(Collection<Integer> ids) {
     StringBuilder idsStringBuilder = new StringBuilder();
     if (ids != null && ids.size() > 0) {
@@ -394,7 +436,7 @@ public class PSExtensionHelper {
    * Converts an array of objects to a list of integers. Non-parsable elements indicies in the
    * inputIds array are returned.
    *
-   * @param inputIds
+   * @param inputIds the input ids
    * @param output list of converted ids
    * @return the collection of objects that failed to convert.
    */

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationships/IPSOParentFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationships/IPSOParentFinder.java
@@ -23,6 +23,9 @@ import com.percussion.services.assembly.PSAssemblyException;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * IPSOParentFinder interface.
+ */
 public interface IPSOParentFinder {
   /**
    * Finds all parents for an item. Convenience method for {@link #findAllParents(PSLocator,
@@ -31,8 +34,8 @@ public interface IPSOParentFinder {
    * @param contentid the item content id
    * @param slotName the slot name
    * @return the set of parent locators. Never <code>null</code> but may be <code>empty</code>.
-   * @throws PSAssemblyException
-   * @throws PSCmsException
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findAllParents(String contentid, String slotName)
       throws PSAssemblyException, PSCmsException;
@@ -44,8 +47,8 @@ public interface IPSOParentFinder {
    * @param dependent the dependent item.
    * @param slotName the slot name. Must not be null or empty.
    * @return the set of parent locators. Never <code>null</code> but may be <code>empty</code>.
-   * @throws PSAssemblyException
-   * @throws PSCmsException
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findAllParents(PSLocator dependent, String slotName)
       throws PSAssemblyException, PSCmsException;
@@ -58,8 +61,8 @@ public interface IPSOParentFinder {
    * @param slotName the slot name.
    * @param usePublic the public revision flag.
    * @return the set of parent locators. Never <code>null</code> but may be <code>empty</code>.
-   * @throws PSAssemblyException
-   * @throws PSCmsException
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findParents(String contentid, String slotName, boolean usePublic)
       throws PSAssemblyException, PSCmsException;
@@ -68,13 +71,13 @@ public interface IPSOParentFinder {
    * Finds the
    *
    * @param dependent the locator for the dependent item.
-   * @param slotName
+   * @param slotName the slot name
    * @param usePublic the public revision flag. If <code>true</code>, only relationships where the
    *     owner is the public revision will be considered. If<code>false</code>, only relationships
    *     where the owner is the current or edit revision will be considered.
    * @return the set of parent locators. Never <code>null</code> but may be <code>empty</code>.
-   * @throws PSAssemblyException
-   * @throws PSCmsException
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findParents(PSLocator dependent, String slotName, boolean usePublic)
       throws PSAssemblyException, PSCmsException;
@@ -89,8 +92,8 @@ public interface IPSOParentFinder {
    * @param slotName the name of the slot.
    * @param validFlags the list of valid flags.
    * @return <code>true</code> if all of the items ancestors in the slot are public.
-   * @throws PSAssemblyException
-   * @throws PSException
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
    */
   public boolean hasOnlyPublicAncestors(String contentId, String slotName, List<String> validFlags)
       throws PSAssemblyException, PSException;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationships/PSOParentFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationships/PSOParentFinder.java
@@ -57,14 +57,25 @@ public class PSOParentFinder implements IPSOParentFinder {
 
   private static final Logger log = LogManager.getLogger(PSOParentFinder.class);
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSOParentFinder.
+   *
+   */
   public PSOParentFinder() {
     workflow = new PSOWorkflowInfoFinder();
   }
 
   /**
+   * findAllParents operation.
+   *
    * @see com.percussion.pso.relationships.IPSOParentFinder#findAllParents(java.lang.String,
    *     java.lang.String)
+   * @param contentid the contentid
+   * @param slotName the slot name
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findAllParents(String contentid, String slotName)
       throws PSAssemblyException, PSCmsException {
@@ -73,9 +84,16 @@ public class PSOParentFinder implements IPSOParentFinder {
   }
 
   /**
+   * findAllParents operation.
+   *
    * @see
    *     com.percussion.pso.relationships.IPSOParentFinder#findAllParents(com.percussion.design.objectstore.PSLocator,
    *     java.lang.String)
+   * @param dependent the dependent
+   * @param slotName the slot name
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findAllParents(PSLocator dependent, String slotName)
       throws PSAssemblyException, PSCmsException {
@@ -88,8 +106,16 @@ public class PSOParentFinder implements IPSOParentFinder {
   }
 
   /**
+   * findParents operation.
+   *
    * @see com.percussion.pso.relationships.IPSOParentFinder#findParents(java.lang.String,
    *     java.lang.String, boolean)
+   * @param contentid the contentid
+   * @param slotName the slot name
+   * @param usePublic the use public
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findParents(String contentid, String slotName, boolean usePublic)
       throws PSAssemblyException, PSCmsException {
@@ -98,9 +124,17 @@ public class PSOParentFinder implements IPSOParentFinder {
   }
 
   /**
+   * findParents operation.
+   *
    * @see
    *     com.percussion.pso.relationships.IPSOParentFinder#findParents(com.percussion.design.objectstore.PSLocator,
    *     java.lang.String, boolean)
+   * @param dependent the dependent
+   * @param slotName the slot name
+   * @param usePublic the use public
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSCmsException if an error occurs
    */
   public Set<PSLocator> findParents(PSLocator dependent, String slotName, boolean usePublic)
       throws PSAssemblyException, PSCmsException {
@@ -129,8 +163,16 @@ public class PSOParentFinder implements IPSOParentFinder {
   }
 
   /**
+   * hasOnlyPublicAncestors operation.
+   *
    * @see com.percussion.pso.relationships.IPSOParentFinder#hasOnlyPublicAncestors(java.lang.String,
    *     java.lang.String, java.util.List)
+   * @param contentId the content id
+   * @param slotName the slot name
+   * @param validFlags the valid flags
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   * @throws PSException if an error occurs
    */
   public boolean hasOnlyPublicAncestors(String contentId, String slotName, List<String> validFlags)
       throws PSAssemblyException, PSException {
@@ -182,6 +224,8 @@ public class PSOParentFinder implements IPSOParentFinder {
   }
 
   /**
+   * Sets the proxy.
+   *
    * @param proxy the proxy to set
    */
   public void setProxy(PSRelationshipProcessorProxy proxy) {
@@ -189,6 +233,8 @@ public class PSOParentFinder implements IPSOParentFinder {
   }
 
   /**
+   * Sets the gmgr.
+   *
    * @param gmgr the gmgr to set
    */
   public void setGmgr(IPSGuidManager gmgr) {
@@ -196,6 +242,8 @@ public class PSOParentFinder implements IPSOParentFinder {
   }
 
   /**
+   * Sets the asm.
+   *
    * @param asm the asm to set
    */
   public void setAsm(IPSAssemblyService asm) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/IItemRestService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/IItemRestService.java
@@ -23,7 +23,9 @@ import com.percussion.pso.restservice.model.results.PagedResult;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
 
-/** */
+/**
+ * REST contract for creating, reading, and updating PSO content items.
+ */
 @Path("/Content/")
 public interface IItemRestService {
   /**
@@ -34,6 +36,13 @@ public interface IItemRestService {
    */
   public Item updateItem(Item item);
 
+  /**
+   * updateItem operation.
+   *
+   * @param item the item
+   * @param updateOnly the update only
+   * @return the result
+   */
   @POST
   @Path("/")
   @Consumes("text/xml")
@@ -83,6 +92,12 @@ public interface IItemRestService {
   @Path("{id}")
   public Item purgeItem(@PathParam("id") int id);
 
+  /**
+   * PurgeAllFolderContent operation.
+   *
+   * @param target the target
+   * @return the result
+   */
   @DELETE
   @Path("/PurgeFolder/{target:.*}")
   public Response PurgeAllFolderContent(@PathParam("target") String target);
@@ -94,6 +109,7 @@ public interface IItemRestService {
    * @param body String
    * @param debug boolean
    * @return Items
+   * @param param the param
    */
   @POST
   @Path("import/{template}")
@@ -133,18 +149,47 @@ public interface IItemRestService {
   @GET
   // On upgrade use @Path("/Sites/{search:.*}") remove limited
   // @Path(value="/Sites/{search}", limited=false)
+  /**
+   * Returns the items.
+   *
+   * @param path the path
+   * @param n the n
+   * @return the result
+   */
   @Path("/Sites/{search:.*}")
   public PagedResult getItems(@PathParam("search") String path, @QueryParam("n") Integer n);
 
+  /**
+   * Returns the type items.
+   *
+   * @param type the type
+   * @param n the n
+   * @return the result
+   */
   @Path("/Type/{typename}")
   public PagedResult getTypeItems(@PathParam("typename") String type, @QueryParam("n") Integer n);
 
   // REFACTORED: CP-JAVA11
 
+  /**
+   * Returns the file.
+   *
+   * @param id the id
+   * @param revision the revision
+   * @param field the field
+   * @return the result
+   */
   @GET
   @Path("{id}/{rev}/field/{fieldname}")
   @Produces("*/*")
   public Response getFile(
+  /**
+   * Returns the file.
+   *
+   * @param id the id
+   * @param field the field
+   * @return the result
+   */
       @PathParam("id") int id,
       @PathParam("rev") int revision,
       @PathParam("fieldname") String field);
@@ -154,6 +199,13 @@ public interface IItemRestService {
   @Produces("*/*")
   public Response getFile(@PathParam("id") int id, @PathParam("fieldname") String field);
 
+  /**
+   * updateItems operation.
+   *
+   * @param debug the debug
+   * @param content_type the content type
+   * @return the result
+   */
   @GET
   @Path("/importfeeds/")
   public Response updateItems(
@@ -162,10 +214,11 @@ public interface IItemRestService {
   /***
    * Given a content id for a Feed Definition will import the specified feed.
    *
-   * @param  debug
-   * @param contentId
-   * @param folderId
+   * @param debug the debug
+   * @param contentId the content id
+   * @param folderId the folder id
    *
+   * @return the result
    */
   @GET
   @Path("/importfeed/")
@@ -177,6 +230,9 @@ public interface IItemRestService {
   /***
    * Finds an item by a key field.
    * @return null or the Item.
+   * @param value the value
+   * @param keyfield the keyfield
+   * @param contextRoot the context root
    */
   @GET
   @Path("/find/v/{value}/k/{keyfield}/p/{contextRoot}/")

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/ItemRestClientLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/ItemRestClientLocator.java
@@ -20,8 +20,17 @@ package com.percussion.pso.restservice;
 import com.percussion.pso.restservice.impl.ItemRestServiceImpl;
 import com.percussion.services.PSBaseServiceLocator;
 
-/** */
+/**
+ * Service locator for the item REST client bean.
+ */
 public class ItemRestClientLocator extends PSBaseServiceLocator {
+  /**
+   * Creates a new ItemRestClientLocator.
+   */
+  public ItemRestClientLocator() {
+    // default
+  }
+
 
   /**
    * Method getItemServiceBase.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/ItemRestServiceLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/ItemRestServiceLocator.java
@@ -19,8 +19,17 @@ package com.percussion.pso.restservice;
 // REFACTORED: CP-JAVA11
 import com.percussion.services.PSBaseServiceLocator;
 
-/** */
+/**
+ * Service locator for the item REST service bean.
+ */
 public class ItemRestServiceLocator extends PSBaseServiceLocator {
+  /**
+   * Creates a new ItemRestServiceLocator.
+   */
+  public ItemRestServiceLocator() {
+    // default
+  }
+
 
   /**
    * Method getItemServiceBase.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/exception/ItemRestException.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/exception/ItemRestException.java
@@ -20,36 +20,68 @@ import com.percussion.pso.restservice.model.Error.ErrorCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * ItemRestException class.
+ */
 public class ItemRestException extends Exception {
 
-  /** */
-  private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
   private static final Logger log = LogManager.getLogger(ItemRestException.class);
   private ErrorCode errorCode = ErrorCode.UNKNOWN_ERROR;
 
+  /**
+   * Creates a new ItemRestException.
+   */
   public ItemRestException() {}
 
+  /**
+   * Creates a new ItemRestException.
+   *
+   * @param errorCode the error code
+   * @param msg the msg
+   */
   public ItemRestException(ErrorCode errorCode, String msg) {
     super(msg);
     this.errorCode = errorCode;
     log.debug("Rest exception {}", msg);
   }
 
+  /**
+   * Creates a new ItemRestException.
+   *
+   * @param msg the msg
+   */
   public ItemRestException(String msg) {
     super(msg);
     log.debug("Rest exception {}", msg);
   }
 
+  /**
+   * Creates a new ItemRestException.
+   *
+   * @param msg the msg
+   * @param e the e
+   */
   public ItemRestException(String msg, Exception e) {
     super(msg, e);
     log.debug("Rest exception {} {}", msg, e);
   }
 
+  /**
+   * Sets the error code.
+   *
+   * @param errorCode the error code
+   */
   public void setErrorCode(ErrorCode errorCode) {
     this.errorCode = errorCode;
   }
 
+  /**
+   * Returns the error code.
+   *
+   * @return the result
+   */
   public ErrorCode getErrorCode() {
     return errorCode;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/exception/ItemRestNotModifiedException.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/exception/ItemRestNotModifiedException.java
@@ -16,15 +16,25 @@
  */
 package com.percussion.pso.restservice.exception;
 
+/**
+ * ItemRestNotModifiedException class.
+ */
 public class ItemRestNotModifiedException extends Exception {
 
-  /** */
-  private static final long serialVersionUID = 3648810270110415531L;
+    private static final long serialVersionUID = 3648810270110415531L;
 
+  /**
+   * Creates a new ItemRestNotModifiedException.
+   */
   public ItemRestNotModifiedException() {
     super();
   }
 
+  /**
+   * Creates a new ItemRestNotModifiedException.
+   *
+   * @param msg the msg
+   */
   public ItemRestNotModifiedException(String msg) {
     super(msg);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ArchivedException.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ArchivedException.java
@@ -17,15 +17,31 @@
 
 package com.percussion.pso.restservice.impl;
 
+/**
+ * Exception indicating the requested item is archived.
+ */
 public class ArchivedException extends Exception {
   private static final long serialVersionUID = 1L;
 
   private String message;
 
+  /**
+   * Creates a new ArchivedException.
+   */
+  /**
+   * Creates an exception with the given message.
+   *
+   * @param message the detail message
+   */
   public ArchivedException(String message) {
     this.message = message;
   }
 
+  /**
+   * Returns the Message.
+   *
+   * @return the value
+   */
   public String getMessage() {
     return message;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ItemRestServiceImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/impl/ItemRestServiceImpl.java
@@ -184,7 +184,9 @@ import org.dom4j.Document;
 import org.dom4j.io.DocumentResult;
 import org.springframework.stereotype.Service;
 
-/** */
+/**
+ * Default implementation of the item REST service.
+ */
 @Service(value = "restItemService")
 @Path("/Content/")
 @Produces("text/xml")
@@ -245,7 +247,11 @@ public class ItemRestServiceImpl implements IItemRestService {
     this.uri = uri;
   }
 
-  /** Constructor for ItemRestServiceImpl. */
+  /**
+   * Constructor for ItemRestServiceImpl.
+   * Creates a new ItemRestServiceImpl.
+   *
+   */
   public ItemRestServiceImpl() {
     super();
   }
@@ -409,6 +415,12 @@ public class ItemRestServiceImpl implements IItemRestService {
     return item;
   }
 
+  /**
+   * updateItem operation.
+   *
+   * @param item the item
+   * @return the result
+   */
   public Item updateItem(Item item) {
     return updateItem(item, false);
   }
@@ -419,6 +431,7 @@ public class ItemRestServiceImpl implements IItemRestService {
    * @param item Item
    * @return Item
    * @see IItemRestService#updateItem(Item)
+   * @param updateOnly the update only
    */
   @POST
   @Path("/")
@@ -812,7 +825,7 @@ public class ItemRestServiceImpl implements IItemRestService {
    * @param itemdef PSItemDefinition
    * @param child boolean
    * @return Field
-   * @throws RepositoryException
+   * @throws RepositoryException if an error occurs
    */
   private Field convertPSFieldtoField(
       Property field, Node parentNode, PSField psfield, PSItemDefinition itemdef, boolean child)
@@ -1151,7 +1164,7 @@ public class ItemRestServiceImpl implements IItemRestService {
    * Method locateItem.
    *
    * @param item Item
-   * @throws ItemRestException
+   * @throws ItemRestException if an error occurs
    */
   public void locateItem(Item item) throws ItemRestException {
     int foundId = -1;
@@ -1475,7 +1488,7 @@ public class ItemRestServiceImpl implements IItemRestService {
    *
    * @param is InputStream
    * @return Item
-   * @throws JAXBException
+   * @throws JAXBException if an error occurs
    */
   public Item getItemFromStream(InputStream is) throws JAXBException {
     JAXBContext jc = JAXBContext.newInstance(Item.class);
@@ -1601,10 +1614,10 @@ public class ItemRestServiceImpl implements IItemRestService {
    *
    * @param item Item
    * @param psItem PSCoreItem
-   * @throws IOException
-   * @throws FileNotFoundException
-   * @throws ItemRestException
-   * @throws ItemRestNotModifiedException
+   * @throws IOException if an error occurs
+   * @throws FileNotFoundException if an error occurs
+   * @throws ItemRestException if an error occurs
+   * @throws ItemRestNotModifiedException if an error occurs
    */
   private void updateFields(Item item, PSCoreItem psItem)
       throws IOException, ItemRestException, ItemRestNotModifiedException {
@@ -1633,8 +1646,8 @@ public class ItemRestServiceImpl implements IItemRestService {
    *
    * @param field Field
    * @param psField PSItemField
-   * @throws ItemRestException
-   * @throws ItemRestNotModifiedException
+   * @throws ItemRestException if an error occurs
+   * @throws ItemRestNotModifiedException if an error occurs
    */
   private void updateFieldValue(Field field, PSItemField psField)
       throws ItemRestException, ItemRestNotModifiedException {
@@ -1666,12 +1679,12 @@ public class ItemRestServiceImpl implements IItemRestService {
    * Method getFieldValue.
    *
    * @param value Value
-   * @param psField
+   * @param psField the ps field
    * @return IPSFieldValue
-   * @throws ItemRestException
-   * @throws ItemRestNotModifiedException
-   * @throws IOException
-   * @throws FileNotFoundException
+   * @throws ItemRestException if an error occurs
+   * @throws ItemRestNotModifiedException if an error occurs
+   * @throws IOException if an error occurs
+   * @throws FileNotFoundException if an error occurs
    */
   private IPSFieldValue getFieldValue(Value value, PSItemField psField)
       throws ItemRestException, ItemRestNotModifiedException {
@@ -1943,6 +1956,12 @@ public class ItemRestServiceImpl implements IItemRestService {
     return item;
   }
 
+  /**
+   * PurgeAllFolderContent operation.
+   *
+   * @param target the target
+   * @return the result
+   */
   @DELETE
   @Path("/PurgeFolder/{target:.*}")
   public Response PurgeAllFolderContent(@PathParam("target") String target) {
@@ -1965,6 +1984,7 @@ public class ItemRestServiceImpl implements IItemRestService {
    * @param body String
    * @param debug boolean
    * @return Items
+   * @param param the param
    */
   @POST
   @Path("import/{template}")
@@ -2089,11 +2109,25 @@ public class ItemRestServiceImpl implements IItemRestService {
   @GET
   // On upgrade use @Path("/Sites/{search:.*}") remove limited
   // @Path(value="/Sites/{search}", limited=false)
+  /**
+   * Returns the items.
+   *
+   * @param path the path
+   * @param n the n
+   * @return the result
+   */
   @Path("/Sites/{search:.*}")
   public PagedResult getItems(@PathParam("search") String path, @QueryParam("n") Integer n) {
     return jcrSearch("select rx:sys_contentid from nt:base ", n, "/Sites/" + path + "%");
   }
 
+  /**
+   * Returns the type items.
+   *
+   * @param type the type
+   * @param n the n
+   * @return the result
+   */
   @GET
   @Path("/Type/{typename}")
   public PagedResult getTypeItems(@PathParam("typename") String type, @QueryParam("n") Integer n) {
@@ -2134,6 +2168,7 @@ public class ItemRestServiceImpl implements IItemRestService {
    * @param contentid int
    * @param revision int
    * @return String
+   * @param field the field
    */
   public String generateFileLink(int contentid, int revision, String field) {
     // builder starts with current URI and has appended path of getCustomer
@@ -2172,6 +2207,13 @@ public class ItemRestServiceImpl implements IItemRestService {
     return builder.build().toASCIIString();
   }
 
+  /**
+   * Returns the file.
+   *
+   * @param id the id
+   * @param field the field
+   * @return the result
+   */
   @GET
   @Path("{id}/field/{fieldname}")
   @Produces("*/*")
@@ -2184,6 +2226,14 @@ public class ItemRestServiceImpl implements IItemRestService {
     return getFile(head.getId(), head.getRevision(), field);
   }
 
+  /**
+   * Returns the file.
+   *
+   * @param id the id
+   * @param revision the revision
+   * @param field the field
+   * @return the result
+   */
   @GET
   @Path("{id}/{rev}/field/{fieldname}")
   @Produces("*/*")
@@ -2222,6 +2272,12 @@ public class ItemRestServiceImpl implements IItemRestService {
     return rb.build();
   }
 
+  /**
+   * switchCommunity operation.
+   *
+   * @param communityid the communityid
+   * @throws PSUserNotMemberOfCommunityException if an error occurs
+   */
   public void switchCommunity(int communityid) throws PSUserNotMemberOfCommunityException {
     PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(KEY_PSREQUEST);
 
@@ -2273,6 +2329,13 @@ public class ItemRestServiceImpl implements IItemRestService {
     return navonId;
   }
 
+  /**
+   * updateItems operation.
+   *
+   * @param debug the debug
+   * @param content_type the content type
+   * @return the result
+   */
   @GET
   @Path("/importfeeds/")
   public Response updateItems(
@@ -2326,6 +2389,10 @@ public class ItemRestServiceImpl implements IItemRestService {
   /***
    * Given the specified content id, will load the Feed Definition
    * parameters and execute the import template specified by the feed.
+   * @param debug the debug
+   * @param sys_contentid the sys contentid
+   * @param sys_folderid the sys folderid
+   * @return the result
    */
   @GET
   @Path("/importfeed/")
@@ -2558,6 +2625,14 @@ public class ItemRestServiceImpl implements IItemRestService {
     return builder.build();
   }
 
+  /**
+   * findByKeyField operation.
+   *
+   * @param value the value
+   * @param keyfield the keyfield
+   * @param contextRoot the context root
+   * @return the result
+   */
   @GET
   @Path("/find/v/{value}/k/{keyfield}/p/{contextRoot}/")
   public Item findByKeyField(String value, String keyfield, String contextRoot) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/jexl/PSOImportJexl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/jexl/PSOImportJexl.java
@@ -67,8 +67,17 @@ import org.jsoup.Jsoup;
 import org.jsoup.helper.W3CDom;
 import org.xml.sax.XMLReader;
 
-/** */
+/**
+ * JEXL expression helpers used during REST-based content import.
+ */
 public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
+  /**
+   * Creates a new PSOImportJexl.
+   */
+  public PSOImportJexl() {
+    // default
+  }
+
 
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOImportJexl.class);
@@ -87,6 +96,12 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
       description =
           "Gets html posted to the template and converts it to tidied xml compliant output ",
       params = {})
+  /**
+   * Returns the post body as dom.
+   *
+   * @return the result
+   * @throws IOException if an error occurs
+   */
   public Document getPostBodyAsDom() throws IOException {
     PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
     HttpServletRequest sreq = req.getServletRequest();
@@ -116,6 +131,12 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Extracts html from a url and convert to dom",
       params = {@IPSJexlParam(name = "url", description = "the url to connect to")})
+  /**
+   * Returns the http as dom.
+   *
+   * @param url the url
+   * @return the result
+   */
   public Document getHttpAsDom(String url) {
     Document doc = null;
     HttpClient client = createHttpClient();
@@ -173,6 +194,14 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
             name = "contextroot",
             description = "The root path within the system where this item may already be stored.")
       })
+  /**
+   * Returns the http as dom.
+   *
+   * @param url the url
+   * @param keyfield the keyfield
+   * @param contextRoot the context root
+   * @return the result
+   */
   public HttpDOMResponse getHttpAsDom(String url, String keyfield, String contextRoot) {
     HttpDOMResponse ret = null;
     Document doc = null;
@@ -243,11 +272,17 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
    * Method getPostBody.
    *
    * @return String
-   * @throws IOException
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Gets posted body as string",
       params = {})
+  /**
+   * Returns the post body.
+   *
+   * @return the result
+   * @throws IOException if an error occurs
+   */
   public String getPostBody() throws IOException {
     PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
     HttpServletRequest sreq = req.getServletRequest();
@@ -297,11 +332,17 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
    * Method getPostDom.
    *
    * @return Document
-   * @throws IOException
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Gets posted body as DOM",
       params = {})
+  /**
+   * Returns the post dom.
+   *
+   * @return the result
+   * @throws IOException if an error occurs
+   */
   public Document getPostDom() throws IOException {
     PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
     HttpServletRequest sreq = req.getServletRequest();
@@ -324,11 +365,18 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
    *
    * @param string String
    * @return Document
-   * @throws IOException
+   * @throws IOException if an error occurs
    */
   @IPSJexlMethod(
       description = "Gets Dom from String",
       params = {@IPSJexlParam(name = "string", description = "the xml string ")})
+  /**
+   * Returns the dom from string.
+   *
+   * @param string the string
+   * @return the result
+   * @throws IOException if an error occurs
+   */
   public Document getDomFromString(String string) throws IOException {
 
     Document document = null;
@@ -360,6 +408,14 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "xpath", description = "the xpath string"),
         @IPSJexlParam(name = "namespaces", description = "a map of namespace prefixes")
       })
+  /**
+   * xpathSelectSingleNode operation.
+   *
+   * @param doc the doc
+   * @param xpathString the xpath string
+   * @param namespaces the namespaces
+   * @return the result
+   */
   public Node xpathSelectSingleNode(
       Object doc, String xpathString, Map<String, String> namespaces) {
     Node nd = (Node) doc;
@@ -385,6 +441,14 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "xpath", description = "the xpath string"),
         @IPSJexlParam(name = "namespaces", description = "a map of namespace prefixes")
       })
+  /**
+   * xpathSelectNodes operation.
+   *
+   * @param doc the doc
+   * @param xpathString the xpath string
+   * @param namespaces the namespaces
+   * @return the result
+   */
   public List<?> xpathSelectNodes(Object doc, String xpathString, Map<String, String> namespaces) {
     XPath xpath = DocumentHelper.createXPath(xpathString);
     xpath.setNamespaceURIs(namespaces);
@@ -401,6 +465,12 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Gets gets the xml for an existing content item by id",
       params = {@IPSJexlParam(name = "contentId", description = "the id for the Item")})
+  /**
+   * Returns the item xml.
+   *
+   * @param contentId the content id
+   * @return the result
+   */
   public Document getItemXml(int contentId) {
     IItemRestService itemservice = ItemRestServiceLocator.getItemServiceBase();
     /*	ItemRestService itemservice = JAXRSClientFactory.create("http://localhost:9992/Rhythmyx/services",ItemRestService.class,"admin1","demo",null);
@@ -446,6 +516,14 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
             name = "contextroot",
             description = "The root path within the system where this item may already be stored.")
       })
+  /**
+   * Returns the wild html as dom.
+   *
+   * @param url the url
+   * @param keyfield the keyfield
+   * @param contextRoot the context root
+   * @return the result
+   */
   public HttpHtmlResponse getWildHtmlAsDom(String url, String keyfield, String contextRoot) {
     HttpHtmlResponse ret = null;
     org.jsoup.nodes.Document doc = null;
@@ -556,6 +634,13 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "url", description = "The base url"),
         @IPSJexlParam(name = "html", description = "The body content")
       })
+  /**
+   * cleanRelativeLinks operation.
+   *
+   * @param url the url
+   * @param html the html
+   * @return the result
+   */
   public String cleanRelativeLinks(String url, String html) {
 
     String ret = html;
@@ -582,6 +667,12 @@ public class PSOImportJexl extends PSJexlUtilBase implements IPSJexlExpression {
   @IPSJexlMethod(
       description = "Returns a SHA-1 hash for the specified string.",
       params = {@IPSJexlParam(name = "data", description = "The data to hash")})
+  /**
+   * Returns the hash.
+   *
+   * @param data the data
+   * @return the result
+   */
   public String getHash(String data) {
     String ret = String.valueOf(data.hashCode());
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/AclItem.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/AclItem.java
@@ -19,67 +19,139 @@ package com.percussion.pso.restservice.model;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+/**
+ * REST model for a single ACL entry on a content item.
+ */
 @XmlRootElement(name = "AclEntry")
 public class AclItem {
+  /** Principal type (for example user or role). */
   private String type;
+  /** Whether read permission is granted. */
   private boolean read;
+  /** Whether write permission is granted. */
   private boolean write;
+  /** Whether admin permission is granted. */
   private boolean admin;
+  /** Whether this entry is an explicit deny. */
   private boolean deny;
+  /** Principal name for this ACL entry. */
   private String name;
 
+  /**
+   * Creates an empty ACL entry.
+   */
   public AclItem() {}
 
+  /**
+   * Returns the principal name.
+   *
+   * @return the principal name
+   */
   @XmlAttribute
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the principal name.
+   *
+   * @param name the principal name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the principal type.
+   *
+   * @return the principal type
+   */
   @XmlAttribute
   public String getType() {
     return type;
   }
 
+  /**
+   * Sets the principal type.
+   *
+   * @param type the principal type
+   */
   public void setType(String type) {
     this.type = type;
   }
 
+  /**
+   * Returns whether read is granted.
+   *
+   * @return {@code true} if read is granted
+   */
   @XmlAttribute
   public boolean isRead() {
     return read;
   }
 
+  /**
+   * Sets whether read is granted.
+   *
+   * @param read {@code true} to grant read
+   */
   public void setRead(boolean read) {
     this.read = read;
   }
 
+  /**
+   * Returns whether write is granted.
+   *
+   * @return {@code true} if write is granted
+   */
   @XmlAttribute
   public boolean isWrite() {
     return write;
   }
 
+  /**
+   * Sets whether write is granted.
+   *
+   * @param write {@code true} to grant write
+   */
   public void setWrite(boolean write) {
     this.write = write;
   }
 
+  /**
+   * Returns whether admin is granted.
+   *
+   * @return {@code true} if admin is granted
+   */
   @XmlAttribute
   public boolean isAdmin() {
     return admin;
   }
 
+  /**
+   * Sets whether admin is granted.
+   *
+   * @param admin {@code true} to grant admin
+   */
   public void setAdmin(boolean admin) {
     this.admin = admin;
   }
 
+  /**
+   * Returns whether this entry is a deny rule.
+   *
+   * @return {@code true} if this is a deny entry
+   */
   @XmlAttribute
   public boolean isDeny() {
     return deny;
   }
 
+  /**
+   * Sets whether this entry is a deny rule.
+   *
+   * @param deny {@code true} if this is a deny entry
+   */
   public void setDeny(boolean deny) {
     this.deny = deny;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/BaseHttpResponse.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/BaseHttpResponse.java
@@ -19,32 +19,46 @@ package com.percussion.pso.restservice.model;
 import java.net.http.HttpHeaders;
 import org.apache.commons.lang3.StringUtils;
 
+/**
+ * Base type for HTTP responses that carry headers and an optional existing item.
+ */
 public abstract class BaseHttpResponse {
 
+  /** Optional previously loaded item associated with the response. */
   private Item existingItem;
 
   /** Package-visible for subclass single-shot constructors (avoids this-escape). */
   HttpHeaders headers;
 
-  /***
-   * Sets the HTTP Headers collection for this response.
-   * @param headers
+  /**
+   * Creates an empty HTTP response holder.
+   */
+  protected BaseHttpResponse() {
+    // default
+  }
+
+  /**
+   * Sets the HTTP headers collection for this response.
+   *
+   * @param headers the response headers
    */
   public final void setHeaders(HttpHeaders headers) {
     this.headers = headers;
   }
 
-  /***
-   * Gets the HTTP Headers collection for this response.
+  /**
+   * Gets the HTTP headers collection for this response.
    *
+   * @return the headers, or {@code null} if not set
    */
   public HttpHeaders getHeaders() {
     return headers;
   }
 
-  /***
-   * Will return the ETag header if it is set or the empty string.
+  /**
+   * Returns the ETag header if set, otherwise the empty string.
    *
+   * @return the ETag value or empty string
    */
   public String getETag() {
     if (headers == null) {
@@ -53,9 +67,10 @@ public abstract class BaseHttpResponse {
     return headers.firstValue("ETag").orElse("");
   }
 
-  /***
-   * Will return the last modified header if it is set or the empty string.
+  /**
+   * Returns the last-modified header if set, otherwise the Date header, otherwise empty string.
    *
+   * @return the last-modified timestamp string or empty string
    */
   public String getLastModified() {
     String ret = "";
@@ -74,10 +89,20 @@ public abstract class BaseHttpResponse {
     return ret;
   }
 
+  /**
+   * Sets the existing item associated with this response.
+   *
+   * @param existingItem the existing item
+   */
   public void setExistingItem(Item existingItem) {
     this.existingItem = existingItem;
   }
 
+  /**
+   * Returns the existing item associated with this response.
+   *
+   * @return the existing item, or {@code null}
+   */
   public Item getExistingItem() {
     return existingItem;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Child.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Child.java
@@ -21,9 +21,18 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
-/** */
+/**
+ * REST model for a child field group on a content item.
+ */
 @XmlRootElement(name = "Child")
 public class Child {
+
+  /**
+   * Creates a new Child.
+   */
+  public Child() {
+    // default
+  }
   /** Field name. */
   private String name;
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/ChildRow.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/ChildRow.java
@@ -20,8 +20,17 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import java.util.List;
 
-/** */
+/**
+ * REST model for a single row within a child field group.
+ */
 public class ChildRow {
+
+  /**
+   * Creates a new ChildRow.
+   */
+  public ChildRow() {
+    // default
+  }
   /** Field fields. */
   private List<Field> fields = null;
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Copy.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Copy.java
@@ -16,5 +16,12 @@
  */
 package com.percussion.pso.restservice.model;
 
-/** */
-public class Copy extends Relationship {}
+/**
+ * REST model representing a content copy relationship.
+ */
+public class Copy extends Relationship {
+  /**
+   * Creates an empty copy relationship.
+   */
+  public Copy() {}
+}

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/DateValue.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/DateValue.java
@@ -26,10 +26,19 @@ import java.util.Date;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/** */
+/**
+ * REST model for a date field value.
+ */
 @XmlRootElement(name = "DateValue")
 @XmlAccessorType(XmlAccessType.NONE)
 public class DateValue implements Value {
+
+  /**
+   * Creates a new DateValue.
+   */
+  public DateValue() {
+    // default
+  }
 
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(DateValue.class);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Error.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Error.java
@@ -20,63 +20,128 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlValue;
 
+/**
+ * REST model representing an error returned for an item operation.
+ */
 @XmlRootElement(name = "Error")
 public class Error {
 
+  /**
+   * Well-known error codes for item REST responses.
+   */
   public static enum ErrorCode {
+    /** Item was not found. */
     NOT_FOUND,
+    /** Item was purged. */
     PURGED,
+    /** Unexpected error. */
     UNKNOWN_ERROR,
+    /** Assembly failed. */
     ASSEMBLY_ERROR,
+    /** Operation was skipped. */
     SKIP
-  };
+  }
 
+  /** Structured error code. */
   private ErrorCode errorCode;
+  /** Human-readable error message. */
   private String errorMessage;
+  /** Optional related content id. */
   private Integer contentId;
 
+  /**
+   * Creates an error with {@link ErrorCode#UNKNOWN_ERROR}.
+   */
   public Error() {
     // Direct field assignment avoids this-escape from overridable setters in ctor.
     this.errorCode = ErrorCode.UNKNOWN_ERROR;
   }
 
+  /**
+   * Creates an error with a code and message.
+   *
+   * @param errorCode the error code
+   * @param message the error message
+   */
   public Error(ErrorCode errorCode, String message) {
     this.errorCode = errorCode;
     this.errorMessage = message;
   }
 
+  /**
+   * Creates an error with a code, content id, and message.
+   *
+   * @param errorCode the error code
+   * @param contentId related content id
+   * @param message the error message
+   */
   public Error(ErrorCode errorCode, Integer contentId, String message) {
     this.errorCode = errorCode;
     this.errorMessage = message;
     this.contentId = contentId;
   }
 
+  /**
+   * Creates an error with only a code.
+   *
+   * @param errorCode the error code
+   */
   public Error(ErrorCode errorCode) {
     this.errorCode = errorCode;
   }
 
+  /**
+   * Returns the error code.
+   *
+   * @return the error code
+   */
   @XmlAttribute
   public ErrorCode getErrorCode() {
     return errorCode;
   }
 
+  /**
+   * Sets the error code.
+   *
+   * @param errorCode the error code
+   */
   public void setErrorCode(ErrorCode errorCode) {
     this.errorCode = errorCode;
   }
 
+  /**
+   * Returns the error message.
+   *
+   * @return the error message
+   */
   @XmlValue
   public String getErrorMessage() {
     return errorMessage;
   }
 
+  /**
+   * Sets the error message.
+   *
+   * @param errorMessage the error message
+   */
   public void setErrorMessage(String errorMessage) {
     this.errorMessage = errorMessage;
   }
 
+  /**
+   * Sets the related content id.
+   *
+   * @param contentId the content id
+   */
   public void setContentId(Integer contentId) {
     this.contentId = contentId;
   }
 
+  /**
+   * Returns the related content id.
+   *
+   * @return the content id, or {@code null}
+   */
   @XmlAttribute
   public Integer getContentId() {
     return contentId;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Field.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Field.java
@@ -19,7 +19,9 @@ package com.percussion.pso.restservice.model;
 import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
-/** */
+/**
+ * REST model for a content item field and its value(s).
+ */
 @XmlRootElement
 @XmlSeeAlso({StringValue.class, XhtmlValue.class, DateValue.class, FileValue.class})
 public class Field {
@@ -143,6 +145,11 @@ public class Field {
     @XmlElementRef(type = DateValue.class),
     @XmlElementRef(type = FileValue.class)
   })
+  /**
+   * Returns the value.
+   *
+   * @return the result
+   */
   public Value getValue() {
     return value;
   }
@@ -171,11 +178,20 @@ public class Field {
     @XmlElementRef(type = DateValue.class),
     @XmlElementRef(type = FileValue.class)
   })
+  /**
+   * Returns the values.
+   *
+   * @return the result
+   */
   public List<Value> getValues() {
     return values;
   }
 
-  /** Constructor for Field. */
+  /**
+   * Constructor for Field.
+   * Creates a new Field.
+   *
+   */
   public Field() {
     super();
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FileValue.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FileValue.java
@@ -20,9 +20,18 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlValue;
 
-/** */
+/**
+ * REST model for a file or binary field value.
+ */
 @XmlRootElement(name = "FileValue")
 public class FileValue implements Value {
+
+  /**
+   * Creates a new FileValue.
+   */
+  public FileValue() {
+    // default
+  }
 
   /** Field stringValue. */
   private String stringValue;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FolderAcl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FolderAcl.java
@@ -20,25 +20,55 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import java.util.List;
 
+/**
+ * REST model for a folder ACL and its entries.
+ */
 public class FolderAcl {
 
+  /** ACL entries for the folder. */
   private List<AclItem> entries;
+  /** Community name associated with this folder ACL. */
   private String communityName;
 
+  /**
+   * Creates an empty folder ACL.
+   */
+  public FolderAcl() {}
+
+  /**
+   * Returns the ACL entries.
+   *
+   * @return the entries
+   */
   @XmlElement(name = "AclEntry")
   public List<AclItem> getEntries() {
     return entries;
   }
 
+  /**
+   * Sets the ACL entries.
+   *
+   * @param entries the entries
+   */
   public void setEntries(List<AclItem> entries) {
     this.entries = entries;
   }
 
+  /**
+   * Returns the community name.
+   *
+   * @return the community name
+   */
   @XmlAttribute
   public String getCommunityName() {
     return communityName;
   }
 
+  /**
+   * Sets the community name.
+   *
+   * @param communityName the community name
+   */
   public void setCommunityName(String communityName) {
     this.communityName = communityName;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FolderInfo.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FolderInfo.java
@@ -22,8 +22,18 @@ import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
+/**
+ * REST model for folder metadata and ACL.
+ */
 @XmlRootElement
 public class FolderInfo {
+
+  /**
+   * Creates a new FolderInfo.
+   */
+  public FolderInfo() {
+    // default
+  }
 
   private FolderAcl folderAcl;
   private String pubFileName;
@@ -33,37 +43,73 @@ public class FolderInfo {
 
   @XmlElementWrapper(name = "Contents")
   @XmlElement(name = "Item")
+  /**
+   * Returns the FolderItems.
+   *
+   * @return the value
+   */
   public List<ItemRef> getFolderItems() {
     return folderItems;
   }
 
+  /**
+   * Sets the FolderItems.
+   * @param folderItems the folder items
+   */
   public void setFolderItems(List<ItemRef> folderItems) {
     this.folderItems = folderItems;
   }
 
+  /**
+   * Sets the FolderAcl.
+   * @param folderAcl the folder acl
+   */
   public void setFolderAcl(FolderAcl folderAcl) {
     this.folderAcl = folderAcl;
   }
 
   @XmlElement
+  /**
+   * Returns the FolderAcl.
+   *
+   * @return the value
+   */
   public FolderAcl getFolderAcl() {
     return folderAcl;
   }
 
+  /**
+   * Sets the PubFileName.
+   * @param pubFileName the pub file name
+   */
   public void setPubFileName(String pubFileName) {
     this.pubFileName = pubFileName;
   }
 
   @XmlAttribute
+  /**
+   * Returns the PubFileName.
+   *
+   * @return the value
+   */
   public String getPubFileName() {
     return pubFileName;
   }
 
+  /**
+   * Sets the GlobalTemplate.
+   * @param globalTemplate the global template
+   */
   public void setGlobalTemplate(String globalTemplate) {
     this.globalTemplate = globalTemplate;
   }
 
   @XmlAttribute
+  /**
+   * Returns the GlobalTemplate.
+   *
+   * @return the value
+   */
   public String getGlobalTemplate() {
     return globalTemplate;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FolderInfo.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/FolderInfo.java
@@ -40,14 +40,14 @@ public class FolderInfo {
   private String globalTemplate;
 
   List<ItemRef> folderItems;
-
-  @XmlElementWrapper(name = "Contents")
-  @XmlElement(name = "Item")
   /**
    * Returns the FolderItems.
    *
    * @return the value
    */
+
+  @XmlElementWrapper(name = "Contents")
+  @XmlElement(name = "Item")
   public List<ItemRef> getFolderItems() {
     return folderItems;
   }
@@ -67,13 +67,13 @@ public class FolderInfo {
   public void setFolderAcl(FolderAcl folderAcl) {
     this.folderAcl = folderAcl;
   }
-
-  @XmlElement
   /**
    * Returns the FolderAcl.
    *
    * @return the value
    */
+
+  @XmlElement
   public FolderAcl getFolderAcl() {
     return folderAcl;
   }
@@ -85,13 +85,13 @@ public class FolderInfo {
   public void setPubFileName(String pubFileName) {
     this.pubFileName = pubFileName;
   }
-
-  @XmlAttribute
   /**
    * Returns the PubFileName.
    *
    * @return the value
    */
+
+  @XmlAttribute
   public String getPubFileName() {
     return pubFileName;
   }
@@ -103,13 +103,13 @@ public class FolderInfo {
   public void setGlobalTemplate(String globalTemplate) {
     this.globalTemplate = globalTemplate;
   }
-
-  @XmlAttribute
   /**
    * Returns the GlobalTemplate.
    *
    * @return the value
    */
+
+  @XmlAttribute
   public String getGlobalTemplate() {
     return globalTemplate;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpDOMResponse.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpDOMResponse.java
@@ -30,7 +30,7 @@ public class HttpDOMResponse extends BaseHttpResponse {
 
   /***
    * Sets the DOM Document for the content returned in this response.
-   * @param document
+   * @param document the document
    */
   public void setDocument(Document document) {
     this.document = document;
@@ -39,6 +39,7 @@ public class HttpDOMResponse extends BaseHttpResponse {
   /***
    * Gets the DOM document for this response.
    *
+   * @return the result
    */
   public Document getDocument() {
     return document;
@@ -51,8 +52,8 @@ public class HttpDOMResponse extends BaseHttpResponse {
 
   /***
    * Single Shot Constructor
-   * @param doc
-   * @param head
+   * @param doc the doc
+   * @param head the head
    */
   public HttpDOMResponse(Document doc, HttpHeaders head) {
     // Direct field assignment (headers is package-visible on base) — no this-escape.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpHtmlResponse.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/HttpHtmlResponse.java
@@ -19,24 +19,40 @@ package com.percussion.pso.restservice.model;
 import java.net.http.HttpHeaders;
 import org.jsoup.nodes.Document;
 
+/**
+ * HTTP response holding an HTML document payload.
+ */
 public class HttpHtmlResponse extends BaseHttpResponse {
 
   private Document document;
 
+  /**
+   * Creates a new HttpHtmlResponse.
+   */
   public HttpHtmlResponse() {}
 
+  /**
+   * Sets the document.
+   *
+   * @param document the document
+   */
   public void setDocument(Document document) {
     this.document = document;
   }
 
+  /**
+   * Returns the document.
+   *
+   * @return the result
+   */
   public Document getDocument() {
     return document;
   }
 
   /***
    * Single Shot Constructor
-   * @param doc
-   * @param head
+   * @param doc the doc
+   * @param head the head
    */
   public HttpHtmlResponse(Document doc, HttpHeaders head) {
     // Direct field assignment (headers is package-visible on base) — no this-escape.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Item.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Item.java
@@ -40,6 +40,9 @@ import java.util.List;
       "depRelationships",
       "errors"
     })
+/**
+ * Item class.
+ */
 public class Item {
 
   private String forceCheckin; // never (default), always, user;
@@ -71,172 +74,357 @@ public class Item {
   private List<String> folders = null;
   private FolderInfo folderInfo;
 
+  /**
+   * Returns the update type.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getUpdateType() {
     return updateType;
   }
 
+  /**
+   * Sets the update type.
+   *
+   * @param updateType the update type
+   */
   public void setUpdateType(String updateType) {
     this.updateType = updateType;
   }
 
+  /**
+   * Returns the key field.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getKeyField() {
     return keyField;
   }
 
+  /**
+   * Sets the key field.
+   *
+   * @param keyField the key field
+   */
   public void setKeyField(String keyField) {
     this.keyField = keyField;
   }
 
+  /**
+   * Returns the context root.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getContextRoot() {
     return contextRoot;
   }
 
+  /**
+   * Sets the context root.
+   *
+   * @param contextRoot the context root
+   */
   public void setContextRoot(String contextRoot) {
     this.contextRoot = contextRoot;
   }
 
+  /**
+   * Returns the content type.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getContentType() {
     return contentType;
   }
 
+  /**
+   * Sets the content type.
+   *
+   * @param contentType the content type
+   */
   public void setContentType(String contentType) {
     this.contentType = contentType;
   }
 
+  /**
+   * Returns the community name.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getCommunityName() {
     return communityName;
   }
 
+  /**
+   * Sets the community name.
+   *
+   * @param communityName the community name
+   */
   public void setCommunityName(String communityName) {
     this.communityName = communityName;
   }
 
+  /**
+   * Returns the state.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getState() {
     return state;
   }
 
+  /**
+   * Sets the state.
+   *
+   * @param state the state
+   */
   public void setState(String state) {
     this.state = state;
   }
 
+  /**
+   * Returns the workflow.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getWorkflow() {
     return workflow;
   }
 
+  /**
+   * Sets the workflow.
+   *
+   * @param workflow the workflow
+   */
   public void setWorkflow(String workflow) {
     this.workflow = workflow;
   }
 
+  /**
+   * Returns the checkout user name.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getCheckoutUserName() {
     return checkoutUserName;
   }
 
+  /**
+   * Sets the checkout user name.
+   *
+   * @param checkoutUserName the checkout user name
+   */
   public void setCheckoutUserName(String checkoutUserName) {
     this.checkoutUserName = checkoutUserName;
   }
 
+  /**
+   * Returns the revision.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public Integer getRevision() {
     return revision;
   }
 
+  /**
+   * Sets the revision.
+   *
+   * @param revision the revision
+   */
   public void setRevision(Integer revision) {
     this.revision = revision;
   }
 
+  /**
+   * Returns the content id.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public Integer getContentId() {
     return contentId;
   }
 
+  /**
+   * Sets the content id.
+   *
+   * @param contentId the content id
+   */
   public void setContentId(Integer contentId) {
     this.contentId = contentId;
   }
 
+  /**
+   * Sets the locale.
+   *
+   * @param locale the locale
+   */
   public void setLocale(String locale) {
     this.locale = locale;
   }
 
+  /**
+   * Returns the locale.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getLocale() {
     return locale;
   }
 
+  /**
+   * Creates a new Item.
+   */
   public Item() {
     super();
   }
 
+  /**
+   * Returns the fields.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Field")
   @XmlElementWrapper(name = "Fields")
   public List<Field> getFields() {
     return this.fields;
   }
 
+  /**
+   * Sets the fields.
+   *
+   * @param fields the fields
+   */
   public void setFields(List<Field> fields) {
     this.fields = fields;
   }
 
+  /**
+   * Returns the children.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Child")
   @XmlElementWrapper(name = "Children")
   public List<Child> getChildren() {
     return children;
   }
 
+  /**
+   * Sets the children.
+   *
+   * @param children the children
+   */
   public void setChildren(List<Child> children) {
     this.children = children;
   }
 
+  /**
+   * Sets the folders.
+   *
+   * @param folders the folders
+   */
   public void setFolders(List<String> folders) {
     this.folders = folders;
   }
 
+  /**
+   * Returns the folders.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Path")
   @XmlElementWrapper(name = "Folders")
   public List<String> getFolders() {
     return folders;
   }
 
+  /**
+   * Sets the relationships.
+   *
+   * @param relationships the relationships
+   */
   public void setRelationships(Relationships relationships) {
     this.relationships = relationships;
   }
 
+  /**
+   * Returns the relationships.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Relationships")
   public Relationships getRelationships() {
     return relationships;
   }
 
+  /**
+   * Sets the dep relationships.
+   *
+   * @param relationships the relationships
+   */
   public void setDepRelationships(Relationships relationships) {
     this.depRelationships = relationships;
   }
 
+  /**
+   * Returns the dep relationships.
+   *
+   * @return the result
+   */
   @XmlElement(name = "DepRelationships")
   public Relationships getDepRelationships() {
     return depRelationships;
   }
 
+  /**
+   * Returns the errors.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Error")
   @XmlElementWrapper(name = "Errors")
   public List<Error> getErrors() {
     return errors;
   }
 
+  /**
+   * Sets the errors.
+   *
+   * @param errors the errors
+   */
   public void setErrors(List<Error> errors) {
     this.errors = errors;
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   * @param message the message
+   */
   public void addError(Error.ErrorCode error, String message) {
     if (errors == null) errors = new ArrayList<Error>();
     errors.add(new Error(error, message));
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   * @param e the e
+   */
   public void addError(Error.ErrorCode error, Exception e) {
     if (errors == null) errors = new ArrayList<Error>();
     String message = e.getMessage();
@@ -245,6 +433,13 @@ public class Item {
     errors.add(new Error(error, contentId, message + ":" + sw.toString()));
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   * @param message the message
+   * @param e the e
+   */
   public void addError(Error.ErrorCode error, String message, Exception e) {
     if (errors == null) errors = new ArrayList<Error>();
     String messageex = e.getMessage() + "\n";
@@ -253,11 +448,22 @@ public class Item {
     errors.add(new Error(error, contentId, messageex + "\n" + message + "\n" + sw.toString()));
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   */
   public void addError(Error.ErrorCode error) {
     if (errors == null) errors = new ArrayList<Error>();
     errors.add(new Error(error, contentId, ""));
   }
 
+  /**
+   * hasError operation.
+   *
+   * @param error the error
+   * @return the result
+   */
   public boolean hasError(Error.ErrorCode error) {
     if (errors != null) {
       for (Error errorTest : errors) {
@@ -269,36 +475,68 @@ public class Item {
     return false;
   }
 
+  /**
+   * Sets the folder info.
+   *
+   * @param folderInfo the folder info
+   */
   @XmlElement
   public void setFolderInfo(FolderInfo folderInfo) {
     this.folderInfo = folderInfo;
   }
 
+  /**
+   * Returns the folder info.
+   *
+   * @return the result
+   */
   public FolderInfo getFolderInfo() {
     return folderInfo;
   }
 
+  /**
+   * Sets the title.
+   *
+   * @param title the title
+   */
   public void setTitle(String title) {
     this.title = title;
   }
 
+  /**
+   * Returns the title.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getTitle() {
     return title;
   }
 
+  /**
+   * Sets the force checkin.
+   *
+   * @param forceCheckin the force checkin
+   */
   public void setForceCheckin(String forceCheckin) {
     this.forceCheckin = forceCheckin;
   }
 
+  /**
+   * Returns the force checkin.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public String getForceCheckin() {
     return forceCheckin;
   }
 
   /**
-   * @param key
+   * Sets the key.
+   * @param key the key
    * @see java.util.HashMap#containsKey(Object)
+   * @return the result
    */
   public boolean containsField(String key) {
     if (fields != null) {
@@ -310,7 +548,8 @@ public class Item {
   }
 
   /**
-   * @param newField
+   * Sets the newField.
+   * @param newField the new field
    * @see java.util.HashMap#put(Object, Object)
    */
   @XmlTransient
@@ -328,8 +567,10 @@ public class Item {
   }
 
   /**
-   * @param name
+   * Sets the name.
+   * @param name the name
    * @see java.util.HashMap#get(Object)
+   * @return the result
    */
   public Field getField(String name) {
     if (fields != null) {
@@ -340,16 +581,27 @@ public class Item {
     return null;
   }
 
+  /**
+   * Sets the check in only.
+   *
+   * @param checkInOnly the check in only
+   */
   @XmlAttribute
   public void setCheckInOnly(Boolean checkInOnly) {
     this.checkInOnly = checkInOnly;
   }
 
+  /**
+   * Returns the check in only.
+   *
+   * @return the result
+   */
   public Boolean getCheckInOnly() {
     return checkInOnly;
   }
 
   /**
+   * Sets the updatedDateField.
    * @param updatedDateField the updatedDateField to set
    */
   @XmlAttribute
@@ -358,26 +610,47 @@ public class Item {
   }
 
   /**
+   * Returns the updatedDateField.
    * @return the updatedDateField
    */
   public String getUpdatedDateField() {
     return updatedDateField;
   }
 
+  /**
+   * Sets the transition.
+   *
+   * @param transition the transition
+   */
   @XmlAttribute
   public void setTransition(String transition) {
     this.transition = transition;
   }
 
+  /**
+   * Returns the transition.
+   *
+   * @return the result
+   */
   public String getTransition() {
     return transition;
   }
 
+  /**
+   * Sets the edit transition.
+   *
+   * @param editTransition the edit transition
+   */
   @XmlAttribute
   public void setEditTransition(String editTransition) {
     this.editTransition = editTransition;
   }
 
+  /**
+   * Returns the edit transition.
+   *
+   * @return the result
+   */
   public String getEditTransition() {
     return editTransition;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/ItemRef.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/ItemRef.java
@@ -18,8 +18,17 @@ package com.percussion.pso.restservice.model;
 
 import jakarta.xml.bind.annotation.XmlAttribute;
 
-/** */
+/**
+ * REST model that references another content item by id or path.
+ */
 public class ItemRef {
+  /**
+   * Creates a new ItemRef.
+   */
+  public ItemRef() {
+    // default
+  }
+
   /** Field contentId. */
   private Integer contentId;
 
@@ -145,10 +154,20 @@ public class ItemRef {
     return contentType;
   }
 
+  /**
+   * Sets the title.
+   *
+   * @param title the title
+   */
   public void setTitle(String title) {
     this.title = title;
   }
 
+  /**
+   * Returns the title.
+   *
+   * @return the result
+   */
   public String getTitle() {
     return title;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Items.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Items.java
@@ -26,38 +26,80 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Items class.
+ */
 @XmlRootElement(name = "Items")
 public class Items {
+  /**
+   * Creates a new Items.
+   */
+  public Items() {
+    // default
+  }
+
   private List<Item> items = new ArrayList<>();
   private List<Error> errors = null;
 
+  /**
+   * Returns the items.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Item")
   public List<Item> getItems() {
     return items;
   }
 
+  /**
+   * Sets the items.
+   *
+   * @param items the items
+   */
   public void setItems(List<Item> items) {
     this.items = items;
   }
 
   private static final Logger log = LogManager.getLogger(Items.class);
 
+  /**
+   * Returns the errors.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Error")
   @XmlElementWrapper(name = "Errors")
   public List<Error> getErrors() {
     return errors;
   }
 
+  /**
+   * Sets the errors.
+   *
+   * @param errors the errors
+   */
   public void setErrors(List<Error> errors) {
     this.errors = errors;
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   * @param message the message
+   */
   public void addError(Error.ErrorCode error, String message) {
     if (errors == null) errors = new ArrayList<>();
     errors.add(new Error(error, message));
     log.debug("Error is: {}", message);
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   * @param e the e
+   */
   public void addError(Error.ErrorCode error, Exception e) {
     if (errors == null) errors = new ArrayList<>();
     String message = e.getMessage();
@@ -66,6 +108,13 @@ public class Items {
     errors.add(new Error(error, message + ":" + sw));
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   * @param message the message
+   * @param e the e
+   */
   public void addError(Error.ErrorCode error, String message, Exception e) {
     if (errors == null) errors = new ArrayList<>();
     String messageex = e.getMessage() + "\n";
@@ -75,12 +124,23 @@ public class Items {
     log.debug("Error is: {}", message);
   }
 
+  /**
+   * addError operation.
+   *
+   * @param error the error
+   */
   public void addError(Error.ErrorCode error) {
     if (errors == null) errors = new ArrayList<>();
     errors.add(new Error(error));
     log.debug("Error is: {}", error);
   }
 
+  /**
+   * hasError operation.
+   *
+   * @param error the error
+   * @return the result
+   */
   public boolean hasError(Error.ErrorCode error) {
     if (errors != null) {
       for (Error errorTest : errors) {
@@ -92,6 +152,11 @@ public class Items {
     return false;
   }
 
+  /**
+   * hasItems operation.
+   *
+   * @return the result
+   */
   public boolean hasItems() {
     if (items != null && !items.isEmpty()) {
       return true;
@@ -99,6 +164,11 @@ public class Items {
     return false;
   }
 
+  /**
+   * hasErrors operation.
+   *
+   * @return the result
+   */
   public boolean hasErrors() {
     if (errors != null && !errors.isEmpty()) {
       return true;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Relationship.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Relationship.java
@@ -18,8 +18,17 @@ package com.percussion.pso.restservice.model;
 
 import jakarta.xml.bind.annotation.XmlAttribute;
 
-/** */
+/**
+ * Base REST model for a relationship between content items.
+ */
 public class Relationship extends ItemRef {
+  /**
+   * Creates a new Relationship.
+   */
+  public Relationship() {
+    // default
+  }
+
 
   /** Field relId. */
   private int relId;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Relationships.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Relationships.java
@@ -20,8 +20,17 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import java.util.List;
 
-/** */
+/**
+ * REST model container for the relationships of a content item.
+ */
 public class Relationships {
+  /**
+   * Creates a new Relationships.
+   */
+  public Relationships() {
+    // default
+  }
+
   /** Field slots. */
   List<Slot> slots = null;
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Slot.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Slot.java
@@ -21,9 +21,18 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
-/** */
+/**
+ * REST model for an assembly slot and its items.
+ */
 @XmlRootElement(name = "Slot")
 public class Slot implements Comparable<Slot> {
+
+  /**
+   * Creates a new Slot.
+   */
+  public Slot() {
+    // default
+  }
 
   /** Field name. */
   String name;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/SlotItem.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/SlotItem.java
@@ -19,8 +19,17 @@ package com.percussion.pso.restservice.model;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 
-/** */
+/**
+ * REST model for an item placed in an assembly slot.
+ */
 public class SlotItem extends Relationship implements Comparable<SlotItem> {
+  /**
+   * Creates a new SlotItem.
+   */
+  public SlotItem() {
+    // default
+  }
+
   /** Field template. */
   private String template;
 
@@ -119,6 +128,11 @@ public class SlotItem extends Relationship implements Comparable<SlotItem> {
     return this.sortRank - o.sortRank;
   }
 
+  /**
+   * hashCode operation.
+   *
+   * @return the result
+   */
   @Override
   public int hashCode() {
     final int prime = 31;
@@ -130,6 +144,12 @@ public class SlotItem extends Relationship implements Comparable<SlotItem> {
     return result;
   }
 
+  /**
+   * equals operation.
+   *
+   * @param obj the obj
+   * @return the result
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/StringValue.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/StringValue.java
@@ -19,9 +19,18 @@ package com.percussion.pso.restservice.model;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlValue;
 
-/** */
+/**
+ * REST model for a simple string field value.
+ */
 @XmlRootElement(name = "Value")
 public class StringValue implements Value {
+
+  /**
+   * Creates a new StringValue.
+   */
+  public StringValue() {
+    // default
+  }
 
   /** Field stringValue. */
   private String stringValue;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Translation.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Translation.java
@@ -18,8 +18,17 @@ package com.percussion.pso.restservice.model;
 
 import jakarta.xml.bind.annotation.XmlAttribute;
 
-/** */
+/**
+ * REST model for a translation relationship.
+ */
 public class Translation extends Relationship {
+  /**
+   * Creates a new Translation.
+   */
+  public Translation() {
+    // default
+  }
+
   /** Field locale. */
   private String locale;
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Value.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/Value.java
@@ -16,7 +16,9 @@
  */
 package com.percussion.pso.restservice.model;
 
-/** */
+/**
+ * Marker interface for typed field values in the REST item model.
+ */
 public interface Value {
   /** Type constant. */
   public static final int TYPE = -1;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/XhtmlValue.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/XhtmlValue.java
@@ -22,9 +22,18 @@ import jakarta.xml.bind.annotation.XmlValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/** */
+/**
+ * REST model for an XHTML/rich-text field value.
+ */
 @XmlRootElement(name = "XmlValue")
 public class XhtmlValue implements Value {
+
+  /**
+   * Creates a new XhtmlValue.
+   */
+  public XhtmlValue() {
+    // default
+  }
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(XhtmlValue.class);
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/results/PagedResult.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/model/results/PagedResult.java
@@ -23,37 +23,77 @@ import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
+/**
+ * PagedResult class.
+ */
 @XmlRootElement(name = "Results")
 public class PagedResult {
+  /**
+   * Creates a new PagedResult.
+   */
+  public PagedResult() {
+    // default
+  }
+
 
   List<ItemRef> itemRefs;
   String next;
   Integer nextId;
 
+  /**
+   * Returns the next id.
+   *
+   * @return the result
+   */
   @XmlAttribute
   public Integer getNextId() {
     return nextId;
   }
 
+  /**
+   * Sets the next id.
+   *
+   * @param nextId the next id
+   */
   public void setNextId(Integer nextId) {
     this.nextId = nextId;
   }
 
+  /**
+   * Returns the next.
+   *
+   * @return the result
+   */
   @XmlElement
   public String getNext() {
     return next;
   }
 
+  /**
+   * Sets the next.
+   *
+   * @param next the next
+   */
   public void setNext(String next) {
     this.next = next;
   }
 
+  /**
+   * Returns the item refs.
+   *
+   * @return the result
+   */
   @XmlElement(name = "Item")
   @XmlElementWrapper(name = "Items")
   public List<ItemRef> getItemRefs() {
     return itemRefs;
   }
 
+  /**
+   * Sets the item refs.
+   *
+   * @param itemRefs the item refs
+   */
   public void setItemRefs(List<ItemRef> itemRefs) {
     this.itemRefs = itemRefs;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/support/IImportItemSystemInfo.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/support/IImportItemSystemInfo.java
@@ -19,7 +19,9 @@ package com.percussion.pso.restservice.support;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
 
-/** */
+/**
+ * Provides system metadata used while importing items via the REST service.
+ */
 public interface IImportItemSystemInfo {
 
   // Helper methods
@@ -88,6 +90,12 @@ public interface IImportItemSystemInfo {
    */
   public String getCommunityName(int id);
 
+  /**
+   * Returns the community id.
+   *
+   * @param name the name
+   * @return the result
+   */
   public int getCommunityId(String name);
 
   /**
@@ -95,7 +103,7 @@ public interface IImportItemSystemInfo {
    *
    * @param contentType String
    * @return PSItemDefinition
-   * @throws PSInvalidContentTypeException
+   * @throws PSInvalidContentTypeException if an error occurs
    */
   public PSItemDefinition getItemDefinition(String contentType)
       throws PSInvalidContentTypeException;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/support/ImportItemSystemInfoLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/support/ImportItemSystemInfoLocator.java
@@ -18,8 +18,17 @@ package com.percussion.pso.restservice.support;
 
 import com.percussion.services.PSBaseServiceLocator;
 
-/** */
+/**
+ * Service locator for the import item system info bean.
+ */
 public class ImportItemSystemInfoLocator extends PSBaseServiceLocator {
+  /**
+   * Creates a new ImportItemSystemInfoLocator.
+   */
+  public ImportItemSystemInfoLocator() {
+    // default
+  }
+
 
   /**
    * Gets the PSO Workflow Action Service bean.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/support/impl/ImportItemSystemInfoImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/support/impl/ImportItemSystemInfoImpl.java
@@ -54,8 +54,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/** */
+/**
+ * Default implementation of import item system info.
+ */
 public class ImportItemSystemInfoImpl implements IImportItemSystemInfo {
+  /**
+   * Creates a new ImportItemSystemInfoImpl.
+   */
+  public ImportItemSystemInfoImpl() {
+    // default
+  }
+
 
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(ImportItemSystemInfoImpl.class);
@@ -295,6 +304,12 @@ public class ImportItemSystemInfoImpl implements IImportItemSystemInfo {
     return name;
   }
 
+  /**
+   * Returns the community id.
+   *
+   * @param name the name
+   * @return the result
+   */
   public int getCommunityId(String name) {
     initServices();
     List<PSCommunity> comms = rolemgr.findCommunitiesByName(name);
@@ -310,7 +325,7 @@ public class ImportItemSystemInfoImpl implements IImportItemSystemInfo {
    *
    * @param contentType String
    * @return PSItemDefinition
-   * @throws PSInvalidContentTypeException
+   * @throws PSInvalidContentTypeException if an error occurs
    * @see IImportItemSystemInfo#getItemDefinition(String)
    */
   public PSItemDefinition getItemDefinition(String contentType)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/FileProcessor.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/FileProcessor.java
@@ -32,10 +32,24 @@ import javax.imageio.ImageIO;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Utilities for processing file fields on content items.
+ */
 public class FileProcessor {
+
+  /**
+   * Creates a new FileProcessor.
+   */
+  private FileProcessor() {
+    // default
+  }
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(FileProcessor.class);
 
+  /**
+   * process operation.
+   * @param psItem the ps item
+   */
   public static void process(PSCoreItem psItem) {
     log.debug("Processing Files");
     Iterator<PSItemField> iterator = psItem.getAllFields();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/HtmlLinkHelper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/HtmlLinkHelper.java
@@ -34,17 +34,24 @@ import org.jsoup.select.Elements;
  * @author natechadwick
  */
 public class HtmlLinkHelper {
+  /**
+   * Creates a new HtmlLinkHelper.
+   */
+  public HtmlLinkHelper() {
+    // default
+  }
+
 
   private static final Logger log = LogManager.getLogger(HtmlLinkHelper.class);
 
   /***
    * Given the specified base url, will convert the supplied link from relative
    * to abolute and return a string the result.
-   * @param base
-   * @param src
+   * @param base the base
+   * @param src the src
    * @return An absolute version of the supplied url
-   * @throws URISyntaxException
-   * @throws MalformedURLException
+   * @throws URISyntaxException if an error occurs
+   * @throws MalformedURLException if an error occurs
    */
   public static String convertToAbsoluteLink(String base, String src)
       throws URISyntaxException, MalformedURLException {
@@ -57,10 +64,11 @@ public class HtmlLinkHelper {
 
   /***
    * Returns the base link
-   * @param link
+   * @param link the link
    *
-   * @throws URISyntaxException
-   * @throws MalformedURLException
+   * @throws URISyntaxException if an error occurs
+   * @throws MalformedURLException if an error occurs
+   * @return the result
    */
   public static String getBaseLink(String link) throws URISyntaxException, MalformedURLException {
 
@@ -69,6 +77,15 @@ public class HtmlLinkHelper {
     return u.getScheme() + "://" + u.getAuthority() + "/";
   }
 
+  /**
+   * convertLinksToAbsolute operation.
+   *
+   * @param link the link
+   * @param doc the doc
+   * @return the result
+   * @throws MalformedURLException if an error occurs
+   * @throws URISyntaxException if an error occurs
+   */
   public static org.jsoup.nodes.Document convertLinksToAbsolute(
       String link, org.jsoup.nodes.Document doc) throws MalformedURLException, URISyntaxException {
 
@@ -108,11 +125,12 @@ public class HtmlLinkHelper {
 
   /***
    * Converts all links in the specified string to absolute.
-   * @param link
-   * @param text
+   * @param link the link
+   * @param text the text
    *
-   * @throws MalformedURLException
-   * @throws URISyntaxException
+   * @throws MalformedURLException if an error occurs
+   * @throws URISyntaxException if an error occurs
+   * @return the result
    */
   public static String convertLinksToAbsolute(String link, String text)
       throws MalformedURLException, URISyntaxException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/InputStreamValue.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/InputStreamValue.java
@@ -23,21 +23,40 @@ import java.io.InputStream;
 import java.util.Arrays;
 
 // Work in progress
+/**
+ * InputStreamValue class.
+ */
 public class InputStreamValue extends PSFieldValue {
 
   private InputStream is;
   private PSPurgableTempFile ptf;
 
+  /**
+   * Creates a new InputStreamValue.
+   *
+   * @param is the is
+   */
   public InputStreamValue(InputStream is) {
     this.is = is;
   }
 
+  /**
+   * Returns the value.
+   *
+   * @return the result
+   */
   @Override
   public Object getValue() {
     // TODO Auto-generated method stub
     return null;
   }
 
+  /**
+   * Returns the value as string.
+   *
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   */
   @Override
   public String getValueAsString() throws PSCmsException {
     // TODO Auto-generated method stub
@@ -45,6 +64,11 @@ public class InputStreamValue extends PSFieldValue {
   }
 
   // see IPSFieldValue#clone() interface for description
+  /**
+   * clone operation.
+   *
+   * @return the result
+   */
   public Object clone() {
     PSFieldValue copy = null;
     copy = (PSFieldValue) super.clone();
@@ -70,6 +94,8 @@ public class InputStreamValue extends PSFieldValue {
    * compared with case ignored. Are they equal?
    *
    * @return <code>true</code>if they are, otherwise <code>false</code>.
+   * @param a the a
+   * @param b the b
    */
   protected boolean compare(Object a, Object b) {
     if (a == null || b == null) {
@@ -84,12 +110,23 @@ public class InputStreamValue extends PSFieldValue {
     return true;
   }
 
+  /**
+   * equals operation.
+   *
+   * @param obj the obj
+   * @return the result
+   */
   @Override
   public boolean equals(Object obj) {
     // TODO Auto-generated method stub
     return false;
   }
 
+  /**
+   * hashCode operation.
+   *
+   * @return the result
+   */
   @Override
   public int hashCode() {
     // TODO Auto-generated method stub

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/ItemServiceHelper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/ItemServiceHelper.java
@@ -31,8 +31,17 @@ import org.apache.logging.log4j.Logger;
 import org.dom4j.Document;
 import org.dom4j.io.DocumentResult;
 
-/** */
+/**
+ * Helpers for mapping between REST item models and server content services.
+ */
 public class ItemServiceHelper {
+  /**
+   * Creates a new ItemServiceHelper.
+   */
+  public ItemServiceHelper() {
+    // default
+  }
+
 
   private static final Logger log = LogManager.getLogger(ItemServiceHelper.class);
 
@@ -64,7 +73,7 @@ public class ItemServiceHelper {
    *
    * @param is InputStream
    * @return Item
-   * @throws JAXBException
+   * @throws JAXBException if an error occurs
    */
   public static Item getItemFromXml(InputStream is) throws JAXBException {
     JAXBContext jc = JAXBContext.newInstance(Item.class);
@@ -78,7 +87,7 @@ public class ItemServiceHelper {
    *
    * @param is InputStream
    * @return Items
-   * @throws JAXBException
+   * @throws JAXBException if an error occurs
    */
   public static Items getItemsFromXml(InputStream is) throws JAXBException {
     JAXBContext jc = JAXBContext.newInstance(Items.class);
@@ -92,7 +101,7 @@ public class ItemServiceHelper {
    *
    * @param string String
    * @return Item
-   * @throws JAXBException
+   * @throws JAXBException if an error occurs
    */
   public static Item getItemFromXml(String string) throws JAXBException {
     ByteArrayInputStream input = new ByteArrayInputStream(string.getBytes());
@@ -104,7 +113,7 @@ public class ItemServiceHelper {
    *
    * @param string String
    * @return Items
-   * @throws JAXBException
+   * @throws JAXBException if an error occurs
    */
   public static Items getItemsFromXml(String string) throws JAXBException {
     ByteArrayInputStream input = new ByteArrayInputStream(string.getBytes());

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/MethodCacheInterceptor.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/restservice/utils/MethodCacheInterceptor.java
@@ -26,10 +26,19 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
 /**
+ * AOP interceptor that caches results of selected service methods.
+ *
  * @author stephenbolton
  * @version $Revision: 1.0 $
  */
 public class MethodCacheInterceptor implements MethodInterceptor, InitializingBean {
+  /**
+   * Creates a new MethodCacheInterceptor.
+   */
+  public MethodCacheInterceptor() {
+    // default
+  }
+
   /** Field logger. */
   private static final Logger logger = LogManager.getLogger(MethodCacheInterceptor.class);
 
@@ -48,7 +57,7 @@ public class MethodCacheInterceptor implements MethodInterceptor, InitializingBe
   /**
    * Checks if required attributes are provided.
    *
-   * @throws Exception
+   * @throws Exception if an error occurs
    * @see InitializingBean#afterPropertiesSet()
    */
   public void afterPropertiesSet() throws Exception {
@@ -61,7 +70,7 @@ public class MethodCacheInterceptor implements MethodInterceptor, InitializingBe
    *
    * @param invocation MethodInvocation
    * @return Object
-   * @throws Throwable
+   * @throws Throwable if an error occurs
    * @see MethodInterceptor#invoke(MethodInvocation)
    */
   public Object invoke(MethodInvocation invocation) throws Throwable {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/spring/NamespacedInternalResourceViewResolver.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/spring/NamespacedInternalResourceViewResolver.java
@@ -20,7 +20,17 @@ import java.util.Locale;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
+/**
+ * NamespacedInternalResourceViewResolver class.
+ */
 public class NamespacedInternalResourceViewResolver extends InternalResourceViewResolver {
+  /**
+   * Creates a new NamespacedInternalResourceViewResolver.
+   */
+  public NamespacedInternalResourceViewResolver() {
+    // default
+  }
+
 
   private String m_namespace;
 
@@ -30,6 +40,14 @@ public class NamespacedInternalResourceViewResolver extends InternalResourceView
    * @see
    * org.springframework.web.servlet.view.UrlBasedViewResolver#loadView(java
    * .lang.String, java.util.Locale)
+   */
+  /**
+   * loadView operation.
+   *
+   * @param viewName the view name
+   * @param locale the locale
+   * @return the result
+   * @throws Exception if an error occurs
    */
   @Override
   protected View loadView(String viewName, Locale locale) throws Exception {
@@ -44,6 +62,8 @@ public class NamespacedInternalResourceViewResolver extends InternalResourceView
   }
 
   /**
+   * Returns the namespace.
+   *
    * @return the namespace
    */
   public String getNamespace() {
@@ -51,6 +71,8 @@ public class NamespacedInternalResourceViewResolver extends InternalResourceView
   }
 
   /**
+   * Sets the namespace.
+   *
    * @param namespace the namespace to set
    */
   public void setNamespace(String namespace) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedCategory.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedCategory.java
@@ -39,19 +39,34 @@ import com.rometools.modules.mediarss.types.Category;
  */
 public class PSSynFeedCategory {
 
+  /** sceheme flickr tags. */
   public static final String SCEHEME_FLICKR_TAGS = Category.SCHEME_FLICKR_TAGS;
 
   private Category category;
 
+  /**
+   * Creates a new PSSynFeedCategory.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedCategory(Category arg) {
     this.category = arg;
   }
 
-  /** */
+  /**
+   * Returns the scheme.
+   *
+   * @return the result
+   */
   public String getScheme() {
     return category.getScheme();
   }
 
+  /**
+   * Returns the value.
+   *
+   * @return the result
+   */
   public String getValue() {
     return category.getValue();
   }
@@ -59,11 +74,17 @@ public class PSSynFeedCategory {
   /***
    * label is the human readable label that can be displayed in end user applications. It is an optional attribute.
    *
+   * @return the result
    */
   public String getLabel() {
     return category.getLabel();
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   @Override
   public String toString() {
     return category.getLabel();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedCredit.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedCredit.java
@@ -83,24 +83,45 @@ public class PSSynFeedCredit {
 
   private Credit credit;
 
+  /**
+   * Returns the name.
+   *
+   * @return the result
+   */
   public String getName() {
     return credit.getName();
   }
 
+  /**
+   * Returns the role.
+   *
+   * @return the result
+   */
   public String getRole() {
     return credit.getRole();
   }
 
+  /**
+   * Returns the scheme.
+   *
+   * @return the result
+   */
   public String getScheme() {
     return credit.getScheme();
   }
 
+  /**
+   * Creates a new PSSynFeedCredit.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedCredit(Credit arg) {
     credit = arg;
   }
 
   /***
    * Returns in &lt;Role&gt;: &lt;Name&gt; format.
+   * @return the result
    */
   @Override
   public String toString() {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedEnclosure.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedEnclosure.java
@@ -32,6 +32,7 @@ public class PSSynFeedEnclosure {
   /***
    * Returns the enclosure length.
    *
+   * @return the result
    */
   public long getLength() {
     return enc.getLength();
@@ -40,6 +41,7 @@ public class PSSynFeedEnclosure {
   /***
    * Returns the enclosure type.
    *
+   * @return the result
    */
   public String getType() {
     return enc.getType();
@@ -48,11 +50,17 @@ public class PSSynFeedEnclosure {
   /***
    * Returns the enclosure URL.
    *
+   * @return the result
    */
   public String getUrl() {
     return enc.getUrl();
   }
 
+  /**
+   * Creates a new PSSynFeedEnclosure.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedEnclosure(SyndEnclosure arg) {
     this.enc = arg;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedEntry.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedEntry.java
@@ -40,6 +40,7 @@ public class PSSynFeedEntry {
   /***
    * Returns the name of the first entry author in the collection of authors.
    *
+   * @return the result
    */
   public String getAuthor() {
     String ret = "";
@@ -51,6 +52,7 @@ public class PSSynFeedEntry {
   /***
    * Returns the entry authors.
    *
+   * @return the result
    */
   public List<SyndPerson> getAuthorsList() {
     return entry.getAuthors();
@@ -59,6 +61,7 @@ public class PSSynFeedEntry {
   /***
    * Returns a comma seperated list of the entry authors.
    *
+   * @return the result
    */
   public String getAuthors() {
     String ret = "";
@@ -78,6 +81,7 @@ public class PSSynFeedEntry {
   /***
    * Returns the feed categories.
    *
+   * @return the result
    */
   public List<SyndCategory> getCategoriesList() {
     return entry.getCategories();
@@ -86,6 +90,7 @@ public class PSSynFeedEntry {
   /***
    * Returns the feed categories as a comma separated string.
    *
+   * @return the result
    */
   public String getCategories() {
     String ret = "";
@@ -103,6 +108,7 @@ public class PSSynFeedEntry {
   /***
    * the feed author.
    *
+   * @return the result
    */
   public String getContributors() {
     String ret = "";
@@ -119,6 +125,11 @@ public class PSSynFeedEntry {
     return ret;
   }
 
+  /**
+   * Returns the contributors list.
+   *
+   * @return the result
+   */
   public List<SyndPerson> getContributorsList() {
     return entry.getContributors();
   }
@@ -126,6 +137,7 @@ public class PSSynFeedEntry {
   /***
    * Returns the entry contents.
    *
+   * @return the result
    */
   public String getContents() {
     String ret = "";
@@ -140,6 +152,7 @@ public class PSSynFeedEntry {
   /***
    * Returns the entry description.
    *
+   * @return the result
    */
   public String getDescription() {
     String ret = "";
@@ -150,6 +163,11 @@ public class PSSynFeedEntry {
     return ret;
   }
 
+  /**
+   * Returns the enclosures.
+   *
+   * @return the result
+   */
   public List<PSSynFeedEnclosure> getEnclosures() {
     ArrayList<PSSynFeedEnclosure> ret = new ArrayList<PSSynFeedEnclosure>();
 
@@ -161,6 +179,7 @@ public class PSSynFeedEntry {
 
   /***
    *  Returns the entry link.
+   * @return the result
    */
   public String getLink() {
     String ret = "";
@@ -173,12 +192,18 @@ public class PSSynFeedEntry {
   /***
    * Returns the entry links
    *
+   * @return the result
    */
   public List<SyndLink> getLinks() {
     List<SyndLink> links = entry.getLinks();
     return links;
   }
 
+  /**
+   * Returns the media rsscontent.
+   *
+   * @return the result
+   */
   public List<PSSynFeedMediaContent> getMediaRSSContent() {
     MediaEntryModule mediaModule = null;
 
@@ -198,6 +223,7 @@ public class PSSynFeedEntry {
   /***
    * Returns the entry published date.
    *
+   * @return the result
    */
   public Date getPublishedDate() {
     return entry.getPublishedDate();
@@ -206,6 +232,7 @@ public class PSSynFeedEntry {
   /***
    *  Returns the entry title.
    *
+   * @return the result
    */
   public String getTitle() {
     String ret = "";
@@ -216,6 +243,7 @@ public class PSSynFeedEntry {
   /***
    *  Returns the entry updated date.
    *
+   * @return the result
    */
   public Date getUpdatedDate() {
     if (entry.getUpdatedDate() != null) {
@@ -227,10 +255,20 @@ public class PSSynFeedEntry {
     }
   }
 
+  /**
+   * Returns the uri.
+   *
+   * @return the result
+   */
   public String getUri() {
     return entry.getUri();
   }
 
+  /**
+   * Creates a new PSSynFeedEntry.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedEntry(SyndEntry arg) {
     entry = arg;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedImage.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedImage.java
@@ -26,6 +26,7 @@ public class PSSynFeedImage {
   /***
    * Returns the image link.
    *
+   * @return the result
    */
   public String getLink() {
     return image.getLink();
@@ -34,6 +35,7 @@ public class PSSynFeedImage {
   /***
    * Returns the image title.
    *
+   * @return the result
    */
   public String getTitle() {
     return image.getTitle();
@@ -42,6 +44,7 @@ public class PSSynFeedImage {
   /***
    *    Returns the image URL.
    *
+   * @return the result
    */
   public String getUrl() {
     return image.getUrl();
@@ -50,11 +53,17 @@ public class PSSynFeedImage {
   /***
    * Returns the image description.
    *
+   * @return the result
    */
   public String getDescription() {
     return image.getDescription();
   }
 
+  /**
+   * Creates a new PSSynFeedImage.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedImage(SyndImage arg) {
     this.image = arg;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedMediaContent.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedMediaContent.java
@@ -54,6 +54,7 @@ public class PSSynFeedMediaContent {
   /***
    * channels is number of audio channels in the media object.
    *
+   * @return the result
    */
   public Integer getAudioChannels() {
     Integer ret = 0;
@@ -66,6 +67,7 @@ public class PSSynFeedMediaContent {
   /***
    * bitrate is the kilobits per second rate of media.
    *
+   * @return the result
    */
   public Float getBitrate() {
     Float ret = (float) 0;
@@ -78,6 +80,7 @@ public class PSSynFeedMediaContent {
   /***
    * duration is the number of seconds the media object plays.
    *
+   * @return the result
    */
   public Long getDuration() {
     Long ret = (long) 0;
@@ -90,6 +93,7 @@ public class PSSynFeedMediaContent {
   /***
    * expression determines if the object is a sample or the full version of the object, or even if it is a continuous stream (sample | full | nonstop).
    *
+   * @return the result
    */
   public String getExpression() {
     String ret = "";
@@ -103,6 +107,7 @@ public class PSSynFeedMediaContent {
   /***
    * fileSize is the number of bytes of the media object.
    *
+   * @return the result
    */
   public Long getFileSize() {
     Long ret = (long) 0;
@@ -115,6 +120,7 @@ public class PSSynFeedMediaContent {
   /***
    * framerate is the number of frames per second for the media object.
    *
+   * @return the result
    */
   public Float getFramerate() {
     Float ret = (float) 0;
@@ -127,6 +133,7 @@ public class PSSynFeedMediaContent {
   /***
    * height is the height of the media object.
    *
+   * @return the result
    */
   public Integer getHeight() {
     Integer ret = 0;
@@ -139,6 +146,7 @@ public class PSSynFeedMediaContent {
   /***
    * lang is the primary language encapsulated in the media object.
    *
+   * @return the result
    */
   public String getLanguage() {
     String ret = "";
@@ -151,6 +159,7 @@ public class PSSynFeedMediaContent {
    * The player or URL reference for the item
    * &lt;media:player&gt;
    *
+   * @return the result
    */
   public String getPlayerUrl() {
     String ret = "";
@@ -161,6 +170,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the target url.
+   *
+   * @return the result
+   */
   public String getTargetUrl() {
     String ret = "";
 
@@ -172,6 +186,7 @@ public class PSSynFeedMediaContent {
   /***
    * samplingrate is the number of samples per second taken to create the media object.
    *
+   * @return the result
    */
   public Float getSamplingrate() {
     Float ret = (float) 0;
@@ -184,6 +199,7 @@ public class PSSynFeedMediaContent {
   /***
    * type is the standard MIME type of the object.
    *
+   * @return the result
    */
   public String getType() {
     String ret = "";
@@ -196,6 +212,7 @@ public class PSSynFeedMediaContent {
   /***
    * Width is the width of the media object.
    *
+   * @return the result
    */
   public Integer getWidth() {
     Integer ret = 0;
@@ -208,6 +225,7 @@ public class PSSynFeedMediaContent {
   /***
    * isDefault determines if this is the default object that should be used
    *
+   * @return the result
    */
   public boolean isDefaultContent() {
     boolean ret = false;
@@ -220,6 +238,7 @@ public class PSSynFeedMediaContent {
   // Meta Data
   /***
    * &lt;media:category&gt;
+   * @return the result
    */
   public List<PSSynFeedCategory> getCategoriesList() {
     ArrayList<PSSynFeedCategory> ret = new ArrayList<PSSynFeedCategory>();
@@ -231,6 +250,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the categories.
+   *
+   * @return the result
+   */
   public String getCategories() {
     String ret = "";
 
@@ -250,6 +274,7 @@ public class PSSynFeedMediaContent {
   /***
    * &lt;media:copyright&gt;
    *
+   * @return the result
    */
   public String getCopyright() {
     String ret = "";
@@ -265,6 +290,7 @@ public class PSSynFeedMediaContent {
   /***
    * &lt;media:credit&gt;
    *
+   * @return the result
    */
   public List<PSSynFeedCredit> getCreditList() {
     ArrayList<PSSynFeedCredit> ret = new ArrayList<PSSynFeedCredit>();
@@ -275,6 +301,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the credits.
+   *
+   * @return the result
+   */
   public String getCredits() {
     String ret = "";
 
@@ -293,6 +324,7 @@ public class PSSynFeedMediaContent {
   /***
    * &lt;media:copyright&gt;
    *
+   * @return the result
    */
   public String getCopyrightUrl() {
     String ret = "";
@@ -307,6 +339,7 @@ public class PSSynFeedMediaContent {
   /***
    * &lt;media:description&gt;
    *
+   * @return the result
    */
   public String getDescription() {
     String ret = "";
@@ -319,9 +352,10 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
-  /***
+  /**
+   * Returns the description type.
    *
-   *
+   * @return the result
    */
   public String getDescriptionType() {
     String ret = "";
@@ -336,6 +370,7 @@ public class PSSynFeedMediaContent {
   /***
    *    &lt;media:hash&gt;
    *
+   * @return the result
    */
   public String getHash() {
     String ret = "";
@@ -352,6 +387,7 @@ public class PSSynFeedMediaContent {
   /***
    * Returns the Algorith used to creat the hash.
    *
+   * @return the result
    */
   public String getHashAlgorithm() {
     String ret = "";
@@ -367,6 +403,7 @@ public class PSSynFeedMediaContent {
   /***
    *  &lt;media:keywords&gt;
    *
+   * @return the result
    */
   public List<String> getKeywordsList() {
     ArrayList<String> ret = new ArrayList<String>();
@@ -377,6 +414,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the keywords.
+   *
+   * @return the result
+   */
   public String getKeywords() {
     String ret = "";
 
@@ -399,6 +441,7 @@ public class PSSynFeedMediaContent {
   /***
    * &lt;media:rating&gt;
    *
+   * @return the result
    */
   public List<PSSynFeedRating> getRatingsList() {
     ArrayList<PSSynFeedRating> ret = new ArrayList<PSSynFeedRating>();
@@ -410,6 +453,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the ratings.
+   *
+   * @return the result
+   */
   public String getRatings() {
     return ""; // @TODO: Implement Me
   }
@@ -417,6 +465,7 @@ public class PSSynFeedMediaContent {
   /***
    *  &lt;media:restriction&gt;
    *
+   * @return the result
    */
   public List<PSSynFeedRestriction> getRestrictionsList() {
     ArrayList<PSSynFeedRestriction> ret = new ArrayList<PSSynFeedRestriction>();
@@ -427,6 +476,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the restrictions.
+   *
+   * @return the result
+   */
   public String getRestrictions() {
     return ""; // @TODO: Implement Restrictions.
   }
@@ -450,20 +504,36 @@ public class PSSynFeedMediaContent {
    *
    * end specifies the end time that the text is relevant. If this attribute is not provided, and a start time is used, it is expected that the end time is either the end of the clip or the start of the next &lt;media:text&gt; element.
    *
+   * @return the result
    */
   public String getTranscript() {
     // @TODO: Implement me.
     return "";
   }
 
+  /**
+   * Returns the transcript start.
+   *
+   * @return the result
+   */
   public String getTranscriptStart() {
     return "";
   }
 
+  /**
+   * Returns the transcript end.
+   *
+   * @return the result
+   */
   public String getTranscriptEnd() {
     return "";
   }
 
+  /**
+   * Returns the transcript type.
+   *
+   * @return the result
+   */
   public String getTranscriptType() {
     return "";
   }
@@ -471,6 +541,7 @@ public class PSSynFeedMediaContent {
   /***
    * &lt;media:thumbnail&gt;
    *
+   * @return the result
    */
   public String getThumbnailUrl() {
 
@@ -485,6 +556,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the thumbnail height.
+   *
+   * @return the result
+   */
   public Integer getThumbnailHeight() {
     Integer ret = 0;
 
@@ -497,6 +573,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the thumbnail width.
+   *
+   * @return the result
+   */
   public Integer getThumbnailWidth() {
     Integer ret = 0;
 
@@ -509,6 +590,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the filename.
+   *
+   * @return the result
+   */
   public String getFilename() {
     String ret = "";
 
@@ -527,6 +613,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the file extension.
+   *
+   * @return the result
+   */
   public String getFileExtension() {
     String ret = "";
 
@@ -537,6 +628,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the thumbnail filename.
+   *
+   * @return the result
+   */
   public String getThumbnailFilename() {
     String ret = "";
 
@@ -559,6 +655,11 @@ public class PSSynFeedMediaContent {
     return ret;
   }
 
+  /**
+   * Returns the title.
+   *
+   * @return the result
+   */
   public String getTitle() {
     return content.getMetadata().getTitle();
   }
@@ -566,11 +667,17 @@ public class PSSynFeedMediaContent {
   /***
    * &lt;media:title&gt;
    *
+   * @return the result
    */
   public String getTitleType() {
     return content.getMetadata().getTitleType();
   }
 
+  /**
+   * Creates a new PSSynFeedMediaContent.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedMediaContent(MediaContent arg) {
     content = arg;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedMediaGroup.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedMediaGroup.java
@@ -25,6 +25,11 @@ public class PSSynFeedMediaGroup {
 
   // @TODO: Implement ME
 
+  /**
+   * Creates a new PSSynFeedMediaGroup.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedMediaGroup(MediaGroup arg) {
     group = arg;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedProxy.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedProxy.java
@@ -55,6 +55,7 @@ public class PSSynFeedProxy {
    * Returns the name of the first feed author in the collection of authors.
    *
    *
+   * @return the result
    */
   public String getAuthor() {
     return feed.getAuthor();
@@ -63,6 +64,7 @@ public class PSSynFeedProxy {
   /***
    *  Returns the feed authors.
    *
+   * @return the result
    */
   public List<SyndPerson> getAuthorList() {
     return feed.getAuthors();
@@ -71,6 +73,7 @@ public class PSSynFeedProxy {
   /***
    * Convenience method that returns the list of Authors as a comma separated string.
    *
+   * @return the result
    */
   public String getAuthors() {
     String ret = "";
@@ -90,6 +93,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed categories.
    *
+   * @return the result
    */
   public List<?> getCategoriesList() {
     return feed.getCategories();
@@ -98,6 +102,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed categories as a comma separated string.
    *
+   * @return the result
    */
   public String getCategories() {
     String ret = "";
@@ -115,6 +120,7 @@ public class PSSynFeedProxy {
   /***
    * the feed author.
    *
+   * @return the result
    */
   public String getContributors() {
     String ret = "";
@@ -131,6 +137,11 @@ public class PSSynFeedProxy {
     return ret;
   }
 
+  /**
+   * Returns the contributors list.
+   *
+   * @return the result
+   */
   public List<SyndPerson> getContributorsList() {
     return feed.getContributors();
   }
@@ -138,6 +149,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed copyright.
    *
+   * @return the result
    */
   public String getCopyright() {
     return feed.getCopyright();
@@ -146,6 +158,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed description.
    *
+   * @return the result
    */
   public String getDescription() {
     // @TODO: Add Ext Description support.
@@ -155,6 +168,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the charset encoding of a the feed.
    *
+   * @return the result
    */
   public String getEncoding() {
     return feed.getEncoding();
@@ -163,6 +177,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed entries.
    *
+   * @return the result
    */
   public List<PSSynFeedEntry> getEntries() {
 
@@ -177,6 +192,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the wire feed type the feed had/will-have when coverted from/to a WireFeed.
    *
+   * @return the result
    */
   public String getFeedType() {
     return feed.getFeedType();
@@ -185,6 +201,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed image.
    *
+   * @return the result
    */
   public PSSynFeedImage getImage() {
     return new PSSynFeedImage(feed.getImage());
@@ -201,6 +218,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed link.
    *
+   * @return the result
    */
   public String getLink() {
     return feed.getLink();
@@ -209,6 +227,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the entry links
    *
+   * @return the result
    */
   public List<String> getLinks() {
     ArrayList<String> ret = new ArrayList<String>();
@@ -222,6 +241,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed published date.
    *
+   * @return the result
    */
   public Date getPublishedDate() {
     return feed.getPublishedDate();
@@ -230,6 +250,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed title.
    *
+   * @return the result
    */
   public String getTitle() {
     // @TODO: Add support for title EX.
@@ -239,6 +260,7 @@ public class PSSynFeedProxy {
   /***
    * Returns the feed URI.
    *
+   * @return the result
    */
   public String getUri() {
     return feed.getUri();
@@ -247,9 +269,10 @@ public class PSSynFeedProxy {
   /***
    * Initializes this instances of the proxy with the specified feed url.
    *
-   * @param urlString
-   * @throws IOException
-   * @throws IllegalArgumentException
+   * @param urlString the url string
+   * @throws IOException if an error occurs
+   * @throws IllegalArgumentException if an error occurs
+   * @throws FeedException if an error occurs
    */
   public PSSynFeedProxy(String urlString)
       throws IOException, IllegalArgumentException, FeedException {
@@ -275,6 +298,16 @@ public class PSSynFeedProxy {
     }
   }
 
+  /**
+   * Creates a new PSSynFeedProxy.
+   *
+   * @param urlString the url string
+   * @param eTag the e tag
+   * @param lastModified the last modified
+   * @throws IllegalArgumentException if an error occurs
+   * @throws FeedException if an error occurs
+   * @throws IOException if an error occurs
+   */
   public PSSynFeedProxy(String urlString, String eTag, String lastModified)
       throws IllegalArgumentException, FeedException, IOException {
     // Set up the proxy server if there is one.

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedRating.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedRating.java
@@ -52,18 +52,38 @@ public class PSSynFeedRating {
 
   private Rating rating;
 
+  /**
+   * Returns the scheme.
+   *
+   * @return the result
+   */
   public String getScheme() {
     return rating.getScheme();
   }
 
+  /**
+   * Returns the value.
+   *
+   * @return the result
+   */
   public String getValue() {
     return rating.getValue();
   }
 
+  /**
+   * Creates a new PSSynFeedRating.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedRating(Rating arg) {
     rating = arg;
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   @Override
   public String toString() {
     return rating.getValue();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedRestriction.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedRestriction.java
@@ -73,12 +73,22 @@ public class PSSynFeedRestriction {
 
   private Restriction r;
 
+  /**
+   * Returns the relationship.
+   *
+   * @return the result
+   */
   public String getRelationship() {
 
     if (r.getRelationship().equals(Restriction.Relationship.ALLOW)) return "allow";
     else return "deny";
   }
 
+  /**
+   * Returns the type.
+   *
+   * @return the result
+   */
   public String getType() {
     if (r.getType().equals(Restriction.Type.COUNTRY)) {
       return "country";
@@ -87,14 +97,29 @@ public class PSSynFeedRestriction {
     }
   }
 
+  /**
+   * Returns the value.
+   *
+   * @return the result
+   */
   public String getValue() {
     return r.getValue();
   }
 
+  /**
+   * Creates a new PSSynFeedRestriction.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedRestriction(Restriction arg) {
     r = arg;
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   @Override
   public String toString() {
     String ret = "";

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedThumbnail.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedThumbnail.java
@@ -58,6 +58,7 @@ public class PSSynFeedThumbnail {
   /***
    * Returns the thumbHeight.
    *
+   * @return the result
    */
   public Integer getHeight() {
     return thumb.getHeight();
@@ -66,6 +67,7 @@ public class PSSynFeedThumbnail {
   /***
    * returns the time that the thumbnail was captured from its source
    *
+   * @return the result
    */
   public String getTime() {
     return thumb.getTime().toString();
@@ -74,15 +76,26 @@ public class PSSynFeedThumbnail {
   /***
    * Return the URL
    *
+   * @return the result
    */
   public String getUrl() {
     return thumb.getUrl().toString();
   }
 
+  /**
+   * Returns the width.
+   *
+   * @return the result
+   */
   public Integer getWidth() {
     return thumb.getWidth();
   }
 
+  /**
+   * Creates a new PSSynFeedThumbnail.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedThumbnail(Thumbnail arg) {
     this.thumb = arg;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedTranscript.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedTranscript.java
@@ -23,6 +23,11 @@ public class PSSynFeedTranscript {
 
   private Text[] transcript;
 
+  /**
+   * Creates a new PSSynFeedTranscript.
+   *
+   * @param arg the arg
+   */
   public PSSynFeedTranscript(Text[] arg) {
     this.transcript = arg;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/tasks/TrashTask.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/tasks/TrashTask.java
@@ -16,6 +16,7 @@
  */
 
 /**
+ * Member documentation.
  * @author Stephen Bolton
  */
 package com.percussion.pso.tasks;
@@ -134,6 +135,13 @@ import org.apache.logging.log4j.Logger;
  */
 @Deprecated()
 public class TrashTask implements IPSTask {
+  /**
+   * Creates a new TrashTask.
+   */
+  public TrashTask() {
+    // default
+  }
+
   /** logger for this class. */
   private static final Logger log = LogManager.getLogger(TrashTask.class);
 
@@ -355,9 +363,9 @@ public class TrashTask implements IPSTask {
    *
    * @param trashfolder String
    * @param req PSRequest
-   * @throws FatalTaskException
+   * @throws FatalTaskException if an error occurs
    * @throws PSException * @throws PSErrorException * @throws NamingException * @throws
-   *     PSORMException * @throws PSErrorResultsException * @throws SQLException
+   *     PSORMException * @throws PSErrorResultsException * @throws SQLException if an error occurs
    */
   private int cleanupOrphans(String trashfolder, PSRequest req) throws FatalTaskException {
 
@@ -470,7 +478,7 @@ public class TrashTask implements IPSTask {
    * Method dedupeTitles.
    *
    * @param pageSumms List<PSComponentSummary>
-   * @throws FatalTaskException * @throws PSORMException
+   * @throws FatalTaskException * @throws PSORMException if an error occurs
    */
   private void dedupeTitles(List<PSComponentSummary> pageSumms) throws FatalTaskException {
     // REFACTORED: CP-JAVA11
@@ -577,8 +585,9 @@ public class TrashTask implements IPSTask {
   }
 
   /**
-   * @return Map<Integer,Set<Integer>> * @throws FatalTaskException
-   * @throws NamingException * @throws SQLException
+   * Returns Map<Integer,Set<Integer>> * @throws FatalTaskException if an error occurs.
+   * @return Map<Integer,Set<Integer>> * @throws FatalTaskException if an error occurs
+   * @throws NamingException * @throws SQLException if an error occurs
    */
   private Map<Integer, Set<Integer>> getOrphanedItems() throws FatalTaskException {
     final Map<Integer, Set<Integer>> orphanIds = new HashMap<Integer, Set<Integer>>();
@@ -644,7 +653,7 @@ public class TrashTask implements IPSTask {
    *
    * @param state String
    * @param numberOfDays int
-   * @throws FatalTaskException
+   * @throws FatalTaskException if an error occurs
    * @throws PSErrorsException * @throws NamingException * @throws SQLException * @throws
    *     PSErrorException
    */
@@ -709,10 +718,10 @@ public class TrashTask implements IPSTask {
    * Method transitionItems.
    *
    * @param contentid int
-   * @return boolean * @throws FatalTaskException
+   * @return boolean * @throws FatalTaskException if an error occurs
    * @throws PSExtensionProcessingException * @throws PSAuthorizationException * @throws
-   *     PSNotFoundException * @throws PSExtensionException * @throws PSParameterMismatchException
-   *     * @throws PSRequestValidationException
+   *     PSNotFoundException * @throws PSExtensionException * @throws PSParameterMismatchException if an error occurs
+   *     * @throws PSRequestValidationException if an error occurs
    */
   private boolean transitionItems(int contentid) throws FatalTaskException {
     final IPSRequestContext ctx = new PSRequestContext(req);
@@ -784,11 +793,11 @@ public class TrashTask implements IPSTask {
    * Method trasitionFolderItems.
    *
    * @param trashFolderLocator PSLocator
-   * @throws FatalTaskException
+   * @throws FatalTaskException if an error occurs
    * @throws PSRequestValidationException * @throws PSExtensionProcessingException * @throws
    *     PSParameterMismatchException * @throws PSCmsException * @throws PSErrorException * @throws
-   *     PSErrorsException * @throws PSAuthorizationException * @throws PSNotFoundException
-   *     * @throws PSExtensionException
+   *     PSErrorsException * @throws PSAuthorizationException * @throws PSNotFoundException if an error occurs
+   *     * @throws PSExtensionException if an error occurs
    */
   private void trasitionFolderItems(PSLocator trashFolderLocator) throws FatalTaskException {
     trasitionFolderItems(trashFolderLocator, 0);
@@ -804,11 +813,11 @@ public class TrashTask implements IPSTask {
    *
    * @param folder PSLocator
    * @param level int
-   * @return boolean * @throws FatalTaskException
+   * @return boolean * @throws FatalTaskException if an error occurs
    * @throws PSParameterMismatchException * @throws PSAuthorizationException * @throws
    *     PSExtensionException * @throws PSErrorException * @throws PSCmsException * @throws
-   *     PSNotFoundException * @throws PSExtensionProcessingException * @throws PSErrorsException
-   *     * @throws PSRequestValidationException
+   *     PSNotFoundException * @throws PSExtensionProcessingException * @throws PSErrorsException if an error occurs
+   *     * @throws PSRequestValidationException if an error occurs
    */
   private boolean trasitionFolderItems(PSLocator folder, int level) throws FatalTaskException {
     boolean containsItems = false;
@@ -901,14 +910,16 @@ public class TrashTask implements IPSTask {
    *
    * @param arg0 IPSExtensionDef
    * @param arg1 File
-   * @throws PSExtensionException
+   * @throws PSExtensionException if an error occurs
    * @see com.percussion.extension.IPSExtension#init(IPSExtensionDef, File)
    */
   public void init(IPSExtensionDef arg0, File arg1) throws PSExtensionException {
     // TODO Auto-generated method stub
   }
 
-  /** */
+  /**
+   * Exception that aborts the trash task when a non-recoverable error occurs.
+   */
   public class FatalTaskException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/HashCodeFieldTransform.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/HashCodeFieldTransform.java
@@ -43,11 +43,26 @@ import org.apache.logging.log4j.Logger;
  * @author natechadwick
  */
 public class HashCodeFieldTransform extends PSDefaultExtension implements IPSFieldInputTransformer {
+  /**
+   * Creates a new HashCodeFieldTransform.
+   */
+  public HashCodeFieldTransform() {
+    // default
+  }
+
 
   private static final Logger log = LogManager.getLogger(HashCodeFieldTransform.class);
 
   private IPSExtensionDef extDef = null;
 
+  /**
+   * processUdf operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @return the result
+   * @throws PSConversionException if an error occurs
+   */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {
 
@@ -56,6 +71,13 @@ public class HashCodeFieldTransform extends PSDefaultExtension implements IPSFie
     return helper.getParameter("source").hashCode();
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   */
   @Override
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     super.init(def, codeRoot);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSOCopyParameter.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSOCopyParameter.java
@@ -47,11 +47,24 @@ public class PSOCopyParameter implements IPSItemInputTransformer, IPSRequestPreP
 
   private static final Logger log = LogManager.getLogger(PSOCopyParameter.class);
 
+  /**
+   * Creates a new PSOCopyParameter.
+   */
   public PSOCopyParameter() {
     // nothing to do
   }
 
   // see IPSRequestPreProcessor
+  /**
+   * preProcessRequest operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @throws PSAuthorizationException if an error occurs
+   * @throws PSRequestValidationException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,
@@ -146,6 +159,13 @@ public class PSOCopyParameter implements IPSItemInputTransformer, IPSRequestPreP
   }
 
   // see IPSRequestPreProcessor
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     // nothing to do
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSODateAdjust.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSODateAdjust.java
@@ -41,12 +41,25 @@ import org.apache.logging.log4j.Logger;
  * @author davidbenua
  */
 public class PSODateAdjust extends PSDefaultExtension implements IPSFieldInputTransformer {
+  /**
+   * Creates a new PSODateAdjust.
+   */
+  public PSODateAdjust() {
+    // default
+  }
+
   private static final Logger log = LogManager.getLogger(PSODateAdjust.class);
   private IPSExtensionDef extDef = null;
 
   /**
+   * processUdf operation.
+   *
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[],
    *     com.percussion.server.IPSRequestContext)
+   * @param params the params
+   * @param request the request
+   * @return the result
+   * @throws PSConversionException if an error occurs
    */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {
@@ -81,16 +94,29 @@ public class PSODateAdjust extends PSDefaultExtension implements IPSFieldInputTr
     return new Timestamp(cal.getTime().getTime());
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param ifile the ifile
+   * @throws PSExtensionException if an error occurs
+   */
   @Override
   public void init(IPSExtensionDef def, File ifile) throws PSExtensionException {
     super.init(def, ifile);
     extDef = def;
   }
 
+  /** years. */
   public static final String YEARS = "years";
+  /** months. */
   public static final String MONTHS = "months";
+  /** days. */
   public static final String DAYS = "days";
+  /** hours. */
   public static final String HOURS = "hours";
+  /** minutes. */
   public static final String MINUTES = "minutes";
+  /** seconds. */
   public static final String SECONDS = "seconds";
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSOSetFieldOnSlottedItemTransform.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSOSetFieldOnSlottedItemTransform.java
@@ -57,6 +57,13 @@ public class PSOSetFieldOnSlottedItemTransform
     implements IPSItemInputTransformer,
         IPSRequestPreProcessor,
         com.percussion.extension.IPSResultDocumentProcessor {
+  /**
+   * Creates a new PSOSetFieldOnSlottedItemTransform.
+   */
+  public PSOSetFieldOnSlottedItemTransform() {
+    // default
+  }
+
 
   private static final Logger log = LogManager.getLogger(PSOSetFieldOnSlottedItemTransform.class);
   private IPSGuidManager mGmgr;
@@ -70,14 +77,19 @@ public class PSOSetFieldOnSlottedItemTransform
    */
   private class ConfiguredParams {
 
+    /** field name. */
     protected String fieldName;
+    /** value if empty. */
     protected String valueIfEmpty;
+    /** value if not empty. */
     protected String valueIfNotEmpty;
+    /** slot name. */
     protected String slotName;
 
     /***
      * Constructor to initialize a new parameter object
-     * @param params
+     * @param params the params
+     * @return the result
      */
     protected ConfiguredParams(Object[] params) {
 
@@ -123,6 +135,16 @@ public class PSOSetFieldOnSlottedItemTransform
     }
   }
 
+  /**
+   * preProcessRequest operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @throws PSAuthorizationException if an error occurs
+   * @throws PSRequestValidationException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,
@@ -225,15 +247,37 @@ public class PSOSetFieldOnSlottedItemTransform
     return mCws;
   }
 
+  /**
+   * init operation.
+   *
+   * @param arg0 the arg0
+   * @param arg1 the arg1
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef arg0, File arg1) throws PSExtensionException {
     log.info("Extension Initialized.");
   }
 
+  /**
+   * canModifyStyleSheet operation.
+   *
+   * @return the result
+   */
   public boolean canModifyStyleSheet() {
     // TODO Auto-generated method stub
     return false;
   }
 
+  /**
+   * processResultDocument operation.
+   *
+   * @param arg0 the arg0
+   * @param arg1 the arg1
+   * @param arg2 the arg2
+   * @return the result
+   * @throws PSParameterMismatchException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public Document processResultDocument(Object[] arg0, IPSRequestContext arg1, Document arg2)
       throws PSParameterMismatchException, PSExtensionProcessingException {
     // TODO Auto-generated method stub

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSOThumbnailGenerator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/transform/PSOThumbnailGenerator.java
@@ -62,6 +62,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Node;
 
+/**
+ * PSOThumbnailGenerator class.
+ */
 public class PSOThumbnailGenerator extends PSFileInfo
     implements IPSItemInputTransformer, IPSRequestPreProcessor {
 
@@ -86,6 +89,9 @@ public class PSOThumbnailGenerator extends PSFileInfo
 
   private float compression = 0.85f;
 
+  /**
+   * Creates a new PSOThumbnailGenerator.
+   */
   public PSOThumbnailGenerator() {}
 
   /**
@@ -113,10 +119,10 @@ public class PSOThumbnailGenerator extends PSFileInfo
    *
    * @param params - parameters
    * @param request - IPSRequestContext
-   * @throws PSAuthorizationException
-   * @throws PSRequestValidationException
-   * @throws PSParameterMismatchException
-   * @throws PSExtensionProcessingException
+   * @throws PSAuthorizationException if an error occurs
+   * @throws PSRequestValidationException if an error occurs
+   * @throws PSParameterMismatchException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
    */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
@@ -280,6 +286,7 @@ public class PSOThumbnailGenerator extends PSFileInfo
    * @param width the desired width of the thumbnail.
    * @param height the desired height of the thumbnail.
    * @return the thumbnail as a file. Will be <code>null</code> if any errors occur.
+   * @param useOriginalType the use original type
    */
   public PSPurgableTempFile makeThumbFile(
       InputStream imageStream,
@@ -327,6 +334,10 @@ public class PSOThumbnailGenerator extends PSFileInfo
    *     JPEG.
    * @param instream the source image as a byte stream.
    * @param maxDim The width and height of the thumbnail must be maxDim pixels or less.
+   * @param width the width
+   * @param height the height
+   * @param useOriginalType the use original type
+   * @throws IOException if an error occurs
    */
   protected void createThumbnail(
       OutputStream outstream,
@@ -557,8 +568,13 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * init operation.
+   *
    * @see com.percussion.extension.PSDefaultExtension#init(com.percussion.extension.IPSExtensionDef,
    *     java.io.File)
+   * @param extDef the ext def
+   * @param initFile the init file
+   * @throws PSExtensionException if an error occurs
    */
   @Override
   public void init(IPSExtensionDef extDef, File initFile) throws PSExtensionException {
@@ -588,6 +604,14 @@ public class PSOThumbnailGenerator extends PSFileInfo
     }
   }
 
+  /**
+   * createBufferedImage operation.
+   *
+   * @param width the width
+   * @param height the height
+   * @param baseImage the base image
+   * @return the result
+   */
   protected BufferedImage createBufferedImage(int width, int height, BufferedImage baseImage) {
     boolean transparency = isTransparent(baseImage);
     log.debug("image transparency is " + transparency);
@@ -607,6 +631,12 @@ public class PSOThumbnailGenerator extends PSFileInfo
     return outImage;
   }
 
+  /**
+   * Returns the graphics.
+   *
+   * @param image the image
+   * @return the result
+   */
   protected Graphics2D getGraphics(BufferedImage image) {
     Graphics2D g2d = image.createGraphics();
     g2d.setRenderingHint(
@@ -626,6 +656,15 @@ public class PSOThumbnailGenerator extends PSFileInfo
     return g2d;
   }
 
+  /**
+   * Returns the transparent metadata.
+   *
+   * @param image the image
+   * @param riter the riter
+   * @param riteParam the rite param
+   * @return the result
+   * @throws IIOInvalidTreeException if an error occurs
+   */
   protected IIOMetadata getTransparentMetadata(
       BufferedImage image, ImageWriter riter, ImageWriteParam riteParam)
       throws IIOInvalidTreeException {
@@ -647,6 +686,11 @@ public class PSOThumbnailGenerator extends PSFileInfo
     return metadata;
   }
 
+  /**
+   * logXml operation.
+   *
+   * @param node the node
+   */
   protected void logXml(Node node) {
     if (!log.isDebugEnabled()) return;
 
@@ -654,6 +698,12 @@ public class PSOThumbnailGenerator extends PSFileInfo
     log.debug(xstr);
   }
 
+  /**
+   * Returns whether transparent.
+   *
+   * @param image the image
+   * @return the result
+   */
   protected boolean isTransparent(BufferedImage image) {
     if (image.getTransparency() == Transparency.OPAQUE) {
       return false;
@@ -694,6 +744,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Returns the step factor.
+   *
    * @return the stepFactor
    */
   public int getStepFactor() {
@@ -701,6 +753,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Sets the step factor.
+   *
    * @param stepFactor the stepFactor to set
    */
   public void setStepFactor(int stepFactor) {
@@ -708,6 +762,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Returns the max interpolation size.
+   *
    * @return the maxInterpolationSize
    */
   public int getMaxInterpolationSize() {
@@ -715,6 +771,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Sets the max interpolation size.
+   *
    * @param maxInterpolationSize the maxInterpolationSize to set
    */
   public void setMaxInterpolationSize(int maxInterpolationSize) {
@@ -722,6 +780,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Returns the image format.
+   *
    * @return the imageFormat
    */
   public String getImageFormat() {
@@ -729,6 +789,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Sets the image format.
+   *
    * @param imageFormat the imageFormat to set
    */
   public void setImageFormat(String imageFormat) {
@@ -736,6 +798,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Returns the compression.
+   *
    * @return the compression
    */
   public float getCompression() {
@@ -743,6 +807,8 @@ public class PSOThumbnailGenerator extends PSFileInfo
   }
 
   /**
+   * Sets the compression.
+   *
    * @param compression the compression to set
    */
   public void setCompression(float compression) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/transformers/PSOHashCodeTransformer.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/transformers/PSOHashCodeTransformer.java
@@ -27,11 +27,29 @@ import java.io.File;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSOHashCodeTransformer class.
+ */
 public class PSOHashCodeTransformer extends PSDefaultExtension implements IPSFieldInputTransformer {
+  /**
+   * Creates a new PSOHashCodeTransformer.
+   */
+  public PSOHashCodeTransformer() {
+    // default
+  }
+
   private static final Logger log = LogManager.getLogger(PSOHashCodeTransformer.class);
 
   private IPSExtensionDef extDef = null;
 
+  /**
+   * processUdf operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @return the result
+   * @throws PSConversionException if an error occurs
+   */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {
 
@@ -40,6 +58,13 @@ public class PSOHashCodeTransformer extends PSDefaultExtension implements IPSFie
     return helper.getParameter("source").hashCode();
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   */
   @Override
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     super.init(def, codeRoot);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/AbstractTemplateExpander.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/AbstractTemplateExpander.java
@@ -66,6 +66,13 @@ import org.apache.logging.log4j.Logger;
 public abstract class AbstractTemplateExpander implements IPSTemplateExpander {
   private static final Logger log = LogManager.getLogger(AbstractTemplateExpander.class);
 
+  /**
+   * Creates a template expander with default settings.
+   */
+  protected AbstractTemplateExpander() {
+    // default
+  }
+
   private boolean NeedsContentNode = false;
 
   private static IPSGuidManager gmgr = null;
@@ -81,14 +88,26 @@ public abstract class AbstractTemplateExpander implements IPSTemplateExpander {
   }
 
   /**
+   * init operation.
+   *
    * @see com.percussion.extension.IPSExtension#init(com.percussion.extension.IPSExtensionDef,
    *     java.io.File)
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
    */
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {}
 
   /**
+   * expand operation.
+   *
    * @see com.percussion.services.publisher.IPSTemplateExpander#expand(javax.jcr.query.QueryResult,
    *     java.util.Map, java.util.Map)
+   * @param results the results
+   * @param parameters the parameters
+   * @param summaryMap the summary map
+   * @return the result
+   * @throws PSPublisherException if an error occurs
    */
   public List<PSContentListItem> expand(
       QueryResult results,
@@ -223,7 +242,7 @@ public abstract class AbstractTemplateExpander implements IPSTemplateExpander {
    * @param summaryMap the map of component summaries. Never <code>null</code>. This map is
    *     guaranteed to contain all items referenced in the query result.
    * @return the map of Nodes.
-   * @throws RepositoryException
+   * @throws RepositoryException if content nodes cannot be loaded
    */
   protected Map<IPSGuid, Node> buildNodeMap(
       QueryResult result, Map<Integer, PSComponentSummary> summaryMap) throws RepositoryException {
@@ -263,28 +282,36 @@ public abstract class AbstractTemplateExpander implements IPSTemplateExpander {
   }
 
   /**
-   * @return the needsContentNode
+   * Returns whether content nodes must be loaded for template selection.
+   *
+   * @return {@code true} if content nodes are required
    */
   protected boolean isNeedsContentNode() {
     return NeedsContentNode;
   }
 
   /**
-   * @param needsContentNode the needsContentNode to set
+   * Sets whether content nodes must be loaded for template selection.
+   *
+   * @param needsContentNode {@code true} if content nodes are required
    */
   protected void setNeedsContentNode(boolean needsContentNode) {
     NeedsContentNode = needsContentNode;
   }
 
   /**
-   * @param gmgr the gmgr to set
+   * Sets the GUID manager. Used for unit testing.
+   *
+   * @param gmgr the GUID manager to set
    */
   public static void setGmgr(IPSGuidManager gmgr) {
     AbstractTemplateExpander.gmgr = gmgr;
   }
 
   /**
-   * @param cmgr the cmgr to set
+   * Sets the content manager. Used for unit testing.
+   *
+   * @param cmgr the content manager to set
    */
   public static void setCmgr(IPSContentMgr cmgr) {
     AbstractTemplateExpander.cmgr = cmgr;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/FileItemDataSource.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/FileItemDataSource.java
@@ -48,6 +48,7 @@ public class FileItemDataSource implements DataSource {
    *
    * @return the stream
    * @see jakarta.activation.DataSource#getInputStream()
+   * @throws IOException if an error occurs
    */
   public InputStream getInputStream() throws IOException {
     return item.getInputStream();
@@ -58,6 +59,7 @@ public class FileItemDataSource implements DataSource {
    *
    * @return the stream.
    * @see jakarta.activation.DataSource#getOutputStream()
+   * @throws IOException if an error occurs
    */
   public OutputStream getOutputStream() throws IOException {
     return item.getOutputStream();
@@ -80,6 +82,11 @@ public class FileItemDataSource implements DataSource {
    * @see jakarta.activation.DataSource#getName()
    */
   // TODO: Remove me @SuppressFBWarnings("FILE_UPLOAD_FILENAME")
+  /**
+   * Returns the name.
+   *
+   * @return the result
+   */
   public String getName() {
     return item.getName();
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/HTTPProxyClientConfig.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/HTTPProxyClientConfig.java
@@ -45,18 +45,38 @@ public class HTTPProxyClientConfig {
   private String proxyServer;
   private String proxyPort;
 
+  /**
+   * Sets the proxy server.
+   *
+   * @param proxyServer the proxy server
+   */
   public void setProxyServer(String proxyServer) {
     this.proxyServer = proxyServer;
   }
 
+  /**
+   * Returns the proxy server.
+   *
+   * @return the result
+   */
   public String getProxyServer() {
     return proxyServer;
   }
 
+  /**
+   * Sets the proxy port.
+   *
+   * @param proxyPort the proxy port
+   */
   public void setProxyPort(String proxyPort) {
     this.proxyPort = proxyPort;
   }
 
+  /**
+   * Returns the proxy port.
+   *
+   * @return the result
+   */
   public String getProxyPort() {
     return proxyPort;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/IPSOItemSummaryFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/IPSOItemSummaryFinder.java
@@ -22,13 +22,45 @@ import com.percussion.error.PSException;
 import com.percussion.utils.guid.IPSGuid;
 
 // REFACTORED: CP-JAVA11
+/**
+ * IPSOItemSummaryFinder interface.
+ */
 public interface IPSOItemSummaryFinder {
+  /**
+   * Returns the current or edit locator.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSLocator getCurrentOrEditLocator(IPSGuid guid) throws PSException;
 
+  /**
+   * Returns the current or edit locator.
+   *
+   * @param contentId the content id
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSLocator getCurrentOrEditLocator(String contentId) throws PSException;
 
+  /**
+   * Returns the current or edit locator.
+   *
+   * @param id the id
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSLocator getCurrentOrEditLocator(int id) throws PSException;
 
+  /**
+   * Returns the checkout status.
+   *
+   * @param contentId the content id
+   * @param userName the user name
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public int getCheckoutStatus(String contentId, String userName) throws PSException;
 
   /**
@@ -40,7 +72,21 @@ public interface IPSOItemSummaryFinder {
    */
   public PSComponentSummary getSummary(String contentId) throws PSException;
 
+  /**
+   * Returns the summary.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSComponentSummary getSummary(IPSGuid guid) throws PSException;
 
+  /**
+   * Returns the summary.
+   *
+   * @param id the id
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public PSComponentSummary getSummary(int id) throws PSException;
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/MultipartFileDataSource.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/MultipartFileDataSource.java
@@ -47,6 +47,8 @@ public class MultipartFileDataSource implements DataSource {
 
   /*
    * @see jakarta.activation.DataSource#getInputStream()
+   * @return the result
+   * @throws IOException if an error occurs
    */
   public InputStream getInputStream() throws IOException {
     return file.getInputStream();
@@ -54,6 +56,8 @@ public class MultipartFileDataSource implements DataSource {
 
   /*
    * @see jakarta.activation.DataSource#getOutputStream()
+   * @return the result
+   * @throws IOException if an error occurs
    */
   public OutputStream getOutputStream() throws IOException {
     throw new IOException("OutputStreams not supported");
@@ -61,6 +65,7 @@ public class MultipartFileDataSource implements DataSource {
 
   /*
    * @see jakarta.activation.DataSource#getContentType()
+   * @return the result
    */
   public String getContentType() {
     return file.getContentType();
@@ -68,6 +73,7 @@ public class MultipartFileDataSource implements DataSource {
 
   /*
    * @see jakarta.activation.DataSource#getName()
+   * @return the result
    */
   public String getName() {
     return file.getName();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/MutableHttpServletRequestWrapper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/MutableHttpServletRequestWrapper.java
@@ -109,7 +109,10 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.ServletRequestWrapper#getParameter(java.lang.String)
+   * @param name the name
+   * @return the result
    */
   @Override
   public String getParameter(String name) {
@@ -121,7 +124,9 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.ServletRequestWrapper#getParameterMap()
+   * @return the result
    */
   @Override
   public Map<String, String[]> getParameterMap() {
@@ -129,7 +134,9 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.ServletRequestWrapper#getParameterNames()
+   * @return the result
    */
   @Override
   public Enumeration<String> getParameterNames() {
@@ -137,7 +144,10 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.ServletRequestWrapper#getParameterValues(java.lang.String)
+   * @param name the name
+   * @return the result
    */
   @Override
   public String[] getParameterValues(String name) {
@@ -145,7 +155,10 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.http.HttpServletRequestWrapper#getHeader(java.lang.String)
+   * @param name the name
+   * @return the result
    */
   @Override
   public String getHeader(String name) {
@@ -162,7 +175,9 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.http.HttpServletRequestWrapper#getHeaderNames()
+   * @return the result
    */
   @Override
   public Enumeration<String> getHeaderNames() {
@@ -180,7 +195,10 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.http.HttpServletRequestWrapper#getHeaders(java.lang.String)
+   * @param name the name
+   * @return the result
    */
   @Override
   public Enumeration<String> getHeaders(String name) {
@@ -194,7 +212,10 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.http.HttpServletRequestWrapper#getIntHeader(java.lang.String)
+   * @param name the name
+   * @return the result
    */
   @Override
   public int getIntHeader(String name) {
@@ -208,7 +229,10 @@ public class MutableHttpServletRequestWrapper extends HttpServletRequestWrapper
   }
 
   /**
+   * See referenced member.
    * @see jakarta.servlet.http.HttpServletRequestWrapper#getDateHeader(java.lang.String)
+   * @param name the name
+   * @return the result
    */
   @Override
   public long getDateHeader(String name) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOEmailUtils.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOEmailUtils.java
@@ -33,7 +33,17 @@ import javax.mail.internet.MimeMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSOEmailUtils class.
+ */
 public class PSOEmailUtils {
+  /**
+   * Creates a new PSOEmailUtils.
+   */
+  public PSOEmailUtils() {
+    // default
+  }
+
 
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOEmailUtils.class);
@@ -41,9 +51,9 @@ public class PSOEmailUtils {
   /***
    * Takes a comma seperated list of email addresses and returns a list of
    * Address instances.
-   * @param list
+   * @param list the list
    *
-   * @throws AddressException
+   * @throws AddressException if an error occurs
    */
   private static List<InternetAddress> splitEmailAddresses(final String list)
       throws AddressException {
@@ -67,14 +77,24 @@ public class PSOEmailUtils {
    * Sends an email using the specified parameters and the SMTP configuration
    * defined in the system /Workflow/rxworkflow.properties file,(the default) or some oether properties file
    *
-   * @param from_line
-   * @param to_line
-   * @param cc_line
-   * @param bcc_line
-   * @param subject
-   * @param body
+   * @param from_line the from line
+   * @param to_line the to line
+   * @param cc_line the cc line
+   * @param bcc_line the bcc line
+   * @param subject the subject
+   * @param body the body
    */
   // TODO: Remove me @SuppressFBWarnings("PATH_TRAVERSAL_IN")
+  /**
+   * sendEmail operation.
+   *
+   * @param from_line the from line
+   * @param to_line the to line
+   * @param cc_line the cc line
+   * @param bcc_line the bcc line
+   * @param subject the subject
+   * @param body the body
+   */
   public static void sendEmail(
       String from_line,
       String to_line,

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOExtensionParamsHelper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOExtensionParamsHelper.java
@@ -120,7 +120,7 @@ public class PSOExtensionParamsHelper {
    * Gets a parameter by first trying to get it from the request then followed by the parameters
    * passed to the extension.
    *
-   * @param paramName
+   * @param paramName the param name
    * @return The value of the parameter, or null if the parameter is not found.
    */
   public String getParameter(String paramName) {
@@ -171,10 +171,22 @@ public class PSOExtensionParamsHelper {
     return null;
   }
 
+  /**
+   * Returns the required parameter as number.
+   *
+   * @param paramName the param name
+   * @return the result
+   */
   public Number getRequiredParameterAsNumber(String paramName) {
     return paramToNumber(paramName, getRequiredParameter(paramName));
   }
 
+  /**
+   * Returns the required parameter as boolean.
+   *
+   * @param paramName the param name
+   * @return the result
+   */
   public Boolean getRequiredParameterAsBoolean(String paramName) {
     return paramToBoolean(paramName, getRequiredParameter(paramName));
   }
@@ -184,7 +196,7 @@ public class PSOExtensionParamsHelper {
    *
    * @param paramName Name of the parameter.
    * @return value of the parameter never null or empty.
-   * @throws IllegalArgumentException
+   * @throws IllegalArgumentException if an error occurs
    */
   public String getRequiredParameter(String paramName) {
     String value = getParameter(paramName);
@@ -196,10 +208,24 @@ public class PSOExtensionParamsHelper {
     return value;
   }
 
+  /**
+   * Returns the optional parameter as number.
+   *
+   * @param paramName the param name
+   * @param defaultValue the default value
+   * @return the result
+   */
   public Number getOptionalParameterAsNumber(String paramName, String defaultValue) {
     return paramToNumber(paramName, getOptionalParameter(paramName, defaultValue));
   }
 
+  /**
+   * Returns the optional parameter as boolean.
+   *
+   * @param paramName the param name
+   * @param defaultValue the default value
+   * @return the result
+   */
   public Boolean getOptionalParameterAsBoolean(String paramName, Boolean defaultValue) {
     String b = (defaultValue.booleanValue()) ? "true" : "false";
     return paramToBoolean(paramName, getOptionalParameter(paramName, b));
@@ -221,12 +247,25 @@ public class PSOExtensionParamsHelper {
     return value;
   }
 
+  /**
+   * errorOnParameter operation.
+   *
+   * @param paramName the param name
+   * @param reason the reason
+   */
   public void errorOnParameter(String paramName, String reason) {
     String error = "Parameter: " + paramName + " is invalid." + " Reason: " + reason;
     log.error(error);
     throw new IllegalArgumentException(error);
   }
 
+  /**
+   * paramToNumber operation.
+   *
+   * @param paramName the param name
+   * @param param the param
+   * @return the result
+   */
   public Number paramToNumber(String paramName, String param) {
     try {
       return NumberUtils.createNumber(param);
@@ -237,6 +276,13 @@ public class PSOExtensionParamsHelper {
     }
   }
 
+  /**
+   * paramToBoolean operation.
+   *
+   * @param paramName the param name
+   * @param param the param
+   * @return the result
+   */
   public Boolean paramToBoolean(String paramName, String param) {
     Converter cvt = new BooleanConverter();
     try {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOItemFolderUtilities.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOItemFolderUtilities.java
@@ -54,12 +54,28 @@ public class PSOItemFolderUtilities {
     return Arrays.asList(ret);
   }
 
+  /**
+   * Returns the folder path.
+   *
+   * @param id the id
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   * @throws PSNotFoundException if an error occurs
+   */
   public static String getFolderPath(int id) throws PSCmsException, PSNotFoundException {
     PSServerFolderProcessor folderproc = PSServerFolderProcessor.getInstance();
     String[] ret = folderproc.getItemPaths(new PSLocator(id, -1));
     return (ret.length > 0) ? ret[0] : null;
   }
 
+  /**
+   * Returns the parent folder id.
+   *
+   * @param itemId the item id
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   * @throws PSNotFoundException if an error occurs
+   */
   public static int getParentFolderId(int itemId) throws PSCmsException, PSNotFoundException {
     PSServerFolderProcessor folderproc = PSServerFolderProcessor.getInstance();
     return folderproc.getIdByPath(getFolderPath(itemId));
@@ -70,7 +86,9 @@ public class PSOItemFolderUtilities {
    *
    * @param id The Content ID of the item
    *
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
+   * @return the result
+   * @throws PSNotFoundException if an error occurs
    */
   public static String getItemFolderPath(int id) throws PSCmsException, PSNotFoundException {
     PSServerFolderProcessor folderproc = PSServerFolderProcessor.getInstance();
@@ -83,6 +101,14 @@ public class PSOItemFolderUtilities {
     return (ret.length > 0) ? ret[0] : null;
   }
 
+  /**
+   * Returns the item parent folder id.
+   *
+   * @param itemId the item id
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   * @throws PSNotFoundException if an error occurs
+   */
   public static int getItemParentFolderId(int itemId) throws PSCmsException, PSNotFoundException {
     PSServerFolderProcessor folderproc = PSServerFolderProcessor.getInstance();
     return folderproc.getIdByPath(getItemFolderPath(itemId));

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOItemSummaryFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOItemSummaryFinder.java
@@ -32,6 +32,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * PSOItemSummaryFinder class.
+ */
 public class PSOItemSummaryFinder {
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOItemSummaryFinder.class);
@@ -47,11 +50,25 @@ public class PSOItemSummaryFinder {
     }
   }
 
+  /**
+   * Returns the current or edit locator.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public static PSLocator getCurrentOrEditLocator(IPSGuid guid) throws PSException {
     int id = guid.getUUID();
     return getCurrentOrEditLocator(id);
   }
 
+  /**
+   * Returns the current or edit locator.
+   *
+   * @param contentId the content id
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public static PSLocator getCurrentOrEditLocator(String contentId) throws PSException {
     if (StringUtils.isBlank(contentId) || !StringUtils.isNumeric(contentId)) {
       String emsg = "Content id must be numeric " + contentId;
@@ -62,6 +79,13 @@ public class PSOItemSummaryFinder {
     return getCurrentOrEditLocator(id);
   }
 
+  /**
+   * Returns the current or edit locator.
+   *
+   * @param id the id
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public static PSLocator getCurrentOrEditLocator(int id) throws PSException {
     PSComponentSummary cs = getSummary(id);
     PSLocator loc = cs.getCurrentLocator();
@@ -72,10 +96,21 @@ public class PSOItemSummaryFinder {
     return loc;
   }
 
+  /** checkout none. */
   public static final int CHECKOUT_NONE = 1;
+  /** checkout by me. */
   public static final int CHECKOUT_BY_ME = 2;
+  /** checkout by other. */
   public static final int CHECKOUT_BY_OTHER = 3;
 
+  /**
+   * Returns the checkout status.
+   *
+   * @param contentId the content id
+   * @param userName the user name
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public static int getCheckoutStatus(String contentId, String userName) throws PSException {
     if (StringUtils.isBlank(userName)) {
       String emsg = "User name must not be blank";
@@ -98,7 +133,7 @@ public class PSOItemSummaryFinder {
    *
    * @param contentId the content id
    * @return the component summary. Never <code>null</code>
-   * @throws PSException
+   * @throws PSException if an error occurs
    */
   public static PSComponentSummary getSummary(String contentId) throws PSException {
     if (StringUtils.isBlank(contentId) || !StringUtils.isNumeric(contentId)) {
@@ -110,11 +145,25 @@ public class PSOItemSummaryFinder {
     return getSummary(id);
   }
 
+  /**
+   * Returns the summary.
+   *
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public static PSComponentSummary getSummary(IPSGuid guid) throws PSException {
     int id = guid.getUUID();
     return getSummary(id);
   }
 
+  /**
+   * Returns the summary.
+   *
+   * @param id the id
+   * @return the result
+   * @throws PSException if an error occurs
+   */
   public static PSComponentSummary getSummary(int id) throws PSException {
     initServices();
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOItemSummaryFinderWrapper.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOItemSummaryFinderWrapper.java
@@ -34,60 +34,99 @@ import com.percussion.utils.guid.IPSGuid;
  * @author DavidBenua
  */
 public class PSOItemSummaryFinderWrapper implements IPSOItemSummaryFinder {
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSOItemSummaryFinderWrapper.
+   *
+   */
   public PSOItemSummaryFinderWrapper() {}
 
   /**
+   * Returns the current or edit locator.
+   *
    * @see
    *     com.percussion.pso.utils.IPSOItemSummaryFinder#getCurrentOrEditLocator(com.percussion.utils.guid.IPSGuid)
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSLocator getCurrentOrEditLocator(IPSGuid guid) throws PSException {
     return PSOItemSummaryFinder.getCurrentOrEditLocator(guid);
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.utils.IPSOItemSummaryFinder#getCurrentOrEditLocator(java.lang.String)
+   * @param contentId the content id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSLocator getCurrentOrEditLocator(String contentId) throws PSException {
     return PSOItemSummaryFinder.getCurrentOrEditLocator(contentId);
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.utils.IPSOItemSummaryFinder#getCurrentOrEditLocator(int)
+   * @param id the id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSLocator getCurrentOrEditLocator(int id) throws PSException {
     return PSOItemSummaryFinder.getCurrentOrEditLocator(id);
   }
 
+  /** checkout none. */
   public static final int CHECKOUT_NONE = 1;
+  /** checkout by me. */
   public static final int CHECKOUT_BY_ME = 2;
+  /** checkout by other. */
   public static final int CHECKOUT_BY_OTHER = 3;
 
   /**
+   * Returns the checkout status.
+   *
    * @see com.percussion.pso.utils.IPSOItemSummaryFinder#getCheckoutStatus(java.lang.String,
    *     java.lang.String)
+   * @param contentId the content id
+   * @param userName the user name
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public int getCheckoutStatus(String contentId, String userName) throws PSException {
     return PSOItemSummaryFinder.getCheckoutStatus(contentId, userName);
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.utils.IPSOItemSummaryFinder#getSummary(java.lang.String)
+   * @param contentId the content id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSComponentSummary getSummary(String contentId) throws PSException {
     return PSOItemSummaryFinder.getSummary(contentId);
   }
 
   /**
+   * Returns the summary.
+   *
    * @see
    *     com.percussion.pso.utils.IPSOItemSummaryFinder#getSummary(com.percussion.utils.guid.IPSGuid)
+   * @param guid the guid
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSComponentSummary getSummary(IPSGuid guid) throws PSException {
     return PSOItemSummaryFinder.getSummary(guid);
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.utils.IPSOItemSummaryFinder#getSummary(int)
+   * @param id the id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSComponentSummary getSummary(int id) throws PSException {
     return PSOItemSummaryFinder.getSummary(id);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOMutableUrl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOMutableUrl.java
@@ -34,8 +34,13 @@ public class PSOMutableUrl {
   private String m_base = null;
   Map<String, Object> m_param = new HashMap<String, Object>();
 
-  /** */
-  public PSOMutableUrl(String Url) throws PSRequestParsingException {
+    /**
+     * Creates a new PSOMutableUrl.
+     *
+     * @param Url the url
+     * @throws PSRequestParsingException if an error occurs
+     */
+    public PSOMutableUrl(String Url) throws PSRequestParsingException {
     int sepPos = Url.indexOf(QUERY_SEP);
     String queryString = "";
     if (sepPos < 0) {
@@ -51,6 +56,7 @@ public class PSOMutableUrl {
   }
 
   /**
+   * Returns Returns the m_base..
    * @return Returns the m_base.
    */
   public String getBase() {
@@ -58,20 +64,38 @@ public class PSOMutableUrl {
   }
 
   /**
+   * Sets the base.
    * @param base The base to set.
    */
   public void setBase(String base) {
     this.m_base = base;
   }
 
+  /**
+   * Sets the param.
+   *
+   * @param pName the p name
+   * @param pValue the p value
+   */
   public void setParam(String pName, String pValue) {
     this.m_param.put(pName, pValue);
   }
 
+  /**
+   * Sets the param list.
+   *
+   * @param newParams the new params
+   */
   public void setParamList(Map<String, Object> newParams) {
     this.m_param.putAll(newParams);
   }
 
+  /**
+   * Returns the param.
+   *
+   * @param pName the p name
+   * @return the result
+   */
   public String getParam(String pName) {
     Object obj = this.m_param.get(pName);
     if (obj == null) {
@@ -80,14 +104,29 @@ public class PSOMutableUrl {
     return obj.toString();
   }
 
+  /**
+   * dropParam operation.
+   *
+   * @param pName the p name
+   */
   public void dropParam(String pName) {
     this.m_param.remove(pName);
   }
 
+  /**
+   * Returns the param map.
+   *
+   * @return the result
+   */
   public Map<String, Object> getParamMap() {
     return m_param;
   }
 
+  /**
+   * toString operation.
+   *
+   * @return the result
+   */
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(m_base);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSONodeCataloger.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSONodeCataloger.java
@@ -48,7 +48,11 @@ public class PSONodeCataloger {
 
   private IPSContentMgr cmgr = null;
 
-  /** Sole constructor. */
+  /**
+   * Sole constructor.
+   * Creates a new PSONodeCataloger.
+   *
+   */
   public PSONodeCataloger() {}
 
   /** Initialize service pointers. */
@@ -62,7 +66,7 @@ public class PSONodeCataloger {
    * Get Content Type Names
    *
    * @return return the list of content type names defined in the system.
-   * @throws RepositoryException
+   * @throws RepositoryException if an error occurs
    */
   public List<String> getContentTypeNames() throws RepositoryException {
     init();
@@ -114,8 +118,8 @@ public class PSONodeCataloger {
    *
    * @param typeName the type name. If the typename does not begive with "rx:", it will be added.
    * @return the list of field names. Never <code>null</code> but may be <code>empty</code>
-   * @throws NoSuchNodeTypeException
-   * @throws RepositoryException
+   * @throws NoSuchNodeTypeException if an error occurs
+   * @throws RepositoryException if an error occurs
    */
   public List<String> getFieldNamesForContentType(String typeName)
       throws NoSuchNodeTypeException, RepositoryException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOParseUrlQueryString.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOParseUrlQueryString.java
@@ -28,11 +28,19 @@ import java.util.StringTokenizer;
  */
 public class PSOParseUrlQueryString {
   /**
+   * Creates a new PSOParseUrlQueryString.
+   */
+  public PSOParseUrlQueryString() {
+    // default
+  }
+
+  /**
    * Add the request parameters defined in the specified parameter string to the specified hash map.
    *
    * @param paramString the URL query string, may not be <code>null</code>, can be empty.
    * @throws IllegalArgumentException if paramString is <code>null</code>
    * @throws PSRequestParsingException if an error occurs parsing the parameters.
+   * @return the result
    */
   public static Map<String, Object> parseParameters(String paramString)
       throws PSRequestParsingException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSORequestContext.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSORequestContext.java
@@ -63,6 +63,7 @@ public final class PSORequestContext extends PSRequestContext {
    * no home application.
    *
    * @see com.percussion.server.IPSRequestContext#isTraceEnabled()
+   * @return the result
    */
   @Override
   public boolean isTraceEnabled() {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSimpleSqlQuery.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSimpleSqlQuery.java
@@ -59,8 +59,6 @@ import org.apache.logging.log4j.Logger;
  * <p>This class makes no attempt to handle complex datatypes. Longs, CLOBs, Blobs, etc. are not
  * handled.
  *
- * <p>
- *
  * @author DavidBenua
  */
 public class PSOSimpleSqlQuery {
@@ -80,8 +78,8 @@ public class PSOSimpleSqlQuery {
    * @param params a list of Objects that represent the placeholders in the SQL. Never <code>null
    *     </code>. May be <code>empty</code>.
    * @return a List of Object[] representing the rows of the result set.
-   * @throws SQLException
-   * @throws NamingException
+   * @throws SQLException if an error occurs
+   * @throws NamingException if an error occurs
    */
   public static List<Object[]> doQuery(String query, List<? extends Object> params)
       throws SQLException, NamingException {
@@ -119,8 +117,8 @@ public class PSOSimpleSqlQuery {
    *
    * @param ir the internal request.
    * @return a List of Object[] representing the rows of the result set.
-   * @throws PSInternalRequestCallException
-   * @throws SQLException
+   * @throws PSInternalRequestCallException if an error occurs
+   * @throws SQLException if an error occurs
    */
   public static List<Object[]> doQuery(IPSInternalRequest ir)
       throws PSInternalRequestCallException, SQLException {
@@ -155,8 +153,8 @@ public class PSOSimpleSqlQuery {
    * @param params a List of Objects that represent the parameters.
    * @return an Object[] that represents the first row returned from the query. May be <code>null
    *     </code>.
-   * @throws SQLException
-   * @throws NamingException
+   * @throws SQLException if an error occurs
+   * @throws NamingException if an error occurs
    */
   public static Object[] doSingleRowQuery(String query, List<? extends Object> params)
       throws SQLException, NamingException {
@@ -191,8 +189,8 @@ public class PSOSimpleSqlQuery {
    *
    * @param ir the Internal Request.
    * @return an Object[] representing the columns returned by the query. May be <code>null</code>
-   * @throws SQLException
-   * @throws PSInternalRequestCallException
+   * @throws SQLException if an error occurs
+   * @throws PSInternalRequestCallException if an error occurs
    */
   public static Object[] doSingleRowQuery(IPSInternalRequest ir)
       throws SQLException, PSInternalRequestCallException {
@@ -251,7 +249,7 @@ public class PSOSimpleSqlQuery {
    * @param stmt the prepared statement. Must not be <code>null</code>
    * @param params a List of Object suitable for the parameters. Must not be <code>null</code> but
    *     may be <code>empty</code>
-   * @throws SQLException
+   * @throws SQLException if an error occurs
    */
   private static void setInternalParams(PreparedStatement stmt, List<? extends Object> params)
       throws SQLException {
@@ -269,7 +267,7 @@ public class PSOSimpleSqlQuery {
    *
    * @param rs the result set. Must not be <code>null</code>
    * @return the array of objects representing the current row of the result set.
-   * @throws SQLException
+   * @throws SQLException if an error occurs
    */
   private static Object[] buildRowResult(ResultSet rs) throws SQLException {
     ResultSetMetaData meta = rs.getMetaData();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotContents.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotContents.java
@@ -74,7 +74,11 @@ public class PSOSlotContents {
   private static IPSGuidManager gmgr = null;
   private static IPSAssemblyService mAss;
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSOSlotContents.
+   *
+   */
   public PSOSlotContents() {}
 
   /**
@@ -84,7 +88,7 @@ public class PSOSlotContents {
    * @param slot the slot
    * @return all relationships in the given slot for this parent. Never <code>null</code>. May be
    *     <code>empty</code>.
-   * @throws PSErrorException
+   * @throws PSErrorException if an error occurs
    */
   public List<PSAaRelationship> getSlotContents(IPSGuid parentItem, IPSGuid slot)
       throws PSErrorException {
@@ -141,12 +145,18 @@ public class PSOSlotContents {
    * @author DavidBenua
    */
   protected class SlotItemComparator implements Comparator<PSAaRelationship> {
+    /**
+     * Creates a new SlotItemComparator.
+     */
     public SlotItemComparator() {}
 
     /**
      * Compares PSAaRelationships by sort rank.
      *
      * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+     * @param rel1 the rel1
+     * @param rel2 the rel2
+     * @return the result
      */
     public int compare(PSAaRelationship rel1, PSAaRelationship rel2) {
       if (rel1 == null || rel2 == null) {
@@ -166,6 +176,8 @@ public class PSOSlotContents {
      * All SlotItemComparators return the same order.
      *
      * @see java.lang.Object#equals(java.lang.Object)
+     * @param obj the obj
+     * @return the result
      */
     @Override
     public boolean equals(Object obj) {
@@ -177,6 +189,7 @@ public class PSOSlotContents {
 
     /**
      * All instances of this comparator are equal, so all share one hash code.
+     * @return the result
      */
     @Override
     public int hashCode() {
@@ -185,6 +198,7 @@ public class PSOSlotContents {
   }
 
   /**
+   * Sets the cws.
    * @param cws the cws to set. Used for testing.
    */
   public void setCws(IPSContentWs cws) {
@@ -192,6 +206,7 @@ public class PSOSlotContents {
   }
 
   /**
+   * Sets the gmgr.
    * @param gmgr the gmgr to set. Used for testing
    */
   public void setGmgr(IPSGuidManager gmgr) {
@@ -216,6 +231,11 @@ public class PSOSlotContents {
     return ret;
   }
 
+  /**
+   * Returns the assembly service.
+   *
+   * @return the result
+   */
   protected static IPSAssemblyService getAssemblyService() {
     if (mAss == null) {
       mAss = PSAssemblyServiceLocator.getAssemblyService();

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotRelations.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PSOSlotRelations.java
@@ -69,7 +69,7 @@ public class PSOSlotRelations {
    * @param slot the Slot template
    * @param session the Percussion CMS session id.
    * @return a List of PSAaRelations. Never <code>null</code> but may be empty.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   public static List<PSAaRelationship> getSlotRelations(
       IPSGuid owner, IPSTemplateSlot slot, String session) throws PSCmsException {
@@ -88,7 +88,7 @@ public class PSOSlotRelations {
    *
    * @param relations the list of relationships;
    * @param session the Percussion CMS session id. Never <code>null</code>
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   public static void saveSlotRelations(List<PSAaRelationship> relations, String session)
       throws PSCmsException {
@@ -103,7 +103,7 @@ public class PSOSlotRelations {
    *
    * @param relations a list of new relationships to add.
    * @param session the Percussion CMS session id;
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   public static void addSlotRelations(List<PSAaRelationship> relations, String session)
       throws PSCmsException {
@@ -117,7 +117,7 @@ public class PSOSlotRelations {
    *
    * @param relations the relations to remove
    * @param session the Percussion CMS session id.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   public static void removeSlotRelations(List<PSAaRelationship> relations, String session)
       throws PSCmsException {
@@ -133,7 +133,7 @@ public class PSOSlotRelations {
    * @param top if <code>true</code> move the relationships to the top of the slot. Otherwise, they
    *     will be placed at the end of the slot.
    * @param session the Percussion CMS session id.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   public static void reorderSlotRelations(
       List<PSAaRelationship> relations, boolean top, String session) throws PSCmsException {
@@ -148,7 +148,7 @@ public class PSOSlotRelations {
    *
    * @param session the Percussion CMS session id. Never <code>null</code>
    * @return the proxy to use.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   private static PSActiveAssemblyProcessorProxy getProxy(String session) throws PSCmsException {
     PSActiveAssemblyProcessorProxy proxy = null;
@@ -179,7 +179,7 @@ public class PSOSlotRelations {
    *
    * @param relList the relationship list.
    * @return the List of relations, never <code>null</code> but may be <code>empty</code>
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   private static List<PSAaRelationship> fromRelList(PSAaRelationshipList relList)
       throws PSCmsException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PathCleanupUtils.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/PathCleanupUtils.java
@@ -19,8 +19,30 @@ package com.percussion.pso.utils;
 
 import org.apache.commons.lang3.StringUtils;
 
+/**
+ * PathCleanupUtils class.
+ */
 public class PathCleanupUtils {
+  /**
+   * Creates a new PathCleanupUtils.
+   */
+  public PathCleanupUtils() {
+    // default
+  }
 
+
+  /**
+   * cleanupPathPart operation.
+   *
+   * @param path the path
+   * @param forceLower the force lower
+   * @param includesExtension the includes extension
+   * @param stripExtension the strip extension
+   * @param prefix the prefix
+   * @param suffix the suffix
+   * @param forceExtension the force extension
+   * @return the result
+   */
   public static String cleanupPathPart(
       String path,
       boolean forceLower,
@@ -59,6 +81,14 @@ public class PathCleanupUtils {
     return path;
   }
 
+  /**
+   * cleanupPathPart operation.
+   *
+   * @param path the path
+   * @param forceLower the force lower
+   * @param includesExtension the includes extension
+   * @return the result
+   */
   public static String cleanupPathPart(String path, boolean forceLower, boolean includesExtension) {
     return cleanupPathPart(path, forceLower, includesExtension, false, "", "", "");
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/RxItemUtils.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/RxItemUtils.java
@@ -42,6 +42,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Utility methods for working with Rhythmyx content items and fields.
+ *
  * @author DavidBenua
  */
 public class RxItemUtils {
@@ -80,7 +82,7 @@ public class RxItemUtils {
    * @param fieldName the field name
    * @return the value as an <code>Object</code>. Will be <code>null</code> if the field does not
    *     exist or has no values.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   public static Object getFieldValueRaw(IPSItemAccessor item, String fieldName)
       throws PSCmsException {
@@ -163,7 +165,7 @@ public class RxItemUtils {
    * @param fieldName the field name
    * @return the date value. Will be <code>null</code> if the field does not exist, has no values or
    *     is not a date.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs
    */
   public static Date getFieldDate(IPSItemAccessor item, String fieldName) throws PSCmsException {
     PSItemField fld = item.getFieldByName(fieldName);
@@ -183,6 +185,14 @@ public class RxItemUtils {
     return null;
   }
 
+  /**
+   * Returns the field binary.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   */
   public static byte[] getFieldBinary(IPSItemAccessor item, String fieldName)
       throws PSCmsException {
     PSItemField fld = item.getFieldByName(fieldName);
@@ -202,6 +212,14 @@ public class RxItemUtils {
     return null;
   }
 
+  /**
+   * Returns the field values.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @return the result
+   * @throws PSCmsException if an error occurs
+   */
   public static List<String> getFieldValues(IPSItemAccessor item, String fieldName)
       throws PSCmsException {
     List<String> list = new ArrayList<String>();
@@ -219,6 +237,13 @@ public class RxItemUtils {
     return list;
   }
 
+  /**
+   * Sets the field value.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @param value the value
+   */
   public static void setFieldValue(IPSItemAccessor item, String fieldName, IPSFieldValue value) {
     PSItemField fld = item.getFieldByName(fieldName);
     if (fld == null) {
@@ -230,18 +255,39 @@ public class RxItemUtils {
     fld.addValue(value);
   }
 
+  /**
+   * Sets the field value.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @param textValue the text value
+   */
   public static void setFieldValue(IPSItemAccessor item, String fieldName, String textValue) {
     log.debug("setting field " + fieldName + " value " + textValue);
     IPSFieldValue val = new PSTextValue(textValue);
     setFieldValue(item, fieldName, val);
   }
 
+  /**
+   * Sets the field value.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @param dateValue the date value
+   */
   public static void setFieldValue(IPSItemAccessor item, String fieldName, Date dateValue) {
     log.debug("setting field " + fieldName + " value " + dateValue);
     IPSFieldValue val = new PSDateValue(dateValue);
     setFieldValue(item, fieldName, val);
   }
 
+  /**
+   * Sets the field value.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @param numbValue the numb value
+   */
   public static void setFieldValue(IPSItemAccessor item, String fieldName, Number numbValue) {
     log.debug("setting field " + fieldName + " value " + numbValue);
     String textValue = String.valueOf(numbValue);
@@ -249,6 +295,13 @@ public class RxItemUtils {
     setFieldValue(item, fieldName, val);
   }
 
+  /**
+   * Sets the field value.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @param data the data
+   */
   public static void setFieldValue(IPSItemAccessor item, String fieldName, DataSource data) {
     log.debug("setting binary field " + fieldName);
     try {
@@ -259,6 +312,13 @@ public class RxItemUtils {
     }
   }
 
+  /**
+   * Sets the field value.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @param streamValue the stream value
+   */
   public static void setFieldValue(
       IPSItemAccessor item, String fieldName, InputStream streamValue) {
     IPSFieldValue val;
@@ -271,6 +331,13 @@ public class RxItemUtils {
     }
   }
 
+  /**
+   * Sets the field value.
+   *
+   * @param item the item
+   * @param fieldName the field name
+   * @param listValue the list value
+   */
   public static void setFieldValue(IPSItemAccessor item, String fieldName, List<String> listValue) {
     log.debug("setting mult-value field " + fieldName);
     PSItemField fld = item.getFieldByName(fieldName);

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/RxRequestUtils.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/RxRequestUtils.java
@@ -53,7 +53,7 @@ public class RxRequestUtils {
   /**
    * Convience function to get the rx username from a servlet request.
    *
-   * @param req
+   * @param req the req
    * @return the user name
    */
   public static String getUserName(ServletRequest req) {
@@ -61,6 +61,12 @@ public class RxRequestUtils {
     return irq.getUserName();
   }
 
+  /**
+   * Returns the session id.
+   *
+   * @param req the req
+   * @return the result
+   */
   public static String getSessionId(ServletRequest req) {
     IPSRequestContext irq = getRequest(req);
     if (irq == null) {
@@ -74,5 +80,6 @@ public class RxRequestUtils {
     return sessionid;
   }
 
+  /** request attribute. */
   public static final String REQUEST_ATTRIBUTE = "RX_REQUEST_CONTEXT";
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/RxServerUtils.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/RxServerUtils.java
@@ -47,7 +47,7 @@ public class RxServerUtils {
    * <p><em>WARNING:</em> This method works only on Windows, and should not be relied upon in cross
    * platform code.
    *
-   * @throws InterruptedException
+   * @throws InterruptedException if an error occurs
    */
   public static void waitForServerReady() throws InterruptedException {
     FileLock lock = null;
@@ -85,8 +85,8 @@ public class RxServerUtils {
   /***
    * Get the value of the PERCUSSION_HOME environment variable or null if it is not set.
    *
-   * @author natechadwick
    *
+   * @return the result
    */
   public static String getRhythmyxHome() {
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/SimplifyParameters.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/SimplifyParameters.java
@@ -31,6 +31,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Normalizes servlet parameter maps into simple string maps for extensions.
+ *
  * @author DavidBenua
  */
 public class SimplifyParameters {
@@ -40,6 +42,12 @@ public class SimplifyParameters {
   /** Static methods only */
   private SimplifyParameters() {}
 
+  /**
+   * simplifyMap operation.
+   *
+   * @param input the input
+   * @return the result
+   */
   public static Map<String, String> simplifyMap(Map<String, Object> input) {
     Map<String, String> outMap = new LinkedHashMap<String, String>();
 
@@ -53,6 +61,12 @@ public class SimplifyParameters {
     return outMap;
   }
 
+  /**
+   * simplifyMapStringStringArray operation.
+   *
+   * @param input the input
+   * @return the result
+   */
   public static Map<String, String> simplifyMapStringStringArray(Map<String, String[]> input) {
     Map<String, String> outMap = new LinkedHashMap<String, String>();
 
@@ -66,6 +80,12 @@ public class SimplifyParameters {
     return outMap;
   }
 
+  /**
+   * simplifyValue operation.
+   *
+   * @param value the value
+   * @return the result
+   */
   public static String simplifyValue(Object value) {
     if (value == null) {
       log.debug("null value");
@@ -95,6 +115,12 @@ public class SimplifyParameters {
     return sval;
   }
 
+  /**
+   * Returns the value as list.
+   *
+   * @param value the value
+   * @return the result
+   */
   public static List<String> getValueAsList(Object value) {
     List<String> result = new ArrayList<String>();
     if (value == null) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/UniqueIdLocatorSet.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/utils/UniqueIdLocatorSet.java
@@ -38,35 +38,43 @@ public class UniqueIdLocatorSet extends HashSet<PSLocator>
     implements Set<PSLocator>, Iterable<PSLocator> {
   private static final long serialVersionUID = 1L;
 
-  /** */
-  public UniqueIdLocatorSet() {
+    /**
+     * Creates a new UniqueIdLocatorSet.
+     */
+    public UniqueIdLocatorSet() {
     super();
   }
 
   /**
-   * @param c
+   * Sets the c.
+   * @param c the c
    */
   public UniqueIdLocatorSet(Collection<? extends PSLocator> c) {
     super(c);
   }
 
   /**
-   * @param initialCapacity
+   * Sets the initialCapacity.
+   * @param initialCapacity the initial capacity
    */
   public UniqueIdLocatorSet(int initialCapacity) {
     super(initialCapacity);
   }
 
   /**
-   * @param initialCapacity
-   * @param loadFactor
+   * Sets the initialCapacity.
+   * @param initialCapacity the initial capacity
+   * @param loadFactor the load factor
    */
   public UniqueIdLocatorSet(int initialCapacity, float loadFactor) {
     super(initialCapacity, loadFactor);
   }
 
   /**
+   * See referenced member.
    * @see java.util.HashSet#add(java.lang.Object)
+   * @param loc the loc
+   * @return the result
    */
   @Override
   public boolean add(PSLocator loc) {
@@ -77,7 +85,10 @@ public class UniqueIdLocatorSet extends HashSet<PSLocator>
   }
 
   /**
+   * See referenced member.
    * @see java.util.HashSet#contains(java.lang.Object)
+   * @param o the o
+   * @return the result
    */
   @Override
   public boolean contains(Object o) {
@@ -86,7 +97,10 @@ public class UniqueIdLocatorSet extends HashSet<PSLocator>
   }
 
   /**
+   * See referenced member.
    * @see java.util.HashSet#remove(java.lang.Object)
+   * @param o the o
+   * @return the result
    */
   @Override
   public boolean remove(Object o) {
@@ -114,7 +128,7 @@ public class UniqueIdLocatorSet extends HashSet<PSLocator>
   /**
    * Gets the locator with the specified content id.
    *
-   * @param id
+   * @param id the id
    * @return the locator, or <code>null</code> if there is no locator in the set with this id.
    */
   protected PSLocator getLocatorById(int id) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOAbstractItemValidationExit.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOAbstractItemValidationExit.java
@@ -52,7 +52,11 @@ public abstract class PSOAbstractItemValidationExit extends PSOItemXMLSupport
 
   private IPSOWorkflowInfoFinder finder = null;
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PSOAbstractItemValidationExit.
+   *
+   */
   protected PSOAbstractItemValidationExit() {}
 
   /** Initialize the service pointers. */
@@ -63,16 +67,26 @@ public abstract class PSOAbstractItemValidationExit extends PSOItemXMLSupport
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.extension.IPSResultDocumentProcessor#canModifyStyleSheet()
+   * @return the result
    */
   public boolean canModifyStyleSheet() {
     return false;
   }
 
   /**
+   * processResultDocument operation.
+   *
    * @see
    *     com.percussion.extension.IPSResultDocumentProcessor#processResultDocument(java.lang.Object[],
    *     com.percussion.server.IPSRequestContext, org.w3c.dom.Document)
+   * @param params the params
+   * @param request the request
+   * @param resultDoc the result doc
+   * @return the result
+   * @throws PSParameterMismatchException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
    */
   public Document processResultDocument(
       Object[] params, IPSRequestContext request, Document resultDoc)
@@ -93,6 +107,15 @@ public abstract class PSOAbstractItemValidationExit extends PSOItemXMLSupport
     return null;
   }
 
+  /**
+   * validateDocs operation.
+   *
+   * @param inputDoc the input doc
+   * @param errorDoc the error doc
+   * @param req the req
+   * @param params the params
+   * @throws Exception if an error occurs
+   */
   protected abstract void validateDocs(
       Document inputDoc, Document errorDoc, IPSRequestContext req, Object[] params)
       throws Exception;
@@ -129,7 +152,7 @@ public abstract class PSOAbstractItemValidationExit extends PSOItemXMLSupport
    * @param transitionid the transition id
    * @param allowedStates the list of destination state names that match.
    * @return <code>true</code> when a match occurs,<code>false</code> otherwise.
-   * @throws PSException
+   * @throws PSException if an error occurs
    */
   protected boolean matchDestinationState(
       String contentid, String transitionid, String allowedStates) throws PSException {
@@ -149,10 +172,23 @@ public abstract class PSOAbstractItemValidationExit extends PSOItemXMLSupport
     return allowed.contains(state.getName());
   }
 
+  /**
+   * splitAndTrim operation.
+   *
+   * @param input the input
+   * @return the result
+   */
   protected List<String> splitAndTrim(String input) {
     return splitAndTrim(input, ",");
   }
 
+  /**
+   * splitAndTrim operation.
+   *
+   * @param input the input
+   * @param delimiter the delimiter
+   * @return the result
+   */
   protected List<String> splitAndTrim(String input, String delimiter) {
     List<String> result = new ArrayList<>();
     if (StringUtils.isBlank(input)) return result;
@@ -166,12 +202,18 @@ public abstract class PSOAbstractItemValidationExit extends PSOItemXMLSupport
   }
 
   /**
+   * init operation.
+   *
    * @see com.percussion.extension.IPSExtension#init(com.percussion.extension.IPSExtensionDef,
    *     java.io.File)
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
    */
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {}
 
   /**
+   * Sets the finder.
    * @param finder the finder to set. Used only for unit test.
    */
   protected void setFinder(IPSOWorkflowInfoFinder finder) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSODateRangeFieldValidator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSODateRangeFieldValidator.java
@@ -34,9 +34,18 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Field validator that checks a date value falls within a configured range.
+ *
  * @author davidbenua
  */
 public class PSODateRangeFieldValidator extends PSDefaultExtension implements IPSFieldValidator {
+  /**
+   * Creates a new PSODateRangeFieldValidator.
+   */
+  public PSODateRangeFieldValidator() {
+    // default
+  }
+
   // REFACTORED: CP-JAVA11
 
   private static final Logger log = LogManager.getLogger(PSODateRangeFieldValidator.class);
@@ -44,8 +53,14 @@ public class PSODateRangeFieldValidator extends PSDefaultExtension implements IP
   private IPSExtensionDef extDef = null;
 
   /**
+   * processUdf operation.
+   *
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[],
    *     com.percussion.server.IPSRequestContext)
+   * @param params the params
+   * @param request the request
+   * @return the result
+   * @throws PSConversionException if an error occurs
    */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {
@@ -92,14 +107,25 @@ public class PSODateRangeFieldValidator extends PSDefaultExtension implements IP
     return Boolean.TRUE; // validation succeeds
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param ifile the ifile
+   * @throws PSExtensionException if an error occurs
+   */
   @Override
   public void init(IPSExtensionDef def, File ifile) throws PSExtensionException {
     super.init(def, ifile);
     extDef = def;
   }
 
+  /** current field. */
   public static final String CURRENT_FIELD = "currentField";
+  /** source field. */
   public static final String SOURCE_FIELD = "sourceFieldName";
+  /** min days. */
   public static final String MIN_DAYS = "minDays";
+  /** max days. */
   public static final String MAX_DAYS = "maxDays";
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOFileUploadValidation.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOFileUploadValidation.java
@@ -37,6 +37,13 @@ import org.apache.logging.log4j.Logger;
  * @version 1.0
  */
 public class PSOFileUploadValidation implements IPSFieldValidator {
+  /**
+   * Creates a new PSOFileUploadValidation.
+   */
+  public PSOFileUploadValidation() {
+    // default
+  }
+
   // REFACTORED: CP-JAVA11
   // Constants
   private final String CLASSNAME = getClass().getName();
@@ -47,6 +54,8 @@ public class PSOFileUploadValidation implements IPSFieldValidator {
   private long maxFileSize = 0;
 
   /**
+   * init operation.
+   *
    * @param extensionDef default extension definition
    * @param codeRoot the 'root' directory for this extension.
    * @throws PSExtensionException if the codeRoot does not exist, or is not accessible. Also thrown
@@ -59,6 +68,8 @@ public class PSOFileUploadValidation implements IPSFieldValidator {
   }
 
   /**
+   * processUdf operation.
+   *
    * @param params list of parameters
    *     <ul>
    *       <li><code>fieldName</code> - the name attribute of the PSXField that is mapped to a

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOItemXMLSupport.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOItemXMLSupport.java
@@ -34,6 +34,13 @@ import org.w3c.dom.Element;
  * @author DavidBenua
  */
 public class PSOItemXMLSupport {
+  /**
+   * Creates a new PSOItemXMLSupport.
+   */
+  public PSOItemXMLSupport() {
+    // default
+  }
+
   // REFACTORED: CP-JAVA11
   private static final Logger log = LogManager.getLogger(PSOItemXMLSupport.class);
 
@@ -124,6 +131,12 @@ public class PSOItemXMLSupport {
     return false;
   }
 
+  /**
+   * Returns the field values.
+   *
+   * @param field the field
+   * @return the result
+   */
   public List<String> getFieldValues(Element field) {
     List<String> values = new ArrayList<String>();
 

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSORequiredFieldsItemValidation.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSORequiredFieldsItemValidation.java
@@ -50,15 +50,24 @@ public class PSORequiredFieldsItemValidation extends PSOAbstractItemValidationEx
   // REFACTORED: CP-JAVA11
   private static final Logger log = LogManager.getLogger(PSORequiredFieldsItemValidation.class);
 
-  /** */
-  public PSORequiredFieldsItemValidation() {
+    /**
+     * Creates a new PSORequiredFieldsItemValidation.
+     */
+    public PSORequiredFieldsItemValidation() {
     super();
   }
 
   /**
+   * validateDocs operation.
+   *
    * @see
    *     com.percussion.pso.validation.PSOAbstractItemValidationExit#validateDocs(org.w3c.dom.Document,
    *     org.w3c.dom.Document, com.percussion.server.IPSRequestContext, java.lang.Object[])
+   * @param inputDoc the input doc
+   * @param errorDoc the error doc
+   * @param req the req
+   * @param params the params
+   * @throws Exception if an error occurs
    */
   @Override
   protected void validateDocs(

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOUniqueFieldWithInFoldersValidator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOUniqueFieldWithInFoldersValidator.java
@@ -74,6 +74,13 @@ import org.apache.logging.log4j.Logger;
  * @author adamgent
  */
 public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
+  /**
+   * Creates a new PSOUniqueFieldWithInFoldersValidator.
+   */
+  public PSOUniqueFieldWithInFoldersValidator() {
+    // default
+  }
+
 
   private IPSExtensionDef extensionDef = null;
   private IPSContentWs contentWs = null;
@@ -82,6 +89,14 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
   private PSONodeCataloger nodeCataloger = null;
   private IPSSystemWs systemWs = null;
 
+  /**
+   * processUdf operation.
+   *
+   * @param params the params
+   * @param request the request
+   * @return the result
+   * @throws PSConversionException if an error occurs
+   */
   public Boolean processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {
     String cmd = request.getParameter(IPSHtmlParameters.SYS_COMMAND);
@@ -157,9 +172,10 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
    * @param fieldName field name to check for uniqueness.
    * @param fieldValue the value of the field.
    * @return true if its unique
-   * @throws PSErrorException
-   * @throws InvalidQueryException
-   * @throws RepositoryException
+   * @throws PSErrorException if an error occurs
+   * @throws InvalidQueryException if an error occurs
+   * @throws RepositoryException if an error occurs
+   * @param typeList the type list
    */
   public boolean isFieldValueUniqueInFolderForExistingItem(
       int contentId, String fieldName, String fieldValue, String typeList)
@@ -176,9 +192,10 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
    * @param fieldValue the value of the field.
    * @param path If set will check this path for uniqueness, can use % to check subfolders
    * @return true if its unique
-   * @throws PSErrorException
-   * @throws InvalidQueryException
-   * @throws RepositoryException
+   * @throws PSErrorException if an error occurs
+   * @throws InvalidQueryException if an error occurs
+   * @throws RepositoryException if an error occurs
+   * @param typeList the type list
    */
   public boolean isFieldValueUniqueInFolderForExistingItem(
       int contentId, String fieldName, String fieldValue, String typeList, String path)
@@ -227,10 +244,11 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
    * @param fieldName name of the field
    * @param fieldValue the desired value of the field for the new item.
    * @return true if its unique.
-   * @throws PSErrorException
-   * @throws InvalidQueryException
-   * @throws RepositoryException
-   * @throws PSErrorResultsException
+   * @throws PSErrorException if an error occurs
+   * @throws InvalidQueryException if an error occurs
+   * @throws RepositoryException if an error occurs
+   * @throws PSErrorResultsException if an error occurs
+   * @param typeList the type list
    */
   public boolean isFieldValueUniqueInFolder(
       int folderId, String fieldName, String fieldValue, String typeList)
@@ -246,10 +264,11 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
    * @param fieldValue the desired value of the field for the new item.
    * @param path If set will check this path for uniqueness, can use % to check subfolders
    * @return true if its unique.
-   * @throws PSErrorException
-   * @throws InvalidQueryException
-   * @throws RepositoryException
-   * @throws PSErrorResultsException
+   * @throws PSErrorException if an error occurs
+   * @throws InvalidQueryException if an error occurs
+   * @throws RepositoryException if an error occurs
+   * @throws PSErrorResultsException if an error occurs
+   * @param typeList the type list
    */
   public boolean isFieldValueUniqueInFolder(
       int folderId, String fieldName, String fieldValue, String typeList, String path)
@@ -291,6 +310,16 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
     return unique;
   }
 
+  /**
+   * Returns the query for value in folders.
+   *
+   * @param contentId the content id
+   * @param fieldName the field name
+   * @param fieldValue the field value
+   * @param path the path
+   * @param typeList the type list
+   * @return the result
+   */
   public String getQueryForValueInFolders(
       int contentId, String fieldName, String fieldValue, String path, String typeList) {
     String jcrQuery =
@@ -307,6 +336,15 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
     return jcrQuery;
   }
 
+  /**
+   * Returns the query for value in folder.
+   *
+   * @param fieldName the field name
+   * @param fieldValue the field value
+   * @param path the path
+   * @param typeList the type list
+   * @return the result
+   */
   public String getQueryForValueInFolder(
       String fieldName, String fieldValue, String path, String typeList) {
     return format(
@@ -319,6 +357,12 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
         fieldName, fieldValue, path, typeList);
   }
 
+  /**
+   * Returns the folder id.
+   *
+   * @param request the request
+   * @return the result
+   */
   protected Integer getFolderId(IPSRequestContext request) {
     // get the target parent folder id from the redirect url
     String folderId = null;
@@ -344,6 +388,13 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
     return rvalue;
   }
 
+  /**
+   * makeTypeList operation.
+   *
+   * @param fieldname the fieldname
+   * @return the result
+   * @throws RepositoryException if an error occurs
+   */
   protected String makeTypeList(String fieldname) throws RepositoryException {
     List<String> types = nodeCataloger.getContentTypeNamesWithField(fieldname);
     StringBuilder sb = new StringBuilder();
@@ -364,7 +415,7 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
    *
    * @param contentid the content id for the item
    * @return <code>true</code> if a PV relationship is found.
-   * @throws PSErrorException
+   * @throws PSErrorException if an error occurs
    */
   protected boolean isPromotable(int contentid) throws PSErrorException {
     if (contentid == 0) {
@@ -382,6 +433,13 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
     return (rels.size() > 0) ? true : false;
   }
 
+  /**
+   * init operation.
+   *
+   * @param extensionDef the extension def
+   * @param arg1 the arg1
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef extensionDef, File arg1) throws PSExtensionException {
     setExtensionDef(extensionDef);
     if (contentManager == null) setContentManager(PSContentMgrLocator.getContentMgr());
@@ -391,10 +449,20 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
     if (systemWs == null) setSystemWs(PSSystemWsLocator.getSystemWebservice());
   }
 
+  /**
+   * Returns the extension def.
+   *
+   * @return the result
+   */
   public IPSExtensionDef getExtensionDef() {
     return extensionDef;
   }
 
+  /**
+   * Sets the extension def.
+   *
+   * @param extensionDef the extension def
+   */
   public void setExtensionDef(IPSExtensionDef extensionDef) {
     this.extensionDef = extensionDef;
   }
@@ -403,19 +471,35 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
   private static final Logger log =
       LogManager.getLogger(PSOUniqueFieldWithInFoldersValidator.class);
 
+  /**
+   * Sets the content ws.
+   *
+   * @param contentWs the content ws
+   */
   public void setContentWs(IPSContentWs contentWs) {
     this.contentWs = contentWs;
   }
 
+  /**
+   * Sets the guid manager.
+   *
+   * @param guidManager the guid manager
+   */
   public void setGuidManager(IPSGuidManager guidManager) {
     this.guidManager = guidManager;
   }
 
+  /**
+   * Sets the content manager.
+   *
+   * @param contentManager the content manager
+   */
   public void setContentManager(IPSContentMgr contentManager) {
     this.contentManager = contentManager;
   }
 
   /**
+   * Sets the nodeCataloger.
    * @param nodeCataloger the nodeCataloger to set
    */
   public void setNodeCataloger(PSONodeCataloger nodeCataloger) {
@@ -423,6 +507,7 @@ public class PSOUniqueFieldWithInFoldersValidator implements IPSFieldValidator {
   }
 
   /**
+   * Sets the systemWs.
    * @param systemWs the systemWs to set
    */
   public void setSystemWs(IPSSystemWs systemWs) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOValidateRelatedItems.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/validation/PSOValidateRelatedItems.java
@@ -74,6 +74,13 @@ import org.w3c.dom.Document;
  */
 public class PSOValidateRelatedItems extends PSDefaultExtension
     implements IPSResultDocumentProcessor, IPSItemValidator {
+  /**
+   * Creates a new PSOValidateRelatedItems.
+   */
+  public PSOValidateRelatedItems() {
+    // default
+  }
+
   /** Logger for this class */
   private static final Logger logger = LogManager.getLogger(PSOValidateRelatedItems.class);
 
@@ -97,6 +104,7 @@ public class PSOValidateRelatedItems extends PSDefaultExtension
    * @param mustOccur - the mustOccur operation value.
    * @param numoftimes - the number of times value.
    * @throws PSParameterMismatchException when mustOccur is not MORE_THAN, LESS_THAN or EXACTLY.
+   * @return the result
    */
   protected boolean isValid(int slotSize, String mustOccur, int numoftimes)
       throws PSParameterMismatchException {
@@ -110,12 +118,24 @@ public class PSOValidateRelatedItems extends PSDefaultExtension
     }
   }
 
-  /** Method implemented by IPSResultDocumentProcessor interface */
+  /**
+   * Method implemented by IPSResultDocumentProcessor interface
+   * canModifyStyleSheet operation.
+   * @return the result
+   *
+   */
   public boolean canModifyStyleSheet() {
     return false;
   }
 
-  /** Initialize extension method implemented by class PSDefaultExtension */
+  /**
+   * Initialize extension method implemented by class PSDefaultExtension
+   * init operation.
+   * @param extensionDef the extension def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   *
+   */
   public void init(IPSExtensionDef extensionDef, java.io.File codeRoot)
       throws PSExtensionException {
     System.out.println("2- Initializing PSOValidateRelatedItems exit");
@@ -158,11 +178,13 @@ public class PSOValidateRelatedItems extends PSDefaultExtension
    * The sixth and tenth is the number of items.
    *
    * @param params Parameters must be passed in the following order: 1 - url to query resource
-   * @param request
-   * @param resultDoc
+   * @param request the request
+   * @param resultDoc the result doc
    * @return an XML document - Error page if validation fails, null if not.
    * @exception PSParameterMismatchException
    * @exception PSExtensionProcessingException
+   * @throws PSParameterMismatchException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
    */
   public Document processResultDocument(
       Object[] params, IPSRequestContext request, Document resultDoc)

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/IPSOWFActionService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/IPSOWFActionService.java
@@ -77,7 +77,7 @@ public interface IPSOWFActionService {
    * @param workflowid the workflow id.
    * @param transitionid the transition id.
    * @return a list of workflow actions. The actions are already loaded and ready for execution.
-   * @throws Exception
+   * @throws Exception if an error occurs
    */
   public List<IPSWorkflowAction> getActions(int workflowid, int transitionid) throws Exception;
 
@@ -86,8 +86,8 @@ public interface IPSOWFActionService {
    *
    * @param workflowActionName the name of the workflow action
    * @return the workflow action. May be <code>null</code> if the extension was not found.
-   * @throws PSExtensionException
-   * @throws PSNotFoundException
+   * @throws PSExtensionException if an error occurs
+   * @throws PSNotFoundException if an error occurs
    */
   public IPSWorkflowAction getWorkflowAction(String workflowActionName)
       throws PSExtensionException, PSNotFoundException;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/IPSOWorkflowInfoFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/IPSOWorkflowInfoFinder.java
@@ -24,6 +24,9 @@ import com.percussion.services.workflow.data.PSTransitionBase;
 import com.percussion.services.workflow.data.PSWorkflow;
 import java.util.Collection;
 
+/**
+ * IPSOWorkflowInfoFinder interface.
+ */
 public interface IPSOWorkflowInfoFinder {
   /**
    * Finds a workflow by id.
@@ -119,7 +122,7 @@ public interface IPSOWorkflowInfoFinder {
    * @param contentId the content id for the item
    * @param validFlags the list of valid flags.
    * @return <code>true</code> if the content valid value is one of the listed ones.
-   * @throws PSException
+   * @throws PSException if an error occurs
    */
   public boolean IsWorkflowValid(String contentId, Collection<String> validFlags)
       throws PSException;
@@ -132,7 +135,7 @@ public interface IPSOWorkflowInfoFinder {
    * @param transitionId the transition id
    * @return the state where the transition goes. May be <code>null</code> if the transition is not
    *     found.
-   * @throws PSException
+   * @throws PSException if an error occurs
    */
   public PSState findDestinationState(String contentId, String transitionId) throws PSException;
 
@@ -143,7 +146,7 @@ public interface IPSOWorkflowInfoFinder {
    * @param state the current workflow state
    * @param transitionId the transition id
    * @return the destination state. May be <code>null</code> if the transition id is not found.
-   * @throws PSException
+   * @throws PSException if an error occurs
    */
   public PSState findDestinationState(PSState state, String transitionId) throws PSException;
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOPublishContent.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOPublishContent.java
@@ -34,6 +34,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Workflow action that publishes content by invoking a publish edition.
+ *
  * @author DavidBenua
  */
 public class PSOPublishContent extends PSDefaultExtension implements IPSWorkflowAction {
@@ -42,8 +44,10 @@ public class PSOPublishContent extends PSDefaultExtension implements IPSWorkflow
 
   private static PublishEditionService svc = null;
 
-  /** */
-  public PSOPublishContent() {
+    /**
+     * Creates a new PSOPublishContent.
+     */
+    public PSOPublishContent() {
     super();
   }
 
@@ -54,9 +58,14 @@ public class PSOPublishContent extends PSDefaultExtension implements IPSWorkflow
   }
 
   /**
+   * performAction operation.
+   *
    * @see
    *     com.percussion.extension.IPSWorkflowAction#performAction(com.percussion.extension.IPSWorkFlowContext,
    *     com.percussion.server.IPSRequestContext)
+   * @param wfContext the wf context
+   * @param request the request
+   * @throws PSExtensionProcessingException if an error occurs
    */
   public void performAction(IPSWorkFlowContext wfContext, IPSRequestContext request)
       throws PSExtensionProcessingException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOPublishEditionServiceLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOPublishEditionServiceLocator.java
@@ -26,12 +26,19 @@ import com.percussion.services.PSBaseServiceLocator;
  *
  */
 /**
+ * Service locator for the PSO publish edition service.
+ *
  * @author DavidBenua
  */
 public class PSOPublishEditionServiceLocator extends PSBaseServiceLocator {
   /** static methods only, never constructed. */
   private PSOPublishEditionServiceLocator() {}
 
+  /**
+   * Returns the publish edition service.
+   *
+   * @return the result
+   */
   public static PublishEditionService getPublishEditionService() {
     return (PublishEditionService) getBean(PSOPUBLISHSERVICEBEAN);
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSetRevisionLock.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSetRevisionLock.java
@@ -59,9 +59,7 @@ public class PSOSetRevisionLock extends PSDefaultExtension implements IPSWorkflo
   /** Logger for this class */
   private static final Logger log = LogManager.getLogger(PSOSetRevisionLock.class);
 
-  /** */
-
-  /**
+    /**
    * Initializes system services. Used to prevent references to these services during extension
    * registration.
    */
@@ -73,6 +71,9 @@ public class PSOSetRevisionLock extends PSDefaultExtension implements IPSWorkflo
     }
   }
 
+  /**
+   * Creates a new PSOSetRevisionLock.
+   */
   public PSOSetRevisionLock() {
     super();
   }
@@ -83,6 +84,9 @@ public class PSOSetRevisionLock extends PSDefaultExtension implements IPSWorkflo
    * @see
    *     com.percussion.extension.IPSWorkflowAction#performAction(com.percussion.extension.IPSWorkFlowContext,
    *     com.percussion.server.IPSRequestContext)
+   * @param wfCtx the wf ctx
+   * @param req the req
+   * @throws PSExtensionProcessingException if an error occurs
    */
   public void performAction(IPSWorkFlowContext wfCtx, IPSRequestContext req)
       throws PSExtensionProcessingException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSpringWorkflowActionDispatcher.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSpringWorkflowActionDispatcher.java
@@ -40,12 +40,21 @@ public class PSOSpringWorkflowActionDispatcher extends PSDefaultExtension
   private static final Logger log = LogManager.getLogger(PSOSpringWorkflowActionDispatcher.class);
   IPSOWFActionService asvc = null;
 
-  /** Default constructor */
+  /**
+   * Default constructor
+   * Creates a new PSOSpringWorkflowActionDispatcher.
+   *
+   */
   public PSOSpringWorkflowActionDispatcher() {}
 
   /**
+   * init operation.
+   *
    * @see com.percussion.extension.PSDefaultExtension#init(com.percussion.extension.IPSExtensionDef,
    *     java.io.File)
+   * @param extensionDef the extension def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
    */
   public void init(IPSExtensionDef extensionDef, File codeRoot) throws PSExtensionException {
     super.init(extensionDef, codeRoot);
@@ -62,6 +71,9 @@ public class PSOSpringWorkflowActionDispatcher extends PSDefaultExtension
    * @see
    *     com.percussion.extension.IPSWorkflowAction#performAction(com.percussion.extension.IPSWorkFlowContext,
    *     com.percussion.server.IPSRequestContext)
+   * @param wfContext the wf context
+   * @param request the request
+   * @throws PSExtensionProcessingException if an error occurs
    */
   public void performAction(IPSWorkFlowContext wfContext, IPSRequestContext request)
       throws PSExtensionProcessingException {
@@ -84,6 +96,7 @@ public class PSOSpringWorkflowActionDispatcher extends PSDefaultExtension
   }
 
   /**
+   * Sets the asvc.
    * @param asvc the asvc to set. Used for unit test only.
    */
   protected void setAsvc(IPSOWFActionService asvc) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSwitchCommunityWorkflowAction.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOSwitchCommunityWorkflowAction.java
@@ -72,6 +72,13 @@ import org.apache.logging.log4j.Logger;
  * @author natechadwick
  */
 public class PSOSwitchCommunityWorkflowAction implements IPSWorkflowAction {
+  /**
+   * Creates a new PSOSwitchCommunityWorkflowAction.
+   */
+  public PSOSwitchCommunityWorkflowAction() {
+    // default
+  }
+
 
   /** The name of the default community to switch the item to. */
   public static final String DEFAULT_COMMUNITY_NAME = "defaultCommunityName";
@@ -88,6 +95,7 @@ public class PSOSwitchCommunityWorkflowAction implements IPSWorkflowAction {
    * OverrideVisibility determines if the community switch will ignore
    * visbility problems with the Workflow and State
    *
+   * @return the result
    */
   public boolean getOverrideVisibility() {
     return overrideVisibility;
@@ -96,12 +104,19 @@ public class PSOSwitchCommunityWorkflowAction implements IPSWorkflowAction {
   /***
    * A boolean value that when true, will ignore validation of visibility rules.
    * False by default.
-   * @param overrideVisibility
+   * @param overrideVisibility the override visibility
    */
   public void setOverrideVisibility(boolean overrideVisibility) {
     this.overrideVisibility = overrideVisibility;
   }
 
+  /**
+   * init operation.
+   *
+   * @param exDef the ex def
+   * @param arg1 the arg1
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef exDef, File arg1) throws PSExtensionException {
     log.debug("Initializing Services..");
     initServices();
@@ -114,6 +129,13 @@ public class PSOSwitchCommunityWorkflowAction implements IPSWorkflowAction {
     }
   }
 
+  /**
+   * performAction operation.
+   *
+   * @param wfCtx the wf ctx
+   * @param request the request
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public void performAction(IPSWorkFlowContext wfCtx, IPSRequestContext request)
       throws PSExtensionProcessingException {
 
@@ -283,7 +305,7 @@ public class PSOSwitchCommunityWorkflowAction implements IPSWorkflowAction {
 
   /***
    * Locate the given community by name.
-   * @param name
+   * @param name the name
    *
    */
   private PSCommunity findCommunityByName(String name) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionDispatcher.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionDispatcher.java
@@ -75,17 +75,34 @@ import org.apache.logging.log4j.Logger;
 public class PSOWFActionDispatcher extends PSDefaultExtension implements IPSWorkflowAction {
   private static final Logger log = LogManager.getLogger(PSOWFActionDispatcher.class);
 
+  /**
+   * Creates a new PSOWFActionDispatcher.
+   */
   public PSOWFActionDispatcher() {
     m_extensionDef = null;
     m_codeRoot = null;
   }
 
+  /**
+   * init operation.
+   *
+   * @param extensionDef the extension def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef extensionDef, File codeRoot) throws PSExtensionException {
     log.debug("Initializing WFActionDispatcher...");
     m_extensionDef = extensionDef;
     m_codeRoot = codeRoot;
   }
 
+  /**
+   * performAction operation.
+   *
+   * @param wfContext the wf context
+   * @param request the request
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public void performAction(IPSWorkFlowContext wfContext, IPSRequestContext request)
       throws PSExtensionProcessingException {
     String sName = "performAction";

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionService.java
@@ -99,12 +99,20 @@ public class PSOWFActionService implements IPSOWFActionService {
    */
   private Map<String, Map<String, List<String>>> transitionActions;
 
-  /** Default Constructor. */
+  /**
+   * Default Constructor.
+   * Creates a new PSOWFActionService.
+   *
+   */
   public PSOWFActionService() {
     transitionActions = new HashMap<String, Map<String, List<String>>>(); // add empty map.
   }
 
-  /** Initialization method. Should be called from Spring after initialization is complete. */
+  /**
+   * Initialization method. Should be called from Spring after initialization is complete.
+   * init operation.
+   *
+   */
   public void init() {
     /*
      * The reason for this complexity is that when the init method
@@ -115,6 +123,9 @@ public class PSOWFActionService implements IPSOWFActionService {
      */
     Thread t =
         new Thread() {
+          /**
+           * run operation.
+           */
           @Override
           public void run() {
             try {
@@ -145,7 +156,12 @@ public class PSOWFActionService implements IPSOWFActionService {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWFActionService#getActions(int, int)
+   * @param workflowid the workflowid
+   * @param transitionid the transitionid
+   * @return the result
+   * @throws Exception if an error occurs
    */
   public List<IPSWorkflowAction> getActions(int workflowid, int transitionid) throws Exception {
     initServices();
@@ -178,7 +194,12 @@ public class PSOWFActionService implements IPSOWFActionService {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWFActionService#getWorkflowAction(java.lang.String)
+   * @param workflowActionName the workflow action name
+   * @return the result
+   * @throws PSExtensionException if an error occurs
+   * @throws PSNotFoundException if an error occurs
    */
   public IPSWorkflowAction getWorkflowAction(String workflowActionName)
       throws PSExtensionException, PSNotFoundException {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionServiceLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWFActionServiceLocator.java
@@ -28,6 +28,13 @@ import com.percussion.services.PSBaseServiceLocator;
  */
 public class PSOWFActionServiceLocator extends PSBaseServiceLocator {
   /**
+   * Creates a new PSOWFActionServiceLocator.
+   */
+  public PSOWFActionServiceLocator() {
+    // default
+  }
+
+  /**
    * Gets the PSO Workflow Action Service bean.
    *
    * @return the PSO Workflow Action Service bean.
@@ -36,5 +43,6 @@ public class PSOWFActionServiceLocator extends PSBaseServiceLocator {
     return (IPSOWFActionService) PSBaseServiceLocator.getBean(PSO_WF_ACTION_SERVICE_BEAN);
   }
 
+  /** pso wf action service bean. */
   public static final String PSO_WF_ACTION_SERVICE_BEAN = "psoWFActionService";
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWorkflowInfoFinder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PSOWorkflowInfoFinder.java
@@ -54,7 +54,11 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   private IPSGuidManager gmgr = null;
   private List<PSWorkflow> workflows = null;
 
-  /** Creates a new finder. */
+  /**
+   * Creates a new finder.
+   * Creates a new PSOWorkflowInfoFinder.
+   *
+   */
   public PSOWorkflowInfoFinder() {
     super();
   }
@@ -73,7 +77,10 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflow(int)
+   * @param id the id
+   * @return the result
    */
   public PSWorkflow findWorkflow(int id) {
     initServices();
@@ -86,9 +93,14 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * findWorkflowState operation.
+   *
    * @see
    *     com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflowState(com.percussion.services.workflow.data.PSWorkflow,
    *     int)
+   * @param wf the wf
+   * @param state the state
+   * @return the result
    */
   public PSState findWorkflowState(PSWorkflow wf, int state) {
     for (PSState st : wf.getStates()) {
@@ -101,7 +113,11 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflowTransition(int, int)
+   * @param workflow the workflow
+   * @param transid the transid
+   * @return the result
    */
   public PSTransition findWorkflowTransition(int workflow, int transid) {
     PSWorkflow wf = findWorkflow(workflow);
@@ -114,7 +130,11 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflowAnyTransition(int, int)
+   * @param workflow the workflow
+   * @param transid the transid
+   * @return the result
    */
   public PSTransitionBase findWorkflowAnyTransition(int workflow, int transid) {
     PSWorkflow wf = findWorkflow(workflow);
@@ -127,18 +147,38 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * findWorkflowTransition operation.
+   *
    * @see
    *     com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflowTransition(com.percussion.services.workflow.data.PSWorkflow,
    *     int)
+   * @param wf the wf
+   * @param transid the transid
+   * @return the result
    */
   public PSTransition findWorkflowTransition(PSWorkflow wf, int transid) {
     return (PSTransition) findWorkflowAnyTransitionInternal(wf, transid, false);
   }
 
+  /**
+   * findWorkflowAnyTransition operation.
+   *
+   * @param wf the wf
+   * @param transid the transid
+   * @return the result
+   */
   public PSTransitionBase findWorkflowAnyTransition(PSWorkflow wf, int transid) {
     return findWorkflowAnyTransitionInternal(wf, transid, true);
   }
 
+  /**
+   * findWorkflowAnyTransitionInternal operation.
+   *
+   * @param wf the wf
+   * @param transid the transid
+   * @param includeAging the include aging
+   * @return the result
+   */
   protected PSTransitionBase findWorkflowAnyTransitionInternal(
       PSWorkflow wf, int transid, boolean includeAging) {
     PSTransitionBase result = null;
@@ -165,7 +205,11 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflowState(int, int)
+   * @param workflow the workflow
+   * @param state the state
+   * @return the result
    */
   public PSState findWorkflowState(int workflow, int state) {
     PSWorkflow wf = this.findWorkflow(workflow);
@@ -178,7 +222,11 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflowState(java.lang.String)
+   * @param contentId the content id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSState findWorkflowState(String contentId) throws PSException {
     PSComponentSummary sum = PSOItemSummaryFinder.getSummary(contentId);
@@ -188,7 +236,11 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * See referenced member.
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findWorkflowStateName(java.lang.String)
+   * @param contentId the content id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public String findWorkflowStateName(String contentId) throws PSException {
     PSState state = findWorkflowState(contentId);
@@ -201,8 +253,14 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * IsWorkflowValid operation.
+   *
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#IsWorkflowValid(java.lang.String,
    *     java.util.Collection)
+   * @param contentId the content id
+   * @param validFlags the valid flags
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public boolean IsWorkflowValid(String contentId, Collection<String> validFlags)
       throws PSException {
@@ -222,8 +280,14 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * findDestinationState operation.
+   *
    * @see com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findDestinationState(java.lang.String,
    *     java.lang.String)
+   * @param contentId the content id
+   * @param transitionId the transition id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSState findDestinationState(String contentId, String transitionId) throws PSException {
     PSState state = findWorkflowState(contentId);
@@ -231,9 +295,15 @@ public class PSOWorkflowInfoFinder implements IPSOWorkflowInfoFinder {
   }
 
   /**
+   * findDestinationState operation.
+   *
    * @see
    *     com.percussion.pso.workflow.IPSOWorkflowInfoFinder#findDestinationState(com.percussion.services.workflow.data.PSState,
    *     java.lang.String)
+   * @param state the state
+   * @param transitionId the transition id
+   * @return the result
+   * @throws PSException if an error occurs
    */
   public PSState findDestinationState(PSState state, String transitionId) throws PSException {
     String emsg;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PublishEditionService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/PublishEditionService.java
@@ -67,7 +67,11 @@ public class PublishEditionService implements InitializingBean {
   private Map<String, Map<String, Map<String, String>>> workflows =
       new HashMap<String, Map<String, Map<String, String>>>();
 
-  /** Default constructor. */
+  /**
+   * Default constructor.
+   * Creates a new PublishEditionService.
+   *
+   */
   public PublishEditionService() {}
 
   private void initServices() {
@@ -80,12 +84,19 @@ public class PublishEditionService implements InitializingBean {
   }
 
   /**
+   * See referenced member.
    * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+   * @throws Exception if an error occurs
    */
   public void afterPropertiesSet() throws Exception {
     initServices();
   }
 
+  /**
+   * runQueuedEdition operation.
+   *
+   * @param ed the ed
+   */
   @SuppressWarnings("deprecation")
   public void runQueuedEdition(QueuedEdition ed) {
     runEdition(ed.getEditionId());
@@ -102,11 +113,24 @@ public class PublishEditionService implements InitializingBean {
     rps.startPublishingJob(guid, null);
   }
 
+  /**
+   * retryQueuedEdition operation.
+   *
+   * @param ed the ed
+   */
   @SuppressWarnings("deprecation")
   public void retryQueuedEdition(QueuedEdition ed) {
     log.info("retryQueuedEdition is no longer used");
   }
 
+  /**
+   * findEdition operation.
+   *
+   * @param workflow the workflow
+   * @param transition the transition
+   * @param community the community
+   * @return the result
+   */
   public int findEdition(int workflow, int transition, int community) {
     String workKey = String.valueOf(workflow);
     Map<String, Map<String, String>> workMap = workflows.get(workKey);
@@ -142,9 +166,10 @@ public class PublishEditionService implements InitializingBean {
   /**
    * Makes a Queued Edition. This is no longer necessary, but supported for backwards compatibility
    *
-   * @param editionId
-   * @param sessionId
+   * @param editionId the edition id
+   * @param sessionId the session id
    * @deprecated
+   * @return the result
    */
   @Deprecated
   @SuppressWarnings("deprecation")
@@ -201,6 +226,7 @@ public class PublishEditionService implements InitializingBean {
   }
 
   /**
+   * Returns Returns the workflows..
    * @return Returns the workflows.
    */
   public Map<String, Map<String, Map<String, String>>> getWorkflows() {
@@ -208,6 +234,7 @@ public class PublishEditionService implements InitializingBean {
   }
 
   /**
+   * Sets the workflows.
    * @param workflows The workflows to set.
    */
   public void setWorkflows(Map<String, Map<String, Map<String, String>>> workflows) {
@@ -273,6 +300,7 @@ public class PublishEditionService implements InitializingBean {
   }
 
   /**
+   * Returns Returns the retryCount..
    * @return Returns the retryCount.
    * @deprecated
    */
@@ -282,6 +310,7 @@ public class PublishEditionService implements InitializingBean {
   }
 
   /**
+   * Sets the retryCount.
    * @param retryCount The retryCount to set.
    * @deprecated
    */

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/QueuedEdition.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/workflow/QueuedEdition.java
@@ -42,8 +42,16 @@ public class QueuedEdition {
   private String listenerPort;
   private int retryCount = 0;
 
-  /** */
-  public QueuedEdition(String uri, String port, String editionId, boolean local, int retries) {
+    /**
+     * Creates a new QueuedEdition.
+     *
+     * @param uri the uri
+     * @param port the port
+     * @param editionId the edition id
+     * @param local the local
+     * @param retries the retries
+     */
+    public QueuedEdition(String uri, String port, String editionId, boolean local, int retries) {
     this.uri = uri;
     this.listenerPort = port;
     this.editionId = editionId;
@@ -52,6 +60,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Returns Returns the cmsPassword..
    * @return Returns the cmsPassword.
    */
   public String getCmsPassword() {
@@ -59,6 +68,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Sets the cmsPassword.
    * @param cmsPassword The cmsPassword to set.
    */
   public void setCmsPassword(String cmsPassword) {
@@ -66,6 +76,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Returns Returns the cmsUser..
    * @return Returns the cmsUser.
    */
   public String getCmsUser() {
@@ -73,6 +84,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Sets the cmsUser.
    * @param cmsUser The cmsUser to set.
    */
   public void setCmsUser(String cmsUser) {
@@ -80,6 +92,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Returns Returns the editionId..
    * @return Returns the editionId.
    */
   public String getEditionId() {
@@ -87,6 +100,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Sets the editionId.
    * @param editionId The editionId to set.
    */
   public void setEditionId(String editionId) {
@@ -94,6 +108,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Returns Returns the sessionId..
    * @return Returns the sessionId.
    */
   public String getSessionId() {
@@ -101,6 +116,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Sets the sessionId.
    * @param sessionId The sessionId to set.
    */
   public void setSessionId(String sessionId) {
@@ -108,6 +124,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Returns Returns the uri..
    * @return Returns the uri.
    */
   public String getUri() {
@@ -115,6 +132,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Sets the uri.
    * @param uri The uri to set.
    */
   public void setUri(String uri) {
@@ -122,6 +140,7 @@ public class QueuedEdition {
   }
 
   /**
+   * Returns Returns the local flag..
    * @return Returns the local flag.
    */
   public boolean isLocal() {
@@ -129,18 +148,25 @@ public class QueuedEdition {
   }
 
   /**
+   * Returns Returns the retryCount..
    * @return Returns the retryCount.
    */
   public int getRetryCount() {
     return retryCount;
   }
 
+  /**
+   * decrementAndTestRetries operation.
+   *
+   * @return the result
+   */
   public boolean decrementAndTestRetries() {
     retryCount--;
     return (retryCount > 0);
   }
 
   /**
+   * Returns Returns the listenerPort..
    * @return Returns the listenerPort.
    */
   public String getListenerPort() {

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/AbstractSimplyProperty.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/AbstractSimplyProperty.java
@@ -23,34 +23,99 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 
+/**
+ * Convenience base that implements JCR property accessors via {@link #getValue()}.
+ */
 public abstract class AbstractSimplyProperty {
 
+  /**
+   * Creates a property helper.
+   */
+  protected AbstractSimplyProperty() {
+    // default
+  }
+
   // REFACTORED: CP-JAVA11
+  /**
+   * Returns this property as a boolean.
+   *
+   * @return the boolean value
+   * @throws ValueFormatException if conversion fails
+   * @throws RepositoryException if a repository error occurs
+   */
   public boolean getBoolean() throws ValueFormatException, RepositoryException {
     return getValue().getBoolean();
   }
 
+  /**
+   * Returns this property as a date.
+   *
+   * @return the calendar value
+   * @throws ValueFormatException if conversion fails
+   * @throws RepositoryException if a repository error occurs
+   */
   public Calendar getDate() throws ValueFormatException, RepositoryException {
     return getValue().getDate();
   }
 
+  /**
+   * Returns this property as a double.
+   *
+   * @return the double value
+   * @throws ValueFormatException if conversion fails
+   * @throws RepositoryException if a repository error occurs
+   */
   public double getDouble() throws ValueFormatException, RepositoryException {
     return getValue().getDouble();
   }
 
+  /**
+   * Returns this property as a long.
+   *
+   * @return the long value
+   * @throws ValueFormatException if conversion fails
+   * @throws RepositoryException if a repository error occurs
+   */
   public long getLong() throws ValueFormatException, RepositoryException {
     return getValue().getLong();
   }
 
+  /**
+   * Returns this property as a string.
+   *
+   * @return the string value
+   * @throws ValueFormatException if conversion fails
+   * @throws RepositoryException if a repository error occurs
+   */
   public String getString() throws ValueFormatException, RepositoryException {
     return getValue().getString();
   }
 
+  /**
+   * Returns the JCR property type of this property.
+   *
+   * @return the property type constant
+   * @throws RepositoryException if a repository error occurs
+   */
   public int getType() throws RepositoryException {
     return getValue().getType();
   }
 
+  /**
+   * Returns the single value for this property.
+   *
+   * @return the value
+   * @throws ValueFormatException if conversion fails
+   * @throws RepositoryException if a repository error occurs
+   */
   public abstract Value getValue() throws ValueFormatException, RepositoryException;
 
+  /**
+   * Returns all values for this multi-valued property.
+   *
+   * @return the values
+   * @throws ValueFormatException if conversion fails
+   * @throws RepositoryException if a repository error occurs
+   */
   public abstract Value[] getValues() throws ValueFormatException, RepositoryException;
 }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/NodeUtils.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/NodeUtils.java
@@ -38,12 +38,31 @@ import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * NodeUtils class.
+ */
 public class NodeUtils {
+  /**
+   * Creates a new NodeUtils.
+   */
+  public NodeUtils() {
+    // default
+  }
+
 
   public abstract static class BeanPropertyToNodePropertyNameTranslator {
+    /**
+     * Returns the property name.
+     *
+     * @param d the d
+     * @return the result
+     */
     public abstract String getPropertyName(PropertyDescriptor d);
   }
 
+  /**
+   * DefaultTranslator class.
+   */
   public static class DefaultTranslator extends BeanPropertyToNodePropertyNameTranslator {
 
     // REFACTORED: CP-JAVA11
@@ -51,6 +70,13 @@ public class NodeUtils {
     private Collection<String> ignoreFields;
     private Map<String, String> nameMap;
 
+    /**
+     * Creates a new DefaultTranslator.
+     *
+     * @param fieldPrefix the field prefix
+     * @param ignoreFields the ignore fields
+     * @param nameMap the name map
+     */
     public DefaultTranslator(
         String fieldPrefix, Collection<String> ignoreFields, Map<String, String> nameMap) {
       super();
@@ -59,6 +85,12 @@ public class NodeUtils {
       this.nameMap = nameMap;
     }
 
+    /**
+     * Returns the property name.
+     *
+     * @param d the d
+     * @return the result
+     */
     @Override
     public String getPropertyName(PropertyDescriptor d) {
       String name = d.getName();
@@ -68,6 +100,13 @@ public class NodeUtils {
     }
   }
 
+  /**
+   * copyFromNode operation.
+   *
+   * @param node the node
+   * @param object the object
+   * @param t the t
+   */
   public static <T> void copyFromNode(
       Node node, T object, BeanPropertyToNodePropertyNameTranslator t) {
     notNull(node);
@@ -114,6 +153,13 @@ public class NodeUtils {
     }
   }
 
+  /**
+   * Returns the string.
+   *
+   * @param node the node
+   * @param name the name
+   * @return the result
+   */
   public static String getString(Node node, String name) {
     notNull(node);
     notEmpty(name);
@@ -124,6 +170,13 @@ public class NodeUtils {
     }
   }
 
+  /**
+   * Returns the date.
+   *
+   * @param node the node
+   * @param name the name
+   * @return the result
+   */
   public static Date getDate(Node node, String name) {
     notNull(node);
     notEmpty(name);
@@ -134,6 +187,12 @@ public class NodeUtils {
     }
   }
 
+  /**
+   * Returns the content type.
+   *
+   * @param node the node
+   * @return the result
+   */
   public static String getContentType(Node node) {
     try {
       String contentType = ((IPSNodeDefinition) node.getDefinition()).getInternalName();
@@ -143,11 +202,28 @@ public class NodeUtils {
     }
   }
 
+  /**
+   * copyFromNode operation.
+   *
+   * @param node the node
+   * @param object the object
+   * @param propertyPrefix the property prefix
+   * @param ignoreProperties the ignore properties
+   */
   public static <T> void copyFromNode(
       Node node, T object, String propertyPrefix, Collection<String> ignoreProperties) {
     copyFromNode(node, object, new DefaultTranslator(propertyPrefix, ignoreProperties, null));
   }
 
+  /**
+   * copyFromNode operation.
+   *
+   * @param node the node
+   * @param object the object
+   * @param propertyPrefix the property prefix
+   * @param ignoreProperties the ignore properties
+   * @param nameMap the name map
+   */
   public static <T> void copyFromNode(
       Node node,
       T object,
@@ -157,18 +233,37 @@ public class NodeUtils {
     copyFromNode(node, object, new DefaultTranslator(propertyPrefix, ignoreProperties, nameMap));
   }
 
+  /**
+   * NodeUtilsException class.
+   */
   public static class NodeUtilsException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Creates a new NodeUtilsException.
+     *
+     * @param message the message
+     */
     public NodeUtilsException(String message) {
       super(message);
     }
 
+    /**
+     * Creates a new NodeUtilsException.
+     *
+     * @param message the message
+     * @param cause the cause
+     */
     public NodeUtilsException(String message, Throwable cause) {
       super(message, cause);
     }
 
+    /**
+     * Creates a new NodeUtilsException.
+     *
+     * @param cause the cause
+     */
     public NodeUtilsException(Throwable cause) {
       super(cause);
     }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/PropertyData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/PropertyData.java
@@ -21,6 +21,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * PropertyData class.
+ */
 public class PropertyData implements Serializable {
 
   /** Safe to serialize */
@@ -36,13 +39,17 @@ public class PropertyData implements Serializable {
 
   private String name;
 
-  /** Constructor for Serializers. */
+  /**
+   * Constructor for Serializers.
+   * Creates a new PropertyData.
+   *
+   */
   public PropertyData() {}
 
   /**
    * Constructor for Single value property.
    *
-   * @param data
+   * @param data the data
    */
   public PropertyData(ValueData data) {
     if ((data) == null) throw new IllegalArgumentException("Value Data cannot be null");
@@ -51,26 +58,56 @@ public class PropertyData implements Serializable {
     values.add(data);
   }
 
+  /**
+   * Returns whether multiple.
+   *
+   * @return the result
+   */
   public boolean isMultiple() {
     return multiple;
   }
 
+  /**
+   * Sets the multiple.
+   *
+   * @param multiple the multiple
+   */
   public void setMultiple(boolean multiple) {
     this.multiple = multiple;
   }
 
+  /**
+   * Returns the values.
+   *
+   * @return the result
+   */
   public List<ValueData> getValues() {
     return values;
   }
 
+  /**
+   * Sets the values.
+   *
+   * @param values the values
+   */
   public void setValues(List<ValueData> values) {
     this.values = values == null ? null : new ArrayList<>(values);
   }
 
+  /**
+   * Returns the name.
+   *
+   * @return the result
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the name.
+   *
+   * @param name the name
+   */
   public void setName(String name) {
     this.name = name;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/PropertyUtil.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/PropertyUtil.java
@@ -19,7 +19,23 @@ package com.percussion.soln.jcr.data;
 
 import static com.percussion.soln.jcr.data.ValueUtil.*;
 
+/**
+ * PropertyUtil class.
+ */
 public class PropertyUtil {
+  /**
+   * Creates a new PropertyUtil.
+   */
+  public PropertyUtil() {
+    // default
+  }
+
+  /**
+   * createPropertyData operation.
+   *
+   * @param obj the obj
+   * @return the result
+   */
   public static PropertyData createPropertyData(Object obj) {
     return new PropertyData(createValueData(obj));
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/ValueData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/ValueData.java
@@ -23,6 +23,9 @@ import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.ValueFormatException;
 
+/**
+ * ValueData class.
+ */
 public class ValueData implements Serializable {
 
   /** Serial id. */
@@ -37,77 +40,160 @@ public class ValueData implements Serializable {
   /** JCR property type. */
   int type;
 
+  /**
+   * Creates a new ValueData.
+   */
   public ValueData() {
     // For general serializers that use the setters and getters.
     type = PropertyType.STRING;
     stringData = "";
   }
 
+  /**
+   * Creates a new ValueData.
+   *
+   * @param data the data
+   */
   public ValueData(boolean data) {
     booleanData = data;
     type = PropertyType.BOOLEAN;
   }
 
+  /**
+   * Creates a new ValueData.
+   *
+   * @param data the data
+   */
   public ValueData(String data) {
     stringData = data;
     type = PropertyType.STRING;
   }
 
+  /**
+   * Creates a new ValueData.
+   *
+   * @param data the data
+   */
   public ValueData(Calendar data) {
     dateData = data;
     type = PropertyType.DATE;
   }
 
+  /**
+   * Creates a new ValueData.
+   *
+   * @param data the data
+   */
   public ValueData(double data) {
     doubleData = data;
     type = PropertyType.DOUBLE;
   }
 
+  /**
+   * Creates a new ValueData.
+   *
+   * @param data the data
+   */
   public ValueData(long data) {
     longData = data;
     type = PropertyType.LONG;
   }
 
+  /**
+   * Returns the boolean data.
+   *
+   * @return the result
+   */
   public Boolean getBooleanData() {
     return booleanData;
   }
 
+  /**
+   * Sets the boolean data.
+   *
+   * @param booleanData the boolean data
+   */
   public void setBooleanData(boolean booleanData) {
     this.booleanData = booleanData;
   }
 
+  /**
+   * Returns the date data.
+   *
+   * @return the result
+   */
   public Calendar getDateData() {
     return dateData;
   }
 
+  /**
+   * Sets the date data.
+   *
+   * @param dateData the date data
+   */
   public void setDateData(Calendar dateData) {
     this.dateData = dateData;
   }
 
+  /**
+   * Returns the double data.
+   *
+   * @return the result
+   */
   public Double getDoubleData() {
     return doubleData;
   }
 
+  /**
+   * Sets the double data.
+   *
+   * @param doubleData the double data
+   */
   public void setDoubleData(double doubleData) {
     this.doubleData = doubleData;
   }
 
+  /**
+   * Returns the long data.
+   *
+   * @return the result
+   */
   public Long getLongData() {
     return longData;
   }
 
+  /**
+   * Sets the long data.
+   *
+   * @param longData the long data
+   */
   public void setLongData(long longData) {
     this.longData = longData;
   }
 
+  /**
+   * Returns the string data.
+   *
+   * @return the result
+   */
   public String getStringData() {
     return stringData;
   }
 
+  /**
+   * Sets the string data.
+   *
+   * @param stringData the string data
+   */
   public void setStringData(String stringData) {
     this.stringData = stringData;
   }
 
+  /**
+   * Returns the type.
+   *
+   * @return the result
+   */
   public int getType() {
     return type;
   }
@@ -117,7 +203,7 @@ public class ValueData implements Serializable {
    * DATE, LONG, DOUBLE, and BINARY are supported at this time.
    *
    * @param datatype The type to set.
-   * @throws RepositoryException
+   * @throws RepositoryException if an error occurs
    */
   public void setType(int datatype) throws RepositoryException {
     switch (datatype) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/ValueUtil.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/jcr/data/ValueUtil.java
@@ -27,9 +27,30 @@ import javax.jcr.ValueFactory;
 import javax.jcr.ValueFormatException;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
 
+/**
+ * ValueUtil class.
+ */
 public class ValueUtil {
+  /**
+   * Creates a new ValueUtil.
+   */
+  public ValueUtil() {
+    // default
+  }
+
+  /**
+   * Returns the instance.
+   *
+   * @return the result
+   */
   public static ValueFactory valueFactory = ValueFactoryImpl.getInstance();
 
+  /**
+   * dataToJCRValue operation.
+   *
+   * @param data the data
+   * @return the result
+   */
   public static Value dataToJCRValue(ValueData data) {
     if (data == null) throw new IllegalArgumentException("Data cannot be null");
     switch (data.getType()) {
@@ -48,6 +69,12 @@ public class ValueUtil {
     }
   }
 
+  /**
+   * dataToJCRValues operation.
+   *
+   * @param data the data
+   * @return the result
+   */
   public static Value[] dataToJCRValues(List<ValueData> data) {
     if (data == null && data.isEmpty())
       throw new IllegalArgumentException("Data cannot be null or empty");
@@ -61,6 +88,12 @@ public class ValueUtil {
     return values;
   }
 
+  /**
+   * jcrValueToData operation.
+   *
+   * @param data the data
+   * @return the result
+   */
   public static ValueData jcrValueToData(Value data) {
     if (data == null) throw new IllegalArgumentException("Data cannot be null");
     try {
@@ -88,6 +121,12 @@ public class ValueUtil {
     }
   }
 
+  /**
+   * createValueData operation.
+   *
+   * @param obj the obj
+   * @return the result
+   */
   public static ValueData createValueData(Object obj) {
 
     if (obj == null) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/FolderTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/FolderTools.java
@@ -67,7 +67,11 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
   private IPSContentWs contentWs;
   private IPSGuidManager guidManager;
 
-  /** Extensions manager will use this constructor. */
+  /**
+   * Extensions manager will use this constructor.
+   * Creates a new FolderTools.
+   *
+   */
   public FolderTools() {
     super();
   }
@@ -83,7 +87,13 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
     init(contentWs, guidManager);
   }
 
-  /** Final so the preferred constructor may call without this-escape. */
+  /**
+   * Final so the preferred constructor may call without this-escape.
+   * init operation.
+   * @param contentWs the content ws
+   * @param guidManager the guid manager
+   *
+   */
   protected final void init(IPSContentWs contentWs, IPSGuidManager guidManager) {
     this.contentWs = contentWs;
     this.guidManager = guidManager;
@@ -95,12 +105,20 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param itemId the GUID for the item
    * @return the parent folder path. If there are multiple paths, the first one will be returned.
    *     Will be return empty list if the item is not in any folders.
-   * @throws PSErrorException
-   * @throws PSExtensionProcessingException
+   * @throws PSErrorException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the folder path for this item",
       params = {@IPSJexlParam(name = "itemId", description = "the item GUID")})
+  /**
+   * Returns the parent folder paths.
+   *
+   * @param itemId the item id
+   * @return the result
+   * @throws PSErrorException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public List<String> getParentFolderPaths(IPSGuid itemId)
       throws PSErrorException, PSExtensionProcessingException {
     String errmsg;
@@ -132,12 +150,20 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param itemId the GUID for the item
    * @return the parent folder path. If there are multiple paths, the first one will be returned.
    *     Will be <code>null</code> if the item is not in any folders.
-   * @throws PSErrorException
-   * @throws PSExtensionProcessingException
+   * @throws PSErrorException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the folder path for this item",
       params = {@IPSJexlParam(name = "itemId", description = "the item GUID")})
+  /**
+   * Returns the parent folder path.
+   *
+   * @param itemId the item id
+   * @return the result
+   * @throws PSErrorException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   */
   public String getParentFolderPath(IPSGuid itemId)
       throws PSErrorException, PSExtensionProcessingException {
     String errmsg;
@@ -162,14 +188,23 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
    *
    * @param assemblyItem the assembly item whose parent folder will be fetched.
    * @return the folder path of the containing folder.
-   * @throws PSErrorResultsException
-   * @throws PSExtensionProcessingException
-   * @throws PSErrorException
+   * @throws PSErrorResultsException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSErrorException if an error occurs
    */
   @IPSJexlMethod(
       description = "get the folder path for this item",
       params = {@IPSJexlParam(name = "assemblyItem", description = "$sys.assemblyItem")},
       returns = "the path of the folder that contains this item")
+  /**
+   * Returns the parent folder path.
+   *
+   * @param assemblyItem the assembly item
+   * @return the result
+   * @throws PSErrorResultsException if an error occurs
+   * @throws PSExtensionProcessingException if an error occurs
+   * @throws PSErrorException if an error occurs
+   */
   public String getParentFolderPath(IPSAssemblyItem assemblyItem)
       throws PSErrorResultsException, PSExtensionProcessingException, PSErrorException {
     int id = assemblyItem.getFolderId();
@@ -235,6 +270,12 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
       description = "Gets the folder properties of a folder.",
       params = {@IPSJexlParam(name = "path", description = "folder path")},
       returns = "The folder properties (Map)")
+  /**
+   * Returns the folder properties.
+   *
+   * @param path the path
+   * @return the result
+   */
   public Map<String, String> getFolderProperties(String path) {
     try {
       PSFolder folder = getContentWs().loadFolders(new String[] {path}).get(0);
@@ -251,6 +292,13 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
     }
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param codeRoot the code root
+   * @throws PSExtensionException if an error occurs
+   */
   @Override
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     super.init(def, codeRoot);
@@ -259,18 +307,38 @@ public class FolderTools extends PSJexlUtilBase implements IPSJexlExpression {
     init(contentWs, guidManager);
   }
 
+  /**
+   * Returns the content ws.
+   *
+   * @return the result
+   */
   public IPSContentWs getContentWs() {
     return contentWs;
   }
 
+  /**
+   * Sets the content ws.
+   *
+   * @param contentWs the content ws
+   */
   public void setContentWs(IPSContentWs contentWs) {
     this.contentWs = contentWs;
   }
 
+  /**
+   * Returns the guid manager.
+   *
+   * @return the result
+   */
   public IPSGuidManager getGuidManager() {
     return guidManager;
   }
 
+  /**
+   * Sets the guid manager.
+   *
+   * @param guidManager the guid manager
+   */
   public void setGuidManager(IPSGuidManager guidManager) {
     this.guidManager = guidManager;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/JCRQueryBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/JCRQueryBuilder.java
@@ -35,6 +35,13 @@ import java.util.List;
  * @author adamgent
  */
 public class JCRQueryBuilder {
+  /**
+   * Creates a new JCRQueryBuilder.
+   */
+  public JCRQueryBuilder() {
+    // default
+  }
+
   // REFACTORED: CP-JAVA11
   private String startDate = null;
   private String endDate = null;
@@ -46,16 +53,34 @@ public class JCRQueryBuilder {
   private Collection<String> folderPaths = emptyList();
   private String query;
 
+  /**
+   * validate operation.
+   */
   public void validate() {
     if (isEmpty(selectFields) || isEmpty(fromTypes)) {
       throw new IllegalStateException("Configuration of ListBuilder invalid");
     }
   }
 
+  /**
+   * buildTextField operation.
+   *
+   * @param field the field
+   * @param value the value
+   * @return the result
+   */
   protected String buildTextField(String field, String value) {
     return format("( {0} like ''%{1}%'' )", field, value);
   }
 
+  /**
+   * buildQuery operation.
+   *
+   * @param fields the fields
+   * @param types the types
+   * @param cond the cond
+   * @return the result
+   */
   public String buildQuery(List<String> fields, Collection<String> types, String cond) {
     String f = join(fields.iterator(), ", ");
     String t = join(types.iterator(), ", ");
@@ -63,6 +88,14 @@ public class JCRQueryBuilder {
     return format("select {0} from {1}", f, t);
   }
 
+  /**
+   * buildDateRange operation.
+   *
+   * @param field the field
+   * @param startDate the start date
+   * @param endDate the end date
+   * @return the result
+   */
   public String buildDateRange(String field, String startDate, String endDate) {
     if (isNotBlank(field) && isNotBlank(startDate) && isNotBlank(endDate))
       return format("(''{0}'' < {1} and {1} < ''{2}'')", startDate, field, endDate);
@@ -71,16 +104,33 @@ public class JCRQueryBuilder {
     else return "";
   }
 
+  /**
+   * buildDateCond operation.
+   *
+   * @return the result
+   */
   protected String buildDateCond() {
     return buildDateRange(queryStartDateField, startDate, endDate);
   }
 
+  /**
+   * buildTitleCond operation.
+   *
+   * @return the result
+   */
   protected String buildTitleCond() {
     if (isBlank(queryTitleField)) return "";
     if (isBlank(titleContains)) return "";
     return format(" {0} like ''%{1}%'' ", queryTitleField, titleContains);
   }
 
+  /**
+   * buildCond operation.
+   *
+   * @param sep the sep
+   * @param cond the cond
+   * @return the result
+   */
   public String buildCond(String sep, List<String> cond) {
     cond = removeBlank(cond);
     if (isEmpty(cond)) return "";
@@ -104,6 +154,12 @@ public class JCRQueryBuilder {
     return rvalue;
   }
 
+  /**
+   * buildPathsLikeCond operation.
+   *
+   * @param paths the paths
+   * @return the result
+   */
   public String buildPathsLikeCond(Collection<String> paths) {
     if (isEmpty(paths)) return "";
     List<String> conds = new ArrayList<String>();
@@ -117,6 +173,11 @@ public class JCRQueryBuilder {
     return "(" + join(conds.iterator(), " or ") + ")";
   }
 
+  /**
+   * buildCond operation.
+   *
+   * @return the result
+   */
   public String buildCond() {
     //        String taxCond = buildTaxCond();
     //        String tagCond = buildTagCond();
@@ -132,6 +193,11 @@ public class JCRQueryBuilder {
     return cond;
   }
 
+  /**
+   * Returns the query.
+   *
+   * @return the result
+   */
   public String getQuery() {
     if (isNotBlank(this.query)) return this.query;
     validate();
@@ -142,70 +208,155 @@ public class JCRQueryBuilder {
     return buildQuery(fields, types, cond);
   }
 
+  /**
+   * Sets the query.
+   *
+   * @param query the query
+   */
   public void setQuery(String query) {
     this.query = query;
   }
 
+  /**
+   * Returns the query start date field.
+   *
+   * @return the result
+   */
   public String getQueryStartDateField() {
     return queryStartDateField;
   }
 
+  /**
+   * Sets the query start date field.
+   *
+   * @param queryStartDateField the query start date field
+   */
   public void setQueryStartDateField(String queryStartDateField) {
     this.queryStartDateField = queryStartDateField;
   }
 
+  /**
+   * Returns the query title field.
+   *
+   * @return the result
+   */
   public String getQueryTitleField() {
     return queryTitleField;
   }
 
+  /**
+   * Sets the query title field.
+   *
+   * @param queryTitleField the query title field
+   */
   public void setQueryTitleField(String queryTitleField) {
     this.queryTitleField = queryTitleField;
   }
 
+  /**
+   * Returns the select fields.
+   *
+   * @return the result
+   */
   public List<String> getSelectFields() {
     return selectFields;
   }
 
+  /**
+   * Sets the select fields.
+   *
+   * @param selectFields the select fields
+   */
   public void setSelectFields(List<String> selectFields) {
     this.selectFields = selectFields;
   }
 
+  /**
+   * Returns the from types.
+   *
+   * @return the result
+   */
   public Collection<String> getFromTypes() {
     return fromTypes;
   }
 
+  /**
+   * Sets the from types.
+   *
+   * @param fromTypes the from types
+   */
   public void setFromTypes(Collection<String> fromTypes) {
     this.fromTypes = fromTypes;
   }
 
+  /**
+   * Returns the start date.
+   *
+   * @return the result
+   */
   public String getStartDate() {
     return startDate;
   }
 
+  /**
+   * Sets the start date.
+   *
+   * @param startDate the start date
+   */
   public void setStartDate(String startDate) {
     this.startDate = startDate;
   }
 
+  /**
+   * Returns the end date.
+   *
+   * @return the result
+   */
   public String getEndDate() {
     return endDate;
   }
 
+  /**
+   * Sets the end date.
+   *
+   * @param endDate the end date
+   */
   public void setEndDate(String endDate) {
     this.endDate = endDate;
   }
 
+  /**
+   * Returns the title contains.
+   *
+   * @return the result
+   */
   public String getTitleContains() {
     return titleContains;
   }
 
+  /**
+   * Sets the title contains.
+   *
+   * @param titleContains the title contains
+   */
   public void setTitleContains(String titleContains) {
     this.titleContains = titleContains;
   }
 
+  /**
+   * Returns the folder paths.
+   *
+   * @return the result
+   */
   public Collection<String> getFolderPaths() {
     return folderPaths;
   }
 
+  /**
+   * Sets the folder paths.
+   *
+   * @param folderPaths the folder paths
+   */
   public void setFolderPaths(Collection<String> folderPaths) {
     this.folderPaths = folderPaths;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/ListBuilderItem.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/ListBuilderItem.java
@@ -26,6 +26,13 @@ import java.util.Collection;
  * @author adamgent // REFACTORED: CP-JAVA11
  */
 public class ListBuilderItem {
+  /**
+   * Creates a new ListBuilderItem.
+   */
+  public ListBuilderItem() {
+    // default
+  }
+
 
   private String dateRangeStart;
   private String dateRangeEnd;
@@ -40,90 +47,200 @@ public class ListBuilderItem {
   private Collection<String> contentTypes = new ArrayList<>();
   private Long count;
 
+  /**
+   * Returns the folder path.
+   *
+   * @return the result
+   */
   public String getFolderPath() {
     return folderPath;
   }
 
+  /**
+   * Sets the folder path.
+   *
+   * @param folderPath the folder path
+   */
   public void setFolderPath(String folderPath) {
     this.folderPath = folderPath;
   }
 
+  /**
+   * Returns the content types.
+   *
+   * @return the result
+   */
   public Collection<String> getContentTypes() {
     return contentTypes;
   }
 
+  /**
+   * Sets the content types.
+   *
+   * @param contentTypes the content types
+   */
   public void setContentTypes(Collection<String> contentTypes) {
     this.contentTypes = contentTypes;
   }
 
+  /**
+   * Returns the folder paths.
+   *
+   * @return the result
+   */
   public Collection<String> getFolderPaths() {
     return folderPaths;
   }
 
+  /**
+   * Sets the folder paths.
+   *
+   * @param folderPaths the folder paths
+   */
   public void setFolderPaths(Collection<String> folderPaths) {
     this.folderPaths = folderPaths;
   }
 
+  /**
+   * Returns the date range start.
+   *
+   * @return the result
+   */
   public String getDateRangeStart() {
     return dateRangeStart;
   }
 
+  /**
+   * Sets the date range start.
+   *
+   * @param dateRangeStart the date range start
+   */
   public void setDateRangeStart(String dateRangeStart) {
     this.dateRangeStart = dateRangeStart;
   }
 
+  /**
+   * Returns the date range end.
+   *
+   * @return the result
+   */
   public String getDateRangeEnd() {
     return dateRangeEnd;
   }
 
+  /**
+   * Sets the date range end.
+   *
+   * @param dateRangeEnd the date range end
+   */
   public void setDateRangeEnd(String dateRangeEnd) {
     this.dateRangeEnd = dateRangeEnd;
   }
 
+  /**
+   * Returns the title contains.
+   *
+   * @return the result
+   */
   public String getTitleContains() {
     return titleContains;
   }
 
+  /**
+   * Sets the title contains.
+   *
+   * @param titleContains the title contains
+   */
   public void setTitleContains(String titleContains) {
     this.titleContains = titleContains;
   }
 
+  /**
+   * Returns the content type.
+   *
+   * @return the result
+   */
   public String getContentType() {
     return contentType;
   }
 
+  /**
+   * Sets the content type.
+   *
+   * @param contentType the content type
+   */
   public void setContentType(String contentType) {
     this.contentType = contentType;
   }
 
+  /**
+   * Returns the slot.
+   *
+   * @return the result
+   */
   public String getSlot() {
     return slot;
   }
 
+  /**
+   * Sets the slot.
+   *
+   * @param slot the slot
+   */
   public void setSlot(String slot) {
     this.slot = slot;
   }
 
+  /**
+   * Returns the child snippet.
+   *
+   * @return the result
+   */
   public String getChildSnippet() {
     return childSnippet;
   }
 
+  /**
+   * Sets the child snippet.
+   *
+   * @param childSnippet the child snippet
+   */
   public void setChildSnippet(String childSnippet) {
     this.childSnippet = childSnippet;
   }
 
+  /**
+   * Returns the jcr query.
+   *
+   * @return the result
+   */
   public String getJcrQuery() {
     return jcrQuery;
   }
 
+  /**
+   * Sets the jcr query.
+   *
+   * @param jcrQuery the jcr query
+   */
   public void setJcrQuery(String jcrQuery) {
     this.jcrQuery = jcrQuery;
   }
 
+  /**
+   * Returns the count.
+   *
+   * @return the result
+   */
   public Long getCount() {
     return count;
   }
 
+  /**
+   * Sets the count.
+   *
+   * @param count the count
+   */
   public void setCount(Long count) {
     this.count = count;
   }

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/ListBuilderJexl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/listbuilder/ListBuilderJexl.java
@@ -31,7 +31,17 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * ListBuilderJexl class.
+ */
 public class ListBuilderJexl implements IPSJexlExpression {
+  /**
+   * Creates a new ListBuilderJexl.
+   */
+  public ListBuilderJexl() {
+    // default
+  }
+
   // REFACTORED: CP-JAVA11
 
   private static final String PROPERTY_PREFIX = "rx:soln_list_";
@@ -42,6 +52,13 @@ public class ListBuilderJexl implements IPSJexlExpression {
       description = "Creates a Query Builder from a Node",
       params = {@IPSJexlParam(name = "node", description = "$sys.assemblyItem")},
       returns = "List builder item")
+  /**
+   * Returns the list builder item.
+   *
+   * @param assemblyItem the assembly item
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   public ListBuilderItem getListBuilderItem(IPSAssemblyItem assemblyItem) throws Exception {
     ListBuilderItem item = new ListBuilderItem();
     NodeUtils.copyFromNode(assemblyItem.getNode(), item, PROPERTY_PREFIX, null);
@@ -50,6 +67,13 @@ public class ListBuilderJexl implements IPSJexlExpression {
     return item;
   }
 
+  /**
+   * Returns the folder path.
+   *
+   * @param assemblyItem the assembly item
+   * @return the result
+   * @throws Exception if an error occurs
+   */
   protected String getFolderPath(IPSAssemblyItem assemblyItem) throws Exception {
     return folderTools.getParentFolderPath(assemblyItem);
   }
@@ -63,6 +87,12 @@ public class ListBuilderJexl implements IPSJexlExpression {
       description = "Creates a Query Builder from a List builder",
       params = {@IPSJexlParam(name = "lbn", description = "getListBuilderItem($sys.item)")},
       returns = "JCRQueryBuilder")
+  /**
+   * Returns the query builder.
+   *
+   * @param lbn the lbn
+   * @return the result
+   */
   public JCRQueryBuilder getQueryBuilder(ListBuilderItem lbn) {
     notNull(lbn);
     JCRQueryBuilder b = new JCRQueryBuilder();
@@ -87,11 +117,22 @@ public class ListBuilderJexl implements IPSJexlExpression {
     return b;
   }
 
+  /**
+   * resolveQuery operation.
+   *
+   * @param lbn the lbn
+   */
   public void resolveQuery(ListBuilderItem lbn) {
     JCRQueryBuilder b = getQueryBuilder(lbn);
     resolveQuery(lbn, b);
   }
 
+  /**
+   * resolveQuery operation.
+   *
+   * @param lbn the lbn
+   * @param b the b
+   */
   public void resolveQuery(ListBuilderItem lbn, JCRQueryBuilder b) {
     notNull(lbn);
     notNull(b);
@@ -102,6 +143,12 @@ public class ListBuilderJexl implements IPSJexlExpression {
       description = "Creates slot parameters from a list builder",
       params = {@IPSJexlParam(name = "lbn", description = "getListBuilderItem($sys.item)")},
       returns = "Map of slot parameters")
+  /**
+   * Returns the slot parameters.
+   *
+   * @param lbn the lbn
+   * @return the result
+   */
   public Map<String, String> getSlotParameters(ListBuilderItem lbn) {
     notNull(lbn);
     Map<String, String> params = new HashMap<>();
@@ -116,10 +163,22 @@ public class ListBuilderJexl implements IPSJexlExpression {
     map.entrySet().removeIf(e -> isBlank(e.getValue()));
   }
 
+  /**
+   * Sets the folder tools.
+   *
+   * @param folderTools the folder tools
+   */
   public void setFolderTools(FolderTools folderTools) {
     this.folderTools = folderTools;
   }
 
+  /**
+   * init operation.
+   *
+   * @param def the def
+   * @param file the file
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef def, File file) throws PSExtensionException {
     FolderTools ft = new FolderTools();
     ft.init(def, file);

--- a/modules/perc-toolkit/src/main/java/com/percussion/soln/rss/RssJexl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/soln/rss/RssJexl.java
@@ -43,19 +43,47 @@ import java.util.regex.Pattern;
 import javax.jcr.Node;
 import org.apache.commons.collections.Predicate;
 
+/**
+ * RssJexl class.
+ */
 public class RssJexl implements IPSJexlExpression {
+  /**
+   * Creates a new RssJexl.
+   */
+  public RssJexl() {
+    // default
+  }
+
 
   private PSLocationUtils locationUtils;
   private IPSAssemblyService assemblyService;
 
+  /**
+   * createEntries operation.
+   *
+   * @return the result
+   */
   public List<SyndEntry> createEntries() {
     return new ArrayList<>();
   }
 
+  /**
+   * createFeed operation.
+   *
+   * @return the result
+   */
   public SyndFeed createFeed() {
     return new SyndFeedImpl();
   }
 
+  /**
+   * createFeed operation.
+   *
+   * @param node the node
+   * @param titleFields the title fields
+   * @param bodyFields the body fields
+   * @return the result
+   */
   public SyndFeed createFeed(Node node, String titleFields, String bodyFields) {
     SyndFeed feed = createFeed();
     String title = getValue(node, titleFields);
@@ -65,10 +93,23 @@ public class RssJexl implements IPSJexlExpression {
     return feed;
   }
 
+  /**
+   * createEntry operation.
+   *
+   * @return the result
+   */
   public SyndEntry createEntry() {
     return new SyndEntryImpl();
   }
 
+  /**
+   * createEntry operation.
+   *
+   * @param node the node
+   * @param titleFields the title fields
+   * @param bodyFields the body fields
+   * @return the result
+   */
   public SyndEntry createEntry(Node node, String titleFields, String bodyFields) {
     SyndEntry entry = createEntry();
     String title = getValue(node, titleFields);
@@ -83,24 +124,60 @@ public class RssJexl implements IPSJexlExpression {
     return entry;
   }
 
+  /**
+   * Returns the value.
+   *
+   * @param node the node
+   * @param titleFields the title fields
+   * @return the result
+   */
   protected String getValue(Node node, String titleFields) {
     return locationUtils.getFirstDefined(node, titleFields, "");
   }
 
+  /**
+   * createContent operation.
+   *
+   * @return the result
+   */
   public SyndContent createContent() {
     return new SyndContentImpl();
   }
 
+  /**
+   * Returns the rss.
+   *
+   * @param feed the feed
+   * @return the result
+   * @throws IOException if an error occurs
+   * @throws FeedException if an error occurs
+   */
   public String getRss(SyndFeed feed) throws IOException, FeedException {
     feed.setFeedType("rss_2.0");
     return feedToString(feed);
   }
 
+  /**
+   * Returns the atom.
+   *
+   * @param feed the feed
+   * @return the result
+   * @throws IOException if an error occurs
+   * @throws FeedException if an error occurs
+   */
   public String getAtom(SyndFeed feed) throws IOException, FeedException {
     feed.setFeedType("atom_1.0");
     return feedToString(feed);
   }
 
+  /**
+   * feedToString operation.
+   *
+   * @param feed the feed
+   * @return the result
+   * @throws IOException if an error occurs
+   * @throws FeedException if an error occurs
+   */
   public String feedToString(SyndFeed feed) throws IOException, FeedException {
     StringWriter writer = new StringWriter();
     SyndFeedOutput output = new SyndFeedOutput();
@@ -109,19 +186,43 @@ public class RssJexl implements IPSJexlExpression {
     return writer.getBuffer().toString();
   }
 
+  /**
+   * init operation.
+   *
+   * @param arg0 the arg0
+   * @param arg1 the arg1
+   * @throws PSExtensionException if an error occurs
+   */
   public void init(IPSExtensionDef arg0, File arg1) throws PSExtensionException {
     setLocationUtils(new PSLocationUtils());
     setAssemblyService(PSAssemblyServiceLocator.getAssemblyService());
   }
 
+  /**
+   * Sets the assembly service.
+   *
+   * @param assemblyService the assembly service
+   */
   public void setAssemblyService(IPSAssemblyService assemblyService) {
     this.assemblyService = assemblyService;
   }
 
+  /**
+   * Sets the location utils.
+   *
+   * @param locationUtils the location utils
+   */
   public void setLocationUtils(PSLocationUtils locationUtils) {
     this.locationUtils = locationUtils;
   }
 
+  /**
+   * findEntryTemplate operation.
+   *
+   * @param node the node
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   */
   public String findEntryTemplate(Node node) throws PSAssemblyException {
     String contentType = getContentType(node);
     Collection<IPSAssemblyTemplate> templates =
@@ -129,6 +230,13 @@ public class RssJexl implements IPSJexlExpression {
     return pickTemplate(templates);
   }
 
+  /**
+   * findFeedTemplate operation.
+   *
+   * @param node the node
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   */
   public String findFeedTemplate(Node node) throws PSAssemblyException {
     String contentType = getContentType(node);
     Collection<IPSAssemblyTemplate> templates =
@@ -136,6 +244,12 @@ public class RssJexl implements IPSJexlExpression {
     return pickTemplate(templates);
   }
 
+  /**
+   * Returns the content type.
+   *
+   * @param node the node
+   * @return the result
+   */
   protected String getContentType(Node node) {
     return NodeUtils.getContentType(node);
   }
@@ -145,6 +259,16 @@ public class RssJexl implements IPSJexlExpression {
     return templates.iterator().next().getName();
   }
 
+  /**
+   * findTemplates operation.
+   *
+   * @param name the name
+   * @param description the description
+   * @param mimeType the mime type
+   * @param format the format
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   */
   public Collection<IPSAssemblyTemplate> findTemplates(
       final String name, final String description, final String mimeType, final OutputFormat format)
       throws PSAssemblyException {
@@ -160,6 +284,12 @@ public class RssJexl implements IPSJexlExpression {
     filter(
         templates,
         new TemplatePredicate() {
+          /**
+           * evalTemplate operation.
+           *
+           * @param t the t
+           * @return the result
+           */
           @Override
           public boolean evalTemplate(IPSAssemblyTemplate t) {
             String name = fix(t.getName());
@@ -175,6 +305,12 @@ public class RssJexl implements IPSJexlExpression {
     return templates;
   }
 
+  /**
+   * findAllTemplates operation.
+   *
+   * @return the result
+   * @throws PSAssemblyException if an error occurs
+   */
   protected Collection<IPSAssemblyTemplate> findAllTemplates() throws PSAssemblyException {
     return assemblyService.findAllTemplates();
   }
@@ -186,10 +322,22 @@ public class RssJexl implements IPSJexlExpression {
 
   public abstract static class TemplatePredicate implements Predicate {
 
+    /**
+     * evaluate operation.
+     *
+     * @param t the t
+     * @return the result
+     */
     public boolean evaluate(Object t) {
       return evalTemplate((IPSAssemblyTemplate) t);
     }
 
+    /**
+     * evalTemplate operation.
+     *
+     * @param t the t
+     * @return the result
+     */
     public abstract boolean evalTemplate(IPSAssemblyTemplate t);
   }
 }


### PR DESCRIPTION
## Summary

Clears remaining **maven-javadoc-plugin** residual for **`modules/perc-toolkit`** after main/test project `-Xlint` already reached **0** (PR #2982 / #2658 / #2419).

| Metric | Before | After |
|--------|--------|-------|
| Javadoc warnings (`-Xmaxwarns 10000`) | **943** (100 capped in default plugin output) | **0** |
| Main/test Xlint | 0 / 0 | unchanged (not re-opened) |

**Parent tracker:** #2200  
**Slice of:** #2030  
**Issue:** #2983

### Approach

Prefer real Javadoc over doclint suppressions:

- Class/interface main descriptions (including reordering javadoc above annotations)
- Method `@param` / `@return` / `@throws` completion
- Field comments and documented default constructors where doclint requires them
- Empty comments / empty `<p>` cleanup

No production logic changes; mechanical documentation only.

## Test plan

- [x] `cd modules/perc-toolkit && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **245**, Failures: **0**, Errors: **0**, Skipped: **16**
- [x] `cd modules/perc-toolkit && ../../mvnw.cmd clean javadoc:javadoc "-DadditionalJOption=-Xmaxwarns 10000"` — **0** warnings, BUILD SUCCESS
- [x] Erlang self-review: javadoc-only; portable paths N/A; no API behavior intended beyond documented default ctors for doclint

### C3 evidence

- **modules_built:** `modules/perc-toolkit`
- **build_evidence:** `cd modules/perc-toolkit && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 245, Failures: 0, Errors: 0, Skipped: 16; javadoc warnings 943→0
- **downstream_checked:** none (documentation / default-ctor doclint companions only; C2 final/API shape N/A for call-site breakage; module suite green)

## Product documentation

- [x] N/A — pure tech-debt javadoc cleanup; no operator/user/API/product surface change

## Checklist

- [x] Fixes #2983
- [x] Links parent #2030 / grandparent #2200
- [x] Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2983
