### PR TITLE
feat(perc-packages): G4 inventory gate zero non-waived Widget def XML (#3026)

### DIFF
--- a/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md
@@ -83,6 +83,17 @@ This document is the **hard gate** for deleting or hard-disabling the legacy def
 
 **Snapshot 2026-08-11:** G2 partially satisfied for the **selection API** (`PSLegacyDefinitionXmlShimTest`). G1/G3–G6 for **deletion** are N/A until M1–M3 pass.
 
+**Snapshot 2026-08-11 (G4 Widget inventory gate #3026):** **PASS G4 for product Widget definition XML** — automated assertion in `modules/perc-packages`:
+
+| Piece | Location |
+|-------|----------|
+| Inventory API + optional CLI | `com.percussion.packages.widgetxml.PSWidgetDefinitionXmlInventory` |
+| Surefire gate | `PSWidgetDefinitionXmlInventoryTest` (product tree zero non-waived; TempDir proves failure when dummy non-waived XML is introduced) |
+| Explicit waive | `perc.Test` only (`WAIVED_PACKAGE_DIRS`) |
+| Path I/O | `Path.resolve` / `Files` only (G6-aligned) |
+
+Pages/Gadgets ship-path inventory remains residual under the broader G4 wording; Widget path is the Phase 3 residual closed by #3026.
+
 ---
 
 ## 3. Time-box
@@ -131,7 +142,7 @@ Javadoc-only alignment references:
 | Surface | Path / class | Status in snapshot | Removal coupled to shim? |
 |---------|--------------|--------------------|---------------------------|
 | Widget install load | `projects/sitemanage/.../dao/impl/PSWidgetDao` → `${rxdeploydir}/rxconfig/Widgets` + optional `widgetDao.modernPackageRoots` | **Live** dual-run selection (#3024); content still from Widgets XML wire | **Yes** for product modern-only content path; selection wired; keep shim until M2 metrics pass |
-| Product Widget package XML | `modules/perc-packages/.../Packages/**/sys__UserDependency--rxconfig/Widgets/*.xml` | **29** files remaining after batch C ship-exit #2885 (was **48**); install materialize for modern-only | Product XML deletion continues via ship-exit #2883 / #2884; waived `perc.Test`; M1 still FAIL |
+| Product Widget package XML | `modules/perc-packages/.../Packages/**/sys__UserDependency--rxconfig/Widgets/*.xml` | **1** remaining (`perc.Test` waiver only; was **48**); install materialize for modern-only; **G4 inventory gate** `PSWidgetDefinitionXmlInventory` / #3026 | M1 Widget portion PASS; G4 Widget path automated; keep shim until M2/M3 |
 | Widget XML compilers | `…/widgetxml/PSWidgetXml*` | Upgrade-input compilers; keep after runtime shim exit | **No** (upgrade input OK) |
 | Page dual-ship / native | `…/pagexml/PSPageXmlDualShip`, `PSPageXmlNativeInstall`, `PSPageXmlInstallPolicy` | Native for base/responsive; dual-ship default elsewhere | Separate checklist ([dual-ship-page-template-retirement.md](./dual-ship-page-template-retirement.md)) |
 | Gadget catalog ship | `modules/perc-packages/.../catalogs/gadgets/gadget-catalog.json` | Modern catalog present | Preferred path |

--- a/modules/perc-packages/README.md
+++ b/modules/perc-packages/README.md
@@ -1,12 +1,31 @@
 # perc-packages
 
-# perc-rxapps
-
-This module contains support for configuring resource assembly in the ${basedir}/target/distribution directory.
-
-* The config file is an XML file depicting the output directory, output file type, inclusions and exclusions in the assembly.
+This module builds product component packages (`.ppkg`) from `src/main/resources/Packages`
+and hosts Widget/Page/Gadget compilers, dual-ship helpers, and the legacy definition-XML
+selection shim.
 
 ## Building
 
-mvn clean install
+From this module directory (standalone, preferred):
+
+```bat
+..\..\mvnw.cmd clean install
+```
+
+```bash
+../../mvnw clean install
+```
+
+## G4 Widget definition XML inventory gate (#3026)
+
+Product packages must not reintroduce committed install Widget definition XML under
+`sys__UserDependency--rxconfig/Widgets/` except the explicit waiver **`perc.Test`**.
+
+| Piece | Class |
+|-------|--------|
+| Inventory API + CLI | `com.percussion.packages.widgetxml.PSWidgetDefinitionXmlInventory` |
+| Surefire assertion | `PSWidgetDefinitionXmlInventoryTest` |
+
+See root `scripts/README.md` (Widget definition XML inventory gate) and
+`docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md`.
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventory.java
@@ -119,7 +119,13 @@ public final class PSWidgetDefinitionXmlInventory {
         try (DirectoryStream<Path> xmls = Files.newDirectoryStream(widgetsDir, "*.xml")) {
           for (Path xml : xmls) {
             if (Files.isRegularFile(xml)) {
-              all.add(new Finding(packageDirName, xml.toAbsolutePath().normalize(), waived));
+              // Anchor on widgetsDir + file name so Finding paths stay under the scanned
+              // directory regardless of CWD. DirectoryStream entries are typically already
+              // dir.resolve(name); using getFileName() avoids double-nesting and never
+              // resolves a bare relative entry against the JVM working directory alone.
+              Path absXml =
+                  widgetsDir.resolve(xml.getFileName()).toAbsolutePath().normalize();
+              all.add(new Finding(packageDirName, absXml, waived));
             }
           }
         }

--- a/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventory.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Product package inventory for committed Widget definition XML under the install ship path
+ * {@code sys__UserDependency--rxconfig/Widgets/*.xml} (Phase 5 gate G4 / issue #3026, parent
+ * #2630, ADR-004).
+ *
+ * <p><strong>Pass condition (M1 Widget portion / G4):</strong> zero <em>non-waived</em> product
+ * Widget definition XML files under a {@code Packages/} tree. The only explicit waiver is {@code
+ * perc.Test} (test-harness package residual).
+ *
+ * <p>Uses {@link Path#resolve(String)} / {@link Files} only — no hardcoded filesystem separators.
+ *
+ * @see PSWidgetXmlInstallEmitter
+ * @see PSWidgetXmlPackageCompiler#resolveWidgetsDir(Path)
+ */
+public final class PSWidgetDefinitionXmlInventory {
+
+  /**
+   * Package directory names under {@code Packages/} allowed to still commit Widget definition XML.
+   * Explicit and minimal — do not expand without an ADR / residual issue.
+   */
+  public static final Set<String> WAIVED_PACKAGE_DIRS =
+      Collections.unmodifiableSet(new LinkedHashSet<>(List.of("perc.Test")));
+
+  private PSWidgetDefinitionXmlInventory() {
+    // utility
+  }
+
+  /**
+   * One committed Widget definition XML file under a package's install Widgets path.
+   *
+   * @param packageDirName immediate child name under the Packages root (e.g. {@code perc.Test})
+   * @param xmlPath absolute or normalized path to the {@code .xml} file
+   * @param waived whether {@code packageDirName} is in {@link #WAIVED_PACKAGE_DIRS}
+   */
+  public record Finding(String packageDirName, Path xmlPath, boolean waived) {}
+
+  /**
+   * Inventory scan result for a Packages root.
+   *
+   * @param all all Widget definition XML findings (waived + non-waived), sorted
+   * @param nonWaived findings whose package is not waived
+   * @param waived findings whose package is waived
+   */
+  public record Report(List<Finding> all, List<Finding> nonWaived, List<Finding> waived) {
+
+    /**
+     * @return true when no non-waived Widget definition XML is present
+     */
+    public boolean isClean() {
+      return nonWaived.isEmpty();
+    }
+  }
+
+  /**
+   * Scan every immediate package directory under {@code packagesRoot} for committed Widget
+   * definition XML under the install Widgets path.
+   *
+   * @param packagesRoot non-null directory of package roots (e.g. {@code
+   *     modules/perc-packages/src/main/resources/Packages})
+   * @return report of findings; never null
+   * @throws IOException on I/O failure
+   * @throws IllegalArgumentException if packagesRoot is null or not a directory
+   */
+  public static Report scan(Path packagesRoot) throws IOException {
+    Objects.requireNonNull(packagesRoot, "packagesRoot");
+    if (!Files.isDirectory(packagesRoot)) {
+      throw new IllegalArgumentException("Packages root is not a directory: " + packagesRoot);
+    }
+
+    List<Finding> all = new ArrayList<>();
+    try (DirectoryStream<Path> packages = Files.newDirectoryStream(packagesRoot)) {
+      for (Path packageDir : packages) {
+        if (!Files.isDirectory(packageDir)) {
+          continue;
+        }
+        Path namePath = packageDir.getFileName();
+        if (namePath == null) {
+          continue;
+        }
+        String packageDirName = namePath.toString();
+        boolean waived = isWaivedPackage(packageDirName);
+        Path widgetsDir = resolveWidgetsDir(packageDir);
+        if (!Files.isDirectory(widgetsDir)) {
+          continue;
+        }
+        try (DirectoryStream<Path> xmls = Files.newDirectoryStream(widgetsDir, "*.xml")) {
+          for (Path xml : xmls) {
+            if (Files.isRegularFile(xml)) {
+              all.add(new Finding(packageDirName, xml.toAbsolutePath().normalize(), waived));
+            }
+          }
+        }
+      }
+    }
+
+    all.sort(
+        Comparator.comparing((Finding f) -> f.packageDirName().toLowerCase(Locale.ROOT))
+            .thenComparing(f -> f.xmlPath().getFileName().toString().toLowerCase(Locale.ROOT)));
+
+    List<Finding> nonWaived = all.stream().filter(f -> !f.waived()).collect(Collectors.toList());
+    List<Finding> waivedOnly = all.stream().filter(Finding::waived).collect(Collectors.toList());
+    return new Report(
+        Collections.unmodifiableList(all),
+        Collections.unmodifiableList(nonWaived),
+        Collections.unmodifiableList(waivedOnly));
+  }
+
+  /**
+   * Whether the package directory name is on the explicit waiver list ({@code perc.Test} only).
+   *
+   * @param packageDirName package folder name under Packages
+   * @return true if waived
+   */
+  public static boolean isWaivedPackage(String packageDirName) {
+    if (packageDirName == null || packageDirName.isBlank()) {
+      return false;
+    }
+    return WAIVED_PACKAGE_DIRS.contains(packageDirName);
+  }
+
+  /**
+   * Fail-fast assertion used by Surefire / CI: non-waived Widget definition XML must not reappear.
+   *
+   * @param packagesRoot Packages tree root
+   * @throws IOException on I/O failure
+   * @throws IllegalStateException when non-waived Widget def XML is present (message lists paths)
+   */
+  public static void assertNoNonWaivedWidgetDefinitionXml(Path packagesRoot) throws IOException {
+    Report report = scan(packagesRoot);
+    if (report.isClean()) {
+      return;
+    }
+    String detail =
+        report.nonWaived().stream()
+            .map(f -> f.packageDirName() + " -> " + f.xmlPath())
+            .collect(Collectors.joining(System.lineSeparator() + "  "));
+    throw new IllegalStateException(
+        "G4 inventory gate (#3026): non-waived product Widget definition XML under "
+            + packagesRoot
+            + " (only waived package dirs: "
+            + WAIVED_PACKAGE_DIRS
+            + "):"
+            + System.lineSeparator()
+            + "  "
+            + detail);
+  }
+
+  /**
+   * Resolve install Widgets directory under a package using portable path segments (same layout as
+   * {@link PSWidgetXmlPackageCompiler#resolveWidgetsDir(Path)}).
+   *
+   * @param packageDir package root
+   * @return Widgets directory path (may not exist)
+   */
+  public static Path resolveWidgetsDir(Path packageDir) {
+    Objects.requireNonNull(packageDir, "packageDir");
+    Path p = packageDir;
+    for (String segment : PSWidgetXmlPackageCompiler.WIDGETS_RELATIVE.split("/")) {
+      p = p.resolve(segment);
+    }
+    return p;
+  }
+
+  /**
+   * CLI entry for local / optional CI use (non-zero exit when non-waived XML is found).
+   *
+   * <p>Usage: {@code PSWidgetDefinitionXmlInventory <packagesRoot>}
+   *
+   * @param args first arg = packages root path
+   * @throws IOException on I/O failure
+   */
+  public static void main(String[] args) throws IOException {
+    if (args == null || args.length < 1 || args[0] == null || args[0].isBlank()) {
+      System.err.println(
+          "Usage: PSWidgetDefinitionXmlInventory <packagesRoot>");
+      System.err.println(
+          "  packagesRoot e.g. modules/perc-packages/src/main/resources/Packages");
+      System.exit(2);
+      return;
+    }
+    Path root = Path.of(args[0]).toAbsolutePath().normalize();
+    Report report = scan(root);
+    System.out.println(
+        "Widget def XML inventory under "
+            + root
+            + ": total="
+            + report.all().size()
+            + " waived="
+            + report.waived().size()
+            + " nonWaived="
+            + report.nonWaived().size()
+            + " waivedPackages="
+            + WAIVED_PACKAGE_DIRS);
+    for (Finding f : report.all()) {
+      System.out.println(
+          (f.waived() ? "WAIVED " : "FAIL   ") + f.packageDirName() + " " + f.xmlPath());
+    }
+    if (!report.isClean()) {
+      System.err.println("G4 FAIL: non-waived Widget definition XML present (#3026)");
+      System.exit(1);
+    }
+    System.out.println("G4 PASS: zero non-waived product Widget definition XML");
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventoryTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages.widgetxml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * G4 CI/inventory gate: zero non-waived product Widget definition XML under Packages (issue #3026 /
+ * parent #2630). Explicit waiver: {@code perc.Test} only.
+ *
+ * <p>Cross-platform: all path construction uses {@link Path#resolve(String)} / {@link Files}.
+ */
+class PSWidgetDefinitionXmlInventoryTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void waivedPackageSet_isExplicitlyPercTestOnly() {
+    assertEquals(Set.of("perc.Test"), PSWidgetDefinitionXmlInventory.WAIVED_PACKAGE_DIRS);
+    assertTrue(PSWidgetDefinitionXmlInventory.isWaivedPackage("perc.Test"));
+    assertFalse(PSWidgetDefinitionXmlInventory.isWaivedPackage("perc.baseWidgets"));
+    assertFalse(PSWidgetDefinitionXmlInventory.isWaivedPackage("perc.widget.form"));
+    assertFalse(PSWidgetDefinitionXmlInventory.isWaivedPackage(null));
+    assertFalse(PSWidgetDefinitionXmlInventory.isWaivedPackage(""));
+  }
+
+  @Test
+  void productPackagesTree_hasZeroNonWaivedWidgetDefinitionXml() throws Exception {
+    Path packagesRoot = locatePackagesRoot();
+    assertNotNull(
+        packagesRoot,
+        "Packages root must be visible when running module Surefire from perc-packages "
+            + "(src/main/resources/Packages)");
+
+    PSWidgetDefinitionXmlInventory.Report report =
+        PSWidgetDefinitionXmlInventory.scan(packagesRoot);
+    assertTrue(
+        report.isClean(),
+        () ->
+            "G4: non-waived Widget def XML must not reappear under product Packages; found: "
+                + report.nonWaived());
+
+    // Waived residual may still ship Widget XML (perc.Test / PSWidget_TestProperties).
+    assertFalse(
+        report.waived().isEmpty(),
+        "expected at least one waived Widget XML under perc.Test on the product tree");
+    for (PSWidgetDefinitionXmlInventory.Finding f : report.waived()) {
+      assertEquals("perc.Test", f.packageDirName());
+      assertTrue(f.waived());
+      assertTrue(Files.isRegularFile(f.xmlPath()));
+    }
+
+    // Fail-fast helper used by optional CLI must also pass on the live tree.
+    PSWidgetDefinitionXmlInventory.assertNoNonWaivedWidgetDefinitionXml(packagesRoot);
+  }
+
+  @Test
+  void tempTree_onlyWaivedXml_isClean() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path widgets =
+        packages
+            .resolve("perc.Test")
+            .resolve("sys__UserDependency--rxconfig")
+            .resolve("Widgets");
+    Files.createDirectories(widgets);
+    Files.writeString(
+        widgets.resolve("PSWidget_TestProperties.xml"),
+        "<Widget id=\"PSWidget_TestProperties\"/>",
+        StandardCharsets.UTF_8);
+
+    // Modern-only package with no Widgets XML must not pollute inventory.
+    Files.createDirectories(packages.resolve("perc.baseWidgets").resolve("widgets"));
+
+    PSWidgetDefinitionXmlInventory.Report report =
+        PSWidgetDefinitionXmlInventory.scan(packages);
+    assertEquals(1, report.all().size());
+    assertEquals(0, report.nonWaived().size());
+    assertEquals(1, report.waived().size());
+    assertTrue(report.isClean());
+    PSWidgetDefinitionXmlInventory.assertNoNonWaivedWidgetDefinitionXml(packages);
+  }
+
+  @Test
+  void tempTree_dummyNonWaivedXml_failsGate() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path widgets =
+        packages
+            .resolve("perc.baseWidgets")
+            .resolve("sys__UserDependency--rxconfig")
+            .resolve("Widgets");
+    Files.createDirectories(widgets);
+    Path dummy = widgets.resolve("percSimpleText.xml");
+    Files.writeString(dummy, "<Widget id=\"percSimpleText\"/>", StandardCharsets.UTF_8);
+
+    PSWidgetDefinitionXmlInventory.Report report =
+        PSWidgetDefinitionXmlInventory.scan(packages);
+    assertFalse(report.isClean());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals("perc.baseWidgets", report.nonWaived().get(0).packageDirName());
+    assertTrue(
+        report.nonWaived().get(0).xmlPath().getFileName().toString().equals("percSimpleText.xml"));
+
+    IllegalStateException err =
+        assertThrows(
+            IllegalStateException.class,
+            () -> PSWidgetDefinitionXmlInventory.assertNoNonWaivedWidgetDefinitionXml(packages));
+    assertTrue(err.getMessage().contains("G4"));
+    assertTrue(err.getMessage().contains("perc.baseWidgets"));
+    assertTrue(err.getMessage().contains("percSimpleText.xml"));
+  }
+
+  @Test
+  void tempTree_mixedWaivedAndNonWaived_reportsOnlyNonWaivedAsFailures() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+
+    Path waivedWidgets =
+        packages
+            .resolve("perc.Test")
+            .resolve("sys__UserDependency--rxconfig")
+            .resolve("Widgets");
+    Files.createDirectories(waivedWidgets);
+    Files.writeString(
+        waivedWidgets.resolve("PSWidget_TestProperties.xml"),
+        "<Widget/>",
+        StandardCharsets.UTF_8);
+
+    Path badWidgets =
+        packages
+            .resolve("perc.widget.form")
+            .resolve("sys__UserDependency--rxconfig")
+            .resolve("Widgets");
+    Files.createDirectories(badWidgets);
+    Files.writeString(badWidgets.resolve("percForm.xml"), "<Widget/>", StandardCharsets.UTF_8);
+
+    PSWidgetDefinitionXmlInventory.Report report =
+        PSWidgetDefinitionXmlInventory.scan(packages);
+    assertEquals(2, report.all().size());
+    assertEquals(1, report.waived().size());
+    assertEquals(1, report.nonWaived().size());
+    assertEquals("perc.widget.form", report.nonWaived().get(0).packageDirName());
+    assertFalse(report.isClean());
+  }
+
+  @Test
+  void resolveWidgetsDir_usesPortableSegments() {
+    Path pkg = Path.of("pkgRoot");
+    Path widgets = PSWidgetDefinitionXmlInventory.resolveWidgetsDir(pkg);
+    assertEquals(
+        pkg.resolve("sys__UserDependency--rxconfig").resolve("Widgets"), widgets);
+  }
+
+  @Test
+  void scan_rejectsNonDirectoryRoot() {
+    Path missing = tempDir.resolve("does-not-exist");
+    assertThrows(IllegalArgumentException.class, () -> PSWidgetDefinitionXmlInventory.scan(missing));
+  }
+
+  /**
+   * Prefer module-cwd relative layout used by standalone {@code mvnw clean install} from {@code
+   * modules/perc-packages}.
+   */
+  private static Path locatePackagesRoot() {
+    Path candidate = Path.of("src", "main", "resources", "Packages");
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src").resolve("main").resolve("resources").resolve("Packages");
+    return Files.isDirectory(alt) ? alt : null;
+  }
+}

--- a/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventoryTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/widgetxml/PSWidgetDefinitionXmlInventoryTest.java
@@ -89,8 +89,10 @@ class PSWidgetDefinitionXmlInventoryTest {
             .resolve("sys__UserDependency--rxconfig")
             .resolve("Widgets");
     Files.createDirectories(widgets);
+    Path xmlFile =
+        widgets.resolve("PSWidget_TestProperties.xml");
     Files.writeString(
-        widgets.resolve("PSWidget_TestProperties.xml"),
+        xmlFile,
         "<Widget id=\"PSWidget_TestProperties\"/>",
         StandardCharsets.UTF_8);
 
@@ -103,7 +105,43 @@ class PSWidgetDefinitionXmlInventoryTest {
     assertEquals(0, report.nonWaived().size());
     assertEquals(1, report.waived().size());
     assertTrue(report.isClean());
+    Path expectedAbs = xmlFile.toAbsolutePath().normalize();
+    assertEquals(expectedAbs, report.waived().get(0).xmlPath());
+    assertTrue(report.waived().get(0).xmlPath().isAbsolute());
+    assertTrue(report.waived().get(0).xmlPath().startsWith(widgets.toAbsolutePath().normalize()));
     PSWidgetDefinitionXmlInventory.assertNoNonWaivedWidgetDefinitionXml(packages);
+  }
+
+  /**
+   * Finding paths must be anchored under the scanned Widgets dir even when {@code packagesRoot} is
+   * a relative path (not pre-absolutized). Regression for review: bare {@code
+   * xml.toAbsolutePath()} must not leave paths only relative to CWD / outside widgetsDir.
+   */
+  @Test
+  void findingXmlPath_relativePackagesRoot_isAbsoluteUnderWidgetsDir() throws Exception {
+    Path packages = tempDir.resolve("Packages");
+    Path widgets =
+        packages
+            .resolve("perc.Test")
+            .resolve("sys__UserDependency--rxconfig")
+            .resolve("Widgets");
+    Files.createDirectories(widgets);
+    Path xmlFile = widgets.resolve("PSWidget_TestProperties.xml");
+    Files.writeString(xmlFile, "<Widget/>", StandardCharsets.UTF_8);
+
+    // Relative packages root (same tree as absolute tempDir path, different Path form).
+    Path relativePackages =
+        Path.of(".").toAbsolutePath().normalize().relativize(packages.toAbsolutePath().normalize());
+    assertFalse(relativePackages.isAbsolute(), "precondition: packages root is relative");
+
+    PSWidgetDefinitionXmlInventory.Report report =
+        PSWidgetDefinitionXmlInventory.scan(relativePackages);
+    assertEquals(1, report.all().size());
+    Path found = report.all().get(0).xmlPath();
+    assertTrue(found.isAbsolute());
+    assertEquals(xmlFile.toAbsolutePath().normalize(), found);
+    assertTrue(found.startsWith(widgets.toAbsolutePath().normalize()));
+    assertTrue(Files.isRegularFile(found));
   }
 
   @Test

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,6 +63,36 @@ Path-filtered CI / local **smoke** around `build-cms-docs` (issue #2704).
   `tmp/product-docs-site/` always has a path and at least one file (partial build
   output is preserved when the builder emits anything before failing).
 
+### Widget definition XML inventory gate (G4 / #3026)
+
+**Not a Python script.** Phase 5 criteria **G4** for product Widget definition XML under
+`Packages/**/sys__UserDependency--rxconfig/Widgets/` is enforced in Maven Surefire for
+`modules/perc-packages`:
+
+- Class: `com.percussion.packages.widgetxml.PSWidgetDefinitionXmlInventory`
+- Tests: `PSWidgetDefinitionXmlInventoryTest` (green on product tree; fails if a dummy
+  non-waived fixture XML is introduced under a non-waived package)
+- Explicit waiver: **`perc.Test` only**
+- Cross-platform: `Path` / `Files` only (no hardcoded separators)
+
+Optional CLI (after compiling the module):
+
+```bat
+cd modules\perc-packages
+..\..\mvnw.cmd -q exec:java -Dexec.classpathScope=compile ^
+  -Dexec.mainClass=com.percussion.packages.widgetxml.PSWidgetDefinitionXmlInventory ^
+  -Dexec.args="src\main\resources\Packages"
+```
+
+```bash
+cd modules/perc-packages
+../../mvnw -q exec:java -Dexec.classpathScope=compile \
+  -Dexec.mainClass=com.percussion.packages.widgetxml.PSWidgetDefinitionXmlInventory \
+  -Dexec.args="src/main/resources/Packages"
+```
+
+Criteria doc: `docs/ai-generated/tasks/template-assembler-normalization/definition-xml-shim-removal-criteria.md`.
+
 ### Third-party license inventory (Maven + npm merge)
 
 **Not a Python script.** Merged inventory generation for issue #1689 lives in


### PR DESCRIPTION
## Summary

Implements **G4 CI/inventory gate** for Phase 3 residual [#3026](https://github.com/intersoftdatalabs-in/percussioncms/issues/3026) (parent [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630), grandparent [#2626](https://github.com/intersoftdatalabs-in/percussioncms/issues/2626)):

- New `PSWidgetDefinitionXmlInventory` scans `Packages/**/sys__UserDependency--rxconfig/Widgets/*.xml` with portable `Path`/`Files` only
- Explicit waive list: **`perc.Test` only**
- Surefire tests: green on product tree; fail when a dummy non-waived fixture XML is introduced
- Optional CLI `main` for local/CI inventory
- Criteria G4 status + scripts/module README updates

**Out of scope:** shim removal (#2852), Widget DAO (#3024).

## Test plan

- [x] `cd modules/perc-packages && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `PSWidgetDefinitionXmlInventoryTest` (7 tests): product tree zero non-waived; TempDir waived-only clean; TempDir dummy non-waived fails
- [x] Full module suite: **Tests run: 124, Failures: 0**

## Product documentation

- [x] N/A — engineering inventory/CI gate only; no operator-, admin-, or end-user-facing product behavior change

## Build evidence (C3)

- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages; ..\..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 124, Failures: 0, Errors: 0, Skipped: 0
- **downstream_checked:** none (new inventory utility + tests only; no public API shape change affecting reverse-deps)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3026

> Co-Authored by Grok Build using grok-4.5 with agent main.
