### PR TITLE
fix(system): virtual participant registry durability/SPI (#3019)

### DIFF
--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -51,6 +51,21 @@ See [Installation](id:install-overview).
 
 Details: [Frontmatter reference](id:reference-frontmatter).
 
+## Virtual participant registry lifetime
+
+During a Virtual Site build, each page’s frontmatter **`id`** is registered against its published
+HTML path in the **virtual participant registry** (`IPSVirtualParticipantService`). Phase 1 does
+**not** create CMS content IDs or `PSX_MANAGEDLINK` rows.
+
+| Mode | Behavior |
+|------|----------|
+| **Process-scoped (default)** | Registrations live in memory until the process exits, or until `clear(siteKey)` / `clearAll()` is called (SPI reset API). Unit tests and one-shot builds use this mode when no store directory is supplied. |
+| **Path-backed (optional)** | Construct the registry with a portable `java.nio.file.Path` base (CLI uses `outputRoot/_meta`). Existing `participants-<siteKey>.jsonl` files are loaded on construct; `flush(siteKey)` rewrites that site’s file. Survives JVM restart when the same Path base is reused. |
+| **Full rebuild** | A complete site build **clears** that site key, then upserts every discovered page, then flushes. A second build therefore does not keep pages removed from the source tree, and does not lose current ids. |
+
+Operators can treat the JSONL under the build meta directory as a diagnostic dump of stable ids after
+an offline docs build. The registry is **not** a substitute for Git as the system of record.
+
 ## Site properties (CMS)
 
 When a Percussion Site is configured as virtual (Phase 1 property contract — no new `RXSITES`

--- a/product-docs/8.2/reference/frontmatter.md
+++ b/product-docs/8.2/reference/frontmatter.md
@@ -30,7 +30,7 @@ deprecated: false
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `id` | **Yes** | Stable identity for virtual participants / links. Unique within a version. |
+| `id` | **Yes** | Stable identity for virtual participants / links. Unique within a version. Registered at build time as id → published path; see [Virtual Sites](id:developer-virtual-sites) (registry lifetime). |
 | `title` | **Yes** | Page title. |
 | `description` | No | Short summary. |
 | `version` | No | Inherited from version folder name when omitted. |

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualParticipantService.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualParticipantService.java
@@ -20,15 +20,56 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
 
-/** Registry of Virtual Site page identities for link integrity (Phase 1: file/memory). */
+/**
+ * Registry of Virtual Site page identities for link integrity and stable cross-page references.
+ *
+ * <p>Each registration maps a frontmatter {@code id} (stable id) to the published HTML path for a
+ * given site key (and version is recorded on the participant).
+ *
+ * <h2>Lifetime (Phase 1)</h2>
+ *
+ * <ul>
+ *   <li><strong>Process-scoped default</strong> — entries live in memory until {@link
+ *       #clear(String)}, {@link #clearAll()}, or JVM exit. Suitable for unit tests and one-shot
+ *       offline builds that do not need cross-process durability.
+ *   <li><strong>Optional durable store</strong> — implementations may accept a portable {@link
+ *       java.nio.file.Path} base (for example build {@code outputRoot/_meta} or a deploy/config
+ *       directory). When configured, {@link #flush(String)} persists JSONL and construction (or
+ *       explicit reload) reloads prior registrations after a process restart.
+ *   <li><strong>Full rebuild replaces a site</strong> — {@link PSVirtualSiteBuildService} clears
+ *       the site key at the start of a build, then upserts every discovered page, then flushes.
+ *       That way a second build does not incorrectly retain pages removed from the source tree,
+ *       and all current frontmatter ids are re-registered.
+ * </ul>
+ *
+ * <p>Phase 1 deliberately avoids CMS content IDs and {@code PSX_MANAGEDLINK}.
+ */
 public interface IPSVirtualParticipantService {
 
+  /** Insert or replace a participant for {@code participant.siteKey()} / {@code stableId()}. */
   void upsert(VirtualParticipant participant);
 
+  /** Lookup by site key and frontmatter stable id; empty when never registered or cleared. */
   Optional<VirtualParticipant> find(String siteKey, String stableId);
 
+  /** All participants for a site (empty collection when none). */
   Collection<VirtualParticipant> list(String siteKey);
 
-  /** Persist all participants for a site (implementation-specific). */
+  /**
+   * Persist all participants for a site (implementation-specific). No-op when no durable store is
+   * configured.
+   */
   void flush(String siteKey) throws IOException;
+
+  /**
+   * Remove all participants for one site from memory and, when durable storage is configured,
+   * delete that site's store file.
+   */
+  void clear(String siteKey) throws IOException;
+
+  /**
+   * Reset the entire registry (all sites). Clears memory and, when durable storage is configured,
+   * removes known store files under the store directory.
+   */
+  void clearAll() throws IOException;
 }

--- a/system/services/src/com/percussion/services/virtualsite/PSInMemoryVirtualParticipantService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSInMemoryVirtualParticipantService.java
@@ -17,7 +17,9 @@
 package com.percussion.services.virtualsite;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -29,24 +31,50 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * In-memory virtual participant registry with optional JSON-lines flush for offline builds.
+ * Virtual participant registry: process-scoped memory with optional Path-backed JSONL durability.
  *
- * <p>Not a Hibernate entity — Phase 1 avoids CMS content IDs and {@code PSX_MANAGEDLINK}.
+ * <p>When constructed with a non-null store directory, existing {@code participants-*.jsonl} files
+ * under that directory are loaded so a new JVM can see prior registrations. {@link #flush(String)}
+ * writes the current in-memory map for a site. {@link #clear(String)} / {@link #clearAll()} reset
+ * memory and delete store files when durability is enabled.
+ *
+ * <p>Not a Hibernate entity — Phase 1 avoids CMS content IDs and {@code PSX_MANAGEDLINK}. Paths are
+ * portable {@link Path} values (no Unix-only hardcodes).
+ *
+ * @see IPSVirtualParticipantService
  */
 public class PSInMemoryVirtualParticipantService implements IPSVirtualParticipantService {
 
-  private final Map<String, Map<String, VirtualParticipant>> bySite = new ConcurrentHashMap<>();
-  private final Path flushDirectory;
+  private static final String FILE_PREFIX = "participants-";
+  private static final String FILE_SUFFIX = ".jsonl";
 
+  private final Map<String, Map<String, VirtualParticipant>> bySite = new ConcurrentHashMap<>();
+  private final Path storeDirectory;
+
+  /** Process-scoped only — no disk I/O; lost on JVM exit unless the caller re-upserts. */
   public PSInMemoryVirtualParticipantService() {
     this(null);
   }
 
   /**
-   * @param flushDirectory if non-null, {@link #flush(String)} writes {@code participants-<site>.jsonl}
+   * @param storeDirectory if non-null, load existing JSONL on construct and write on {@link
+   *     #flush(String)}; must be a portable {@link Path} (e.g. {@code outputRoot.resolve("_meta")})
    */
-  public PSInMemoryVirtualParticipantService(Path flushDirectory) {
-    this.flushDirectory = flushDirectory;
+  public PSInMemoryVirtualParticipantService(Path storeDirectory) {
+    this.storeDirectory = storeDirectory;
+    if (storeDirectory != null) {
+      try {
+        loadAllFromStore();
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+            "Failed to load virtual participant store from " + storeDirectory, e);
+      }
+    }
+  }
+
+  /** Optional durable base directory, or empty when process-scoped only. */
+  public Optional<Path> storeDirectory() {
+    return Optional.ofNullable(storeDirectory);
   }
 
   @Override
@@ -76,24 +104,97 @@ public class PSInMemoryVirtualParticipantService implements IPSVirtualParticipan
 
   @Override
   public void flush(String siteKey) throws IOException {
-    if (flushDirectory == null) {
+    if (storeDirectory == null) {
       return;
     }
-    Files.createDirectories(flushDirectory);
-    Path out = flushDirectory.resolve("participants-" + sanitize(siteKey) + ".jsonl");
+    Files.createDirectories(storeDirectory);
+    Path out = siteFile(siteKey);
     Collection<VirtualParticipant> all = list(siteKey);
-    List<String> lines = new ArrayList<>();
+    List<String> lines = new ArrayList<>(all.size());
     for (VirtualParticipant p : all) {
       lines.add(toJsonLine(p));
     }
     Files.write(out, lines, StandardCharsets.UTF_8);
   }
 
-  private static String sanitize(String siteKey) {
+  @Override
+  public void clear(String siteKey) throws IOException {
+    bySite.remove(siteKey);
+    if (storeDirectory != null) {
+      Path file = siteFile(siteKey);
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Override
+  public void clearAll() throws IOException {
+    bySite.clear();
+    if (storeDirectory == null || !Files.isDirectory(storeDirectory)) {
+      return;
+    }
+    try (DirectoryStream<Path> stream =
+        Files.newDirectoryStream(storeDirectory, FILE_PREFIX + "*" + FILE_SUFFIX)) {
+      for (Path p : stream) {
+        Files.deleteIfExists(p);
+      }
+    }
+  }
+
+  /**
+   * Reload all sites from the store directory into memory (no-op when process-scoped). Existing
+   * in-memory entries for sites present on disk are replaced by the file contents; sites only in
+   * memory are left unchanged unless the caller {@link #clearAll()} first.
+   */
+  public void reloadFromStore() throws IOException {
+    if (storeDirectory == null) {
+      return;
+    }
+    loadAllFromStore();
+  }
+
+  /** Snapshot of all sites (testing). */
+  public Map<String, Map<String, VirtualParticipant>> snapshot() {
+    Map<String, Map<String, VirtualParticipant>> copy = new LinkedHashMap<>();
+    for (Map.Entry<String, Map<String, VirtualParticipant>> e : bySite.entrySet()) {
+      copy.put(e.getKey(), Map.copyOf(e.getValue()));
+    }
+    return copy;
+  }
+
+  private void loadAllFromStore() throws IOException {
+    if (storeDirectory == null || !Files.isDirectory(storeDirectory)) {
+      return;
+    }
+    try (DirectoryStream<Path> stream =
+        Files.newDirectoryStream(storeDirectory, FILE_PREFIX + "*" + FILE_SUFFIX)) {
+      for (Path file : stream) {
+        loadSiteFile(file);
+      }
+    }
+  }
+
+  private void loadSiteFile(Path file) throws IOException {
+    List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+    for (String line : lines) {
+      if (line == null || line.isBlank()) {
+        continue;
+      }
+      VirtualParticipant p = fromJsonLine(line.trim());
+      if (p != null) {
+        upsert(p);
+      }
+    }
+  }
+
+  private Path siteFile(String siteKey) {
+    return storeDirectory.resolve(FILE_PREFIX + sanitize(siteKey) + FILE_SUFFIX);
+  }
+
+  static String sanitize(String siteKey) {
     return siteKey.replaceAll("[^a-zA-Z0-9._-]", "_");
   }
 
-  private static String toJsonLine(VirtualParticipant p) {
+  static String toJsonLine(VirtualParticipant p) {
     // Minimal JSON without pulling a full object mapper dependency into this path.
     return "{"
         + "\"siteKey\":\""
@@ -114,19 +215,59 @@ public class PSInMemoryVirtualParticipantService implements IPSVirtualParticipan
         + "}";
   }
 
-  private static String esc(String s) {
+  /**
+   * Parse one JSONL line produced by {@link #toJsonLine(VirtualParticipant)}. Returns null for
+   * unusable lines.
+   */
+  static VirtualParticipant fromJsonLine(String line) {
+    if (line == null || line.isBlank() || line.charAt(0) != '{') {
+      return null;
+    }
+    String siteKey = readJsonStringField(line, "siteKey");
+    String stableId = readJsonStringField(line, "stableId");
+    String versionId = readJsonStringField(line, "versionId");
+    String publishedPath = readJsonStringField(line, "publishedPath");
+    String sourcePath = readJsonStringField(line, "sourcePath");
+    if (siteKey == null || stableId == null || publishedPath == null) {
+      return null;
+    }
+    return new VirtualParticipant(
+        siteKey, stableId, versionId != null ? versionId : "", publishedPath, sourcePath);
+  }
+
+  /**
+   * Extract a string field from a single-line minimal JSON object (same escape rules as {@link
+   * #esc(String)}).
+   */
+  static String readJsonStringField(String json, String field) {
+    String needle = "\"" + field + "\":\"";
+    int start = json.indexOf(needle);
+    if (start < 0) {
+      return null;
+    }
+    int i = start + needle.length();
+    StringBuilder sb = new StringBuilder();
+    while (i < json.length()) {
+      char c = json.charAt(i);
+      if (c == '\\' && i + 1 < json.length()) {
+        char n = json.charAt(i + 1);
+        sb.append(n);
+        i += 2;
+        continue;
+      }
+      if (c == '"') {
+        return sb.toString();
+      }
+      sb.append(c);
+      i++;
+    }
+    return null;
+  }
+
+  static String esc(String s) {
     if (s == null) {
       return "";
     }
     return s.replace("\\", "\\\\").replace("\"", "\\\"");
-  }
-
-  /** Snapshot of all sites (testing). */
-  public Map<String, Map<String, VirtualParticipant>> snapshot() {
-    Map<String, Map<String, VirtualParticipant>> copy = new LinkedHashMap<>();
-    for (Map.Entry<String, Map<String, VirtualParticipant>> e : bySite.entrySet()) {
-      copy.put(e.getKey(), Map.copyOf(e.getValue()));
-    }
-    return copy;
   }
 }

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -74,6 +74,10 @@ public class PSVirtualSiteBuildService {
       throws IOException, VirtualSiteException {
     Files.createDirectories(outputRoot);
 
+    // Full rebuild replaces this site's registry so removed pages do not linger and all current
+    // frontmatter ids are re-registered (see IPSVirtualParticipantService lifetime notes).
+    participants.clear(config.siteKey());
+
     List<VirtualItemRef> refs = source.discover(config);
     List<VirtualItem> items = new ArrayList<>();
     for (VirtualItemRef ref : refs) {

--- a/system/src/test/java/com/percussion/services/virtualsite/PSInMemoryVirtualParticipantServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSInMemoryVirtualParticipantServiceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.virtualsite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Behavioral tests for virtual participant registry (upsert / miss / reset / durable). */
+class PSInMemoryVirtualParticipantServiceTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void upsertAndFindRoundTrip() {
+    PSInMemoryVirtualParticipantService reg = new PSInMemoryVirtualParticipantService();
+    reg.upsert(sample("site-a", "page-one", "8.2/page-one.html"));
+
+    Optional<VirtualParticipant> found = reg.find("site-a", "page-one");
+    assertTrue(found.isPresent());
+    assertEquals("8.2/page-one.html", found.get().publishedPath());
+    assertEquals("8.2", found.get().versionId());
+  }
+
+  @Test
+  void lookupMissingTargetIsEmpty() {
+    PSInMemoryVirtualParticipantService reg = new PSInMemoryVirtualParticipantService();
+    reg.upsert(sample("site-a", "page-one", "8.2/page-one.html"));
+
+    assertTrue(reg.find("site-a", "does-not-exist").isEmpty());
+    assertTrue(reg.find("other-site", "page-one").isEmpty());
+    assertTrue(reg.list("ghost").isEmpty());
+  }
+
+  @Test
+  void clearResetsSiteAndClearAllResetsRegistry() throws Exception {
+    PSInMemoryVirtualParticipantService reg = new PSInMemoryVirtualParticipantService();
+    reg.upsert(sample("site-a", "a1", "a.html"));
+    reg.upsert(sample("site-b", "b1", "b.html"));
+
+    reg.clear("site-a");
+    assertTrue(reg.find("site-a", "a1").isEmpty());
+    assertTrue(reg.find("site-b", "b1").isPresent());
+
+    reg.clearAll();
+    assertTrue(reg.find("site-b", "b1").isEmpty());
+    assertTrue(reg.snapshot().isEmpty());
+  }
+
+  @Test
+  void durableFlushReloadAndClearDeletesStoreFile() throws Exception {
+    Path store = tempDir.resolve("meta");
+    PSInMemoryVirtualParticipantService first = new PSInMemoryVirtualParticipantService(store);
+    first.upsert(sample("docs", "install-overview", "8.2/getting-started/install.html"));
+    first.upsert(
+        new VirtualParticipant(
+            "docs",
+            "path-with-quote",
+            "8.2",
+            "8.2/path\"with.html",
+            "8.2/path\"with.md"));
+    first.flush("docs");
+
+    Path jsonl = store.resolve("participants-docs.jsonl");
+    assertTrue(Files.isRegularFile(jsonl), "flush must write JSONL under store Path");
+
+    // New process-scoped instance loads from the same portable Path base.
+    PSInMemoryVirtualParticipantService second = new PSInMemoryVirtualParticipantService(store);
+    Optional<VirtualParticipant> reloaded = second.find("docs", "install-overview");
+    assertTrue(reloaded.isPresent());
+    assertEquals(
+        "8.2/getting-started/install.html", reloaded.get().publishedPath().replace('\\', '/'));
+    Optional<VirtualParticipant> quoted = second.find("docs", "path-with-quote");
+    assertTrue(quoted.isPresent());
+    assertEquals("8.2/path\"with.html", quoted.get().publishedPath());
+
+    second.clear("docs");
+    assertFalse(Files.exists(jsonl), "clear must delete durable site file");
+    assertTrue(second.find("docs", "install-overview").isEmpty());
+  }
+
+  @Test
+  void secondBuildReplacesSiteWithoutLosingCurrentIds() throws Exception {
+    Path store = tempDir.resolve("meta-rebuild");
+    PSInMemoryVirtualParticipantService reg = new PSInMemoryVirtualParticipantService(store);
+    reg.upsert(sample("docs", "old-page", "8.2/old.html"));
+    reg.upsert(sample("docs", "keep-page", "8.2/keep.html"));
+    reg.flush("docs");
+
+    // Simulate full rebuild: clear site, upsert current tree only, flush.
+    reg.clear("docs");
+    reg.upsert(sample("docs", "keep-page", "8.2/keep.html"));
+    reg.upsert(sample("docs", "new-page", "8.2/new.html"));
+    reg.flush("docs");
+
+    assertTrue(reg.find("docs", "old-page").isEmpty(), "removed page must not linger");
+    assertTrue(reg.find("docs", "keep-page").isPresent());
+    assertTrue(reg.find("docs", "new-page").isPresent());
+
+    PSInMemoryVirtualParticipantService reloaded = new PSInMemoryVirtualParticipantService(store);
+    assertTrue(reloaded.find("docs", "old-page").isEmpty());
+    assertTrue(reloaded.find("docs", "new-page").isPresent());
+  }
+
+  @Test
+  void jsonLineEscapingRoundTrip() {
+    VirtualParticipant p =
+        new VirtualParticipant(
+            "s\\k", "id\"1", "v", "path\\with\\sep", "src\"x");
+    String line = PSInMemoryVirtualParticipantService.toJsonLine(p);
+    VirtualParticipant back = PSInMemoryVirtualParticipantService.fromJsonLine(line);
+    assertEquals(p.siteKey(), back.siteKey());
+    assertEquals(p.stableId(), back.stableId());
+    assertEquals(p.publishedPath(), back.publishedPath());
+    assertEquals(p.sourcePath(), back.sourcePath());
+  }
+
+  @Test
+  void sanitizeKeepsSafeFileNames() {
+    assertEquals("product-docs", PSInMemoryVirtualParticipantService.sanitize("product-docs"));
+    assertEquals("a_b", PSInMemoryVirtualParticipantService.sanitize("a/b"));
+  }
+
+  private static VirtualParticipant sample(String site, String id, String published) {
+    return new VirtualParticipant(site, id, "8.2", published, published.replace(".html", ".md"));
+  }
+}

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -68,6 +68,16 @@ class PSVirtualSiteBuildServiceTest {
     participants.flush("sample");
     assertTrue(Files.isRegularFile(meta.resolve("participants-sample.jsonl")));
 
+    // Second build replaces site registry (stale ids gone; current ids retained)
+    participants.upsert(
+        new VirtualParticipant("sample", "stale-only", "8.2", "8.2/stale.html", "8.2/stale.md"));
+    PSVirtualSiteBuildResult second = service.build(sample, out, "sample");
+    assertEquals(3, second.pageCount());
+    assertTrue(participants.find("sample", "install-overview").isPresent());
+    assertTrue(
+        participants.find("sample", "stale-only").isEmpty(),
+        "full rebuild must clear site then re-register only current pages");
+
     // Link report is always written next to static HTML for operator review
     Path linkReport = out.resolve("link-report.txt");
     assertTrue(Files.isRegularFile(linkReport), "missing link-report.txt");


### PR DESCRIPTION
## Summary
Hardens Phase 1 **virtual participant registry** (Parent epic #2678, slice #3019):

- Document SPI lifetime on `IPSVirtualParticipantService` (process-scoped default, optional Path-backed durability, full-rebuild replaces site)
- Add `clear(siteKey)` / `clearAll()` reset API
- `PSInMemoryVirtualParticipantService`: load JSONL from portable store `Path` on construct, flush/clear durable files, JSONL parse round-trip
- `PSVirtualSiteBuildService` clears the site registry before upserting frontmatter `id` → published path on each full build
- Unit tests: upsert, lookup-missing, reset, durable reload, second-build replace
- product-docs operator note on registry lifetime

Out of scope (unchanged): `PSX_MANAGEDLINK`, WebUI registry browser, extra source adapters.

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `PSInMemoryVirtualParticipantServiceTest` — Tests run: 7, Failures: 0
- [x] `PSVirtualSiteBuildServiceTest` — Tests run: 4, Failures: 0 (includes second-build replace)
- [x] Module suite — Tests run: 1819, Failures: 0, Errors: 0, Skipped: 241

## Product documentation
- [x] Updated pages under `product-docs/`:
  - `product-docs/8.2/developer/virtual-sites.md` — registry lifetime table
  - `product-docs/8.2/reference/frontmatter.md` — link to lifetime note

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system; ..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1819, Failures: 0; virtualsite registry tests 7+4 green
- **downstream_checked:** grep for `implements IPSVirtualParticipantService` / subclasses — only `PSInMemoryVirtualParticipantService` in `system` (no reverse-dep modules compile against SPI elsewhere)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3019
Parent: #2678

> Co-Authored by Grok Build using grok-4.5 with agent main.
