### PR TITLE
feat(WebUI): Create Site affordance in Explorer (#3002)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/siteCreateApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/siteCreateApi.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Site create transport for modern Explorer (#3002 / parent #2989).
+ *
+ * <p>Reuses the proven sitemanage create contract used by classic
+ * {@code perc_newsitedialog}: {@code POST /services/sitemanage/site/}
+ * with a {@code Site} body. Traditional (repository) sites are the default —
+ * no virtual properties are sent. Public REST {@code SitesAdaptor#createSite}
+ * is intentionally not used (not implemented on the adaptor).</p>
+ */
+
+import { formatApiError, get, post } from "../client";
+import { PATHS } from "../paths";
+
+/** Product default base template (IPSSitemanageConstants.PLAIN_BASE_TEMPLATE_NAME). */
+export const PLAIN_BASE_TEMPLATE_NAME = "perc.base.plain";
+
+/** Default home / navigation title for a new traditional site. */
+export const DEFAULT_HOME_PAGE_TITLE = "Home Page";
+
+/** Wire body for {@code POST /sitemanage/site/} (legacy Site wrapper). */
+export interface CreateSiteRequest {
+  name: string;
+  label?: string;
+  description?: string;
+  homePageTitle?: string;
+  navigationTitle?: string;
+  baseTemplateName: string;
+  templateName: string;
+}
+
+/** Minimal site summary returned after create (name is required for navigation). */
+export interface CreatedSiteSummary {
+  name: string;
+  id?: string;
+  label?: string;
+}
+
+/** Base template row from pagemanagement readonly summary. */
+export interface BaseTemplateSummary {
+  id?: string;
+  name: string;
+  label?: string;
+  thumbPath?: string;
+}
+
+/**
+ * Build the JSON body matching classic perc_newsitedialog.
+ */
+export function buildCreateSiteBody(req: CreateSiteRequest): {
+  Site: Record<string, string>;
+} {
+  const name = req.name.trim();
+  const home = (req.homePageTitle ?? DEFAULT_HOME_PAGE_TITLE).trim() || DEFAULT_HOME_PAGE_TITLE;
+  const nav = (req.navigationTitle ?? home).trim() || home;
+  return {
+    Site: {
+      name,
+      label: (req.label ?? name).trim() || name,
+      description: (req.description ?? "").trim(),
+      homePageTitle: home,
+      navigationTitle: nav,
+      baseTemplateName: req.baseTemplateName.trim(),
+      templateName: req.templateName.trim(),
+    },
+  };
+}
+
+/**
+ * Parse create-site response (Jackson root wrap {@code Site} or plain object).
+ */
+export function parseCreatedSite(payload: unknown): CreatedSiteSummary {
+  if (payload == null || typeof payload !== "object") {
+    throw new Error("Unexpected create-site response");
+  }
+  const root = payload as Record<string, unknown>;
+  const site =
+    (root.Site as Record<string, unknown> | undefined) ??
+    (root.site as Record<string, unknown> | undefined) ??
+    root;
+  const name =
+    typeof site.name === "string"
+      ? site.name.trim()
+      : typeof site.Name === "string"
+        ? site.Name.trim()
+        : "";
+  if (!name) {
+    throw new Error("Create-site response missing site name");
+  }
+  const idRaw = site.id ?? site.Id;
+  const id =
+    idRaw != null && String(idRaw).trim().length > 0
+      ? String(idRaw).trim()
+      : undefined;
+  const label =
+    typeof site.label === "string"
+      ? site.label
+      : typeof site.Label === "string"
+        ? site.Label
+        : undefined;
+  return { name, id, label };
+}
+
+const TEMPLATE_LIST_KEYS = [
+  "TemplateSummary",
+  "templateSummary",
+  "Template",
+  "templates",
+  "entries",
+] as const;
+
+/**
+ * Normalize base-template catalog payload to a simple name list.
+ */
+export function parseBaseTemplateList(payload: unknown): BaseTemplateSummary[] {
+  if (payload == null) {
+    return [];
+  }
+  let rows: unknown[] = [];
+  if (Array.isArray(payload)) {
+    rows = payload;
+  } else if (typeof payload === "object") {
+    const obj = payload as Record<string, unknown>;
+    for (const key of TEMPLATE_LIST_KEYS) {
+      const raw = obj[key];
+      if (raw == null) continue;
+      if (Array.isArray(raw)) {
+        rows = raw;
+        break;
+      }
+      if (typeof raw === "object") {
+        rows = [raw];
+        break;
+      }
+    }
+  }
+  const out: BaseTemplateSummary[] = [];
+  for (const row of rows) {
+    if (row == null || typeof row !== "object") continue;
+    const r = row as Record<string, unknown>;
+    const name =
+      typeof r.name === "string"
+        ? r.name.trim()
+        : typeof r.Name === "string"
+          ? r.Name.trim()
+          : "";
+    if (!name) continue;
+    const id =
+      r.id != null && String(r.id).trim().length > 0
+        ? String(r.id).trim()
+        : undefined;
+    const label =
+      typeof r.label === "string"
+        ? r.label
+        : typeof r.displayName === "string"
+          ? r.displayName
+          : undefined;
+    const thumbPath =
+      typeof r.thumbPath === "string"
+        ? r.thumbPath
+        : typeof r.imagePath === "string"
+          ? r.imagePath
+          : undefined;
+    out.push({ id, name, label, thumbPath });
+  }
+  return out;
+}
+
+/**
+ * Pick a default base template: prefer {@link PLAIN_BASE_TEMPLATE_NAME}, else first.
+ */
+export function pickDefaultBaseTemplate(
+  templates: ReadonlyArray<BaseTemplateSummary>,
+): string {
+  if (templates.length === 0) {
+    return PLAIN_BASE_TEMPLATE_NAME;
+  }
+  const plain = templates.find((t) => t.name === PLAIN_BASE_TEMPLATE_NAME);
+  if (plain) {
+    return plain.name;
+  }
+  return templates[0]!.name;
+}
+
+/**
+ * POST traditional site create via sitemanage (legacy Site contract).
+ */
+export async function createTraditionalSite(
+  req: CreateSiteRequest,
+): Promise<CreatedSiteSummary> {
+  try {
+    const body = buildCreateSiteBody(req);
+    // Trailing slash matches classic SITE_CREATE + "/"
+    const payload = await post<unknown>(`${PATHS.SITES_ALL}/`, body);
+    return parseCreatedSite(payload);
+  } catch (err: unknown) {
+    throw new Error(formatApiError(err, "Could not create site"));
+  }
+}
+
+/**
+ * GET base template library ({@code type=base}).
+ */
+export async function listBaseTemplates(
+  type: "base" | "resp" = "base",
+): Promise<BaseTemplateSummary[]> {
+  const url = `${PATHS.TEMPLATES_READONLY}?type=${encodeURIComponent(type)}`;
+  try {
+    const payload = await get<unknown>(url);
+    return parseBaseTemplateList(payload);
+  } catch (err: unknown) {
+    throw new Error(formatApiError(err, "Could not load base templates"));
+  }
+}
+
+/**
+ * Explorer folder path for a newly created site (product path form).
+ */
+export function siteFolderPath(siteName: string): string {
+  const name = siteName.trim().replace(/^\/+|\/+$/g, "");
+  return `/Sites/${name}`;
+}

--- a/WebUI/src/main/ts/api/contentExplorer/siteCreateApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/siteCreateApi.ts
@@ -153,6 +153,8 @@ export function parseBaseTemplateList(payload: unknown): BaseTemplateSummary[] {
   for (const row of rows) {
     if (row == null || typeof row !== "object") continue;
     const r = row as Record<string, unknown>;
+    // Require string name (or Name). Non-string name values are intentionally
+    // skipped so a single bad catalog row cannot break the create-site wizard.
     const name =
       typeof r.name === "string"
         ? r.name.trim()

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -98,6 +98,13 @@ export const PATHS = {
   get TEMPLATES_BY_SITE() {
     return `${SERVICES_ROOT}/sitemanage/sitetemplates/templates`;
   },
+  /**
+   * Read-only template summaries (base / responsive libraries).
+   * Query: {@code ?type=base|resp} — used by Create Site (#3002).
+   */
+  get TEMPLATES_READONLY() {
+    return `${SERVICES_ROOT}/pagemanagement/template/summary/all/readonly`;
+  },
   /** Full template load (widgets / region associations). */
   get TEMPLATE_LOAD() {
     return `${SERVICES_ROOT}/pagemanagement/template`;

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -94,6 +94,7 @@ import {
 } from "./styles";
 import { TranslationsPanel } from "./TranslationsPanel";
 import { SiteCopyWizard } from "./wizards/SiteCopyWizard";
+import { SiteCreateWizard } from "./wizards/SiteCreateWizard";
 import { SubfolderCopyWizard } from "./wizards/SubfolderCopyWizard";
 import { RelationshipsView } from "./views/RelationshipsView";
 import { DependencyViewer } from "./views/DependencyViewer";
@@ -390,6 +391,8 @@ export function ContentExplorerShell({
   const [showSecurity, setShowSecurity] = useState(false);
   const [showClipboard, setShowClipboard] = useState(false);
   const [showTranslations, setShowTranslations] = useState(false);
+  /** Content → Create Site wizard panel (#3002 / parent #2989). */
+  const [showSiteCreate, setShowSiteCreate] = useState(false);
   /** Content → Site Copy wizard panel (#2767 / parent #2400). */
   const [showSiteCopy, setShowSiteCopy] = useState(false);
   /** Content → Subfolder Copy wizard panel (#2792 / parent #2400). */
@@ -728,6 +731,9 @@ export function ContentExplorerShell({
         case "content-clipboard-add":
           handleAddToClipboard();
           break;
+        case "content-create-site":
+          setShowSiteCreate((v) => !v);
+          break;
         case "content-site-copy":
           // Only open when a site is in context; menu item is disabled otherwise.
           if (siteNameForCopy) {
@@ -847,6 +853,7 @@ export function ContentExplorerShell({
             showDependencies={showDependencies}
             hasDependencyItem={hasDependencyItem}
             showClipboard={showClipboard}
+            showSiteCreate={showSiteCreate}
             showSiteCopy={showSiteCopy}
             showSubfolderCopy={showSubfolderCopy}
             multiSelectedCount={multiSelectedIds.size}
@@ -1065,6 +1072,31 @@ export function ContentExplorerShell({
             {message(EXPLORER_MSG.TRANSLATIONS_SELECT_ITEM)}
           </div>
         )}
+      {showSiteCreate && (
+        <section
+          id="explorer-site-create-panel"
+          style={sidePanelStyle}
+          data-testid="explorer-site-create-panel"
+          aria-label={message(EXPLORER_MSG.SITE_CREATE_PANEL_REGION)}
+        >
+          <SiteCreateWizard
+            onCreated={({ folderPath }) => {
+              // Success path: open the new site under Sites (acceptance #3002).
+              setSelection({ folderPath, item: null });
+              setMultiSelectedIds(new Set<string>());
+              setMultiSelectedItems(new Map<string, PSPathItem>());
+              setListEpoch((n) => n + 1);
+              setShowSiteCreate(false);
+              setError(null);
+            }}
+            onSettled={(ok) => {
+              if (!ok) {
+                // Keep panel open so the operator can fix validation / retry.
+              }
+            }}
+          />
+        </section>
+      )}
       {showSiteCopy && siteNameForCopy && (
         <section
           id="explorer-site-copy-panel"

--- a/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerMenuBar.tsx
@@ -44,6 +44,8 @@ export interface ExplorerMenuBarProps {
   /** True when a content item is selected (for deps aria-controls). */
   hasDependencyItem?: boolean;
   showClipboard: boolean;
+  /** Content → Create Site panel open (#3002). */
+  showSiteCreate?: boolean;
   /** Content → Site Copy panel open (#2767). */
   showSiteCopy?: boolean;
   /** Content → Subfolder Copy panel open (#2792). */
@@ -137,6 +139,7 @@ function isToggleChecked(
     | "showDependencies"
     | "hasDependencyItem"
     | "showClipboard"
+    | "showSiteCreate"
     | "showSiteCopy"
     | "showSubfolderCopy"
   >,
@@ -155,6 +158,8 @@ function isToggleChecked(
       return props.showDependencies;
     case "view-clipboard":
       return props.showClipboard;
+    case "content-create-site":
+      return props.showSiteCreate === true;
     case "content-site-copy":
       return props.showSiteCopy === true;
     case "content-subfolder-copy":
@@ -195,6 +200,7 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
     showDependencies,
     hasDependencyItem = false,
     showClipboard,
+    showSiteCreate = false,
     showSiteCopy = false,
     showSubfolderCopy = false,
     multiSelectedCount,
@@ -335,6 +341,7 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                           showDependencies,
                           hasDependencyItem,
                           showClipboard,
+                          showSiteCreate,
                           showSiteCopy,
                           showSubfolderCopy,
                         })
@@ -373,15 +380,17 @@ export function ExplorerMenuBar(props: ExplorerMenuBarProps): React.JSX.Element 
                                         : "explorer-dependencies-hint"
                                       : item.id === "view-clipboard"
                                         ? "explorer-clipboard-panel"
-                                        : item.id === "content-site-copy"
-                                          ? hasSiteContext
-                                            ? "explorer-site-copy-panel"
-                                            : "explorer-site-copy-hint"
-                                          : item.id === "content-subfolder-copy"
-                                            ? hasFolderContext
-                                              ? "explorer-subfolder-copy-panel"
-                                              : "explorer-subfolder-copy-hint"
-                                            : undefined
+                                        : item.id === "content-create-site"
+                                          ? "explorer-site-create-panel"
+                                          : item.id === "content-site-copy"
+                                            ? hasSiteContext
+                                              ? "explorer-site-copy-panel"
+                                              : "explorer-site-copy-hint"
+                                            : item.id === "content-subfolder-copy"
+                                              ? hasFolderContext
+                                                ? "explorer-subfolder-copy-panel"
+                                                : "explorer-subfolder-copy-hint"
+                                              : undefined
                           }
                           data-testid={
                             item.testId ?? `explorer-menu-item-${item.id}`

--- a/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
+++ b/WebUI/src/main/ts/contentExplorer/menuBarModel.ts
@@ -29,6 +29,7 @@ import { EXPLORER_MSG } from "./messages";
 export type ExplorerMenuCommandId =
   | "content-search"
   | "content-clipboard-add"
+  | "content-create-site"
   | "content-site-copy"
   | "content-subfolder-copy"
   | "view-refresh"
@@ -97,6 +98,13 @@ export function buildExplorerMenuBarGroups(): ReadonlyArray<ExplorerMenuBarGroup
           ariaLabelKey: EXPLORER_MSG.CLIPBOARD_ADD,
           testId: "explorer-clipboard-add",
           disabledWhen: "noSelection",
+        },
+        {
+          id: "content-create-site",
+          labelKey: EXPLORER_MSG.SITE_CREATE_TITLE,
+          ariaLabelKey: EXPLORER_MSG.TOGGLE_SITE_CREATE_ARIA,
+          testId: "explorer-content-create-site",
+          toggle: true,
         },
         {
           id: "content-site-copy",

--- a/WebUI/src/main/ts/contentExplorer/messages.ts
+++ b/WebUI/src/main/ts/contentExplorer/messages.ts
@@ -98,6 +98,30 @@ export const EXPLORER_MSG = {
   SITE_COPY_SELECT_SITE:
     "perc.ui.explorer@Open a site under Sites to copy it.",
 
+  // Create Site (#3002 / parent #2989) — traditional repository default
+  SITE_CREATE_TITLE: "perc.ui.explorer@Create Site",
+  SITE_CREATE_STEP_DETAILS: "perc.ui.explorer@Site details",
+  SITE_CREATE_STEP_TEMPLATE: "perc.ui.explorer@Base template",
+  SITE_CREATE_STEP_CONFIRM: "perc.ui.explorer@Confirm",
+  SITE_CREATE_STEP_PROGRESS: "perc.ui.explorer@Progress",
+  SITE_CREATE_PANEL_REGION: "perc.ui.explorer@Create site panel",
+  TOGGLE_SITE_CREATE_ARIA: "perc.ui.explorer@Show or hide create site wizard",
+  SITE_CREATE_NAME_LABEL: "perc.ui.explorer@Site name",
+  SITE_CREATE_DESCRIPTION_LABEL: "perc.ui.explorer@Description",
+  SITE_CREATE_TEMPLATE_NAME_LABEL: "perc.ui.explorer@Template name",
+  SITE_CREATE_BASE_TEMPLATE_LABEL: "perc.ui.explorer@Base template",
+  SITE_CREATE_TRADITIONAL_NOTE:
+    "perc.ui.explorer@Creates a traditional repository site (default).",
+  SITE_CREATE_REPOSITORY_KIND: "perc.ui.explorer@Repository",
+  SITE_CREATE_TRADITIONAL: "perc.ui.explorer@Traditional",
+  SITE_CREATE_TEMPLATES_LOADING: "perc.ui.explorer@Loading base templates…",
+  SITE_CREATE_TEMPLATES_ERROR: "perc.ui.explorer@Could not load base templates",
+  SITE_CREATE_VALIDATION:
+    "perc.ui.explorer@Enter a valid site name, template name, and base template",
+  SITE_CREATE_SUBMIT: "perc.ui.explorer@Create site",
+  SITE_CREATE_SUBMITTING: "perc.ui.explorer@Creating site…",
+  SITE_CREATE_SUCCESS: "perc.ui.explorer@Site {name} created",
+
   SUBFOLDER_COPY_TITLE: "perc.ui.explorer@Subfolder Copy",
   SUBFOLDER_COPY_STEP_SOURCE: "perc.ui.explorer@Source folder",
   SUBFOLDER_COPY_STEP_TARGET: "perc.ui.explorer@Target folder",

--- a/WebUI/src/main/ts/contentExplorer/wizards/SiteCreateWizard.tsx
+++ b/WebUI/src/main/ts/contentExplorer/wizards/SiteCreateWizard.tsx
@@ -1,0 +1,443 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Create Site wizard for modern Explorer (#3002 / parent #2989).
+ *
+ * <p>Four-step flow: details → template → confirm → progress.
+ * Creates a traditional (repository) site via sitemanage
+ * {@code POST /site/} — no Virtual Site options. Success navigates the
+ * host to {@code /Sites/&lt;name&gt;} via {@link SiteCreateWizardProps.onCreated}.</p>
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  createTraditionalSite,
+  listBaseTemplates,
+  pickDefaultBaseTemplate,
+  PLAIN_BASE_TEMPLATE_NAME,
+  siteFolderPath,
+  type BaseTemplateSummary,
+  type CreateSiteRequest,
+  type CreatedSiteSummary,
+} from "../../api/contentExplorer/siteCreateApi";
+import { message } from "../../i18n/message";
+import { EXPLORER_MSG } from "../messages";
+import {
+  advance,
+  back,
+  createWizard,
+  finishWizard,
+  isFinalStep,
+  resetWizard,
+  type WizardState,
+} from "./state";
+import {
+  canSubmitCreateSite,
+  clampSiteDescription,
+  defaultTemplateNameForSite,
+  filterSiteNameInput,
+  filterTemplateNameInput,
+  validateSiteName,
+  validateTemplateName,
+} from "./siteCreateValidation";
+
+export interface SiteCreateWizardProps {
+  /** Optional submit override (default: POST /sitemanage/site/). */
+  submit?: (request: CreateSiteRequest) => Promise<CreatedSiteSummary>;
+  /** Optional base-template loader (default: GET readonly base templates). */
+  loadBaseTemplates?: () => Promise<BaseTemplateSummary[]>;
+  /** Optional seed site name. */
+  initialSiteName?: string;
+  /** Fired after successful create with site name + folder path. */
+  onCreated?: (result: {
+    siteName: string;
+    folderPath: string;
+    site: CreatedSiteSummary;
+  }) => void;
+  onSettled?: (ok: boolean) => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+const STEPS = ["details", "template", "confirm", "progress"];
+
+export function SiteCreateWizard(
+  props: SiteCreateWizardProps,
+): React.JSX.Element {
+  const {
+    submit: submitOverride,
+    loadBaseTemplates = listBaseTemplates,
+    initialSiteName = "",
+    onCreated,
+    onSettled,
+    ariaLabel,
+    className,
+  } = props;
+
+  const [wizard, setWizard] = useState<WizardState>(() => createWizard(STEPS));
+  const [siteName, setSiteName] = useState(() =>
+    filterSiteNameInput(initialSiteName),
+  );
+  const [description, setDescription] = useState("");
+  const [templateName, setTemplateName] = useState(() =>
+    defaultTemplateNameForSite(initialSiteName),
+  );
+  /** When true, site-name edits keep regenerating the default template name. */
+  const [templateNameFollowsSite, setTemplateNameFollowsSite] = useState(true);
+  const [baseTemplateName, setBaseTemplateName] = useState(
+    PLAIN_BASE_TEMPLATE_NAME,
+  );
+  const [templates, setTemplates] = useState<BaseTemplateSummary[]>([]);
+  const [templatesError, setTemplatesError] = useState<string | null>(null);
+  const [templatesLoading, setTemplatesLoading] = useState(true);
+  const [createdName, setCreatedName] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setTemplatesLoading(true);
+    loadBaseTemplates()
+      .then((list) => {
+        if (cancelled) return;
+        const rows = list ?? [];
+        setTemplates(rows);
+        setBaseTemplateName(pickDefaultBaseTemplate(rows));
+        setTemplatesError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setTemplates([]);
+        setBaseTemplateName(PLAIN_BASE_TEMPLATE_NAME);
+        setTemplatesError(
+          err instanceof Error && err.message
+            ? err.message
+            : message(EXPLORER_MSG.SITE_CREATE_TEMPLATES_ERROR),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setTemplatesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadBaseTemplates]);
+
+  async function handleRun(): Promise<void> {
+    const site = validateSiteName(siteName);
+    const tmpl = validateTemplateName(templateName);
+    if (!site.ok || !tmpl.ok || !baseTemplateName.trim()) {
+      setWizard((w) =>
+        finishWizard(w, {
+          kind: "error",
+          message: message(EXPLORER_MSG.SITE_CREATE_VALIDATION),
+        }),
+      );
+      onSettled?.(false);
+      return;
+    }
+    setWizard((w) => ({ ...w, submitting: true }));
+    const req: CreateSiteRequest = {
+      name: site.name,
+      label: site.name,
+      description: clampSiteDescription(description),
+      baseTemplateName: baseTemplateName.trim(),
+      templateName: tmpl.name,
+    };
+    try {
+      const fn = submitOverride ?? createTraditionalSite;
+      const created = await fn(req);
+      const folderPath = siteFolderPath(created.name);
+      setCreatedName(created.name);
+      setWizard((w) => finishWizard(w, { kind: "ok" }));
+      onCreated?.({ siteName: created.name, folderPath, site: created });
+      onSettled?.(true);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err ?? "unknown");
+      setWizard((w) => finishWizard(w, { kind: "error", message: msg }));
+      onSettled?.(false);
+    }
+  }
+
+  function handleSiteNameChange(value: string): void {
+    const next = filterSiteNameInput(value);
+    setSiteName(next);
+    if (templateNameFollowsSite) {
+      setTemplateName(defaultTemplateNameForSite(next));
+    }
+  }
+
+  function handleTemplateNameChange(value: string): void {
+    setTemplateNameFollowsSite(false);
+    setTemplateName(filterTemplateNameInput(value));
+  }
+
+  function handleReset(): void {
+    setWizard((w) => resetWizard(w));
+    setCreatedName(null);
+  }
+
+  const detailsReady =
+    validateSiteName(siteName).ok && validateTemplateName(templateName).ok;
+  const templateReady = baseTemplateName.trim().length > 0;
+  const canSubmit = canSubmitCreateSite({
+    siteName,
+    templateName,
+    baseTemplateName,
+  });
+
+  function renderStep(): React.JSX.Element {
+    switch (wizard.current) {
+      case 0:
+        return (
+          <fieldset data-testid="site-create-step-details">
+            <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_DETAILS)}</legend>
+            <p
+              style={{ color: "#555", fontSize: "0.9em", margin: "0 0 8px 0" }}
+              data-testid="site-create-traditional-note"
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL_NOTE)}
+            </p>
+            <label
+              htmlFor="site-create-name"
+              style={{ display: "block", margin: "4px 0" }}
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_NAME_LABEL)}
+              <input
+                id="site-create-name"
+                type="text"
+                data-testid="site-create-name"
+                autoComplete="off"
+                value={siteName}
+                maxLength={100}
+                onChange={(e) => handleSiteNameChange(e.target.value)}
+                style={{ marginLeft: 8, width: 240 }}
+              />
+            </label>
+            <label
+              htmlFor="site-create-description"
+              style={{ display: "block", margin: "4px 0" }}
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_DESCRIPTION_LABEL)}
+              <input
+                id="site-create-description"
+                type="text"
+                data-testid="site-create-description"
+                value={description}
+                maxLength={255}
+                onChange={(e) =>
+                  setDescription(clampSiteDescription(e.target.value))
+                }
+                style={{ marginLeft: 8, width: 320 }}
+              />
+            </label>
+            <label
+              htmlFor="site-create-template-name"
+              style={{ display: "block", margin: "4px 0" }}
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}
+              <input
+                id="site-create-template-name"
+                type="text"
+                data-testid="site-create-template-name"
+                value={templateName}
+                maxLength={100}
+                onChange={(e) => handleTemplateNameChange(e.target.value)}
+                style={{ marginLeft: 8, width: 240 }}
+              />
+            </label>
+          </fieldset>
+        );
+      case 1:
+        return (
+          <fieldset data-testid="site-create-step-template">
+            <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_TEMPLATE)}</legend>
+            {templatesLoading ? (
+              <p role="status" data-testid="site-create-templates-loading">
+                {message(EXPLORER_MSG.SITE_CREATE_TEMPLATES_LOADING)}
+              </p>
+            ) : null}
+            {templatesError ? (
+              <p
+                role="alert"
+                data-testid="site-create-templates-error"
+                style={{ color: "#b00020" }}
+              >
+                {templatesError}
+              </p>
+            ) : null}
+            <label
+              htmlFor="site-create-base-template"
+              style={{ display: "block", margin: "4px 0" }}
+            >
+              {message(EXPLORER_MSG.SITE_CREATE_BASE_TEMPLATE_LABEL)}
+              {templates.length > 0 ? (
+                <select
+                  id="site-create-base-template"
+                  data-testid="site-create-base-template"
+                  value={baseTemplateName}
+                  onChange={(e) => setBaseTemplateName(e.target.value)}
+                  style={{ marginLeft: 8, minWidth: 240 }}
+                >
+                  {templates.map((t) => (
+                    <option key={t.id ?? t.name} value={t.name}>
+                      {t.label || t.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  id="site-create-base-template"
+                  type="text"
+                  data-testid="site-create-base-template"
+                  value={baseTemplateName}
+                  onChange={(e) => setBaseTemplateName(e.target.value)}
+                  style={{ marginLeft: 8, width: 240 }}
+                />
+              )}
+            </label>
+          </fieldset>
+        );
+      case 2:
+        return (
+          <fieldset data-testid="site-create-step-confirm">
+            <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_CONFIRM)}</legend>
+            <ul
+              style={{ listStyle: "none", padding: 0 }}
+              data-testid="site-create-confirm-summary"
+            >
+              <li>
+                <strong>{message(EXPLORER_MSG.SITE_CREATE_NAME_LABEL)}:</strong>{" "}
+                <code>{siteName}</code>
+              </li>
+              <li>
+                <strong>
+                  {message(EXPLORER_MSG.SITE_CREATE_TEMPLATE_NAME_LABEL)}:
+                </strong>{" "}
+                <code>{templateName}</code>
+              </li>
+              <li>
+                <strong>
+                  {message(EXPLORER_MSG.SITE_CREATE_BASE_TEMPLATE_LABEL)}:
+                </strong>{" "}
+                <code>{baseTemplateName}</code>
+              </li>
+              <li>
+                <strong>
+                  {message(EXPLORER_MSG.SITE_CREATE_REPOSITORY_KIND)}:
+                </strong>{" "}
+                {message(EXPLORER_MSG.SITE_CREATE_TRADITIONAL)}
+              </li>
+            </ul>
+          </fieldset>
+        );
+      case 3:
+        return (
+          <fieldset data-testid="site-create-step-progress">
+            <legend>{message(EXPLORER_MSG.SITE_CREATE_STEP_PROGRESS)}</legend>
+            <p
+              role="status"
+              aria-live="polite"
+              data-testid="site-create-progress"
+            >
+              {wizard.submitting
+                ? message(EXPLORER_MSG.SITE_CREATE_SUBMITTING)
+                : wizard.result?.kind === "ok"
+                  ? message(EXPLORER_MSG.SITE_CREATE_SUCCESS).replace(
+                      "{name}",
+                      createdName ?? siteName,
+                    )
+                  : wizard.result?.kind === "error"
+                    ? `${message(EXPLORER_MSG.WIZARD_ERROR)}: ${wizard.result.message}`
+                    : ""}
+            </p>
+          </fieldset>
+        );
+      default:
+        return <></>;
+    }
+  }
+
+  const finalStep = isFinalStep(wizard);
+  const result = wizard.result;
+
+  return (
+    <section
+      role="region"
+      aria-label={ariaLabel ?? message(EXPLORER_MSG.SITE_CREATE_TITLE)}
+      data-testid="site-create-wizard"
+      className={className}
+      style={{ border: "1px solid #ccc", padding: 12, background: "#fff" }}
+    >
+      <h2 style={{ fontSize: "1rem", margin: "0 0 8px 0" }}>
+        {message(EXPLORER_MSG.SITE_CREATE_TITLE)}
+      </h2>
+      <p
+        role="status"
+        aria-live="polite"
+        data-testid="site-create-step-count"
+        style={{ color: "#888", margin: "0 0 8px 0" }}
+      >
+        {message(EXPLORER_MSG.WIZARD_STEP)} {wizard.current + 1}{" "}
+        {message(EXPLORER_MSG.WIZARD_OF)} {STEPS.length}
+      </p>
+      {renderStep()}
+      <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+        <button
+          type="button"
+          data-testid="site-create-back"
+          disabled={
+            wizard.current === 0 || wizard.submitting || result !== undefined
+          }
+          onClick={() => setWizard((w) => back(w))}
+        >
+          {message(EXPLORER_MSG.WIZARD_BACK)}
+        </button>
+        {!finalStep ? (
+          <button
+            type="button"
+            data-testid="site-create-next"
+            disabled={
+              wizard.submitting ||
+              (wizard.current === 0 && !detailsReady) ||
+              (wizard.current === 1 && !templateReady)
+            }
+            onClick={() => setWizard((w) => advance(w))}
+          >
+            {message(EXPLORER_MSG.WIZARD_NEXT)}
+          </button>
+        ) : (
+          <button
+            type="button"
+            data-testid="site-create-run"
+            disabled={
+              wizard.submitting || result !== undefined || !canSubmit
+            }
+            onClick={() => void handleRun()}
+          >
+            {message(EXPLORER_MSG.SITE_CREATE_SUBMIT)}
+          </button>
+        )}
+        <button
+          type="button"
+          data-testid="site-create-cancel"
+          onClick={handleReset}
+        >
+          {message(EXPLORER_MSG.WIZARD_CANCEL)}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/WebUI/src/main/ts/contentExplorer/wizards/siteCreateValidation.ts
+++ b/WebUI/src/main/ts/contentExplorer/wizards/siteCreateValidation.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure validation / name helpers for Explorer Create Site (#3002).
+ *
+ * <p>Mirrors classic hostname filter for site names (alpha-numeric, dash,
+ * dot) and provides default template-name derivation so the wizard shell
+ * can be unit-tested without DOM or REST.</p>
+ */
+
+/** Max length aligned with PSSiteDataRestService site-name allow-list (1–100). */
+export const SITE_NAME_MAX_LENGTH = 100;
+
+/** Description maxlength from classic new-site dialog. */
+export const SITE_DESCRIPTION_MAX_LENGTH = 255;
+
+/**
+ * Classic HOSTNAME filter: keep only alpha-numeric, {@code -}, and {@code .}.
+ */
+export function filterSiteNameInput(raw: string): string {
+  if (raw == null) return "";
+  return String(raw).replace(/[^a-zA-Z0-9\-.]/g, "");
+}
+
+/**
+ * Classic URL-ish filter for template names: strip spaces and path separators.
+ */
+export function filterTemplateNameInput(raw: string): string {
+  if (raw == null) return "";
+  return String(raw).replace(/[\s\\/]/g, "");
+}
+
+export type SiteNameValidation =
+  | { ok: true; name: string }
+  | { ok: false; reason: "empty" | "invalidChars" | "tooLong" };
+
+/**
+ * Validate a site name after hostname filtering.
+ */
+export function validateSiteName(raw: string): SiteNameValidation {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    return { ok: false, reason: "empty" };
+  }
+  const filtered = filterSiteNameInput(trimmed);
+  if (filtered !== trimmed) {
+    return { ok: false, reason: "invalidChars" };
+  }
+  if (filtered.length > SITE_NAME_MAX_LENGTH) {
+    return { ok: false, reason: "tooLong" };
+  }
+  return { ok: true, name: filtered };
+}
+
+export type TemplateNameValidation =
+  | { ok: true; name: string }
+  | { ok: false; reason: "empty" | "tooLong" };
+
+/**
+ * Validate template name (required non-blank, max 100).
+ */
+export function validateTemplateName(raw: string): TemplateNameValidation {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    return { ok: false, reason: "empty" };
+  }
+  if (trimmed.length > SITE_NAME_MAX_LENGTH) {
+    return { ok: false, reason: "tooLong" };
+  }
+  return { ok: true, name: trimmed };
+}
+
+/**
+ * Default site template name from site name (classic: operator-chosen; we
+ * seed {@code {SiteName}Template} for a one-click QA path).
+ */
+export function defaultTemplateNameForSite(siteName: string): string {
+  const base = filterSiteNameInput((siteName ?? "").trim());
+  if (!base) {
+    return "SiteTemplate";
+  }
+  const candidate = `${base}Template`;
+  return candidate.length > SITE_NAME_MAX_LENGTH
+    ? candidate.slice(0, SITE_NAME_MAX_LENGTH)
+    : candidate;
+}
+
+/**
+ * Clamp description to product max length.
+ */
+export function clampSiteDescription(raw: string): string {
+  const s = raw ?? "";
+  if (s.length <= SITE_DESCRIPTION_MAX_LENGTH) {
+    return s;
+  }
+  return s.slice(0, SITE_DESCRIPTION_MAX_LENGTH);
+}
+
+/**
+ * True when the create form has enough fields to submit (client-side only).
+ */
+export function canSubmitCreateSite(fields: {
+  siteName: string;
+  templateName: string;
+  baseTemplateName: string;
+}): boolean {
+  const site = validateSiteName(fields.siteName);
+  const tmpl = validateTemplateName(fields.templateName);
+  const base = (fields.baseTemplateName ?? "").trim();
+  return site.ok && tmpl.ok && base.length > 0;
+}

--- a/WebUI/src/main/ts/registry.ts
+++ b/WebUI/src/main/ts/registry.ts
@@ -69,6 +69,10 @@ const loaders: Record<string, Loader> = {
     import("./contentExplorer/wizards/SiteCopyWizard").then((m) => ({
       default: m.SiteCopyWizard,
     })),
+  SiteCreateWizard: () =>
+    import("./contentExplorer/wizards/SiteCreateWizard").then((m) => ({
+      default: m.SiteCreateWizard,
+    })),
   SubfolderCopyWizard: () =>
     import("./contentExplorer/wizards/SubfolderCopyWizard").then((m) => ({
       default: m.SubfolderCopyWizard,

--- a/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerMenuBar.test.tsx
@@ -107,6 +107,21 @@ describe("ExplorerMenuBar (#2731)", () => {
     expect(onCommand).toHaveBeenCalledWith("content-clipboard-add");
   });
 
+  it("Content → Create Site is always enabled and toggles (#3002)", () => {
+    const { onCommand } = renderBar({ showSiteCreate: false });
+    fireEvent.click(screen.getByTestId("explorer-menu-content"));
+    const item = screen.getByTestId(
+      "explorer-content-create-site",
+    ) as HTMLButtonElement;
+    expect(item.disabled).toBe(false);
+    expect(item.getAttribute("role")).toBe("menuitemcheckbox");
+    expect(item.getAttribute("aria-controls")).toBe(
+      "explorer-site-create-panel",
+    );
+    fireEvent.click(item);
+    expect(onCommand).toHaveBeenCalledWith("content-create-site");
+  });
+
   it("Content → Site Copy is disabled without site context (#2767)", () => {
     renderBar({ hasSiteContext: false });
     fireEvent.click(screen.getByTestId("explorer-menu-content"));

--- a/WebUI/src/test/ts/contentExplorer/SiteCreateWizard.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/SiteCreateWizard.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { CreateSiteRequest } from "../../../main/ts/api/contentExplorer/siteCreateApi";
+import { SiteCreateWizard } from "../../../main/ts/contentExplorer/wizards/SiteCreateWizard";
+import { renderA11yGate } from "./a11y";
+
+const baseTemplates = [
+  { name: "perc.base.plain", id: "1", label: "Plain" },
+  { name: "perc.base.other", id: "2", label: "Other" },
+];
+
+function renderWizard(
+  overrides: Partial<ComponentProps<typeof SiteCreateWizard>> = {},
+) {
+  return render(
+    <SiteCreateWizard
+      loadBaseTemplates={async () => baseTemplates}
+      {...overrides}
+    />,
+  );
+}
+
+describe("SiteCreateWizard (#3002)", () => {
+  it("renders the 4-step wizard at details", async () => {
+    renderWizard();
+    expect(screen.getByTestId("site-create-wizard")).toBeTruthy();
+    expect(screen.getByTestId("site-create-step-details")).toBeTruthy();
+    expect(screen.getByTestId("site-create-step-count").textContent).toMatch(
+      /Step 1.*of 4/,
+    );
+    expect(screen.getByTestId("site-create-traditional-note")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
+    });
+  });
+
+  it("Next is disabled until site name and template name are valid", async () => {
+    renderWizard();
+    await waitFor(() => {
+      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
+    });
+    const next = screen.getByTestId("site-create-next") as HTMLButtonElement;
+    expect(next.disabled).toBe(true);
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Acme" },
+    });
+    // Template name auto-seeds from site name.
+    expect(
+      (screen.getByTestId("site-create-template-name") as HTMLInputElement)
+        .value,
+    ).toBe("AcmeTemplate");
+    expect(next.disabled).toBe(false);
+  });
+
+  it("filters invalid site name characters on input", async () => {
+    renderWizard();
+    await waitFor(() => {
+      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
+    });
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Bad Name!" },
+    });
+    expect(
+      (screen.getByTestId("site-create-name") as HTMLInputElement).value,
+    ).toBe("BadName");
+  });
+
+  it("advances through template and confirm steps", async () => {
+    renderWizard();
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    expect(screen.getByTestId("site-create-step-template")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    expect(screen.getByTestId("site-create-step-confirm")).toBeTruthy();
+    expect(screen.getByTestId("site-create-confirm-summary").textContent).toContain(
+      "Acme",
+    );
+  });
+
+  it("Run invokes submit and fires onCreated with /Sites path", async () => {
+    const submit = vi.fn().mockResolvedValue({ name: "Acme", id: "9" });
+    const onCreated = vi.fn();
+    renderWizard({ submit, onCreated });
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    expect(screen.getByTestId("site-create-step-progress")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("site-create-run"));
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+    const req: CreateSiteRequest = submit.mock.calls[0]?.[0];
+    expect(req.name).toBe("Acme");
+    expect(req.baseTemplateName).toBe("perc.base.plain");
+    expect(req.templateName).toBe("AcmeTemplate");
+    expect(onCreated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteName: "Acme",
+        folderPath: "/Sites/Acme",
+      }),
+    );
+    expect(screen.getByTestId("site-create-progress").textContent).toMatch(
+      /Acme/,
+    );
+  });
+
+  it("Run surfaces submit errors", async () => {
+    const submit = vi.fn().mockRejectedValue(new Error("duplicate site"));
+    renderWizard({ submit });
+    fireEvent.change(screen.getByTestId("site-create-name"), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    await waitFor(() => {
+      expect(screen.getByTestId("site-create-base-template")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fireEvent.click(screen.getByTestId("site-create-next"));
+    fireEvent.click(screen.getByTestId("site-create-run"));
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId("site-create-progress").textContent).toContain(
+      "duplicate site",
+    );
+  });
+
+  it("passes the zero serious/critical axe-core gate (step 0)", async () => {
+    const { container } = renderWizard();
+    await waitFor(() => {
+      expect(screen.queryByTestId("site-create-templates-loading")).toBeNull();
+    });
+    await renderA11yGate(container);
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuBarModel.test.ts
@@ -67,6 +67,15 @@ describe("buildExplorerMenuBarGroups (#2731 DCE ContentExplorerMenu.xml)", () =>
     expect(search?.ariaLabelKey).toBe(EXPLORER_MSG.TOGGLE_SEARCH_ARIA);
   });
 
+  it("puts Create Site under Content always enabled (#3002)", () => {
+    const content = buildExplorerMenuBarGroups().find((g) => g.id === "content");
+    const create = content?.items.find((i) => i.id === "content-create-site");
+    expect(create?.testId).toBe("explorer-content-create-site");
+    expect(create?.disabledWhen).toBeUndefined();
+    expect(create?.toggle).toBe(true);
+    expect(create?.labelKey).toBe(EXPLORER_MSG.SITE_CREATE_TITLE);
+  });
+
   it("puts Site Copy under Content with site-context disable (#2767)", () => {
     const content = buildExplorerMenuBarGroups().find((g) => g.id === "content");
     const siteCopy = content?.items.find((i) => i.id === "content-site-copy");

--- a/WebUI/src/test/ts/contentExplorer/siteCreateApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/siteCreateApi.test.ts
@@ -49,6 +49,22 @@ describe("siteCreateApi helpers (#3002)", () => {
     });
   });
 
+  it("parseCreatedSite accepts lowercase site wrapper (Jackson variant)", () => {
+    expect(parseCreatedSite({ site: { name: "C", id: "3" } })).toEqual({
+      name: "C",
+      id: "3",
+      label: undefined,
+    });
+  });
+
+  it("parseCreatedSite accepts capitalized Name/Id/Label Jackson properties", () => {
+    expect(parseCreatedSite({ Name: "D", Id: "4", Label: "Dee" })).toEqual({
+      name: "D",
+      id: "4",
+      label: "Dee",
+    });
+  });
+
   it("parseCreatedSite rejects missing name", () => {
     expect(() => parseCreatedSite({})).toThrow(/missing site name/i);
   });
@@ -63,6 +79,17 @@ describe("siteCreateApi helpers (#3002)", () => {
     expect(list).toHaveLength(2);
     expect(list[0]?.name).toBe("perc.base.plain");
     expect(list[1]?.label).toBe("Other");
+  });
+
+  it("parseBaseTemplateList skips non-string name rows without throwing", () => {
+    const list = parseBaseTemplateList({
+      TemplateSummary: [
+        { name: 42, id: "bad" },
+        { name: "ok", id: "good" },
+        { Name: null, id: "also-bad" },
+      ],
+    });
+    expect(list).toEqual([{ id: "good", name: "ok", label: undefined, thumbPath: undefined }]);
   });
 
   it("pickDefaultBaseTemplate prefers plain base", () => {

--- a/WebUI/src/test/ts/contentExplorer/siteCreateApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/siteCreateApi.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildCreateSiteBody,
+  DEFAULT_HOME_PAGE_TITLE,
+  parseBaseTemplateList,
+  parseCreatedSite,
+  pickDefaultBaseTemplate,
+  PLAIN_BASE_TEMPLATE_NAME,
+  siteFolderPath,
+} from "../../../main/ts/api/contentExplorer/siteCreateApi";
+
+describe("siteCreateApi helpers (#3002)", () => {
+  it("buildCreateSiteBody matches classic Site wrapper contract", () => {
+    const body = buildCreateSiteBody({
+      name: " QA-Site ",
+      description: "demo",
+      baseTemplateName: "perc.base.plain",
+      templateName: "QA-SiteTemplate",
+    });
+    expect(body.Site.name).toBe("QA-Site");
+    expect(body.Site.label).toBe("QA-Site");
+    expect(body.Site.description).toBe("demo");
+    expect(body.Site.homePageTitle).toBe(DEFAULT_HOME_PAGE_TITLE);
+    expect(body.Site.navigationTitle).toBe(DEFAULT_HOME_PAGE_TITLE);
+    expect(body.Site.baseTemplateName).toBe("perc.base.plain");
+    expect(body.Site.templateName).toBe("QA-SiteTemplate");
+  });
+
+  it("parseCreatedSite accepts Site-wrapped and plain payloads", () => {
+    expect(parseCreatedSite({ Site: { name: "A", id: "1" } })).toEqual({
+      name: "A",
+      id: "1",
+      label: undefined,
+    });
+    expect(parseCreatedSite({ name: "B", label: "Bee" })).toEqual({
+      name: "B",
+      id: undefined,
+      label: "Bee",
+    });
+  });
+
+  it("parseCreatedSite rejects missing name", () => {
+    expect(() => parseCreatedSite({})).toThrow(/missing site name/i);
+  });
+
+  it("parseBaseTemplateList unwraps known keys", () => {
+    const list = parseBaseTemplateList({
+      TemplateSummary: [
+        { name: "perc.base.plain", id: "1" },
+        { name: "other", label: "Other" },
+      ],
+    });
+    expect(list).toHaveLength(2);
+    expect(list[0]?.name).toBe("perc.base.plain");
+    expect(list[1]?.label).toBe("Other");
+  });
+
+  it("pickDefaultBaseTemplate prefers plain base", () => {
+    expect(
+      pickDefaultBaseTemplate([
+        { name: "other" },
+        { name: PLAIN_BASE_TEMPLATE_NAME },
+      ]),
+    ).toBe(PLAIN_BASE_TEMPLATE_NAME);
+    expect(pickDefaultBaseTemplate([{ name: "only" }])).toBe("only");
+    expect(pickDefaultBaseTemplate([])).toBe(PLAIN_BASE_TEMPLATE_NAME);
+  });
+
+  it("siteFolderPath builds product /Sites path", () => {
+    expect(siteFolderPath("Acme")).toBe("/Sites/Acme");
+    expect(siteFolderPath("/Acme/")).toBe("/Sites/Acme");
+  });
+});

--- a/WebUI/src/test/ts/contentExplorer/siteCreateValidation.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/siteCreateValidation.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  canSubmitCreateSite,
+  clampSiteDescription,
+  defaultTemplateNameForSite,
+  filterSiteNameInput,
+  filterTemplateNameInput,
+  SITE_DESCRIPTION_MAX_LENGTH,
+  SITE_NAME_MAX_LENGTH,
+  validateSiteName,
+  validateTemplateName,
+} from "../../../main/ts/contentExplorer/wizards/siteCreateValidation";
+
+describe("siteCreateValidation (#3002)", () => {
+  it("filterSiteNameInput keeps hostname-safe characters only", () => {
+    expect(filterSiteNameInput("My Site!")).toBe("MySite");
+    expect(filterSiteNameInput("a-b.c_d")).toBe("a-b.cd");
+    expect(filterSiteNameInput("")).toBe("");
+  });
+
+  it("filterTemplateNameInput strips spaces and path separators", () => {
+    expect(filterTemplateNameInput("My Template")).toBe("MyTemplate");
+    expect(filterTemplateNameInput("a/b\\c")).toBe("abc");
+  });
+
+  it("validateSiteName requires non-empty hostname-safe name", () => {
+    expect(validateSiteName("")).toEqual({ ok: false, reason: "empty" });
+    expect(validateSiteName("  ")).toEqual({ ok: false, reason: "empty" });
+    expect(validateSiteName("bad name")).toEqual({
+      ok: false,
+      reason: "invalidChars",
+    });
+    expect(validateSiteName("Good-Site.1")).toEqual({
+      ok: true,
+      name: "Good-Site.1",
+    });
+    const long = "a".repeat(SITE_NAME_MAX_LENGTH + 1);
+    expect(validateSiteName(long)).toEqual({ ok: false, reason: "tooLong" });
+  });
+
+  it("validateTemplateName requires non-empty trimmed name", () => {
+    expect(validateTemplateName("")).toEqual({ ok: false, reason: "empty" });
+    expect(validateTemplateName("T1")).toEqual({ ok: true, name: "T1" });
+  });
+
+  it("defaultTemplateNameForSite seeds {name}Template", () => {
+    expect(defaultTemplateNameForSite("Acme")).toBe("AcmeTemplate");
+    expect(defaultTemplateNameForSite("")).toBe("SiteTemplate");
+  });
+
+  it("clampSiteDescription enforces product max length", () => {
+    const long = "x".repeat(SITE_DESCRIPTION_MAX_LENGTH + 10);
+    expect(clampSiteDescription(long).length).toBe(SITE_DESCRIPTION_MAX_LENGTH);
+  });
+
+  it("canSubmitCreateSite requires site, template, and base template", () => {
+    expect(
+      canSubmitCreateSite({
+        siteName: "A",
+        templateName: "ATemplate",
+        baseTemplateName: "perc.base.plain",
+      }),
+    ).toBe(true);
+    expect(
+      canSubmitCreateSite({
+        siteName: "",
+        templateName: "ATemplate",
+        baseTemplateName: "perc.base.plain",
+      }),
+    ).toBe(false);
+    expect(
+      canSubmitCreateSite({
+        siteName: "A",
+        templateName: "ATemplate",
+        baseTemplateName: "  ",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **Create Site** affordance to modern Explorer so operators/QA can create a traditional repository site without leaving Explorer (slice 2 of #2989).

### What shipped
1. **Content → Create Site** menu toggle (always enabled; no site context required)
2. **SiteCreateWizard** (details → base template → confirm → progress)
3. Transport: proven classic contract `POST /services/sitemanage/site/` with `Site` body (not unimplemented `SitesAdaptor#createSite`)
4. Traditional repository default (no Virtual Site options)
5. Success path navigates Explorer to `/Sites/<name>` and refreshes the list
6. Vitest: validation helpers, API body/parse helpers, wizard shell, menu model/bar

### Out of scope (slice #3003)
- Playwright E2E / surface filter
- product-docs customer pages for Create Site

Parent epic: #2989. Coordinates with #3001 (empty Sites listing / demo seed).

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] Vitest: siteCreateValidation, siteCreateApi, SiteCreateWizard, menuBarModel, ExplorerMenuBar Create Site cases
- [x] `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [ ] Human QA: Explorer → Content → Create Site → create traditional site → tree/list shows `/Sites/<name>`

## Product documentation
- [x] N/A — product-docs for Sites create/list UX is slice **#3003** (Playwright + product-docs); this PR is UI affordance + Vitest only per issue scope

## Gates evidence (C3)
- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI; ..\mvnw.cmd clean install` → BUILD SUCCESS; Surefire Tests run: 37 (Java); Vitest Test Files 268 passed / Tests 1900 passed
- **downstream_checked:** none (no public Java API final/signature change; WebUI-only)

Fixes #3002
Partial #2989

> Co-Authored by Grok Build using grok-4.5 with agent main.
