### PR TITLE
feat(sitemanage): wire PSWidgetDao modern-first dual-run selection (#3024)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
@@ -54,7 +54,9 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 | Widget DAO path | Production widget load no longer depends solely on `${rxdeploydir}/rxconfig/Widgets/*.xml` for product widgets | Code + install smoke |
 | Gadget registry dual-load | WebUI `GadgetRegistry` last load source is modern catalog in product installs (legacy XML only for waived customer cases) | `GadgetRegistry.getLastLoadSource()` / tests |
 
-**Snapshot 2026-08-11:** **FAIL M2** — selection API exists and is unit-tested, but **no production caller** outside `modules/perc-packages` shim package + javadoc cross-refs wires `PSLegacyDefinitionXmlShim` into live load paths. `PSWidgetDao` still binds `@Value("${rxdeploydir}/rxconfig/Widgets")`. `GadgetRegistry` dual-load (modern catalog preferred, legacy `GadgetRegistry.xml` fallback) is still active.
+**Snapshot 2026-08-11:** **FAIL M2** — selection API existed and was unit-tested, but **no production caller** outside `modules/perc-packages` shim package + javadoc cross-refs wired `PSLegacyDefinitionXmlShim` into live load paths. `PSWidgetDao` still bound only `@Value("${rxdeploydir}/rxconfig/Widgets")`. `GadgetRegistry` dual-load (modern catalog preferred, legacy `GadgetRegistry.xml` fallback) is still active.
+
+**Snapshot 2026-08-11 (slice #3024):** **PARTIAL M2** — `PSWidgetDao` now wires `PSLegacyDefinitionXmlShim.selectDefinition` (modern-first) with test-visible `getLastSelectionKind()` / `getSelectionKindsById()` and INFO metrics `modern=` / `legacyWidgetXml=`. Optional Spring property `widgetDao.modernPackageRoots` (`File.pathSeparator` list). Content still loads install Widget XML (materialized wire format); selection kind reports MODERN when a modern package root is present for the id. **M2 still FAIL overall** until production installs configure modern roots and runtime metrics show zero (or waived) `LEGACY_WIDGET_XML` over the time-box, and gadget dual-load residual (#3025) closes. Shim **must remain** (#2852).
 
 ### M3 — Customer upgrade window closed (or accepted residual)
 
@@ -113,7 +115,12 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 | `…/shim/PSDefinitionSourceNotFoundException.java` | Neither modern nor legacy | Yes |
 | `…/shim/PSLegacyDefinitionXmlShimTest.java` | Unit coverage for selection | Test only |
 
-**Production callers of `PSLegacyDefinitionXmlShim` (excluding self + tests):** **none**.  
+**Production callers of `PSLegacyDefinitionXmlShim` (excluding self + tests):**
+
+| Caller | Module | Notes |
+|--------|--------|-------|
+| `PSWidgetDao` (`selectDefinitionSource` + poll `recordSelectionKinds`) | `projects/sitemanage` | #3024 modern-first wire; keeps legacy Widgets load |
+
 Javadoc-only alignment references:
 
 - `com.percussion.packages.pagexml.PSPageXmlInstallPolicy`
@@ -123,7 +130,7 @@ Javadoc-only alignment references:
 
 | Surface | Path / class | Status in snapshot | Removal coupled to shim? |
 |---------|--------------|--------------------|---------------------------|
-| Widget install load | `projects/sitemanage/.../dao/impl/PSWidgetDao` → `${rxdeploydir}/rxconfig/Widgets` | **Live** legacy XML directory load | **Yes** for product modern-only; must rewire before shim delete |
+| Widget install load | `projects/sitemanage/.../dao/impl/PSWidgetDao` → `${rxdeploydir}/rxconfig/Widgets` + optional `widgetDao.modernPackageRoots` | **Live** dual-run selection (#3024); content still from Widgets XML wire | **Yes** for product modern-only content path; selection wired; keep shim until M2 metrics pass |
 | Product Widget package XML | `modules/perc-packages/.../Packages/**/sys__UserDependency--rxconfig/Widgets/*.xml` | **29** files remaining after batch C ship-exit #2885 (was **48**); install materialize for modern-only | Product XML deletion continues via ship-exit #2883 / #2884; waived `perc.Test`; M1 still FAIL |
 | Widget XML compilers | `…/widgetxml/PSWidgetXml*` | Upgrade-input compilers; keep after runtime shim exit | **No** (upgrade input OK) |
 | Page dual-ship / native | `…/pagexml/PSPageXmlDualShip`, `PSPageXmlNativeInstall`, `PSPageXmlInstallPolicy` | Native for base/responsive; dual-ship default elsewhere | Separate checklist ([dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md)) |

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md
@@ -46,7 +46,7 @@ Hard order for a package root or definition id:
 
 | Surface | Path / class | Role today | Dual-run note |
 |---------|--------------|------------|---------------|
-| Widget definitions (install) | `${rxdeploydir}/rxconfig/Widgets/*.xml` via `PSWidgetDao` (`projects/sitemanage/.../dao/impl/PSWidgetDao`) | Loads legacy Widget XML by file id | Prefer modern package when present; XML remains fallback for unconverted customer defs |
+| Widget definitions (install) | `${rxdeploydir}/rxconfig/Widgets/*.xml` via `PSWidgetDao` (`projects/sitemanage/.../dao/impl/PSWidgetDao`) | Loads install Widget XML by file id; dual-run selection via `PSLegacyDefinitionXmlShim` (#3024) | Prefer modern when `widgetDao.modernPackageRoots` has a matching `component-package.json`; selection kind test-visible; XML content remains install wire / customer fallback |
 | Package source trees | `modules/perc-packages/src/main/resources/Packages/<pkg>/` | Ships product `.ppkg` content including `sys__UserDependency--rxconfig/Widgets/*.xml` | Product conversion (#2751+) emits modern manifest; batch A dual-ships modern `widgets/<stem>/` (#2831) while install XML remains; product source of truth moves off XML (ADR-004) |
 | Package staging Widgets | `sys__UserDependency--rxconfig/Widgets/` or `rxconfig/Widgets/` under a package root | Upgrade-input / deploy layout | Shim package-root API resolves either layout |
 | Gadget registry | `WebUI/.../GadgetRegistry.xml` (+ residual definition XML) | Registry; per-gadget XML largely gone | Modern: `gadget-catalog.json` + per-gadget packages (#2771); dual-load residual for WebUI |
@@ -57,8 +57,7 @@ Hard order for a package root or definition id:
 - `PSLegacyDefinitionXmlShim.selectByPresence(...)` — pure flags (tests / metrics)
 - `PSLegacyDefinitionXmlShim.selectForPackageRoot(Path)` — package directory
 - `PSLegacyDefinitionXmlShim.selectDefinition(id, modernRoots, widgetsDir, pagesDir, gadgetsDir)` — dual-run by id
-
-Deep rewiring of `PSWidgetDao` to call the shim for every load is **incremental** and may land with residual wiring after modern packages appear on disk; this slice ships the **policy + tested selection** and operator docs.
+- **Production wire (#3024):** `PSWidgetDao.selectDefinitionSource(id)` and poll-time `recordSelectionKinds` call `selectDefinition`; optional Spring `widgetDao.modernPackageRoots` (`File.pathSeparator` list); `getLastSelectionKind()` / `getSelectionKindsById()` for tests and support.
 
 ## Time box / deprecation
 
@@ -92,7 +91,7 @@ The dual-run window ends when **all** of the following hold. **Authoritative met
 - [x] Product **page layout** packages `perc.baseTemplates` / `perc.responsiveTemplates` are **not** authored as `*.templateDef` (#2786; native install mode #2806 — dual-ship roots off).
 - [ ] Remaining product packages in repo/install are **not** authored as Page / Widget / Gadget definition XML (ADR-004 ship bar) — Baseline page templates done; **widget dual-ship batch A** modern roots landed (#2831, 8 widgets); remaining ~40 product widgets still dual-ship XML as install authoring until further batches + native install. **Inventory detail:** product Widget definition XMLs under Packages (`sys__UserDependency--rxconfig/Widgets`) — see [definition-xml-shim-removal-criteria.md](./definition-xml-shim-removal-criteria.md).
 - [ ] Customer upgrade path documented and used for remaining XML (window still open for 8.2 dual-run).
-- [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived. **Snapshot:** selection API un-wired into `PSWidgetDao`; no M2 metrics yet.
+- [ ] Runtime metrics (or support inventory) show no production dependence on legacy definition XML loads — or remaining cases are explicitly waived. **Snapshot (#3024):** `PSWidgetDao` logs dual-run counts and exposes selection kinds; M2 still open until modern roots are configured in product installs and legacy rate is zero/waived.
 - [ ] Phase 5 (#2632) removes or hard-disables the shim and updates help — **blocked** until criteria doc M1–M3 + G1–G6 pass; residual tracks the deletion PR.
 
 **Do not** mass-delete the customer-facing shim while any box above is open.

--- a/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/shim/PSLegacyDefinitionXmlShim.java
@@ -53,20 +53,23 @@ import java.util.Optional;
  * Dual-run policy and exit criteria: {@code
  * docs/ai-generated/tasks/template-assembler-normalization/dual-run-legacy-definition-xml-shim.md}.
  *
- * <h2>Runtime entry points (document only — wiring is incremental)</h2>
+ * <h2>Runtime entry points</h2>
  *
  * <ul>
- *   <li>Widgets: {@code projects/sitemanage/.../dao/impl/PSWidgetDao} — repository {@code
- *       ${rxdeploydir}/rxconfig/Widgets} (legacy XML files named by definition id).
+ *   <li>Widgets: {@code projects/sitemanage/.../dao/impl/PSWidgetDao} — production dual-run wire
+ *       (#3024). Repository {@code ${rxdeploydir}/rxconfig/Widgets} loads install Widget XML;
+ *       optional {@code widgetDao.modernPackageRoots} feeds this API so modern manifests win when
+ *       present. Selection kinds are test-visible on the DAO. Do <strong>not</strong> delete this
+ *       shim (#2852).
  *   <li>Package source trees: {@code modules/perc-packages/.../Packages/<id>/} with either {@code
  *       component-package.json} (modern) or {@code sys__UserDependency--rxconfig/Widgets/*.xml}
  *       (legacy).
  *   <li>Gadget registry / page meta: see dual-run operator doc for remaining load surfaces.
  * </ul>
  *
- * <p>This class owns <strong>selection logic</strong> only. Full product conversion and DAO
- * rewrites are sibling / residual slices; callers pass paths and act on the returned {@link
- * PSDefinitionSourceSelection}.
+ * <p>This class owns <strong>selection logic</strong>. Callers pass paths and act on the returned
+ * {@link PSDefinitionSourceSelection}. Content loaders may still read install Widget XML while
+ * reporting modern as the preferred dual-run kind when a Component Package Manifest is present.
  *
  * <p>Filesystem APIs use {@link Path} / {@link Files} (portable Windows / Linux / macOS).
  */

--- a/projects/sitemanage/pom.xml
+++ b/projects/sitemanage/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>perc-deployer</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <!-- Dual-run definition source selection (PSLegacyDefinitionXmlShim) for PSWidgetDao #3024 -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>perc-packages</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.percussion</groupId>
             <artifactId>utils</artifactId>

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSWidgetDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSWidgetDao.java
@@ -20,19 +20,49 @@ package com.percussion.pagemanagement.dao.impl;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
+import com.percussion.packages.shim.PSDefinitionSourceKind;
+import com.percussion.packages.shim.PSDefinitionSourceNotFoundException;
+import com.percussion.packages.shim.PSDefinitionSourceSelection;
+import com.percussion.packages.shim.PSLegacyDefinitionXmlShim;
 import com.percussion.pagemanagement.dao.IPSWidgetDao;
 import com.percussion.pagemanagement.data.PSWidgetDefinition;
 import com.percussion.server.PSServer;
 import com.percussion.share.dao.PSFileDataRepository;
 import com.percussion.share.dao.PSXmlFileDataRepository;
 import com.percussion.share.service.exception.PSDataServiceException;
+import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
+/**
+ * Loads widget definitions from install {@code rxconfig/Widgets} (legacy Widget definition XML wire
+ * format).
+ *
+ * <p><strong>Dual-run modern-first selection (ADR-004 / #3024 / parent #2630):</strong> when modern
+ * package roots are configured, each loaded definition id is classified via {@link
+ * PSLegacyDefinitionXmlShim#selectDefinition} so product installs prefer {@link
+ * PSDefinitionSourceKind#MODERN_COMPONENT_PACKAGE} when a Component Package Manifest is present for
+ * that id. Legacy {@link PSDefinitionSourceKind#LEGACY_WIDGET_XML} remains the fallback when modern
+ * is absent. Selection kind is test-visible and logged for Phase 5 exit metrics; the shim itself is
+ * <strong>not</strong> deleted here (#2852).
+ *
+ * <p>Content continues to load from the Widgets XML repository (install wire format materialised
+ * from modern packages by package-build emitters). Selection records which dual-run source won for
+ * each id.
+ *
+ * <p>Paths use portable {@link Path} / {@link File#pathSeparator} for multi-root lists.
+ */
 @Component("widgetDao")
 @Lazy
 public class PSWidgetDao
@@ -40,7 +70,7 @@ public class PSWidgetDao
     implements IPSWidgetDao {
 
   public static class PSWidgetDefinitionData {
-    protected Map<String, PSWidgetDefinition> widgetDefinitionsMap = new HashMap<>();
+    protected Map<String, PSWidgetDefinition> widgetDefinitionsMap = new LinkedHashMap<>();
 
     protected void add(PSWidgetDefinition def) {
       notNull(def);
@@ -48,6 +78,17 @@ public class PSWidgetDao
       widgetDefinitionsMap.put(def.getId(), def);
     }
   }
+
+  /** Last dual-run selection kind recorded by {@link #selectDefinitionSource(String)} or poll. */
+  private final AtomicReference<PSDefinitionSourceKind> lastSelectionKind =
+      new AtomicReference<>();
+
+  /** Per-definition selection kinds from the most recent repository poll / update. */
+  private final AtomicReference<Map<String, PSDefinitionSourceKind>> selectionKindsById =
+      new AtomicReference<>(Map.of());
+
+  /** Modern package roots consulted before legacy Widgets XML (empty = legacy-only selection). */
+  private volatile List<Path> modernPackageRoots = List.of();
 
   public PSWidgetDao() {
     super(PSWidgetDefinition.class);
@@ -67,7 +108,155 @@ public class PSWidgetDao
         log.error("Failed to parse widget definition: {}", fe.getFileName(), e);
       }
     }
+    recordSelectionKinds(data);
     return data;
+  }
+
+  /**
+   * Classify every loaded widget id with modern-first dual-run selection and publish metrics.
+   *
+   * @param data loaded widget definitions (non-null)
+   */
+  private void recordSelectionKinds(PSWidgetDefinitionData data) {
+    Path widgetsDir = resolveWidgetsDir();
+    List<Path> modernRoots = modernPackageRoots;
+    Map<String, PSDefinitionSourceKind> kinds = new LinkedHashMap<>();
+    PSDefinitionSourceKind last = null;
+    int modernCount = 0;
+    int legacyCount = 0;
+    for (String id : data.widgetDefinitionsMap.keySet()) {
+      try {
+        PSDefinitionSourceSelection selection =
+            PSLegacyDefinitionXmlShim.selectDefinition(
+                id, modernRoots, widgetsDir, null, null);
+        kinds.put(id, selection.getKind());
+        last = selection.getKind();
+        if (selection.isModern()) {
+          modernCount++;
+        } else {
+          legacyCount++;
+        }
+        if (log.isDebugEnabled()) {
+          log.debug(
+              "Widget definition dual-run source id={} kind={} path={}",
+              id,
+              selection.getKind(),
+              selection.getPrimaryPath().map(Path::toString).orElse(""));
+        }
+      } catch (PSDefinitionSourceNotFoundException e) {
+        // Definition was just loaded from XML; selection should not fail unless files vanished.
+        log.warn(
+            "Widget definition selection failed for loaded id '{}': {}", id, e.getMessage());
+      }
+    }
+    selectionKindsById.set(Collections.unmodifiableMap(kinds));
+    if (last != null) {
+      lastSelectionKind.set(last);
+    }
+    if (!kinds.isEmpty()) {
+      log.info(
+          "Widget definition dual-run selection: modern={}, legacyWidgetXml={}, total={}",
+          modernCount,
+          legacyCount,
+          kinds.size());
+    }
+  }
+
+  /**
+   * Dual-run selection for a single definition id (modern preferred, legacy Widgets XML fallback).
+   * Updates {@link #getLastSelectionKind()}. Does not invent a source when neither is present.
+   *
+   * @param definitionId non-blank widget definition id
+   * @return selection result (never null)
+   * @throws PSDefinitionSourceNotFoundException when neither modern package nor legacy XML exists
+   * @throws IllegalArgumentException when {@code definitionId} is blank
+   */
+  public PSDefinitionSourceSelection selectDefinitionSource(String definitionId)
+      throws PSDefinitionSourceNotFoundException {
+    PSDefinitionSourceSelection selection =
+        PSLegacyDefinitionXmlShim.selectDefinition(
+            definitionId, modernPackageRoots, resolveWidgetsDir(), null, null);
+    lastSelectionKind.set(selection.getKind());
+    log.debug(
+        "Widget selectDefinitionSource id={} kind={}", definitionId, selection.getKind());
+    return selection;
+  }
+
+  /**
+   * Source kind chosen by the most recent {@link #selectDefinitionSource(String)} or repository
+   * poll that classified at least one definition.
+   *
+   * @return last kind, or {@code null} if nothing has been selected yet
+   */
+  public PSDefinitionSourceKind getLastSelectionKind() {
+    return lastSelectionKind.get();
+  }
+
+  /**
+   * Per-id selection kinds from the most recent repository {@code update} / poll.
+   *
+   * @return unmodifiable map (never null; may be empty)
+   */
+  public Map<String, PSDefinitionSourceKind> getSelectionKindsById() {
+    return selectionKindsById.get();
+  }
+
+  /**
+   * Modern package roots used for dual-run selection (directories that may contain {@code
+   * component-package.json} or nested {@code widgets/&lt;id&gt;/component-package.json}).
+   *
+   * @return unmodifiable list (never null)
+   */
+  public List<Path> getModernPackageRoots() {
+    return modernPackageRoots;
+  }
+
+  /**
+   * Sets modern package roots for dual-run selection (programmatic / tests).
+   *
+   * @param roots package root directories; {@code null} or empty means legacy-only selection
+   */
+  public void setModernPackageRoots(List<Path> roots) {
+    if (roots == null || roots.isEmpty()) {
+      this.modernPackageRoots = List.of();
+      return;
+    }
+    List<Path> normalized = new ArrayList<>(roots.size());
+    for (Path p : roots) {
+      if (p != null) {
+        normalized.add(p.toAbsolutePath().normalize());
+      }
+    }
+    this.modernPackageRoots = List.copyOf(normalized);
+  }
+
+  /**
+   * Spring property: modern package roots as a {@link File#pathSeparator}-separated list of paths
+   * (portable on Windows/Unix). Empty default keeps legacy Widgets-only selection.
+   *
+   * @param rootsProperty path list or blank
+   */
+  @Value("${widgetDao.modernPackageRoots:}")
+  public void setModernPackageRootsProperty(String rootsProperty) {
+    if (rootsProperty == null || rootsProperty.isBlank()) {
+      this.modernPackageRoots = List.of();
+      return;
+    }
+    List<Path> roots = new ArrayList<>();
+    for (String part : rootsProperty.split(File.pathSeparator)) {
+      if (part != null && !part.isBlank()) {
+        roots.add(Path.of(part.trim()).toAbsolutePath().normalize());
+      }
+    }
+    this.modernPackageRoots = List.copyOf(roots);
+  }
+
+  private Path resolveWidgetsDir() {
+    String dir = getRepositoryDirectory();
+    if (dir == null || dir.isBlank()) {
+      return null;
+    }
+    return Path.of(dir).toAbsolutePath().normalize();
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/PSXmlFileDataRepository.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/PSXmlFileDataRepository.java
@@ -17,12 +17,13 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.share.dao;
 
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.stream.Collectors;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,18 +48,17 @@ public abstract class PSXmlFileDataRepository<T, ITEM> extends PSFileDataReposit
 
   protected ITEM fileToObject(PSFileDataRepository.PSFileEntry fileEntry)
       throws IOException, PSXmlFileDataRepositoryException {
-    var data = fileEntry.getInputStream();
     ITEM object;
     try {
       var p = Paths.get(fileEntry.getFileName());
       if (isContainBOM(p)) {
         removeBom(p);
       }
-      var text =
-          new BufferedReader(new InputStreamReader(data)).lines().collect(Collectors.joining("\n"));
-      object = PSSerializerUtils.unmarshal(text.trim(), type);
+      // Portable close: Files.readString (not a leaked FileInputStream). Windows locks open files.
+      var text = Files.readString(p).trim();
+      object = PSSerializerUtils.unmarshal(text, type);
       if (object == null) {
-        log.debug("Unable to process XML {}", data);
+        log.debug("Unable to process XML {}", fileEntry.getFileName());
       }
     } catch (Exception e) {
       throw new PSXmlFileDataRepositoryException(

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/dao/PSWidgetDaoTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/dao/PSWidgetDaoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,207 @@
 
 package com.percussion.pagemanagement.dao;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("stubbed during cleanup")
-public class PSWidgetDaoTest {
+import com.percussion.packages.shim.PSDefinitionSourceKind;
+import com.percussion.packages.shim.PSDefinitionSourceNotFoundException;
+import com.percussion.packages.shim.PSDefinitionSourceSelection;
+import com.percussion.packages.shim.PSLegacyDefinitionXmlShim;
+import com.percussion.pagemanagement.dao.impl.PSWidgetDao;
+import com.percussion.pagemanagement.data.PSWidgetDefinition;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral tests for {@link PSWidgetDao} dual-run modern-first selection (#3024 / parent #2630).
+ *
+ * <p>Policy via {@link PSLegacyDefinitionXmlShim}: modern component package preferred; legacy
+ * Widgets XML fallback; neither → clear {@link PSDefinitionSourceNotFoundException} (no silent
+ * invent). Selection kinds are test-visible on the DAO.
+ */
+class PSWidgetDaoTest {
+
+  private static final String MINIMAL_WIDGET_XML =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Widget>
+        <WidgetPrefs title="Test Widget"
+          contenttype_name="TestWidgetCT"
+          description="Dual-run test widget"
+          author="Intersoft Data Labs" />
+      </Widget>
+      """;
+
+  @TempDir Path tempDir;
+
+  private PSWidgetDao dao;
+  private Path widgetsDir;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    widgetsDir = tempDir.resolve("rxconfig").resolve("Widgets");
+    Files.createDirectories(widgetsDir);
+    dao = new PSWidgetDao();
+    dao.setRepositoryDirectory(widgetsDir.toString());
+  }
+
   @Test
-  @Disabled("placeholder")
-  void placeholder() {}
+  void selectDefinitionSource_prefersModernWhenBothPresent() throws Exception {
+    String id = "percSimpleText";
+    writeWidgetXml(id);
+    Path modernRoot = writeModernPackageRoot(id);
+
+    dao.setModernPackageRoots(List.of(modernRoot));
+
+    PSDefinitionSourceSelection selection = dao.selectDefinitionSource(id);
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, selection.getKind());
+    assertTrue(selection.isModern());
+    assertFalse(selection.isLegacyXml());
+    assertEquals(PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, dao.getLastSelectionKind());
+    assertTrue(selection.getPrimaryPath().isPresent());
+    assertTrue(
+        selection
+            .getPrimaryPath()
+            .orElseThrow()
+            .endsWith(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME));
+  }
+
+  @Test
+  void selectDefinitionSource_fallsBackToLegacyWidgetXmlWhenModernAbsent() throws Exception {
+    String id = "percRawHtml";
+    Path xml = writeWidgetXml(id);
+
+    dao.setModernPackageRoots(List.of());
+
+    PSDefinitionSourceSelection selection = dao.selectDefinitionSource(id);
+    assertEquals(PSDefinitionSourceKind.LEGACY_WIDGET_XML, selection.getKind());
+    assertTrue(selection.isLegacyXml());
+    assertEquals(PSDefinitionSourceKind.LEGACY_WIDGET_XML, dao.getLastSelectionKind());
+    assertEquals(xml.toAbsolutePath().normalize(), selection.getPrimaryPath().orElseThrow());
+  }
+
+  @Test
+  void selectDefinitionSource_neitherThrowsClearError() {
+    dao.setModernPackageRoots(List.of());
+
+    PSDefinitionSourceNotFoundException ex =
+        assertThrows(
+            PSDefinitionSourceNotFoundException.class,
+            () -> dao.selectDefinitionSource("missingWidget"));
+    assertEquals("missingWidget", ex.getDefinitionId());
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("missingWidget"));
+    assertTrue(
+        msg.contains(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME) || msg.contains("modern"));
+    assertTrue(msg.contains("legacy") || msg.contains("XML"));
+  }
+
+  @Test
+  void pollRecordsSelectionKinds_modernWinsOverCoLocatedXml() throws Exception {
+    String id = "percRichText";
+    writeWidgetXml(id);
+    Path modernRoot = writeModernPackageRoot(id);
+    // Dual-ship nested layout also recognized: packageRoot/widgets/<id>/manifest
+    Path multiPkg = tempDir.resolve("perc.baseWidgets");
+    Path nested = multiPkg.resolve("widgets").resolve(id);
+    Files.createDirectories(nested);
+    Files.writeString(
+        nested.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME),
+        "{\"schemaVersion\":\"1.0\",\"id\":\"" + id + "\",\"name\":\"Rich\",\"version\":\"1.0.0\"}",
+        StandardCharsets.UTF_8);
+
+    dao.setModernPackageRoots(List.of(modernRoot, multiPkg));
+    dao.poll();
+
+    PSWidgetDefinition def = dao.find(id);
+    assertNotNull(def);
+    assertEquals(id, def.getId());
+
+    MapAssert.assertKind(
+        dao.getSelectionKindsById(), id, PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE);
+    assertEquals(
+        PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE, dao.getLastSelectionKind());
+  }
+
+  @Test
+  void pollRecordsSelectionKinds_legacyWhenOnlyXml() throws Exception {
+    String id = "customCustomerWidget";
+    writeWidgetXml(id);
+
+    dao.setModernPackageRoots(List.of());
+    dao.poll();
+
+    assertNotNull(dao.find(id));
+    MapAssert.assertKind(
+        dao.getSelectionKindsById(), id, PSDefinitionSourceKind.LEGACY_WIDGET_XML);
+    assertEquals(PSDefinitionSourceKind.LEGACY_WIDGET_XML, dao.getLastSelectionKind());
+  }
+
+  @Test
+  void setModernPackageRootsProperty_usesPathSeparator() throws Exception {
+    String id = "sepWidget";
+    writeWidgetXml(id);
+    Path modernRoot = writeModernPackageRoot(id);
+
+    // Single root via property (pathSeparator list form)
+    dao.setModernPackageRootsProperty(modernRoot.toString());
+    assertEquals(1, dao.getModernPackageRoots().size());
+    assertEquals(
+        modernRoot.toAbsolutePath().normalize(), dao.getModernPackageRoots().get(0));
+
+    assertEquals(
+        PSDefinitionSourceKind.MODERN_COMPONENT_PACKAGE,
+        dao.selectDefinitionSource(id).getKind());
+  }
+
+  @Test
+  void findAll_returnsLoadedWidgets() throws Exception {
+    writeWidgetXml("w1");
+    writeWidgetXml("w2");
+    dao.poll();
+
+    List<PSWidgetDefinition> all = dao.findAll();
+    assertEquals(2, all.size());
+  }
+
+  private Path writeWidgetXml(String id) throws Exception {
+    Path xml = widgetsDir.resolve(id + ".xml");
+    Files.writeString(xml, MINIMAL_WIDGET_XML, StandardCharsets.UTF_8);
+    return xml.toAbsolutePath().normalize();
+  }
+
+  private Path writeModernPackageRoot(String definitionId) throws Exception {
+    Path modernRoot = tempDir.resolve("modern").resolve(definitionId);
+    Files.createDirectories(modernRoot);
+    Files.writeString(
+        modernRoot.resolve(PSLegacyDefinitionXmlShim.MODERN_MANIFEST_FILE_NAME),
+        "{\"schemaVersion\":\"1.0\",\"id\":\""
+            + definitionId
+            + "\",\"name\":\""
+            + definitionId
+            + "\",\"version\":\"1.0.0\"}",
+        StandardCharsets.UTF_8);
+    return modernRoot.toAbsolutePath().normalize();
+  }
+
+  /** Tiny assertion helper to keep test method bodies readable. */
+  private static final class MapAssert {
+    static void assertKind(
+        java.util.Map<String, PSDefinitionSourceKind> map,
+        String id,
+        PSDefinitionSourceKind expected) {
+      assertNotNull(map);
+      assertTrue(map.containsKey(id), "expected selection kind for id " + id + " in " + map);
+      assertEquals(expected, map.get(id));
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Wires production `PSWidgetDao` to **modern-first** dual-run selection via `PSLegacyDefinitionXmlShim` (parent Phase 3 #2630 residual #3024). Keeps the legacy Widgets XML content path and **does not delete** the shim (#2852).

- `PSWidgetDao.selectDefinitionSource(id)` + poll-time classification via `PSLegacyDefinitionXmlShim.selectDefinition`
- Test-visible `getLastSelectionKind()` / `getSelectionKindsById()`
- INFO metrics: `modern=` / `legacyWidgetXml=` / `total=`
- Optional Spring `widgetDao.modernPackageRoots` (`File.pathSeparator` list of package roots)
- Content still loads install Widget XML (materialized wire format); selection kind is MODERN when a modern package root is present
- Companion: close XML file handles in `PSXmlFileDataRepository.fileToObject` (`Files.readString`) so Windows temp dirs unlock after poll
- Docs: dual-run operator doc + Phase 5 criteria M2 snapshot **PARTIAL** after #3024

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2630 · Grandparent: #2626 · Fixes #3024

## Test plan
- [x] Unit tests in `PSWidgetDaoTest`: modern preferred; legacy fallback; neither → clear `PSDefinitionSourceNotFoundException`; poll records kinds
- [x] Standalone `modules/perc-packages` `mvnw clean install` (BUILD SUCCESS)
- [x] Standalone `projects/sitemanage` `mvnw clean install` (BUILD SUCCESS; Tests run: 1027, Failures: 0, Errors: 0, Skipped: 125)

## Product documentation
- [x] N/A — internal dual-run wiring + engineering criteria snapshot; operator dual-run checklist already exists under `docs/ai-generated/...` (no new operator-facing product surface)

## Build evidence (C3)
- **modules_built:** `modules/perc-packages`, `projects/sitemanage`
- **build_evidence:**
  - `cd modules/perc-packages && ../../mvnw.cmd clean install` → BUILD SUCCESS
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1027, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** none (C2 N/A — no `final`/signature break on shared reverse-dep types; sitemanage depends on perc-packages for selection API)

## Out of scope
- Shim deletion (#2852)
- GadgetRegistry hardening (#3025)
- CI inventory G4 (#3026)