### PR TITLE
feat(objectstore): ObjectStoreErrorCodes call-site batch I (design.objectstore A-C) (#3040)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSAbstractParamValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAbstractParamValue.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -201,11 +203,11 @@ public abstract class PSAbstractParamValue extends PSComponent implements IPSPar
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, getNodeName());
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, getNodeName());
 
       if (false == getNodeName().equals(sourceNode.getNodeName())) {
         Object[] args = {getNodeName(), sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       String sTemp = sourceNode.getAttribute(ATTR_ID);
@@ -213,7 +215,7 @@ public abstract class PSAbstractParamValue extends PSComponent implements IPSPar
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {getNodeName(), ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -226,7 +228,7 @@ public abstract class PSAbstractParamValue extends PSComponent implements IPSPar
         if (node == null) {
           Object[] args = {getNodeName(), EL_VALUE, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
 
         // now figure out which type it is

--- a/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -415,12 +417,12 @@ public class PSAcl extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       // make sure we got the ACL type node
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -431,7 +433,7 @@ public class PSAcl extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // read ACL Entries. Make the m_entries empty before reading into it

--- a/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -521,13 +523,13 @@ public class PSAclEntry extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
     }
 
     // make sure we got the ACL type node
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -537,20 +539,20 @@ public class PSAclEntry extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // get the ACLEntry type element from attribute
     sTemp = tree.getElementData("type");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "type", "empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else if (sTemp.equals(XML_FLAG_TYPE_USER)) m_type = ACE_TYPE_USER;
     else if (sTemp.equals(XML_FLAG_TYPE_GROUP)) m_type = ACE_TYPE_GROUP;
     else if (sTemp.equals(XML_FLAG_TYPE_ROLE)) m_type = ACE_TYPE_ROLE;
     else {
       Object[] args = {ms_NodeType, "type", sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // Read name element of the ACLEntry
@@ -635,7 +637,7 @@ public class PSAclEntry extends PSComponent {
 
     if (m_id < 0) {
       Object[] args = {ms_NodeType, "" + m_id};
-      cxt.validationWarning(this, IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      cxt.validationWarning(this, ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID.numericCode(), args);
     }
 
     // validate that only server access level flags are set if this is a

--- a/system/src/main/java/com/percussion/design/objectstore/PSActionLink.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSActionLink.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -187,11 +189,11 @@ public class PSActionLink extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -218,7 +220,7 @@ public class PSActionLink extends PSComponent {
       node = tree.getNextElement(PSDisplayText.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSDisplayText.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else m_displayText = new PSDisplayText(node, parentDoc, parentComponents);
 
       // OPTIONAL: get the parameters
@@ -258,7 +260,7 @@ public class PSActionLink extends PSComponent {
     context.pushParent(this);
     try {
       if (m_displayText != null) ((IPSComponent) m_displayText).validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_ACTION_LINK, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_ACTION_LINK, null);
     } finally {
       context.popParent();
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSActionLinkList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSActionLinkList.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -125,11 +127,11 @@ public class PSActionLinkList extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplication.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplication.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.legacy.IPSComponentConverter;
 import com.percussion.error.PSException;
 import com.percussion.extension.PSExtensionRef;
@@ -1740,16 +1742,16 @@ public final class PSApplication implements IPSDocument {
   private void fromXmlBase(Document sourceDoc)
       throws PSUnknownDocTypeException, PSUnknownNodeTypeException {
     if (null == sourceDoc)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     Element root = sourceDoc.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the correct root node tag
     if (!ms_NodeType.equals(root.getNodeName())) {
       Object[] args = {ms_NodeType, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // Read PSXApplication object attributes
@@ -1771,7 +1773,7 @@ public final class PSApplication implements IPSDocument {
       } catch (Exception e) {
         Object[] args = {"1.0", "1.1", e.toString()};
         throw new PSUnknownDocTypeException(
-            IPSObjectStoreErrors.DOC_CONVERSION_FAILED
+            ObjectStoreErrorCodes.DOC_CONVERSION_FAILED
             /*code*/
             ,
             args);
@@ -1783,7 +1785,7 @@ public final class PSApplication implements IPSDocument {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData(ATTR_APPLICATION_TYPE);
@@ -1807,7 +1809,7 @@ public final class PSApplication implements IPSDocument {
       if (null != sTemp) m_startPriority = Integer.parseInt(sTemp);
     } catch (NumberFormatException e) {
       Object[] args = {ms_NodeType + "/@" + STARTPRIORITY_ATTRNAME, sTemp};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // get application name element
@@ -1881,7 +1883,7 @@ public final class PSApplication implements IPSDocument {
         m_maxThreads = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "maxThreads", sTemp};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -1893,7 +1895,7 @@ public final class PSApplication implements IPSDocument {
         m_maxRequestTime = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "maxRequestTime", sTemp};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -1905,7 +1907,7 @@ public final class PSApplication implements IPSDocument {
         m_maxRequestsInQueue = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "maxRequestsInQueue", sTemp};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -1921,7 +1923,7 @@ public final class PSApplication implements IPSDocument {
         m_sessionTimeout = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "userSessionTimeout", sTemp};
-        throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
 
@@ -2018,7 +2020,7 @@ public final class PSApplication implements IPSDocument {
         // warn that custom login page is ignored
         PSConsole.printInfoMsg(
             "Server",
-            IPSObjectStoreErrors.APP_LOGIN_PAGE_NOT_SUPPORTED,
+            ObjectStoreErrorCodes.APP_LOGIN_PAGE_NOT_SUPPORTED.numericCode(),
             new Object[] {m_name},
             Level.INFO);
       }
@@ -2033,7 +2035,7 @@ public final class PSApplication implements IPSDocument {
     // Check for old backend credentials declaration
     if (tree.getNextElement(PSBackEndCredential.ms_NodeType, walkerFlags) != null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.APP_BACKEND_CREDS_NOT_SUPPORTED, m_name);
+          ObjectStoreErrorCodes.APP_BACKEND_CREDS_NOT_SUPPORTED, m_name);
     }
 
     // are logins allowed to pass through to the back end?
@@ -2053,7 +2055,7 @@ public final class PSApplication implements IPSDocument {
       } while (tree.getNextElement("PSXRole", walkerFlags) != null);
 
       Object[] args = {roleNames};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.APP_ROLES_NOT_SUPPORTED, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.APP_ROLES_NOT_SUPPORTED, args);
     }
 
     // create PSNotifier elements
@@ -2200,7 +2202,7 @@ public final class PSApplication implements IPSDocument {
     if (m_dataSets != null) {
       if (m_dataSets.size() == 0) {
         // no data sets; the app won't do anything useful
-        cxt.validationWarning(null, IPSObjectStoreErrors.APP_NO_DATASETS, m_name);
+        cxt.validationWarning(null, ObjectStoreErrorCodes.APP_NO_DATASETS.numericCode(), m_name);
       }
 
       // to keep track of possible request page duplicates
@@ -2225,7 +2227,7 @@ public final class PSApplication implements IPSDocument {
           // Error
           Object[] args = new Object[] {set.getRequestor().getRequestPage(), m_name};
 
-          cxt.validationError(null, IPSObjectStoreErrors.REQUEST_NAME_DUP, args);
+          cxt.validationError(null, ObjectStoreErrorCodes.REQUEST_NAME_DUP, args);
         } else {
           requestKeys.add(key);
         }
@@ -2233,12 +2235,12 @@ public final class PSApplication implements IPSDocument {
         if (null != dsNames.get(dsName)) {
           Object[] args = new Object[] {m_name, dsName};
 
-          cxt.validationError(null, IPSObjectStoreErrors.APP_DATASET_NAMES_DUP, args);
+          cxt.validationError(null, ObjectStoreErrorCodes.APP_DATASET_NAMES_DUP, args);
         } else dsNames.put(dsName, dsName);
       }
     } else {
       // no data sets; the app won't do anything useful
-      cxt.validationWarning(null, IPSObjectStoreErrors.APP_NO_DATASETS, m_name);
+      cxt.validationWarning(null, ObjectStoreErrorCodes.APP_NO_DATASETS.numericCode(), m_name);
     }
 
     if (m_logger != null) m_logger.validate(cxt);

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplicationFlow.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.HashMap;
@@ -320,11 +322,11 @@ public final class PSApplicationFlow extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -347,7 +349,7 @@ public final class PSApplicationFlow extends PSComponent {
       node = tree.getNextElement(COMMAND_HANDLER_ELEM, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, COMMAND_HANDLER_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (node != null) {
         Node current = tree.getCurrent();
@@ -355,7 +357,7 @@ public final class PSApplicationFlow extends PSComponent {
         String name = node.getAttribute(COMMAND_HANDLER_NAME_ATTR);
         if (name == null || name.trim().length() == 0) {
           Object[] args = {COMMAND_HANDLER_ELEM, COMMAND_HANDLER_NAME_ATTR, "null"};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         // OPTIONAL: get all conditional redirects
@@ -372,7 +374,7 @@ public final class PSApplicationFlow extends PSComponent {
         if (node == null) {
           Object[] args = {XML_NODE_NAME, PSUrlRequest.XML_NODE_NAME, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         PSUrlRequest redirect = new PSUrlRequest(node, parentDoc, parentComponents);
 
@@ -435,7 +437,7 @@ public final class PSApplicationFlow extends PSComponent {
         Iterator it = getRedirects((String) names.next());
         if (!it.hasNext()) {
           context.validationError(
-              this, IPSObjectStoreErrors.INVALID_COMMAND_HANDLER_REDIRECTS, null);
+              this, ObjectStoreErrorCodes.INVALID_COMMAND_HANDLER_REDIRECTS, null);
         }
         while (it.hasNext()) ((PSConditionalRequest) it.next()).validate(context);
       }

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplyWhen.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplyWhen.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -98,11 +100,11 @@ public class PSApplyWhen extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttribute.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.server.PSDatabaseComponentLoader;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -292,13 +294,13 @@ public class PSAttribute extends PSDatabaseComponentCollection {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
     }
 
     // make sure we got the Attribute type node
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -308,7 +310,7 @@ public class PSAttribute extends PSDatabaseComponentCollection {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ID_ATTR, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // Restore our db state
@@ -319,7 +321,7 @@ public class PSAttribute extends PSDatabaseComponentCollection {
       setName(sTemp);
     } catch (IllegalArgumentException e) {
       Object[] args = {ms_NodeType, NAME_ATTR, (sTemp == null) ? "null" : sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // just delegate to our collection to get the values

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttributeList.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -190,11 +192,11 @@ public class PSAttributeList extends PSDatabaseComponentCollection implements IP
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // just delegate to our collection

--- a/system/src/main/java/com/percussion/design/objectstore/PSAttributeValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAttributeValue.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -179,13 +181,13 @@ public class PSAttributeValue extends PSDatabaseComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
     }
 
     // make sure we got the AttributeValue type node
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -195,7 +197,7 @@ public class PSAttributeValue extends PSDatabaseComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     getComponentState(sourceNode);
@@ -204,7 +206,7 @@ public class PSAttributeValue extends PSDatabaseComponent {
     String value = tree.getElementData(XML_VALUE_ELEMENT);
     if (value == null) {
       Object[] args = {ms_NodeType, XML_VALUE_ELEMENT, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } else m_value = value;
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.legacy.security.deprecated.PSCryptographer;
 import com.percussion.legacy.security.deprecated.PSLegacyEncrypter;
 import com.percussion.security.PSEncryptionException;
@@ -349,11 +351,11 @@ public final class PSAuthentication extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -366,7 +368,7 @@ public final class PSAuthentication extends PSComponent {
     Element credentials = tree.getNextElement(XML_ELEM_CREDENTIALS);
     if (credentials == null) {
       Object[] args = {XML_ELEM_CREDENTIALS, null};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     String data = tree.getElementData(XML_ELEM_USER, false);
@@ -375,7 +377,7 @@ public final class PSAuthentication extends PSComponent {
     Element user = tree.getNextElement(XML_ELEM_USER);
     if (user == null) {
       Object[] args = {XML_ELEM_USER, null};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     String appendBaseDn = tree.getElementData(XML_ATTR_APPENDBASEDN, false);
     if (appendBaseDn != null) setAppendBaseDn(appendBaseDn.equalsIgnoreCase(XML_ATTRVALUE_YES));
@@ -386,7 +388,7 @@ public final class PSAuthentication extends PSComponent {
     Element password = tree.getNextElement(XML_ELEM_PASSWORD);
     if (password == null) {
       Object[] args = {XML_ELEM_PASSWORD, null};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     String encryptedValue = tree.getElementData(XML_ATTR_ENCRYPTED, false);

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -452,12 +454,12 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
   private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the ACL type node
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -467,7 +469,7 @@ public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, I
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     String tableAlias = tree.getElementData("tableAlias");

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndConnection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndConnection.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -437,11 +439,11 @@ public class PSBackEndConnection extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -451,14 +453,14 @@ public class PSBackEndConnection extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // get the driver name
       sTemp = tree.getElementData("jdbcDriverName");
       if ((sTemp == null) || (sTemp.length() == 0)) {
         Object[] args = {ms_NodeType, "jdbcDriverName", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_jdbcDriverName = sTemp;
 
@@ -466,7 +468,7 @@ public class PSBackEndConnection extends PSComponent {
       sTemp = tree.getElementData("jdbcClassName");
       if ((sTemp == null) || (sTemp.length() == 0)) {
         Object[] args = {ms_NodeType, "jdbcClassName", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_jdbcClassName = sTemp;
 
@@ -484,7 +486,7 @@ public class PSBackEndConnection extends PSComponent {
         m_connMin = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "connectionMin", ((sTemp == null) ? "" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // read max connection count
@@ -493,7 +495,7 @@ public class PSBackEndConnection extends PSComponent {
         m_connMax = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "connectionMax", ((sTemp == null) ? "" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // read idle connection timeout (in seconds)
@@ -502,7 +504,7 @@ public class PSBackEndConnection extends PSComponent {
         m_idleTimeoutSeconds = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "connectionIdleTimeout", ((sTemp == null) ? "" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // read refresh period (in seconds) -- optional
@@ -512,7 +514,7 @@ public class PSBackEndConnection extends PSComponent {
           setRefreshPeriodSeconds(Integer.parseInt(sTemp));
         } catch (Exception e) {
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD,
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD,
               new Object[] {ms_NodeType, "connectionRefreshPeriod", sTemp});
         }
     } finally {
@@ -554,7 +556,7 @@ public class PSBackEndConnection extends PSComponent {
       Class.forName(m_jdbcClassName);
     } catch (Exception e) {
       Object[] args = new Object[] {m_jdbcClassName, e.toString()};
-      cxt.validationError(this, IPSObjectStoreErrors.JDBC_DRIVER_CLASS_LOAD_ERROR, args);
+      cxt.validationError(this, ObjectStoreErrorCodes.JDBC_DRIVER_CLASS_LOAD_ERROR, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.jdbc.IPSConnectionInfo;
@@ -319,11 +321,11 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -333,7 +335,7 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // read Alias name
@@ -355,7 +357,7 @@ public class PSBackEndCredential extends PSComponent implements IPSConnectionInf
     try { // private      String          m_dataSource;
       Element dsEl = tree.getNextElement("datasource", tree.GET_NEXT_ALLOW_CHILDREN);
       if (dsEl == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, "datasource");
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "datasource");
       setDataSource(tree.getElementData(dsEl));
     } catch (IllegalArgumentException e) {
       // Ignore

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -363,11 +365,11 @@ public final class PSBackEndDataTank extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -377,7 +379,7 @@ public final class PSBackEndDataTank extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // Get the PSXBackEndTables, parent of back end tables collection
@@ -449,7 +451,7 @@ public final class PSBackEndDataTank extends PSComponent {
     int tabSize = (m_tables == null) ? 0 : m_tables.size();
 
     // validate the tables
-    if (tabSize == 0) cxt.validationError(this, IPSObjectStoreErrors.BE_TABLE_NULL, null);
+    if (tabSize == 0) cxt.validationError(this, ObjectStoreErrorCodes.BE_TABLE_NULL, null);
     else {
       cxt.pushParent(this);
       try {

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndJoin.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndJoin.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -393,7 +395,7 @@ public class PSBackEndJoin extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       sTemp = tree.getElementData("joinType");
@@ -412,7 +414,7 @@ public class PSBackEndJoin extends PSComponent {
       // left column, private PSBackEndColumn m_leftColumn = null;
       if (tree.getNextElement("leftColumn", firstFlags) == null) {
         Object[] args = {ms_NodeType, "leftColumn", "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else {
         /* need a new tree rooted on the leftColumn so we don't jump to
          * the right column's data accidentally
@@ -421,7 +423,7 @@ public class PSBackEndJoin extends PSComponent {
         if (t2.getNextElement(PSBackEndColumn.ms_NodeType, firstFlags) == null) {
           Object[] args = {ms_NodeType + "/leftColumn", PSBackEndColumn.ms_NodeType, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
 
         m_leftColumn = new PSBackEndColumn((Element) t2.getCurrent(), parentDoc, parentComponents);
@@ -432,7 +434,7 @@ public class PSBackEndJoin extends PSComponent {
       // right column private PSBackEndColumn m_rightColumn = null;
       if (tree.getNextElement("rightColumn", firstFlags) == null) {
         Object[] args = {ms_NodeType, "rightColumn", "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else {
         /* need a new tree rooted on the rightColumn so we don't jump to
          * the some other data accidentally
@@ -441,7 +443,7 @@ public class PSBackEndJoin extends PSComponent {
         if (t2.getNextElement(PSBackEndColumn.ms_NodeType, firstFlags) == null) {
           Object[] args = {ms_NodeType + "/rightColumn", PSBackEndColumn.ms_NodeType, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_rightColumn = new PSBackEndColumn((Element) t2.getCurrent(), parentDoc, parentComponents);
       }
@@ -489,14 +491,14 @@ public class PSBackEndJoin extends PSComponent {
         // ok
         break;
       default:
-        cxt.validationError(this, IPSObjectStoreErrors.BE_JOIN_UNKNOWN_TYPE, "" + m_joinType);
+        cxt.validationError(this, ObjectStoreErrorCodes.BE_JOIN_UNKNOWN_TYPE, "" + m_joinType);
     }
 
     if (m_leftColumn == null)
-      cxt.validationError(this, IPSObjectStoreErrors.BE_JOIN_LCOL_NULL, null);
+      cxt.validationError(this, ObjectStoreErrorCodes.BE_JOIN_LCOL_NULL, null);
 
     if (m_rightColumn == null)
-      cxt.validationError(this, IPSObjectStoreErrors.BE_JOIN_RCOL_NULL, null);
+      cxt.validationError(this, ObjectStoreErrorCodes.BE_JOIN_RCOL_NULL, null);
 
     // do children
     cxt.pushParent(this);

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.legacy.IPSComponentConverter;
 import com.percussion.error.PSException;
 import com.percussion.utils.jdbc.PSConnectionDetail;
@@ -299,11 +301,11 @@ public class PSBackEndTable extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -313,7 +315,7 @@ public class PSBackEndTable extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     try { // private String m_alias;
@@ -326,7 +328,7 @@ public class PSBackEndTable extends PSComponent {
     try { // private String m_dataSource;
       Element dsEl = tree.getNextElement("datasource", tree.GET_NEXT_ALLOW_CHILDREN);
       if (dsEl == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, "datasource");
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, "datasource");
       setDataSource(tree.getElementData(dsEl));
     } catch (IllegalArgumentException e) {
       // Ignore

--- a/system/src/main/java/com/percussion/design/objectstore/PSCgiVariable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCgiVariable.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -57,7 +59,7 @@ public class PSCgiVariable extends PSNamedReplacementValue {
 
   // see base class for description
   protected int getErrorCode() {
-    return IPSObjectStoreErrors.CGI_VAR_NAME_EMPTY;
+    return ObjectStoreErrorCodes.CGI_VAR_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with this instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoiceFilter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoiceFilter.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.objectstore.client.PSLightWeightField;
 import com.percussion.util.PSCollection;
 import java.util.Iterator;
@@ -67,11 +69,11 @@ public class PSChoiceFilter extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     boolean hasDependentField = false;
@@ -100,13 +102,13 @@ public class PSChoiceFilter extends PSComponent {
     if (!hasDependentField) {
       Object[] args = {XML_NODE_NAME, DependentField.XML_NODE_NAME, "null"};
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     if (!hasPSXUrlRequest) {
       Object[] args = {XML_NODE_NAME, PSUrlRequest.XML_NODE_NAME, "null"};
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
   }
 
@@ -117,7 +119,7 @@ public class PSChoiceFilter extends PSComponent {
     if (m_dependentFields.size() <= 0) {
       Object[] args = {DependentField.XML_NODE_NAME};
       context.validationError(
-          this, IPSObjectStoreErrors.CHOICE_FILTER_MISSING_REQUIRED_CHILD, args);
+          this, ObjectStoreErrorCodes.CHOICE_FILTER_MISSING_REQUIRED_CHILD, args);
     } else {
       for (int i = 0; i < m_dependentFields.size(); i++) {
         DependentField df = (DependentField) m_dependentFields.elementAt(i);
@@ -128,7 +130,7 @@ public class PSChoiceFilter extends PSComponent {
     if (m_lookup == null) {
       Object[] args = {PSUrlRequest.XML_NODE_NAME};
       context.validationError(
-          this, IPSObjectStoreErrors.CHOICE_FILTER_MISSING_REQUIRED_CHILD, args);
+          this, ObjectStoreErrorCodes.CHOICE_FILTER_MISSING_REQUIRED_CHILD, args);
     } else {
       m_lookup.validate(context);
     }
@@ -260,24 +262,24 @@ public class PSChoiceFilter extends PSComponent {
     public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
         throws PSUnknownNodeTypeException {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
       if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
         Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       m_fieldRef = sourceNode.getAttribute(XML_ATTR_fieldRef);
       if (m_fieldRef == null || m_fieldRef.trim().length() <= 0) {
         Object[] args = {XML_NODE_NAME, XML_ATTR_fieldRef, "null"};
 
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       m_dependencyType = sourceNode.getAttribute(XML_ATTR_dependencyType);
       if (m_dependencyType == null || m_dependencyType.trim().length() <= 0) {
         Object[] args = {XML_NODE_NAME, XML_ATTR_dependencyType, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
 
@@ -290,14 +292,14 @@ public class PSChoiceFilter extends PSComponent {
       if (m_fieldRef == null || m_fieldRef.trim().length() <= 0) {
         Object[] args = {XML_ATTR_fieldRef};
         context.validationError(
-            this, IPSObjectStoreErrors.CHOICE_FILTER_DEPENDENT_FIELD_MISSING_ATTR, args);
+            this, ObjectStoreErrorCodes.CHOICE_FILTER_DEPENDENT_FIELD_MISSING_ATTR, args);
       }
 
       // REQUIRED: dependencyType attr
       if (m_dependencyType == null || m_dependencyType.trim().length() <= 0) {
         Object[] args = {XML_ATTR_dependencyType};
         context.validationError(
-            this, IPSObjectStoreErrors.CHOICE_FILTER_DEPENDENT_FIELD_MISSING_ATTR, args);
+            this, ObjectStoreErrorCodes.CHOICE_FILTER_DEPENDENT_FIELD_MISSING_ATTR, args);
       }
     }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoiceTableInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoiceTableInfo.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.services.datasource.PSDatasourceMgrLocator;
 import com.percussion.util.PSPreparedStatement;
 import com.percussion.util.PSSqlHelper;
@@ -141,11 +143,11 @@ public class PSChoiceTableInfo extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -351,11 +353,11 @@ public final class PSChoices extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -384,7 +386,7 @@ public final class PSChoices extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, TYPE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -401,7 +403,7 @@ public final class PSChoices extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, SORT_ORDER_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -416,14 +418,14 @@ public final class PSChoices extends PSComponent {
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, CHOICE_LIST_KEY_ELEM, key == null ? "null" : key};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       } else if (m_type == TYPE_LOCAL) {
         node = tree.getNextElement(PSEntry.XML_NODE_NAME, firstFlags);
         if (node == null) {
           Object[] args = {XML_NODE_NAME, PSEntry.XML_NODE_NAME, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         Node current = tree.getCurrent();
         while (node != null) {
@@ -436,7 +438,7 @@ public final class PSChoices extends PSComponent {
         if (node == null) {
           Object[] args = {XML_NODE_NAME, PSUrlRequest.XML_NODE_NAME, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_lookup = new PSUrlRequest(node, parentDoc, parentComponents);
       } else if (m_type == TYPE_TABLE_INFO) {
@@ -444,7 +446,7 @@ public final class PSChoices extends PSComponent {
         if (node == null) {
           Object[] args = {XML_NODE_NAME, PSChoiceTableInfo.XML_NODE_NAME, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_tableInfo = new PSChoiceTableInfo(node, parentDoc, parentComponents);
       }
@@ -522,14 +524,14 @@ public final class PSChoices extends PSComponent {
         && m_type != TYPE_INTERNAL_LOOKUP
         && m_type != TYPE_TABLE_INFO) {
       Object[] args = {TYPE_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_CHOICE_TYPE, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_CHOICE_TYPE, args);
     }
 
     if (m_sortOrder != SORT_ORDER_ASCENDING
         && m_sortOrder != SORT_ORDER_DESCENDING
         && m_sortOrder != SORT_ORDER_USER) {
       Object[] args = {SORT_ORDER_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_SORT_ORDER, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_SORT_ORDER, args);
     }
 
     // do children
@@ -538,22 +540,22 @@ public final class PSChoices extends PSComponent {
       if (m_type == TYPE_GLOBAL) {
         if (m_global < 0) {
           Object[] args = {Integer.toString(m_global)};
-          context.validationError(this, IPSObjectStoreErrors.INVALID_GLOBAL_TABLE_ID, args);
+          context.validationError(this, ObjectStoreErrorCodes.INVALID_GLOBAL_TABLE_ID, args);
         }
       } else if (m_type == TYPE_LOCAL) {
         if (m_local == null || m_local.isEmpty()) {
-          context.validationError(this, IPSObjectStoreErrors.LOCAL_CHOICES_NULL_OR_EMPTY, null);
+          context.validationError(this, ObjectStoreErrorCodes.LOCAL_CHOICES_NULL_OR_EMPTY, null);
         } else {
           Iterator it = getLocal();
           while (it.hasNext()) ((PSEntry) it.next()).validate(context);
         }
       } else if (m_type == TYPE_TABLE_INFO) {
         if (m_tableInfo == null) {
-          context.validationError(this, IPSObjectStoreErrors.LOOKUP_TABLE_INFO_NULL, null);
+          context.validationError(this, ObjectStoreErrorCodes.LOOKUP_TABLE_INFO_NULL, null);
         }
       } else {
         if (m_lookup == null) {
-          context.validationError(this, IPSObjectStoreErrors.LOOKUP_CHOICES_NULL, null);
+          context.validationError(this, ObjectStoreErrorCodes.LOOKUP_CHOICES_NULL, null);
         } else m_lookup.validate(context);
       }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCommandHandlerStylesheets.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.collections.PSIteratorUtils;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -285,11 +287,11 @@ public final class PSCommandHandlerStylesheets extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -312,7 +314,7 @@ public final class PSCommandHandlerStylesheets extends PSComponent {
       node = tree.getNextElement(COMMAND_HANDLER_ELEM, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, COMMAND_HANDLER_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (node != null) {
         Node current = tree.getCurrent();
@@ -320,7 +322,7 @@ public final class PSCommandHandlerStylesheets extends PSComponent {
         String name = node.getAttribute(COMMAND_HANDLER_NAME_ATTR);
         if (name == null || name.trim().length() == 0) {
           Object[] args = {COMMAND_HANDLER_ELEM, COMMAND_HANDLER_NAME_ATTR, "null"};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
 
         // OPTIONAL: get all stylesheets
@@ -338,7 +340,7 @@ public final class PSCommandHandlerStylesheets extends PSComponent {
         if (node == null) {
           Object[] args = {XML_NODE_NAME, PSStylesheet.XML_NODE_NAME, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         PSStylesheet stylesheet = new PSStylesheet(node, parentDoc, parentComponents);
 
@@ -403,7 +405,7 @@ public final class PSCommandHandlerStylesheets extends PSComponent {
         Iterator it = getStylesheets((String) names.next());
         if (!it.hasNext()) {
           context.validationError(
-              this, IPSObjectStoreErrors.INVALID_COMMAND_HANDLER_STYLESHEETS, null);
+              this, ObjectStoreErrorCodes.INVALID_COMMAND_HANDLER_STYLESHEETS, null);
         }
         while (it.hasNext()) ((PSConditionalStylesheet) it.next()).validate(context);
       }

--- a/system/src/main/java/com/percussion/design/objectstore/PSComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSComponent.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.legacy.IPSComponentConverter;
 import com.percussion.design.objectstore.legacy.IPSComponentUpdater;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -284,7 +286,7 @@ public abstract class PSComponent implements IPSComponent, Serializable {
       throws PSUnknownNodeTypeException {
     if (null == expectedName) throw new IllegalArgumentException("expectedName cannot be null");
     if (null == elem)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, expectedName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, expectedName);
 
     // TODO: support namespaces correctly (requires DOM level 2)
     // String localName = elem.getLocalName();
@@ -293,7 +295,7 @@ public abstract class PSComponent implements IPSComponent, Serializable {
 
     if (!expectedName.equals(localName)) {
       Object[] args = {expectedName, localName};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
   }
 
@@ -365,7 +367,7 @@ public abstract class PSComponent implements IPSComponent, Serializable {
       if (!found) {
         String parentName = tree.getCurrent().getNodeName();
         Object[] args = {parentName, attrName, data};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
     }
 
@@ -395,7 +397,7 @@ public abstract class PSComponent implements IPSComponent, Serializable {
     if (data == null || data.trim().length() == 0) {
       String parentName = tree.getCurrent().getNodeName();
       Object[] args = {parentName, elemName, "null or empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     return data;
@@ -449,7 +451,7 @@ public abstract class PSComponent implements IPSComponent, Serializable {
       setId(Integer.parseInt(data));
     } catch (NumberFormatException e) {
       String[] args = {source.getNodeName(), ((data == null) ? "null" : data)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditional.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditional.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -428,11 +430,11 @@ public class PSConditional extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -442,7 +444,7 @@ public class PSConditional extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       int firstFlags = PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN;
@@ -538,15 +540,15 @@ public class PSConditional extends PSComponent {
         || m_operator.equalsIgnoreCase(OPTYPE_LIKE)
         || m_operator.equalsIgnoreCase(OPTYPE_NOTLIKE)) {
     } else {
-      cxt.validationError(this, IPSObjectStoreErrors.COND_OPTYPE_UNKNOWN, m_operator);
+      cxt.validationError(this, ObjectStoreErrorCodes.COND_OPTYPE_UNKNOWN, m_operator);
     }
 
     if (!m_boolean.equals(OPBOOL_AND) && !m_boolean.equals(OPBOOL_OR)) {
-      cxt.validationError(this, IPSObjectStoreErrors.COND_BOOL_UNKNOWN, m_boolean);
+      cxt.validationError(this, ObjectStoreErrorCodes.COND_BOOL_UNKNOWN, m_boolean);
     }
 
     if (m_value == null && !isUnaryOp(m_operator)) {
-      cxt.validationError(this, IPSObjectStoreErrors.COND_VALUE_NULL, m_operator);
+      cxt.validationError(this, ObjectStoreErrorCodes.COND_VALUE_NULL, m_operator);
     }
 
     cxt.pushParent(this);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalEffect.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalEffect.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.relationship.IPSExecutionContext;
 import com.percussion.relationship.PSExecutionContext;
 import com.percussion.util.PSCollection;
@@ -119,11 +121,11 @@ public class PSConditionalEffect extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -174,11 +176,11 @@ public class PSConditionalExit extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -202,7 +204,7 @@ public class PSConditionalExit extends PSComponent {
       node = tree.getNextElement(PSExtensionCallSet.ms_NodeType, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSExtensionCallSet.ms_NodeType, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_rules = new PSExtensionCallSet(node, parentDoc, parentComponents);
 
@@ -238,7 +240,7 @@ public class PSConditionalExit extends PSComponent {
     context.pushParent(this);
     try {
       if (m_rules == null) {
-        context.validationError(this, IPSObjectStoreErrors.INVALID_CONDITIONAL_EXIT, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_CONDITIONAL_EXIT, null);
       } else m_rules.validate(context);
 
       if (m_condition != null) m_condition.validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalExtension.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalExtension.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -137,11 +139,11 @@ public class PSConditionalExtension extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -161,7 +163,7 @@ public class PSConditionalExtension extends PSComponent {
       node = tree.getNextElement(PSExtensionCall.ms_NodeType, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSExtensionCall.ms_NodeType, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_extension = new PSExtensionCall(node, parentDoc, parentComponents);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -159,11 +161,11 @@ public class PSConditionalRequest extends PSUrlRequest {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -187,12 +189,12 @@ public class PSConditionalRequest extends PSUrlRequest {
       node = tree.getNextElement(CONDITIONS_ELEM, nextFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, CONDITIONS_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       node = tree.getNextElement(PSRule.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSRule.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (node != null) {
         m_conditions.add(new PSRule(node, parentDoc, parentComponents));
@@ -231,7 +233,7 @@ public class PSConditionalRequest extends PSUrlRequest {
       super.validate(context);
 
       if (m_conditions == null) {
-        context.validationError(this, IPSObjectStoreErrors.INVALID_CONDITIONAL_REQUEST, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_CONDITIONAL_REQUEST, null);
       } else {
         Iterator it = getConditions();
         while (it.hasNext()) ((PSRule) it.next()).validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -133,11 +135,11 @@ public class PSConditionalStylesheet extends PSStylesheet {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -162,12 +164,12 @@ public class PSConditionalStylesheet extends PSStylesheet {
       node = tree.getNextElement(CONDITIONS_ELEM, nextFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, CONDITIONS_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       node = tree.getNextElement(PSRule.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSRule.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       while (node != null) {
         m_conditions.add(new PSRule(node, parentDoc, parentComponents));
@@ -206,7 +208,7 @@ public class PSConditionalStylesheet extends PSStylesheet {
       super.validate(context);
 
       if (m_conditions == null) {
-        context.validationError(this, IPSObjectStoreErrors.INVALID_CONDITIONAL_STYLESHEET, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_CONDITIONAL_STYLESHEET, null);
       } else {
         Iterator it = getConditions();
         while (it.hasNext()) ((PSRule) it.next()).validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentItemData.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentItemData.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -72,7 +74,7 @@ public class PSContentItemData extends PSNamedReplacementValue {
 
   // see base class for description
   public int getErrorCode() {
-    return IPSObjectStoreErrors.RELATIONSHIP_PROPERTY_NAME_EMPTY;
+    return ObjectStoreErrorCodes.RELATIONSHIP_PROPERTY_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentItemStatus.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentItemStatus.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSStringOperation;
 import java.util.List;
 import org.w3c.dom.Element;
@@ -130,7 +132,7 @@ public class PSContentItemStatus extends PSNamedReplacementValue {
 
   // see base class for description
   public int getErrorCode() {
-    return IPSObjectStoreErrors.RELATIONSHIP_PROPERTY_NAME_EMPTY;
+    return ObjectStoreErrorCodes.RELATIONSHIP_PROPERTY_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentType.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentType.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.objectstore.PSCmsObject;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -79,18 +81,18 @@ public class PSContentType extends PSComponent {
     String objectType = sourceNode.getAttribute(OBJECT_TYPE_ATTR);
     if (objectType == null) {
       Object[] args = {XML_NODE_NAME, OBJECT_TYPE_ATTR, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     try {
       int type = Integer.parseInt(objectType);
       if (!PSCmsObject.isValidType(type)) {
         Object[] args = {XML_NODE_NAME, OBJECT_TYPE_ATTR, "" + type};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       } else m_objectType = type;
     } catch (NumberFormatException e) {
       Object[] args = {XML_NODE_NAME, OBJECT_TYPE_ATTR, "invalid number"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // get the optional elements

--- a/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSControlRef.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
@@ -178,14 +180,14 @@ public final class PSControlRef extends PSComponent {
           m_id = Integer.parseInt(sTemp);
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, sTemp};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
         }
 
       // REQUIRED: get the name attribute
       m_name = tree.getElementData(NAME_ATTR);
       if (m_name == null || m_name.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // OPTIONAL: get all parameters
@@ -219,7 +221,7 @@ public final class PSControlRef extends PSComponent {
 
     // the name is required
     if (m_name == null || m_name.trim().length() == 0)
-      context.validationError(this, IPSObjectStoreErrors.INVALID_CONTROL_REF, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_CONTROL_REF, null);
 
     // do children
     context.pushParent(this);

--- a/system/src/main/java/com/percussion/design/objectstore/PSCookie.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCookie.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -55,7 +57,7 @@ public class PSCookie extends PSNamedReplacementValue {
 
   // see base class for description
   protected int getErrorCode() {
-    return IPSObjectStoreErrors.COOKIE_NAME_EMPTY;
+    return ObjectStoreErrorCodes.COOKIE_NAME_EMPTY.numericCode();
   }
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomActionGroup.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.collections.PSIteratorUtils;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -194,11 +196,11 @@ public final class PSCustomActionGroup extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -220,7 +222,7 @@ public final class PSCustomActionGroup extends PSComponent {
       node = tree.getNextElement(PSLocation.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSLocation.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else m_location = new PSLocation(node, parentDoc, parentComponents);
 
       Node current = tree.getCurrent();
@@ -242,7 +244,7 @@ public final class PSCustomActionGroup extends PSComponent {
       node = tree.getNextElement(PSFormAction.XML_NODE_NAME, nextFlags);
       if (node == null && !foundRemovals) {
         Object[] args = {XML_NODE_NAME, PSFormAction.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else if (node != null) {
         m_formAction = new PSFormAction(node, parentDoc, parentComponents);
       }
@@ -251,7 +253,7 @@ public final class PSCustomActionGroup extends PSComponent {
       node = tree.getNextElement(PSActionLinkList.XML_NODE_NAME, nextFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSActionLinkList.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_actionLinkList = new PSActionLinkList(node, parentDoc, parentComponents);
     } finally {
@@ -295,13 +297,13 @@ public final class PSCustomActionGroup extends PSComponent {
     context.pushParent(this);
     try {
       if (m_location != null) ((IPSComponent) m_location).validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_CUSTOM_ACTION_GROUP, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_CUSTOM_ACTION_GROUP, null);
 
       if (m_actionLinkList != null) ((IPSComponent) m_actionLinkList).validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_CUSTOM_ACTION_GROUP, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_CUSTOM_ACTION_GROUP, null);
 
       if (m_formAction != null) ((IPSComponent) m_formAction).validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_CUSTOM_ACTION_GROUP, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_CUSTOM_ACTION_GROUP, null);
     } finally {
       context.popParent();
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSCustomError.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCustomError.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -116,7 +118,7 @@ public class PSCustomError extends PSComponent {
 
   private static PSIllegalArgumentException validateErrorCode(String error) {
     if ((error == null) || (error.length() == 0))
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.CUSTOM_ERROR_CODE_EMPTY);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.CUSTOM_ERROR_CODE_EMPTY.numericCode());
 
     return null;
   }
@@ -192,11 +194,11 @@ public class PSCustomError extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -206,7 +208,7 @@ public class PSCustomError extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     try { // get the error code
@@ -219,13 +221,13 @@ public class PSCustomError extends PSComponent {
     sTemp = tree.getElementData("url");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "url", ""};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     try {
       m_url = new URL(sTemp);
     } catch (java.net.MalformedURLException e) {
       Object[] args = {ms_NodeType, "url", "(URL: " + sTemp + ") " + e.getMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
   }
 
@@ -246,7 +248,7 @@ public class PSCustomError extends PSComponent {
     PSException ex = validateErrorCode(m_error);
     if (ex != null) cxt.validationError(this, ex.getErrorCode(), ex.getErrorArguments());
 
-    if (m_url == null) cxt.validationError(this, IPSObjectStoreErrors.CUSTOM_ERROR_URL_EMPTY, null);
+    if (m_url == null) cxt.validationError(this, ObjectStoreErrorCodes.CUSTOM_ERROR_URL_EMPTY, null);
   }
 
   @Override

--- a/system/src/main/java/com/percussion/design/objectstore/legacy/PSBaseDSConverter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/legacy/PSBaseDSConverter.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.objectstore.legacy;
 
-import com.percussion.design.objectstore.IPSObjectStoreErrors;
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSJdbcDriverConfig;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.legacy.security.deprecated.PSCryptographer;
@@ -275,21 +275,21 @@ public abstract class PSBaseDSConverter {
     // locate matching driver
     PSJdbcDriverConfig driver = getDriver(driverName);
     if (driver == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.NO_JDBC_DRIVER_CONFIG, driverName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.NO_JDBC_DRIVER_CONFIG, driverName);
     }
 
     // locate matching datsource
     IPSJndiDatasource ds = getJndiDatasource(driver, server);
     if (ds == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.NO_JNDI_DATASOURCE, new String[] {driver.getDriverName(), server});
+          ObjectStoreErrorCodes.NO_JNDI_DATASOURCE, new String[] {driver.getDriverName(), server});
     }
 
     // locate matching connection
     String dsName = getDatasourceName(ds, database, origin);
     if (dsName == null) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.NO_DATASOURCE_CONNECTION,
+          ObjectStoreErrorCodes.NO_DATASOURCE_CONNECTION,
           new String[] {ds.getName(), database, origin});
     }
 

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchITest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchITest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.error.PSIllegalArgumentException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Batch I (#3040): design.objectstore A–C cohort call sites must throw typed {@link
+ * ObjectStoreErrorCodes} (not bare {@code IPSObjectStoreErrors} ints) where IPSErrorCode ctors
+ * exist.
+ */
+public class PSDesignObjectstoreTypedErrorCodeBatchITest {
+
+  @Test
+  public void actionLinkNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSActionLink((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void actionLinkWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotActionLink");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSActionLink(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void applyWhenNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSApplyWhen((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void applyWhenWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotApplyWhen");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSApplyWhen(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void attributeNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSAttribute((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void attributeWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotAttribute");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSAttribute(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void customErrorNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSCustomError((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void customErrorWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotCustomError");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSCustomError(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void customErrorEmptyCodeUsesNumericObjectStoreCode() {
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> new PSCustomError("", null));
+    assertEquals(ObjectStoreErrorCodes.CUSTOM_ERROR_CODE_EMPTY.numericCode(), ex.getErrorCode());
+  }
+
+  @Test
+  public void aclEntryNullSourceUsesTypedNull() {
+    PSAclEntry entry = new PSAclEntry();
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> entry.fromXml(null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void aclEntryWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotAclEntry");
+    PSAclEntry entry = new PSAclEntry();
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> entry.fromXml(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void controlRefWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotControlRef");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSControlRef(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void componentValidateElementNameNullUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> PSComponent.validateElementName(null, "Expected"));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void componentValidateElementNameWrongTypeUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "Actual");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> PSComponent.validateElementName(wrong, "Expected"));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+}


### PR DESCRIPTION
## Summary
Call-site migration **batch I** for parent epic #2616 / slice #3040: migrate `com.percussion.design.objectstore` **A–C alphabetical cohort** from raw `IPSObjectStoreErrors` ints to typed `ObjectStoreErrorCodes`.

### Scope
- **38 files**, ~**184** call sites migrated (root A–C + `legacy/PSBaseDSConverter`)
- Typed construction via existing `IPSErrorCode` ctors (`PSUnknownNodeTypeException`, `PSUnknownDocTypeException`, `validationError`)
- Int-only APIs use `.numericCode()`: `validationWarning`, `getErrorCode()` returns, `PSIllegalArgumentException`, `PSConsole.printInfoMsg`
- **Left as `IPSObjectStoreErrors`:** `ACL_ENTRY_LEVEL_NOT_FOUND`, `ACL_SECURITY_LEVEL_INVALID`, `ACL_TYPE_INVALID` (not on `ObjectStoreErrorCodes`; live on `DesignErrorCodes` instead — out of scope for this slice)
- Did **not** rework batches F–H files (`PSContentEditor*`, clone/config/container peers)

### Residual inventory (after this PR)
- `design.objectstore` still ~**121 files / ~634 sites** (mostly D–Z + server/legacy)
- Residual issue will cover the next PR-sized cohort

### Parent
Parent: #2616 · Prior: #3023 (batch H) · Sibling batch J: #3041

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` (JDK 21) — **BUILD SUCCESS**
- [x] New `PSDesignObjectstoreTypedErrorCodeBatchITest` — **Tests run: 14, Failures: 0**
- [x] Module suite aggregate surefire — **Tests run: 1800, Failures: 0, Errors: 0**

## Product documentation
- [x] N/A — pure tech-debt call-site migration; no operator/user/API surface change

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system; $env:JAVA_HOME=...jdk-21...; ..\mvnw.cmd clean install` → jars installed to local m2; Tests run: 1800, Failures: 0; batch I tests: 14
- **downstream_checked:** none (call-site only; no public/protected signature or `final`/`sealed` changes)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3040

> Co-Authored by Grok Build using grok-4.5 with agent main.
