### PR TITLE
fix(perc-content-explorer): PSOptionManager rawtypes residual (#3012)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3012-psoptionmanager-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3012-psoptionmanager-rawtypes-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — #3012 PSOptionManager rawtypes residual
+
+**Scope:** `modules/DesktopContentExplorer` — `PSOptionManager` + `PSOptionManagerTest`  
+**Reviewer persona:** Erlang (independent of implementer)  
+**Date:** 2026-08-11
+
+## Change class
+
+Compiler tech-debt: parameterize residual raw `Collection`/`Iterator`/`Map`/`HashMap` on option load/save helpers. No product behavior change intended.
+
+## Findings
+
+| Severity | Finding | Disposition |
+|----------|---------|-------------|
+| none | Bugs in new logic | Pass — `toXmlCollection` typed to `Collection<? extends IPSClientObjects>`; null element still rejected with `IllegalArgumentException` |
+| none | Missing behavioral tests | Pass — `PSOptionManagerTest` covers null args, empty, append, null element, and `compare` cases |
+| none | Non-portable paths | N/A — no file I/O |
+| none | Blanket class-level `@SuppressWarnings` | Pass — none added |
+| none | Product-docs gate | N/A — pure generics; no operator surface |
+
+## Companions checked
+
+- Peer pattern: #2993 / PR #3011 (`PSSearchDialog` + pure-helper unit tests)
+- Module standalone `mvnw clean install` required (done)
+- Did not touch #2439 `PSFolderAclEditorDialog` (still In Progress)
+
+## Verdict
+
+**Pass** — ready for commit/PR.

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSOptionManager.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
@@ -131,20 +130,16 @@ public class PSOptionManager {
    *     </code>.
    * @param doc - on which to create elements, must not be <code>null</code>.
    * @param col - must not be <code>null</code>, must contain objects of <code>IPSClientObjects
-   *     </code>, may be empty.
+   *     </code>, may be empty. Null elements are rejected with {@link IllegalArgumentException} to
+   *     match historical raw-collection validation.
    */
-  static void toXmlCollection(Element el, Document doc, Collection col) {
+  static void toXmlCollection(Element el, Document doc, Collection<? extends IPSClientObjects> col) {
     if (el == null || doc == null || col == null)
       throw new IllegalArgumentException("arguments must not be null");
 
-    Iterator it = col.iterator();
-    IPSClientObjects comp = null;
-    while (it.hasNext()) {
-      Object o = it.next();
-      if (!(o instanceof IPSClientObjects))
+    for (IPSClientObjects comp : col) {
+      if (comp == null)
         throw new IllegalArgumentException("Collection must contain only IPSClientObjects values");
-
-      comp = (IPSClientObjects) o;
       el.appendChild(comp.toXml(doc));
     }
   }
@@ -188,7 +183,7 @@ public class PSOptionManager {
               + "updateTimeout="
               + updateSessionTimeout;
 
-      Map params = new HashMap();
+      Map<String, String> params = new HashMap<>();
       params.put(SESSIONOBJECT_CXOPTIONS, PSXmlDocumentBuilder.toString(postDoc));
 
       m_applet.getActionManager().postData(appPath, params);

--- a/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSOptionManagerTest.java
+++ b/modules/DesktopContentExplorer/src/test/java/com/percussion/cx/PSOptionManagerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cx.error.PSContentExplorerException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral tests for pure helpers on {@link PSOptionManager} after rawtypes cleanup (#3012). Does
+ * not open the Swing applet (requires live server resources).
+ */
+public class PSOptionManagerTest {
+
+  @Test
+  public void toXmlCollectionRejectsNullArgs() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = doc.createElement("root");
+    List<IPSClientObjects> empty = Collections.emptyList();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> PSOptionManager.toXmlCollection(null, doc, empty));
+    assertThrows(
+        IllegalArgumentException.class, () -> PSOptionManager.toXmlCollection(root, null, empty));
+    assertThrows(
+        IllegalArgumentException.class, () -> PSOptionManager.toXmlCollection(root, doc, null));
+  }
+
+  @Test
+  public void toXmlCollectionEmptyLeavesParentUnchanged() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = doc.createElement("root");
+    doc.appendChild(root);
+
+    PSOptionManager.toXmlCollection(root, doc, Collections.emptyList());
+
+    assertEquals(0, root.getChildNodes().getLength());
+  }
+
+  @Test
+  public void toXmlCollectionAppendsElementsFromTypedCollection() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = doc.createElement("root");
+    doc.appendChild(root);
+
+    List<IPSClientObjects> items = new ArrayList<>();
+    items.add(new StubClientObject("first"));
+    items.add(new StubClientObject("second"));
+
+    PSOptionManager.toXmlCollection(root, doc, items);
+
+    assertEquals(2, root.getChildNodes().getLength());
+    assertEquals("first", ((Element) root.getChildNodes().item(0)).getTagName());
+    assertEquals("second", ((Element) root.getChildNodes().item(1)).getTagName());
+  }
+
+  @Test
+  public void toXmlCollectionRejectsNullElementInCollection() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = doc.createElement("root");
+    List<IPSClientObjects> items = new ArrayList<>();
+    items.add(null);
+
+    assertThrows(
+        IllegalArgumentException.class, () -> PSOptionManager.toXmlCollection(root, doc, items));
+  }
+
+  @Test
+  public void compareBothNullIsTrue() {
+    assertTrue(PSOptionManager.compare(null, null));
+  }
+
+  @Test
+  public void compareOneNullIsFalse() {
+    assertFalse(PSOptionManager.compare("a", null));
+    assertFalse(PSOptionManager.compare(null, "b"));
+  }
+
+  @Test
+  public void compareStringsIgnoreCase() {
+    assertTrue(PSOptionManager.compare("Abc", "abc"));
+    assertFalse(PSOptionManager.compare("Abc", "abd"));
+  }
+
+  @Test
+  public void compareObjectArrays() {
+    assertTrue(PSOptionManager.compare(new String[] {"a", "b"}, new String[] {"a", "b"}));
+    assertFalse(PSOptionManager.compare(new String[] {"a"}, new String[] {"b"}));
+  }
+
+  @Test
+  public void compareUsesEqualsForNonStringObjects() {
+    assertTrue(PSOptionManager.compare(Integer.valueOf(7), Integer.valueOf(7)));
+    assertFalse(PSOptionManager.compare(Integer.valueOf(7), Integer.valueOf(8)));
+    assertTrue(PSOptionManager.compare(Arrays.asList("x"), Arrays.asList("x")));
+  }
+
+  /** Minimal {@link IPSClientObjects} that emits a named empty element. */
+  private static final class StubClientObject implements IPSClientObjects {
+    private final String tagName;
+
+    StubClientObject(String tagName) {
+      this.tagName = tagName;
+    }
+
+    @Override
+    public void fromXml(Element sourceNode) throws PSContentExplorerException {
+      // not needed for toXml tests
+    }
+
+    @Override
+    public Element toXml(Document doc) {
+      return doc.createElement(tagName);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Parameterize residual rawtypes on Desktop Content Explorer **PSOptionManager** after #2993 / PR #3011.

- **PSOptionManager**: `toXmlCollection` uses `Collection<? extends IPSClientObjects>` + for-each (null elements still rejected); save path uses `Map<String, String>` for postData
- Unit tests: `PSOptionManagerTest` (9) covering pure helpers `toXmlCollection` and `compare`
- **Did not touch** `PSFolderAclEditorDialog` (#2439 In Progress)
- **Left for next residual:** `PSItemAssemblyManager` (module still has raw Iterator/Map on assembly APIs)

No product behavior change (compiler tech-debt only).

Parent residual tracker: #2326  
Parent module: #2045  
Monorepo: #2200  
Prior slice: #2993  

Fixes #3012

## Test plan
- [x] `cd modules/DesktopContentExplorer && ../../mvnw.cmd clean install`
- [x] BUILD SUCCESS — Tests run: 148, Failures: 0
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-3012-psoptionmanager-rawtypes-erlang.md`

## Product documentation
- [x] N/A — pure rawtypes/generics tech-debt; no operator/user/API surface change

## Build evidence (C3)
- **modules_built:** `modules/DesktopContentExplorer`
- **build_evidence:** `cd modules/DesktopContentExplorer; ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 148, Failures: 0, Errors: 0, Skipped: 0
- **downstream_checked:** none (C2 N/A — no final/sealed; no public/protected signature change beyond package-private static helper generic param; module suite compiled + tested)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
