### PR TITLE
fix(deployer): Xlint batch 10 — ContentAssembler/Content/ContentListDef (#2028)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentAssemblerDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentAssemblerDependencyHandler.java
@@ -182,7 +182,8 @@ public class PSContentAssemblerDependencyHandler extends PSDependencyHandler {
    * @return An iterator over zero or more types as <code>String</code> objects, never <code>null
    *     </code>, does not contain <code>null</code> or empty entries.
    */
-  public Iterator getChildTypes() {
+  @Override
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentDependencyHandler.java
@@ -126,7 +126,8 @@ public class PSContentDependencyHandler extends PSDataObjectDependencyHandler {
    * @return An iterator over zero or more types as <code>String</code> objects, never <code>null
    *     </code>, does not contain <code>null</code> or empty entries.
    */
-  public Iterator getChildTypes() {
+  @Override
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
@@ -184,7 +185,7 @@ public class PSContentDependencyHandler extends PSDataObjectDependencyHandler {
   private PSDependencyHandler m_ctHandler = null;
 
   /** List of child types supported by this handler, it will never be <code>null</code> or empty. */
-  private static List ms_childTypes = new ArrayList();
+  private static final List<String> ms_childTypes = new ArrayList<>();
 
   private static final String CONTENT_ID = "CONTENTID";
   private static final String CONTENTTYPE_ID = "CONTENTTYPEID";

--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentListDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentListDefDependencyHandler.java
@@ -155,7 +155,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
 
   // see base class
   @Override
-  public Iterator getChildDependencies(PSSecurityToken tok, PSDependency dep)
+  public Iterator<PSDependency> getChildDependencies(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException, PSNotFoundException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
 
@@ -261,7 +261,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
    * @return iterator on a set of names
    * @throws PSDeployException if there are any errors loading the names.
    */
-  public Iterator getContentListNames(String nameFilter) throws PSDeployException {
+  public Iterator<String> getContentListNames(String nameFilter) throws PSDeployException {
     init();
     return m_publisherHelper.getAllContentListNames(nameFilter).iterator();
   }
@@ -276,19 +276,17 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
     m_publisherHelper
         .getNamedContentListMap()
         .forEach(
-            (key, value) -> {
-              var cList = (IPSContentList) value;
-              deps.add(
-                  createDeployableElement(
-                      m_def, String.valueOf(cList.getGUID().longValue()), cList.getName()));
-            });
+            (key, cList) ->
+                deps.add(
+                    createDeployableElement(
+                        m_def, String.valueOf(cList.getGUID().longValue()), cList.getName())));
 
     return deps.iterator();
   }
 
   // see base class
   @Override
-  public Iterator getDependencyFiles(PSSecurityToken tok, PSDependency dep)
+  public Iterator<PSDependencyFile> getDependencyFiles(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException {
     if (tok == null) throw new IllegalArgumentException("tok may not be null");
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
@@ -388,8 +386,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
       ((PSContentList) cList).setVersion(null);
     }
     // retrieve data, followed by its child data if any
-    PSDependencyFile depFile =
-        (PSDependencyFile) getContentListDependecyFilesFromArchive(archive, dep).next();
+    PSDependencyFile depFile = getContentListDependecyFilesFromArchive(archive, dep).next();
     cList = generateContentListFromFile(archive, depFile, cList);
     doTransforms(dep, ctx, cList, isNew);
     saveContentList(cList, ver);
@@ -436,12 +433,12 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
    * @throws PSDeployException if there is no dependency file in the archive for the specified
    *     dependency object, or any other error occurs.
    */
-  protected Iterator getContentListDependecyFilesFromArchive(
+  protected Iterator<PSDependencyFile> getContentListDependecyFilesFromArchive(
       PSArchiveHandler archive, PSDependency dep) throws PSDeployException {
     if (archive == null) throw new IllegalArgumentException("archive may not be null");
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
 
     if (!files.hasNext()) {
       Object[] args = {
@@ -457,7 +454,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
 
   // see base class
   @Override
-  public Iterator getChildTypes() {
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
@@ -503,18 +500,13 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
     String url = cList.getUrl();
     if (url != null) {
       // parse params
-      Map paramMap = PSDeployComponentUtils.parseParams(url, null);
-      List mappings = new ArrayList();
+      Map<String, Object> paramMap = PSDeployComponentUtils.parseParams(url, null);
+      List<PSApplicationIDTypeMapping> mappings = new ArrayList<>();
 
       // check each param for idtypes
-      Iterator entries = paramMap.entrySet().iterator();
-      while (entries.hasNext()) {
-        Map.Entry entry = (Map.Entry) entries.next();
-
+      for (Map.Entry<String, Object> entry : paramMap.entrySet()) {
         // convert to PSParam to leverage existing transformer code
-        Iterator params = PSDeployComponentUtils.convertToParams(entry).iterator();
-        while (params.hasNext()) {
-          PSParam param = (PSParam) params.next();
+        for (PSParam param : PSDeployComponentUtils.convertToParams(entry)) {
           PSAppTransformer.checkParam(mappings, param, null);
         }
       }
@@ -546,14 +538,9 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
     Map<String, String> paramMap = cList.getExpanderParams();
     List<PSApplicationIDTypeMapping> mappings = new ArrayList<>();
     // check each param for idtypes
-    Iterator<Map.Entry<String, String>> entries = paramMap.entrySet().iterator();
-    while (entries.hasNext()) {
-      Map.Entry<String, String> entry = entries.next();
-
+    for (Map.Entry<String, String> entry : paramMap.entrySet()) {
       // convert to PSParam to leverage existing transformer code
-      Iterator params = PSDeployComponentUtils.convertToParams(entry).iterator();
-      while (params.hasNext()) {
-        PSParam param = (PSParam) params.next();
+      for (PSParam param : PSDeployComponentUtils.convertToParams(entry)) {
         PSAppTransformer.checkParam(mappings, param, null);
       }
     }
@@ -563,22 +550,12 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
         mappings.iterator());
 
     // Add any generator params
-    paramMap.clear();
-    paramMap = null;
-    mappings.clear();
-    mappings = null;
-
     paramMap = cList.getGeneratorParams();
     mappings = new ArrayList<>();
     // check each param for idtypes
-    entries = paramMap.entrySet().iterator();
-    while (entries.hasNext()) {
-      Map.Entry<String, String> entry = entries.next();
-
+    for (Map.Entry<String, String> entry : paramMap.entrySet()) {
       // convert to PSParam to leverage existing transformer code
-      Iterator params = PSDeployComponentUtils.convertToParams(entry).iterator();
-      while (params.hasNext()) {
-        PSParam param = (PSParam) params.next();
+      for (PSParam param : PSDeployComponentUtils.convertToParams(entry)) {
         PSAppTransformer.checkParam(mappings, param, null);
       }
     }
@@ -588,30 +565,19 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
         mappings.iterator());
 
     // Add any filter params
-    paramMap.clear();
-    paramMap = null;
-    mappings.clear();
-    mappings = null;
     IPSItemFilter f = cList.getFilter();
     try {
       if (f != null) {
         // ADD ANY EXPANDER PARAMS THAT ARE ID-TYPED
         Set<IPSItemFilterRuleDef> ruleDefSet = f.getRuleDefs();
-        Iterator<IPSItemFilterRuleDef> iter = ruleDefSet.iterator();
-        while (iter.hasNext()) {
-          IPSItemFilterRuleDef ruleDef = iter.next();
+        for (IPSItemFilterRuleDef ruleDef : ruleDefSet) {
           paramMap = ruleDef.getParams();
 
           mappings = new ArrayList<>();
           // check each param for idtypes
-          entries = paramMap.entrySet().iterator();
-          while (entries.hasNext()) {
-            Map.Entry<String, String> entry = entries.next();
-
+          for (Map.Entry<String, String> entry : paramMap.entrySet()) {
             // convert to PSParam to leverage existing transformer code
-            Iterator params = PSDeployComponentUtils.convertToParams(entry).iterator();
-            while (params.hasNext()) {
-              PSParam param = (PSParam) params.next();
+            for (PSParam param : PSDeployComponentUtils.convertToParams(entry)) {
               PSAppTransformer.checkParam(mappings, param, null);
             }
           }
@@ -644,58 +610,34 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
       throw new IllegalArgumentException("invalid object type");
     }
 
-    Map paramMap = (Map) object;
+    @SuppressWarnings("unchecked")
+    Map<String, Object> paramMap = (Map<String, Object>) object;
     // walk id types and perform any transforms
-    Iterator resources = idTypes.getResourceList(false);
+    Iterator<String> resources = idTypes.getResourceList(false);
     while (resources.hasNext()) {
-      String resource = (String) resources.next();
-      Iterator elements = idTypes.getElementList(resource, false);
+      String resource = resources.next();
+      Iterator<String> elements = idTypes.getElementList(resource, false);
       while (elements.hasNext()) {
-        String element = (String) elements.next();
-        Iterator mappings = idTypes.getIdTypeMappings(resource, element, false);
+        String element = elements.next();
+        Iterator<PSApplicationIDTypeMapping> mappings =
+            idTypes.getIdTypeMappings(resource, element, false);
         while (mappings.hasNext()) {
 
-          PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
+          PSApplicationIDTypeMapping mapping = mappings.next();
 
           if (mapping.getType().equals(PSApplicationIDTypeMapping.TYPE_NONE)) {
             continue;
           }
 
           if (element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_CONTENTLIST_EXPANDER_PARAMS)
-              || element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_CONTENTLIST_GENERATOR_PARAMS)) {
+              || element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_CONTENTLIST_GENERATOR_PARAMS)
+              || element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_URL_PARAMS)) {
             // transform the params
-            Iterator entries = paramMap.entrySet().iterator();
-            while (entries.hasNext()) {
+            for (Map.Entry<String, Object> entry : paramMap.entrySet()) {
               // convert to PSParam(s) to leverage existing code
               List<String> valList = new ArrayList<>();
-              Map.Entry entry = (Map.Entry) entries.next();
-              List paramList = PSDeployComponentUtils.convertToParams(entry);
-              Iterator params = paramList.iterator();
-              while (params.hasNext()) {
-                PSParam param = (PSParam) params.next();
-
-                // transform
-                PSAppTransformer.transformParam(param, mapping, idMap);
-                valList.add(param.getValue().getValueText());
-              }
-              Object newVal;
-              if (valList.size() > 1) newVal = valList;
-              else newVal = valList.get(0);
-
-              entry.setValue(newVal);
-            }
-          } else if (element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_URL_PARAMS)) {
-            // transform the params
-            Iterator entries = paramMap.entrySet().iterator();
-            while (entries.hasNext()) {
-              // convert to PSParam(s) to leverage existing code
-              List<String> valList = new ArrayList<String>();
-              Map.Entry entry = (Map.Entry) entries.next();
-              List paramList = PSDeployComponentUtils.convertToParams(entry);
-              Iterator params = paramList.iterator();
-              while (params.hasNext()) {
-                PSParam param = (PSParam) params.next();
-
+              List<PSParam> paramList = PSDeployComponentUtils.convertToParams(entry);
+              for (PSParam param : paramList) {
                 // transform
                 PSAppTransformer.transformParam(param, mapping, idMap);
                 valList.add(param.getValue().getValueText());
@@ -829,7 +771,7 @@ public class PSContentListDefDependencyHandler extends PSDependencyHandler
     PSIdMap idMap = ctx.getCurrentIdMap();
     String url = cList.getUrl();
     StringBuilder base = new StringBuilder();
-    Map params = PSDeployComponentUtils.parseParams(url, base);
+    Map<String, Object> params = PSDeployComponentUtils.parseParams(url, base);
 
     if (!params.isEmpty()) {
       // tranform params using idtypes

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSContentListHandlersTypedTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSContentListHandlersTypedTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.server.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.deployer.objectstore.PSDependency;
+import com.percussion.deployer.objectstore.PSDependencyFile;
+import com.percussion.security.PSSecurityToken;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Signature smoke for typed ContentAssembler / Content / ContentListDef dependency handler surfaces
+ * (issue #2028 Xlint residual batch 10 after #2915 / PR #2981). Runtime paths require a live CMS;
+ * these tests lock compile-time API shapes that cleared rawtypes diagnostics.
+ */
+public class PSContentListHandlersTypedTest {
+
+  @Test
+  public void contentAssemblerChildTypesReturnTypedIterator() throws Exception {
+    assertTypedIterator(
+        PSContentAssemblerDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertTypedIterator(
+        PSContentAssemblerDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertEquals("ContentAssembler", PSContentAssemblerDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void contentHandlerChildTypesAndListAreTyped() throws Exception {
+    assertTypedIterator(
+        PSContentDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertTypedIterator(
+        PSContentDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertEquals("Content", PSContentDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void contentListDefDependenciesAndChildTypesReturnTypedIterators() throws Exception {
+    assertTypedIterator(
+        PSContentListDefDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSContentListDefDependencyHandler.class.getMethod(
+            "getDependencies", PSSecurityToken.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSContentListDefDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class),
+        PSDependencyFile.class);
+    assertTypedIterator(
+        PSContentListDefDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertTypedIterator(
+        PSContentListDefDependencyHandler.class.getMethod(
+            "getContentListNames", String.class),
+        String.class);
+    assertEquals("ContentListDef", PSContentListDefDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  private static void assertTypedIterator(Method method, Class<?> typeArg) {
+    assertEquals(Iterator.class, method.getReturnType());
+    Type generic = method.getGenericReturnType();
+    assertTrue(generic instanceof ParameterizedType, method.getName() + " should be parameterized");
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(typeArg, args[0], method.getName() + " type arg");
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-2028-deployer-xlint-content-list-handlers-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2028-deployer-xlint-content-list-handlers-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review — issue #2028 batch 10 (perc-deployer Content* handlers)
+
+**Verdict: PASS**
+
+## Scope
+Xlint residual cleanup after #2915 / PR #2981 on:
+- `PSContentAssemblerDependencyHandler`
+- `PSContentDependencyHandler`
+- `PSContentListDefDependencyHandler`
+
+## Findings
+### Bugs
+None. Signature changes only add type parameters matching base
+`PSDependencyHandler` / `IPSDependencyHandler` contracts. Behavior of
+id-type walks and transform loops is preserved (for-each over previously
+raw iterators).
+
+### Tests
+- `PSContentListHandlersTypedTest` — 3 signature smoke tests lock typed
+  `Iterator` returns for the three handlers.
+- Module suite: Tests run: 235, Failures: 0, Errors: 0, Skipped: 19.
+
+### Cross-platform paths
+No file I/O or path construction changes.
+
+### Change-class companions
+Peer pattern: batch 8 `PSComponentSlotContentDefHandlersTypedTest`.
+Companions delivered: production generics + typed test class.
+
+### C2 / API blast radius
+No `final`/`sealed`. Methods only added type arguments on overrides
+already present in the abstract base (`Iterator<String>`,
+`Iterator<PSDependency>`, `Iterator<PSDependencyFile>`).
+`downstream_checked=none`.
+
+### Product docs
+N/A — pure tech-debt Xlint cleanup, no operator/user surface change.
+
+## Residual
+~939 main-source Xlint diags remain (was ~997). Next coherent slice:
+`PSContentRelationDependencyHandler` (~68) then
+`PSContentTypeDependencyHandler` (~69).


### PR DESCRIPTION
## Summary
Xlint residual cleanup for **perc-deployer** ContentAssembler / Content / ContentListDef dependency handlers (issue #2028, residual after batch 9 #2915 / PR #2981, parent tracker #2200).

Post-#2981 uncapped main-source inventory: **997** diagnostics across 81 files. This batch clears the three Content* handlers that head the residual list (~**58** diags → **0** on targets; module residual **~939**).

### Main changes
- **PSContentAssemblerDependencyHandler**: `Iterator<String> getChildTypes()`
- **PSContentDependencyHandler**: typed `getChildTypes()` + `List<String> ms_childTypes`
- **PSContentListDefDependencyHandler**: typed `getChildDependencies` / `getDependencyFiles` / `getChildTypes` / `getContentListNames` / archive file iterator; `Map`/`List`/`Iterator` generics in id-type and transform paths; drop redundant casts

### Tests
- `PSContentListHandlersTypedTest` — signature smoke (3 tests)

## Test plan
- [x] `cd deployer && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **235**, Failures: **0**, Errors: **0**, Skipped: **19**
- [x] Target files cleared from main-source Xlint report (Assembler / Content / ContentListDef)
- [x] C2: no final/sealed; overrides only add type parameters — **downstream_checked=none**
- [x] No monorepo-wide reformat

## Gates
- Erlang-style self-review: `docs/ai-generated/code-reviews/issue-2028-deployer-xlint-content-list-handlers-erlang.md` — PASS
- Pre-PR Maven: standalone module clean install green
- Operator: Grok: night-issue-prs (model grok-4.5)

### C3 evidence
- **modules_built:** deployer
- **build_evidence:** `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 235, Failures: 0, Errors: 0, Skipped: 19
- **downstream_checked:** none (C2 not required — no final/sealed or public signature removals)

## Product documentation
- [x] N/A — pure tech-debt Xlint/generics cleanup; no operator-, admin-, integrator-, or end-user-facing behavior change

## Partial / residual
~939 main-source Xlint diags remain. Next coherent PR-sized slice: **PSContentRelationDependencyHandler** (~68) then **PSContentTypeDependencyHandler** (~69). Residual issue filed from this run.

Fixes: partial #2028 (batch 10). Parent monorepo: #2200.
