### PR TITLE
fix(deployer): Xlint ContentType handler generics (#3047)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeDependencyHandler.java
@@ -141,11 +141,10 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
     PSCollection dataSetColl = app.getDataSets();
     if (dataSetColl != null) {
-      Iterator datasets = dataSetColl.iterator();
       PSDependencyHandler wfHandler =
           getDependencyHandler(PSWorkflowDependencyHandler.DEPENDENCY_TYPE);
-      while (datasets.hasNext()) {
-        PSDataSet ds = (PSDataSet) datasets.next();
+      for (Object rawDs : dataSetColl) {
+        PSDataSet ds = (PSDataSet) rawDs;
         if (ds instanceof PSContentEditor) {
           PSContentEditor ce = (PSContentEditor) ds;
           // add system def if haven't already
@@ -190,7 +189,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
           PSDependencyHandler sharedHandler =
               getDependencyHandler(PSSharedGroupDependencyHandler.DEPENDENCY_TYPE);
-          Iterator sharedIncludes = ceMapper.getSharedFieldIncludes();
+          Iterator<?> sharedIncludes = ceMapper.getSharedFieldIncludes();
           while (sharedIncludes.hasNext()) {
             String groupName = (String) sharedIncludes.next();
             PSDependency sharedGrpDep = sharedHandler.getDependency(tok, groupName);
@@ -266,7 +265,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
   // see base class
   @Override
-  public Iterator getChildDependencies(PSSecurityToken tok, PSDependency dep)
+  public Iterator<PSDependency> getChildDependencies(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException, PSNotFoundException {
     if (tok == null || dep == null || !dep.getObjectType().equals(DEPENDENCY_TYPE)) {
       throw new IllegalArgumentException("Invalid arguments provided");
@@ -363,12 +362,12 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
    * @throws PSDeployException if there are any errors. if there is no dependency file in the
    *     archive for the specified dependency object, or any other error occurs.
    */
-  protected static Iterator getItemDefFilesFromArchive(PSArchiveHandler archive, PSDependency dep)
-      throws PSDeployException {
+  protected static Iterator<PSDependencyFile> getItemDefFilesFromArchive(
+      PSArchiveHandler archive, PSDependency dep) throws PSDeployException {
     if (archive == null) throw new IllegalArgumentException("archive may not be null");
     if (dep == null) throw new IllegalArgumentException("dep may not be null");
 
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
 
     if (!files.hasNext()) {
       Object[] args = {
@@ -384,7 +383,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
   // see base class
   @Override
-  public Iterator getDependencyFiles(PSSecurityToken tok, PSDependency dep)
+  public Iterator<PSDependencyFile> getDependencyFiles(PSSecurityToken tok, PSDependency dep)
       throws PSDeployException, PSNotFoundException {
     if (tok == null || dep == null || !dep.getObjectType().equals(DEPENDENCY_TYPE)) {
       throw new IllegalArgumentException("Invalid arguments provided");
@@ -687,9 +686,9 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
     PSDependencyFile nodeFile = null;
     Set<PSContentTemplateDesc> tmpRel = null;
 
-    Iterator files = archive.getFiles(dep);
+    Iterator<PSDependencyFile> files = archive.getFiles(dep);
     while (files.hasNext()) {
-      PSDependencyFile depFile = (PSDependencyFile) files.next();
+      PSDependencyFile depFile = files.next();
       if (depFile.getType() == PSDependencyFile.TYPE_NODE_DEFINITION) {
         nodeFile = depFile;
         break;
@@ -896,7 +895,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
             PSExceptionUtils.getMessageForLog(e));
       }
     }
-    return new PSPair(item, curVer);
+    return new PSPair<>(item, curVer);
   }
 
   /**
@@ -988,11 +987,13 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
         Integer defaultWfId = getDefaultWorkflowId(wfInfo);
         if (defaultWfId != -1) {
           if (wfInfo == null) {
-            wfInfo = new PSWorkflowInfo(PSWorkflowInfo.TYPE_INCLUSIONARY, new ArrayList());
+            wfInfo =
+                new PSWorkflowInfo(PSWorkflowInfo.TYPE_INCLUSIONARY, new ArrayList<Integer>());
             ce.setWorkflowInfo(wfInfo);
           }
 
-          List wfIds = wfInfo.getWorkflowIds();
+          @SuppressWarnings("unchecked")
+          List<Integer> wfIds = wfInfo.getWorkflowIds();
           if (!wfIds.contains(defaultWfId)) {
             wfIds.add(defaultWfId);
           }
@@ -1188,7 +1189,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
    *     </code>, does not contain <code>null</code> or empty entries.
    */
   @Override
-  public Iterator getChildTypes() {
+  public Iterator<String> getChildTypes() {
     return ms_childTypes.iterator();
   }
 
@@ -1232,10 +1233,9 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
       if (dataSetColl == null) return idTypes;
 
-      Iterator datasets = dataSetColl.iterator();
-      while (datasets.hasNext()) {
-        List mappings = new ArrayList();
-        PSDataSet ds = (PSDataSet) datasets.next();
+      for (Object rawDs : dataSetColl) {
+        List<PSApplicationIDTypeMapping> mappings = new ArrayList<>();
+        PSDataSet ds = (PSDataSet) rawDs;
         String reqName = PSApplicationDependencyHandler.getResourceName(ds);
 
         // check page selection/validation properties
@@ -1272,7 +1272,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
           idTypes.addMappings(
               reqName, IPSDeployConstants.ID_TYPE_ELEMENT_CE_UI_DEF, mappings.iterator());
 
-          // walk all other possiblities
+          // walk all other possibilities
           PSApplicationFlow appFlow = ce.getApplicationFlow();
           if (appFlow != null) {
             mappings.clear();
@@ -1301,7 +1301,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
               mappings.iterator());
 
           mappings.clear();
-          Iterator links = ce.getSectionLinkList();
+          Iterator<?> links = ce.getSectionLinkList();
           while (links.hasNext()) {
             PSAppTransformer.checkUrlRequest(mappings, (PSUrlRequest) links.next(), null);
           }
@@ -1412,7 +1412,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
           } else if (element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_CE_OUTPUT_TRANSLATIONS)) {
             PSAppTransformer.transformConditionalExits(ce.getOutputTranslations(), mapping, idMap);
           } else if (element.equals(IPSDeployConstants.ID_TYPE_ELEMENT_CE_SECTION_LINK_LIST)) {
-            Iterator links = ce.getSectionLinkList();
+            Iterator<?> links = ce.getSectionLinkList();
             while (links.hasNext()) {
               PSAppTransformer.transformUrlRequest((PSUrlRequest) links.next(), mapping, idMap);
             }

--- a/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSContentTypeHandlerTypedTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/dependencies/PSContentTypeHandlerTypedTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.deployer.server.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.deployer.objectstore.PSDependency;
+import com.percussion.deployer.objectstore.PSDependencyFile;
+import com.percussion.security.PSSecurityToken;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Signature smoke for typed ContentType dependency handler surfaces (issue #3047 / #2028 Xlint
+ * residual after ContentRelation #3017). Runtime packaging paths require a live CMS; these tests
+ * lock compile-time API shapes that cleared rawtypes diagnostics.
+ */
+public class PSContentTypeHandlerTypedTest {
+
+  @Test
+  public void contentTypeChildDependenciesAndFilesReturnTypedIterators() throws Exception {
+    assertTypedIterator(
+        PSContentTypeDependencyHandler.class.getMethod(
+            "getChildDependencies", PSSecurityToken.class, PSDependency.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSContentTypeDependencyHandler.class.getMethod(
+            "getDependencies", PSSecurityToken.class),
+        PSDependency.class);
+    assertTypedIterator(
+        PSContentTypeDependencyHandler.class.getMethod(
+            "getDependencyFiles", PSSecurityToken.class, PSDependency.class),
+        PSDependencyFile.class);
+    assertTypedIterator(
+        PSContentTypeDependencyHandler.class.getMethod("getChildTypes"), String.class);
+    assertEquals("ContentType", PSContentTypeDependencyHandler.DEPENDENCY_TYPE);
+  }
+
+  @Test
+  public void contentTypeChildTypesListIsStringParameterized() throws Exception {
+    var field = PSContentTypeDependencyHandler.class.getDeclaredField("ms_childTypes");
+    field.setAccessible(true);
+    Type generic = field.getGenericType();
+    assertTrue(generic instanceof ParameterizedType, "ms_childTypes should be parameterized");
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(String.class, args[0]);
+    assertEquals(List.class, field.getType());
+  }
+
+  @Test
+  public void contentTypeItemDefFilesFromArchiveReturnsTypedIterator() throws Exception {
+    Method method =
+        PSContentTypeDependencyHandler.class.getDeclaredMethod(
+            "getItemDefFilesFromArchive",
+            com.percussion.deployer.server.PSArchiveHandler.class,
+            PSDependency.class);
+    method.setAccessible(true);
+    assertTypedIterator(method, PSDependencyFile.class);
+  }
+
+  private static void assertTypedIterator(Method method, Class<?> typeArg) {
+    assertEquals(Iterator.class, method.getReturnType());
+    Type generic = method.getGenericReturnType();
+    assertTrue(generic instanceof ParameterizedType, method.getName() + " should be parameterized");
+    Type[] args = ((ParameterizedType) generic).getActualTypeArguments();
+    assertEquals(1, args.length);
+    assertEquals(typeArg, args[0], method.getName() + " type arg");
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-3047-deployer-xlint-content-type-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3047-deployer-xlint-content-type-erlang.md
@@ -1,0 +1,26 @@
+# Erlang-style review — issue #3047 PSContentTypeDependencyHandler Xlint
+
+**Scope:** perc-deployer main-source Xlint residual on `PSContentTypeDependencyHandler` (~69 → 0).
+
+**Change class:** pure generics / rawtypes cleanup (no product behavior).
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / behavior change | None — typed iterators, diamond constructors, enhanced for-loops only |
+| Whole-class `@SuppressWarnings("unchecked")` | None; one local suppress on `PSWorkflowInfo.getWorkflowIds()` raw return |
+| Portable paths | N/A — no path/file I/O changes |
+| Behavioral unit tests | `PSContentTypeHandlerTypedTest` locks typed override + package-private returns |
+| Product docs | N/A — tech-debt only |
+| Module clean install | Required before PR (`cd deployer && ../mvnw clean install`) |
+
+## Peers followed
+
+- #3017 / PR #3046 `PSContentRelationDependencyHandler`
+- #3016 batch 10 ContentAssembler/Content/ContentListDef
+- `PSApplicationDependencyHandler.getIdTypes` typed `List<PSApplicationIDTypeMapping>` + for-each over `PSCollection`
+
+## Residual (not this PR)
+
+Other perc-deployer main residuals remain (SystemDef / SharedGroup / WorkflowDef / FilterDef / Custom / Context*, etc.) under epic #2028 / monorepo #2200.


### PR DESCRIPTION
## Summary

Continue perc-deployer Xlint cleanup after ContentRelation (#3017 / PR #3046). This slice clears **PSContentTypeDependencyHandler** (~69 → **0** main-source diagnostics) with real generics:

- Typed `Iterator<PSDependency>` / `Iterator<PSDependencyFile>` / `Iterator<String>` overrides for child deps, files, child types
- `List<PSApplicationIDTypeMapping>` for `getIdTypes`; enhanced for-each over `PSCollection`
- Typed archive `Iterator<PSDependencyFile>`; diamond `PSPair<>`; local typed workflow id list (one site-local suppress on raw `PSWorkflowInfo.getWorkflowIds()`)
- Signature unit test `PSContentTypeHandlerTypedTest` (3 tests)
- No product behavior change; no whole-class `@SuppressWarnings`

**Fixes #3047**  
**Partial #2028** (perc-deployer Xlint epic)  
**Partial #2200** (monorepo Xlint/javadoc tracker)  
Prior: PR #3046 ContentRelation

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `cd deployer && ../mvnw.cmd clean install` (JDK 21) — expect BUILD SUCCESS
2. Confirm `PSContentTypeHandlerTypedTest` runs (3 tests)
3. Confirm zero compiler warnings on `PSContentTypeDependencyHandler.java`
4. Residual inventory remains for other handlers (SystemDef / SharedGroup / WorkflowDef / FilterDef / …) under #2028

## Checklist

- [x] **Product documentation** — N/A (pure generics tech-debt; no operator/behavior change)
- [x] **Unit / module tests** — `PSContentTypeHandlerTypedTest`; deployer standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 240, Failures: 0, Errors: 0, Skipped: 19
- [x] **Cross-platform** — N/A (no path/file I/O changes)

### C3 evidence

- **modules_built:** `deployer`
- **build_evidence:** `cd deployer; ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 240, Failures: 0; `PSContentTypeHandlerTypedTest` Tests run: 3, Failures: 0; zero Xlint on `PSContentTypeDependencyHandler` (was 69)
- **downstream_checked:** none (no public API shape / final / signature change beyond method return generics already present on overrides; no reverse-dep compile risk)

> Co-Authored by Grok Build using grok-4.5 with agent main.
