### PR TITLE
fix(perc-content-explorer): PSSearchDialog rawtypes residual (#2993)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2993-pssearchdialog-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2993-pssearchdialog-rawtypes-erlang.md
@@ -1,0 +1,50 @@
+# Erlang code review — #2993 PSSearchDialog rawtypes
+
+**Reviewer persona:** Erlang (independent of implementer)  
+**Change class:** Desktop Content Explorer Swing dialog rawtypes / generics cleanup (tech-debt)  
+**Date:** 2026-08-11  
+**Branch:** `fix/issue-2993-pssearchdialog-rawtypes`
+
+## Scope reviewed
+
+| Path | Role |
+|------|------|
+| `modules/DesktopContentExplorer/.../PSSearchDialog.java` | Parameterize ctor/field Maps + Iterators; extract pure helpers |
+| `modules/DesktopContentExplorer/.../PSSearchDialogTest.java` | Behavioral unit tests for helpers |
+
+**Explicitly out of scope:** `PSFolderAclEditorDialog` (#2439), `PSOptionManager` (next residual).
+
+## Verdict
+
+**PASS** — safe to commit / open PR.
+
+## Checklist
+
+| Gate | Result | Notes |
+|------|--------|-------|
+| Bugs / behavior change | Pass | Types only; display-format map and synonym char scan logic preserved |
+| Unit tests for new/changed logic | Pass | 9 tests on package-private helpers |
+| Cross-platform paths | N/A | No path/file I/O changes |
+| Change-class companions | Pass | Prior peer #2939 pattern (typed dialog + helper tests); module suite green |
+| Product docs | N/A | Pure compiler tech-debt |
+| API / reverse-deps (C2) | Pass | Ctor Maps now typed; sole call sites in `PSActionManager` already pass `Map<?, ?>` + `Map<String, PSContentEditorFieldCataloger>` |
+| Copyright on new files | Pass | 2026 Intersoft header on test |
+
+## Findings
+
+None (no bugs / missing behavioral tests / non-portable I/O).
+
+## Build evidence
+
+```text
+cd modules/DesktopContentExplorer
+../../mvnw.cmd clean install
+→ BUILD SUCCESS
+→ Tests run: 139, Failures: 0, Errors: 0, Skipped: 0
+```
+
+## Residual note
+
+Module still has rawtypes elsewhere (e.g. `PSOptionManager`); not part of this PR-sized slice.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchDialog.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSSearchDialog.java
@@ -119,11 +119,11 @@ public class PSSearchDialog extends PSDialog {
       PSSearchViewActionManager mgr,
       PSRemoteCataloger cataloger,
       PSNode searchNode,
-      Map filterMap,
+      Map<?, ?> filterMap,
       boolean isNewSearch,
       boolean isRcSearch,
       PSSearchConfig searchConfig,
-      Map searchableFieldsCache,
+      Map<String, PSContentEditorFieldCataloger> searchableFieldsCache,
       URL codeBase)
       throws PSCmsException {
     super(parent, mgr.getApplet().getResourceString(PSSearchDialog.class, "Content Search"));
@@ -224,11 +224,12 @@ public class PSSearchDialog extends PSDialog {
    * @throws PSCmsException if an error occurs.
    */
   private void initFieldCatalog(
-      int controlflags, PSRemoteCataloger cataloger, Map searchableFieldsCache, URL codeBase)
+      int controlflags,
+      PSRemoteCataloger cataloger,
+      Map<String, PSContentEditorFieldCataloger> searchableFieldsCache,
+      URL codeBase)
       throws PSCmsException {
-    Set<String> fieldNames = new HashSet<String>();
-    Iterator fields = m_search.getFields();
-    while (fields.hasNext()) fieldNames.add(((PSSearchField) (fields.next())).getFieldName());
+    Set<String> fieldNames = collectSearchFieldNames(m_search.getFields());
 
     if (searchableFieldsCache == null) {
       if (m_applet.isDebug()) log.debug("Load searchableFields no cache");
@@ -238,7 +239,7 @@ public class PSSearchDialog extends PSDialog {
       // key is the combination of "code base" and the "control flags"
       String key = codeBase.toString() + "@" + controlflags;
 
-      m_fieldCatalog = (PSContentEditorFieldCataloger) searchableFieldsCache.get(key);
+      m_fieldCatalog = searchableFieldsCache.get(key);
       if (m_fieldCatalog == null) {
         if (m_applet.isDebug()) log.debug("Load searchableFields for key = " + key);
 
@@ -246,6 +247,66 @@ public class PSSearchDialog extends PSDialog {
         searchableFieldsCache.put(key, m_fieldCatalog);
       }
     }
+  }
+
+  /**
+   * Collects field names from a search field iterator. Package-private for unit tests.
+   *
+   * @param fields may be {@code null}; treated as empty
+   * @return never {@code null}; may be empty
+   */
+  static Set<String> collectSearchFieldNames(Iterator<PSSearchField> fields) {
+    Set<String> fieldNames = new HashSet<>();
+    if (fields == null) {
+      return fieldNames;
+    }
+    while (fields.hasNext()) {
+      fieldNames.add(fields.next().getFieldName());
+    }
+    return fieldNames;
+  }
+
+  /**
+   * Builds display-format id → name map for {@link PSSearchSimplePanel}. Package-private for unit
+   * tests.
+   *
+   * @param formats may be {@code null}; treated as empty
+   * @return never {@code null}; may be empty
+   */
+  static Map<String, String> buildDisplayFormatIdNameMap(Iterator<PSDisplayFormat> formats) {
+    Map<String, String> map = new HashMap<>();
+    if (formats == null) {
+      return map;
+    }
+    while (formats.hasNext()) {
+      PSDisplayFormat format = formats.next();
+      map.put(Integer.toString(format.getDisplayId()), format.getDisplayName());
+    }
+    return map;
+  }
+
+  /**
+   * Finds Lucene special characters in a full-text query that are disallowed when synonym
+   * expansion is enabled. Package-private for unit tests.
+   *
+   * @param ftQueryText may be {@code null}
+   * @return comma-separated special characters found, or {@code null} if none
+   */
+  static String findDisallowedSynonymExpansionChars(String ftQueryText) {
+    if (ftQueryText == null) {
+      return null;
+    }
+    String spChars = null;
+    for (String specialChar : ms_specialChars) {
+      if (ftQueryText.indexOf(specialChar) != -1) {
+        if (spChars == null) {
+          spChars = specialChar;
+        } else {
+          spChars += ", " + specialChar;
+        }
+      }
+    }
+    return spChars;
   }
 
   /*
@@ -282,12 +343,7 @@ public class PSSearchDialog extends PSDialog {
             m_fieldCatalog);
     setFieldEditorSize();
 
-    Map map = new HashMap();
-    Iterator iter = m_mgr.getDisplayFormats();
-    while (iter.hasNext()) {
-      PSDisplayFormat format = (PSDisplayFormat) iter.next();
-      map.put(Integer.toString(format.getDisplayId()), format.getDisplayName());
-    }
+    Map<String, String> map = buildDisplayFormatIdNameMap(m_mgr.getDisplayFormats());
     m_searchSimplePanel =
         new PSSearchSimplePanel(m_isEngineAvailable, map, m_searchConfig.getMaxSearchResult());
     m_ftQuery = m_searchSimplePanel.getQueryText();
@@ -663,15 +719,15 @@ public class PSSearchDialog extends PSDialog {
     // updates the data objects.
     if (!m_fieldEditorCtrl.save()) return;
 
-    Iterator iter = m_fieldEditorCtrl.getFields();
+    Iterator<PSSearchField> iter = m_fieldEditorCtrl.getFields();
     String missingFieldNames = "";
     /*If isRestrictToUserCommunity is true then check whether all fields
     belongs to user community or not. If not warn the user about it.
     */
     if (isRestrictToUserCommunity()) {
-      List<PSSearchField> missingFields = new ArrayList<PSSearchField>();
+      List<PSSearchField> missingFields = new ArrayList<>();
       while (iter.hasNext()) {
-        PSSearchField field = (PSSearchField) iter.next();
+        PSSearchField field = iter.next();
         /**
          * @todo The field need to be checked in m_fieldCatalog.getAll(), but some reason it is not
          *     working that need to be fixed.
@@ -786,13 +842,7 @@ public class PSSearchDialog extends PSDialog {
    *     false</code> otherwise.
    */
   private boolean validateForSynonymExp(String ftQueryText) {
-    String spChars = null;
-    for (String specialChar : ms_specialChars) {
-      if (ftQueryText.indexOf(specialChar) != -1) {
-        if (spChars == null) spChars = specialChar;
-        else spChars += ", " + specialChar;
-      }
-    }
+    String spChars = findDisallowedSynonymExpansionChars(ftQueryText);
 
     if (spChars != null) {
       String message =
@@ -804,7 +854,7 @@ public class PSSearchDialog extends PSDialog {
               + " "
               + spChars;
 
-      int selection = showErrorDialog(message);
+      showErrorDialog(message);
       return false;
     }
 
@@ -901,10 +951,10 @@ public class PSSearchDialog extends PSDialog {
   private PSNode m_searchNode = null;
 
   /**
-   * The Content Explorer search node, Never <code>null</code> after initailization of the dialog
-   * box.
+   * Search field filter map (field name → filter), may be {@code null} when no filters apply.
+   * Never modified after initialization of the dialog box.
    */
-  private Map m_searchFieldFilterMap = null;
+  private Map<?, ?> m_searchFieldFilterMap = null;
 
   /** This dynamic fields panel */
   private PSSearchFieldEditor m_fieldEditorCtrl = null;
@@ -1022,7 +1072,7 @@ public class PSSearchDialog extends PSDialog {
    * Synonym expansion may not be used if any of these characters are included in a full text search
    * query.
    */
-  private static final List<String> ms_specialChars = new ArrayList<String>();
+  private static final List<String> ms_specialChars = new ArrayList<>();
 
   static {
     ms_specialChars.add("+");

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSSearchDialogTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSSearchDialogTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.PSCmsException;
+import com.percussion.cms.objectstore.PSDisplayFormat;
+import com.percussion.cms.objectstore.PSSearchField;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for pure helpers on {@link PSSearchDialog} after rawtypes cleanup (#2993). Does
+ * not open the Swing dialog (requires live applet resources).
+ */
+public class PSSearchDialogTest {
+
+  @Test
+  public void collectSearchFieldNamesNullIteratorReturnsEmpty() {
+    Set<String> names = PSSearchDialog.collectSearchFieldNames(null);
+    assertTrue(names.isEmpty());
+  }
+
+  @Test
+  public void collectSearchFieldNamesEmptyIteratorReturnsEmpty() {
+    Set<String> names = PSSearchDialog.collectSearchFieldNames(Collections.emptyIterator());
+    assertTrue(names.isEmpty());
+  }
+
+  @Test
+  public void collectSearchFieldNamesCollectsDistinctNames() {
+    List<PSSearchField> fields = new ArrayList<>();
+    fields.add(field("sys_title"));
+    fields.add(field("sys_contentid"));
+    fields.add(field("sys_title")); // duplicate name — Set collapses
+
+    Set<String> names = PSSearchDialog.collectSearchFieldNames(fields.iterator());
+    assertEquals(2, names.size());
+    assertTrue(names.contains("sys_title"));
+    assertTrue(names.contains("sys_contentid"));
+  }
+
+  @Test
+  public void buildDisplayFormatIdNameMapNullIteratorReturnsEmpty() {
+    Map<String, String> map = PSSearchDialog.buildDisplayFormatIdNameMap(null);
+    assertTrue(map.isEmpty());
+  }
+
+  @Test
+  public void buildDisplayFormatIdNameMapEmptyIteratorReturnsEmpty() {
+    Map<String, String> map =
+        PSSearchDialog.buildDisplayFormatIdNameMap(Collections.emptyIterator());
+    assertTrue(map.isEmpty());
+  }
+
+  @Test
+  public void buildDisplayFormatIdNameMapMapsIdToDisplayName() throws PSCmsException {
+    PSDisplayFormat format = new PSDisplayFormat();
+    format.setDisplayName("Default Format");
+    // Default ctor leaves display id as -1 until persisted
+    Map<String, String> map =
+        PSSearchDialog.buildDisplayFormatIdNameMap(Collections.singletonList(format).iterator());
+    assertEquals(1, map.size());
+    assertEquals("Default Format", map.get(Integer.toString(format.getDisplayId())));
+  }
+
+  @Test
+  public void findDisallowedSynonymExpansionCharsNullReturnsNull() {
+    assertNull(PSSearchDialog.findDisallowedSynonymExpansionChars(null));
+  }
+
+  @Test
+  public void findDisallowedSynonymExpansionCharsPlainTextReturnsNull() {
+    assertNull(PSSearchDialog.findDisallowedSynonymExpansionChars("simple query text"));
+  }
+
+  @Test
+  public void findDisallowedSynonymExpansionCharsFindsSpecials() {
+    // Order follows ms_specialChars static init: + then - then && ...
+    assertEquals("+", PSSearchDialog.findDisallowedSynonymExpansionChars("a+b"));
+    assertEquals("*", PSSearchDialog.findDisallowedSynonymExpansionChars("star*"));
+    String multi = PSSearchDialog.findDisallowedSynonymExpansionChars("a+b*c");
+    assertTrue(multi.contains("+"));
+    assertTrue(multi.contains("*"));
+  }
+
+  private static PSSearchField field(String name) {
+    return new PSSearchField(name, name, null, PSSearchField.TYPE_TEXT, null);
+  }
+}


### PR DESCRIPTION
## Summary
Parameterize residual rawtypes/unchecked on Desktop Content Explorer **PSSearchDialog** after #2939 / PR #2992.

- **PSSearchDialog**: ctor/`m_searchFieldFilterMap` use `Map<?, ?>`; searchable fields cache `Map<String, PSContentEditorFieldCataloger>`; typed `Iterator<PSSearchField>` / `Iterator<PSDisplayFormat>`
- Extracted pure helpers: `collectSearchFieldNames`, `buildDisplayFormatIdNameMap`, `findDisallowedSynonymExpansionChars`
- Unit tests: `PSSearchDialogTest` (9)
- **Did not touch** `PSFolderAclEditorDialog` (#2439 In Progress)
- **Left for next residual:** `PSOptionManager` (module still has raw Collection/Iterator/Map)

No product behavior change (compiler tech-debt only).

Parent residual tracker: #2326  
Parent module: #2045  
Monorepo: #2200  
Prior slice: #2939  

Fixes #2993

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install`
- [x] BUILD SUCCESS — Tests run: 139, Failures: 0
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-2993-pssearchdialog-rawtypes-erlang.md`

## Product documentation
- [x] N/A — pure rawtypes/generics tech-debt; no operator/user/API surface change

## Build evidence (C3)
- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `cd modules/DesktopContentExplorer; ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 139, Failures: 0, Errors: 0, Skipped: 0
- **downstream_checked:** none (C2 N/A for final/sealed; ctor Maps tightened to types already used at sole call sites in `PSActionManager` — module suite compiled + tested)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
