### PR TITLE
fix(perc-system): type install upgrade-plugin rawtypes residual (#2942)

### DIFF
--- a/system/src/main/java/com/percussion/install/PSUpgradeDbAndHtmlAndXslFilesForSlotNames.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradeDbAndHtmlAndXslFilesForSlotNames.java
@@ -94,12 +94,12 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
     config.getLogStream().println();
     config.getLogStream().println("Running plugin to upgrade slot names to remove blank spaces...");
     config.getLogStream().println();
-    List fileList = null;
+    List<File> fileList = null;
 
     File root = new File(RxUpgrade.getRxRoot());
 
     try {
-      List slotNames = updateLabelsAndLoadSlotNamesFromDatabase(config.getLogStream());
+      List<String> slotNames = updateLabelsAndLoadSlotNamesFromDatabase(config.getLogStream());
       if (slotNames.isEmpty()) {
         config.getLogStream().println("No slot names in the system");
         return null;
@@ -128,9 +128,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
       return null;
     }
 
-    Iterator iter = fileList.iterator();
-    while (iter.hasNext()) {
-      File appFile = (File) iter.next();
+    for (File appFile : fileList) {
 
       String fileName = appFile.getName();
       String appFolder = fileName.substring(0, fileName.length() - ".xml".length());
@@ -223,11 +221,11 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
    *
    * @param slotNames list of slot names, assumed not null.
    */
-  private void buildNameMapAndArray(List slotNames) {
-    m_oldNewNameMap = new HashMap();
-    Set newNames = new HashSet();
+  private void buildNameMapAndArray(List<String> slotNames) {
+    m_oldNewNameMap = new HashMap<>();
+    Set<String> newNames = new HashSet<>();
     for (int i = 0; i < slotNames.size(); i++) {
-      String oldName = (String) slotNames.get(i);
+      String oldName = slotNames.get(i);
       String newName = InstallUtil.modifyName(oldName);
 
       // Make sure names are unique by appending trialing "X"
@@ -237,21 +235,16 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
       m_oldNewNameMap.put(oldName, newName);
     }
 
-    Iterator iter = m_oldNewNameMap.keySet().iterator();
-    while (iter.hasNext()) {
-      String oldName = (String) iter.next();
-      String newName = (String) m_oldNewNameMap.get(oldName);
+    for (Map.Entry<String, String> e : m_oldNewNameMap.entrySet()) {
+      String oldName = e.getKey();
+      String newName = e.getValue();
       if (!oldName.equals(newName)) m_oldNewNameModifiedMap.put(oldName, newName);
     }
 
-    m_sortedSlotNames = (String[]) m_oldNewNameModifiedMap.keySet().toArray(new String[0]);
+    m_sortedSlotNames = m_oldNewNameModifiedMap.keySet().toArray(new String[0]);
     Arrays.sort(
         m_sortedSlotNames,
-        new Comparator() {
-          public int compare(Object o1, Object o2) {
-            return (((String) o2).length() - ((String) o1).length());
-          }
-        });
+        Comparator.comparingInt(String::length).reversed());
   }
 
   /**
@@ -266,18 +259,16 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
     if (app == null) throw new IllegalArgumentException("app may not be null");
 
     int convertedSlots = 0;
-    Iterator dataSets = app.getDataSets().iterator();
-    while (dataSets.hasNext()) {
-      PSDataSet dataSet = (PSDataSet) dataSets.next();
+    for (Object dataSetObj : app.getDataSets()) {
+      PSDataSet dataSet = (PSDataSet) dataSetObj;
       PSPipe pipe = dataSet.getPipe();
 
       if (pipe != null) {
         PSExtensionCallSet resultDataExts = pipe.getResultDataExtensions();
 
         if (resultDataExts != null) {
-          Iterator callSet = resultDataExts.iterator();
-          while (callSet.hasNext()) {
-            PSExtensionCall call = (PSExtensionCall) callSet.next();
+          for (Object callObj : resultDataExts) {
+            PSExtensionCall call = (PSExtensionCall) callObj;
 
             if (call.getName().equals("rxs_NavTreeSlotMarker")) {
               PSExtensionParamValue[] values = call.getParamValues();
@@ -313,11 +304,11 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
    * @return List of files matching the pattern, may be <code>null</code> or empty.
    * @throws IOException
    */
-  private List getFilesOfType(File folder, String extnPattern) throws IOException {
+  private List<File> getFilesOfType(File folder, String extnPattern) throws IOException {
     if (!folder.isDirectory()) {
       throw new IOException(folder.getAbsolutePath() + " is not a directory");
     }
-    List fileList;
+    List<File> fileList;
     PSPatternMatcher pattern = new PSPatternMatcher('?', '*', extnPattern);
     PSFileFilter filter = new PSFileFilter(PSFileFilter.IS_FILE);
     filter.setNamePattern(pattern);
@@ -351,7 +342,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
       throws MalformedURLException, IOException {
     // Upgrade all source Html files
     File srcDir = new File(folder, "src");
-    List htmlFiles = getFilesOfType(folder, "*.htm*");
+    List<File> htmlFiles = getFilesOfType(folder, "*.htm*");
     if (srcDir.exists()) upgradeHtmlFiles(srcDir, testMode, logStream);
     else logStream.println("HTML source directory does not exist.");
     // May be some html files are not in the "src" directory ...
@@ -367,9 +358,9 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
     File editDir = new File(folder, "edit");
     if (!editDir.exists()) return;
 
-    List xslFilesToDelete = getFilesOfType(editDir, ".xsl");
+    List<File> xslFilesToDelete = getFilesOfType(editDir, ".xsl");
     for (int i = 0; i < xslFilesToDelete.size(); i++) {
-      File file = (File) xslFilesToDelete.get(i);
+      File file = xslFilesToDelete.get(i);
       logStream.println("Deleting file '" + file.getAbsolutePath() + "'...");
       try {
         file.delete();
@@ -395,9 +386,9 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
       throws IOException {
     logStream.println("modifying XSL files from: " + folder.getAbsolutePath() + "directory...");
 
-    List xslFiles = getFilesOfType(folder, "*.xsl");
+    List<File> xslFiles = getFilesOfType(folder, "*.xsl");
     for (int i = 0; i < xslFiles.size(); i++) {
-      File file = (File) xslFiles.get(i);
+      File file = xslFiles.get(i);
       try {
         upgradeFile(file, testMode, logStream);
       } catch (Exception e) {
@@ -421,7 +412,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
       throws IOException {
     logStream.println("modifying HTML files from: " + folder.getAbsolutePath() + "directory...");
 
-    List htmlFiles = getFilesOfType(folder, "*.htm*");
+    List<File> htmlFiles = getFilesOfType(folder, "*.htm*");
     for (int i = 0; i < htmlFiles.size(); i++) {
       File file = (File) htmlFiles.get(i);
       try {
@@ -453,8 +444,8 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
     StringBuilder sbOld = new StringBuilder();
     StringBuilder sbNew = new StringBuilder();
     List allStartTags = source.findAllStartTags();
-    for (Iterator i = allStartTags.iterator(); i.hasNext(); ) {
-      StartTag sTag = (StartTag) i.next();
+    for (Object tagObj : allStartTags) {
+      StartTag sTag = (StartTag) tagObj;
       Attributes attributes = sTag.getAttributes();
 
       if (attributes == null) continue;
@@ -584,7 +575,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
       int oldNameIndex = valueUpper.indexOf(oldName.toUpperCase());
       if (oldNameIndex != -1) {
         slotNames[0] = value.substring(oldNameIndex, oldNameIndex + oldNameLength);
-        slotNames[1] = (String) m_oldNewNameModifiedMap.get(oldName);
+        slotNames[1] = m_oldNewNameModifiedMap.get(oldName);
         return slotNames;
       }
     }
@@ -597,7 +588,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
    * @param logStream print stream for logging, assumed not null.
    * @return List of all slot names in the system, never <code>null</code> may be empty.
    */
-  private static List updateLabelsAndLoadSlotNamesFromDatabase(PrintStream logStream)
+  private static List<String> updateLabelsAndLoadSlotNamesFromDatabase(PrintStream logStream)
       throws Exception {
     logStream.println("Filling empty slot labels...");
     Connection conn = RxUpgrade.getJdbcConnection();
@@ -629,7 +620,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
     String queryStmt = "SELECT " + qualTableName + ".SLOTNAME " + "FROM " + qualTableName;
 
     ResultSet rs = stmt.executeQuery(queryStmt);
-    List result = new ArrayList();
+    List<String> result = new ArrayList<>();
     while (rs.next()) result.add(rs.getString("SLOTNAME"));
 
     return result;
@@ -642,7 +633,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
    *     be empty.
    * @param logStream print stream for logging, assumed not null.
    */
-  private static void updateSlotNamesInDatabase(Map oldNewNameMap, PrintStream logStream)
+  private static void updateSlotNamesInDatabase(Map<String, String> oldNewNameMap, PrintStream logStream)
       throws Exception {
     logStream.println("Updating slot names with new ones...");
 
@@ -665,10 +656,9 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
             + ".SLOTNAME="
             + "?";
 
-    Iterator iter = oldNewNameMap.keySet().iterator();
-    while (iter.hasNext()) {
-      String oldName = (String) iter.next();
-      String newName = (String) oldNewNameMap.get(oldName);
+    for (Map.Entry<String, String> e : oldNewNameMap.entrySet()) {
+      String oldName = e.getKey();
+      String newName = e.getValue();
       logStream.println("Replacing '" + oldName + "' with '" + newName + "'...");
       PreparedStatement stmt = conn.prepareStatement(updateStmt);
       stmt.setString(1, newName);
@@ -680,7 +670,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
   }
 
   /** Set of special app folder names to exclude from upgrade. */
-  private static Set EXCLUDE_APP_SET = new HashSet();
+  private static final Set<String> EXCLUDE_APP_SET = new HashSet<>();
 
   static {
     EXCLUDE_APP_SET.add("Administration");
@@ -691,13 +681,13 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
   }
 
   /** Map of old and new slot names, old names being the keys. */
-  private Map m_oldNewNameMap = null;
+  private Map<String, String> m_oldNewNameMap = null;
 
   /** Array of old slot names (modified only) sorted by the length of the string. */
   private String[] m_sortedSlotNames = null;
 
   /** This will be the subset of m_oldNewNameMap in which the key and values are different. */
-  private Map m_oldNewNameModifiedMap = new HashMap();
+  private Map<String, String> m_oldNewNameModifiedMap = new HashMap<>();
 
   /**
    * Name of the property holding the list slot names in the property file {@link
@@ -718,7 +708,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
     PSUpgradeDbAndHtmlAndXslFilesForSlotNames plugin =
         new PSUpgradeDbAndHtmlAndXslFilesForSlotNames();
 
-    List fileList = null;
+    List<File> fileList = null;
 
     File root = new File("f:/Rhythmyx");
 
@@ -727,9 +717,7 @@ public class PSUpgradeDbAndHtmlAndXslFilesForSlotNames implements IPSUpgradePlug
 
     System.out.println("Running in test mode. Files will not be changed");
 
-    Iterator iter = fileList.iterator();
-    while (iter.hasNext()) {
-      File appFile = (File) iter.next();
+    for (File appFile : fileList) {
 
       String fileName = appFile.getName();
       String appFolder = fileName.substring(0, fileName.length() - ".xml".length());

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginCleanContentStatus.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginCleanContentStatus.java
@@ -30,9 +30,7 @@ import java.io.FileInputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Properties;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -140,7 +138,6 @@ public class PSUpgradePluginCleanContentStatus implements IPSUpgradePlugin {
 
     Iterator<PSJdbcRowData> rows = csData.getRows();
     PSJdbcRowData tRow = null;
-    Map<String, PSJdbcRowData> nullntRows = new HashMap<>();
     String title = "";
     String newTitle = "title_";
     String contentid = "0";

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginCleanContentStatus.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginCleanContentStatus.java
@@ -138,9 +138,9 @@ public class PSUpgradePluginCleanContentStatus implements IPSUpgradePlugin {
     PSJdbcTableData csData = csSchema.getTableData();
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
 
-    Iterator rows = csData.getRows();
+    Iterator<PSJdbcRowData> rows = csData.getRows();
     PSJdbcRowData tRow = null;
-    Map nullntRows = new HashMap();
+    Map<String, PSJdbcRowData> nullntRows = new HashMap<>();
     String title = "";
     String newTitle = "title_";
     String contentid = "0";
@@ -149,7 +149,7 @@ public class PSUpgradePluginCleanContentStatus implements IPSUpgradePlugin {
 
     // Scan each row
     while (rows.hasNext()) {
-      tRow = (PSJdbcRowData) rows.next();
+      tRow = rows.next();
       title = tRow.getColumn("TITLE").getValue();
       contentid = tRow.getColumn("CONTENTID").getValue();
 

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginCleanLocationSchemes.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginCleanLocationSchemes.java
@@ -156,22 +156,22 @@ public class PSUpgradePluginCleanLocationSchemes implements IPSUpgradePlugin {
       PSJdbcTableSchema paramsSchema) {
     log("Checking for non-unique location schemes so they can be deleted.");
 
-    List schemeIds = new ArrayList();
-    List schemeKeys = new ArrayList();
-    List lsDeleteData = new ArrayList();
-    List paramsDeleteData = new ArrayList();
+    List<String> schemeIds = new ArrayList<>();
+    List<SchemeKey> schemeKeys = new ArrayList<>();
+    List<PSJdbcRowData> lsDeleteData = new ArrayList<>();
+    List<PSJdbcRowData> paramsDeleteData = new ArrayList<>();
     StringBuilder lsDeletedRows = new StringBuilder();
     StringBuilder paramsDeletedRows = new StringBuilder();
     PSJdbcTableData lsData = lsSchema.getTableData();
     PSJdbcTableData paramsData = paramsSchema.getTableData();
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
 
-    Iterator rows = paramsData.getRows();
+    Iterator<PSJdbcRowData> rows = paramsData.getRows();
     PSJdbcRowData tRow = null;
-    Map paramsKeys = new HashMap();
+    Map<String, PSJdbcRowData> paramsKeys = new HashMap<>();
 
     while (rows.hasNext()) {
-      tRow = (PSJdbcRowData) rows.next();
+      tRow = rows.next();
       paramsKeys.put(tRow.getColumn("SCHEMEPARAMID").getValue(), tRow);
     }
 
@@ -183,7 +183,7 @@ public class PSUpgradePluginCleanLocationSchemes implements IPSUpgradePlugin {
     SchemeKey sk = null;
 
     while (rows.hasNext()) {
-      tRow = (PSJdbcRowData) rows.next();
+      tRow = rows.next();
       schemeId = tRow.getColumn("SCHEMEID").getValue();
       variantId = tRow.getColumn("VARIANTID").getValue();
       contextId = tRow.getColumn("CONTEXTID").getValue();
@@ -197,17 +197,15 @@ public class PSUpgradePluginCleanLocationSchemes implements IPSUpgradePlugin {
                 tRow.toXml(doc), PSXmlDocumentBuilder.FLAG_OMIT_XML_DECL));
         schemeIds.add(schemeId);
 
-        List cols = new ArrayList();
+        List<PSJdbcColumnData> cols = new ArrayList<>();
         cols.add(new PSJdbcColumnData("SCHEMEID", schemeId));
         lsDeleteData.add(new PSJdbcRowData(cols.iterator(), PSJdbcRowData.ACTION_DELETE));
 
         // Setup to delete all LOCATIONSCHEMEPARAMS rows with
         // this SCHEMEID
-        Iterator keys = paramsKeys.keySet().iterator();
-
-        while (keys.hasNext()) {
-          String schemeparamid = (String) keys.next();
-          PSJdbcRowData theRow = (PSJdbcRowData) paramsKeys.get(schemeparamid);
+        for (Map.Entry<String, PSJdbcRowData> keyEntry : paramsKeys.entrySet()) {
+          String schemeparamid = keyEntry.getKey();
+          PSJdbcRowData theRow = keyEntry.getValue();
           String value = theRow.getColumn("SCHEMEID").getValue();
           cols.clear();
 

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginConvertCommunityVisibility.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginConvertCommunityVisibility.java
@@ -46,10 +46,8 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import javax.naming.NamingException;
 import org.apache.commons.lang3.StringUtils;
@@ -70,10 +68,10 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    * The known community ids. Used for cases where we are returning the shown communities from the
    * hidden
    */
-  private List m_communityIds = new ArrayList();
+  private List<Long> m_communityIds = new ArrayList<>();
 
   /** A map of community ids to names. */
-  private Map m_communityIdToName = new HashMap();
+  private Map<Long, String> m_communityIdToName = new HashMap<>();
 
   /** The connection details, used to qualify the table name */
   private PSConnectionDetail m_details;
@@ -90,12 +88,10 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
     fixCommunityNames();
 
     // Record all community ids
-    final List communities = getRoleMgr().findCommunitiesByName(null);
-    Iterator citer = communities.iterator();
-    while (citer.hasNext()) {
-      PSCommunity community = (PSCommunity) citer.next();
-      m_communityIds.add(new Long(community.getId()));
-      m_communityIdToName.put(new Long(community.getId()), community.getName());
+    final List<PSCommunity> communities = getRoleMgr().findCommunitiesByName(null);
+    for (PSCommunity community : communities) {
+      m_communityIds.add(Long.valueOf(community.getId()));
+      m_communityIdToName.put(Long.valueOf(community.getId()), community.getName());
     }
 
     log("Performing Community Visibility Conversion");
@@ -116,7 +112,7 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
     StringBuilder problems = new StringBuilder();
 
     IPSAclService asvc = PSAclServiceLocator.getAclService();
-    List acls = new ArrayList();
+    List<IPSAcl> acls = new ArrayList<>();
 
     try {
       for (int i = 0; i < count; i++) {
@@ -143,7 +139,7 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    * @param limit if the list has at least the number of elements in the limit, then save.
    * @throws Exception if there's an error saving the acls
    */
-  private void saveAcls(IPSAclService asvc, List acls, int limit) throws Exception {
+  private void saveAcls(IPSAclService asvc, List<IPSAcl> acls, int limit) throws Exception {
     if (acls.size() >= limit) {
       asvc.saveAcls(acls);
       acls.clear();
@@ -152,12 +148,12 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
 
   /** Replaces spaces with underscores in community names. */
   private void fixCommunityNames() {
-    final List communities = getRoleMgr().findCommunitiesByName(null);
-    final List communitiesToFixNames = findCommunitiesToFixNames(communities);
-    final Set communityNames = getCommunityNames(communities);
+    final List<PSCommunity> communities = getRoleMgr().findCommunitiesByName(null);
+    final List<PSCommunity> communitiesToFixNames =
+        findCommunitiesToFixNames(communities);
+    final Set<String> communityNames = getCommunityNames(communities);
 
-    for (Iterator i = communitiesToFixNames.iterator(); i.hasNext(); ) {
-      final PSCommunity community = (PSCommunity) i.next();
+    for (final PSCommunity community : communitiesToFixNames) {
       community.setName(
           PSNameSpacesUtil.removeWhitespacesFromName(community.getName(), communityNames));
       communityNames.add(community.getName());
@@ -165,11 +161,13 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
     }
   }
 
-  /** Selects communities from the list which need their names to be fixed. */
-  private List findCommunitiesToFixNames(final List communities) {
-    final List communitiesToFixNames = new ArrayList();
-    for (Iterator i = communities.iterator(); i.hasNext(); ) {
-      final PSCommunity community = (PSCommunity) i.next();
+  /**
+   * Selects communities from the list which need their names to be fixed. Package-visible static
+   * for unit tests (no Spring context required).
+   */
+  static List<PSCommunity> findCommunitiesToFixNames(final List<PSCommunity> communities) {
+    final List<PSCommunity> communitiesToFixNames = new ArrayList<>();
+    for (final PSCommunity community : communities) {
       final String name = community.getName();
       if (!name.equals(StringUtils.deleteWhitespace(name))) {
         communitiesToFixNames.add(community);
@@ -178,11 +176,13 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
     return communitiesToFixNames;
   }
 
-  /** Set of community names extracted from the provided communities. */
-  private Set getCommunityNames(final List communities) {
-    final Set names = new HashSet();
-    for (Iterator i = communities.iterator(); i.hasNext(); ) {
-      final PSCommunity community = (PSCommunity) i.next();
+  /**
+   * Set of community names extracted from the provided communities. Package-visible static for unit
+   * tests (no Spring context required).
+   */
+  static Set<String> getCommunityNames(final List<PSCommunity> communities) {
+    final Set<String> names = new HashSet<>();
+    for (final PSCommunity community : communities) {
       names.add(community.getName());
     }
     return names;
@@ -197,7 +197,7 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    * @return <code>null</code> if there are no errors, otherwise a description of the problem(s)
    *     found
    */
-  private String processEntry(Node el, List acls) {
+  private String processEntry(Node el, List<IPSAcl> acls) {
     if (el == null) {
       throw new IllegalArgumentException("el may not be null");
     }
@@ -206,25 +206,22 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
     short ordinal = Short.parseShort(type);
 
     try {
-      Map data = getData(element);
+      Map<Long, List<Long>> data = getData(element);
 
       IPSAclService asvc = PSAclServiceLocator.getAclService();
-      Iterator iter = data.keySet().iterator();
-      Map guidToAcl = new HashMap();
+      Map<PSGuid, IPSAcl> guidToAcl = new HashMap<>();
 
       log("Beginning community visibility conversion for data");
 
-      while (iter.hasNext()) {
-        Long oid = (Long) iter.next();
-        List communities = (List) data.get(oid);
-        Iterator citer = communities.iterator();
-        while (citer.hasNext()) {
-          Long c = (Long) citer.next();
+      for (Map.Entry<Long, List<Long>> dataEntry : data.entrySet()) {
+        Long oid = dataEntry.getKey();
+        List<Long> communities = dataEntry.getValue();
+        for (Long c : communities) {
 
           String community_name;
 
           if (c.longValue() > 0) {
-            community_name = (String) m_communityIdToName.get(c);
+            community_name = m_communityIdToName.get(c);
             if (community_name == null) {
               log("Warning - community not present for id: " + c);
               continue;
@@ -237,7 +234,7 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
           guid.setType(ordinal);
           guid.setUUID(oid.intValue());
 
-          IPSAcl object_acl = (IPSAcl) guidToAcl.get(guid);
+          IPSAcl object_acl = guidToAcl.get(guid);
           if (object_acl == null) {
             object_acl = asvc.loadAclForObject(guid);
             if (object_acl != null) continue;
@@ -287,7 +284,7 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    * @throws SQLException
    * @throws NamingException
    */
-  private Map getData(Element element) throws SQLException, NamingException {
+  private Map<Long, List<Long>> getData(Element element) throws SQLException, NamingException {
     String style = element.getAttribute("style");
 
     if (style != null && style.equals("join")) {
@@ -355,7 +352,7 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    * @throws SQLException
    * @throws NamingException
    */
-  private Map getPropertyData(Element element) throws SQLException, NamingException {
+  private Map<Long, List<Long>> getPropertyData(Element element) throws SQLException, NamingException {
     // Get parameters
     String objectIdColumn = element.getAttribute("objectid").toUpperCase();
     String propertyColumn = element.getAttribute("property-column").toUpperCase();
@@ -396,7 +393,7 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    * @throws SQLException
    * @throws NamingException
    */
-  private Map getJoinData(Element element) throws SQLException, NamingException {
+  private Map<Long, List<Long>> getJoinData(Element element) throws SQLException, NamingException {
     // Get parameters
     String objectIdColumn = element.getAttribute("objectid").toUpperCase();
     String community = element.getAttribute("community").toUpperCase();
@@ -426,10 +423,10 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    * @throws SQLException
    * @throws NamingException
    */
-  private Map getQueryResults(StringBuilder query, boolean hide)
+  private Map<Long, List<Long>> getQueryResults(StringBuilder query, boolean hide)
       throws SQLException, NamingException {
     Connection c = null;
-    Map rval = new HashMap();
+    Map<Long, List<Long>> rval = new HashMap<>();
 
     try {
       c = m_dbm.getDbConnection(m_info);
@@ -443,25 +440,21 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
         Long objectid, communityid;
         objectid = convertToLong(rs.getObject(1));
         communityid = convertToLong(rs.getObject(2));
-        List communities = (List) rval.get(objectid);
+        List<Long> communities = rval.get(objectid);
         if (communities == null) {
-          communities = new ArrayList();
+          communities = new ArrayList<>();
           rval.put(objectid, communities);
         }
         communities.add(communityid);
       }
 
       if (hide) {
-        Iterator eiter = rval.entrySet().iterator();
-        while (eiter.hasNext()) {
-          Map.Entry entry = (Entry) eiter.next();
-          List communities = (List) entry.getValue();
+        for (Map.Entry<Long, List<Long>> entry : rval.entrySet()) {
+          List<Long> communities = entry.getValue();
           // Invert the collections to include those communities that
           // are *not* listed
-          List newclist = new ArrayList();
-          Iterator iter = m_communityIds.iterator();
-          while (iter.hasNext()) {
-            Long cid = (Long) iter.next();
+          List<Long> newclist = new ArrayList<>();
+          for (Long cid : m_communityIds) {
             if (!communities.contains(cid)) {
               newclist.add(cid);
             }
@@ -486,9 +479,9 @@ public class PSUpgradePluginConvertCommunityVisibility extends PSSpringUpgradePl
    */
   private Long convertToLong(Object object) {
     if (object instanceof String) {
-      return new Long((String) object);
+      return Long.valueOf((String) object);
     } else if (object instanceof Number) {
-      return new Long(((Number) object).longValue());
+      return Long.valueOf(((Number) object).longValue());
     } else {
       throw new RuntimeException("Unknown type found " + object.getClass());
     }

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginPublishing.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginPublishing.java
@@ -213,13 +213,13 @@ public class PSUpgradePluginPublishing implements IPSUpgradePlugin {
    *     </code> statements or (2) 0 for SQL statements that return nothing
    * @throws Exception if an error occurs.
    */
-  private int executeUpdate(PrintStream logger, Connection conn, List bindValue, String sqlStmt)
+  private int executeUpdate(PrintStream logger, Connection conn, List<?> bindValue, String sqlStmt)
       throws Exception {
     return executeUpdate(logger, conn, sqlStmt, bindValue.toArray());
   }
 
   /** Convenience method that calls {@link #executeUpdate(null, Connection, List, String)}. */
-  private int executeUpdate(Connection conn, String sqlStmt, List bindValue) throws Exception {
+  private int executeUpdate(Connection conn, String sqlStmt, List<?> bindValue) throws Exception {
     return executeUpdate(null, conn, bindValue, sqlStmt);
   }
 
@@ -427,7 +427,7 @@ public class PSUpgradePluginPublishing implements IPSUpgradePlugin {
           if (pubop != null && !pubop.toUpperCase().equals(STATUS_PUBLISH))
             operation = IPSSiteItem.Operation.UNPUBLISH.ordinal();
 
-          List bindValues = new ArrayList();
+          List<Object> bindValues = new ArrayList<>();
           bindValues.add(referenceid);
           bindValues.add(Integer.valueOf(pubstatusval.getPublicationId()));
           bindValues.add(Integer.valueOf(contentid));

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginSpringBeans.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginSpringBeans.java
@@ -138,9 +138,9 @@ public class PSUpgradePluginSpringBeans implements IPSUpgradePlugin {
       PSSpringConfiguration reqbeans = new PSSpringConfiguration(source);
 
       // Check each bean and add if missing
-      Iterator iditer = reqbeans.getBeanIds();
+      Iterator<String> iditer = reqbeans.getBeanIds();
       while (iditer.hasNext()) {
-        String name = (String) iditer.next();
+        String name = iditer.next();
         Element sourceel = reqbeans.getBeanXml(name);
         Element destel = config.getBeanXml(name);
         if (destel == null) {
@@ -179,12 +179,12 @@ public class PSUpgradePluginSpringBeans implements IPSUpgradePlugin {
     String microVersion = versionProps.getProperty("microVersion");
 
     if (majorVersion.equals("6") && minorVersion.equals("0") && microVersion.equals("0")) {
-      List cfgids = new ArrayList();
-      Iterator cfgiter = config.getBeanIds();
-      while (cfgiter.hasNext()) cfgids.add((String) cfgiter.next());
+      List<String> cfgids = new ArrayList<>();
+      Iterator<String> cfgiter = config.getBeanIds();
+      while (cfgiter.hasNext()) cfgids.add(cfgiter.next());
 
       for (int i = 0; i < cfgids.size(); i++) {
-        String id = (String) cfgids.get(i);
+        String id = cfgids.get(i);
         if (ms_systemSpringBeans60Set.contains(id)) {
           Element origel = config.getBeanXml(id);
           config.removeBean(id);
@@ -196,12 +196,12 @@ public class PSUpgradePluginSpringBeans implements IPSUpgradePlugin {
     }
 
     // Remove all unsupported attributes from each bean
-    List configIds = new ArrayList();
-    Iterator cfgit = config.getBeanIds();
-    while (cfgit.hasNext()) configIds.add((String) cfgit.next());
+    List<String> configIds = new ArrayList<>();
+    Iterator<String> cfgit = config.getBeanIds();
+    while (cfgit.hasNext()) configIds.add(cfgit.next());
 
     for (int j = 0; j < configIds.size(); j++) {
-      String id = (String) configIds.get(j);
+      String id = configIds.get(j);
       Element el = config.getBeanXml(id);
 
       // Remove unsupported attributes from datasource resolver sub-bean

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginUpdateExtensions.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginUpdateExtensions.java
@@ -78,20 +78,20 @@ public class PSUpgradePluginUpdateExtensions implements IPSUpgradePlugin {
    * @param ifName the interface name that needs to be added, never <code>null</code>
    */
   private void updateExtensions(
-      IPSExtensionManager mgr, String ifPattern, Set extSet, String ifName)
+      IPSExtensionManager mgr, String ifPattern, Set<String> extSet, String ifName)
       throws PSExtensionException {
-    Iterator refs = null;
-    refs = mgr.getExtensionNames("Java", null, ifPattern, null);
+    @SuppressWarnings("rawtypes")
+    Iterator refs = mgr.getExtensionNames("Java", null, ifPattern, null);
     while (refs.hasNext()) {
       PSExtensionRef ref = (PSExtensionRef) refs.next();
       try {
         IPSExtensionDef def = null;
         if (extSet.contains(ref.getExtensionName())) {
           def = mgr.getExtensionDef(ref);
-          Iterator resources = def.getResourceLocations();
+          Iterator<java.net.URL> resources = def.getResourceLocations();
           boolean exists = def.implementsInterface(ifName);
           if (!exists) {
-            Collection ifCol = new ArrayList();
+            Collection<String> ifCol = new ArrayList<>();
             CollectionUtils.addAll(ifCol, def.getInterfaces());
             ifCol.add(ifName);
             ((PSExtensionDef) def).setInterfaces(ifCol);
@@ -219,13 +219,13 @@ public class PSUpgradePluginUpdateExtensions implements IPSUpgradePlugin {
   private IPSUpgradeModule m_config;
 
   /** List of extension names for which a new interface must be added */
-  private Set m_itemValidators = new HashSet();
+  private final Set<String> m_itemValidators = new HashSet<>();
 
   /** List of extension names for which a new interface must be added */
-  private Set m_fieldValidators = new HashSet();
+  private final Set<String> m_fieldValidators = new HashSet<>();
 
   /** List of extension names for which a new interface must be added */
-  private Set m_fieldTransformers = new HashSet();
+  private final Set<String> m_fieldTransformers = new HashSet<>();
 
   /** A string defining the interface that needs to be added */
   private static final String ITEM_VALIDATOR = "com.percussion.extension.IPSItemValidator";

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginUpdateExtensions.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginUpdateExtensions.java
@@ -80,10 +80,10 @@ public class PSUpgradePluginUpdateExtensions implements IPSUpgradePlugin {
   private void updateExtensions(
       IPSExtensionManager mgr, String ifPattern, Set<String> extSet, String ifName)
       throws PSExtensionException {
-    @SuppressWarnings("rawtypes")
-    Iterator refs = mgr.getExtensionNames("Java", null, ifPattern, null);
+    @SuppressWarnings("unchecked")
+    Iterator<PSExtensionRef> refs = mgr.getExtensionNames("Java", null, ifPattern, null);
     while (refs.hasNext()) {
-      PSExtensionRef ref = (PSExtensionRef) refs.next();
+      PSExtensionRef ref = refs.next();
       try {
         IPSExtensionDef def = null;
         if (extSet.contains(ref.getExtensionName())) {

--- a/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
+++ b/system/src/test/java/com/percussion/install/PSInstallPackageTypedTest.java
@@ -20,13 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.services.security.data.PSCommunity;
 import com.percussion.tablefactory.PSJdbcDbmsDef;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +38,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Behavioral tests for typed install/upgrade helpers after install-package rawtypes cleanup (#2933
- * / #2877 slice 1).
+ * / #2877 / #2942 upgrade-plugin slices).
  */
 @Tag("UnitTest")
 @DisplayName("install package generics")
@@ -135,5 +138,56 @@ class PSInstallPackageTypedTest {
     assertTrue(RxUpgrade.getResponses().isEmpty());
     Iterator<PSPluginResponse> it = RxUpgrade.getResponses().iterator();
     assertFalse(it.hasNext());
+  }
+
+  @Test
+  @DisplayName("community visibility findCommunitiesToFixNames is typed")
+  void convertCommunityVisibilityFindsNamesWithSpaces() {
+    List<PSCommunity> communities = new ArrayList<>();
+    communities.add(communityWithName("NoSpace"));
+    communities.add(communityWithName("Has Space"));
+    communities.add(communityWithName("Also_Ok"));
+
+    List<PSCommunity> toFix =
+        PSUpgradePluginConvertCommunityVisibility.findCommunitiesToFixNames(communities);
+    assertEquals(1, toFix.size());
+    assertEquals("Has Space", toFix.get(0).getName());
+  }
+
+  @Test
+  @DisplayName("community visibility getCommunityNames returns typed String set")
+  void convertCommunityVisibilityCommunityNames() {
+    List<PSCommunity> communities = new ArrayList<>();
+    communities.add(communityWithName("Alpha"));
+    communities.add(communityWithName("Beta"));
+
+    Set<String> names =
+        PSUpgradePluginConvertCommunityVisibility.getCommunityNames(communities);
+    assertEquals(2, names.size());
+    assertTrue(names.contains("Alpha"));
+    assertTrue(names.contains("Beta"));
+  }
+
+  /** Avoids PSCommunity(String,String) which needs a live guid manager Spring bean. */
+  private static PSCommunity communityWithName(String name) {
+    PSCommunity c = new PSCommunity();
+    c.setName(name);
+    return c;
+  }
+
+  @Test
+  @DisplayName("slot name modifyName collapses spaces for upgrade maps")
+  void slotNameModifyNameTyped() {
+    assertEquals("My_Slot", InstallUtil.modifyName("My Slot"));
+    assertEquals("Already_Ok", InstallUtil.modifyName("Already_Ok"));
+    assertEquals(null, InstallUtil.modifyName(null));
+  }
+
+  @Test
+  @DisplayName("convertSlotName rejects null application")
+  void convertSlotNameNullApp() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSUpgradeDbAndHtmlAndXslFilesForSlotNames.convertSlotName(null));
   }
 }


### PR DESCRIPTION
## Summary

PR-sized install upgrade-plugin `-Xlint` residual for **#2942** (parent **#2877**, after #2933 / PR #2941).

**Skipped** `PSUpgradePluginRelationship` — already absorbed by open thrash cluster **PR #2952** (#2949).

### Typed this batch (no behavior change)

| File | Typing focus |
|------|----------------|
| `PSUpgradePluginConvertCommunityVisibility` | `List<Long>`, `Map<Long,List<Long>>`, `List<IPSAcl>`, `List/Set` of `PSCommunity` |
| `PSUpgradeDbAndHtmlAndXslFilesForSlotNames` | `List<File>`, `List<String>` slot names, `Map<String,String>` |
| `PSUpgradePluginCleanLocationSchemes` | `List<PSJdbcRowData>`, `Map<String,PSJdbcRowData>`, typed iterators |
| `PSUpgradePluginCleanContentStatus` | `Iterator<PSJdbcRowData>` |
| `PSUpgradePluginSpringBeans` | `Iterator<String>` bean ids, `List<String>` |
| `PSUpgradePluginUpdateExtensions` | `Set<String>` extension name sets, `Collection<String>` interfaces |
| `PSUpgradePluginPublishing` | `List<?>` / `List<Object>` bind values |

### Tests

Extended `PSInstallPackageTypedTest` for community name helpers, `InstallUtil.modifyName`, `convertSlotName(null)`.

## Test plan / gates evidence

```bat
cd system
..\mvnw.cmd clean install
```

- **BUILD SUCCESS**
- **Tests run: 1704, Failures: 0, Errors: 0, Skipped: 238** (surefire XML aggregate)
- modules_built: `system`
- downstream_checked: **none** (C2 N/A — no public/protected signature or final/sealed changes)

## Product documentation

- [x] **N/A** — mechanical generics typing on install upgrade plugins; no operator/user-facing behavior change

## Checklist

- [x] Unit tests for typed helpers
- [x] Pre-PR Maven: standalone system clean install
- [x] Fixes #2942 (residual remaining install plugins filed separately)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2877 / #2022 / #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.
