### PR TITLE
feat(objectstore): ObjectStoreErrorCodes call-site batch J (cms.objectstore) (#3041)

### DIFF
--- a/system/src/main/java/com/percussion/cms/PSCmsException.java
+++ b/system/src/main/java/com/percussion/cms/PSCmsException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cms;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import java.util.Objects;
 
@@ -32,6 +33,15 @@ public class PSCmsException extends PSException {
    */
   public PSCmsException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSCmsException(IPSErrorCode code) {
+    super(code);
   }
 
   /**
@@ -91,6 +101,17 @@ public class PSCmsException extends PSException {
   }
 
   /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleMessage the sole argument to use as the arguments in the error message, may be
+   *     {@code null}
+   */
+  public PSCmsException(IPSErrorCode code, String singleMessage) {
+    super(code, singleMessage);
+  }
+
+  /**
    * Construct an exception for messages taking multiple arguments.
    *
    * @param msgCode the error string to load
@@ -99,6 +120,17 @@ public class PSCmsException extends PSException {
    */
   public PSCmsException(int msgCode, Object[] arrayArgs) {
     super(msgCode, arrayArgs);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message, may be
+   *     {@code null}
+   */
+  public PSCmsException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**
@@ -111,5 +143,17 @@ public class PSCmsException extends PSException {
    */
   public PSCmsException(int msgCode, Object[] arrayArgs, Throwable cause) {
     super(msgCode, arrayArgs, cause);
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message, may be
+   *     {@code null}
+   * @param cause the underlying cause, may be {@code null}
+   */
+  public PSCmsException(IPSErrorCode code, Object[] arrayArgs, Throwable cause) {
+    super(code, arrayArgs, cause);
   }
 }

--- a/system/src/main/java/com/percussion/cms/handlers/PSConditionalCloneHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSConditionalCloneHandler.java
@@ -26,7 +26,7 @@ import com.percussion.cms.objectstore.server.PSRelationshipProcessor;
 import com.percussion.data.PSDataExtractionException;
 import com.percussion.data.PSExecutionData;
 import com.percussion.data.PSInternalRequestCallException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSObjectException;
 import com.percussion.design.objectstore.PSProcessCheck;
@@ -153,7 +153,7 @@ public class PSConditionalCloneHandler extends PSCloneHandler {
 
         if (!canClone(data)) {
           // the current object does not allow cloning
-          throw new PSObjectException(IPSObjectStoreErrors.OBJECT_CLONING_NOT_ALLOWED, "item");
+          throw new PSObjectException(ObjectStoreErrorCodes.OBJECT_CLONING_NOT_ALLOWED, "item");
         }
 
         /*

--- a/system/src/main/java/com/percussion/cms/handlers/PSContentEditorHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSContentEditorHandler.java
@@ -30,7 +30,7 @@ import com.percussion.data.PSExecutionData;
 import com.percussion.data.PSInternalRequestCallException;
 import com.percussion.data.PSMimeContentResult;
 import com.percussion.design.objectstore.IPSBackEndMapping;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSApplication;
 import com.percussion.design.objectstore.PSApplicationFlow;
@@ -801,7 +801,7 @@ public class PSContentEditorHandler
         if (locator == null) {
           // throw validation error!
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_MISSING_FIELD_ELEMENT,
+              ObjectStoreErrorCodes.CE_MISSING_FIELD_ELEMENT,
               new Object[] {field.getSubmitName(), PSField.DATA_LOCATOR_ELEM});
         }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSAaRelationshipList.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSAaRelationshipList.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSCollectionComponent;
 import com.percussion.design.objectstore.PSRelationship;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -75,11 +75,11 @@ public final class PSAaRelationshipList extends PSCollectionComponent {
   private void fromXmlLoad(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
     }
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSAction.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSAction.java
@@ -17,7 +17,7 @@
 package com.percussion.cms.objectstore;
 
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -243,12 +243,12 @@ public final class PSAction extends PSVersionableDbComponent implements IPSCatal
       int ver = Integer.parseInt(PSComponentUtils.getRequiredAttribute(sourceNode, VERSION_ATTR));
       if (ver < 0) {
         Object[] args = {getNodeNameSafe(), VERSION_ATTR, "negative"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       m_version = ver;
     } catch (NumberFormatException e) {
       Object[] args = {getNodeNameSafe(), VERSION_ATTR, e.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_description = "";

--- a/system/src/main/java/com/percussion/cms/objectstore/PSActiveAssemblerHandlerRequest.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSActiveAssemblerHandlerRequest.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -181,7 +181,7 @@ public final class PSActiveAssemblerHandlerRequest extends PSCmsComponent {
     // make sure we got the correct root node tag
     if (!getNodeName().equals(source.getNodeName())) {
       Object[] args = {getNodeName(), source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(source);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCloneSiteFolderRequest.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCloneSiteFolderRequest.java
@@ -19,7 +19,7 @@ package com.percussion.cms.objectstore;
 import com.percussion.cms.objectstore.ws.PSRemoteFolderProcessor;
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -153,11 +153,11 @@ public final class PSCloneSiteFolderRequest extends PSComponent {
   public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(source);
@@ -165,7 +165,7 @@ public final class PSCloneSiteFolderRequest extends PSComponent {
     Element sourceElem = walker.getNextElement(true);
     if (sourceElem == null) {
       Object[] args = {XML_NODE_NAME, SOURCE_ELEM, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     Node current = walker.getCurrent();
     m_source = new PSLocator(walker.getNextElement(true));
@@ -174,7 +174,7 @@ public final class PSCloneSiteFolderRequest extends PSComponent {
     Element targetElem = walker.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
     if (targetElem == null) {
       Object[] args = {XML_NODE_NAME, TARGET_ELEM, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     current = walker.getCurrent();
     m_target = new PSLocator(walker.getNextElement(true));
@@ -183,7 +183,7 @@ public final class PSCloneSiteFolderRequest extends PSComponent {
     Element optionsElem = walker.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
     if (optionsElem == null) {
       Object[] args = {XML_NODE_NAME, PSCloningOptions.XML_NODE_NAME, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_options = new PSCloningOptions(optionsElem, parent, parentComponents);
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -387,11 +387,11 @@ public final class PSCloningOptions extends PSComponent {
   public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     m_type = toInteger(source.getAttribute(TYPE_ATTR), ms_typeNames, TYPE_ATTR);
@@ -402,7 +402,7 @@ public final class PSCloningOptions extends PSComponent {
     String folderName = source.getAttribute(FOLDER_NAME_ATTR);
     if (folderName == null || folderName.trim().length() == 0) {
       Object[] args = {XML_NODE_NAME, FOLDER_NAME_ATTR, folderName};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_folderName = folderName;
 
@@ -429,7 +429,7 @@ public final class PSCloningOptions extends PSComponent {
           sourceId = Integer.parseInt(src);
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, SOURCEID_ATTR, src};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         int targetId = 0;
@@ -438,7 +438,7 @@ public final class PSCloningOptions extends PSComponent {
           targetId = Integer.parseInt(tgt);
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, TARGETID_ATTR, tgt};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         m_communityMappings.put(Integer.valueOf(sourceId), Integer.valueOf(targetId));
@@ -459,7 +459,7 @@ public final class PSCloningOptions extends PSComponent {
           sourceId = Integer.parseInt(src);
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, SOURCEID_ATTR, src};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         int targetId = 0;
@@ -468,7 +468,7 @@ public final class PSCloningOptions extends PSComponent {
           targetId = Integer.parseInt(tgt);
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, TARGETID_ATTR, tgt};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         m_siteMappings.put(Integer.valueOf(sourceId), Integer.valueOf(targetId));
@@ -552,7 +552,7 @@ public final class PSCloningOptions extends PSComponent {
     }
 
     Object[] args = {XML_NODE_NAME, attrName, value};
-    throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+    throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCmsProperty.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCmsProperty.java
@@ -17,7 +17,7 @@
 package com.percussion.cms.objectstore;
 
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -283,7 +283,7 @@ public abstract class PSCmsProperty extends PSDbComponent {
     if (values.isEmpty()) {
       // Class-derived node name during construction (no virtual getNodeName / this-escape).
       String[] args = {nodeNameFor(getClass()), "Value", "missing node"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // Direct single-value assign — avoid overridable setValues during construction (this-escape).

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cms.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationshipConfig;
@@ -971,7 +972,7 @@ public final class PSComponentSummary extends PSDbComponent implements Serializa
     if (!found) {
       String[] args = {"PSXComponentSummary", XML_ATTR_STATE, strState};
       throw new PSUnknownNodeTypeException(
-          com.percussion.design.objectstore.IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     setState(i - 1);
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSContentType.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSContentType.java
@@ -18,7 +18,7 @@
 package com.percussion.cms.objectstore;
 
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
@@ -254,7 +254,7 @@ public class PSContentType extends PSDbComponent {
     if (!verifyUrlFormat(m_queryRequest)) {
       // Fixed node name for error args (loadFieldsFromXml may run from Element ctor).
       Object[] args = {"PSXContentType", XML_ELEM_QueryRequest, m_queryRequest};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     walker.setCurrent(sourceNode);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCoreItem.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCoreItem.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
@@ -418,7 +418,7 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
         field = (PSItemField) m_fieldNameFieldMap.get(fieldName);
         if (field == null) {
           Object[] args = {name, fieldName, PSItemFieldMeta.ATTR_NAME};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         field.loadXmlData(el);
       } else if (name.equals(PSItemChild.EL_CHILD)) {
@@ -426,7 +426,7 @@ public class PSCoreItem extends PSItemComponent implements IPSItemAccessor {
         child = (PSItemChild) m_childNameChildMap.get(childName);
         if (child == null) {
           Object[] args = {name, childName, PSItemChild.ATTR_NAME};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         child.loadXmlData(el, clearValues);
       } else if (name.equals(EL_RELATED_ITEMS)) {

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.cms.IPSCmsErrors;
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSStringOperation;
 import com.percussion.util.PSXMLDomUtil;
@@ -366,7 +366,7 @@ public abstract class PSDbComponent implements IPSDbComponent {
     }
     if (!found) {
       String[] args = {nodeName, XML_ATTR_STATE, strState};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     setStateInternal(i - 1);
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDependent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDependent.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSPropertySet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -190,7 +190,7 @@ public final class PSDependent extends PSCmsComponent {
     // make sure we got the correct root node tag
     if (!getNodeName().equals(source.getNodeName())) {
       Object[] args = {getNodeName(), source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(source);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDependentSet.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDependentSet.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSCollectionComponent;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -57,11 +57,11 @@ public final class PSDependentSet extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, getNodeName());
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, getNodeName());
 
     if (!getNodeName().equals(sourceNode.getNodeName())) {
       Object[] args = {getNodeName(), sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
@@ -17,7 +17,7 @@
 package com.percussion.cms.objectstore;
 
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -747,7 +747,7 @@ public final class PSDisplayFormat extends PSVersionableDbComponent
       setVersion(Integer.parseInt(tree.getElementData(elVersion)));
     } catch (NumberFormatException ex) {
       Object[] args = {getNodeName(), XML_NODE_VERSION, ex.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // optional

--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolderAcl.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolderAcl.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cms.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -136,7 +136,7 @@ public class PSFolderAcl extends PSObjectAcl {
       return Integer.parseInt(temp);
     } catch (Exception ex) {
       Object[] args = {src.getNodeName(), attrName, temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemChildEntry.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemChildEntry.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cms.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.services.guidmgr.data.PSLegacyGuid;
@@ -313,7 +313,7 @@ public class PSItemChildEntry extends PSItemComponent implements IPSItemAccessor
       field = (PSItemField) m_fieldNameFieldMap.get(attrName);
       if (field == null) {
         Object[] args = {PSItemFieldMeta.EL_FIELD_META, attrName, PSItemFieldMeta.ATTR_NAME};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       field.loadXmlData(el);
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefSummary.java
@@ -19,7 +19,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -296,7 +296,7 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     final String nodeName = getNodeName();
     if (false == nodeName.equals(source.getNodeName())) {
       Object[] args = {nodeName, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(source);
@@ -305,7 +305,7 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     temp = walker.getElementData(attrName);
     if (null == temp || temp.trim().length() == 0) {
       Object[] args = {nodeName, attrName, temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else m_name = temp;
 
     attrName = "label";
@@ -320,13 +320,13 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     temp = walker.getElementData(attrName);
     if (null == temp || temp.trim().length() == 0) {
       Object[] args = {nodeName, attrName, temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else {
       try {
         m_typeId = Integer.parseInt(temp);
       } catch (NumberFormatException nfe) {
         Object[] args = {nodeName, attrName, temp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
 
@@ -342,7 +342,7 @@ public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummar
     temp = walker.getElementData(attrName);
     if (null == temp || temp.trim().length() == 0) {
       Object[] args = {nodeName, attrName, temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else m_editorUrl = temp;
 
     String desc = walker.getElementData("Description");

--- a/system/src/main/java/com/percussion/cms/objectstore/PSObjectAclEntry.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSObjectAclEntry.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cms.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -320,7 +320,7 @@ public final class PSObjectAclEntry extends PSDbComponent {
       m_type = Integer.parseInt(temp);
     } catch (Exception ex) {
       Object[] args = {XML_NODE_NAME, XML_ATTR_TYPE, temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     validateType(m_type);
@@ -331,7 +331,7 @@ public final class PSObjectAclEntry extends PSDbComponent {
       m_permissions = Integer.parseInt(temp);
     } catch (Exception ex) {
       Object[] args = {XML_NODE_NAME, XML_ATTR_PERMISSIONS, temp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // child elements
@@ -340,7 +340,7 @@ public final class PSObjectAclEntry extends PSDbComponent {
     temp = PSXmlTreeWalker.getElementData(el);
     if ((temp == null) || (temp.trim().length() < 1)) {
       Object[] args = {el.getTagName(), "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_name = temp.trim();
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSProcessorProxy.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSProcessorProxy.java
@@ -18,7 +18,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.cms.IPSCmsErrors;
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -149,7 +149,7 @@ public abstract class PSProcessorProxy {
       if (null == root || !root.getNodeName().equals(rootName)) {
         // use error codes for PSUnknownDocTypeException
         String[] args = {rootName, root.getNodeName()};
-        throw new PSCmsException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSCmsException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       ProcessorConfig pc = null;

--- a/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipInfo.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSRelationshipInfo.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cms.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -141,11 +141,11 @@ public final class PSRelationshipInfo implements IPSCmsComponent {
   // See IPSCmsComponent interface
   public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     int firstFlags =
@@ -159,19 +159,19 @@ public final class PSRelationshipInfo implements IPSCmsComponent {
     m_name = tree.getElementData(NAME_ATTR);
     if (m_name == null || m_name.trim().length() == 0) {
       Object[] args = {XML_NODE_NAME, NAME_ATTR, "null or empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_label = tree.getElementData(LABEL_ATTR);
     if (m_label == null || m_label.trim().length() == 0) {
       Object[] args = {XML_NODE_NAME, LABEL_ATTR, "null or empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_category = tree.getElementData(CATEGORY_ATTR);
     if (m_category == null || m_category.trim().length() == 0) {
       Object[] args = {XML_NODE_NAME, CATEGORY_ATTR, "null or empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // OPTIONAL: Description element

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSaveResults.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSaveResults.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cms.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -131,7 +131,7 @@ public final class PSSaveResults implements IPSCmsComponent {
     Element stats = w.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (null == stats) {
       String[] args = {getNodeName(), PSProcessingStatistics.XML_NODE_NAME, "missing node"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_stats = new PSProcessingStatistics(stats);
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
@@ -17,7 +17,7 @@
 package com.percussion.cms.objectstore;
 
 import com.percussion.cms.PSCmsException;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -395,7 +395,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
 
     if (elDis == null) {
       Object[] args = {getNodeName(), XML_NODE_DISPLAYNAME, "missing"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_strDisplayName = PSXmlTreeWalker.getElementData(elDis);
@@ -405,7 +405,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
 
     if (elInternal == null) {
       Object[] args = {getNodeName(), XML_NODE_INTERNALNAME, "missing"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_strInternalName = PSXmlTreeWalker.getElementData(elInternal);
@@ -415,7 +415,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
 
     if (elParentCat == null) {
       Object[] args = {getNodeName(), XML_NODE_PARENTCATEGORY, "missing"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     try {
@@ -423,7 +423,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
       setParentCategory(Integer.parseInt(strVal), false);
     } catch (NumberFormatException ex) {
       Object[] args = {getNodeName(), XML_NODE_PARENTCATEGORY, ex.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     Element elDisplayFormat = tree.getNextElement(XML_NODE_DF);
@@ -431,7 +431,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
 
     if (elDisplayFormat == null) {
       Object[] args = {getNodeName(), XML_NODE_DF, "missing"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_strDisplayId = PSXmlTreeWalker.getElementData(elDisplayFormat);
@@ -487,7 +487,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
 
     if (elVersion == null) {
       Object[] args = {getNodeName(), XML_NODE_VERSION, "missing"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     try {
@@ -495,7 +495,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
       setVersion(Integer.parseInt(strVal));
     } catch (NumberFormatException ex) {
       Object[] args = {getNodeName(), XML_NODE_VERSION, ex.getLocalizedMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // Load the columns (optional)
@@ -508,7 +508,7 @@ public final class PSSearch extends PSVersionableDbComponent implements IPSCatal
         m_fields = new PSSFields();
       } catch (PSCmsException ex) {
         Object[] args = {getNodeName(), PSSFields.XML_NODE_NAME, ex.getLocalizedMessage()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearchField.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearchField.java
@@ -20,7 +20,7 @@ package com.percussion.cms.objectstore;
 
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.PSDisplayChoices;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSStringOperation;
 import com.percussion.util.PSXMLDomUtil;
@@ -186,13 +186,13 @@ public final class PSSearchField extends PSDbComponent implements IPSSequencedCo
     tree.setCurrent(e);
     if (elOp == null) {
       Object[] args = {nodeName, XML_NODE_OPERATOR, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     String op = PSXmlTreeWalker.getElementData(elOp);
     if (!isValidOperator(op)) {
       Object[] args = {nodeName, XML_NODE_OPERATOR, op};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // this one is optional for backward compatibility
@@ -204,21 +204,21 @@ public final class PSSearchField extends PSDbComponent implements IPSSequencedCo
     tree.setCurrent(e);
     if (elFieldType == null) {
       Object[] args = {nodeName, XML_NODE_FIELDTYPE, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_strFieldType = PSXmlTreeWalker.getElementData(elFieldType);
 
     if (!isValidFieldType(m_strFieldType)) {
       Object[] args = {nodeName, XML_NODE_FIELDTYPE, m_strFieldType};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     Element elFieldLabel = tree.getNextElement(XML_NODE_FIELDLABEL);
     tree.setCurrent(e);
     if (elFieldLabel == null) {
       Object[] args = {nodeName, XML_NODE_FIELDLABEL, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_strDisplayName = PSXmlTreeWalker.getElementData(elFieldLabel);

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSecurityProviderInstanceSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSecurityProviderInstanceSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.cms.objectstore;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSSecurityProviderInstance;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.security.PSSecurityProvider;
@@ -120,7 +120,7 @@ public final class PSSecurityProviderInstanceSummary implements IPSCmsComponent 
     NodeList nodes = src.getElementsByTagName(XML_ELEMENT_NAME);
     if (null == nodes) {
       String[] array = {"PSSecurityProviderInstanceSummary.fromXml node: " + XML_ELEMENT_NAME};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, array);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, array);
     }
     m_instance = ((Text) nodes.item(0).getFirstChild()).getData();
   }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
@@ -19,7 +19,7 @@ package com.percussion.cms.objectstore;
 import com.percussion.cms.PSCmsException;
 import com.percussion.design.objectstore.IPSComponent;
 import com.percussion.design.objectstore.IPSDocument;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSComponent;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSException;
@@ -135,11 +135,11 @@ public final class PSSite extends PSComponent {
   public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     super.fromXml(source);
@@ -147,7 +147,7 @@ public final class PSSite extends PSComponent {
     m_name = source.getAttribute(NAME_ATTR);
     if (m_name == null || m_name.trim().length() == 0) {
       Object[] args = {XML_NODE_NAME, NAME_ATTR, m_name};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     // FB: RV_RETURN_VALUE_IGNORED NC 1-17-16
     m_name = m_name.trim();
@@ -174,7 +174,7 @@ public final class PSSite extends PSComponent {
     }
     if (!isValid(test, VALID_STATES)) {
       Object[] args = {XML_NODE_NAME, STATE_ATTR, m_state};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_folderRoot = source.getAttribute(FOLDERROOT_ATTR);

--- a/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteProcessor.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteProcessor.java
@@ -20,7 +20,7 @@ import com.percussion.cms.IPSCmsErrors;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSProcessingStatistics;
 import com.percussion.cms.objectstore.PSProcessorCommon;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.system.utils.PSUrlUtils;
 import com.percussion.util.IPSRemoteRequester;
@@ -138,7 +138,7 @@ public class PSRemoteProcessor extends PSProcessorCommon {
       Map<String, Object> params = toRequestParams(ids);
       Document doc = m_conn.getDocument(resourceName, params);
       if (null == doc || null == doc.getDocumentElement()) {
-        throw new PSCmsException(IPSObjectStoreErrors.XML_ELEMENT_NULL, "PSXExecStatistics");
+        throw new PSCmsException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "PSXExecStatistics");
       }
 
       PSProcessingStatistics stats = new PSProcessingStatistics(root);
@@ -171,7 +171,7 @@ public class PSRemoteProcessor extends PSProcessorCommon {
       Document doc = m_conn.getDocument("sys_psxCms/idgen.xml", params);
       String nodeName = "PSXIdGenerator";
       if (null == doc || null == doc.getDocumentElement()) {
-        throw new PSCmsException(IPSObjectStoreErrors.XML_ELEMENT_NULL, nodeName);
+        throw new PSCmsException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, nodeName);
       }
 
       Element root = doc.getDocumentElement();

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSLocalCataloger.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSLocalCataloger.java
@@ -28,7 +28,7 @@ import com.percussion.cms.objectstore.PSRelationshipInfo;
 import com.percussion.cms.objectstore.PSRelationshipInfoSet;
 import com.percussion.data.PSDataExtractionException;
 import com.percussion.data.PSExecutionData;
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSChoices;
 import com.percussion.design.objectstore.PSContentEditorMapper;
 import com.percussion.design.objectstore.PSContentEditorPipe;
@@ -683,7 +683,7 @@ public class PSLocalCataloger implements IPSCataloger {
 
           String msg =
               PSErrorManager.createMessage(
-                  IPSObjectStoreErrors.INVALID_CE_FIELD_CHOICES_ERROR, args);
+                  ObjectStoreErrorCodes.INVALID_CE_FIELD_CHOICES_ERROR.numericCode(), args);
 
           // log it
           PSServerLogHandler.logException(msg, e);

--- a/system/src/main/java/com/percussion/design/objectstore/PSObjectException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSObjectException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.design.objectstore;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -36,6 +37,16 @@ public class PSObjectException extends PSException {
   }
 
   /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSObjectException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
    * Pass-through constructor to super class.
    *
    * @see PSException#PSException(int,Object[])
@@ -45,11 +56,30 @@ public class PSObjectException extends PSException {
   }
 
   /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSObjectException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
    * Pass-through constructor to super class.
    *
    * @see PSException#PSException(int)
    */
   public PSObjectException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSObjectException(IPSErrorCode code) {
+    super(code);
   }
 }

--- a/system/src/test/java/com/percussion/cms/objectstore/PSCmsObjectstoreTypedErrorCodeTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSCmsObjectstoreTypedErrorCodeTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.cms.PSCmsException;
+import com.percussion.design.objectstore.PSObjectException;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Batch J: cms.objectstore residual call sites must throw typed {@link ObjectStoreErrorCodes} (not
+ * bare {@code IPSObjectStoreErrors} ints). Samples cover null/wrong-type/invalid-attr paths and
+ * typed exception constructors added for this cohort.
+ */
+public class PSCmsObjectstoreTypedErrorCodeTest {
+
+  @Test
+  public void aaRelationshipListNullUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSAaRelationshipList(null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void aaRelationshipListWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotAaList");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSAaRelationshipList(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void siteWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotSite");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSSite(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void siteMissingNameUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element site = PSXmlDocumentBuilder.createRoot(doc, PSSite.XML_NODE_NAME);
+    // id required by PSDbComponent.fromXml before PSSite validates name
+    site.setAttribute("id", "1");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSSite(site, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void relationshipInfoWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotRelInfo");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSRelationshipInfo(wrong));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void relationshipInfoMissingNameUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty = PSXmlDocumentBuilder.createRoot(doc, PSRelationshipInfo.XML_NODE_NAME);
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSRelationshipInfo(empty));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void dependentSetNullUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSDependentSet(null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void cloneSiteFolderRequestWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotCloneReq");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSCloneSiteFolderRequest(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void cloneSiteFolderRequestEmptyUsesTypedInvalidChild() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty =
+        PSXmlDocumentBuilder.createRoot(doc, PSCloneSiteFolderRequest.XML_NODE_NAME);
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSCloneSiteFolderRequest(empty, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void cmsExceptionTypedCtorRetainsCode() {
+    PSCmsException ex =
+        new PSCmsException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "PSXExecStatistics");
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void objectExceptionTypedCtorRetainsCode() {
+    PSObjectException ex =
+        new PSObjectException(ObjectStoreErrorCodes.OBJECT_CLONING_NOT_ALLOWED, "item");
+    assertEquals(
+        ObjectStoreErrorCodes.OBJECT_CLONING_NOT_ALLOWED.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.OBJECT_CLONING_NOT_ALLOWED, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}


### PR DESCRIPTION
## Summary
ObjectStoreErrorCodes **call-site batch J** (Parent [#2616](https://github.com/intersoftdatalabs-in/percussioncms/issues/2616), Fixes [#3041](https://github.com/intersoftdatalabs-in/percussioncms/issues/3041)).

Migrate residual `com.percussion.cms.objectstore*` (and adjacent cms handlers using ObjectStore XML/validation codes) from raw `IPSObjectStoreErrors` ints to typed `ObjectStoreErrorCodes` construction, matching peer batches F/G/H.

### Changes
- **28 production files** under `system/.../cms` — zero remaining `IPSObjectStoreErrors` residuals in that tree
- Typed `IPSErrorCode` constructors on `PSCmsException` and `PSObjectException` (needed for this cohort's `PSCmsException` / `PSObjectException` throw sites)
- `PSLocalCataloger` message path uses `ObjectStoreErrorCodes.….numericCode()` (createMessage still int-based)
- New behavioral unit tests: `PSCmsObjectstoreTypedErrorCodeTest` (11 cases — null/wrong-type/invalid-attr/invalid-child + typed exception ctors)

### Out of scope
- Full `design.objectstore` residual (batch I / #3040)

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1849**, Failures: **0**, Errors: **0**, Skipped: 241
- [x] New tests: `PSCmsObjectstoreTypedErrorCodeTest` — 11/11 green
- [x] Residual grep: zero `IPSObjectStoreErrors` under `system/src/main/java/com/percussion/cms`

## Product documentation
- [x] N/A — pure tech-debt refactor (typed error-code call sites); no operator/UI/REST/install behavior change

## Pre-PR Maven verification (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1849, Failures: 0, Errors: 0, Skipped: 241
- **downstream_checked:** none — additive typed ctor overloads only (no final/sealed, no existing signature changes)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3041
Parent: #2616

> Co-Authored by Grok Build using grok-4.5 with agent main.
