### PR TITLE
feat(objectstore): ObjectStoreErrorCodes call-site batch K1 (design.objectstore D-H) (#3062)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSDataEncryptor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataEncryptor.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -227,11 +229,11 @@ public class PSDataEncryptor extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -241,7 +243,7 @@ public class PSDataEncryptor extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // is SSL (encryption) required?
@@ -251,13 +253,13 @@ public class PSDataEncryptor extends PSComponent {
     // what's the key strength?
     sTemp = tree.getElementData("keyStrength");
     if ((sTemp == null) && m_encryption) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.DATAENC_KEY_STRENGTH_REQD);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.DATAENC_KEY_STRENGTH_REQD);
     } else if (sTemp != null) {
       try {
         m_keyStrength = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {ms_NodeType, "keyStrength", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataMapper.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -124,11 +126,11 @@ public final class PSDataMapper extends PSCollectionComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (!ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -142,7 +144,7 @@ public final class PSDataMapper extends PSCollectionComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // clear any mappings, then read in the new mappings
@@ -180,7 +182,7 @@ public final class PSDataMapper extends PSCollectionComponent {
     if (!cxt.startValidation(this, null)) return;
 
     if (super.isEmpty()) {
-      cxt.validationError(this, IPSObjectStoreErrors.APP_MAPPER_EMPTY, null);
+      cxt.validationError(this, ObjectStoreErrorCodes.APP_MAPPER_EMPTY, null);
     }
 
     super.validate(cxt);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataMapping.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.security.validation.SerializationValidation;
 import com.percussion.util.PSCharSets;
 import com.percussion.util.PSCollection;
@@ -390,11 +392,11 @@ public final class PSDataMapping extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (!ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -404,7 +406,7 @@ public final class PSDataMapping extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       sTemp = tree.getElementData("groupId");
@@ -413,7 +415,7 @@ public final class PSDataMapping extends PSComponent {
         else m_groupId = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, "groupId", ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // A document mapping will represent the front end now.
@@ -421,7 +423,7 @@ public final class PSDataMapping extends PSComponent {
       Element node = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
       if (node == null) {
         Object[] args = {ms_NodeType, "documentMapping", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       try {
@@ -439,7 +441,7 @@ public final class PSDataMapping extends PSComponent {
           } catch (Exception e) { // should only be a class cast, but...
             Object[] args = {ms_NodeType, "documentMapping", node.getTagName()};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       } catch (IllegalArgumentException e) {
@@ -450,7 +452,7 @@ public final class PSDataMapping extends PSComponent {
       node = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS);
       if (node == null) {
         Object[] args = {ms_NodeType, "backEndMapping", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       try {
@@ -459,7 +461,7 @@ public final class PSDataMapping extends PSComponent {
                 createMappingObject(node, "backEndMapping", parentDoc, parentComponents);
       } catch (Exception e) { // should only be a class cast, but...
         Object[] args = {ms_NodeType, "backEndMapping", node.getTagName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       int firstFlags =
@@ -514,7 +516,7 @@ public final class PSDataMapping extends PSComponent {
           } catch (Exception e) {
             Object[] args = {ms_NodeType, "textFormatter", e.toString()};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       }
@@ -571,7 +573,7 @@ public final class PSDataMapping extends PSComponent {
     if (ex != null) cxt.validationError(this, 0, ex.getLocalizedMessage());
 
     if (m_docMapping == null) {
-      cxt.validationError(this, IPSObjectStoreErrors.DATAMAPPING_XML_FIELD_EMPTY, null);
+      cxt.validationError(this, ObjectStoreErrorCodes.DATAMAPPING_XML_FIELD_EMPTY, null);
     }
 
     ex = validateGroupId(m_groupId);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSelector.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSelector.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -646,11 +648,11 @@ public final class PSDataSelector extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -660,7 +662,7 @@ public final class PSDataSelector extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       sTemp = tree.getElementData("unique");
@@ -671,12 +673,12 @@ public final class PSDataSelector extends PSComponent {
       sTemp = tree.getElementData("method");
       if (sTemp == null) {
         Object[] args = {ms_NodeType, "method", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else if (sTemp.equals(XML_FLAG_METHOD_WHERE)) m_selector |= DS_BY_WHERE_CLAUSE;
       else if (sTemp.equals(XML_FLAG_METHOD_NATIVE)) m_selector |= DS_BY_NATIVE_STATEMENT;
       else {
         Object[] args = {ms_NodeType, "method", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       int firstFlags = PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN;
@@ -736,7 +738,7 @@ public final class PSDataSelector extends PSComponent {
 
         sTemp = tree.getElementData("type", false);
         if ((sTemp == null) && m_caching)
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.DATASEL_CACHE_TYPE_REQD);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.DATASEL_CACHE_TYPE_REQD);
         else if (sTemp != null) {
           if (sTemp.equals(XML_FLAG_CACHE_TYPE_INTERVAL)) m_cacheType = DS_CACHE_TYPE_INTERVAL;
           else if (sTemp.equals(XML_FLAG_CACHE_TYPE_TIME)) m_cacheType = DS_CACHE_TYPE_TIME;
@@ -745,7 +747,7 @@ public final class PSDataSelector extends PSComponent {
           else {
             Object[] args = {ms_NodeType, "Caching/type", sTemp};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
           }
         }
 
@@ -757,7 +759,7 @@ public final class PSDataSelector extends PSComponent {
           } catch (NumberFormatException e) {
             Object[] args = {ms_NodeType, "Caching/ageInterval", sTemp};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
 
@@ -771,7 +773,7 @@ public final class PSDataSelector extends PSComponent {
               ms_NodeType, "Caching/ageTime", "(Value: " + sTemp + ") " + e.toString()
             };
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
         }
       }
@@ -801,7 +803,7 @@ public final class PSDataSelector extends PSComponent {
       if ((0 != (DS_BY_WHERE_CLAUSE & m_selector))
           && (0 != (DS_BY_NATIVE_STATEMENT & m_selector))) {
         args = new Object[] {"" + m_selector};
-        cxt.validationError(this, IPSObjectStoreErrors.DATASEL_SEL_TYPE_INVALID, args);
+        cxt.validationError(this, ObjectStoreErrorCodes.DATASEL_SEL_TYPE_INVALID, args);
       }
 
       // turn on all invalid bits and make sure none of them are specified
@@ -809,7 +811,7 @@ public final class PSDataSelector extends PSComponent {
 
       if (0 != (m_selector & all_flags_compliment)) {
         args = new Object[] {"" + m_selector};
-        cxt.validationError(this, IPSObjectStoreErrors.DATASEL_SEL_TYPE_INVALID, args);
+        cxt.validationError(this, ObjectStoreErrorCodes.DATASEL_SEL_TYPE_INVALID, args);
       }
     }
 
@@ -836,12 +838,12 @@ public final class PSDataSelector extends PSComponent {
               }
             }
 
-            cxt.validationError(this, IPSObjectStoreErrors.DATASEL_CACHE_AGE_TIME_REQUIRED, dsName);
+            cxt.validationError(this, ObjectStoreErrorCodes.DATASEL_CACHE_AGE_TIME_REQUIRED, dsName);
           }
           break; // end valid cache types
         default:
           cxt.validationError(
-              this, IPSObjectStoreErrors.DATASEL_CACHE_TYPE_INVALID, "" + m_cacheType);
+              this, ObjectStoreErrorCodes.DATASEL_CACHE_TYPE_INVALID, "" + m_cacheType);
       }
     }
 
@@ -851,7 +853,7 @@ public final class PSDataSelector extends PSComponent {
 
     if (m_cacheAgeInterval < 0)
       cxt.validationError(
-          this, IPSObjectStoreErrors.DATASEL_CACHE_AGE_INTERVAL_INVALID, "" + m_cacheAgeInterval);
+          this, ObjectStoreErrorCodes.DATASEL_CACHE_AGE_INTERVAL_INVALID, "" + m_cacheAgeInterval);
 
     // validate children
     cxt.pushParent(this);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.error.PSException;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -671,11 +673,11 @@ public class PSDataSet extends PSComponent {
   private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -685,7 +687,7 @@ public class PSDataSet extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     try { // private          String          m_name = "";
@@ -711,7 +713,7 @@ public class PSDataSet extends PSComponent {
         m_transactionType = DS_TRANSACTION_ALL_ROWS;
       else {
         Object[] args = {ms_NodeType, "transactionType", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     } else m_transactionType = DS_TRANSACTION_DISABLED;
 
@@ -798,7 +800,7 @@ public class PSDataSet extends PSComponent {
             if ((requestLinkCheck != null) && (!requestLinkCheck.equals(requestLink)))
               cxt.validationError(
                   this,
-                  IPSObjectStoreErrors.DATASET_XMLFIELD_MULTI_LINK_ERROR,
+                  ObjectStoreErrorCodes.DATASET_XMLFIELD_MULTI_LINK_ERROR,
                   requestLink.getXmlField());
             fieldLinks.put(requestLink.getXmlField(), requestLink);
           }
@@ -811,7 +813,7 @@ public class PSDataSet extends PSComponent {
     // if (m_results == null
     //    &&   (m_requestor != null && m_requestor.getOutputMimeType() == null
     //       && m_requestor.isHtmlOutputEnabled()))
-    //    cxt.validationError(this, IPSObjectStoreErrors.DATASET_RESULT_PAGES_NULL,
+    //    cxt.validationError(this, ObjectStoreErrorCodes.DATASET_RESULT_PAGES_NULL,
     //    null);
 
     // do children

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSet.java
@@ -813,7 +813,7 @@ public class PSDataSet extends PSComponent {
     // if (m_results == null
     //    &&   (m_requestor != null && m_requestor.getOutputMimeType() == null
     //       && m_requestor.isHtmlOutputEnabled()))
-    //    cxt.validationError(this, ObjectStoreErrorCodes.DATASET_RESULT_PAGES_NULL,
+    //    cxt.validationError(this, IPSObjectStoreErrors.DATASET_RESULT_PAGES_NULL,
     //    null);
 
     // do children

--- a/system/src/main/java/com/percussion/design/objectstore/PSDataSynchronizer.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDataSynchronizer.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -248,11 +250,11 @@ public final class PSDataSynchronizer extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -262,7 +264,7 @@ public final class PSDataSynchronizer extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // private      boolean         m_insert = false;
@@ -331,7 +333,7 @@ public final class PSDataSynchronizer extends PSComponent {
       }
 
       // we require update pipes if insert or update is enabled
-      cxt.validationError(this, IPSObjectStoreErrors.SYNC_NO_UPDATE_COLUMNS, dsName);
+      cxt.validationError(this, ObjectStoreErrorCodes.SYNC_NO_UPDATE_COLUMNS, dsName);
     }
 
     // validate children

--- a/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponent.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponent.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.data.PSIdGenerator;
 import com.percussion.design.objectstore.server.PSDatabaseComponentLoader;
 import com.percussion.error.PSDatabaseComponentException;
@@ -304,7 +306,7 @@ public abstract class PSDatabaseComponent implements IPSDatabaseComponent, Seria
     } catch (Exception ex) {
       Object[] args = {c.getName(), ex.toString()};
       throw new PSDatabaseComponentException(
-          IPSObjectStoreErrors.DB_COMPONENT_LOAD_EXCEPTION, args);
+          ObjectStoreErrorCodes.DB_COMPONENT_LOAD_EXCEPTION.numericCode(), args);
     }
 
     component.fromDatabaseXml(e, cl, rc);
@@ -342,7 +344,7 @@ public abstract class PSDatabaseComponent implements IPSDatabaseComponent, Seria
         m_componentState = Integer.parseInt(sTemp);
       } catch (NumberFormatException ex) {
         throw new PSUnknownNodeTypeException(
-            IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, XML_COMPONENT_STATE_ATTR);
+            ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, XML_COMPONENT_STATE_ATTR);
       }
     }
 
@@ -350,14 +352,14 @@ public abstract class PSDatabaseComponent implements IPSDatabaseComponent, Seria
     sTemp = e.getAttribute(DATABASE_COMPONENT_ID_XML_ATTR_NAME);
     if (sTemp == null || sTemp.trim().length() == 0) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, DATABASE_COMPONENT_ID_XML_ATTR_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, DATABASE_COMPONENT_ID_XML_ATTR_NAME);
     }
 
     try {
       m_databaseComponentId = Integer.parseInt(sTemp);
     } catch (Exception ex) {
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, DATABASE_COMPONENT_ID_XML_ATTR_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, DATABASE_COMPONENT_ID_XML_ATTR_NAME);
     }
   }
 
@@ -377,7 +379,7 @@ public abstract class PSDatabaseComponent implements IPSDatabaseComponent, Seria
 
     if ((dbId == null) || (dbId.length() == 0))
       throw new PSUnknownNodeTypeException(
-          IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, DATABASE_COMPONENT_ID_XML_ATTR_NAME);
+          ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, DATABASE_COMPONENT_ID_XML_ATTR_NAME);
 
     return dbId;
   }
@@ -391,7 +393,7 @@ public abstract class PSDatabaseComponent implements IPSDatabaseComponent, Seria
       m_databaseComponentId = PSIdGenerator.getNextId(getComponentType());
     } catch (SQLException e) {
       throw new PSDatabaseComponentException(
-          IPSObjectStoreErrors.DB_COMPONENT_NEW_ID, PSSqlException.getFormattedExceptionText(e));
+          ObjectStoreErrorCodes.DB_COMPONENT_NEW_ID.numericCode(), PSSqlException.getFormattedExceptionText(e));
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponentCollection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDatabaseComponentCollection.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.server.PSDatabaseComponentLoader;
 import com.percussion.error.PSDatabaseComponentException;
 import com.percussion.util.PSCollection;
@@ -165,7 +167,7 @@ public class PSDatabaseComponentCollection extends PSDatabaseComponent implement
     m_deletes.clear();
 
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDateLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDateLiteral.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Date;
@@ -225,12 +227,12 @@ public class PSDateLiteral extends PSLiteral {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the ACL type node
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -240,34 +242,34 @@ public class PSDateLiteral extends PSLiteral {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // get the date format object first
     String format = tree.getElementData("format");
     if ((format == null) || (format.length() == 0)) {
       Object[] args = {ms_NodeType, "format", "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     try {
 
       m_format = FastDateFormat.getInstance(format);
     } catch (Throwable t) {
       Object[] args = {ms_NodeType, "format", (format + " (Exception: " + t.toString() + ")")};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // then get the date and parse it using the formatter
     sTemp = tree.getElementData("date");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "date", "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     try {
       m_date = m_format.parse(sTemp);
     } catch (Throwable t) {
       Object[] args = {ms_NodeType, "date", (format + " (Exception: " + t.toString() + ")")};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSDefaultSelected.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDefaultSelected.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -138,11 +140,11 @@ public class PSDefaultSelected extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -171,7 +173,7 @@ public class PSDefaultSelected extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, TYPE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -180,14 +182,14 @@ public class PSDefaultSelected extends PSComponent {
         if (sourceNode == null) {
           Object[] args = {XML_NODE_NAME, "Default Number", "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_sequence = Integer.parseInt(tree.getElementData(sourceNode));
       } else if (m_type == TYPE_TEXT) {
         if (sourceNode == null) {
           Object[] args = {XML_NODE_NAME, "Default Text", "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_text = tree.getElementData(sourceNode);
       }
@@ -219,13 +221,13 @@ public class PSDefaultSelected extends PSComponent {
 
     if (m_type != TYPE_NULL_ENTRY && m_type != TYPE_SEQUENCE && m_type != TYPE_TEXT) {
       Object[] args = {TYPE_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_DEFAULT_SELECTED_TYPE, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_DEFAULT_SELECTED_TYPE, args);
     }
 
     if (m_type == TYPE_SEQUENCE && m_sequence < 0) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_DEFAULT_SELECTED, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_DEFAULT_SELECTED, null);
     } else if (m_type == TYPE_TEXT && (m_text == null || m_text.trim().length() == 0)) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_DEFAULT_SELECTED, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_DEFAULT_SELECTED, null);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSDependency.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDependency.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -111,7 +113,7 @@ public class PSDependency extends PSComponent {
     else if (status.equals("setupOptional")) m_status = SETUP_OPTIONAL_STATUS;
     else {
       Object[] args = {XML_NODE_NAME, XATTR_STATUS, status};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // @occurrence
@@ -120,7 +122,7 @@ public class PSDependency extends PSComponent {
     else if (occurrence.equals("multiple")) m_occurrence = MULTIPLE_OCCURRENCE;
     else {
       Object[] args = {XML_NODE_NAME, XATTR_OCCURRENCE, occurrence};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     // default
@@ -129,7 +131,7 @@ public class PSDependency extends PSComponent {
       // make sure this node has the right name
       if (!defaultChildElement.getNodeName().equals(XELEM_DEFAULT)) {
         Object[] args = {XML_NODE_NAME, XELEM_DEFAULT, defaultChildElement};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       Element child = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
@@ -144,11 +146,11 @@ public class PSDependency extends PSComponent {
       if (dependent instanceof IPSDependentObject) setDependent((IPSDependentObject) dependent);
       else {
         Object[] args = {XML_NODE_NAME, XELEM_DEFAULT, dependent};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     } else {
       Object[] args = {XML_NODE_NAME, XELEM_DEFAULT, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSDetails.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDetails.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +55,7 @@ public class PSDetails implements Serializable {
   private void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_fieldErrors = new ArrayList<>();
     NodeList fe = sourceNode.getElementsByTagName(PSFieldError.XML_NODE_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectory.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -347,11 +349,11 @@ public final class PSDirectory extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -374,12 +376,12 @@ public final class PSDirectory extends PSComponent {
     Element authentication = tree.getNextElement(XML_ELEM_AUTHENTICATION);
     if (authentication == null) {
       Object[] args = {XML_ELEM_AUTHENTICATION, null};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     Element reference = tree.getNextElement(PSReference.XML_NODE_NAME);
     if (reference == null) {
       Object[] args = {PSReference.XML_NODE_NAME, null};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_authenticationRef = new PSReference(reference, parentDoc, parentComponents);
 
@@ -418,7 +420,7 @@ public final class PSDirectory extends PSComponent {
         if (groupProvider == null || groupProvider.trim().length() == 0) {
           Object[] args = {GROUP_PROVIDERS_ELEMENT, GROUP_NAME_ELEMENT, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
         m_groupProviderNames.add(groupProvider);
         groupName = tree.getNextElement(GROUP_NAME_ELEMENT, nextFlags);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDirectorySet.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -159,11 +161,11 @@ public final class PSDirectorySet extends PSCollectionComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -183,7 +185,7 @@ public final class PSDirectorySet extends PSCollectionComponent {
       if (data == null || data.trim().length() == 0) {
         String parentName = tree.getCurrent().getNodeName();
         Object[] args = {parentName, XML_ATTR_NAME, "null or empty"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       setName(data);
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayError.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayError.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.utils.xml.PSInvalidXmlException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -87,7 +89,7 @@ public class PSDisplayError implements Serializable {
       throws PSUnknownNodeTypeException, PSInvalidXmlException {
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_errorCount = sourceNode.getAttribute(XML_ATTR_NAME_ERROR_COUNT);
     NodeList gms = sourceNode.getElementsByTagName(XML_ELEM_GENERIC_MESSAGE);

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayFieldRef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayFieldRef.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -122,11 +124,11 @@ public class PSDisplayFieldRef extends PSComponent implements IPSMutatableReplac
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -141,13 +143,13 @@ public class PSDisplayFieldRef extends PSComponent implements IPSMutatableReplac
         m_id = Integer.parseInt(data);
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       m_fieldRef = tree.getElementData(FIELD_REF_ELEM);
       if (m_fieldRef == null) {
         Object[] args = {XML_NODE_NAME, FIELD_REF_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     } finally {
       resetParentList(parentComponents, parentSize);
@@ -170,7 +172,7 @@ public class PSDisplayFieldRef extends PSComponent implements IPSMutatableReplac
     if (!context.startValidation(this, null)) return;
 
     if (m_fieldRef == null || m_fieldRef.trim().length() == 0)
-      context.validationError(this, IPSObjectStoreErrors.INVALID_FIELD, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_FIELD, null);
   }
 
   /** The value type associated with instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapper.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.utils.types.PSPair;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -154,11 +156,11 @@ public final class PSDisplayMapper extends PSCollectionComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -175,14 +177,14 @@ public final class PSDisplayMapper extends PSCollectionComponent {
         m_id = Integer.parseInt(data);
       } catch (Exception e) {
         Object[] args = {XML_NODE_NAME, ((data == null) ? "null" : data)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // REQUIRED: get the fieldSetRef attribute
       m_fieldSetRef = tree.getElementData(FIELD_SET_REF_ATTR);
       if (m_fieldSetRef == null) {
         Object[] args = {XML_NODE_NAME, FIELD_SET_REF_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       int firstFlags = PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN;
@@ -228,11 +230,11 @@ public final class PSDisplayMapper extends PSCollectionComponent {
     if (!context.startValidation(this, null)) return;
 
     if (getId() == 0) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_DISPLAY_MAPPER, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_DISPLAY_MAPPER, null);
     }
 
     if (m_fieldSetRef == null || m_fieldSetRef.trim().length() == 0) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_DISPLAY_MAPPER, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_DISPLAY_MAPPER, null);
     }
 
     super.validate(context);
@@ -407,7 +409,7 @@ public final class PSDisplayMapper extends PSCollectionComponent {
       if (!usedMappings.contains(fieldRef)) {
         /* No placeholder in this mapper for merging with child mapper.
          */
-        throw new PSSystemValidationException(IPSObjectStoreErrors.CE_UNUSED_MAPPER, fieldRef);
+        throw new PSSystemValidationException(ObjectStoreErrorCodes.CE_UNUSED_MAPPER, fieldRef);
       }
     } else {
       // add mappings that are not already there.
@@ -728,7 +730,7 @@ public final class PSDisplayMapper extends PSCollectionComponent {
     if ((targetChildMapper != null) && (sourceChildMapper == null)) {
       // target cannot have a child if source does not
       throw new PSSystemValidationException(
-          IPSObjectStoreErrors.CE_MAPPING_INVALID_CHILD, targetMapping.getFieldRef());
+          ObjectStoreErrorCodes.CE_MAPPING_INVALID_CHILD, targetMapping.getFieldRef());
     } else if (sourceChildMapper != null) {
       if (targetChildMapper == null) {
         // recursively add, which will apply source defaults as well
@@ -801,7 +803,7 @@ public final class PSDisplayMapper extends PSCollectionComponent {
       } else {
         // target may not contain fields not in the source
         throw new PSSystemValidationException(
-            IPSObjectStoreErrors.CE_MAPPING_INVALID_CHILD_FIELDS,
+            ObjectStoreErrorCodes.CE_MAPPING_INVALID_CHILD_FIELDS,
             targetChildMapper.getFieldSetRef());
       }
     }
@@ -863,7 +865,7 @@ public final class PSDisplayMapper extends PSCollectionComponent {
       if (!isMatch) {
         // a default set specified that does not exist!
         throw new PSSystemValidationException(
-            IPSObjectStoreErrors.CE_MAPPING_INVALID_DEFAULT_UISET, defaultName);
+            ObjectStoreErrorCodes.CE_MAPPING_INVALID_DEFAULT_UISET, defaultName);
       }
     }
 
@@ -1034,7 +1036,7 @@ public final class PSDisplayMapper extends PSCollectionComponent {
     if ((targetChildMapper != null) && (sourceChildMapper == null)) {
       // target cannot have a child if source does not
       throw new PSSystemValidationException(
-          IPSObjectStoreErrors.CE_MAPPING_INVALID_CHILD, targetMapping.getFieldRef());
+          ObjectStoreErrorCodes.CE_MAPPING_INVALID_CHILD, targetMapping.getFieldRef());
     } else if (sourceChildMapper != null && targetChildMapper != null) {
       resultMapping.setDisplayMapper(
           getDemergedChildMapper(
@@ -1104,7 +1106,7 @@ public final class PSDisplayMapper extends PSCollectionComponent {
         // definition of this child mapper
         // target may not contain fields not in the source
         throw new PSSystemValidationException(
-            IPSObjectStoreErrors.CE_MAPPING_INVALID_CHILD_FIELDS,
+            ObjectStoreErrorCodes.CE_MAPPING_INVALID_CHILD_FIELDS,
             targetChildMapper.getFieldSetRef());
       }
     }
@@ -1159,7 +1161,7 @@ public final class PSDisplayMapper extends PSCollectionComponent {
       if (!isMatch) {
         // a default set specified that does not exist!
         throw new PSSystemValidationException(
-            IPSObjectStoreErrors.CE_MAPPING_INVALID_DEFAULT_UISET, defaultName);
+            ObjectStoreErrorCodes.CE_MAPPING_INVALID_DEFAULT_UISET, defaultName);
       }
     }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayMapping.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -172,11 +174,11 @@ public final class PSDisplayMapping extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -196,7 +198,7 @@ public final class PSDisplayMapping extends PSComponent {
       m_fieldRef = tree.getElementData(node);
       if (m_fieldRef == null || m_fieldRef.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, FIELD_REF_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // REQUIRED: get the UI set
@@ -205,7 +207,7 @@ public final class PSDisplayMapping extends PSComponent {
         m_uiSet = new PSUISet(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSUISet.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // OPTIONAL: get the display mapper
@@ -242,14 +244,14 @@ public final class PSDisplayMapping extends PSComponent {
     if (!context.startValidation(this, null)) return;
 
     if (m_fieldRef == null || m_fieldRef.trim().length() == 0) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_DISPLAY_MAPPING, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_DISPLAY_MAPPING, null);
     }
 
     // do children
     context.pushParent(this);
     try {
       if (m_uiSet != null) m_uiSet.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_DISPLAY_MAPPING, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_DISPLAY_MAPPING, null);
 
       if (m_displayMapper != null) m_displayMapper.validate(context);
     } finally {

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayText.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayText.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -121,11 +123,11 @@ public class PSDisplayText extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -157,7 +159,7 @@ public class PSDisplayText extends PSComponent {
     if (!context.startValidation(this, null)) return;
 
     if (m_text == null) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_DISPLAY_TEXT, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_DISPLAY_TEXT, null);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSEntry.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -274,11 +276,11 @@ public class PSEntry extends PSComponent {
   private void fromXmlBase(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     int firstFlags =
@@ -312,7 +314,7 @@ public class PSEntry extends PSComponent {
     node = tree.getNextElement(PSDisplayText.XML_NODE_NAME, firstFlags);
     if (node == null) {
       Object[] args = {XML_NODE_NAME, PSDisplayText.XML_NODE_NAME, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_label = new PSDisplayText(node, parentDoc, parentComponents);
 
@@ -320,7 +322,7 @@ public class PSEntry extends PSComponent {
     node = tree.getNextElement(VALUE_ELEM, nextFlags);
     if (node == null) {
       Object[] args = {XML_NODE_NAME, VALUE_ELEM, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_value = tree.getElementData(node);
   }
@@ -348,14 +350,14 @@ public class PSEntry extends PSComponent {
     if (!context.startValidation(this, null)) return;
 
     if (m_value == null) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_ENTRY, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_ENTRY, null);
     }
 
     // do children
     context.pushParent(this);
     try {
       if (m_label == null) {
-        context.validationError(this, IPSObjectStoreErrors.INVALID_ENTRY, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_ENTRY, null);
       } else m_label.validate(context);
     } finally {
       context.popParent();

--- a/system/src/main/java/com/percussion/design/objectstore/PSErrorWebPages.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSErrorWebPages.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -198,11 +200,11 @@ public class PSErrorWebPages extends PSCollectionComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -212,7 +214,7 @@ public class PSErrorWebPages extends PSCollectionComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // private          boolean         m_html = true;

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionCall.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionCall.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.extension.PSExtensionRef;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -364,11 +366,11 @@ public class PSExtensionCall extends PSComponent
     int parentSize = parentComponents.size() - 1;
 
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -378,7 +380,7 @@ public class PSExtensionCall extends PSComponent
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // Find the exit and check its name for validity
@@ -387,7 +389,7 @@ public class PSExtensionCall extends PSComponent
     if (exitName == null || (!(PSExtensionRef.isValidFullName(exitName)))) {
       Object[] args = {ms_NodeType, "'name'", ((exitName == null) ? "null" : exitName)};
 
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     m_ext = new PSExtensionRef(exitName);
@@ -432,7 +434,7 @@ public class PSExtensionCall extends PSComponent
     if (!cxt.startValidation(this, null)) return;
 
     if (m_columns == null)
-      cxt.validationError(this, IPSObjectStoreErrors.EXT_CALL_PARAM_VALUE_NULL, null);
+      cxt.validationError(this, ObjectStoreErrorCodes.EXT_CALL_PARAM_VALUE_NULL, null);
 
     if (m_params != null) {
       cxt.pushParent(this);

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionCallSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionCallSet.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -109,11 +111,11 @@ public class PSExtensionCallSet extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -123,7 +125,7 @@ public class PSExtensionCallSet extends PSCollectionComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // get all the exit calls

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionParamDef.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionParamDef.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.extension.IPSExtensionParamDef;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -238,11 +240,11 @@ public class PSExtensionParamDef extends PSComponent implements IPSExtensionPara
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -252,7 +254,7 @@ public class PSExtensionParamDef extends PSComponent implements IPSExtensionPara
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     try { // private      String          m_name = "";

--- a/system/src/main/java/com/percussion/design/objectstore/PSFeature.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFeature.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -89,13 +91,13 @@ public class PSFeature {
    */
   public PSFeature(Element sourceNode) throws PSUnknownNodeTypeException {
     if (sourceNode == null) {
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeName);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_nodeName);
     }
 
     // make sure we got the correct type node
     if (false == ms_nodeName.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_nodeName, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -104,7 +106,7 @@ public class PSFeature {
     String sTemp = tree.getElementData("Name");
     if (sTemp == null) {
       Object[] args = {ms_nodeName, "Name", "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     } else m_featureName = sTemp;
 
     int firstFlags = PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN;
@@ -124,7 +126,7 @@ public class PSFeature {
     } else {
       // must be at least one
       Object[] args = {ms_nodeName, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSFeatureSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFeatureSet.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -62,16 +64,16 @@ public class PSFeatureSet {
   public void fromXml(Document sourceDoc)
       throws PSUnknownDocTypeException, PSUnknownNodeTypeException {
     if (null == sourceDoc)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeName);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_nodeName);
 
     Element root = sourceDoc.getDocumentElement();
     if (root == null)
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_nodeName);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_nodeName);
 
     // make sure we got the correct root node tag
     if (!ms_nodeName.equals(root.getNodeName())) {
       Object[] args = {ms_nodeName, root.getNodeName()};
-      throw new PSUnknownDocTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownDocTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     // Read in all of the features

--- a/system/src/main/java/com/percussion/design/objectstore/PSField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSField.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -1584,11 +1586,11 @@ public final class PSField extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_userProps.clear();
     parentComponents = updateParentList(parentComponents);
@@ -1612,7 +1614,7 @@ public final class PSField extends PSComponent {
       m_submitName = tree.getElementData(NAME_ATTR);
       if (m_submitName == null) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // OPTIONAL: get the mime type attribute
@@ -1706,7 +1708,7 @@ public final class PSField extends PSComponent {
           if (!node.getTagName().equals(DATA_LOCATOR_ELEM)) {
             Object[] args = {DEFAULT_VALUE_ELEM, DATA_LOCATOR_ELEM, "null"};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
           node = tree.getNextElement(true);
           m_default =
@@ -1736,7 +1738,7 @@ public final class PSField extends PSComponent {
             if (!found) {
               Object[] args = {OCCURRENCE_ELEM, OCCURRENCE_DIMENSION_ATTR, data};
               throw new PSUnknownNodeTypeException(
-                  IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+                  ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
             }
           }
 
@@ -1749,7 +1751,7 @@ public final class PSField extends PSComponent {
               } catch (NumberFormatException e) {
                 Object[] args = {XML_NODE_NAME, OCCURRENCE_ELEM, data};
                 throw new PSUnknownNodeTypeException(
-                    IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                    ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
               }
             }
           }
@@ -1773,7 +1775,7 @@ public final class PSField extends PSComponent {
             if (!found) {
               Object[] args = {OCCURRENCE_ELEM, OCCURRENCE_MULTI_VALUED_TYPE_ATTR, data};
               throw new PSUnknownNodeTypeException(
-                  IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+                  ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
             }
           }
 
@@ -1790,7 +1792,7 @@ public final class PSField extends PSComponent {
             } catch (NumberFormatException e) {
               Object[] args = {OCCURRENCE_ELEM, TRANSITION_ID_ATTR, data};
               throw new PSUnknownNodeTypeException(
-                  IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+                  ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
             }
           }
 
@@ -2054,7 +2056,7 @@ public final class PSField extends PSComponent {
     }
 
     if (m_submitName == null || m_submitName.trim().length() == 0) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_FIELD, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_FIELD, null);
     }
 
     // do children
@@ -2081,7 +2083,7 @@ public final class PSField extends PSComponent {
    */
   public static void validateType(int type) throws PSSystemValidationException {
     if (type != TYPE_SYSTEM && type != TYPE_SHARED && type != TYPE_LOCAL)
-      throw new PSSystemValidationException(IPSObjectStoreErrors.UNSUPPORTED_FIELD_TYPE, TYPE_ENUM);
+      throw new PSSystemValidationException(ObjectStoreErrorCodes.UNSUPPORTED_FIELD_TYPE, TYPE_ENUM);
   }
 
   /**
@@ -2185,7 +2187,7 @@ public final class PSField extends PSComponent {
       else if (fbOverride) setting = "force binary";
       PSSystemValidationException ex =
           new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_INVALID_FIELD_OVERRIDE,
+              ObjectStoreErrorCodes.CE_INVALID_FIELD_OVERRIDE,
               new Object[] {getSubmitName(), TYPE_ENUM[source.getType()], setting});
       ms_logger.warn(ex.getMessage());
     }
@@ -2205,12 +2207,12 @@ public final class PSField extends PSComponent {
 
         if (!local.doesMatch(other)) {
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_INVALID_FIELD_OVERRIDE,
+              ObjectStoreErrorCodes.CE_INVALID_FIELD_OVERRIDE,
               new Object[] {getSubmitName(), TYPE_ENUM[source.getType()], "backend data locator"});
         }
       } else // the locator instances itself didn't match
       throw new PSSystemValidationException(
-            IPSObjectStoreErrors.CE_INVALID_FIELD_OVERRIDE,
+            ObjectStoreErrorCodes.CE_INVALID_FIELD_OVERRIDE,
             new Object[] {getSubmitName(), TYPE_ENUM[source.getType()], "data locator"});
     }
 
@@ -3054,7 +3056,7 @@ public final class PSField extends PSComponent {
           && dimension != OCCURRENCE_DIMENSION_REQUIRED
           && dimension != OCCURRENCE_DIMENSION_ZERO_OR_MORE)
         throw new PSSystemValidationException(
-            IPSObjectStoreErrors.UNSUPPORTED_OCCURRENCE_DIMENSION, OCCURRENCE_DIMENSION_ENUM);
+            ObjectStoreErrorCodes.UNSUPPORTED_OCCURRENCE_DIMENSION, OCCURRENCE_DIMENSION_ENUM);
     }
 
     /**
@@ -3069,7 +3071,7 @@ public final class PSField extends PSComponent {
       if (multiValuedType != OCCURRENCE_MULTI_VALUED_TYPE_DELIMITED
           && multiValuedType != OCCURRENCE_MULTI_VALUED_TYPE_SEPARATE)
         throw new PSSystemValidationException(
-            IPSObjectStoreErrors.UNSUPPORTED_OCCURRENCE_MULTI_VALUED_TYPE,
+            ObjectStoreErrorCodes.UNSUPPORTED_OCCURRENCE_MULTI_VALUED_TYPE,
             OCCURRENCE_MULTI_VALUED_TYPE_ENUM);
     }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldError.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldError.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.Serializable;
 import org.apache.commons.lang3.StringUtils;
@@ -53,7 +55,7 @@ public class PSFieldError implements Serializable {
   private void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
     m_submitName = sourceNode.getAttribute(XML_ATTR_NAME_SUBMIT_NAME);
     m_displayName = sourceNode.getAttribute(XML_ATTR_NAME_DISPLAY_NAME);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldSet.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -247,19 +249,19 @@ public final class PSFieldSet extends PSComponent {
     Iterator fields = getAll();
     if (!fields.hasNext()) {
       String[] args = {getName(), "" + 1, "" + 1};
-      throw new PSSystemValidationException(IPSObjectStoreErrors.CE_INCORRECT_FIELD_COUNT, args);
+      throw new PSSystemValidationException(ObjectStoreErrorCodes.CE_INCORRECT_FIELD_COUNT, args);
     }
 
     Object o = fields.next();
     if (!(o instanceof PSField)) {
       throw new PSSystemValidationException(
-          IPSObjectStoreErrors.CE_CANNOT_HAVE_FIELDSETS, getName());
+          ObjectStoreErrorCodes.CE_CANNOT_HAVE_FIELDSETS, getName());
     }
 
     PSField field = (PSField) o;
     if (fields.hasNext()) {
       String[] args = {getName(), "" + 0, "" + 1};
-      throw new PSSystemValidationException(IPSObjectStoreErrors.CE_INCORRECT_FIELD_COUNT, args);
+      throw new PSSystemValidationException(ObjectStoreErrorCodes.CE_INCORRECT_FIELD_COUNT, args);
     }
 
     return field;
@@ -726,11 +728,11 @@ public final class PSFieldSet extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -750,7 +752,7 @@ public final class PSFieldSet extends PSComponent {
       m_name = tree.getElementData(NAME_ATTR);
       if (m_name == null) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // OPTIONAL: get the type attribute
@@ -766,7 +768,7 @@ public final class PSFieldSet extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, TYPE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -783,7 +785,7 @@ public final class PSFieldSet extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, REPEATABILITY_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -792,17 +794,17 @@ public final class PSFieldSet extends PSComponent {
         data = tree.getElementData(COUNT_ATTR);
         if (data == null) {
           Object[] args = {XML_NODE_NAME, COUNT_ATTR, "null"};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         try {
           m_count = Integer.parseInt(data);
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, COUNT_ATTR, e.toString()};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
         if (m_count <= 0) {
           Object[] args = {XML_NODE_NAME, COUNT_ATTR, Integer.toString(m_count)};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -959,18 +961,18 @@ public final class PSFieldSet extends PSComponent {
 
     if (!isValidType(m_type)) {
       Object[] args = {TYPE_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_FIELD_SET_TYPE, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_FIELD_SET_TYPE, args);
     }
 
     if (m_repeatability != REPEATABILITY_ONE_OR_MORE
         && m_repeatability != REPEATABILITY_ZERO_OR_MORE
         && m_repeatability != REPEATABILITY_COUNT) {
       Object[] args = {REPEATABILITY_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_FIELD_SET_REPEATABILITY, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_FIELD_SET_REPEATABILITY, args);
     }
 
     if (m_name == null || m_name.trim().length() == 0) {
-      context.validationError(this, IPSObjectStoreErrors.INVALID_FIELD_SET_NAME, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_FIELD_SET_NAME, null);
     }
 
     // do children
@@ -1033,7 +1035,7 @@ public final class PSFieldSet extends PSComponent {
         else {
           // throw error
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_DUPLICATE_MERGED_FIELD_NAME, name);
+              ObjectStoreErrorCodes.CE_DUPLICATE_MERGED_FIELD_NAME, name);
         }
       }
 
@@ -1093,7 +1095,7 @@ public final class PSFieldSet extends PSComponent {
         else {
           // throw error
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_DUPLICATE_MERGED_FIELD_NAME, name);
+              ObjectStoreErrorCodes.CE_DUPLICATE_MERGED_FIELD_NAME, name);
         }
       }
 
@@ -1150,7 +1152,7 @@ public final class PSFieldSet extends PSComponent {
         if (!contains(exclude)) {
           Object[] args = {exclude, getName()};
           throw new PSSystemValidationException(
-              IPSObjectStoreErrors.CE_EXCLUDED_FIELD_MISSING, args);
+              ObjectStoreErrorCodes.CE_EXCLUDED_FIELD_MISSING, args);
         }
       }
     }
@@ -1193,7 +1195,7 @@ public final class PSFieldSet extends PSComponent {
             PSBackEndTable table =
                 (PSBackEndTable) tables.get(col.getTable().getAlias().toLowerCase());
             if (null == table) {
-              throw new PSSystemValidationException(IPSObjectStoreErrors.BE_TABLE_NULL);
+              throw new PSSystemValidationException(ObjectStoreErrorCodes.BE_TABLE_NULL);
             }
             col.setTable(table);
           }

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldTranslation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldTranslation.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -130,11 +132,11 @@ public final class PSFieldTranslation extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -155,7 +157,7 @@ public final class PSFieldTranslation extends PSComponent {
         m_translations = new PSExtensionCallSet(node, parentDoc, parentComponents);
       } else {
         Object[] args = {XML_NODE_NAME, PSExtensionCallSet.ms_NodeType, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       // OPTIONAL: the error message (ErrorLabel/PSXDisplayText)
@@ -167,7 +169,7 @@ public final class PSFieldTranslation extends PSComponent {
         } else {
           Object[] args = {PSExtensionCallSet.ms_NodeType, ERROR_LABEL_ELEM, "null"};
           throw new PSUnknownNodeTypeException(
-              IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+              ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         }
       }
     } finally {
@@ -204,7 +206,7 @@ public final class PSFieldTranslation extends PSComponent {
     context.pushParent(this);
     try {
       if (m_translations != null) m_translations.validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_FIELD_TRANSLATION, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_FIELD_TRANSLATION, null);
 
       if (m_errorMessage != null) m_errorMessage.validate(context);
     } finally {

--- a/system/src/main/java/com/percussion/design/objectstore/PSFieldValidationRules.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFieldValidationRules.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -227,11 +229,11 @@ public final class PSFieldValidationRules extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFile.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFile.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.content.IPSMimeContent;
 import com.percussion.content.PSContentFactory;
 import com.percussion.content.PSMimeContentAdapter;
@@ -302,7 +304,7 @@ public abstract class PSFile extends PSComponent {
    */
   public IPSMimeContent getContent() throws PSIllegalStateException {
     if (m_content == null) {
-      int errCode = IPSObjectStoreErrors.APP_FILE_STREAM_EXHAUSTED;
+      int errCode = ObjectStoreErrorCodes.APP_FILE_STREAM_EXHAUSTED.numericCode();
       throw new PSIllegalStateException(errCode);
     }
 
@@ -364,7 +366,7 @@ public abstract class PSFile extends PSComponent {
         content = out.toString("US-ASCII");
       } catch (IOException e) {
         Object[] args = new Object[] {m_url, e.getMessage()};
-        throw new PSRuntimeException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+        throw new PSRuntimeException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
       } finally {
         try {
           if (in != null) in.close();
@@ -428,7 +430,7 @@ public abstract class PSFile extends PSComponent {
       // do the metadata
       if ((nodeType == null) || (!nodeType.equals(sourceNode.getNodeName()))) {
         Object[] args = {nodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -452,7 +454,7 @@ public abstract class PSFile extends PSComponent {
         // {
         //    Object[] args = { CONTENT, XFER_ENC, xferEnc };
         //    throw new PSUnknownNodeTypeException(
-        //       IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        //       ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
         // }
 
         String mimeType = contentEl.getAttribute(MIME_TYPE);
@@ -482,10 +484,10 @@ public abstract class PSFile extends PSComponent {
       throw new RuntimeException("Unrecoverable error in PSFile.fromXML(): " + e.toString());
     } catch (NumberFormatException e) {
       Object[] args = {nodeType, LAST_MOD, lastModified};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     } catch (IOException e) {
       Object[] args = new Object[] {m_url, e.getMessage()};
-      throw new PSRuntimeException(IPSObjectStoreErrors.APP_FILE_IO_ERROR, args);
+      throw new PSRuntimeException(ObjectStoreErrorCodes.APP_FILE_IO_ERROR.numericCode(), args);
     }
   }
 
@@ -495,7 +497,7 @@ public abstract class PSFile extends PSComponent {
     String val = walker.getElementData(elementName);
     if (val == null || val.length() == 0) {
       Object[] args = {nodeType, elementName, ""};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     return val;
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSFile.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFile.java
@@ -454,7 +454,7 @@ public abstract class PSFile extends PSComponent {
         // {
         //    Object[] args = { CONTENT, XFER_ENC, xferEnc };
         //    throw new PSUnknownNodeTypeException(
-        //       ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
+        //       IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
         // }
 
         String mimeType = contentEl.getAttribute(MIME_TYPE);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFileDescriptor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFileDescriptor.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -67,7 +69,7 @@ public class PSFileDescriptor extends PSComponent {
     m_name = sourceNode.getAttribute(XML_ATTR_NAME);
     if (m_name == null || m_name.trim().length() == 0) {
       Object[] args = {sourceNode.getTagName(), XML_ATTR_NAME, "empty"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_type = getEnumeratedAttribute(tree, XML_ATTR_TYPE, TYPE_ENUM);

--- a/system/src/main/java/com/percussion/design/objectstore/PSFormAction.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFormAction.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -141,11 +143,11 @@ public class PSFormAction extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -174,7 +176,7 @@ public class PSFormAction extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, METHOD_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -182,7 +184,7 @@ public class PSFormAction extends PSComponent {
       node = tree.getNextElement(PSUrlRequest.XML_NODE_NAME, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, PSUrlRequest.XML_NODE_NAME, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else m_action = new PSUrlRequest(node, parentDoc, parentComponents);
     } finally {
       resetParentList(parentComponents, parentSize);
@@ -209,7 +211,7 @@ public class PSFormAction extends PSComponent {
     context.pushParent(this);
     try {
       if (m_action != null) ((IPSComponent) m_action).validate(context);
-      else context.validationError(this, IPSObjectStoreErrors.INVALID_FORM_ACTION, null);
+      else context.validationError(this, ObjectStoreErrorCodes.INVALID_FORM_ACTION, null);
     } finally {
       context.popParent();
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSFunctionCall.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFunctionCall.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.data.PSDataExtractionException;
 import com.percussion.data.PSMetaDataCache;
 import com.percussion.extension.PSDatabaseFunctionDef;
@@ -302,7 +304,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
     if (funcDef == null) {
       Object[] args = new Object[] {dbFuncName, driver};
       throw new PSDataExtractionException(
-          IPSObjectStoreErrors.DATABASE_FUNCTION_DEFINITION_NOT_FOUND, args);
+          ObjectStoreErrorCodes.DATABASE_FUNCTION_DEFINITION_NOT_FOUND.numericCode(), args);
     }
 
     PSFunctionParamValue[] params = getParamValues();
@@ -316,7 +318,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
             Integer.valueOf(providedParamsCount), dbFuncName, Integer.valueOf(reqParamsCount)
           };
       throw new PSDataExtractionException(
-          IPSObjectStoreErrors.DATABASE_FUNCTION_CALL_PARAM_COUNT_MISMATCH, args);
+          ObjectStoreErrorCodes.DATABASE_FUNCTION_CALL_PARAM_COUNT_MISMATCH.numericCode(), args);
     }
 
     m_dbFuncDef = funcDef;
@@ -413,11 +415,11 @@ public class PSFunctionCall extends PSNamedReplacementValue
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, getNodeName());
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, getNodeName());
 
       if (false == (getNodeName().equals(sourceNode.getNodeName()))) {
         Object[] args = {getNodeName(), sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       String sTemp = sourceNode.getAttribute(ATTR_ID);
@@ -425,7 +427,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
         m_id = Integer.parseInt(sTemp);
       } catch (NumberFormatException e) {
         Object[] args = {getNodeName(), ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -441,7 +443,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
 
       if ((sTemp == null) || (sTemp.trim().length() < 1)) {
         Object[] args = {getNodeName(), EL_NAME, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_dbFuncName = sTemp;
 
@@ -475,7 +477,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
     if (!cxt.startValidation(this, null)) return;
 
     if (m_columns == null)
-      cxt.validationError(this, IPSObjectStoreErrors.EXT_CALL_PARAM_VALUE_NULL, null);
+      cxt.validationError(this, ObjectStoreErrorCodes.EXT_CALL_PARAM_VALUE_NULL, null);
 
     cxt.pushParent(this);
     try {

--- a/system/src/main/java/com/percussion/design/objectstore/PSGroupProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSGroupProviderInstance.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.security.PSSecurityProvider;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -109,7 +111,7 @@ public abstract class PSGroupProviderInstance extends PSComponent
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {XML_NODE_NAME, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     m_name = getRequiredElement(tree, NAME_ATTR);
@@ -117,7 +119,7 @@ public abstract class PSGroupProviderInstance extends PSComponent
     sTemp = getRequiredElement(tree, CLASSNAME_ATTR);
     if (!validateClass(sTemp)) {
       Object[] args = {XML_NODE_NAME, CLASSNAME_ATTR, sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_className = sTemp;
 
@@ -125,7 +127,7 @@ public abstract class PSGroupProviderInstance extends PSComponent
     int type = PSSecurityProvider.getSecurityProviderTypeFromXmlFlag(sTemp);
     if (type == 0) {
       Object[] args = {XML_NODE_NAME, TYPE_ATTR, sTemp};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     m_type = type;
 
@@ -204,7 +206,7 @@ public abstract class PSGroupProviderInstance extends PSComponent
 
     if (newInstance == null) {
       Object[] args = {XML_NODE_NAME, CLASSNAME_ATTR, className};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     newInstance.fromXml(source, null, null);

--- a/system/src/main/java/com/percussion/design/objectstore/PSHtmlParameter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSHtmlParameter.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -91,7 +93,7 @@ public class PSHtmlParameter extends PSNamedReplacementValue {
 
   // see base class for description
   protected int getErrorCode() {
-    return IPSObjectStoreErrors.HTML_PARAM_NAME_EMPTY;
+    return ObjectStoreErrorCodes.HTML_PARAM_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with this instances of this class. */

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK1Test.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK1Test.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Batch K1 (#3062): design.objectstore D–H cohort call sites must throw typed {@link
+ * ObjectStoreErrorCodes} (not bare {@code IPSObjectStoreErrors} ints) where IPSErrorCode ctors
+ * exist.
+ */
+public class PSDesignObjectstoreTypedErrorCodeBatchK1Test {
+
+  @Test
+  public void dataMappingNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSDataMapping((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void dataMappingWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDataMapping");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSDataMapping(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void defaultSelectedNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSDefaultSelected((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void defaultSelectedWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDefaultSelected");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSDefaultSelected(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void entryNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSEntry((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void entryWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotEntry");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSEntry(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void displayMapperNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSDisplayMapper((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void displayMapperWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDisplayMapper");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSDisplayMapper(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void formActionNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSFormAction((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void formActionWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotFormAction");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSFormAction(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void dataEncryptorNullSourceUsesTypedNull() {
+    PSDataEncryptor encryptor = new PSDataEncryptor(false);
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> encryptor.fromXml(null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void dataEncryptorWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotDataEncryptor");
+    PSDataEncryptor encryptor = new PSDataEncryptor(false);
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> encryptor.fromXml(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void fieldSetNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSFieldSet((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void fieldSetWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotFieldSet");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSFieldSet(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+}


### PR DESCRIPTION
## Summary
Call-site migration **batch K1** for parent residual #3050 / grandparent #2616 / issue #3062: migrate `com.percussion.design.objectstore` **D–H alphabetical cohort** from raw `IPSObjectStoreErrors` ints to typed `ObjectStoreErrorCodes`.

### Scope
- **37 files**, ~**200** call sites migrated (root D–H only)
- Typed construction via existing `IPSErrorCode` ctors (`PSUnknownNodeTypeException`, `PSUnknownDocTypeException`, `PSSystemValidationException`, `validationError`)
- Int-only APIs use `.numericCode()`: `PSRuntimeException`, `PSDatabaseComponentException`, `PSDataExtractionException`, `PSIllegalStateException`, `getErrorCode()` returns
- All 49 distinct codes used in this cohort already exist on `ObjectStoreErrorCodes` (no new enum values)

### Out of scope (remain on residual #3050)
- I–Z design.objectstore root
- server/legacy subpackages
- Design ACL codes / new enums

### Parent
Parent residual: #3050 · Grandparent: #2616 · Prior: #3040 (batch I A–C; PR #3049)

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` (JDK 21) — **BUILD SUCCESS** (artifact installed)
- [x] New `PSDesignObjectstoreTypedErrorCodeBatchK1Test` — **Tests run: 14, Failures: 0**
- [x] Module suite aggregate surefire — **Tests run: 1825, Failures: 0, Errors: 0, Skipped: 238**

## Product documentation
- [x] N/A — pure tech-debt call-site migration; no operator/user/API surface change

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system; $env:JAVA_HOME=…jdk-21…; ..\mvnw.cmd clean install` → perc-system jars installed; Tests run: 1825, Failures: 0; batch K1 tests: 14
- **downstream_checked:** none (call-site only; no public/protected signature or `final`/`sealed` changes)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3062

> Co-Authored by Grok Build using grok-4.5 with agent main.
