### PR TITLE
fix(sitemanage): package tests after Widget XML stop-ship (#2897)

### DIFF
--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercOpenGraphDedupeGuardTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercOpenGraphDedupeGuardTest.java
@@ -46,18 +46,22 @@ class PercOpenGraphDedupeGuardTest {
 
   @Test
   void openGraphWidgetGuardsEachPropertyBeforeAppend() throws Exception {
-    Path widget =
+    // After Widget XML dual-ship stop-ship (#2897 / cluster #2897), product packages author
+    // modern widgets/<stem>/component-package.json only — install Widget XML is materialised.
+    Path manifest =
         resolveRepoRoot()
             .resolve(
                 "modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget"
-                    + "/sys__UserDependency--rxconfig/Widgets/percOpenGraph.xml");
-    if (!Files.isRegularFile(widget)) {
-      fail("expected Open Graph widget at " + widget.toAbsolutePath());
+                    + "/widgets/percOpenGraph/component-package.json");
+    if (!Files.isRegularFile(manifest)) {
+      fail("expected Open Graph modern package at " + manifest.toAbsolutePath());
     }
-    String xml = Files.readString(widget, StandardCharsets.UTF_8);
+    String json = Files.readString(manifest, StandardCharsets.UTF_8);
     for (String prop : OG_PROPS) {
-      String guard = "contains(\"property=\\\"" + prop + "\\\"\")";
-      assertTrue(xml.contains(guard), "missing contains() guard for " + prop);
+      // JSON embeds Jexl as raw text: contains(\"property=\\\"og:title\\\"\")
+      // (backslash-quote escapes inside the JSON string value)
+      String guard = "contains(\\\"property=\\\\\\\"" + prop + "\\\\\\\"\\\")";
+      assertTrue(json.contains(guard), "missing contains() guard for " + prop);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SocialButtonsXRebrandTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SocialButtonsXRebrandTest.java
@@ -46,15 +46,19 @@ class SocialButtonsXRebrandTest {
         root.resolve(
             PKG.resolve(
                 "SupportFile-rx_resources/widgets/percSocialButtons/css/percSocialButtons.css"));
-    Path widget =
-        root.resolve(PKG.resolve("sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml"));
+    // After #2897 dual-ship stop-ship: assembly + snippet live under widgets/<stem>/.
+    Path manifest =
+        root.resolve(PKG.resolve("widgets/percSocialButtons/component-package.json"));
+    Path snippet =
+        root.resolve(
+            PKG.resolve("widgets/percSocialButtons/templates/percSocialButtonsSnippet.vm"));
     Path xsl =
         root.resolve(
             PKG.resolve(
                 "SupportFile-rx_resources/stylesheets/controls/percSocialButtonsControl.xsl"));
     Path archive = root.resolve(PKG.resolve("psx_archiveInfo.xml"));
 
-    for (Path p : new Path[] {css, supportCss, widget, xsl, archive}) {
+    for (Path p : new Path[] {css, supportCss, manifest, snippet, xsl, archive}) {
       if (!Files.isRegularFile(p)) {
         fail("expected " + p.toAbsolutePath());
       }
@@ -69,12 +73,16 @@ class SocialButtonsXRebrandTest {
     String support = Files.readString(supportCss, StandardCharsets.UTF_8);
     assertTrue(support.contains("#111111") && support.contains("mask-size: contain"));
 
-    String widgetXml = Files.readString(widget, StandardCharsets.UTF_8);
-    assertTrue(widgetXml.contains("https://x.com/intent/tweet"), "share link must use x.com");
+    String packageJson = Files.readString(manifest, StandardCharsets.UTF_8);
+    String snippetVm = Files.readString(snippet, StandardCharsets.UTF_8);
+    assertTrue(snippetVm.contains("https://x.com/intent/tweet"), "share link must use x.com");
     assertFalse(
-        widgetXml.contains("https://twitter.com/intent/tweet"), "legacy twitter.com share gone");
-    assertTrue(widgetXml.contains("put('twitter', '111111')"), "velocity standard color");
-    assertTrue(widgetXml.contains(".perc-twitter-social-button i::before"));
+        snippetVm.contains("https://twitter.com/intent/tweet"), "legacy twitter.com share gone");
+    assertFalse(
+        packageJson.contains("https://twitter.com/intent/tweet"),
+        "legacy twitter.com share gone from package json");
+    assertTrue(packageJson.contains("put('twitter', '111111')"), "velocity standard color");
+    assertTrue(snippetVm.contains(".perc-twitter-social-button i::before"));
 
     String xslText = Files.readString(xsl, StandardCharsets.UTF_8);
     assertTrue(xslText.contains("aria-label=\"X (Twitter)\""));

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/TwitterSiteTagEmitOnceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/TwitterSiteTagEmitOnceTest.java
@@ -34,22 +34,23 @@ import org.junit.jupiter.api.Test;
  */
 class TwitterSiteTagEmitOnceTest {
 
-  private static final Path WIDGET =
+  private static final Path MANIFEST =
       Path.of(
           "modules/perc-packages/src/main/resources/Packages/perc.twitterSummaryCards"
-              + "/sys__UserDependency--rxconfig/Widgets/percTwitterSummaryCards.xml");
+              + "/widgets/percTwitterSummaryCards/component-package.json");
 
   @Test
   void twitterSiteAppendedExactlyOnce() throws Exception {
     Path root = resolveRepoRoot();
-    Path widget = root.resolve(WIDGET);
-    if (!Files.isRegularFile(widget)) {
-      fail("expected " + widget.toAbsolutePath());
+    Path manifest = root.resolve(MANIFEST);
+    if (!Files.isRegularFile(manifest)) {
+      fail("expected " + manifest.toAbsolutePath());
     }
-    String xml = Files.readString(widget, StandardCharsets.UTF_8);
+    // After #2897 dual-ship stop-ship: assembly Jexl lives in modern component-package.json.
+    String json = Files.readString(manifest, StandardCharsets.UTF_8);
     Pattern append =
         Pattern.compile("setAdditionalHeadContent\\([^)]*meta_sitename", Pattern.MULTILINE);
-    Matcher m = append.matcher(xml);
+    Matcher m = append.matcher(json);
     int count = 0;
     while (m.find()) {
       count++;
@@ -57,8 +58,8 @@ class TwitterSiteTagEmitOnceTest {
     assertEquals(
         1, count, "twitter:site (meta_sitename) must be setAdditionalHeadContent exactly once");
     assertTrue(
-        xml.contains("if(!empty($use_twitter_site))")
-            || xml.contains("if (!empty($use_twitter_site))"),
+        json.contains("if(!empty($use_twitter_site))")
+            || json.contains("if (!empty($use_twitter_site))"),
         "append must be guarded by use_twitter_site");
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
@@ -76,18 +76,20 @@ class WidgetRegistryRegistrationDeprecationTest {
         root.resolve(
             "modules/perc-packages/src/main/resources/Packages/perc.widget.registration"
                 + "/percRegistrationAsset.nodeDef.contentType");
-    Path widget =
+    // After #2897 dual-ship stop-ship: widget labels live in modern component-package.json.
+    Path manifest =
         root.resolve(
             "modules/perc-packages/src/main/resources/Packages/perc.widget.registration"
-                + "/sys__UserDependency--rxconfig/Widgets/percRegistration.xml");
+                + "/widgets/percRegistration/component-package.json");
 
     assertTrue(Files.isRegularFile(itemDef), "expected itemDef at " + itemDef.toAbsolutePath());
     assertTrue(Files.isRegularFile(nodeDef), "expected nodeDef at " + nodeDef.toAbsolutePath());
-    assertTrue(Files.isRegularFile(widget), "expected widget xml at " + widget.toAbsolutePath());
+    assertTrue(
+        Files.isRegularFile(manifest), "expected modern package at " + manifest.toAbsolutePath());
 
     String itemText = Files.readString(itemDef, StandardCharsets.UTF_8);
     String nodeText = Files.readString(nodeDef, StandardCharsets.UTF_8);
-    String widgetText = Files.readString(widget, StandardCharsets.UTF_8);
+    String packageJson = Files.readString(manifest, StandardCharsets.UTF_8);
 
     assertTrue(
         itemText.contains("label=\"Registration Asset (Deprecated)\""),
@@ -96,12 +98,13 @@ class WidgetRegistryRegistrationDeprecationTest {
         nodeText.contains("<label>Registration Asset (Deprecated)</label>"),
         "nodeDef label must be Registration Asset (Deprecated)");
     assertTrue(
-        widgetText.contains("title=\"Registration (Deprecated)\""),
+        packageJson.contains("\"title\": \"Registration (Deprecated)\"")
+            || packageJson.contains("\"title\":\"Registration (Deprecated)\""),
         "widget title must be Registration (Deprecated)");
     assertTrue(
-        widgetText.contains(
-                "description=\"Widget to build and render a registration form. (Deprecated)\"")
-            || widgetText.contains("registration form. (Deprecated)"),
+        packageJson.contains(
+                "\"description\": \"Widget to build and render a registration form. (Deprecated)\"")
+            || packageJson.contains("registration form. (Deprecated)"),
         "widget description must include form. (Deprecated) suffix, not only title");
   }
 


### PR DESCRIPTION
## Summary
- After cluster PR #2897 (Widget XML dual-ship stop-ship), `sitemanage` on `main` failed with **4 package regression tests** that still expected committed `sys__UserDependency--rxconfig/Widgets/*.xml`.
- Failures: `PercOpenGraphDedupeGuardTest`, `SocialButtonsXRebrandTest`, `TwitterSiteTagEmitOnceTest`, `WidgetRegistryRegistrationDeprecationTest.packageLabelsCarryDeprecatedSuffix`.
- Point those tests at modern `widgets/<stem>/component-package.json` (and Social Buttons snippet/CSS/XSL) while keeping the same behavioral checks.

## Root cause
#2897 correctly removed dual-ship install Widget definition XML from packages. sitemanage tests that walk the monorepo package tree were not updated in that thrash cluster.

## Verification
```
cd projects/sitemanage
../../mvnw.cmd clean install
# BUILD SUCCESS (previously Failures: 4 / Tests run: 1009)
```

## Notes
- Test-only change; no production code.
- Product-docs: N/A (test path update only).

> Co-Authored by Grok using grok-4.5 with agent main.