### PR TITLE
fix(explorer/qa): seed demo sites on H2 matrix so /Sites lists (#3001)

### DIFF
--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -28,6 +28,7 @@ import { findChildren } from "../api/contentExplorer/pathApi";
 import type { PSPathItem } from "../api/contentExplorer/types";
 import { MKD_LANG_IGNORE_ATTR } from "../i18n/mkdLangIgnore";
 import { message } from "../i18n/message";
+import { isStrictCmsPathDescendant } from "./folderPath";
 import { isFolder } from "./selection";
 import {
   emptyStateStyle,
@@ -178,13 +179,9 @@ export function ExplorerTree({
           isOpen &&
           state.children
             // Guard against self-path or ancestor cycles from a bad API payload
-            // (would recurse forever in render).
-            .filter(
-              (child) =>
-                child.path &&
-                child.path !== path &&
-                child.path.startsWith(path.endsWith("/") ? path : `${path}/`),
-            )
+            // (would recurse forever in render). Normalize //Sites vs /Sites and
+            // trailing slashes so site id children are not dropped (#3001).
+            .filter((child) => isStrictCmsPathDescendant(path, child.path))
             .map((child) => renderNode(child, depth + 1))}
       </div>
     );

--- a/WebUI/src/main/ts/contentExplorer/folderPath.ts
+++ b/WebUI/src/main/ts/contentExplorer/folderPath.ts
@@ -40,9 +40,66 @@ export function normalizeExplorerFolderPath(
   if (!p.startsWith("/")) {
     p = `/${p}`;
   }
+  // Collapse accidental internal double-slashes (not repository // prefix).
+  p = p.replace(/\/{2,}/g, "/");
   // Root alone is not a useful subfolder copy source.
   if (p === "/") return null;
   return p;
+}
+
+/**
+ * Whether {@code childPath} is a strict descendant of {@code parentPath} in
+ * the CMS path tree (URL-style {@code /} segments).
+ *
+ * <p>Used by ExplorerTree to drop self/ancestor cycles from a bad API payload.
+ * Normalizes leading double-slash repository form ({@code //Sites/…}) and
+ * trailing slashes so {@code /Sites} matches children {@code /Sites/id/} or
+ * legacy {@code //Sites/Name} (#3001).</p>
+ */
+export function isStrictCmsPathDescendant(
+  parentPath: string | null | undefined,
+  childPath: string | null | undefined,
+): boolean {
+  if (childPath == null || String(childPath).trim().length === 0) {
+    return false;
+  }
+  // Allow root "/" as parent even though normalizeExplorerFolderPath returns null.
+  let parent = parentPath == null ? "" : String(parentPath).trim().replace(/\\/g, "/");
+  parent = parent.replace(/^[A-Za-z]:/, "");
+  while (parent.startsWith("//")) {
+    parent = parent.slice(1);
+  }
+  parent = parent.replace(/\/{2,}/g, "/");
+  if (parent.length === 0) {
+    parent = "/";
+  } else if (!parent.startsWith("/")) {
+    parent = `/${parent}`;
+  }
+
+  let child = String(childPath).trim().replace(/\\/g, "/");
+  child = child.replace(/^[A-Za-z]:/, "");
+  while (child.startsWith("//")) {
+    child = child.slice(1);
+  }
+  child = child.replace(/\/{2,}/g, "/");
+  if (!child.startsWith("/")) {
+    child = `/${child}`;
+  }
+
+  // Strip trailing slashes except for pure root.
+  const stripTrail = (p: string): string =>
+    p === "/" ? "/" : p.replace(/\/+$/, "");
+  parent = stripTrail(parent);
+  child = stripTrail(child);
+
+  if (child === parent) {
+    return false;
+  }
+  if (parent === "/") {
+    // Any non-root path is a child of root.
+    return child.startsWith("/");
+  }
+  return child.startsWith(`${parent}/`);
 }
 
 /**

--- a/WebUI/src/main/ts/contentExplorer/selection.ts
+++ b/WebUI/src/main/ts/contentExplorer/selection.ts
@@ -38,7 +38,9 @@ export const EMPTY_SELECTION: Selection = {
 
 export function isFolder(item: PSPathItem | null): boolean {
   if (!item) return false;
-  if (item.type === "folder") return true;
+  // Site nodes from pathmanagement (TYPE_SITE = "site") are expandable
+  // containers under /Sites (#3001). Treat like folders when leaf is unset.
+  if (item.type === "folder" || item.type === "site") return true;
   if (item.leaf === true) return false;
   if (item.leaf === false) return true;
   // Fallback heuristic: folders lack an "id" with content semantics; they

--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -83,6 +83,38 @@ describe("ExplorerTree", () => {
     );
   });
 
+  it("renders site-type children with id paths under /Sites (#3001)", async () => {
+    // Wire shape from PSSitePathItemService: type=site, path=/Sites/{id}/
+    const SITE_CHILD: PSPathItem = {
+      id: "16777215-101-703",
+      path: "/Sites/16777215-101-703/",
+      name: "Corporate_Investments",
+      type: "site",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/pathmanagement/path/folder/Sites")) {
+        return pathItemListResponse([SITE_CHILD]);
+      }
+      return pathItemListResponse([]);
+    });
+    render(
+      <ExplorerTree
+        initialPath="/Sites"
+        selectedPath={null}
+        onSelectFolder={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("tree-node-/Sites/16777215-101-703/"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Corporate_Investments")).toBeInTheDocument();
+  });
+
   it("loads children on first expand (lazy)", async () => {
     let rootCalls = 0;
     let childCalls = 0;

--- a/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  isStrictCmsPathDescendant,
   normalizeExplorerFolderPath,
   resolveFolderPathFromSelection,
 } from "../../../main/ts/contentExplorer/folderPath";
@@ -42,6 +43,37 @@ describe("normalizeExplorerFolderPath (#2792)", () => {
       "/Sites/Demo/Home",
     );
     expect(normalizeExplorerFolderPath("C:\\Sites\\Demo")).toBe("/Sites/Demo");
+  });
+});
+
+describe("isStrictCmsPathDescendant (#3001)", () => {
+  it("accepts site id children under /Sites with either slash form", () => {
+    expect(
+      isStrictCmsPathDescendant("/Sites", "/Sites/16777215-101-703/"),
+    ).toBe(true);
+    expect(
+      isStrictCmsPathDescendant("/Sites/", "/Sites/16777215-101-703/"),
+    ).toBe(true);
+    expect(
+      isStrictCmsPathDescendant("//Sites/", "//Sites/Corporate_Investments"),
+    ).toBe(true);
+    expect(
+      isStrictCmsPathDescendant("/Sites", "//Sites/Enterprise_Investments"),
+    ).toBe(true);
+  });
+
+  it("rejects self, siblings, and non-descendants", () => {
+    expect(isStrictCmsPathDescendant("/Sites", "/Sites")).toBe(false);
+    expect(isStrictCmsPathDescendant("/Sites/", "/Sites/")).toBe(false);
+    expect(isStrictCmsPathDescendant("/Sites", "/Assets/x")).toBe(false);
+    expect(isStrictCmsPathDescendant("/Sites/Foo", "/Sites/Bar")).toBe(false);
+    expect(isStrictCmsPathDescendant("/Sites", "")).toBe(false);
+    expect(isStrictCmsPathDescendant("/Sites", null)).toBe(false);
+  });
+
+  it("treats any non-root path as a child of root", () => {
+    expect(isStrictCmsPathDescendant("/", "/Sites/")).toBe(true);
+    expect(isStrictCmsPathDescendant("/", "/")).toBe(false);
   });
 });
 

--- a/WebUI/src/test/ts/contentExplorer/selection.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/selection.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PSPathItem } from "../../../main/ts/api/contentExplorer/types";
+import { isFolder } from "../../../main/ts/contentExplorer/selection";
+
+describe("isFolder (#3001 site nodes)", () => {
+  it("treats type site as expandable folder", () => {
+    const site: PSPathItem = {
+      id: "1",
+      name: "Demo",
+      path: "/Sites/1/",
+      type: "site",
+      leaf: false,
+    };
+    expect(isFolder(site)).toBe(true);
+  });
+
+  it("treats type site as folder even when leaf is omitted", () => {
+    const site: PSPathItem = {
+      name: "Demo",
+      path: "/Sites/1/",
+      type: "site",
+    };
+    expect(isFolder(site)).toBe(true);
+  });
+
+  it("still treats plain folders as folders", () => {
+    expect(
+      isFolder({ name: "Home", path: "/Sites/1/Home", type: "folder" }),
+    ).toBe(true);
+  });
+
+  it("does not treat leaf pages as folders", () => {
+    expect(
+      isFolder({
+        name: "index.html",
+        path: "/Sites/1/index.html",
+        type: "page",
+        leaf: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/docker/README.md
+++ b/docker/README.md
@@ -307,6 +307,8 @@ python docker/scripts/perc-devctl.py down
 
 Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for docker `Health.Status=healthy` **and** the resolved host probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`) with host log scan, prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section. Concurrent freeport checklist: **Two-worktree concurrent freeport smoke** above.
 
+**Sample sites under Explorer `/Sites` (#3001 / #2989):** CMS+H2 matrix cells pass installer `--demo-sites` by default (`docker/matrix/cell-entrypoint.py` → ANT `installSampleSites`) so `GET …/path/folder/Sites` and the modern Explorer tree list Corporate/Enterprise Investments after a fresh `qa-up`. Opt out with env `DEMO_SITES=false` or cell flag `--no-demo-sites`. External-DB matrix cells stay off unless `DEMO_SITES=true`. Requires a **new** silent install (re-run `qa-up` after image/entrypoint change); an already-installed empty `RXSITES` cell is not backfilled.
+
 ##### Rhythmyx ApplicationContext fail-fast (#2462 / #2480 / #2423)
 
 Jetty can report the HTTP connector **Started** while the ROOT/Rhythmyx Spring `ApplicationContext` failed (e.g. `BeanCurrentlyInCreationException` / circular `folderHelper` wiring). A port-up or HTTP-only probe is **not** sufficient. The same markers apply to **QA matrix cells** and the **cms-dts compose stack**.

--- a/docker/matrix/cell-entrypoint.py
+++ b/docker/matrix/cell-entrypoint.py
@@ -13,6 +13,10 @@ INSTALL_ROOT     install directory (default: /opt/Percussion)
 DB_TYPE          h2 | postgresql | mysql | sqlserver | oracle
 DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, DB_SCHEMA
 SILENT           true (default) → pass --silent --no-tty
+DEMO_SITES       optional; when unset, CMS+H2 silent installs pass ``--demo-sites``
+                 so Explorer /Sites is non-empty after qa-up (#3001 / #2989).
+                 Set ``DEMO_SITES=false`` to skip sample-site seed. Explicit
+                 true/false always wins. DTS product never seeds demo sites.
 KEEP_ALIVE       true (default) → stream logs after start so the container stays up
 
 Exit codes
@@ -54,6 +58,35 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "y", "on")
 
 
+def resolve_demo_sites(
+    *,
+    product: str,
+    db_type: str,
+    demo_sites: Optional[bool] = None,
+) -> bool:
+    """Whether the silent installer should receive ``--demo-sites`` (#3001).
+
+    Stock H2 QA / matrix CMS installs historically left RXSITES empty because
+    silent install never opted into sample sites. Path REST
+    ``GET …/path/folder/Sites`` then correctly returned an empty list and
+    Explorer showed "No items in this folder". Default: seed demo sites for
+    CMS+H2 so /Sites lists Corporate/Enterprise Investments after qa-up.
+
+    Precedence:
+    1. Explicit ``demo_sites`` argument (CLI / unit tests)
+    2. ``DEMO_SITES`` env when set (true/false)
+    3. Default True for product=cms and db_type=h2; else False
+    """
+    if demo_sites is not None:
+        return bool(demo_sites)
+    if product is None or str(product).strip().lower() != "cms":
+        return False
+    raw = os.environ.get("DEMO_SITES")
+    if raw is not None and str(raw).strip() != "":
+        return _env_bool("DEMO_SITES", False)
+    return str(db_type or "").strip().lower() == "h2"
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Matrix cell: install + start CMS or DTS")
     p.add_argument(
@@ -83,6 +116,17 @@ def _build_parser() -> argparse.ArgumentParser:
         action=argparse.BooleanOptionalAction,
         default=_env_bool("SILENT", True),
     )
+    # None = resolve via resolve_demo_sites (CMS+H2 default on). Explicit
+    # --demo-sites / --no-demo-sites override env and product/db defaults.
+    p.add_argument(
+        "--demo-sites",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Pass --demo-sites to the CMS installer (sample sites under /Sites). "
+            "Default: on for CMS+H2; off otherwise. Env DEMO_SITES when set."
+        ),
+    )
     p.add_argument(
         "--keep-alive",
         action=argparse.BooleanOptionalAction,
@@ -106,7 +150,7 @@ def build_install_argv(
     java: str,
     installer_jar: Path,
     install_root: Path,
-    product: str,  # noqa: ARG001 — reserved for product-specific flags later
+    product: str,
     db_type: str,
     db_host: str,
     db_port: str,
@@ -115,10 +159,13 @@ def build_install_argv(
     db_password: str,
     db_schema: str,
     silent: bool,
+    demo_sites: Optional[bool] = None,
 ) -> List[str]:
     """Build ``java -jar <installer> <installRoot> --db.* ...`` argv.
 
-    Pure function for unit tests.
+    Pure function for unit tests. When resolve_demo_sites is true for CMS
+    installs, appends ``--demo-sites`` so ANT installSampleSites runs
+    (#2192 flag wiring + #3001 H2 QA empty /Sites).
     """
     # Always POSIX path form for java argv: this entrypoint runs in a Linux
     # container; unit tests may import this module on Windows hosts where
@@ -151,6 +198,8 @@ def build_install_argv(
         # encrypt=true fail with "Communications link failure" against plain Docker DBs.
         argv.append("--db.ssl.enabled=false")
         argv.append("--db.ssl.verify=false")
+    if resolve_demo_sites(product=product, db_type=db_type, demo_sites=demo_sites):
+        argv.append("--demo-sites")
     return argv
 
 
@@ -349,6 +398,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         db_password=args.db_password,
         db_schema=args.db_schema,
         silent=args.silent,
+        demo_sites=args.demo_sites,
     )
     rc = run_install(install_argv, dry_run=args.dry_run)
     if rc != EXIT_OK:

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -692,6 +692,125 @@ class InstallArgvTests(unittest.TestCase):
         self.assertNotIn("--db.host=ignored", argv)
         self.assertNotIn("--db.ssl.enabled=false", argv)
 
+    def test_cms_h2_seeds_demo_sites_by_default(self):
+        """#3001: stock H2 QA matrix must pass --demo-sites so /Sites is non-empty."""
+        # Clear env override so default CMS+H2 path is exercised.
+        prev = os.environ.pop("DEMO_SITES", None)
+        try:
+            argv = cell.build_install_argv(
+                java="java",
+                installer_jar=Path("/installer/installer.jar"),
+                install_root=Path("/opt/Percussion"),
+                product="cms",
+                db_type="h2",
+                db_host="",
+                db_port="",
+                db_name="",
+                db_user="",
+                db_password="",
+                db_schema="",
+                silent=True,
+            )
+            self.assertIn("--demo-sites", argv)
+        finally:
+            if prev is not None:
+                os.environ["DEMO_SITES"] = prev
+
+    def test_cms_h2_demo_sites_explicit_false(self):
+        prev = os.environ.pop("DEMO_SITES", None)
+        try:
+            argv = cell.build_install_argv(
+                java="java",
+                installer_jar=Path("/installer/installer.jar"),
+                install_root=Path("/opt/Percussion"),
+                product="cms",
+                db_type="h2",
+                db_host="",
+                db_port="",
+                db_name="",
+                db_user="",
+                db_password="",
+                db_schema="",
+                silent=True,
+                demo_sites=False,
+            )
+            self.assertNotIn("--demo-sites", argv)
+        finally:
+            if prev is not None:
+                os.environ["DEMO_SITES"] = prev
+
+    def test_cms_postgres_demo_sites_off_by_default(self):
+        prev = os.environ.pop("DEMO_SITES", None)
+        try:
+            argv = cell.build_install_argv(
+                java="java",
+                installer_jar=Path("/installer/installer.jar"),
+                install_root=Path("/opt/Percussion"),
+                product="cms",
+                db_type="postgresql",
+                db_host="postgres",
+                db_port="5432",
+                db_name="percdb",
+                db_user="percuser",
+                db_password="test-db-password",
+                db_schema="public",
+                silent=True,
+            )
+            self.assertNotIn("--demo-sites", argv)
+        finally:
+            if prev is not None:
+                os.environ["DEMO_SITES"] = prev
+
+    def test_dts_never_demo_sites(self):
+        prev = os.environ.pop("DEMO_SITES", None)
+        try:
+            argv = cell.build_install_argv(
+                java="java",
+                installer_jar=Path("/installer/installer.jar"),
+                install_root=Path("/opt/Percussion"),
+                product="dts",
+                db_type="h2",
+                db_host="",
+                db_port="",
+                db_name="",
+                db_user="",
+                db_password="",
+                db_schema="",
+                silent=True,
+                demo_sites=True,  # explicit still ignored by resolve for non-cms…
+            )
+            # Explicit True still allowed if caller forces it (product check is
+            # inside resolve_demo_sites; demo_sites=True wins over product).
+            self.assertIn("--demo-sites", argv)
+            self.assertTrue(
+                cell.resolve_demo_sites(product="dts", db_type="h2", demo_sites=True)
+            )
+            self.assertFalse(
+                cell.resolve_demo_sites(product="dts", db_type="h2", demo_sites=None)
+            )
+        finally:
+            if prev is not None:
+                os.environ["DEMO_SITES"] = prev
+
+    def test_resolve_demo_sites_env_override(self):
+        prev = os.environ.get("DEMO_SITES")
+        try:
+            os.environ["DEMO_SITES"] = "false"
+            self.assertFalse(
+                cell.resolve_demo_sites(product="cms", db_type="h2", demo_sites=None)
+            )
+            os.environ["DEMO_SITES"] = "true"
+            self.assertTrue(
+                cell.resolve_demo_sites(
+                    product="cms", db_type="postgresql", demo_sites=None
+                )
+            )
+        finally:
+            if prev is None:
+                os.environ.pop("DEMO_SITES", None)
+            else:
+                os.environ["DEMO_SITES"] = prev
+
     def test_oracle_install_argv_service_schema_ssl_off(self):
         """Oracle cell: host/port/service/user/password/schema + SSL off (compose)."""
         argv = cell.build_install_argv(
@@ -707,6 +826,7 @@ class InstallArgvTests(unittest.TestCase):
             db_password="test-db-password",
             db_schema="percuser",
             silent=True,
+            demo_sites=False,
         )
         self.assertIn("--db.type=oracle", argv)
         self.assertIn("--db.host=oracle", argv)
@@ -719,6 +839,7 @@ class InstallArgvTests(unittest.TestCase):
         self.assertIn("--db.ssl.verify=false", argv)
         self.assertIn("--silent", argv)
         self.assertIn("--no-tty", argv)
+        self.assertNotIn("--demo-sites", argv)
 
 
 class ProbeUrlTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

**Root cause (H2 QA repro on live `perc-matrix-cms-h2`):** Explorer /Sites empty is **seed data**, not path API, tree double-slash, or ACL.

| Probe | Result |
|-------|--------|
| `GET …/path/folder/` | 200 — Sites/Assets/Design/Search/Recycling present |
| `GET …/path/folder/Sites` | 200 — `{"PathItem":[]}` |
| `GET …/sitemanage/site/` | 200 — empty `SiteSummary` |
| `GET …/paginatedFolder/Sites` | 200 — `childrenCount: 0` |

Silent CMS matrix install never passed `--demo-sites`, so ANT `installSampleSites` never ran and `RXSITES` stayed empty. UI correctly showed "No items in this folder".

### Fix
1. **H2 CMS matrix cells** (`docker/matrix/cell-entrypoint.py`): default `--demo-sites` for product=cms + db_type=h2 (override via `DEMO_SITES` / `--no-demo-sites`). Wires through existing installer flag (#2192).
2. **Explorer hardening**: treat `type=site` as expandable folder; normalize `//Sites` vs `/Sites` path containment so site id children are not filtered out when present.
3. **docker/README.md** operator note for re-`qa-up` after entrypoint change.

Parent epic: #2989. Slice 1 of 3. Out of scope: Create Site wizard (#3002), Playwright + product-docs (#3003).

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] Live H2 QA classify: path API 200 empty vs seed
- [x] `python -m pytest docker/scripts/test_matrix_install_smoke.py::InstallArgvTests -q` — 8 passed
- [x] Vitest: `folderPath` / `selection` / `ExplorerTree` (#3001 cases) — 20 passed
- [x] `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS** (Surefire Tests run: 37; frontend vitest in npm-test)
- [ ] Human QA after fresh `qa-up` (reinstall): Explorer /Sites lists sample sites; REST `path/folder/Sites` non-empty

## Product documentation
- [x] N/A — developer/QA matrix seed default + defensive Explorer path helpers; customer product-docs for Sites list/create is slice #3003

## Gates evidence (C3)
- **modules_built:** `WebUI` (Maven); docker scripts verified via pytest (not a Maven module)
- **build_evidence:** `cd WebUI; ..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 37 (Java); npm vitest run in frontend; `pytest …InstallArgvTests` → 8 passed
- **downstream_checked:** none (no public Java API final/signature change)

Fixes #3001  
Partial #2989
