### PR TITLE
feat(WebUI): Build Virtual Site action + Playwright (#3020)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -2,9 +2,14 @@
  * Copyright (c) 2026 Intersoft Data Labs, Inc.
  */
 
-import { get, put } from "../client";
+import { get, post, put } from "../client";
 import { PATHS } from "../paths";
-import type { SiteDef, VirtualSiteProperties } from "./types";
+import type {
+  SiteDef,
+  VirtualSiteBuildRequest,
+  VirtualSiteBuildResult,
+  VirtualSiteProperties,
+} from "./types";
 
 /** Honest design gaps for Developer SY-04 site browse (not full site design). */
 export const SITE_DESIGN_GAPS: string[] = [
@@ -93,9 +98,71 @@ export async function updateVirtualSiteProperties(
   return parseVirtualSiteProperties(payload);
 }
 
+/**
+ * Normalize Virtual Site build result (Jackson root wrap or plain DTO).
+ */
+export function parseVirtualSiteBuildResult(payload: unknown): VirtualSiteBuildResult {
+  if (payload == null || typeof payload !== "object") {
+    return {};
+  }
+  const obj = payload as Record<string, unknown>;
+  const root =
+    (obj.VirtualSiteBuildResult as Record<string, unknown> | undefined) ??
+    (obj.virtualSiteBuildResult as Record<string, unknown> | undefined) ??
+    obj;
+  return {
+    siteName: asNullableString(root.siteName),
+    siteKey: asNullableString(root.siteKey),
+    outputPath: asNullableString(root.outputPath),
+    pagesWritten: asNullableNumber(root.pagesWritten),
+    linkProblemCount: asNullableNumber(root.linkProblemCount),
+    hasLinkProblems:
+      typeof root.hasLinkProblems === "boolean" ? root.hasLinkProblems : undefined,
+    linkProblems: asStringArray(root.linkProblems),
+    writtenFiles: asStringArray(root.writtenFiles),
+  };
+}
+
+/**
+ * POST /services/sites/{nameOrId}/virtual/build
+ *
+ * <p>Uses the Site's <em>saved</em> virtual.* properties on the server. Optional
+ * {@code outputRoot} overrides the default install tmp path. Requires Admin.
+ * Traditional repository Sites return 4xx.
+ */
+export async function buildVirtualSite(
+  nameOrId: string,
+  request?: VirtualSiteBuildRequest | null,
+): Promise<VirtualSiteBuildResult> {
+  const key = encodeURIComponent(nameOrId.trim());
+  const body =
+    request && typeof request.outputRoot === "string" && request.outputRoot.trim()
+      ? { outputRoot: request.outputRoot.trim() }
+      : {};
+  const payload = await post<unknown>(`${PATHS.SITES}/${key}/virtual/build`, body);
+  return parseVirtualSiteBuildResult(payload);
+}
+
 function asNullableString(value: unknown): string | null | undefined {
   if (value === undefined) return undefined;
   if (value === null) return null;
   if (typeof value === "string") return value;
   return undefined;
+}
+
+function asNullableNumber(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (value == null) return undefined;
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((v): v is string => typeof v === "string");
 }

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -686,3 +686,30 @@ export interface VirtualSiteProperties {
   virtual?: boolean | null;
 }
 
+/**
+ * Optional body for {@code POST /services/sites/{nameOrId}/virtual/build}.
+ * When omitted or empty, the server chooses a default output directory.
+ */
+export interface VirtualSiteBuildRequest {
+  /** Absolute or host-relative output directory; blank uses server default. */
+  outputRoot?: string | null;
+}
+
+/**
+ * Outcome of a CMS-integrated Virtual Site static build
+ * ({@code POST /services/sites/{nameOrId}/virtual/build}).
+ *
+ * <p>HTTP 200 may still report link problems via {@code hasLinkProblems}.
+ */
+export interface VirtualSiteBuildResult {
+  siteName?: string | null;
+  siteKey?: string | null;
+  /** Absolute filesystem path of the static HTML output root. */
+  outputPath?: string | null;
+  pagesWritten?: number | null;
+  linkProblemCount?: number | null;
+  hasLinkProblems?: boolean | null;
+  linkProblems?: string[] | null;
+  writtenFiles?: string[] | null;
+}
+

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -17,9 +17,11 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import {
+  buildVirtualSite,
   getVirtualSiteProperties,
   updateVirtualSiteProperties,
 } from "../api/developer/sitesApi";
+import type { VirtualSiteBuildResult } from "../api/developer/types";
 import {
   catalogColors,
   errorAlert,
@@ -28,6 +30,10 @@ import {
 } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import {
+  formatVirtualSiteBuildSummary,
+  shouldShowVirtualBuildChrome,
+} from "./virtualSiteBuild";
 import {
   SOURCE_KIND_GIT_FILESYSTEM,
   SOURCE_KIND_REPOSITORY,
@@ -68,10 +74,47 @@ const primaryButton: React.CSSProperties = {
   fontSize: "0.9rem",
 };
 
+const secondaryButton: React.CSSProperties = {
+  background: "#fff",
+  color: catalogColors.text,
+  border: `1px solid ${catalogColors.softBorder}`,
+  borderRadius: "4px",
+  padding: "8px 14px",
+  cursor: "pointer",
+  fontSize: "0.9rem",
+};
+
 const disabledButton: React.CSSProperties = {
   ...primaryButton,
   background: catalogColors.disabled,
   cursor: "not-allowed",
+};
+
+const disabledSecondaryButton: React.CSSProperties = {
+  ...secondaryButton,
+  color: catalogColors.disabled,
+  borderColor: catalogColors.softBorder,
+  cursor: "not-allowed",
+};
+
+const successNotice: React.CSSProperties = {
+  color: catalogColors.accent,
+  marginTop: "8px",
+  fontSize: "0.9rem",
+};
+
+const buildResultBox: React.CSSProperties = {
+  marginTop: "10px",
+  padding: "10px 12px",
+  border: `1px solid ${catalogColors.headerBorder}`,
+  borderRadius: "4px",
+  background: "#f7fafc",
+  fontSize: "0.9rem",
+};
+
+const buildResultMono: React.CSSProperties = {
+  fontFamily: "monospace",
+  wordBreak: "break-all",
 };
 
 function validationMessage(
@@ -85,7 +128,8 @@ function validationMessage(
 
 /**
  * Site detail section: view/edit Virtual Site source fields via public Site REST
- * ({@code GET|PUT /services/sites/{name}/virtual}).
+ * ({@code GET|PUT /services/sites/{name}/virtual}) and trigger a CMS-integrated
+ * build ({@code POST …/virtual/build}) when source kind is Virtual.
  */
 export function VirtualSiteSourcePanel({
   siteName,
@@ -95,12 +139,15 @@ export function VirtualSiteSourcePanel({
   const [form, setForm] = useState<VirtualSiteFormModel>(emptyVirtualSiteForm);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [building, setBuilding] = useState(false);
   /** Load-time failure (hides form; retry reloads). */
   const [loadError, setLoadError] = useState<string | null>(null);
   /** Save / client validation failure (keeps form mounted). */
   const [formError, setFormError] = useState<string | null>(null);
   const [savedNotice, setSavedNotice] = useState<string | null>(null);
   const [isVirtual, setIsVirtual] = useState(false);
+  const [buildError, setBuildError] = useState<string | null>(null);
+  const [buildResult, setBuildResult] = useState<VirtualSiteBuildResult | null>(null);
 
   const load = useCallback(() => {
     if (!siteName.trim()) {
@@ -113,6 +160,8 @@ export function VirtualSiteSourcePanel({
     setLoadError(null);
     setFormError(null);
     setSavedNotice(null);
+    setBuildError(null);
+    setBuildResult(null);
     getVirtualSiteProperties(siteName)
       .then((props) => {
         if (cancelled) return;
@@ -147,6 +196,7 @@ export function VirtualSiteSourcePanel({
     setSaving(true);
     setFormError(null);
     setSavedNotice(null);
+    setBuildError(null);
     try {
       const body = formToVirtualProps(form);
       const saved = await updateVirtualSiteProperties(siteName, body);
@@ -160,7 +210,34 @@ export function VirtualSiteSourcePanel({
     }
   }
 
+  async function onBuild(): Promise<void> {
+    // Build uses *saved* server properties — validate form only as a soft gate
+    // so operators see client-side issues before a wasted POST.
+    const clientErr = validateVirtualSiteForm(form);
+    if (clientErr) {
+      setBuildError(validationMessage(clientErr));
+      setBuildResult(null);
+      return;
+    }
+    setBuilding(true);
+    setBuildError(null);
+    setBuildResult(null);
+    setFormError(null);
+    try {
+      const result = await buildVirtualSite(siteName);
+      setBuildResult(result);
+    } catch (e: unknown) {
+      setBuildError(panelErrMsg(e, DEV_MSG.SITE_VIRT_BUILD_ERROR));
+    } finally {
+      setBuilding(false);
+    }
+  }
+
   const virtualMode = isVirtualSourceKind(form.sourceKind);
+  /** Build chrome only for virtual source kinds (never for repository). */
+  const showBuildChrome = shouldShowVirtualBuildChrome(form.sourceKind);
+  const busy = saving || building;
+  const buildSummary = buildResult ? formatVirtualSiteBuildSummary(buildResult) : null;
 
   return (
     <section
@@ -224,6 +301,7 @@ export function VirtualSiteSourcePanel({
                 }))
               }
               style={inputStyle}
+              disabled={busy}
             >
               <option value={SOURCE_KIND_REPOSITORY}>{DEV_MSG.SITE_VIRT_KIND_REPOSITORY}</option>
               <option value={SOURCE_KIND_GIT_FILESYSTEM}>
@@ -245,6 +323,7 @@ export function VirtualSiteSourcePanel({
                   style={inputStyle}
                   autoComplete="off"
                   spellCheck={false}
+                  disabled={busy}
                 />
               </div>
               <div style={formRow}>
@@ -259,6 +338,7 @@ export function VirtualSiteSourcePanel({
                   placeholder="_config.yaml"
                   autoComplete="off"
                   spellCheck={false}
+                  disabled={busy}
                 />
               </div>
               <div style={formRow}>
@@ -272,17 +352,18 @@ export function VirtualSiteSourcePanel({
                   style={inputStyle}
                   autoComplete="off"
                   spellCheck={false}
+                  disabled={busy}
                 />
               </div>
             </>
           ) : null}
 
-          <div style={{ display: "flex", gap: "12px", alignItems: "center", marginTop: "8px" }}>
+          <div style={{ display: "flex", gap: "12px", alignItems: "center", marginTop: "8px", flexWrap: "wrap" }}>
             <button
               type="button"
               data-testid="developer-site-virtual-save"
-              style={saving ? disabledButton : primaryButton}
-              disabled={saving}
+              style={busy ? disabledButton : primaryButton}
+              disabled={busy}
               onClick={() => void onSave()}
             >
               {saving ? DEV_MSG.SITE_VIRT_SAVING : DEV_MSG.SITE_VIRT_SAVE}
@@ -293,6 +374,80 @@ export function VirtualSiteSourcePanel({
               </span>
             ) : null}
           </div>
+
+          {/* Build chrome: only when form source kind is Virtual (never for repository). */}
+          {showBuildChrome ? (
+            <div
+              data-testid="developer-site-virtual-build-section"
+              style={{
+                marginTop: "16px",
+                paddingTop: "12px",
+                borderTop: `1px dashed ${catalogColors.headerBorder}`,
+              }}
+            >
+              <p style={{ ...mutedHintText, margin: "0 0 8px" }} data-testid="developer-site-virtual-build-hint">
+                {DEV_MSG.SITE_VIRT_BUILD_HINT}
+              </p>
+              <p style={{ ...mutedHintText, margin: "0 0 10px" }} data-testid="developer-site-virtual-build-save-first">
+                {DEV_MSG.SITE_VIRT_BUILD_SAVE_FIRST}
+              </p>
+              <button
+                type="button"
+                data-testid="developer-site-virtual-build"
+                style={busy ? disabledSecondaryButton : secondaryButton}
+                disabled={busy}
+                onClick={() => void onBuild()}
+              >
+                {building ? DEV_MSG.SITE_VIRT_BUILDING : DEV_MSG.SITE_VIRT_BUILD}
+              </button>
+
+              {building ? (
+                <div data-testid="developer-site-virtual-build-busy" style={{ ...mutedText, marginTop: "10px" }}>
+                  {DEV_MSG.SITE_VIRT_BUILDING}
+                </div>
+              ) : null}
+
+              {buildError ? (
+                <div
+                  role="alert"
+                  data-testid="developer-site-virtual-build-error"
+                  style={{ ...errorAlert, marginTop: "10px" }}
+                >
+                  {buildError}
+                </div>
+              ) : null}
+
+              {buildResult && buildSummary ? (
+                <div data-testid="developer-site-virtual-build-result" style={buildResultBox}>
+                  <div data-testid="developer-site-virtual-build-success" style={successNotice}>
+                    {DEV_MSG.SITE_VIRT_BUILD_SUCCESS}
+                  </div>
+                  <div style={{ marginTop: "6px" }}>
+                    <span>{DEV_MSG.SITE_VIRT_BUILD_PAGES}: </span>
+                    <span data-testid="developer-site-virtual-build-pages" style={buildResultMono}>
+                      {buildSummary.pagesLine}
+                    </span>
+                  </div>
+                  {buildSummary.outputLine ? (
+                    <div style={{ marginTop: "4px" }}>
+                      <span>{DEV_MSG.SITE_VIRT_BUILD_OUTPUT}: </span>
+                      <span data-testid="developer-site-virtual-build-output" style={buildResultMono}>
+                        {buildSummary.outputLine}
+                      </span>
+                    </div>
+                  ) : null}
+                  {buildSummary.hasLinkProblems && buildSummary.linkLine ? (
+                    <div
+                      data-testid="developer-site-virtual-build-link-problems"
+                      style={{ marginTop: "4px", color: catalogColors.error }}
+                    >
+                      {DEV_MSG.SITE_VIRT_BUILD_LINK_PROBLEMS}: {buildSummary.linkLine}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       ) : null}
     </section>

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -758,6 +758,17 @@ export const DEV_MSG_KEYS = {
     "perc.ui.developer@Root path must not contain '..' path segments.",
   SITE_VIRT_ERR_CONFIG_UNSAFE:
     "perc.ui.developer@Config file must be a simple file name (no path separators or '..').",
+  SITE_VIRT_BUILD: "perc.ui.developer@Build Virtual Site",
+  SITE_VIRT_BUILDING: "perc.ui.developer@Building Virtual Site...",
+  SITE_VIRT_BUILD_HINT:
+    "perc.ui.developer@Runs the CMS static build for this Virtual Site using the saved source properties (save first if you changed them). Requires Admin. Output defaults to the server tmp/virtual-sites tree.",
+  SITE_VIRT_BUILD_ERROR: "perc.ui.developer@Could not build Virtual Site.",
+  SITE_VIRT_BUILD_SUCCESS: "perc.ui.developer@Virtual Site build completed.",
+  SITE_VIRT_BUILD_PAGES: "perc.ui.developer@Pages written",
+  SITE_VIRT_BUILD_OUTPUT: "perc.ui.developer@Output path",
+  SITE_VIRT_BUILD_LINK_PROBLEMS: "perc.ui.developer@Link problems",
+  SITE_VIRT_BUILD_SAVE_FIRST:
+    "perc.ui.developer@Save Virtual Site source before building so the server uses the latest properties.",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",
   PLACEHOLDER_BODY: "perc.ui.developer@This section is planned for Developer P0. See docs/ai-generated/tasks/developer-module-p0 and docs/developer-module.",
 } as const;

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { VirtualSiteBuildResult } from "../api/developer/types";
+
+/**
+ * True when the Build Virtual Site control should be shown.
+ * Repository / blank source kinds must not display build chrome.
+ */
+export function shouldShowVirtualBuildChrome(
+  sourceKind: string | null | undefined,
+): boolean {
+  const v = (sourceKind ?? "").trim().toLowerCase();
+  return v.length > 0 && v !== "repository";
+}
+
+/**
+ * Build a short operator-facing success summary from a build result DTO.
+ * Pure helper for Vitest and the panel (no i18n — callers prefix labels).
+ */
+export function formatVirtualSiteBuildSummary(result: VirtualSiteBuildResult): {
+  pagesLine: string;
+  outputLine: string | null;
+  linkLine: string | null;
+  hasLinkProblems: boolean;
+} {
+  const pages =
+    typeof result.pagesWritten === "number" && Number.isFinite(result.pagesWritten)
+      ? result.pagesWritten
+      : 0;
+  const pagesLine = String(pages);
+
+  const output =
+    typeof result.outputPath === "string" && result.outputPath.trim()
+      ? result.outputPath.trim()
+      : null;
+
+  const linkCount =
+    typeof result.linkProblemCount === "number" && Number.isFinite(result.linkProblemCount)
+      ? result.linkProblemCount
+      : 0;
+  const hasLinkProblems =
+    result.hasLinkProblems === true ||
+    linkCount > 0 ||
+    (Array.isArray(result.linkProblems) && result.linkProblems.length > 0);
+
+  const linkLine = hasLinkProblems ? String(linkCount > 0 ? linkCount : result.linkProblems?.length ?? 0) : null;
+
+  return {
+    pagesLine,
+    outputLine: output,
+    linkLine,
+    hasLinkProblems,
+  };
+}

--- a/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
@@ -5,7 +5,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "../../../../main/ts/api/client";
 import {
+  buildVirtualSite,
   getVirtualSiteProperties,
+  parseVirtualSiteBuildResult,
   parseVirtualSiteProperties,
   updateVirtualSiteProperties,
 } from "../../../../main/ts/api/developer/sitesApi";
@@ -13,15 +15,18 @@ import {
 vi.mock("../../../../main/ts/api/client", () => ({
   get: vi.fn(),
   put: vi.fn(),
+  post: vi.fn(),
 }));
 
 const get = client.get as ReturnType<typeof vi.fn>;
 const put = client.put as ReturnType<typeof vi.fn>;
+const post = client.post as ReturnType<typeof vi.fn>;
 
 describe("sitesApi virtual properties", () => {
   beforeEach(() => {
     get.mockReset();
     put.mockReset();
+    post.mockReset();
   });
 
   it("parseVirtualSiteProperties handles plain and wrapped payloads", () => {
@@ -77,5 +82,69 @@ describe("sitesApi virtual properties", () => {
       expect.objectContaining({ sourceKind: "git-filesystem", rootPath: "C:/docs" }),
     );
     expect(out.rootPath).toBe("C:/docs");
+  });
+
+  it("parseVirtualSiteBuildResult handles plain and wrapped payloads", () => {
+    expect(
+      parseVirtualSiteBuildResult({
+        siteName: "Help",
+        pagesWritten: 3,
+        hasLinkProblems: false,
+        linkProblems: [],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        siteName: "Help",
+        pagesWritten: 3,
+        hasLinkProblems: false,
+        linkProblems: [],
+      }),
+    );
+    expect(
+      parseVirtualSiteBuildResult({
+        VirtualSiteBuildResult: {
+          outputPath: "C:/tmp/out",
+          pagesWritten: 1,
+          linkProblemCount: 2,
+          hasLinkProblems: true,
+          linkProblems: ["a", "b"],
+        },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        outputPath: "C:/tmp/out",
+        pagesWritten: 1,
+        linkProblemCount: 2,
+        hasLinkProblems: true,
+        linkProblems: ["a", "b"],
+      }),
+    );
+    expect(parseVirtualSiteBuildResult(null)).toEqual({});
+  });
+
+  it("buildVirtualSite POSTs /virtual/build and parses result", async () => {
+    post.mockResolvedValue({
+      siteName: "Help",
+      outputPath: "C:/tmp/virtual-sites/help",
+      pagesWritten: 5,
+      linkProblemCount: 0,
+      hasLinkProblems: false,
+    });
+    const out = await buildVirtualSite("Help Docs");
+    expect(post).toHaveBeenCalledWith(
+      expect.stringMatching(/\/sites\/Help%20Docs\/virtual\/build$/),
+      {},
+    );
+    expect(out.pagesWritten).toBe(5);
+    expect(out.outputPath).toContain("virtual-sites");
+  });
+
+  it("buildVirtualSite sends outputRoot when provided", async () => {
+    post.mockResolvedValue({ pagesWritten: 1 });
+    await buildVirtualSite("Help", { outputRoot: "C:/custom/out" });
+    expect(post).toHaveBeenCalledWith(
+      expect.stringMatching(/\/sites\/Help\/virtual\/build$/),
+      { outputRoot: "C:/custom/out" },
+    );
   });
 });

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -12,12 +12,14 @@ import { VirtualSiteSourcePanel } from "../../../main/ts/developer/VirtualSiteSo
 vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
   getVirtualSiteProperties: vi.fn(),
   updateVirtualSiteProperties: vi.fn(),
+  buildVirtualSite: vi.fn(),
   listSites: vi.fn(),
   SITE_DESIGN_GAPS: [],
 }));
 
 const getVirtual = sitesApi.getVirtualSiteProperties as ReturnType<typeof vi.fn>;
 const updateVirtual = sitesApi.updateVirtualSiteProperties as ReturnType<typeof vi.fn>;
+const buildVirtual = sitesApi.buildVirtualSite as ReturnType<typeof vi.fn>;
 
 describe("VirtualSiteSourcePanel", () => {
   beforeEach(() => {
@@ -26,6 +28,7 @@ describe("VirtualSiteSourcePanel", () => {
     };
     getVirtual.mockReset();
     updateVirtual.mockReset();
+    buildVirtual.mockReset();
   });
 
   it("shows loading then success form for traditional (repository) site", async () => {
@@ -45,6 +48,9 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-source-kind")).toBeTruthy();
     // Root path hidden until virtual selected
     expect(screen.queryByTestId("developer-site-virtual-root-path")).toBeNull();
+    // Repository sites must not show Build chrome
+    expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
     expect(getVirtual).toHaveBeenCalledWith("Corporate");
   });
 
@@ -190,5 +196,107 @@ describe("VirtualSiteSourcePanel", () => {
     expect(screen.getByTestId("developer-site-virtual-error").textContent).toContain(
       "rootPath is required",
     );
+  });
+
+  it("shows Build chrome for virtual sites and success result", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      configFile: "_config.yaml",
+      siteKey: "product-docs",
+      virtual: true,
+    });
+    buildVirtual.mockResolvedValue({
+      siteName: "Help",
+      siteKey: "product-docs",
+      outputPath: "C:/tmp/virtual-sites/product-docs",
+      pagesWritten: 12,
+      linkProblemCount: 0,
+      hasLinkProblems: false,
+      linkProblems: [],
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-virtual-build-section")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("developer-site-virtual-build"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build-result")).toBeTruthy();
+    });
+    expect(buildVirtual).toHaveBeenCalledWith("Help");
+    expect(screen.getByTestId("developer-site-virtual-build-success").textContent).toContain(
+      DEV_MSG.SITE_VIRT_BUILD_SUCCESS,
+    );
+    expect(screen.getByTestId("developer-site-virtual-build-pages").textContent).toBe("12");
+    expect(screen.getByTestId("developer-site-virtual-build-output").textContent).toContain(
+      "product-docs",
+    );
+  });
+
+  it("surfaces build API errors", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    buildVirtual.mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: { message: "Site is not configured as a Virtual Site" },
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-build"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-virtual-build-error").textContent).toContain(
+      DEV_MSG.SITE_VIRT_BUILD_ERROR,
+    );
+    expect(screen.getByTestId("developer-site-virtual-build-error").textContent).toContain(
+      "not configured",
+    );
+    expect(screen.queryByTestId("developer-site-virtual-build-result")).toBeNull();
+  });
+
+  it("hides Build chrome when switching back to repository", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "C:/docs",
+      virtual: true,
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-site-virtual-source-kind"), {
+      target: { value: "repository" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
+    });
+    expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
+  });
+
+  it("client-validates before build when root is empty", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "git-filesystem",
+      rootPath: "",
+      virtual: true,
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-build"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-build-error").textContent).toContain(
+        DEV_MSG.SITE_VIRT_ERR_ROOT_REQUIRED,
+      );
+    });
+    expect(buildVirtual).not.toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  formatVirtualSiteBuildSummary,
+  shouldShowVirtualBuildChrome,
+} from "../../../main/ts/developer/virtualSiteBuild";
+
+describe("virtualSiteBuild helpers", () => {
+  it("shouldShowVirtualBuildChrome only for virtual source kinds", () => {
+    expect(shouldShowVirtualBuildChrome(null)).toBe(false);
+    expect(shouldShowVirtualBuildChrome("")).toBe(false);
+    expect(shouldShowVirtualBuildChrome("repository")).toBe(false);
+    expect(shouldShowVirtualBuildChrome("Repository")).toBe(false);
+    expect(shouldShowVirtualBuildChrome("git-filesystem")).toBe(true);
+    expect(shouldShowVirtualBuildChrome("  git-filesystem  ")).toBe(true);
+  });
+
+  it("formatVirtualSiteBuildSummary reports pages, output, and link problems", () => {
+    const clean = formatVirtualSiteBuildSummary({
+      pagesWritten: 10,
+      outputPath: "C:/tmp/out",
+      linkProblemCount: 0,
+      hasLinkProblems: false,
+    });
+    expect(clean.pagesLine).toBe("10");
+    expect(clean.outputLine).toBe("C:/tmp/out");
+    expect(clean.hasLinkProblems).toBe(false);
+    expect(clean.linkLine).toBeNull();
+
+    const dirty = formatVirtualSiteBuildSummary({
+      pagesWritten: 2,
+      outputPath: " /docs/out ",
+      linkProblemCount: 3,
+      hasLinkProblems: true,
+      linkProblems: ["a", "b", "c"],
+    });
+    expect(dirty.pagesLine).toBe("2");
+    expect(dirty.outputLine).toBe("/docs/out");
+    expect(dirty.hasLinkProblems).toBe(true);
+    expect(dirty.linkLine).toBe("3");
+
+    const missing = formatVirtualSiteBuildSummary({});
+    expect(missing.pagesLine).toBe("0");
+    expect(missing.outputLine).toBeNull();
+    expect(missing.hasLinkProblems).toBe(false);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -15,10 +15,11 @@
  */
 
 /**
- * Developer Sites → Virtual Site source panel (#2956 / epic #2678).
+ * Developer Sites → Virtual Site source panel (#2956 / #3020 / epic #2678).
  *
  * Opens Sites catalog detail and asserts the Virtual Site source section mounts
- * with source-kind control (repository default) and save chrome.
+ * with source-kind control (repository default), save chrome, and Build Virtual
+ * Site chrome only when source kind is virtual (never for repository).
  *
  * Surface-filtered QA mode:
  * <pre>
@@ -45,7 +46,7 @@ function developerSectionUrl(section) {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
 }
 
-test.describe("Developer Site Virtual Site source panel (#2956)", () => {
+test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(90_000);
     await loginAsAdmin(page);
@@ -112,11 +113,37 @@ test.describe("Developer Site Virtual Site source panel (#2956)", () => {
       await expect(kind).toHaveValue(/repository|git-filesystem/);
       await expect(page.locator('[data-testid="developer-site-virtual-save"]')).toBeVisible();
 
-      // Switch to git-filesystem reveals root path field
+      // Repository mode: Build chrome must not appear (no misleading virtual-build UI)
+      const current = await kind.inputValue();
+      if (current === "repository" || current === "") {
+        await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+        await expect(
+          page.locator('[data-testid="developer-site-virtual-build-section"]'),
+        ).toHaveCount(0);
+      }
+
+      // Switch to git-filesystem reveals root path + Build control
       await kind.selectOption("git-filesystem");
       await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-build-hint"]')).toBeVisible();
+
+      // Optional: click Build without save — expect client validation or API error chrome
+      // (H2 QA rarely has a saved virtual root; do not require full build success)
+      await page.locator('[data-testid="developer-site-virtual-build"]').click();
+      const buildChrome = page.locator(
+        [
+          '[data-testid="developer-site-virtual-build-error"]',
+          '[data-testid="developer-site-virtual-build-result"]',
+          '[data-testid="developer-site-virtual-build-busy"]',
+        ].join(", "),
+      );
+      await expect(buildChrome.first()).toBeVisible({ timeout: 20_000 });
+
       // Restore repository to avoid leaving QA site dirty when save is not exercised
       await kind.selectOption("repository");
+      await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
     }
   });
 });

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -85,7 +85,36 @@ rejected by server validation with clear error messages.
 
 Validation matches the server helper (`PSVirtualSiteHelper`): allow-listed source kinds,
 required root path when virtual, and safe path/config names. After root or config changes,
-re-run the offline docs build or the CMS publish path to verify links.
+re-run the offline docs build, the in-product **Build Virtual Site** action (below), or the
+CMS publish path to verify links.
+
+### Build a Virtual Site from the product UI
+
+When **Source kind** is **Git filesystem** (Virtual), the Site detail panel shows a
+**Build Virtual Site** control. Traditional **Repository** Sites do **not** show this control
+(no misleading virtual-build chrome).
+
+1. Sign in as an **Admin** (the build REST operation requires Admin).
+2. Open **Developer** → **Sites** and open the Virtual Site detail.
+3. Confirm **Virtual Site source** is saved as **Git filesystem** with a valid **Root path**
+   that exists on the CMS host. If you just edited properties, choose **Save Virtual Site source**
+   first — the build uses the **saved** server properties, not unsaved form fields.
+4. Choose **Build Virtual Site**.
+5. Wait for the busy indicator, then review:
+   - **Success** — pages written, absolute output path (default under
+     `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).
+   - **Link problems** — reported in the result panel when internal links fail
+     (the build may still complete with HTTP 200).
+   - **Error** — clear message when the Site is not virtual, the root is missing/invalid,
+     or the caller lacks Admin (for example 400/403 from REST).
+
+Integrators can call the same operation over REST:
+`POST /sites/{nameOrId}/virtual/build` (optional JSON body `outputRoot`). See
+[Site configuration reference](id:reference-site-config) and
+[Virtual Sites (developer)](id:developer-virtual-sites).
+
+Offline scripts (`scripts/build-cms-docs.*`) remain available for developer workstations
+without a running CMS.
 
 See [Virtual Sites (developer)](id:developer-virtual-sites) and
 [Site configuration reference](id:reference-site-config) for full contract and offline build steps.

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -94,6 +94,30 @@ scripts/build-cms-docs.sh
 Default output: `tmp/product-docs-site/`. The build fails non-zero when internal `id:` or relative
 Markdown links cannot be resolved.
 
+## CMS-integrated build (REST and WebUI)
+
+When a CMS Site has Virtual properties configured, an **Admin** can trigger the same build path
+from the running server:
+
+```http
+POST /sites/{nameOrId}/virtual/build
+Content-Type: application/json
+
+{
+  "outputRoot": "C:/tmp/product-docs-site"
+}
+```
+
+The body is optional. Without `outputRoot`, the server writes under
+`{install}/tmp/virtual-sites/{siteKey}` (portable NIO paths). The response summarizes
+`pagesWritten`, link problems, and the absolute `outputPath`. Traditional repository Sites and
+invalid/missing virtual configuration return **400**.
+
+Operators can run the same operation from **Developer → Sites → Site detail → Build Virtual Site**
+(visible only when source kind is Virtual). Save Virtual Site source before building so the server
+uses the latest properties. See [Sites & content structure](id:admin-sites) and
+[Site configuration](id:reference-site-config).
+
 ## What is not in Phase 1
 
 - CMS UI editing of Virtual items as normal content types

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -69,10 +69,31 @@ Integrators can read and write these keys via public Site REST:
 
 - `GET /sites/{nameOrId}/virtual`
 - `PUT /sites/{nameOrId}/virtual` (JSON body: `sourceKind`, `rootPath`, `configFile`, `siteKey`)
+- `POST /sites/{nameOrId}/virtual/build` (optional JSON body: `outputRoot`)
 
 Site detail (`GET /sites/{nameOrId}`) also returns a nested `virtual` object. Validation is
 enforced server-side (allow-listed source kinds, required root path when virtual, portable
 path safety).
+
+#### Build Virtual Site (`POST …/virtual/build`)
+
+Runs the Phase 1 static build for a Site configured with `virtual.sourceKind=git-filesystem`
+and a valid `virtual.rootPath` (directory must exist on the CMS host). Requires **Admin**.
+
+| Status | When |
+|--------|------|
+| `200` | Build finished; response includes `pagesWritten`, `linkProblemCount`, `linkProblems`, `outputPath`, `hasLinkProblems` |
+| `400` | Traditional repository Site, unknown/invalid virtual config, missing root directory, or unsafe `outputRoot` |
+| `403` | Caller is not Admin |
+| `404` | Site not found |
+
+Optional body field `outputRoot` overrides the default output directory
+(`{install}/tmp/virtual-sites/{siteKey}`, or the JVM temp tree when the install root is
+unavailable). Link problems are reported in the JSON result (and in `link-report.txt` under
+the output root) without failing the HTTP status when the build itself succeeds.
+
+The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind is
+Virtual (never for traditional repository Sites). See [Sites & content structure](id:admin-sites).
 
 ## Related
 


### PR DESCRIPTION
## Summary
Adds **Build Virtual Site** on Developer Sites → Virtual Site source panel (parent epic #2678 / slice #3020).

- **WebUI**: Build control only when form `sourceKind` is Virtual (`git-filesystem`); never shown for traditional repository Sites
- Busy / success result (pages written, output path, link-problem count) / error chrome
- `sitesApi.buildVirtualSite` → `POST /services/sites/{name}/virtual/build` (uses **saved** server virtual.* props)
- Pure helpers + Vitest for panel states, API parse/POST, and chrome visibility
- **Playwright**: surface-filtered `developer-site-virtual-source.spec.js` asserts no build chrome for repository and build chrome + error/result chrome when virtual is selected
- **product-docs**: admin Build steps (`admin/sites.md`) + developer/REST notes

Depends on REST build landing (#3018 / PR #3027) for a live successful CMS build; UI client and chrome are complete against that contract.

## Parent
Parent epic: #2678  
Slice: #3020  
Related REST: #3018 / https://github.com/intersoftdatalabs-in/percussioncms/pull/3027

## Test plan
- [x] `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests 1920 passed (Vitest suite)
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Surface Playwright (H2 docker `TEST_CMS_URL=http://127.0.0.1:9993`): `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` — **1 passed**
- [x] `scripts/ci-smoke-product-docs.bat` — **OK** (20 pages)
- [ ] Human QA: full Build success against a Site with saved virtual root + REST #3018 merged/deployed

## Product documentation
- [x] Updated pages under `product-docs/8.2/` (`admin/sites.md`, `developer/virtual-sites.md`, `reference/site-config.md`)

## Build evidence (C3)
- **modules_built:** WebUI, modules/perc-qa-automation
- **build_evidence:**
  - `cd WebUI; ..\mvnw.cmd clean install` → BUILD SUCCESS; Test Files 270 passed; Tests 1920 passed
  - `cd modules/perc-qa-automation; ..\..\mvnw.cmd clean install` → BUILD SUCCESS
  - Playwright surface path tests/developer-site-virtual-source.spec.js → 1 passed
  - product-docs smoke → OK
- **downstream_checked:** none (WebUI + QA + product-docs only; no Java API signature / final changes)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3020

> Co-Authored by Grok Build using grok-4.5 with agent main.
