### PR TITLE
feat(objectstore): ObjectStoreErrorCodes call-site batch G (clone/config/container) (#3022)

### DIFF
--- a/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/SystemErrorCode.java
+++ b/modules/perc-auditlog/src/main/java/com/intsof/percussioncms/auditlog/SystemErrorCode.java
@@ -16,6 +16,8 @@
  */
 package com.intsof.percussioncms.auditlog;
 
+import com.percussion.error.IPSErrorCode;
+
 /**
  * System-wide error / message code implemented by package-local {@code *ErrorCodes} enums.
  *
@@ -23,9 +25,12 @@ package com.intsof.percussioncms.auditlog;
  * reporting this code dual-writes to {@code server.log} and the durable audit store. When {@code
  * false}, the code is operational only (exception text / app log) and must not create an audit row.
  *
+ * <p>Extends {@link IPSErrorCode} so exceptions in {@code utils}/{@code system} can take typed
+ * catalog codes without a reverse dependency on this module beyond the implementing enums.
+ *
  * <p>Message templates use sequential {@code {}} placeholders (SLF4J-style).
  */
-public interface SystemErrorCode {
+public interface SystemErrorCode extends IPSErrorCode {
 
   /** Module that owns this code (drives the {@code [PUB-…]} prefix). */
   AuditModule module();

--- a/modules/utils/src/main/java/com/percussion/design/objectstore/PSUnknownNodeTypeException.java
+++ b/modules/utils/src/main/java/com/percussion/design/objectstore/PSUnknownNodeTypeException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSErrorManager;
 import com.percussion.error.PSException;
 
@@ -42,6 +43,16 @@ public class PSUnknownNodeTypeException extends PSException {
   }
 
   /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSUnknownNodeTypeException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
    * Construct an exception for messages taking an array of arguments. Be sure to store the
    * arguments in the correct order in the array, where {0} in the string is array element 0, etc.
    *
@@ -53,12 +64,31 @@ public class PSUnknownNodeTypeException extends PSException {
   }
 
   /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSUnknownNodeTypeException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
    * Construct an exception for messages taking no arguments.
    *
    * @param msgCode the error string to load
    */
   public PSUnknownNodeTypeException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSUnknownNodeTypeException(IPSErrorCode code) {
+    super(code);
   }
 
   /**

--- a/modules/utils/src/main/java/com/percussion/error/IPSErrorCode.java
+++ b/modules/utils/src/main/java/com/percussion/error/IPSErrorCode.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.error;
+
+/**
+ * Minimal error-code surface for typed exception construction without coupling {@code utils} to
+ * {@code audit-log}.
+ *
+ * <p>Package {@code *ErrorCodes} enums in {@code com.intsof.percussioncms.auditlog} implement the
+ * richer {@code SystemErrorCode} interface, which extends this type. Call sites in modules that
+ * depend on {@code audit-log} should prefer those enums (for example {@code
+ * ObjectStoreErrorCodes}) when throwing {@link PSException} subclasses.
+ *
+ * <p>Legacy {@code IPS*Errors} int constants remain valid via the existing {@code int}-based
+ * constructors; this interface is the migration target for dual-write / {@code isAuditable}
+ * awareness.
+ */
+public interface IPSErrorCode {
+
+  /**
+   * Numeric code matching the historical {@code IPS*Errors} constant used for message lookup and
+   * legacy dual-write registry resolution.
+   */
+  int numericCode();
+
+  /**
+   * When {@code true}, reporting this code should dual-write to the durable audit store. Default
+   * {@code false} keeps operational / structural codes off the audit path.
+   */
+  default boolean isAuditable() {
+    return false;
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/error/PSException.java
+++ b/modules/utils/src/main/java/com/percussion/error/PSException.java
@@ -91,6 +91,7 @@ public class PSException extends java.lang.Exception implements IPSException {
       m_args = psException.getErrorArguments();
       m_lang = psException.getLanguageString();
       m_overridingMessage = psException.m_overridingMessage;
+      m_typedErrorCode = psException.m_typedErrorCode;
     }
   }
 
@@ -211,6 +212,52 @@ public class PSException extends java.lang.Exception implements IPSException {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode} (e.g. package {@code *ErrorCodes}
+   * enums). Sets the legacy numeric code for message lookup / dual-write registry and retains the
+   * typed code for {@link #getTypedErrorCode()} / {@link #isAuditable()}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSException(IPSErrorCode code) {
+    this(requireCode(code).numericCode());
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSException(IPSErrorCode code, Object singleArg) {
+    this(requireCode(code).numericCode(), singleArg);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSException(IPSErrorCode code, Object[] arrayArgs) {
+    this(requireCode(code).numericCode(), arrayArgs);
+    m_typedErrorCode = code;
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   * @param cause causal throwable; may be {@code null}
+   */
+  public PSException(IPSErrorCode code, Object[] arrayArgs, Throwable cause) {
+    this(requireCode(code).numericCode(), arrayArgs, cause);
+    m_typedErrorCode = code;
+  }
+
+  /**
    * Create a chained exception with a specific message
    *
    * @param message message to use in exception. If <code>null</code> then use the localized message
@@ -255,6 +302,7 @@ public class PSException extends java.lang.Exception implements IPSException {
     m_args = e.m_args;
     m_lang = e.m_lang;
     m_overridingMessage = e.m_overridingMessage;
+    m_typedErrorCode = e.m_typedErrorCode;
   }
 
   public static void setErrorManager(IPSErrorManager errorManager) {
@@ -331,6 +379,7 @@ public class PSException extends java.lang.Exception implements IPSException {
    */
   public final void setErrorCode(int code) {
     m_code = code;
+    m_typedErrorCode = null;
   }
 
   /**
@@ -340,6 +389,29 @@ public class PSException extends java.lang.Exception implements IPSException {
    */
   public int getErrorCode() {
     return m_code;
+  }
+
+  /**
+   * Typed error code when this exception was constructed via {@link #PSException(IPSErrorCode)} (or
+   * overloads); otherwise {@code null} for legacy int construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_typedErrorCode;
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when present;
+   * legacy int construction returns {@code false} (handlers resolve auditability via the registry).
+   */
+  public boolean isAuditable() {
+    return m_typedErrorCode != null && m_typedErrorCode.isAuditable();
+  }
+
+  private static IPSErrorCode requireCode(IPSErrorCode code) {
+    if (code == null) {
+      throw new IllegalArgumentException("code may not be null");
+    }
+    return code;
   }
 
   /**
@@ -368,6 +440,21 @@ public class PSException extends java.lang.Exception implements IPSException {
    */
   public void setArgs(int msgCode, Object[] errorArgs) {
     m_code = msgCode;
+    m_typedErrorCode = null;
+    setArgs(errorArgs);
+  }
+
+  /**
+   * Set the arguments for this exception from a typed error code.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param errorArgs the array of arguments to use as the arguments in the error message. May be
+   *     <code>null</code>, but no entry may be <code>null</code>.
+   */
+  public void setArgs(IPSErrorCode code, Object[] errorArgs) {
+    requireCode(code);
+    m_code = code.numericCode();
+    m_typedErrorCode = code;
     setArgs(errorArgs);
   }
 
@@ -441,6 +528,12 @@ public class PSException extends java.lang.Exception implements IPSException {
   protected int m_code;
   protected transient Object[] m_args;
   protected String m_lang;
+
+  /**
+   * Optional typed catalog code retained when constructed via {@link IPSErrorCode} overloads.
+   * Cleared when the numeric code is replaced via legacy {@code int} setters.
+   */
+  protected transient IPSErrorCode m_typedErrorCode;
 
   /**
    * @see #setOverridingMessage(String)

--- a/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
+++ b/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.error;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Typed {@link IPSErrorCode} construction on {@link PSException} and objectstore subclasses that
+ * live in utils (no audit-log dependency).
+ */
+class PSExceptionTypedErrorCodeTest {
+
+  private static final IPSErrorCode SAMPLE =
+      new IPSErrorCode() {
+        @Override
+        public int numericCode() {
+          return 2011;
+        }
+
+        @Override
+        public boolean isAuditable() {
+          return false;
+        }
+      };
+
+  private static final IPSErrorCode AUDITABLE =
+      new IPSErrorCode() {
+        @Override
+        public int numericCode() {
+          return 9002;
+        }
+
+        @Override
+        public boolean isAuditable() {
+          return true;
+        }
+      };
+
+  @Test
+  void typedCtorSetsNumericAndRetainsCode() {
+    PSException ex = new PSException(SAMPLE, "PSXContentEditor");
+    assertEquals(2011, ex.getErrorCode());
+    assertSame(SAMPLE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+    assertEquals(1, ex.getErrorArguments().length);
+    assertEquals("PSXContentEditor", ex.getErrorArguments()[0]);
+  }
+
+  @Test
+  void typedCtorNoArgs() {
+    PSException ex = new PSException(SAMPLE);
+    assertEquals(2011, ex.getErrorCode());
+    assertSame(SAMPLE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  void typedCtorArrayArgs() {
+    Object[] args = {"a", "b"};
+    PSException ex = new PSException(SAMPLE, args);
+    assertEquals(2011, ex.getErrorCode());
+    assertSame(SAMPLE, ex.getTypedErrorCode());
+    assertEquals(2, ex.getErrorArguments().length);
+  }
+
+  @Test
+  void typedCtorRejectsNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSException((IPSErrorCode) null));
+  }
+
+  @Test
+  void legacyIntCtorHasNoTypedCode() {
+    PSException ex = new PSException(2011, "x");
+    assertEquals(2011, ex.getErrorCode());
+    assertNull(ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void setErrorCodeClearsTypedCode() {
+    PSException ex = new PSException(SAMPLE);
+    assertSame(SAMPLE, ex.getTypedErrorCode());
+    ex.setErrorCode(2012);
+    assertEquals(2012, ex.getErrorCode());
+    assertNull(ex.getTypedErrorCode());
+  }
+
+  @Test
+  void setArgsTypedRetainsCode() {
+    PSException ex = new PSException(2011);
+    ex.setArgs(AUDITABLE, new Object[] {"Directory", "ldap1", "jdoe"});
+    assertEquals(9002, ex.getErrorCode());
+    assertSame(AUDITABLE, ex.getTypedErrorCode());
+    assertTrue(ex.isAuditable());
+  }
+
+  @Test
+  void copyCtorPreservesTypedCode() {
+    PSException src = new PSException(AUDITABLE, "x");
+    PSException copy = new PSException(src);
+    assertEquals(9002, copy.getErrorCode());
+    assertSame(AUDITABLE, copy.getTypedErrorCode());
+    assertTrue(copy.isAuditable());
+  }
+
+  @Test
+  void unknownNodeTypeTypedCtor() {
+    PSUnknownNodeTypeException ex =
+        new PSUnknownNodeTypeException(SAMPLE, "PSXContentEditor");
+    assertEquals(2011, ex.getErrorCode());
+    assertSame(SAMPLE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}

--- a/system/src/main/java/com/percussion/design/objectstore/IPSValidationContext.java
+++ b/system/src/main/java/com/percussion/design/objectstore/IPSValidationContext.java
@@ -18,6 +18,7 @@
 package com.percussion.design.objectstore;
 
 import com.percussion.design.objectstore.server.IPSObjectStoreHandler;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.server.PSUserSession;
 import java.util.List;
 
@@ -175,6 +176,38 @@ public interface IPSValidationContext {
    */
   public void validationError(IPSComponent component, int errorCode, Object arg)
       throws PSSystemValidationException;
+
+  /**
+   * Typed overload: registers a validation error using a catalogued {@link IPSErrorCode}. Default
+   * delegates to the legacy int form via {@link IPSErrorCode#numericCode()}.
+   *
+   * @param component component under validation
+   * @param errorCode catalogued code, never {@code null}
+   * @param args message arguments; may be {@code null}
+   */
+  default void validationError(IPSComponent component, IPSErrorCode errorCode, Object[] args)
+      throws PSSystemValidationException {
+    if (errorCode == null) {
+      throw new IllegalArgumentException("errorCode may not be null");
+    }
+    validationError(component, errorCode.numericCode(), args);
+  }
+
+  /**
+   * Typed overload with a single message argument. Default delegates to the int form via {@link
+   * IPSErrorCode#numericCode()}.
+   *
+   * @param component component under validation
+   * @param errorCode catalogued code, never {@code null}
+   * @param arg single message argument; may be {@code null}
+   */
+  default void validationError(IPSComponent component, IPSErrorCode errorCode, Object arg)
+      throws PSSystemValidationException {
+    if (errorCode == null) {
+      throw new IllegalArgumentException("errorCode may not be null");
+    }
+    validationError(component, errorCode.numericCode(), arg);
+  }
 
   /**
    * Marks the start of an object's validation. Returns <CODE>true</CODE> if this component should

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfig.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -95,11 +97,11 @@ public class PSCloneHandlerConfig extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -119,7 +121,7 @@ public class PSCloneHandlerConfig extends PSComponent {
       m_name = tree.getElementData(NAME_ATTR);
       if (m_name == null) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // OPTIONAL: Process checks
@@ -136,7 +138,7 @@ public class PSCloneHandlerConfig extends PSComponent {
               "Duplicate entry, must be unique configuration wide: " + check.getName()
             };
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
           }
 
           // add the new process check sorted in sequence order

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfigSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfigSet.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -69,11 +71,11 @@ public class PSCloneHandlerConfigSet extends PSCollectionComponent implements IP
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -101,7 +103,7 @@ public class PSCloneHandlerConfigSet extends PSCollectionComponent implements IP
             PSCloneHandlerConfig.XML_NODE_NAME,
             "Duplicate entry, must be unique server wide: " + config.getName()
           };
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         add(config);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideField.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.cms.objectstore.PSComponentUtils;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -104,11 +106,11 @@ public class PSCloneOverrideField extends PSComponent {
     parentComponents = updateParentList(parentComponents);
 
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     try {
@@ -130,7 +132,7 @@ public class PSCloneOverrideField extends PSComponent {
     } catch (IllegalArgumentException e) {
       Object[] args = {XML_NODE_NAME, "value", "null or not PSXExtensionCall"};
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_rules.clear();

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideFieldList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideFieldList.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -80,11 +82,11 @@ public class PSCloneOverrideFieldList extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (false == XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConfig.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import jakarta.persistence.Basic;
@@ -219,7 +221,7 @@ public class PSConfig extends PSComponent {
       elem = tree.getNextElement("NAME", firstFlags);
       if (elem == null) {
         Object[] args = {RX_CONFIGURATIONS_ELEM, "NAME", "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_name = tree.getElementData(elem);
 
@@ -228,12 +230,12 @@ public class PSConfig extends PSComponent {
       elem = tree.getNextElement("TYPE", firstFlags);
       if (elem == null) {
         Object[] args = {RX_CONFIGURATIONS_ELEM, "TYPE", "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_type = tree.getElementData(elem);
       if (!m_type.equalsIgnoreCase("xml") && !m_type.equalsIgnoreCase("property")) {
         Object[] args = {RX_CONFIGURATIONS_ELEM, "TYPE", "unsupported type: " + m_type};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // OPTIONAL: the locked flag
@@ -253,7 +255,7 @@ public class PSConfig extends PSComponent {
       elem = tree.getNextElement("CONFIGURATION", firstFlags);
       if (elem == null) {
         Object[] args = {RX_CONFIGURATIONS_ELEM, "CONFIGURATION", "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       setConfig(tree.getElementData(elem));
 
@@ -264,10 +266,10 @@ public class PSConfig extends PSComponent {
       else m_description = "";
     } catch (IOException e) {
       Object[] args = {RX_CONFIGURATIONS_ELEM, "CONFIGURATION", e.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } catch (SAXException e) {
       Object[] args = {RX_CONFIGURATIONS_ELEM, "CONFIGURATION", e.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } finally {
       resetParentList(parentComponents, parentSize);
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.server.IPSServerErrors;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -334,11 +336,11 @@ public final class PSContainerLocator extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -357,7 +359,7 @@ public final class PSContainerLocator extends PSComponent {
       node = tree.getNextElement(PSTableSet.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSTableSet.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (node != null) {
         m_tableSets.add(new PSTableSet(node, parentDoc, parentComponents));
@@ -390,7 +392,7 @@ public final class PSContainerLocator extends PSComponent {
     context.pushParent(this);
     try {
       if (m_tableSets == null) {
-        context.validationError(this, IPSObjectStoreErrors.INVALID_CONTAINER_LOCATOR, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTAINER_LOCATOR, null);
       } else {
         Iterator it = getTableSets();
         while (it.hasNext()) ((PSTableSet) it.next()).validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.cms.objectstore.PSCmsObject;
 import com.percussion.data.IPSInternalRequestHandler;
 import com.percussion.data.PSExecutionData;
@@ -630,11 +632,11 @@ public final class PSContentEditor extends PSDataSet {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -650,7 +652,7 @@ public final class PSContentEditor extends PSDataSet {
         m_contentType = Long.parseLong(data);
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, CONTENT_TYPE_ATTR, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // REQUIRED: get the worflow ID attribute
@@ -659,7 +661,7 @@ public final class PSContentEditor extends PSDataSet {
         m_workflowId = Integer.parseInt(data);
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, WORKFLOW_ID_ATTR, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // OPTIONAL: get the enableRelatedContent flag, defaults to disabled
@@ -684,7 +686,7 @@ public final class PSContentEditor extends PSDataSet {
           m_objectType = objectType;
         } catch (Exception e) {
           Object[] args = {XML_NODE_NAME, OBJECT_TYPE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       } else m_objectType = PSCmsObject.TYPE_ITEM;
 
@@ -698,7 +700,7 @@ public final class PSContentEditor extends PSDataSet {
           m_iconSource = data;
         } catch (Exception e) {
           Object[] args = {XML_NODE_NAME, ICON_SOURCE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       } else {
         m_iconSource = ICON_SOURCE_NONE;
@@ -712,7 +714,7 @@ public final class PSContentEditor extends PSDataSet {
           m_iconValue = data;
         } else {
           Object[] args = {XML_NODE_NAME, ICON_VALUE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
       } else {
@@ -845,11 +847,11 @@ public final class PSContentEditor extends PSDataSet {
     // simple: workflow ids are positive, contentid can't be zero
     if (m_contentType == 0) {
       context.validationError(
-          this, IPSObjectStoreErrors.INVALID_CONTENT_TYPE, String.valueOf(m_contentType));
+          this, ObjectStoreErrorCodes.INVALID_CONTENT_TYPE, String.valueOf(m_contentType));
     }
     if (cmsObject != null && cmsObject.isWorkflowable() && (m_workflowId <= 0)) {
       context.validationError(
-          this, IPSObjectStoreErrors.INVALID_WORKFLOW_ID, String.valueOf(m_workflowId));
+          this, ObjectStoreErrorCodes.INVALID_WORKFLOW_ID, String.valueOf(m_workflowId));
     }
 
     // complex: ensure content type id is registered in the CMS
@@ -864,7 +866,7 @@ public final class PSContentEditor extends PSDataSet {
           ResultSet rs = data.getNextResultSet();
           if (!(rs != null && data.readRow())) {
             context.validationError(
-                this, IPSObjectStoreErrors.INVALID_CONTENT_TYPE, String.valueOf(m_contentType));
+                this, ObjectStoreErrorCodes.INVALID_CONTENT_TYPE, String.valueOf(m_contentType));
           }
         }
       } catch (RuntimeException e) {
@@ -882,7 +884,7 @@ public final class PSContentEditor extends PSDataSet {
     if (pipe == null || !(pipe instanceof PSContentEditorPipe)) {
       String arg = (pipe == null) ? "null" : pipe.getClass().getName();
       Object[] args = {arg};
-      context.validationError(this, IPSObjectStoreErrors.INVALID_CONTENT_EDITOR_PIPE, args);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTENT_EDITOR_PIPE, args);
     }
 
     // do children

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorMapper.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -265,11 +267,11 @@ public final class PSContentEditorMapper extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -328,7 +330,7 @@ public final class PSContentEditorMapper extends PSComponent {
         m_fieldSet = new PSFieldSet(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSFieldSet.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // REQUIRED: get the UI definition
@@ -337,7 +339,7 @@ public final class PSContentEditorMapper extends PSComponent {
         m_uiDefinition = new PSUIDefinition(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSUIDefinition.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     } finally {
       resetParentList(parentComponents, parentSize);
@@ -404,10 +406,10 @@ public final class PSContentEditorMapper extends PSComponent {
     context.pushParent(this);
     try {
       if (m_fieldSet != null) m_fieldSet.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_CONTENT_EDITOR_MAPPER, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTENT_EDITOR_MAPPER, null);
 
       if (m_uiDefinition != null) m_uiDefinition.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_CONTENT_EDITOR_MAPPER, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTENT_EDITOR_MAPPER, null);
     } finally {
       context.popParent();
     }
@@ -568,7 +570,7 @@ public final class PSContentEditorMapper extends PSComponent {
         if (groupFields.getType() == PSFieldSet.TYPE_PARENT) {
           Object[] args = {group.getName(), groupFields.getName()};
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_INVALID_SHARED_FIELDSET_TYPE, args);
+              ObjectStoreErrorCodes.CE_INVALID_SHARED_FIELDSET_TYPE, args);
         }
 
         // remove exluded shared fields
@@ -1008,7 +1010,7 @@ public final class PSContentEditorMapper extends PSComponent {
         if (groupFields.getType() == PSFieldSet.TYPE_PARENT) {
           Object[] args = {group.getName(), groupFields.getName()};
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_INVALID_SHARED_FIELDSET_TYPE, args);
+              ObjectStoreErrorCodes.CE_INVALID_SHARED_FIELDSET_TYPE, args);
         }
 
         groupFields = groupFields.removeFields(m_sharedFieldExcludes, false);
@@ -1113,7 +1115,7 @@ public final class PSContentEditorMapper extends PSComponent {
       if (null == sharedDef) {
         // get name for error message
         include = (String) includes.next();
-        throw new PSSystemValidationException(IPSObjectStoreErrors.CE_SHARED_GROUP_NO_DEF, include);
+        throw new PSSystemValidationException(ObjectStoreErrorCodes.CE_SHARED_GROUP_NO_DEF, include);
       } else {
         PSCollection sharedGroups = new PSCollection(sharedDef.getFieldGroups());
         while (includes.hasNext()) {
@@ -1137,7 +1139,7 @@ public final class PSContentEditorMapper extends PSComponent {
                 Object[] args = {groupName};
                 warnings.add(
                     new PSSystemValidationException(
-                        IPSObjectStoreErrors.CE_GROUPNAME_AND_FIELDSETNAME_MUST_MATCH, args));
+                        ObjectStoreErrorCodes.CE_GROUPNAME_AND_FIELDSETNAME_MUST_MATCH, args));
               }
 
               // Validate that the fieldSet name matches the Display
@@ -1146,7 +1148,7 @@ public final class PSContentEditorMapper extends PSComponent {
                 Object[] args = {groupName};
                 warnings.add(
                     new PSSystemValidationException(
-                        IPSObjectStoreErrors.CE_FIELDSETNAME_AND_FIELDSETREF_MUST_MATCH, args));
+                        ObjectStoreErrorCodes.CE_FIELDSETNAME_AND_FIELDSETREF_MUST_MATCH, args));
               } else if (type == PSFieldSet.TYPE_SIMPLE_CHILD) {
                 // Validate that simple child fields have the required
                 // child display mapping.
@@ -1186,7 +1188,7 @@ public final class PSContentEditorMapper extends PSComponent {
                   Object[] args = {fieldSetRef};
                   warnings.add(
                       new PSSystemValidationException(
-                          IPSObjectStoreErrors.CE_MISSING_OR_INVALID_CHILD_DISPLAY_MAPPING, args));
+                          ObjectStoreErrorCodes.CE_MISSING_OR_INVALID_CHILD_DISPLAY_MAPPING, args));
                 }
               }
 
@@ -1205,7 +1207,7 @@ public final class PSContentEditorMapper extends PSComponent {
 
           if (!hasMatch) {
             throw new PSSystemValidationException(
-                IPSObjectStoreErrors.CE_INCLUDED_GROUP_INVALID, include);
+                ObjectStoreErrorCodes.CE_INCLUDED_GROUP_INVALID, include);
           }
         }
       }
@@ -1221,7 +1223,7 @@ public final class PSContentEditorMapper extends PSComponent {
         buf.append((String) excludes.next());
       }
       Object[] args = {buf.toString()};
-      throw new PSSystemValidationException(IPSObjectStoreErrors.CE_SHARED_EXCLUDE_INVALID, args);
+      throw new PSSystemValidationException(ObjectStoreErrorCodes.CE_SHARED_EXCLUDE_INVALID, args);
     }
 
     return warnings.iterator();
@@ -1308,7 +1310,7 @@ public final class PSContentEditorMapper extends PSComponent {
                 Object args[] = {sharedFieldName, duplicateGroups};
 
                 throw new PSMinorValidationException(
-                    IPSObjectStoreErrors.DUPLICATE_SHARED_FIELD_VALIDATION_WARNING, args);
+                    ObjectStoreErrorCodes.DUPLICATE_SHARED_FIELD_VALIDATION_WARNING, args);
               }
             } else {
               sharedGroupNames = new HashSet<>();
@@ -1350,7 +1352,7 @@ public final class PSContentEditorMapper extends PSComponent {
         buf.append((String) excludes.next());
       }
       Object[] args = {buf.toString()};
-      throw new PSSystemValidationException(IPSObjectStoreErrors.CE_SYSTEM_EXCLUDE_INVALID, args);
+      throw new PSSystemValidationException(ObjectStoreErrorCodes.CE_SYSTEM_EXCLUDE_INVALID, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorPipe.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.error.PSException;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -229,11 +231,11 @@ public final class PSContentEditorPipe extends PSPipe {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -255,7 +257,7 @@ public final class PSContentEditorPipe extends PSPipe {
         m_id = Integer.parseInt(data);
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // REQUIRED: pipe name
@@ -308,7 +310,7 @@ public final class PSContentEditorPipe extends PSPipe {
         m_locator = new PSContainerLocator(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSContainerLocator.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // REQUIRED: get the mappeer
@@ -317,7 +319,7 @@ public final class PSContentEditorPipe extends PSPipe {
         m_mapper = new PSContentEditorMapper(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSContentEditorMapper.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       tree.setCurrent(current);
@@ -419,10 +421,10 @@ public final class PSContentEditorPipe extends PSPipe {
     context.pushParent(this);
     try {
       if (m_locator != null) m_locator.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_CONTENT_EDITOR_PIPE, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTENT_EDITOR_PIPE, null);
 
       if (m_mapper != null) m_mapper.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_CONTENT_EDITOR_PIPE, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTENT_EDITOR_PIPE, null);
     } finally {
       context.popParent();
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSharedDef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSharedDef.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.util.PSCollection;
@@ -267,7 +269,7 @@ public final class PSContentEditorSharedDef extends PSComponent implements IPSDo
   // see IPSDocument
   public final void fromXml(Document doc) throws PSUnknownDocTypeException, PSUnknownNodeTypeException {
     if (null == doc)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
     Element sourceNode = doc.getDocumentElement();
     fromXml(sourceNode, null, null);
   }
@@ -279,11 +281,11 @@ public final class PSContentEditorSharedDef extends PSComponent implements IPSDo
       Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -357,7 +359,7 @@ public final class PSContentEditorSharedDef extends PSComponent implements IPSDo
         Iterator it = getFieldGroups();
         while (it.hasNext()) ((IPSComponent) it.next()).validate(context);
       } else
-        context.validationError(this, IPSObjectStoreErrors.INVALID_CONTENT_EDITOR_SHARED_DEF, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTENT_EDITOR_SHARED_DEF, null);
     } finally {
       context.popParent();
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSystemDef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorSystemDef.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.util.PSCollection;
@@ -404,7 +406,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
    */
   public final void fromXml(Document doc) throws PSUnknownNodeTypeException, PSUnknownDocTypeException {
     if (null == doc)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     Element sourceNode = doc.getDocumentElement();
     PSComponent.validateElementName(sourceNode, XML_NODE_NAME);
@@ -417,7 +419,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
       } catch (NumberFormatException e) {
         Object[] args = {XML_NODE_NAME, ATTR_CACHE_TIMEOUT, timeOut};
 
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
 
@@ -435,7 +437,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
     Element systemLocator = tree.getNextElement(ELEMENT_SYSTEM_LOCATOR, firstFlags);
     if (systemLocator == null)
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, ELEMENT_SYSTEM_LOCATOR);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, ELEMENT_SYSTEM_LOCATOR);
 
     loadSystemLocator(systemLocator);
 
@@ -444,7 +446,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
 
     if (styleSheets == null)
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSCommandHandlerStylesheets.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSCommandHandlerStylesheets.XML_NODE_NAME);
 
     m_styleSheets = new PSCommandHandlerStylesheets(styleSheets, null, null);
 
@@ -453,7 +455,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
 
     if (appFlow == null)
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, PSApplicationFlow.XML_NODE_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, PSApplicationFlow.XML_NODE_NAME);
 
     m_appFlow = new PSApplicationFlow(appFlow, null, null);
 
@@ -625,7 +627,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
         exits.getNodeName(), ATTR_COMMAND_NAME, (cmdName == null ? "null" : cmdName)
       };
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(exits);
@@ -638,7 +640,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
 
     if (inputDataExits == null)
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, ELEMENT_INPUT_DATA_EXITS);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, ELEMENT_INPUT_DATA_EXITS);
 
     // within this element must be the extension call set
     Element inputCallSetEl = tree.getNextElement(firstFlags);
@@ -650,7 +652,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
 
     if (resultDataExits == null)
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_NULL, ELEMENT_RESULT_DATA_EXITS);
+          ObjectStoreErrorCodes.XML_ELEMENT_NULL, ELEMENT_RESULT_DATA_EXITS);
 
     // within this element must be the extension call set
     Element resultCallSetEl = tree.getNextElement(firstFlags);
@@ -681,7 +683,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
     String searchEl = PSParam.XML_NODE_NAME;
     Element paramEl = tree.getNextElement(searchEl, firstFlags);
     if (paramEl == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, searchEl);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, searchEl);
     while (paramEl != null) {
       // create the param object
       PSParam param = new PSParam(paramEl, null, null);
@@ -690,7 +692,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
       String curVal = (String) m_paramNames.get(param.getName());
       if (curVal != null) {
         Object[] args = {ELEMENT_SYSTEM_PARAM_NAMES, searchEl, param.getName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // store in map
@@ -726,7 +728,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
     Element cmdNameEl = tree.getNextElement(searchEl, firstFlags);
     if (cmdNameEl == null) {
       Object[] args = {ELEMENT_INIT_PARAMS, ELEMENT_COMMAND_NAME, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     while (cmdNameEl != null) {
@@ -740,7 +742,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
     Element paramEl = tree.getNextElement(searchEl, nextFlags);
     if (paramEl == null) {
       Object[] args = {ELEMENT_INIT_PARAMS, PSParam.XML_NODE_NAME, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     while (paramEl != null) {
@@ -804,7 +806,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
       else if (fieldSet == null) badEl = PSFieldSet.XML_NODE_NAME;
       else badEl = PSUIDefinition.XML_NODE_NAME;
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, badEl);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, badEl);
     } else if (containerLocator != null) {
       // this means we have found them all
       m_containerLocator = new PSContainerLocator(containerLocator, null, null);
@@ -835,7 +837,7 @@ public final class PSContentEditorSystemDef implements IPSDocument {
     if (containerLocator == null) {
       Object[] args = {ELEMENT_SYSTEM_LOCATOR, PSContainerLocator.XML_NODE_NAME, "null"};
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_systemLocator = new PSContainerLocator(containerLocator, null, null);

--- a/system/src/main/java/com/percussion/design/objectstore/PSMinorValidationException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMinorValidationException.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.percussion.error.IPSErrorCode;
+
 /**
  * PSMinorValidationException is thrown when a recoverable validation error occurs. This usually
  * occurs when an application is being opened by a workbench and an invalid value is detected.
@@ -37,6 +39,16 @@ public class PSMinorValidationException extends PSSystemValidationException {
   }
 
   /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSMinorValidationException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
    * Construct an exception for messages taking an array of arguments. Be sure to store the
    * arguments in the correct order in the array, where {0} in the string is array element 0, etc.
    *
@@ -48,12 +60,31 @@ public class PSMinorValidationException extends PSSystemValidationException {
   }
 
   /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSMinorValidationException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
    * Construct an exception for messages taking no arguments.
    *
    * @param msgCode the error string to load
    */
   public PSMinorValidationException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSMinorValidationException(IPSErrorCode code) {
+    super(code);
   }
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSSystemValidationException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSSystemValidationException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -42,6 +43,16 @@ public class PSSystemValidationException extends PSException {
   }
 
   /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSSystemValidationException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
    * Construct an exception for messages taking an array of arguments. Be sure to store the
    * arguments in the correct order in the array, where {0} in the string is array element 0, etc.
    *
@@ -53,12 +64,31 @@ public class PSSystemValidationException extends PSException {
   }
 
   /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSSystemValidationException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
    * Construct an exception for messages taking no arguments.
    *
    * @param msgCode the error string to load
    */
   public PSSystemValidationException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSSystemValidationException(IPSErrorCode code) {
+    super(code);
   }
 
   public PSSystemValidationException(

--- a/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSTableLocator.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.design.objectstore.legacy.IPSComponentConverter;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -218,11 +220,11 @@ public final class PSTableLocator extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -249,7 +251,7 @@ public final class PSTableLocator extends PSComponent {
             XML_NODE_NAME, PSBackEndCredential.ms_NodeType + " and " + ALIAS_ELEM, "null"
           };
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
 
         m_credentials = new PSBackEndCredential(node, parentDoc, parentComponents);
@@ -279,7 +281,7 @@ public final class PSTableLocator extends PSComponent {
     if (!context.startValidation(this, null)) return;
 
     if (m_aliasRef == null && m_credentials == null)
-      context.validationError(this, IPSObjectStoreErrors.INVALID_TABLE_LOCATOR, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_TABLE_LOCATOR, null);
 
     // do children
     context.pushParent(this);

--- a/system/src/main/java/com/percussion/design/objectstore/PSUnknownDocTypeException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSUnknownDocTypeException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.design.objectstore;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSErrorManager;
 import com.percussion.error.PSException;
 
@@ -42,6 +43,16 @@ public class PSUnknownDocTypeException extends PSException {
   }
 
   /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSUnknownDocTypeException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
    * Construct an exception for messages taking an array of arguments. Be sure to store the
    * arguments in the correct order in the array, where {0} in the string is array element 0, etc.
    *
@@ -53,12 +64,31 @@ public class PSUnknownDocTypeException extends PSException {
   }
 
   /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSUnknownDocTypeException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
    * Construct an exception for messages taking no arguments.
    *
    * @param msgCode the error string to load
    */
   public PSUnknownDocTypeException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSUnknownDocTypeException(IPSErrorCode code) {
+    super(code);
   }
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyTableLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSLegacyTableLocator.java
@@ -17,9 +17,10 @@
 
 package com.percussion.design.objectstore.legacy;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
 import com.percussion.design.objectstore.IPSValidationContext;
 import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSSystemValidationException;
@@ -249,11 +250,11 @@ public class PSLegacyTableLocator extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -280,7 +281,7 @@ public class PSLegacyTableLocator extends PSComponent {
             XML_NODE_NAME, PSLegacyBackEndCredential.ms_NodeType + " and " + ALIAS_ELEM, "null"
           };
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
 
         m_credentials = new PSLegacyBackEndCredential(node, parentDoc, parentComponents);
@@ -322,7 +323,7 @@ public class PSLegacyTableLocator extends PSComponent {
     if (!context.startValidation(this, null)) return;
 
     if (m_aliasRef == null && m_credentials == null)
-      context.validationError(this, IPSObjectStoreErrors.INVALID_TABLE_LOCATOR, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_TABLE_LOCATOR, null);
 
     // do children
     context.pushParent(this);

--- a/system/src/main/java/com/percussion/error/PSErrorHandler.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHandler.java
@@ -18,6 +18,7 @@
 package com.percussion.error;
 
 import com.intsof.percussioncms.auditlog.AuditContext;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.data.PSConversionException;
 import com.percussion.data.PSStyleSheetMerger;
@@ -183,6 +184,20 @@ public class PSErrorHandler {
     try {
       AuditContext context = auditContextFromThreadLocal();
       Object[] args = exception.getErrorArguments();
+      // Prefer typed SystemErrorCode when the exception was built with ObjectStoreErrorCodes /
+      // other *ErrorCodes enums (IPSErrorCode). Non-auditable typed codes short-circuit without
+      // registry lookup. Legacy int construction still goes through LegacyErrorCodeRegistry.
+      if (exception.getTypedErrorCode() instanceof SystemErrorCode typed) {
+        if (!typed.isAuditable()) {
+          return;
+        }
+        if (args == null || args.length == 0) {
+          PSSystemAuditLogger.log(typed, context, typed.defaultOutcome());
+        } else {
+          PSSystemAuditLogger.log(typed, context, typed.defaultOutcome(), args);
+        }
+        return;
+      }
       if (args == null || args.length == 0) {
         PSSystemAuditLogger.logLegacyIfAuditable(exception.getErrorCode(), context);
       } else {

--- a/system/src/test/java/com/percussion/design/objectstore/PSCloneHandlerConfigTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSCloneHandlerConfigTest.java
@@ -18,6 +18,7 @@ package com.percussion.design.objectstore;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.InputStream;
@@ -74,6 +75,21 @@ public class PSCloneHandlerConfigTest {
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       fail("PSCloneHandlerConfigSet toXml failed");
     }
+  }
+
+  /**
+   * Batch G: null source for {@link PSCloneHandlerConfigSet} must use typed {@link
+   * ObjectStoreErrorCodes}.
+   */
+  @Test
+  public void fromXmlNullSourceUsesTypedObjectStoreErrorCode() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSCloneHandlerConfigSet(null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
   }
 
   // collect all tests into a TestSuite and return it - see base class

--- a/system/src/test/java/com/percussion/design/objectstore/PSContainerLocatorTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSContainerLocatorTest.java
@@ -18,6 +18,7 @@ package com.percussion.design.objectstore;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,33 @@ public class PSContainerLocatorTest {
     // create a new object and populate it from our testTo element
     PSContainerLocator testFrom = new PSContainerLocator(elem, null, null);
     assertTrue(testTo.equals(testFrom));
+  }
+
+  /**
+   * Batch G: null source for fromXml must surface typed {@link ObjectStoreErrorCodes} (not bare
+   * legacy ints).
+   */
+  @Test
+  public void fromXmlNullSourceUsesTypedObjectStoreErrorCode() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSContainerLocator((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  /** Batch G: wrong root element type uses typed {@code XML_ELEMENT_WRONG_TYPE}. */
+  @Test
+  public void fromXmlWrongTypeUsesTypedObjectStoreErrorCode() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotContainerLocator");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSContainerLocator(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
   }
 
   // JUnit 5 uses test discovery; explicit suite() removed.

--- a/system/src/test/java/com/percussion/error/PSErrorHandlerAuditBridgeTest.java
+++ b/system/src/test/java/com/percussion/error/PSErrorHandlerAuditBridgeTest.java
@@ -28,9 +28,11 @@ import com.intsof.percussioncms.auditlog.AuditLogService;
 import com.intsof.percussioncms.auditlog.AuditOutcome;
 import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.security.IPSSecurityErrors;
 import com.percussion.server.PSRequest;
 import com.percussion.utils.request.PSRequestInfo;
@@ -92,6 +94,37 @@ class PSErrorHandlerAuditBridgeTest {
         new PSException(IPSSecurityErrors.PROVIDER_UNKNOWN, new Object[] {"Directory", "ldap1"});
 
     PSErrorHandler.fillErrorResponse(ex);
+
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void typedAuditableErrorCodeDualWritesWithoutLegacyInt() {
+    PSException ex =
+        new PSException(
+            SecurityErrorCodes.AUTHENTICATION_FAILED,
+            new Object[] {"Directory", "ldap1", "jdoe"});
+
+    assertEquals(SecurityErrorCodes.AUTHENTICATION_FAILED, ex.getTypedErrorCode());
+    assertTrue(ex.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(ex);
+
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    var rec = ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0);
+    assertEquals(SecurityErrorCodes.AUTHENTICATION_FAILED, rec.code());
+  }
+
+  @Test
+  void typedObjectStoreErrorCodeSkipsDualWrite() {
+    PSUnknownNodeTypeException ex =
+        new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "PSXContentEditor");
+
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertEquals(2011, ex.getErrorCode());
+    assertTrue(!ex.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(ex);
 
     assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
   }


### PR DESCRIPTION
## Summary

**ObjectStore ErrorCodes call-site batch G** (Parent #2616 / issue #3022): migrate design.objectstore **clone / config / container / locator** families from raw `IPSObjectStoreErrors` ints to typed `ObjectStoreErrorCodes` construction.

### What changed

| Area | Detail |
|------|--------|
| Clone | `PSCloneHandlerConfig`, `PSCloneHandlerConfigSet`, `PSCloneOverrideField`, `PSCloneOverrideFieldList` — zero `IPSObjectStoreErrors` residual |
| Config | `PSConfig` — typed invalid-child construction |
| Container / locator | `PSContainerLocator`, `PSTableLocator`, `PSLegacyTableLocator` — null/wrong-type/invalid-child + validation codes |
| Tests | `PSContainerLocatorTest` (+null/wrong-type typed asserts); `PSCloneHandlerConfigTest` (+null typed assert) |
| Sites | ~30 call sites |

**Depends on batch F** (#3021 / PR #3037): typed `IPSErrorCode` constructors on `PSException` / objectstore exceptions and `IPSValidationContext` typed validation overloads. This branch is stacked on `fix/issue-3021-objectstore-batch-f-pscontenteditor`; unique G commit is `2491b416bb`. After #3037 merges, rebase this PR onto `main` to drop the F commit from the diff.

No product behavior change beyond dual-write semantics for typed construction (ObjectStore codes remain non-auditable).

### Product documentation

- [x] N/A — internal tech-debt / audit ErrorCodes call-site migration; no operator/admin/UI/REST surface change

### Build evidence (C3)

- **modules_built:** `system`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **1817**, Failures: 0, Errors: 0, Skipped: 241
  - Focused: `-Dtest=PSContainerLocatorTest,PSCloneHandlerConfigTest` → Tests run: **6**, Failures: 0
- **downstream_checked:** none required for C2 — call-site migration only (no `final`/`sealed`, no signature changes). Batch F infrastructure already covers utils/perc-auditlog reverse-dep install order.

### Operator

Operator: Grok: night-issue-prs (model grok-4.5)

### Parent / related

- Parent tracker: #2616
- Prior: batch F #3021 / PR #3037 (required infra)
- Residual call-site batch H already filed: #3023
- Fixes #3022

## Test plan

1. `cd system && ../mvnw clean install` — confirm BUILD SUCCESS and new typed-code tests green
2. Spot-check: `rg IPSObjectStoreErrors system/src/main/java/com/percussion/design/objectstore/PSClone*.java system/.../PSConfig.java system/.../PSContainerLocator.java system/.../PSTableLocator.java system/.../legacy/PSLegacyTableLocator.java` → empty
3. After #3037 merges: rebase this branch onto `main` and re-verify clean install

> Co-Authored by Grok Build using grok-4.5 with agent main.
