### PR TITLE
fix(WebUI/rest): Template Source editor loads server source (#3039)

### DIFF
--- a/WebUI/src/main/ts/api/developer/assemblyApi.ts
+++ b/WebUI/src/main/ts/api/developer/assemblyApi.ts
@@ -30,6 +30,99 @@ import type {
   TemplateSummary,
 } from "./types";
 
+/**
+ * Jackson {@code @JsonRootName} / WRAP_ROOT_VALUE root for {@code TemplateDetail}.
+ * REST {@code JacksonContextResolver} wraps single-object responses and requires
+ * the same envelope on PUT (UNWRAP_ROOT_VALUE). Without client unwrap, the SPA
+ * reads {@code d.templateSource} on the outer object and the Source editor is
+ * always empty (#3039).
+ */
+export const TEMPLATE_DETAIL_ROOT = "TemplateDetail";
+
+/** Jackson root for {@code SlotDetail} (same WRAP/UNWRAP contract as templates). */
+export const SLOT_DETAIL_ROOT = "SlotDetail";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+/**
+ * Normalize a templates GET/PUT response to a flat {@link TemplateDetail}.
+ *
+ * <p>Prefers {@code { "TemplateDetail": { … } }}; also accepts a flat body
+ * (unit tests / proxies that already unwrapped).
+ */
+export function unwrapTemplateDetail(payload: unknown): TemplateDetail {
+  const root = asRecord(payload);
+  if (!root) {
+    return {};
+  }
+  const nested = asRecord(root[TEMPLATE_DETAIL_ROOT] ?? root.templateDetail);
+  if (nested) {
+    return nested as TemplateDetail;
+  }
+  // Flat body: only treat as detail when it looks like one (has template identity
+  // or source/bindings fields). Bare error envelopes stay empty.
+  if (
+    "name" in root ||
+    "templateId" in root ||
+    "templateSource" in root ||
+    "label" in root ||
+    "bindings" in root
+  ) {
+    return root as TemplateDetail;
+  }
+  return {};
+}
+
+/**
+ * Build the wire JSON body for TemplatesResource PUT under
+ * {@link TEMPLATE_DETAIL_ROOT}. A flat body fails server UNWRAP_ROOT_VALUE
+ * (same class as UserPreference #2708).
+ */
+export function wrapTemplateDetailForWire(
+  body: Partial<
+    Pick<
+      TemplateDetail,
+      "label" | "description" | "templateSource" | "assembler" | "bindings" | "slots"
+    >
+  >,
+): Record<string, typeof body> {
+  return { [TEMPLATE_DETAIL_ROOT]: body };
+}
+
+/**
+ * Normalize a slots GET/PUT response to a flat {@link SlotDetail}.
+ */
+export function unwrapSlotDetail(payload: unknown): SlotDetail {
+  const root = asRecord(payload);
+  if (!root) {
+    return {};
+  }
+  const nested = asRecord(root[SLOT_DETAIL_ROOT] ?? root.slotDetail);
+  if (nested) {
+    return nested as SlotDetail;
+  }
+  if ("name" in root || "label" in root || "associations" in root || "slotLayout" in root) {
+    return root as SlotDetail;
+  }
+  return {};
+}
+
+/**
+ * Wire JSON body for SlotsResource PUT under {@link SLOT_DETAIL_ROOT}.
+ */
+export function wrapSlotDetailForWire(
+  body: Partial<
+    Pick<SlotDetail, "label" | "description" | "associations" | "slotLayout" | "slotStyles">
+  >,
+): Record<string, typeof body> {
+  return { [SLOT_DETAIL_ROOT]: body };
+}
+
 function asArray<T>(payload: unknown, keys: string[]): T[] {
   if (payload == null) return [];
   if (Array.isArray(payload)) return payload as T[];
@@ -58,19 +151,22 @@ export async function listTemplates(): Promise<TemplateSummary[]> {
  * GET /services/templates/{idOrName}
  *
  * <p>Throws {@link ApiError} / {@link SessionRedirectError} on non-2xx (including 404).
- * Callers should not treat a successful response as nullable.
+ * Unwraps Jackson {@link TEMPLATE_DETAIL_ROOT} so callers bind {@code templateSource}
+ * and meta fields from a flat object (#3039).
  */
 export async function getTemplateDetail(
   idOrName: string,
 ): Promise<TemplateDetail> {
   const key = encodeURIComponent(idOrName);
-  return get<TemplateDetail>(`${PATHS.TEMPLATES}/${key}`);
+  const payload = await get<unknown>(`${PATHS.TEMPLATES}/${key}`);
+  return unwrapTemplateDetail(payload);
 }
 
 /**
  * PUT /services/templates/{idOrName} — label, description, source, optional bindings/slots.
  * Omitted fields are left unchanged server-side; {@code bindings}/{@code slots} when present
- * fully replace the collection (including empty list).
+ * fully replace the collection (including empty list). Request body is root-wrapped for
+ * server UNWRAP_ROOT_VALUE; response is unwrapped the same way as GET.
  */
 export async function updateTemplateDetail(
   idOrName: string,
@@ -82,7 +178,11 @@ export async function updateTemplateDetail(
   >,
 ): Promise<TemplateDetail> {
   const key = encodeURIComponent(idOrName);
-  return put<TemplateDetail>(`${PATHS.TEMPLATES}/${key}`, body);
+  const payload = await put<unknown>(
+    `${PATHS.TEMPLATES}/${key}`,
+    wrapTemplateDetailForWire(body),
+  );
+  return unwrapTemplateDetail(payload);
 }
 
 /** GET /services/slots */
@@ -91,19 +191,27 @@ export async function listSlots(): Promise<SlotSummary[]> {
   return asArray<SlotSummary>(payload, ["Slot", "slot", "SlotList"]);
 }
 
-/** GET /services/slots/{idOrName} */
+/** GET /services/slots/{idOrName} — unwraps {@link SLOT_DETAIL_ROOT}. */
 export async function getSlotDetail(idOrName: string): Promise<SlotDetail> {
   const key = encodeURIComponent(idOrName);
-  return get<SlotDetail>(`${PATHS.SLOTS}/${key}`);
+  const payload = await get<unknown>(`${PATHS.SLOTS}/${key}`);
+  return unwrapSlotDetail(payload);
 }
 
-/** PUT /services/slots/{idOrName} — label, description, optional associations replace */
+/**
+ * PUT /services/slots/{idOrName} — label, description, optional associations replace.
+ * Root-wraps request body; unwraps response.
+ */
 export async function updateSlotDetail(
   idOrName: string,
   body: Partial<Pick<SlotDetail, "label" | "description" | "associations" | "slotLayout" | "slotStyles">>,
 ): Promise<SlotDetail> {
   const key = encodeURIComponent(idOrName);
-  return put<SlotDetail>(`${PATHS.SLOTS}/${key}`, body);
+  const payload = await put<unknown>(
+    `${PATHS.SLOTS}/${key}`,
+    wrapSlotDetailForWire(body),
+  );
+  return unwrapSlotDetail(payload);
 }
 
 /** GET /services/communities/find?name=* */

--- a/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
+++ b/WebUI/src/test/ts/api/developer/assemblyApi.templateDetail.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TEMPLATE_DETAIL_ROOT,
+  getTemplateDetail,
+  unwrapTemplateDetail,
+  updateTemplateDetail,
+  wrapTemplateDetailForWire,
+} from "../../../../main/ts/api/developer/assemblyApi";
+import { PATHS } from "../../../../main/ts/api/paths";
+
+describe("unwrapTemplateDetail / wrapTemplateDetailForWire (#3039)", () => {
+  it("unwraps Jackson TemplateDetail root with templateSource", () => {
+    const source = "#header()\n$body\n";
+    const flat = unwrapTemplateDetail({
+      [TEMPLATE_DETAIL_ROOT]: {
+        name: "perc.page",
+        label: "Page",
+        templateSource: source,
+        bindings: [{ executionOrder: 1, variable: "$x", expression: "1" }],
+      },
+    });
+    expect(flat.name).toBe("perc.page");
+    expect(flat.templateSource).toBe(source);
+    expect(flat.bindings?.[0]?.variable).toBe("$x");
+  });
+
+  it("accepts flat payload for tests / already-unwrapped clients", () => {
+    const flat = unwrapTemplateDetail({
+      name: "site.base",
+      templateSource: "#footer()\n",
+    });
+    expect(flat.templateSource).toBe("#footer()\n");
+  });
+
+  it("preserves intentionally empty source", () => {
+    const flat = unwrapTemplateDetail({
+      TemplateDetail: { name: "empty", templateSource: "" },
+    });
+    expect(flat.templateSource).toBe("");
+  });
+
+  it("returns empty object for unrelated envelopes", () => {
+    expect(unwrapTemplateDetail({ Error: { message: "x" } })).toEqual({});
+    expect(unwrapTemplateDetail(null)).toEqual({});
+  });
+
+  it("wrapTemplateDetailForWire nests under TemplateDetail root", () => {
+    const body = { templateSource: "#new\n", label: "L" };
+    expect(wrapTemplateDetailForWire(body)).toEqual({
+      TemplateDetail: body,
+    });
+  });
+});
+
+describe("getTemplateDetail / updateTemplateDetail wire binding (#3039)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("getTemplateDetail unwraps WRAP_ROOT payload so templateSource is bound", async () => {
+    const source = "<html>$sys.item</html>";
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        TemplateDetail: {
+          name: "perc.page",
+          templateSource: source,
+        },
+      }),
+    );
+
+    const d = await getTemplateDetail("perc.page");
+    expect(d.templateSource).toBe(source);
+    expect(d.name).toBe("perc.page");
+    expect(fetchMock).toHaveBeenCalled();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain(`${PATHS.TEMPLATES}/`);
+    expect(url).toContain(encodeURIComponent("perc.page"));
+  });
+
+  it("updateTemplateDetail wraps request and unwraps response", async () => {
+    const savedSource = "#saved\n";
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        TemplateDetail: {
+          name: "site.base",
+          templateSource: savedSource,
+        },
+      }),
+    );
+
+    const out = await updateTemplateDetail("site.base", {
+      templateSource: savedSource,
+    });
+    expect(out.templateSource).toBe(savedSource);
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    const sent = JSON.parse(String(init.body));
+    expect(sent).toEqual({
+      TemplateDetail: { templateSource: savedSource },
+    });
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/developer-template-source-viewer.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-template-source-viewer.spec.js
@@ -15,16 +15,17 @@
  */
 
 /**
- * Developer template detail — source viewer (UI-SRC-01 / #2088).
+ * Developer template detail — source viewer (UI-SRC-01 / #2088) + load binding (#3039).
  *
- * Asserts line-number gutter, copy control, and edit/preview chrome on the
- * template detail panel after opening the first catalog row.
+ * Asserts line-number gutter, copy control, edit/preview chrome, and that
+ * non-empty server templateSource is bound into the Source editor (Jackson
+ * WRAP_ROOT_VALUE unwrap — #3039).
  *
- * Live run requires a CMS with at least one template. Blocked on H2 qa-up
- * (#2065) / related stack issues until automation env is available.
+ * Live run requires a CMS with at least one template. Prefer QA mode:
+ *   perc-devctl qa-up → TEST_CMS_URL → npm run test:surface -- --path tests/developer-template-source-viewer.spec.js
  *
  * Entry: spa.jsp?entry=developer&section=templates
- * Refs #2088, #1690.
+ * Refs #2088, #1690, #3039.
  */
 
 const { test, expect } = require("@playwright/test");
@@ -88,7 +89,37 @@ test.describe("Developer template source viewer (#2088 UI-SRC-01)", () => {
       openBtn,
       "first template row should expose Open control when selectionKey is set",
     ).toBeVisible({ timeout: 5_000 });
+
+    // Capture detail GET (idOrName path segment) to assert UI binds templateSource (#3039).
+    const detailResponsePromise = page.waitForResponse(
+      (r) => {
+        if (r.request().method() !== "GET" || !r.ok()) return false;
+        try {
+          const u = new URL(r.url());
+          // /services/templates/{idOrName} — not the list endpoint
+          return /\/services\/templates\/[^/]+$/.test(u.pathname);
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30_000 },
+    );
+
     await openBtn.click();
+
+    let serverSource = "";
+    try {
+      const detailResp = await detailResponsePromise;
+      const raw = await detailResp.json();
+      const body =
+        raw && typeof raw === "object"
+          ? raw.TemplateDetail || raw.templateDetail || raw
+          : {};
+      serverSource =
+        typeof body.templateSource === "string" ? body.templateSource : "";
+    } catch {
+      // Non-JSON or aborted — fall through; chrome assertions still run
+    }
 
     await expect(
       page.locator('[data-testid="developer-tpl-detail"]'),
@@ -107,10 +138,17 @@ test.describe("Developer template source viewer (#2088 UI-SRC-01)", () => {
       page.locator('[data-testid="developer-tpl-source-ln-1"]'),
     ).toBeVisible();
 
-    // Edit surface by default
-    await expect(
-      page.locator('[data-testid="developer-tpl-source-edit"]'),
-    ).toBeVisible();
+    // Edit surface by default — must mirror server source when non-empty (#3039)
+    const sourceEdit = page.locator(
+      '[data-testid="developer-tpl-source-edit"]',
+    );
+    await expect(sourceEdit).toBeVisible();
+    if (serverSource.length > 0) {
+      await expect(
+        sourceEdit,
+        "Source editor must load non-empty templateSource from GET (#3039)",
+      ).toHaveValue(serverSource);
+    }
 
     // Copy control present; grant clipboard permissions when possible
     const copyBtn = page.locator('[data-testid="developer-tpl-source-copy"]');

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorGetTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorGetTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.templates.TemplateDetail;
+import com.percussion.services.assembly.IPSAssemblyService;
+import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import java.util.ArrayList;
+import java.util.HashSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Ensures getTemplate maps assembly template body into TemplateDetail.templateSource (#3039).
+ */
+@Tag("UnitTest")
+class TemplateAdaptorGetTest {
+
+  private static PSAssemblyTemplate mockTemplate(String name, String source) {
+    PSAssemblyTemplate template = mock(PSAssemblyTemplate.class);
+    PSGuid guid = new PSGuid(PSTypeEnum.TEMPLATE, 42L);
+    when(template.getGUID()).thenReturn(guid);
+    when(template.getName()).thenReturn(name);
+    when(template.getLabel()).thenReturn("Label-" + name);
+    when(template.getDescription()).thenReturn("desc");
+    when(template.getAssembler()).thenReturn("Java/global/percussion/assembly/velocityAssembler");
+    when(template.getBindings()).thenReturn(new ArrayList<>());
+    when(template.getSlots()).thenReturn(new HashSet<>());
+    when(template.getTemplate()).thenReturn(source);
+    when(template.isVariant()).thenReturn(false);
+    return template;
+  }
+
+  @Test
+  void getTemplate_populatesNonEmptyTemplateSource() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    String body = "#header()\n$body\n#footer()\n";
+    // Build template mock before stubbing asm (avoid nested when/thenReturn UnfinishedStubbing).
+    PSAssemblyTemplate template = mockTemplate("site.base", body);
+    when(asm.findTemplateByName("site.base")).thenReturn(template);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    TemplateDetail out = adaptor.getTemplate(null, "site.base");
+
+    assertNotNull(out);
+    assertEquals("site.base", out.getName());
+    assertEquals(body, out.getTemplateSource());
+  }
+
+  @Test
+  void getTemplate_preservesEmptyTemplateSource() throws Exception {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    PSAssemblyTemplate template = mockTemplate("empty.tpl", "");
+    when(asm.findTemplateByName("empty.tpl")).thenReturn(template);
+
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    TemplateDetail out = adaptor.getTemplate(null, "empty.tpl");
+
+    assertNotNull(out);
+    assertEquals("", out.getTemplateSource());
+  }
+
+  @Test
+  void getTemplate_nullWhenBlankId() {
+    IPSAssemblyService asm = mock(IPSAssemblyService.class);
+    IPSContentWs contentWs = mock(IPSContentWs.class);
+    TemplateAdaptor adaptor = new TemplateAdaptor(asm, contentWs);
+    assertNull(adaptor.getTemplate(null, "  "));
+    assertNull(adaptor.getTemplate(null, null));
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.slots;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,8 +26,14 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
 
-/** Assembly slot design detail for the Developer module (read + partial write). */
+/**
+ * Assembly slot design detail for the Developer module (read + partial write).
+ *
+ * <p>Wire root {@code SlotDetail} matches {@code WRAP_ROOT_VALUE}/{@code
+ * UNWRAP_ROOT_VALUE} (see TemplateDetail / issue #3039 companion).
+ */
 @XmlRootElement(name = "SlotDetail")
+@JsonRootName("SlotDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Slot detail with finder and content-type/template associations")
 public class SlotDetail {

--- a/rest/src/main/java/com/percussion/rest/templates/TemplateDetail.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplateDetail.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.templates;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,11 +27,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Read-only assembly template design summary for the Developer module.
+ * Assembly template design detail for the Developer / Design modules.
  *
- * <p>Does not support create/update/delete/lock or full source editing.
+ * <p>Jackson {@code WRAP_ROOT_VALUE}/{@code UNWRAP_ROOT_VALUE} (see {@code
+ * JacksonContextResolver}) emits and expects wire shape {@code {"TemplateDetail":{…}}}. SPA
+ * clients must unwrap GET responses and wrap PUT bodies or {@code templateSource} / meta fields
+ * appear empty (issue #3039).
  */
 @XmlRootElement(name = "TemplateDetail")
+@JsonRootName("TemplateDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Template detail with bindings, slots, and partial write support")
 public class TemplateDetail {

--- a/rest/src/test/java/com/percussion/rest/templates/TemplateDetailSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/templates/TemplateDetailSerialDeserialTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.templates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for TemplateDetail under WRAP_ROOT_VALUE / UNWRAP_ROOT_VALUE (#3039).
+ *
+ * <p>SPA clients must unwrap {@code {"TemplateDetail":{…}}} or source binds empty.
+ */
+@Tag("UnitTest")
+public class TemplateDetailSerialDeserialTest {
+
+  private final ObjectMapper mapper =
+      new JacksonContextResolver().getContext(TemplateDetail.class);
+
+  @Test
+  public void serializesTemplateSourceUnderRoot() {
+    TemplateDetail d = new TemplateDetail();
+    d.setName("perc.page");
+    d.setLabel("Page");
+    d.setTemplateSource("#header()\n$body\n");
+
+    String json = mapper.writeValueAsString(d);
+
+    assertTrue(json.contains("\"TemplateDetail\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"templateSource\""), json);
+    assertTrue(json.contains("#header()"), json);
+  }
+
+  @Test
+  public void deserializesWrappedBodyWithTemplateSource() {
+    String json =
+        "{\"TemplateDetail\":{"
+            + "\"name\":\"site.base\","
+            + "\"templateSource\":\"#footer()\\n\""
+            + "}}";
+
+    TemplateDetail d = mapper.readValue(json, TemplateDetail.class);
+    assertEquals("site.base", d.getName());
+    assertEquals("#footer()\n", d.getTemplateSource());
+  }
+
+  @Test
+  public void roundTripPreservesEmptySource() {
+    TemplateDetail d = new TemplateDetail();
+    d.setName("empty.tpl");
+    d.setTemplateSource("");
+
+    String json = mapper.writeValueAsString(d);
+    TemplateDetail back = mapper.readValue(json, TemplateDetail.class);
+    assertEquals("empty.tpl", back.getName());
+    // empty string is not null; NON_NULL still emits it
+    assertEquals("", back.getTemplateSource());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
@@ -63,6 +63,17 @@ public class TemplatesResourceDetailTest {
   }
 
   @Test
+  public void getTemplateReturnsTemplateSource() {
+    TemplateDetail d = new TemplateDetail();
+    d.setName("perc.page");
+    d.setTemplateSource("#header()\n$body\n");
+    when(adaptor.getTemplate(any(), eq("perc.page"))).thenReturn(d);
+
+    TemplateDetail out = resource.getTemplate("perc.page");
+    assertEquals("#header()\n$body\n", out.getTemplateSource());
+  }
+
+  @Test
   public void getTemplateReturnsStructuredDesignGaps() {
     TemplateDetail d = new TemplateDetail();
     d.setName("perc.page");


### PR DESCRIPTION
## Summary

Fixes **Developer → Templates → Source** (and Design TemplateSourceEditor) always showing an empty source pane.

**Root cause:** REST `JacksonContextResolver` enables `WRAP_ROOT_VALUE` / `UNWRAP_ROOT_VALUE`. `TemplateDetail` responses are wire-shaped as `{"TemplateDetail":{…,"templateSource":"…"}}`, but `getTemplateDetail` treated the outer object as the detail DTO, so `d.templateSource` was always `undefined` and the editor bound `""`. PUT bodies were also sent flat (server unwrap expects the root).

**Fix:**
- Explicit `@JsonRootName("TemplateDetail")` / `SlotDetail` on REST DTOs
- SPA `unwrapTemplateDetail` / `wrapTemplateDetailForWire` (and slot companions) in `assemblyApi.ts`
- Adaptor unit test proves `t.getTemplate()` → `templateSource`
- REST serial/deserial + resource tests
- Vitest wire binding + Playwright asserts editor value matches non-empty server source

## Test plan

- [x] `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 303, Failures: 0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1030, Failures: 0, Errors: 0
- [x] `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS
- [x] Vitest: `assemblyApi.templateDetail.test.ts` + TemplateDetailPanel + TemplateSourceEditor (19 tests)
- [ ] Playwright (QA mode when available): `developer-template-source-viewer.spec.js` — asserts source textarea == server `templateSource` when non-empty

### C3 build evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 303, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1030, Failures: 0, Errors: 0 (Skipped: 125)
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS
  - Vitest focused: 19 passed
- **downstream_checked:** none (no public API signature / final/sealed type change; DTO annotation + SPA unwrap only; sitemanage reverse-dep of rest was clean-installed as the adaptor module)

## Product documentation

- [x] N/A — bugfix restoring expected load of existing template source; no new operator steps or config

## Checklist

- [x] Erlang-style self-review (wire unwrap pattern matches UserPreference / DisplayFormat peers)
- [x] Unit tests for load path
- [x] Playwright surface assertion updated
- [x] Cross-platform: no path I/O changes

Fixes #3039

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
