### PR TITLE
fix(explorer): restore classic //Folders root in left-hand nav (#3044)

### DIFF
--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -83,6 +83,48 @@ describe("ExplorerTree", () => {
     );
   });
 
+  it("renders classic Folders root from path/folder/ children (#3044)", async () => {
+    const FOLDERS_ROOT: PSPathItem = {
+      id: "folders-root",
+      path: "/Folders/",
+      name: "Folders",
+      type: "folder",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    const SITES_ROOT: PSPathItem = {
+      id: "sites-root",
+      path: "/Sites/",
+      name: "Sites",
+      type: "folder",
+      leaf: false,
+      hasFolderChildren: true,
+    };
+    mockFetch(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      // Root children: encodePath("/") → folder/ (empty suffix).
+      if (
+        url.endsWith("/pathmanagement/path/folder/") ||
+        /\/pathmanagement\/path\/folder\/?$/.test(url)
+      ) {
+        return pathItemListResponse([SITES_ROOT, FOLDERS_ROOT]);
+      }
+      return pathItemListResponse([]);
+    });
+    render(
+      <ExplorerTree
+        initialPath="/"
+        selectedPath={null}
+        onSelectFolder={() => undefined}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("tree-node-/Folders/")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("tree-node-/Sites/")).toBeInTheDocument();
+    expect(screen.getByText("Folders")).toBeInTheDocument();
+  });
+
   it("renders site-type children with id paths under /Sites (#3001)", async () => {
     // Wire shape from PSSitePathItemService: type=site, path=/Sites/{id}/
     const SITE_CHILD: PSPathItem = {

--- a/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/folderPath.test.ts
@@ -75,6 +75,21 @@ describe("isStrictCmsPathDescendant (#3001)", () => {
     expect(isStrictCmsPathDescendant("/", "/Sites/")).toBe(true);
     expect(isStrictCmsPathDescendant("/", "/")).toBe(false);
   });
+
+  it("accepts classic Folders root and children under / (#3044)", () => {
+    expect(isStrictCmsPathDescendant("/", "/Folders/")).toBe(true);
+    expect(isStrictCmsPathDescendant("/", "//Folders")).toBe(true);
+    expect(isStrictCmsPathDescendant("/", "/Folders")).toBe(true);
+    expect(
+      isStrictCmsPathDescendant("/Folders", "/Folders/$System$"),
+    ).toBe(true);
+    expect(
+      isStrictCmsPathDescendant("//Folders/", "//Folders/$System$/Assets"),
+    ).toBe(true);
+    // Self is not a strict descendant (tree cycle guard).
+    expect(isStrictCmsPathDescendant("/Folders", "/Folders")).toBe(false);
+    expect(isStrictCmsPathDescendant("/Folders", "/Sites")).toBe(false);
+  });
 });
 
 describe("resolveFolderPathFromSelection (#2792)", () => {

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
@@ -90,6 +90,13 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
       `GET ${PATH_FOLDER}/Sites must not 400 (folder//Sites was the bug)`,
     ).toBe(200);
 
+    // Classic //Folders root (#3044): must resolve like Sites/Assets/Design.
+    const folders = await request.get(`${PATH_FOLDER}/Folders`, { headers });
+    expect(
+      folders.status(),
+      `GET ${PATH_FOLDER}/Folders should be 200 (classic Folders root #3044)`,
+    ).toBe(200);
+
     const bad = await request.get(`${PATH_FOLDER}//Sites`, { headers });
     // Document the server contract the SPA must avoid.
     expect(bad.status()).toBe(400);

--- a/modules/perc-qa-automation/frontend/tests/helpers/pathmanagement-url.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/pathmanagement-url.js
@@ -44,8 +44,17 @@ function isHumanReadableErrorText(text) {
   return t.length >= 3;
 }
 
-/** Well-known CMS root folders returned by path/folder/ on a stock install. */
-const EXPECTED_ROOT_FOLDER_NAMES = Object.freeze(["Sites", "Assets", "Design"]);
+/**
+ * Well-known CMS root folders returned by path/folder/ on a stock install.
+ * Includes classic Rhythmyx Folders (//Folders) next to Sites/Assets/Design (#3044).
+ * Recycling / Search may also appear depending on roles; not required here.
+ */
+const EXPECTED_ROOT_FOLDER_NAMES = Object.freeze([
+  "Sites",
+  "Folders",
+  "Assets",
+  "Design",
+]);
 
 module.exports = {
   isDoubleSlashPathmanagementUrl,

--- a/modules/perc-qa-automation/frontend/tests/unit/pathmanagement-url.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/pathmanagement-url.test.js
@@ -99,8 +99,9 @@ describe("isHumanReadableErrorText", () => {
 });
 
 describe("EXPECTED_ROOT_FOLDER_NAMES", () => {
-  it("includes Sites, Assets, Design", () => {
+  it("includes Sites, Folders, Assets, Design (#3044)", () => {
     assert.ok(EXPECTED_ROOT_FOLDER_NAMES.includes("Sites"));
+    assert.ok(EXPECTED_ROOT_FOLDER_NAMES.includes("Folders"));
     assert.ok(EXPECTED_ROOT_FOLDER_NAMES.includes("Assets"));
     assert.ok(EXPECTED_ROOT_FOLDER_NAMES.includes("Design"));
   });

--- a/product-docs/8.2/admin/content-explorer.md
+++ b/product-docs/8.2/admin/content-explorer.md
@@ -24,6 +24,24 @@ and assets without launching Desktop Content Explorer (DCE). Open it from the SP
 | **Tree + detail list** | Folder navigation and list of children; optional display-format columns |
 | **Context menu** | Right-click an item or folder row for the same catalog filtered for the popup surface |
 
+## Left-hand roots (Sites, Folders, Assets, Design, Recycling)
+
+The Explorer **tree** lists the standard top-level containers returned by the CMS path
+service (roles may hide Design/Recycling for some users):
+
+| Root | Maps to | Purpose |
+|------|---------|---------|
+| **Sites** | `//Sites` | Traditional site folders and pages |
+| **Folders** | `//Folders` | Classic Rhythmyx folder tree (including `$System$` and other repository folders) |
+| **Assets** | `//Folders/$System$/Assets` | Shared asset library (CM1 convenience root) |
+| **Design** | Design file-system area | Templates, themes, web resources (Admin/Designer) |
+| **Recycling** | `//Folders/$System$/Recycling` | Recycled items (Admin/Designer) |
+
+**Folders** is the same classic **//Folders** container available in Desktop Content
+Explorer. Use it when you need the full repository folder hierarchy rather than only the
+Assets or Sites shortcuts. Expanding **Folders** loads children from the server; folder
+visibility still respects folder ACLs.
+
 ## Sites list and Create Site
 
 Under the tree root **Sites** you see traditional site folders available to your community

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSDispatchingPathService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSDispatchingPathService.java
@@ -406,6 +406,9 @@ public class PSDispatchingPathService implements IPSPathService, IPSPathRecycleS
       if (path.toLowerCase().startsWith("sites")) {
         path = replaceIgnoreCase(path, "sites", "Sites");
       }
+      if (path.toLowerCase().startsWith("folders")) {
+        path = replaceIgnoreCase(path, "folders", "Folders");
+      }
       if (path.toLowerCase().startsWith("assets")) {
         path = replaceIgnoreCase(path, "assets", "Assets");
       }
@@ -428,7 +431,8 @@ public class PSDispatchingPathService implements IPSPathService, IPSPathRecycleS
         } else if (strReturn.isEmpty()
             && (pathItem.getName().equalsIgnoreCase("assets")
                 || pathItem.getName().equalsIgnoreCase("design")
-                || pathItem.getName().equalsIgnoreCase("sites"))) {
+                || pathItem.getName().equalsIgnoreCase("sites")
+                || pathItem.getName().equalsIgnoreCase("folders"))) {
           strReturn = pathItem.getPath();
         }
       }

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSFoldersPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSFoldersPathItemService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pathmanagement.service.impl;
+
+import com.percussion.assetmanagement.service.IPSAssetService;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.services.contentmgr.IPSContentMgr;
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.ui.service.IPSListViewHelper;
+import com.percussion.user.service.IPSUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Path item service for the classic Rhythmyx {@code //Folders} repository root.
+ *
+ * <p>Registers as finder path {@code /Folders/} so Explorer {@code findChildren("/")} returns a
+ * <strong>Folders</strong> root next to Sites, Assets, Design, and Recycling (#3044). Children are
+ * the real folder hierarchy under {@code //Folders} (including {@code $System$}).</p>
+ *
+ * <p>CM1 convenience roots ({@code /Assets}, {@code /Recycling}) remain separate path services that
+ * map into {@code //Folders/$System$/…}; this service exposes the full classic tree without
+ * replacing those roots.</p>
+ */
+@Component("foldersPathItemService")
+public class PSFoldersPathItemService extends PSPathItemService {
+
+  @Autowired
+  public PSFoldersPathItemService(
+      IPSFolderHelper folderHelper,
+      IPSIdMapper idMapper,
+      IPSItemWorkflowService itemWorkflowService,
+      IPSAssetService assetService,
+      IPSWidgetAssetRelationshipService widgetAssetRelationshipService,
+      IPSContentMgr contentMgr,
+      IPSWorkflowService workflowService,
+      IPSPageService pageService,
+      @Qualifier("cm1ListViewHelper") IPSListViewHelper listViewHelper,
+      IPSUserService userService) {
+    super(
+        folderHelper,
+        idMapper,
+        itemWorkflowService,
+        assetService,
+        widgetAssetRelationshipService,
+        contentMgr,
+        workflowService,
+        pageService,
+        listViewHelper,
+        userService);
+    setRootName("Folders");
+  }
+
+  @Override
+  protected String getFullFolderPath(String path) throws PSPathNotFoundServiceException {
+    PSPathUtils.validatePath(path);
+    var fullFolderPath = FOLDERS_ROOT;
+    if (!"/".equals(path)) {
+      fullFolderPath = folderHelper.concatPath(fullFolderPath, path);
+    }
+    return fullFolderPath;
+  }
+
+  @Override
+  protected String getFolderRoot() {
+    return FOLDERS_ROOT;
+  }
+
+  @Override
+  protected String getInUsePagesResult() {
+    return FOLDERS_IN_USE_PAGES;
+  }
+
+  @Override
+  protected String getNotAuthorizedResult() {
+    return FOLDERS_NOT_AUTHORIZED;
+  }
+
+  @Override
+  protected String getInUseTemplatesResult() {
+    return FOLDERS_IN_USE_TEMPLATES;
+  }
+
+  /** Internal repository root for classic Rhythmyx folders. */
+  public static final String FOLDERS_ROOT = "//Folders";
+
+  /** Finder / pathmanagement prefix (trailing slash is the registry key form). */
+  public static final String FOLDERS_FINDER_ROOT = "/Folders";
+
+  public static final String FOLDERS_IN_USE_PAGES = "FoldersInUsePages";
+
+  public static final String FOLDERS_NOT_AUTHORIZED = "FoldersNotAuthorized";
+
+  public static final String FOLDERS_IN_USE_TEMPLATES = "FoldersInUseTemplates";
+}

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -1595,7 +1595,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
     <bean id="pathService" class="com.percussion.pathmanagement.service.impl.PSPathService" lazy-init="true">
         <property name="registry">
             <map>
+                <!-- Order: Sites, Folders (classic //Folders, #3044), Assets, Design, Search, Recycling -->
                 <entry key="/Sites/" value-ref="sitePathItemService" />
+                <entry key="/Folders/" value-ref="foldersPathItemService" />
                 <entry key="/Assets/" value-ref="assetPathItemService" />
                 <entry key="/Design/" value-ref="designPathItemService" />
                 <entry key="/Search/" value-ref="searchPathItemService" />

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSPathUtilsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSPathUtilsTest.java
@@ -50,6 +50,12 @@ public class PSPathUtilsTest {
     assertEquals(folderPath, PSPathUtils.getFolderPath(finderPath));
     assertEquals(finderPath, PSPathUtils.getFinderPath("////path"));
     assertEquals(folderPath, PSPathUtils.getFolderPath("////path"));
+
+    // Classic //Folders root (#3044): finder form is /Folders; folder form is //Folders.
+    assertEquals("/Folders", PSPathUtils.getFinderPath("//Folders"));
+    assertEquals("//Folders", PSPathUtils.getFolderPath("/Folders"));
+    assertEquals("/Folders/$System$", PSPathUtils.getFinderPath("//Folders/$System$"));
+    assertEquals("//Folders/$System$", PSPathUtils.getFolderPath("/Folders/$System$"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/impl/PSFoldersPathItemServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/impl/PSFoldersPathItemServiceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pathmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.pathmanagement.service.IPSPathService.PSPathNotFoundServiceException;
+import com.percussion.share.dao.IPSFolderHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for classic {@code //Folders} path mapping (#3044).
+ *
+ * <p>Does not require a running CMS: {@link IPSFolderHelper#concatPath} is stubbed with the same
+ * portable join used by production ({@code /} path segments).</p>
+ */
+public class PSFoldersPathItemServiceTest {
+
+  private TestFoldersPathItemService service;
+  private IPSFolderHelper folderHelper;
+
+  @BeforeEach
+  public void setUp() {
+    folderHelper = Mockito.mock(IPSFolderHelper.class);
+    Mockito.when(folderHelper.concatPath(Mockito.anyString(), Mockito.anyString()))
+        .thenAnswer(
+            inv -> {
+              String start = inv.getArgument(0);
+              String end = inv.getArgument(1);
+              if (end == null || end.isEmpty() || "/".equals(end)) {
+                return start;
+              }
+              String rel = end.startsWith("/") ? end.substring(1) : end;
+              // Strip trailing slash from relative segment for stable concat.
+              if (rel.endsWith("/")) {
+                rel = rel.substring(0, rel.length() - 1);
+              }
+              if (start.endsWith("/")) {
+                return start + rel;
+              }
+              return start + "/" + rel;
+            });
+    service = new TestFoldersPathItemService(folderHelper);
+  }
+
+  @Test
+  public void rootNameIsFolders() {
+    assertEquals("Folders", service.getRootName());
+  }
+
+  @Test
+  public void fullFolderPathAtRootIsClassicDoubleSlashFolders() throws Exception {
+    assertEquals(
+        PSFoldersPathItemService.FOLDERS_ROOT, service.exposeFullFolderPath("/"));
+  }
+
+  @Test
+  public void fullFolderPathConcatenatesRelativeChildren() throws Exception {
+    // PathMatch always normalizes with a trailing slash before calling the service.
+    assertEquals(
+        "//Folders/$System$", service.exposeFullFolderPath("/$System$/"));
+    assertEquals(
+        "//Folders/$System$/Assets/uploads",
+        service.exposeFullFolderPath("/$System$/Assets/uploads/"));
+  }
+
+  @Test
+  public void fullFolderPathRejectsNullOrBlank() {
+    assertThrows(Exception.class, () -> service.exposeFullFolderPath(null));
+    assertThrows(Exception.class, () -> service.exposeFullFolderPath(""));
+  }
+
+  @Test
+  public void folderRootConstantMatchesClassicRepositoryRoot() {
+    assertEquals("//Folders", PSFoldersPathItemService.FOLDERS_ROOT);
+    assertEquals("/Folders", PSFoldersPathItemService.FOLDERS_FINDER_ROOT);
+    assertTrue(PSFoldersPathItemService.FOLDERS_ROOT.startsWith("//"));
+  }
+
+  @Test
+  public void pathUtilsRoundTripForFoldersRoot() {
+    assertEquals(
+        "/Folders",
+        PSPathUtils.getFinderPath(PSFoldersPathItemService.FOLDERS_ROOT));
+    assertEquals(
+        "//Folders/legacy",
+        PSPathUtils.getFolderPath("/Folders/legacy"));
+    assertEquals(
+        "/Folders/legacy",
+        PSPathUtils.getFinderPath("//Folders/legacy"));
+  }
+
+  /**
+   * Test double that wires only {@link IPSFolderHelper} and exposes protected path mapping for
+   * assertions.
+   */
+  private static final class TestFoldersPathItemService extends PSFoldersPathItemService {
+    TestFoldersPathItemService(IPSFolderHelper folderHelper) {
+      super(folderHelper, null, null, null, null, null, null, null, null, null);
+    }
+
+    String exposeFullFolderPath(String path) throws PSPathNotFoundServiceException {
+      return getFullFolderPath(path);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Restores the classic Rhythmyx **Folders** (`//Folders`) root in the modern Explorer left-hand tree next to Sites, Assets, Design, and Recycling.

**Root cause:** `pathService` registry only listed Sites/Assets/Design/Search/Recycling, so `findChildren("/")` never returned Folders. The React ExplorerTree correctly renders whatever the path API returns (no UI filter was dropping Folders).

**Fix:**
- New `PSFoldersPathItemService` mapping finder `/Folders/` → repository `//Folders`
- Registered in `sitemanage-beans.xml` pathService registry
- Path case normalization for `folders` in `validateEnteredPath`
- Vitest coverage for Folders under root / descendant filter
- QA expected roots + bug-1622 REST check for `/path/folder/Folders`
- Product docs: Explorer left-hand roots table

Fixes #3044

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; `PSFoldersPathItemServiceTest` 6/0; `PSPathUtilsTest` 5/0
- [x] `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Java surefire 37 tests; vitest folderPath+ExplorerTree 18 passed
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS; `npm run test:unit` 226 pass (EXPECTED_ROOT includes Folders)
- [ ] Human QA on deployed build: Explorer left nav shows **Folders**; expand loads children; ACL respected
- [ ] After deploy: surface Playwright `bug-1622-explorer-root-folders` / `EXPECTED_ROOT_FOLDER_NAMES`

## Product documentation
- [x] Updated `product-docs/8.2/admin/content-explorer.md` — left-hand roots table including Folders

## Build evidence (C3)
- **modules_built:** `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS; PSFoldersPathItemServiceTest Tests run: 6, Failures: 0
  - `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS; surefire 37 tests; vitest ExplorerTree+folderPath 18 passed
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` → BUILD SUCCESS; frontend test:unit 226 pass
- **downstream_checked:** none (no final/sealed type or public signature breaks; new service + Spring registry entry only)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
