### PR TITLE
fix(sitemanage): Xlint this-escape service/listener residual (#2999)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2999-sitemanage-this-escape-service-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2999-sitemanage-this-escape-service-erlang.md
@@ -1,0 +1,33 @@
+# Erlang-style review — issue #2999 sitemanage this-escape service/listener
+
+## Scope
+PR-sized residual after DTO this-escape batch (#2980 / PR #3000). Cluster: service / listener /
+register-on-construct constructors in `projects/sitemanage` main sources (not remaining DTO /
+parser / serial-field residuals).
+
+## Mitigations
+| Pattern | Approach |
+|---------|----------|
+| Path item services `setRootName` in ctor | Seed protected `rootName` field; keep public `setRootName` final for post-construct use |
+| Monitors / IndexHelper / servlets / wrapper / proxy / package resolver / merged region tree | Mark leaf types `final` (no monorepo subclasses) |
+| Spring beans that publish `this` to registries (`@Transactional` or CGLIB-sensitive) | Justified `@SuppressWarnings("this-escape")` on ctor with comment |
+| `PSResourceAssemblyResultExpander` registry put | Justified suppress (intentional publish-to-registry) |
+| Proxy template ctor | Direct field seeds + final setters + private `copyBindings` |
+
+## Findings
+- **Bugs:** none found. Registration order and Spring wiring types preserved.
+- **Behavior:** no REST / adaptor contract changes; no product surface change.
+- **Tests:** `PSThisEscapeServiceListenerTest` — path root seed, proxy seeds, servlet wrapper, finality.
+- **Cross-platform:** N/A (no path/file I/O changes).
+- **API shape (C2):** several types made `final`; grepped monorepo for `extends <Type>` — only
+  known test subclasses of non-final `PSSitePathItemService` remain. No anonymous subclasses of
+  newly final types.
+
+## Residual (out of this PR)
+- this-escape DTO/parser leftovers: `PSUnusedAssetSummary`, widget-builder data, `PSRegionParserAdapter`
+- serial-field residual + misc Xlint (static qualification, etc.)
+
+## Verdict
+PASS for commit/PR.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/PSLivePublishChangeHandler.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/PSLivePublishChangeHandler.java
@@ -74,6 +74,11 @@ public class PSLivePublishChangeHandler implements IPSContentChangeHandler {
   private IPSPageTemplateService pageTemplateService;
   private IPSResourceDefinitionService resourceDefinitionService;
 
+  /**
+   * Intentional publish-to-registry of {@code this} as a content-change handler. Justified {@code
+   * this-escape} suppress: handler must be registered when the Spring bean is constructed.
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSLivePublishChangeHandler(
       IPSContentChangeService changeSvc,

--- a/projects/sitemanage/src/main/java/com/percussion/monitor/process/PSSearchIndexProcessMonitor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/monitor/process/PSSearchIndexProcessMonitor.java
@@ -34,8 +34,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Monitor the status and size of the search index queue. Sunny Sal says: "Indexing? I'm on it, like
  * a librarian with a barcode scanner!"
+ *
+ * <p>Final so the constructor may publish {@code this} to the notification service without {@code
+ * this-escape} (intentional register-on-construct).
  */
-public class PSSearchIndexProcessMonitor implements IPSNotificationListener {
+public final class PSSearchIndexProcessMonitor implements IPSNotificationListener {
 
   private static final String STATUS_MSG_SOME = " items in queue";
   private static final String STATUS_MSG_ONE = " item in queue";

--- a/projects/sitemanage/src/main/java/com/percussion/monitor/process/PSWorkflowAssignmentProcessMonitor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/monitor/process/PSWorkflowAssignmentProcessMonitor.java
@@ -29,8 +29,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Monitor the number of folders/items undergoing workflow reassignment. Sunny Sal says: "Workflow
  * assignments? I'm on it like a project manager with a Gantt chart!"
+ *
+ * <p>Final so the constructor may publish {@code this} to the notification service without {@code
+ * this-escape} (intentional register-on-construct).
  */
-public class PSWorkflowAssignmentProcessMonitor implements IPSNotificationListener {
+public final class PSWorkflowAssignmentProcessMonitor implements IPSNotificationListener {
 
   private static final String ITEM_STATUS_MSG_SOME = " items queued for workflow assignment";
   private static final String ITEM_STATUS_MSG_ONE = " item queued for workflow assignment";

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSMergedRegionTree.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSMergedRegionTree.java
@@ -42,9 +42,11 @@ import java.util.List;
  * <p>See {@link #isLeaf(PSMergedRegion)} and {@link #chooseTemplateOrPageRegion(PSAbstractRegion,
  * PSAbstractRegion, PSMergedRegion)} for details.
  *
+ * <p>Final so the merge constructor may call {@link #merge} without {@code this-escape}.
+ *
  * @author adamgent
  */
-public class PSMergedRegionTree extends PSAbstractMergedRegionTree {
+public final class PSMergedRegionTree extends PSAbstractMergedRegionTree {
 
   private IPSWidgetService widgetService;
 

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/impl/PSProxyAssemblyTemplate.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/impl/PSProxyAssemblyTemplate.java
@@ -33,9 +33,12 @@ import org.xml.sax.SAXException;
  * A decorator around the real assembly template to enhance performance with cloning and memory
  * footprint. The template, bindings, and assembler properties are not wrapped.
  *
+ * <p>Final so the decorator constructor may seed template/bindings/assembler without {@code
+ * this-escape}.
+ *
  * @author adamgent
  */
-public class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
+public final class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
 
   private static final long serialVersionUID = 1L;
 
@@ -53,9 +56,10 @@ public class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
   public PSProxyAssemblyTemplate(PSAssemblyTemplate assemblyTemplate) {
     super();
     this.assemblyTemplate = assemblyTemplate;
-    setTemplate(assemblyTemplate.getTemplate());
-    setBindings(assemblyTemplate.getBindings());
-    setAssembler(assemblyTemplate.getAssembler());
+    // Direct field seeds (final setters available for post-construction use).
+    this.template = assemblyTemplate.getTemplate();
+    this.bindings = copyBindings(assemblyTemplate.getBindings());
+    this.assembler = assemblyTemplate.getAssembler();
     this.name = assemblyTemplate.getName();
   }
 
@@ -63,7 +67,7 @@ public class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
     return assembler;
   }
 
-  public void setAssembler(String assembler) {
+  public final void setAssembler(String assembler) {
     this.assembler = assembler;
   }
 
@@ -71,7 +75,7 @@ public class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
     return template;
   }
 
-  public void setTemplate(String template) {
+  public final void setTemplate(String template) {
     this.template = template;
   }
 
@@ -79,15 +83,19 @@ public class PSProxyAssemblyTemplate implements IPSAssemblyTemplate, Cloneable {
     return bindings;
   }
 
+  public final void setBindings(List<PSTemplateBinding> bindings) {
+    this.bindings = copyBindings(bindings);
+  }
+
   @SuppressWarnings("unchecked")
-  public void setBindings(List<PSTemplateBinding> bindings) {
+  private static Vector<PSTemplateBinding> copyBindings(List<PSTemplateBinding> bindings) {
     if (bindings == null) {
-      this.bindings = null;
-    } else if (bindings instanceof Vector) {
-      this.bindings = (Vector<PSTemplateBinding>) bindings;
-    } else {
-      this.bindings = new Vector<>(bindings);
+      return null;
     }
+    if (bindings instanceof Vector) {
+      return (Vector<PSTemplateBinding>) bindings;
+    }
+    return new Vector<>(bindings);
   }
 
   public void addBinding(PSTemplateBinding binding) {

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/impl/PSResourceAssemblyResultExpander.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/impl/PSResourceAssemblyResultExpander.java
@@ -54,6 +54,11 @@ public class PSResourceAssemblyResultExpander extends PSAbstractAssemblyResultEx
     this(assemblyItemBridge, publishHandler, ASSEMBLY_RESULT_EXPANDER_NAME);
   }
 
+  /**
+   * Intentional publish-to-registry: expander must be visible to the publish handler immediately.
+   * Justified {@code this-escape} suppress (leaf bean; no subclass observes partial init).
+   */
+  @SuppressWarnings("this-escape")
   protected PSResourceAssemblyResultExpander(
       PSAssemblyItemBridge assemblyItemBridge,
       PSPublishHandler publishHandler,

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageService.java
@@ -193,6 +193,11 @@ public class PSPageService extends PSAbstractDataService<PSPage, PSPage, String>
 
   private static final String RECYCLED_TYPE = PSRelationshipConfig.TYPE_RECYCLED_CONTENT;
 
+  /**
+   * Inner validators and the default page-change handler capture outer {@code this} at
+   * construction (register-on-construct). Justified {@code this-escape} suppress.
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSPageService(
       IPSFolderHelper folderHelperWs,
@@ -1004,7 +1009,7 @@ public class PSPageService extends PSAbstractDataService<PSPage, PSPage, String>
 
   @Override
   /** {@link #addPageChangeListener(IPSPageService)} */
-  public void addPageChangeListener(IPSPageChangeListener pageChangeListener) {
+  public final void addPageChangeListener(IPSPageChangeListener pageChangeListener) {
     pageChangeListeners.add(pageChangeListener);
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateInfo.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateInfo.java
@@ -23,8 +23,11 @@ import org.apache.logging.log4j.Logger;
 /**
  * Servlet for importing/exporting templates as XML files. GET: Exports a template as XML. POST:
  * Imports a template for a given site.
+ *
+ * <p>Final so the constructor may call Spring dependency injection with {@code this} without {@code
+ * this-escape}.
  */
-public class PSTemplateInfo extends HttpServlet {
+public final class PSTemplateInfo extends HttpServlet {
   private static final long serialVersionUID = 1L;
 
   private static final int DEFAULT_BUFFER_SIZE = 20480; // 20KB.

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSWidgetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSWidgetService.java
@@ -52,6 +52,14 @@ import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 import tools.jackson.databind.json.JsonMapper;
 
+/**
+ * Widget catalog / validation service.
+ *
+ * <p>Property validators are initialized with {@code this} at field init (intentional). Justified
+ * {@code this-escape} suppress on the type for that register-style wiring; class left non-final for
+ * Spring friendliness.
+ */
+@SuppressWarnings("this-escape")
 @Component("widgetService")
 public class PSWidgetService implements IPSWidgetService {
 

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSAssetPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSAssetPathItemService.java
@@ -58,7 +58,7 @@ public class PSAssetPathItemService extends PSPathItemService {
         pageService,
         listViewHelper,
         userService);
-    setRootName("Assets");
+    this.rootName = "Assets";
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSDesignPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSDesignPathItemService.java
@@ -42,14 +42,15 @@ public class PSDesignPathItemService extends PSDispatchingPathService {
       IPSRecycleService recycleService) {
     super(uiService, userService, defaultListViewHelper, recycleService, folderHelper);
     this.folderHelper = folderHelper;
-    setRootName("Design");
+    this.rootName = "Design";
   }
 
   public String getRootName() {
     return rootName;
   }
 
-  public void setRootName(String rootName) {
+  /** Final so the constructor may set the root name without {@code this-escape}. */
+  public final void setRootName(String rootName) {
     this.rootName = rootName;
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSFileSystemPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSFileSystemPathItemService.java
@@ -93,7 +93,8 @@ public abstract class PSFileSystemPathItemService implements IPSPathService {
     return rootName;
   }
 
-  public void setRootName(String rootName) {
+  /** Final so constructors may set the root name without {@code this-escape}. */
+  public final void setRootName(String rootName) {
     this.rootName = rootName;
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
@@ -123,7 +123,11 @@ public abstract class PSPathItemService implements IPSPathService {
    * The root name seen in the ui as the base for all items located by this service. Initialized in
    * the spring configuration.
    */
-  private String rootName;
+  /**
+   * Root display name for this path service. Protected so subclass constructors can seed it without
+   * calling {@link #setRootName(String)} during construction ({@code this-escape}).
+   */
+  protected String rootName;
 
   /**
    * A comma separated list of user roles that are allowed to access this service. If it null or
@@ -547,7 +551,10 @@ public abstract class PSPathItemService implements IPSPathService {
     return rootName;
   }
 
-  public void setRootName(String rootName) {
+  /**
+   * Final so path-service subclass constructors may set the root name without {@code this-escape}.
+   */
+  public final void setRootName(String rootName) {
     this.rootName = rootName;
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSRecyclePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSRecyclePathItemService.java
@@ -86,7 +86,7 @@ public class PSRecyclePathItemService extends PSPathItemService {
         userService);
     this.recycleService = recycleService;
     this.navService = navService;
-    this.setRootName("Recycling");
+    this.rootName = "Recycling";
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSearchPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSearchPathItemService.java
@@ -58,7 +58,7 @@ public class PSSearchPathItemService extends PSPathItemService {
         pageService,
         listViewHelper,
         userService);
-    this.setRootName("Search");
+    this.rootName = "Search";
   }
 
   // Not implemented: search path service does not support folder root operations.

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
@@ -97,7 +97,7 @@ public class PSSitePathItemService extends PSPathItemService {
     this.siteDataService = siteDataService;
     this.navService = navService;
     this.pageService = pageService;
-    this.setRootName("Sites");
+    this.rootName = "Sites";
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/queue/impl/PSPageImportQueue.java
+++ b/projects/sitemanage/src/main/java/com/percussion/queue/impl/PSPageImportQueue.java
@@ -78,6 +78,12 @@ public class PSPageImportQueue extends PSAbstractEventQueue<PSSiteQueue>
 
   private IPSPerformPageImport pageImporter = this;
 
+  /**
+   * Intentional publish-to-registry of {@code this} as a notification listener during
+   * construction. Justified {@code this-escape} suppress: not made {@code final} because the bean
+   * is {@code @Transactional} (CGLIB-friendly); registration is required for server lifecycle.
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSPageImportQueue(
       @Qualifier("pageImportService") IPSSiteImportService importService,

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSAssetChangeListener.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSAssetChangeListener.java
@@ -50,6 +50,11 @@ public class PSAssetChangeListener implements IPSEditorChangeListener, IPSHandle
   private final IPSIdMapper idMapper;
   private final IPSPageIndexService pageIndexService;
 
+  /**
+   * Intentional publish-to-registry of {@code this} as a server init listener. Justified {@code
+   * this-escape} suppress: registration must occur when the Spring bean is created.
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSAssetChangeListener(
       IPSWorkflowHelper workflowHelper,

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSIndexHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSIndexHelper.java
@@ -28,10 +28,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
-/** Assists in loading locators into the search index queue using a background thread. */
+/**
+ * Assists in loading locators into the search index queue using a background thread.
+ *
+ * <p>Final so the constructor may start a daemon thread with {@code this} as the runnable without
+ * {@code this-escape}.
+ */
 @Component("indexHelper")
 @Singleton
-public class PSIndexHelper implements Runnable {
+public final class PSIndexHelper implements Runnable {
   private static final Logger log = LogManager.getLogger(PSIndexHelper.class);
 
   private final PSSearchIndexEventQueue queue = PSSearchIndexEventQueue.getInstance();

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchIndexFieldValueModifier.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchIndexFieldValueModifier.java
@@ -46,6 +46,11 @@ public class PSSearchIndexFieldValueModifier
   private final IPSFolderHelper folderHelper;
   private final IPSIdMapper idMapper;
 
+  /**
+   * Intentional publish-to-registry of {@code this} for server-initialized notification. Justified
+   * {@code this-escape} suppress: listener registration is required at bean construction.
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSSearchIndexFieldValueModifier(
       IPSFolderHelper folderHelper,

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSharedRelationshipDeleteListener.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSharedRelationshipDeleteListener.java
@@ -39,6 +39,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class PSSharedRelationshipDeleteListener implements IPSNotificationListener {
   private final IPSPageIndexService indexService;
 
+  /**
+   * Intentional publish-to-registry of {@code this} for relationship-change notification. Justified
+   * {@code this-escape} suppress: listener registration is required at bean construction.
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSSharedRelationshipDeleteListener(
       IPSNotificationService notificationService, IPSPageIndexService indexService) {

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSFolderHelper.java
@@ -155,6 +155,11 @@ public class PSFolderHelper implements IPSFolderHelper {
   private static final String FOLDER_TYPE = PSRelationshipConfig.TYPE_FOLDER_CONTENT;
   private static final String RECYCLING_ROOT = PSRecycleService.RECYCLING_ROOT;
 
+  /**
+   * Intentional publish-to-registry via inner server-startup listener. Not {@code final}: bean is
+   * {@code @Transactional}. Justified {@code this-escape} suppress.
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSFolderHelper(
       IPSContentWs contentWs,
@@ -186,9 +191,11 @@ public class PSFolderHelper implements IPSFolderHelper {
   /**
    * Registers {@link PSCreateBaseFoldersNotificationListener} for server startup.
    *
+   * <p>Final so subclass constructors cannot override registration order.
+   *
    * @param notificationService never <code>null</code>.
    */
-  protected void setupServerStartupListener(IPSNotificationService notificationService) {
+  protected final void setupServerStartupListener(IPSNotificationService notificationService) {
     if (notificationService != null) {
       PSCreateBaseFoldersNotificationListener listener =
           new PSCreateBaseFoldersNotificationListener();

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/PSSiteImportLogViewer.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/importer/PSSiteImportLogViewer.java
@@ -43,9 +43,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.transaction.annotation.Transactional;
 
-/** Servlet that returns the content of a specific template's import log. */
+/**
+ * Servlet that returns the content of a specific template's import log.
+ *
+ * <p>Final so the constructor may call Spring dependency injection with {@code this} without {@code
+ * this-escape}.
+ */
 @Transactional
-public class PSSiteImportLogViewer extends HttpServlet {
+public final class PSSiteImportLogViewer extends HttpServlet {
 
   private static final long serialVersionUID = 1L;
   private static final Logger log = LogManager.getLogger(PSSiteImportLogViewer.class);

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/servlet/PSPreviewItemContent.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/servlet/PSPreviewItemContent.java
@@ -55,9 +55,12 @@ import org.apache.logging.log4j.Logger;
  *
  * <p>Refactored for Java 11 and Google Java Style.
  *
+ * <p>Final so the constructor may call Spring dependency injection with {@code this} without {@code
+ * this-escape}.
+ *
  * @author YuBingChen
  */
-public class PSPreviewItemContent extends HttpServlet {
+public final class PSPreviewItemContent extends HttpServlet {
   private static final long serialVersionUID = 1L;
   private static final Logger log = LogManager.getLogger(PSPreviewItemContent.class);
   private static PSRenderLinkService linkService;

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/servlet/PSServletRequestWrapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/servlet/PSServletRequestWrapper.java
@@ -25,8 +25,13 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** A mutable HTTP servlet request wrapper. Refactored for Java 11 and Google Java Style. */
-public class PSServletRequestWrapper extends HttpServletRequestWrapper {
+/**
+ * A mutable HTTP servlet request wrapper. Refactored for Java 11 and Google Java Style.
+ *
+ * <p>Final so the constructor may copy {@link #getParameterMap()} without {@code this-escape} from
+ * further subclasses.
+ */
+public final class PSServletRequestWrapper extends HttpServletRequestWrapper {
   private Map<String, String[]> wrappedParams = new LinkedHashMap<>();
 
   public PSServletRequestWrapper(HttpServletRequest request) {

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -260,6 +260,11 @@ public class PSUserService implements IPSUserService {
 
   public static final List<String> SYSTEM_USERS = asList(RXSERVER_NAME, PERCUSSION_ADMIN_NAME);
 
+  /**
+   * Intentional publish-to-registry via inner server-startup listener. Justified {@code
+   * this-escape} suppress (lifecycle registration at construction).
+   */
+  @SuppressWarnings("this-escape")
   @Autowired
   public PSUserService(
       IPSUserLoginDao userLoginDao,
@@ -290,9 +295,11 @@ public class PSUserService implements IPSUserService {
   /**
    * Registers {@link PSCreatePercussionUserNotificationListener} for server startup.
    *
+   * <p>Final so subclass constructors cannot override registration order.
+   *
    * @param notificationService never <code>null</code>.
    */
-  protected void setupServerStartupListener(IPSNotificationService notificationService) {
+  protected final void setupServerStartupListener(IPSNotificationService notificationService) {
     if (notificationService != null) {
       PSCreatePercussionUserNotificationListener listener =
           new PSCreatePercussionUserNotificationListener();

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/utils/PSWidgetPackageResolver.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/utils/PSWidgetPackageResolver.java
@@ -28,8 +28,11 @@ import org.apache.commons.lang3.Validate;
  *
  * <p>Sunny Sal says: "Token resolving is like Bollywood plot twists—unexpected, but always resolved
  * by the end!"
+ *
+ * <p>Final so the constructor may call {@link #generateBinding} via field-binding generation without
+ * {@code this-escape}.
  */
-public class PSWidgetPackageResolver implements IPSTokenResolver {
+public final class PSWidgetPackageResolver implements IPSTokenResolver {
 
   private final Map<String, String> tokenMap;
   private final Set<String> optionalTokens;
@@ -107,7 +110,7 @@ public class PSWidgetPackageResolver implements IPSTokenResolver {
    * @param field the widget field
    * @return the generated binding
    */
-  public String generateBinding(PSWidgetBuilderFieldData field) {
+  public final String generateBinding(PSWidgetBuilderFieldData field) {
     for (var generator : bindingGenerators) {
       if (generator.accept(field)) {
         return generator.generateBinding(field);

--- a/projects/sitemanage/src/test/java/com/percussion/share/data/PSThisEscapeServiceListenerTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/data/PSThisEscapeServiceListenerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.monitor.process.PSSearchIndexProcessMonitor;
+import com.percussion.monitor.process.PSWorkflowAssignmentProcessMonitor;
+import com.percussion.pagemanagement.assembler.impl.PSProxyAssemblyTemplate;
+import com.percussion.pathmanagement.service.impl.PSSitePathItemService;
+import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.assembly.data.PSTemplateBinding;
+import com.percussion.sitemanage.servlet.PSServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for service/listener this-escape mitigations (issue #2999): path root field
+ * seeds, final leaf types, proxy template seeds, and servlet request wrapper construction.
+ */
+@Tag("UnitTest")
+class PSThisEscapeServiceListenerTest {
+
+  @Test
+  void sitePathItemServiceCtorSeedsRootNameWithoutSetRootName() {
+    var service =
+        new PSSitePathItemService(
+            null, null, null, null, null, null, null, null, null, null, null, null);
+    assertEquals("Sites", service.getRootName());
+    service.setRootName("Other");
+    assertEquals("Other", service.getRootName());
+  }
+
+  @Test
+  void proxyAssemblyTemplateCtorSeedsFields() {
+    var wrapped = new PSAssemblyTemplate();
+    wrapped.setTemplate("tpl-body");
+    wrapped.setAssembler("asm");
+    wrapped.setName("MyTemplate");
+    var binding = new PSTemplateBinding();
+    wrapped.setBindings(new Vector<>(List.of(binding)));
+
+    var proxy = new PSProxyAssemblyTemplate(wrapped);
+    assertEquals("tpl-body", proxy.getTemplate());
+    assertEquals("asm", proxy.getAssembler());
+    assertEquals("MyTemplate", proxy.getName());
+    assertEquals(1, proxy.getBindings().size());
+    assertTrue(Modifier.isFinal(PSProxyAssemblyTemplate.class.getModifiers()));
+  }
+
+  @Test
+  void servletRequestWrapperCopiesParameters() {
+    var request = mock(HttpServletRequest.class);
+    when(request.getParameterMap()).thenReturn(Map.of("a", new String[] {"1", "2"}));
+    var wrapper = new PSServletRequestWrapper(request);
+    assertEquals("1", wrapper.getParameter("a"));
+    assertEquals(2, wrapper.getParameterValues("a").length);
+    assertTrue(Modifier.isFinal(PSServletRequestWrapper.class.getModifiers()));
+  }
+
+  @Test
+  void serviceListenerLeafTypesAreFinal() {
+    assertTrue(Modifier.isFinal(PSSearchIndexProcessMonitor.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSWorkflowAssignmentProcessMonitor.class.getModifiers()));
+    assertFalse(Modifier.isFinal(PSSitePathItemService.class.getModifiers()));
+  }
+}


### PR DESCRIPTION
## Summary

Partial Xlint cleanup for **sitemanage** residual issue **#2999** (parent module issue **#2032**, monorepo tracker **#2200**). After DTO this-escape (#2980 / PR #3000), this PR clears the **service / listener / register-on-construct** this-escape cluster.

### Main changes
- **Path item services:** seed protected `rootName` in ctors (no overridable `setRootName` during construction); keep public final `setRootName` for post-construct use
- **Leaf finals:** monitors, `PSIndexHelper`, servlets, `PSServletRequestWrapper`, `PSProxyAssemblyTemplate`, `PSMergedRegionTree`, `PSWidgetPackageResolver`
- **Proxy template:** direct field seeds + final setters + private `copyBindings`
- **Justified suppress** for intentional publish-to-registry on Spring beans that must stay non-final (`@Transactional` / CGLIB-friendly): `PSPageImportQueue`, `PSFolderHelper`, listeners, page/widget services, expander registry put

### Tests
- New `PSThisEscapeServiceListenerTest` (4): path root seed, proxy seeds, servlet wrapper, finality

### Inventory (main-source this-escape)
| Metric | Before | After |
|--------|--------|-------|
| this-escape (main) | **32** | **4** |

### Residual
DTO/parser this-escape leftovers, serial-field residual, misc Xlint, test-source this-escape: **#3061**

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Tests run: **1031**, Failures: **0**, Errors: **0**, Skipped: **125**
- [x] `PSThisEscapeServiceListenerTest` (4) green
- [x] C2: grepped monorepo for `extends` of newly final types — none (except intentional non-final `PSSitePathItemService` test subclasses)

## Product documentation
- [x] N/A — pure compiler lint tech debt; no operator/user/API surface change

## Gates / evidence (C3)
- **modules_built:** `projects/sitemanage`
- **build_evidence:** `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1031, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 greps for extends of newly final types (monitors, IndexHelper, servlets, proxy, merged region tree, package resolver) — no hits; path services left non-final for existing test subclasses

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent: #2032 / #2200  
Fixes #2999 (service/listener cluster); residual #3061.

> Co-Authored by Grok Build using grok-4.5 with agent main.
