### PR TITLE
fix(utils): batch 7 JNDI this-escape + PSException suppress strip (#2969)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2969-utils-javac-residual-batch7-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2969-utils-javac-residual-batch7-erlang.md
@@ -1,0 +1,63 @@
+# Erlang review: fix/issue-2969-utils-javac-residual-batch7
+
+## Summary
+
+Batch 7 residual after utils batch 6 (#2414 / PR #2970). Clears the **JNDI datasource this-escape cluster** and **PSException** class-level this-escape with real redesigns (no BeanUtils in copy ctor, final Jetty class + field assigns, direct `m_code` assign). Does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map API. Module `mvnw clean install` green; main compile shows **0** this-escape warnings on changed sources.
+
+## Scope
+
+- Branch: `fix/issue-2969-utils-javac-residual-batch7`
+- Module: `modules/utils` only
+- Parent tracker: #2200 / module #2016 / residual #2969
+- Prior: batch 6 #2414 / PR #2970
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+May commit/push: **yes**
+
+## Cross-platform path review
+
+- No new filesystem path construction.
+- Jetty Properties ctor still uses existing `PathUtils.getRxDir()` / `getRxPath()` APIs (pre-existing portable Path usage).
+- Tests use plain Properties / in-memory objects only.
+
+## Change map
+
+| Area | Fix |
+|------|-----|
+| `PSJBossJndiDatasource` copy ctor | Multi-arg super + protected field overlay; no BeanUtils; strip this-escape |
+| `PSJndiDatasourceImpl` | `id` protected; `setId` final |
+| `PSJettyJndiDatasource` | `final` class; Properties ctor direct field assign; strip this-escape |
+| `PSException` | Direct `m_code = 0` in message+cause ctor; `setErrorCode` final; strip class this-escape |
+
+## Behavioral tests
+
+- `PSJBossJndiDatasourceCopyTest` (3)
+- `PSJettyJndiDatasourcePropsTest` (1)
+- `PSExceptionCauseCtorTest` (2)
+
+## Residual (intentional — file child)
+
+| Area | Notes |
+|------|-------|
+| `PSWorkflowUtilsBase` raw List/Map API | Source-compat; do not reparameterize without policy |
+| `PSCollection` raw/this-escape | Legacy collection; many product subclasses |
+| `PSJexlEvaluator` / `PSXmlSerializationHelper` | Scripting/serialization surfaces |
+| `ConfigurationContextAbstract` CRTP | `(T) this` / BeanUtils.cloneBean |
+| `PSItemIterator` / `PSCopier` | Documented inherent unchecked casts |
+| `PSConcurrentList.readObject` | Serialization unchecked |
+
+## Verification
+
+- `cd modules/utils && ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**
+- Tests: **352** run, **0** failures, **9** skips
+- Main compile: **no** `possible 'this' escape` warnings on changed files
+- Grep: no monorepo `extends PSJettyJndiDatasource` (safe to finalize)
+
+## Issues
+
+None (bug).

--- a/modules/utils/src/main/java/com/percussion/error/PSException.java
+++ b/modules/utils/src/main/java/com/percussion/error/PSException.java
@@ -71,7 +71,6 @@ import org.apache.commons.lang3.StringUtils;
  * @version 1.0
  * @since 1.0
  */
-@SuppressWarnings("this-escape")
 public class PSException extends java.lang.Exception implements IPSException {
 
   private static transient IPSErrorManager errorManager = new PSErrorManagerDefaultImpl();
@@ -223,7 +222,8 @@ public class PSException extends java.lang.Exception implements IPSException {
     if (e == null) {
       throw new IllegalArgumentException("e must never be null");
     }
-    setErrorCode(0);
+    // Direct field assign — avoid overridable setErrorCode during construction (this-escape)
+    m_code = 0;
   }
 
   /**
@@ -325,8 +325,11 @@ public class PSException extends java.lang.Exception implements IPSException {
     return this.getClass().getName() + ": " + getLocalizedMessage();
   }
 
-  /** Set the parsing error code associated with this exception. */
-  public void setErrorCode(int code) {
+  /**
+   * Set the parsing error code associated with this exception. Final so subclasses cannot override
+   * and constructors can safely document that this mutator is not a this-escape vector.
+   */
+  public final void setErrorCode(int code) {
     m_code = code;
   }
 

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSJndiDatasourceImpl.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSJndiDatasourceImpl.java
@@ -34,7 +34,8 @@ public class PSJndiDatasourceImpl implements IPSJndiDatasource {
   protected int idleTimeout = 59000;
   protected String connectionTestQuery;
   protected boolean isEncrypted;
-  private int id;
+  /** Package/subclass-visible so copy constructors may assign without calling setId (this-escape). */
+  protected int id;
 
   public PSJndiDatasourceImpl() {}
 
@@ -185,8 +186,12 @@ public class PSJndiDatasourceImpl implements IPSJndiDatasource {
     return id;
   }
 
+  /**
+   * Final so copy / multi-arg constructors may assign id without {@code this-escape} when a
+   * subclass is still under construction.
+   */
   @Override
-  public void setId(int id) {
+  public final void setId(int id) {
     this.id = id;
   }
 

--- a/modules/utils/src/main/java/com/percussion/utils/container/jboss/PSJBossJndiDatasource.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/jboss/PSJBossJndiDatasource.java
@@ -25,14 +25,12 @@ import com.percussion.utils.xml.PSInvalidXmlException;
 import com.percussion.utils.xml.PSXmlUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -158,12 +156,49 @@ public class PSJBossJndiDatasource extends PSJndiDatasourceImpl
       throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, METADATA);
   }
 
-  @SuppressWarnings("this-escape")
+  /**
+   * Copy constructor. Copies interface properties and, when {@code ds} is a {@link
+   * PSJBossJndiDatasource}, all JBoss-specific round-trip fields. Uses the multi-arg super
+   * constructor (driver-specific defaults) plus direct field assignment so construction does not
+   * leak {@code this} through BeanUtils / overridable setters ({@code this-escape}).
+   *
+   * @param ds source datasource, may not be {@code null}
+   */
   public PSJBossJndiDatasource(IPSJndiDatasource ds) {
-    try {
-      BeanUtils.copyProperties(this, ds);
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException(e);
+    super(
+        Objects.requireNonNull(ds, "ds").getName(),
+        ds.getDriverName(),
+        ds.getDriverClassName(),
+        ds.getServer(),
+        ds.getUserId(),
+        ds.getPassword());
+    // Overlay remaining IPSJndiDatasource properties via protected fields only (no setters / this-escape)
+    this.securityDomain = ds.getSecurityDomain();
+    this.minConnections = ds.getMinConnections();
+    this.maxConnections = ds.getMaxConnections();
+    this.idleTimeout = ds.getIdleTimeout();
+    this.connectionTestQuery = ds.getConnectionTestQuery();
+    this.isEncrypted = ds.isEncrypted();
+    this.id = ds.getId();
+
+    if (ds instanceof PSJBossJndiDatasource src) {
+      this.m_useJavaContext = src.m_useJavaContext;
+      this.m_transactionIsolation = src.m_transactionIsolation;
+      this.m_connectionPropMap = new LinkedHashMap<>(src.m_connectionPropMap);
+      this.m_applicationManagedSecurity = src.m_applicationManagedSecurity;
+      this.m_securityDomainApp = src.m_securityDomainApp;
+      this.m_blockingTimeoutMillis = src.m_blockingTimeoutMillis;
+      this.m_noTxSeparatePools = src.m_noTxSeparatePools;
+      this.m_newConnectionSql = src.m_newConnectionSql;
+      this.m_checkValidConnectionSql = src.m_checkValidConnectionSql;
+      this.m_trackStatements = src.m_trackStatements;
+      this.m_preparedStatementCacheSize = src.m_preparedStatementCacheSize;
+      this.m_depends = new ArrayList<>(src.m_depends);
+      this.m_connectionCheckerClass = src.m_connectionCheckerClass;
+      this.m_backgroundValidation = src.m_backgroundValidation;
+      this.m_backgroundValidationMillis = src.m_backgroundValidationMillis;
+      this.m_validateOnMatch = src.m_validateOnMatch;
+      this.m_exceptionSorterClass = src.m_exceptionSorterClass;
     }
   }
 

--- a/modules/utils/src/main/java/com/percussion/utils/container/jetty/PSJettyJndiDatasource.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/jetty/PSJettyJndiDatasource.java
@@ -39,9 +39,12 @@ import org.w3c.dom.Element;
 /**
  * Represents a Jetty specific JNDI datasource file.
  *
+ * <p>Final so the {@link Properties} constructor may assign name / connection-test / password
+ * without {@code this-escape} diagnostics under {@code -Xlint}.
+ *
  * @author natechadwick
  */
-public class PSJettyJndiDatasource extends PSJBossJndiDatasource {
+public final class PSJettyJndiDatasource extends PSJBossJndiDatasource {
   // additional fields for jetty only
   private String resourceName;
 
@@ -53,9 +56,14 @@ public class PSJettyJndiDatasource extends PSJBossJndiDatasource {
     super(source);
   }
 
-  @SuppressWarnings("this-escape")
+  /**
+   * Build from Jetty install properties. Uses direct field assignment after the multi-arg super
+   * constructor so construction does not call overridable setters ({@code this-escape}).
+   *
+   * @param props install properties, may not be {@code null}
+   */
   public PSJettyJndiDatasource(Properties props) {
-    this(
+    super(
         props.getProperty(DB_NAME_PROPERTY),
         props.getProperty(DB_DRIVER_NAME_PROPERTY),
         props.getProperty(DB_DRIVER_CLASS_NAME_PROPERTY),
@@ -63,13 +71,14 @@ public class PSJettyJndiDatasource extends PSJBossJndiDatasource {
         props.getProperty(UID_PROPERTY),
         props.getProperty(PWD_PROPERTY));
 
-    // add jetty only properties
-    this.setName(props.getProperty(DB_RESOURCE_NAME));
-    this.setConnectionTestQuery(props.getProperty(DB_CONNECTION_TEST_QUERY));
+    // Jetty resource name + connection test: assign protected / local fields directly
+    this.name = props.getProperty(DB_RESOURCE_NAME);
+    this.resourceName = this.name;
+    this.connectionTestQuery = props.getProperty(DB_CONNECTION_TEST_QUERY);
 
     String pwd = props.getProperty(PWD_PROPERTY);
-    String encrypted = props.getProperty(PWD_ENCRYPTED_PROPERTY);
-    if (encrypted != null && encrypted.equalsIgnoreCase("Y")) {
+    String encryptedFlag = props.getProperty(PWD_ENCRYPTED_PROPERTY);
+    if (encryptedFlag != null && encryptedFlag.equalsIgnoreCase("Y")) {
       this.encrypted = true;
       try {
         pwd =
@@ -93,7 +102,7 @@ public class PSJettyJndiDatasource extends PSJBossJndiDatasource {
                     null);
       }
     }
-    this.setPassword(pwd);
+    this.password = pwd;
   }
 
   public PSJettyJndiDatasource(

--- a/modules/utils/src/test/java/com/percussion/error/PSExceptionCauseCtorTest.java
+++ b/modules/utils/src/test/java/com/percussion/error/PSExceptionCauseCtorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.error;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for the message+cause constructor after this-escape strip (issue #2969).
+ */
+@Tag("UnitTest")
+public class PSExceptionCauseCtorTest {
+
+  @Test
+  public void messageCauseCtorSetsCodeZeroAndCause() {
+    RuntimeException cause = new RuntimeException("root");
+    PSException ex = new PSException("wrapped", cause);
+    assertEquals(0, ex.getErrorCode());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  public void messageCauseCtorRejectsNullCause() {
+    assertThrows(IllegalArgumentException.class, () -> new PSException("msg", null));
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/utils/container/jboss/PSJBossJndiDatasourceCopyTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/container/jboss/PSJBossJndiDatasourceCopyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.container.jboss;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.utils.container.IPSJndiDatasource;
+import com.percussion.utils.container.PSJndiDatasourceImpl;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for the BeanUtils-free copy constructor (this-escape redesign, issue #2969).
+ */
+@Tag("UnitTest")
+public class PSJBossJndiDatasourceCopyTest {
+
+  @Test
+  public void copyFromInterfaceCopiesSharedProperties() {
+    IPSJndiDatasource source =
+        new PSJndiDatasourceImpl(
+            "jdbc/rx", "jtds:sqlserver", "net.sourceforge.jtds.jdbc.Driver", "host:1433", "u", "p");
+    source.setMinConnections(3);
+    source.setMaxConnections(30);
+    source.setIdleTimeout(1000);
+    source.setSecurityDomain("rx.realm");
+    source.setId(7);
+
+    PSJBossJndiDatasource copy = new PSJBossJndiDatasource(source);
+
+    assertEquals("jdbc/rx", copy.getName());
+    assertEquals("jtds:sqlserver", copy.getDriverName());
+    assertEquals("net.sourceforge.jtds.jdbc.Driver", copy.getDriverClassName());
+    assertEquals("host:1433", copy.getServer());
+    assertEquals("u", copy.getUserId());
+    assertEquals("p", copy.getPassword());
+    assertEquals(3, copy.getMinConnections());
+    assertEquals(30, copy.getMaxConnections());
+    assertEquals(1000, copy.getIdleTimeout());
+    assertEquals("rx.realm", copy.getSecurityDomain());
+    assertEquals(7, copy.getId());
+  }
+
+  @Test
+  public void copyFromJBossCopiesRoundTripFieldsIndependently() {
+    PSJBossJndiDatasource source =
+        new PSJBossJndiDatasource(
+            "jdbc/oracle",
+            "oracle:thin",
+            "oracle.jdbc.OracleDriver",
+            "host:1521:orcl",
+            "scott",
+            "tiger");
+    source.setMinConnections(5);
+    source.setMaxConnections(50);
+
+    PSJBossJndiDatasource copy = new PSJBossJndiDatasource(source);
+
+    assertEquals(source, copy);
+    assertNotSame(source, copy);
+    // Mutating the copy must not affect the source pool sizes
+    copy.setMinConnections(1);
+    assertEquals(5, source.getMinConnections());
+    assertEquals(1, copy.getMinConnections());
+  }
+
+  @Test
+  public void copyCtorRejectsNullSource() {
+    assertThrows(NullPointerException.class, () -> new PSJBossJndiDatasource((IPSJndiDatasource) null));
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/utils/container/jetty/PSJettyJndiDatasourcePropsTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/container/jetty/PSJettyJndiDatasourcePropsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.container.jetty;
+
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.DB_CONNECTION_TEST_QUERY;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.DB_DRIVER_CLASS_NAME_PROPERTY;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.DB_DRIVER_NAME_PROPERTY;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.DB_NAME_PROPERTY;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.DB_RESOURCE_NAME;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.DB_SERVER_PROPERTY;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.PWD_ENCRYPTED_PROPERTY;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.PWD_PROPERTY;
+import static com.percussion.utils.container.IPSJdbcDbmsDefConstants.UID_PROPERTY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for the final Properties constructor (this-escape redesign, issue #2969).
+ */
+@Tag("UnitTest")
+public class PSJettyJndiDatasourcePropsTest {
+
+  @Test
+  public void propertiesCtorSeedsNamePasswordAndConnectionTest() {
+    Properties props = new Properties();
+    props.setProperty(DB_NAME_PROPERTY, "jdbc/default");
+    props.setProperty(DB_RESOURCE_NAME, "jdbc/rxdefault");
+    props.setProperty(DB_DRIVER_NAME_PROPERTY, "jtds:sqlserver");
+    props.setProperty(DB_DRIVER_CLASS_NAME_PROPERTY, "net.sourceforge.jtds.jdbc.Driver");
+    props.setProperty(DB_SERVER_PROPERTY, "localhost:1433");
+    props.setProperty(UID_PROPERTY, "sa");
+    props.setProperty(PWD_PROPERTY, "plain");
+    props.setProperty(PWD_ENCRYPTED_PROPERTY, "N");
+    props.setProperty(DB_CONNECTION_TEST_QUERY, "SELECT 1");
+
+    PSJettyJndiDatasource ds = new PSJettyJndiDatasource(props);
+
+    assertEquals("jdbc/rxdefault", ds.getName());
+    assertEquals("jtds:sqlserver", ds.getDriverName());
+    assertEquals("net.sourceforge.jtds.jdbc.Driver", ds.getDriverClassName());
+    assertEquals("localhost:1433", ds.getServer());
+    assertEquals("sa", ds.getUserId());
+    assertEquals("plain", ds.getPassword());
+    assertEquals("SELECT 1", ds.getConnectionTestQuery());
+    assertFalse(ds.isEncrypted());
+  }
+}


### PR DESCRIPTION
## Summary

Partial implement for **#2969** (modules/utils javac residual after batch 6) — **batch 7** real **this-escape redesign** cluster (no new blanket suppressions; does **not** reparameterize `PSWorkflowUtilsBase` public raw List/Map API).

| Area | Fix |
|------|-----|
| `PSJBossJndiDatasource` copy ctor | Multi-arg super + protected field overlay; remove BeanUtils; strip this-escape |
| `PSJndiDatasourceImpl` | `id` protected; `setId` final |
| `PSJettyJndiDatasource` | `final` class; Properties ctor direct field assign; strip this-escape |
| `PSException` | Direct `m_code = 0` in message+cause ctor; `setErrorCode` final; strip class this-escape |

**Not changed (by design):** `PSWorkflowUtilsBase` raw public API; `PSCollection` / `PSJexlEvaluator` / `PSXmlSerializationHelper`; CRTP / ItemIterator / Copier / ConcurrentList serialization residuals.

Parent module: **#2016**. Tracker: **#2200**. Residual after this batch: filed with PR (see residual issue).

## Test plan

- [x] Standalone `modules/utils`: `cd modules/utils && ..\..\mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Suite: **352** tests, **0** failures (9 pre-existing skips)
- [x] Project-Xlint: **0** `possible 'this' escape` warnings on changed sources
- [x] New tests: `PSJBossJndiDatasourceCopyTest` (3), `PSJettyJndiDatasourcePropsTest` (1), `PSExceptionCauseCtorTest` (2)

## Product documentation

- [x] N/A — pure compiler hygiene / non-product-facing tech-debt (no operator, admin, integrator, or end-user behavior change)

## Gates evidence (C3)

- **modules_built:** `modules/utils`
- **build_evidence:** `cd modules/utils && ..\..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 352, Failures: 0, Errors: 0, Skipped: 9
- **downstream_checked:** grepped monorepo for `extends PSJettyJndiDatasource` — none (safe to finalize); `setId(int)` on `PSJndiDatasourceImpl` made final (no subclass overrides of that signature)
- Erlang-style self-review: approve — `docs/ai-generated/code-reviews/issue-2969-utils-javac-residual-batch7-erlang.md`

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2969. Parent: #2016. Tracker: #2200.

> Co-Authored by Grok Build using grok-4.5 with agent main.
