### PR TITLE
fix(perc-content-explorer): PSACLNewUserDialog rawtypes residual (#2939)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2939-psacl-new-user-dialog-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2939-psacl-new-user-dialog-rawtypes-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review: issue #2939 PSACLNewUserDialog rawtypes residual
+
+**Scope:** `PSACLNewUserDialog`, `PSDisplayFormatOption`, `PSACLNewUserDialogTest`, `PSDisplayFormatOptionTest`
+**Date:** 2026-08-11
+**Verdict:** PASS
+
+## Bugs
+- None found. Generics-only; dialog load/combo selection control flow preserved.
+- `JComboBox#getSelectedItem` remains Object-typed in the JDK; casts retained at three call sites (same as pre-change).
+- `ProviderType.equals` still uses `appendSuper(Object.equals)` (historic IDE-style equals). Grouping via `List#indexOf` therefore still does not merge same-type providers — behavior preserved; documented in unit test. Not fixed (no product behavior change for this tech-debt slice).
+- `groupProvidersByType` extracted from `loadComboBoxes` with same membership/add order.
+
+## Behavioral tests
+- `PSACLNewUserDialogTest` (6): null/empty iterator, grouping adds instance per provider (historic equals), getInstance by name / null reject, instances list.
+- `PSDisplayFormatOptionTest` (5): empty/have, add/get/remove, path validation, toXml/fromXml round-trip + equals/hashCode, fromXml null reject.
+- Swing dialog not unit-instantiated (live applet resources).
+
+## Cross-platform
+- N/A (no path/file I/O changes). DOM test fixtures only.
+
+## Change-class companions
+- Unit tests for typed helpers/options; module standalone clean install green (130 tests).
+- Product docs N/A (compiler tech-debt, no operator surface change).
+- No Playwright (no WebUI product screen).
+- C2: `ProviderType` made static nested (was non-static); package-visible. No monorepo subclasses. Constructors now take `Iterator<PSSecurityProviderInstanceSummary>` — call site `PSFolderAclEditorDialog` still uses raw `getProviders()` (unchecked conversion only; file not edited — #2439).
+
+## Residual
+- Scope files clear of rawtypes on collections/models.
+- Avoid #2439 PSFolderAclEditorDialog (In Progress).
+- Next PR-sized clusters under #2326: PSSearchDialog, PSOptionManager, etc.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSACLNewUserDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSACLNewUserDialog.java
@@ -49,7 +49,10 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
    * @param applet the content explorer applet that owns this dialog and supplies its resources. May
    *     not be <code>null</code>.
    */
-  public PSACLNewUserDialog(Dialog dialog, Iterator providers, PSContentExplorerApplet applet) {
+  public PSACLNewUserDialog(
+      Dialog dialog,
+      Iterator<PSSecurityProviderInstanceSummary> providers,
+      PSContentExplorerApplet applet) {
     super(dialog, applet.getResourceString(PSACLNewUserDialog.class, "New User ACL Entry"));
 
     if (applet == null) throw new IllegalArgumentException("applet may not be null");
@@ -67,7 +70,10 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
    * @param applet the content explorer applet that owns this dialog and supplies its resources. May
    *     not be <code>null</code>.
    */
-  public PSACLNewUserDialog(Frame frame, Iterator providers, PSContentExplorerApplet applet) {
+  public PSACLNewUserDialog(
+      Frame frame,
+      Iterator<PSSecurityProviderInstanceSummary> providers,
+      PSContentExplorerApplet applet) {
     super(frame, applet.getResourceString(PSACLNewUserDialog.class, "New User ACL Entry"));
 
     if (applet == null) throw new IllegalArgumentException("applet may not be null");
@@ -82,6 +88,7 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
    * @return returns the selected provider. May be <code>null</code>.
    */
   public PSSecurityProviderInstanceSummary getSelectedProvider() {
+    // JComboBox#getSelectedItem remains Object-typed even on JComboBox<E>
     return (PSSecurityProviderInstanceSummary) m_instanceComboBox.getSelectedItem();
   }
 
@@ -99,16 +106,16 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
    *
    * @param providers the iterator of security provider instances.
    */
-  private void initDialog(Iterator providers) {
+  private void initDialog(Iterator<PSSecurityProviderInstanceSummary> providers) {
     JPanel mainPanel = new JPanel(new BorderLayout());
 
     PSPropertyPanel propPanel = new PSPropertyPanel();
     propPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 10));
 
-    m_typeComboBox = new JComboBox();
+    m_typeComboBox = new JComboBox<>();
     m_typeComboBox.addActionListener(new PSAccessibleActionListener());
     m_typeComboBox.addItemListener(this);
-    m_instanceComboBox = new JComboBox();
+    m_instanceComboBox = new JComboBox<>();
     m_instanceComboBox.addActionListener(new PSAccessibleActionListener());
     m_instanceComboBox.addItemListener(this);
     m_nameTextField = new JTextField();
@@ -161,9 +168,10 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
    */
   private void loadInstances(ProviderType provider) {
     if (null == provider) return;
-    Iterator it = provider.getInstances();
     m_instanceComboBox.removeAllItems();
-    while (it.hasNext()) m_instanceComboBox.addItem(it.next());
+    for (PSSecurityProviderInstanceSummary instance : provider.getInstances()) {
+      m_instanceComboBox.addItem(instance);
+    }
   }
 
   /**
@@ -171,27 +179,43 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
    *
    * @param providers. May be <code>null</code>.
    */
-  private void loadComboBoxes(Iterator providers) {
+  private void loadComboBoxes(Iterator<PSSecurityProviderInstanceSummary> providers) {
     if (null == providers) return;
 
-    PSSecurityProviderInstanceSummary provider = null;
-    List temp = new ArrayList();
-    ProviderType type = null;
+    List<ProviderType> temp = groupProvidersByType(providers);
+    for (ProviderType type : temp) {
+      m_typeComboBox.addItem(type);
+    }
+
+    loadInstances((ProviderType) m_typeComboBox.getSelectedItem());
+  }
+
+  /**
+   * Groups security provider instances by provider type for the type combo box. Package-visible for
+   * unit tests. Preserves historic {@link ProviderType#equals(Object)} / list membership behavior.
+   *
+   * @param providers iterator of provider summaries; may be <code>null</code>
+   * @return ordered list of provider type groups; never <code>null</code>
+   */
+  static List<ProviderType> groupProvidersByType(
+      Iterator<PSSecurityProviderInstanceSummary> providers) {
+    List<ProviderType> temp = new ArrayList<>();
+    if (providers == null) {
+      return temp;
+    }
     while (providers.hasNext()) {
-      provider = (PSSecurityProviderInstanceSummary) providers.next();
-      type = new ProviderType(provider.getTypeId(), provider.getTypeName());
-      if (temp.contains(type)) {
-        type = (ProviderType) temp.get(temp.indexOf(type));
+      PSSecurityProviderInstanceSummary provider = providers.next();
+      ProviderType type = new ProviderType(provider.getTypeId(), provider.getTypeName());
+      int existingIndex = temp.indexOf(type);
+      if (existingIndex >= 0) {
+        type = temp.get(existingIndex);
         type.addInstance(provider);
       } else {
         type.addInstance(provider);
         temp.add(type);
       }
     }
-    Iterator it = temp.iterator();
-    while (it.hasNext()) m_typeComboBox.addItem(it.next());
-
-    loadInstances((ProviderType) m_typeComboBox.getSelectedItem());
+    return temp;
   }
 
   // see ItemListener interface for details
@@ -203,8 +227,11 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
     }
   }
 
-  /** Convenience inner class to represent a provider type group */
-  class ProviderType {
+  /**
+   * Convenience nested class to represent a provider type group. Static so grouping helpers can
+   * construct instances without a dialog.
+   */
+  static class ProviderType {
 
     /**
      * Construct new ProviderType object
@@ -228,12 +255,12 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
     }
 
     /**
-     * Returns iterator of instances
+     * Returns instances of this provider type.
      *
-     * @return iterator of instances. Never <code>null</code>.
+     * @return list of instances. Never <code>null</code>.
      */
-    public Iterator getInstances() {
-      return m_instances.iterator();
+    public List<PSSecurityProviderInstanceSummary> getInstances() {
+      return m_instances;
     }
 
     /**
@@ -244,10 +271,7 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
      */
     PSSecurityProviderInstanceSummary getInstance(String name) {
       if (null == name) throw new IllegalArgumentException("Instance name cannot be null.");
-      Iterator it = m_instances.iterator();
-      PSSecurityProviderInstanceSummary inst = null;
-      while (it.hasNext()) {
-        inst = (PSSecurityProviderInstanceSummary) it.next();
+      for (PSSecurityProviderInstanceSummary inst : m_instances) {
         if (inst.getInstanceName().equals(name)) return inst;
       }
       return null;
@@ -287,7 +311,7 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
     }
 
     /** The list of provider instances. Never <code>null</code>, may be empty. */
-    protected List m_instances = new ArrayList();
+    protected List<PSSecurityProviderInstanceSummary> m_instances = new ArrayList<>();
 
     /** The provider type id */
     protected int m_typeId;
@@ -300,13 +324,13 @@ public class PSACLNewUserDialog extends PSDialog implements ItemListener {
    * Security provider type combo box. Initialized in {@link #initDialog(Iterator)}, never <code>
    * null</code> after that.
    */
-  private JComboBox m_typeComboBox;
+  private JComboBox<ProviderType> m_typeComboBox;
 
   /**
    * Provider instance combo box. Initialized in {@link #initDialog(Iterator)}, never <code>null
    * </code> after that.
    */
-  private JComboBox m_instanceComboBox;
+  private JComboBox<PSSecurityProviderInstanceSummary> m_instanceComboBox;
 
   /**
    * User name text field. Initialized in {@link #initDialog(Iterator)}, never <code>null</code>

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSDisplayFormatOption.java
@@ -20,7 +20,6 @@ import com.percussion.cx.error.IPSContentExplorerErrors;
 import com.percussion.cx.error.PSContentExplorerException;
 import com.percussion.util.PSXMLDomUtil;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,10 +87,9 @@ public class PSDisplayFormatOption implements IPSClientObjects {
     // create temp element
     Element el = null;
 
-    Iterator iter = m_map.keySet().iterator();
-    while (iter.hasNext()) {
-      String itemPath = (String) iter.next();
-      String displayFormatId = (String) m_map.get(itemPath);
+    for (Map.Entry<String, String> entry : m_map.entrySet()) {
+      String itemPath = entry.getKey();
+      String displayFormatId = entry.getValue();
 
       el = doc.createElement(ELEM_ITEM);
       el.setAttribute(ATTR_ITEM_PATH, itemPath);
@@ -145,7 +143,7 @@ public class PSDisplayFormatOption implements IPSClientObjects {
     if (itemPath == null || itemPath.trim().length() == 0)
       throw new IllegalArgumentException("itemPath must not be null or empty");
 
-    return (String) m_map.get(itemPath);
+    return m_map.get(itemPath);
   }
 
   /**
@@ -189,7 +187,7 @@ public class PSDisplayFormatOption implements IPSClientObjects {
    * The map representing the items display formats, set to an empty map here, may be changed. The
    * key is the item path, the value is the display format for the specific item.
    */
-  private Map m_map = new HashMap();
+  private final Map<String, String> m_map = new HashMap<>();
 
   /** Name of the Root element of the XML document representing a item display format option. */
   private static final String ELEM_DISPLAY_FORMAT_OPTION = "PSXDisplayFormatOption";

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSACLNewUserDialogTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSACLNewUserDialogTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.PSSecurityProviderInstanceSummary;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral tests for typed provider grouping helpers on {@link PSACLNewUserDialog} after rawtypes
+ * cleanup (#2939). Does not open the Swing dialog (requires live applet resources).
+ */
+public class PSACLNewUserDialogTest {
+
+  @Test
+  public void groupProvidersByTypeNullIteratorReturnsEmpty() {
+    List<PSACLNewUserDialog.ProviderType> groups =
+        PSACLNewUserDialog.groupProvidersByType(null);
+    assertTrue(groups.isEmpty());
+  }
+
+  @Test
+  public void groupProvidersByTypeEmptyIteratorReturnsEmpty() {
+    List<PSACLNewUserDialog.ProviderType> groups =
+        PSACLNewUserDialog.groupProvidersByType(Collections.emptyIterator());
+    assertTrue(groups.isEmpty());
+  }
+
+  @Test
+  public void groupProvidersByTypeAddsInstancePerProvider() {
+    PSSecurityProviderInstanceSummary a = summary(1, "Directory", "ldap-a");
+    PSSecurityProviderInstanceSummary b = summary(2, "WebServer", "ws-b");
+
+    List<PSSecurityProviderInstanceSummary> providers = new ArrayList<>();
+    providers.add(a);
+    providers.add(b);
+
+    List<PSACLNewUserDialog.ProviderType> groups =
+        PSACLNewUserDialog.groupProvidersByType(providers.iterator());
+
+    // Historic ProviderType.equals uses Object.equals super, so distinct ProviderType objects
+    // never match — each provider becomes its own group (preserves pre-generics dialog behavior).
+    assertEquals(2, groups.size());
+    assertEquals(1, groups.get(0).getInstances().size());
+    assertSame(a, groups.get(0).getInstances().get(0));
+    assertEquals("Directory", groups.get(0).toString());
+    assertEquals(1, groups.get(1).getInstances().size());
+    assertSame(b, groups.get(1).getInstances().get(0));
+    assertEquals("WebServer", groups.get(1).toString());
+  }
+
+  @Test
+  public void providerTypeGetInstanceFindsByName() {
+    PSSecurityProviderInstanceSummary a = summary(1, "Directory", "ldap-a");
+    PSSecurityProviderInstanceSummary b = summary(1, "Directory", "ldap-b");
+    PSACLNewUserDialog.ProviderType type = new PSACLNewUserDialog.ProviderType(1, "Directory");
+    type.addInstance(a);
+    type.addInstance(b);
+    type.addInstance(null); // ignored
+
+    assertSame(a, type.getInstance("ldap-a"));
+    assertSame(b, type.getInstance("ldap-b"));
+    assertNull(type.getInstance("missing"));
+  }
+
+  @Test
+  public void providerTypeGetInstanceRejectsNullName() {
+    PSACLNewUserDialog.ProviderType type = new PSACLNewUserDialog.ProviderType(1, "Directory");
+    assertThrows(IllegalArgumentException.class, () -> type.getInstance(null));
+  }
+
+  @Test
+  public void providerTypeGetInstancesIsMutableListBackingField() {
+    PSACLNewUserDialog.ProviderType type = new PSACLNewUserDialog.ProviderType(1, "Directory");
+    assertTrue(type.getInstances().isEmpty());
+    type.addInstance(summary(1, "Directory", "x"));
+    assertEquals(1, type.getInstances().size());
+    Iterator<PSSecurityProviderInstanceSummary> it = type.getInstances().iterator();
+    assertTrue(it.hasNext());
+  }
+
+  private static PSSecurityProviderInstanceSummary summary(
+      int typeId, String typeName, String instanceName) {
+    try {
+      Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+      Element root = doc.createElement(PSSecurityProviderInstanceSummary.XML_ELEMENT_ROOT);
+      root.setAttribute(PSSecurityProviderInstanceSummary.XML_ATTRIB_TYPEID, String.valueOf(typeId));
+      root.setAttribute(PSSecurityProviderInstanceSummary.XML_ATTRIB_TYPENAME, typeName);
+      Element name = doc.createElement(PSSecurityProviderInstanceSummary.XML_ELEMENT_NAME);
+      name.appendChild(doc.createTextNode(instanceName));
+      root.appendChild(name);
+      return new PSSecurityProviderInstanceSummary(root);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatOptionTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSDisplayFormatOptionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/** Behavioral tests for typed {@link PSDisplayFormatOption} map after rawtypes cleanup (#2939). */
+public class PSDisplayFormatOptionTest {
+
+  @Test
+  public void emptyOptionHasNoDisplayFormats() {
+    PSDisplayFormatOption option = new PSDisplayFormatOption();
+    assertFalse(option.haveDisplayFormats());
+  }
+
+  @Test
+  public void addGetRemoveRoundTrip() {
+    PSDisplayFormatOption option = new PSDisplayFormatOption();
+    option.addItemDisplayFormat("/Sites/a", "df-1");
+    assertTrue(option.haveDisplayFormats());
+    assertEquals("df-1", option.getItemDisplayFormat("/Sites/a"));
+    assertNull(option.getItemDisplayFormat("/Sites/missing"));
+
+    option.removeItemDisplayFormat("/Sites/a");
+    assertFalse(option.haveDisplayFormats());
+    assertNull(option.getItemDisplayFormat("/Sites/a"));
+  }
+
+  @Test
+  public void addRejectsNullOrEmptyPath() {
+    PSDisplayFormatOption option = new PSDisplayFormatOption();
+    assertThrows(IllegalArgumentException.class, () -> option.addItemDisplayFormat(null, "df"));
+    assertThrows(IllegalArgumentException.class, () -> option.addItemDisplayFormat("  ", "df"));
+    assertThrows(IllegalArgumentException.class, () -> option.getItemDisplayFormat(null));
+    assertThrows(IllegalArgumentException.class, () -> option.removeItemDisplayFormat(""));
+  }
+
+  @Test
+  public void toXmlEmitsItemsAndFromXmlRestores() throws Exception {
+    PSDisplayFormatOption option = new PSDisplayFormatOption();
+    option.addItemDisplayFormat("/Sites/a", "df-1");
+    option.addItemDisplayFormat("/Sites/b", "df-2");
+
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    Element root = option.toXml(doc);
+    assertEquals("PSXDisplayFormatOption", root.getNodeName());
+    NodeList items = root.getElementsByTagName("Item");
+    assertEquals(2, items.getLength());
+
+    PSDisplayFormatOption restored = new PSDisplayFormatOption();
+    restored.fromXml(root);
+    assertTrue(restored.haveDisplayFormats());
+    assertEquals("df-1", restored.getItemDisplayFormat("/Sites/a"));
+    assertEquals("df-2", restored.getItemDisplayFormat("/Sites/b"));
+    assertEquals(option, restored);
+    assertEquals(option.hashCode(), restored.hashCode());
+  }
+
+  @Test
+  public void fromXmlRejectsNull() {
+    PSDisplayFormatOption option = new PSDisplayFormatOption();
+    assertThrows(IllegalArgumentException.class, () -> option.fromXml(null));
+  }
+}


### PR DESCRIPTION
## Summary
Parameterize residual rawtypes/unchecked on Desktop Content Explorer after display cluster (#2875 / PR #2940).

- **PSACLNewUserDialog**: `Iterator`/`List`/`JComboBox` typed; `ProviderType` static nested; `groupProvidersByType` extracted for tests
- **PSDisplayFormatOption** (optional small companion): `Map<String,String>` + entrySet `toXml`
- Unit tests: `PSACLNewUserDialogTest` (6) + `PSDisplayFormatOptionTest` (5)
- **Did not touch** `PSFolderAclEditorDialog` (#2439 In Progress)
- **Left for next residual:** `PSSearchDialog` (large raw Map/Iterator surface)

No product behavior change (compiler tech-debt only).

Parent residual tracker: #2326  
Parent module: #2045  
Monorepo: #2200  
Prior slice: #2875  

Fixes #2939

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install`
- [x] BUILD SUCCESS — Tests run: 130, Failures: 0
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-2939-psacl-new-user-dialog-rawtypes-erlang.md`

## Product documentation
- [x] N/A — pure rawtypes/generics tech-debt; no operator/user/API surface change

## Build evidence (C3)
- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `cd modules/DesktopContentExplorer; ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 130, Failures: 0, Errors: 0, Skipped: 0
- **downstream_checked:** none (C2 N/A — no final/sealed public API; ctor now takes typed Iterator; sole call site PSFolderAclEditorDialog uses raw cataloger iterator with unchecked conversion only; file not edited per #2439)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
