### PR TITLE
fix(objectstore): ObjectStoreErrorCodes call-site batch K2 (design.objectstore I-P) (#3063)

### DIFF
--- a/system/src/main/java/com/percussion/design/objectstore/PSInputTranslations.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSInputTranslations.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -99,11 +101,11 @@ public class PSInputTranslations extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSJavaPlugin.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSJavaPlugin.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -235,31 +237,31 @@ public class PSJavaPlugin implements IPSJavaPlugin {
 
     if (m_osKey.trim().length() < 1) {
       Object[] args = {XML_NODE_NAME, ATTR_OSKEY, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_browserKey = sourceNode.getAttribute(ATTR_BROWSERKEY);
     if (m_browserKey.trim().length() < 1) {
       Object[] args = {XML_NODE_NAME, ATTR_BROWSERKEY, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_versionToUse = sourceNode.getAttribute(ATTR_VERSIONTOUSE);
     if (m_versionToUse.trim().length() < 1) {
       Object[] args = {XML_NODE_NAME, ATTR_VERSIONTOUSE, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_versioningType = sourceNode.getAttribute(ATTR_VERSIONINGTYPE);
     if (m_versioningType.trim().length() < 1) {
       Object[] args = {XML_NODE_NAME, ATTR_VERSIONINGTYPE, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_downloadLocation = sourceNode.getAttribute(ATTR_DOWNLOADLOCATION);
     if (m_downloadLocation.trim().length() < 1) {
       Object[] args = {XML_NODE_NAME, ATTR_DOWNLOADLOCATION, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSJndiGroupProviderInstance.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSJndiGroupProviderInstance.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -155,7 +157,7 @@ public class PSJndiGroupProviderInstance extends PSGroupProviderInstance {
     if (root == null) {
       String parentName = source.getNodeName();
       Object[] args = {parentName, XML_NODE_NAME, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     // load object classes
@@ -163,7 +165,7 @@ public class PSJndiGroupProviderInstance extends PSGroupProviderInstance {
     Element objectClasses = tree.getNextElement(OBJECT_CLASSES_ELEMENT, firstFlags);
     if (objectClasses == null) {
       Object[] args = {XML_NODE_NAME, OBJECT_CLASSES_ELEMENT, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     Element objectClass = tree.getNextElement(OBJECT_CLASS_ELEMENT, firstFlags);
@@ -171,13 +173,13 @@ public class PSJndiGroupProviderInstance extends PSGroupProviderInstance {
       String name = objectClass.getAttribute(NAME_ATTR);
       if (name == null || name.trim().length() == 0) {
         Object[] args = {OBJECT_CLASS_ELEMENT, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       String memberAttr = objectClass.getAttribute(MEMBER_ATTR);
       if (memberAttr == null || memberAttr.trim().length() == 0) {
         Object[] args = {OBJECT_CLASS_ELEMENT, MEMBER_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       int type = -1;
@@ -192,7 +194,7 @@ public class PSJndiGroupProviderInstance extends PSGroupProviderInstance {
 
         if (type == -1) {
           Object[] args = {OBJECT_CLASS_ELEMENT, MEMBER_ATTR, attrType};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -206,7 +208,7 @@ public class PSJndiGroupProviderInstance extends PSGroupProviderInstance {
     Element groupNodes = tree.getNextElement(GROUP_NODES_ELEMENT, nextFlags);
     if (groupNodes == null) {
       Object[] args = {XML_NODE_NAME, GROUP_NODES_ELEMENT, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     Element groupNode = tree.getNextElement(GROUP_NODE_ELEMENT, firstFlags);
@@ -214,7 +216,7 @@ public class PSJndiGroupProviderInstance extends PSGroupProviderInstance {
       String node = tree.getElementData(groupNode);
       if (node.trim().length() == 0) {
         Object[] args = {GROUP_NODES_ELEMENT, GROUP_NODE_ELEMENT, node};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       m_groupNodes.add(node);

--- a/system/src/main/java/com/percussion/design/objectstore/PSLiteralSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLiteralSet.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -105,11 +107,11 @@ public class PSLiteralSet extends PSCollectionComponent implements IPSReplacemen
       throws PSUnknownNodeTypeException {
 
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/main/java/com/percussion/design/objectstore/PSLocation.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLocation.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -230,11 +232,11 @@ public class PSLocation extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -263,7 +265,7 @@ public class PSLocation extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, PAGE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -280,7 +282,7 @@ public class PSLocation extends PSComponent {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, TYPE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -292,7 +294,7 @@ public class PSLocation extends PSComponent {
           m_sequence = Integer.parseInt(data);
         } catch (NumberFormatException e) {
           Object[] args = {XML_NODE_NAME, SEQUENCE_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -303,7 +305,7 @@ public class PSLocation extends PSComponent {
           Object[] args = {
             FIELDREF_ELEM,
           };
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, args);
         }
 
         do {
@@ -311,7 +313,7 @@ public class PSLocation extends PSComponent {
           if (fieldRef.trim().length() == 0) {
             Object[] args = {XML_NODE_NAME, FIELDREF_ELEM, ""};
             throw new PSUnknownNodeTypeException(
-                IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+                ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
           }
           m_fieldRefs.add(fieldRef);
           node = tree.getNextElement(FIELDREF_ELEM, nextFlags);
@@ -351,7 +353,7 @@ public class PSLocation extends PSComponent {
     try {
       if ((PAGE_SUMMARY_VIEW == m_page || (PAGE_ROW_EDIT == m_page && TYPE_FORM == m_type))
           && m_fieldRefs.size() == 0) {
-        context.validationError(this, IPSObjectStoreErrors.INVALID_LOCATION, null);
+        context.validationError(this, ObjectStoreErrorCodes.INVALID_LOCATION, null);
       }
     } finally {
       context.popParent();

--- a/system/src/main/java/com/percussion/design/objectstore/PSLockedException.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLockedException.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.error.PSException;
 
 /**
@@ -79,41 +81,40 @@ public class PSLockedException extends PSException {
   }
 
   public void constructArguments() {
-    switch (m_code) {
-      case IPSObjectStoreErrors.LOCK_ALREADY_HELD:
-        /**
-         * The object was already exclusively locked by someone else.
-         *
-         * <p>The arguments passed in for this message are:
-         *
-         * <TABLE BORDER="1">
-         * <TR><TH>Arg</TH><TH>Description</TH></TR>
-         * <TR><TD>0</TD><TD>The name of the locked object</TD></TR>
-         * <TR><TD>1</TD><TD>The name of the user currently holding the lock</TD></TR>
-         * <TR><TD>2</TD><TD>How many minutes from now the lock will expire if the
-         * user does not renew it</TD></TR>
-         * </TABLE>
-         */
-        m_args = new Object[] {m_objectName, m_user, "" + m_minutes};
-        break;
-      case IPSObjectStoreErrors.LOCK_ALREADY_HELD_SAME_USER:
-      default:
-        /**
-         * The object was already exclusively locked by the user requesting the lock, but under a
-         * different user session.
-         *
-         * <p>The arguments passed in for this message are:
-         *
-         * <TABLE BORDER="1">
-         * <TR><TH>Arg</TH><TH>Description</TH></TR>
-         * <TR><TD>0</TD><TD>The name of the locked object</TD></TR>
-         * <TR><TD>1</TD><TD>The name of the user currently holding the lock</TD></TR>
-         * <TR><TD>2</TD><TD>How many minutes from now the lock will expire if the
-         * user does not renew it</TD></TR>
-         * <TR><TD>3</TD><TD>The session id of the session holding the lock</TD></TR>
-         * </TABLE>
-         */
-        m_args = new Object[] {m_objectName, m_user, "" + m_minutes, m_sessionId};
+    // numericCode() is not a switch-case constant expression; compare via if/else.
+    if (m_code == ObjectStoreErrorCodes.LOCK_ALREADY_HELD.numericCode()) {
+      /**
+       * The object was already exclusively locked by someone else.
+       *
+       * <p>The arguments passed in for this message are:
+       *
+       * <TABLE BORDER="1">
+       * <TR><TH>Arg</TH><TH>Description</TH></TR>
+       * <TR><TD>0</TD><TD>The name of the locked object</TD></TR>
+       * <TR><TD>1</TD><TD>The name of the user currently holding the lock</TD></TR>
+       * <TR><TD>2</TD><TD>How many minutes from now the lock will expire if the
+       * user does not renew it</TD></TR>
+       * </TABLE>
+       */
+      m_args = new Object[] {m_objectName, m_user, "" + m_minutes};
+    } else {
+      // LOCK_ALREADY_HELD_SAME_USER and any other lock code: include session id.
+      /**
+       * The object was already exclusively locked by the user requesting the lock, but under a
+       * different user session.
+       *
+       * <p>The arguments passed in for this message are:
+       *
+       * <TABLE BORDER="1">
+       * <TR><TH>Arg</TH><TH>Description</TH></TR>
+       * <TR><TD>0</TD><TD>The name of the locked object</TD></TR>
+       * <TR><TD>1</TD><TD>The name of the user currently holding the lock</TD></TR>
+       * <TR><TD>2</TD><TD>How many minutes from now the lock will expire if the
+       * user does not renew it</TD></TR>
+       * <TR><TD>3</TD><TD>The session id of the session holding the lock</TD></TR>
+       * </TABLE>
+       */
+      m_args = new Object[] {m_objectName, m_user, "" + m_minutes, m_sessionId};
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSLogger.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLogger.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -483,11 +485,11 @@ public class PSLogger extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -497,7 +499,7 @@ public class PSLogger extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     /* get the logging options */
@@ -559,7 +561,7 @@ public class PSLogger extends PSComponent {
             | LOG_EXECUTION_PLAN);
 
     if (0 != (m_options & all_flags_compliment)) {
-      cxt.validationError(this, IPSObjectStoreErrors.LOGGER_OPTIONS_INVALID, "" + m_options);
+      cxt.validationError(this, ObjectStoreErrorCodes.LOGGER_OPTIONS_INVALID, "" + m_options);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
@@ -214,7 +214,7 @@ public class PSLoginWebPage extends PSComponent {
       // default login page
       // Object[] args = { ms_NodeType, "url", "" };
       // throw new PSUnknownNodeTypeException(
-      //    ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
+      //    IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
       m_url = null;
     } else {
       try {
@@ -243,7 +243,7 @@ public class PSLoginWebPage extends PSComponent {
     // this is no longer true. if no URL is specified, we use our
     // default login page
     // if (m_url == null)
-    //    cxt.validationError(this, ObjectStoreErrorCodes.LOGIN_WEBPAGE_URL_EMPTY, null);
+    //    cxt.validationError(this, IPSObjectStoreErrors.LOGIN_WEBPAGE_URL_EMPTY, null);
   }
 
   @Override

--- a/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLoginWebPage.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -186,11 +188,11 @@ public class PSLoginWebPage extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -200,7 +202,7 @@ public class PSLoginWebPage extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData("secure");
@@ -212,14 +214,14 @@ public class PSLoginWebPage extends PSComponent {
       // default login page
       // Object[] args = { ms_NodeType, "url", "" };
       // throw new PSUnknownNodeTypeException(
-      //    IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      //    ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       m_url = null;
     } else {
       try {
         m_url = new URL(sTemp);
       } catch (java.net.MalformedURLException e) {
         Object[] args = {ms_NodeType, "url", "(URL: " + sTemp + ") " + e.getMessage()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
     }
   }
@@ -241,7 +243,7 @@ public class PSLoginWebPage extends PSComponent {
     // this is no longer true. if no URL is specified, we use our
     // default login page
     // if (m_url == null)
-    //    cxt.validationError(this, IPSObjectStoreErrors.LOGIN_WEBPAGE_URL_EMPTY, null);
+    //    cxt.validationError(this, ObjectStoreErrorCodes.LOGIN_WEBPAGE_URL_EMPTY, null);
   }
 
   @Override

--- a/system/src/main/java/com/percussion/design/objectstore/PSMacro.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMacro.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import java.util.List;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -119,7 +121,7 @@ public class PSMacro extends PSNamedReplacementValue {
 
   // see base class for description
   protected int getErrorCode() {
-    return IPSObjectStoreErrors.MACRO_NAME_EMPTY;
+    return ObjectStoreErrorCodes.MACRO_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with this instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinition.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinition.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -148,7 +150,7 @@ public final class PSMacroDefinition extends PSComponent {
     String strId = source.getAttribute(PSComponent.ID_ATTR);
     if (strId == null) {
       Object[] args = {XML_NODE_NAME, PSComponent.ID_ATTR, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     int id = 0;
@@ -156,7 +158,7 @@ public final class PSMacroDefinition extends PSComponent {
       id = Integer.parseInt(strId);
     } catch (NumberFormatException e) {
       Object[] args = {XML_NODE_NAME, PSComponent.ID_ATTR, strId};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     setId(id);
 
@@ -164,14 +166,14 @@ public final class PSMacroDefinition extends PSComponent {
       setName(tree.getElementData(ELEM_NAME));
     } catch (IllegalArgumentException e) {
       Object[] args = {XML_NODE_NAME, ELEM_NAME, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     try {
       setClassName(tree.getElementData(ELEM_CLASS));
     } catch (IllegalArgumentException e) {
       Object[] args = {XML_NODE_NAME, ELEM_CLASS, "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     setDescription(tree.getElementData(ELEM_DESCRIPTION));

--- a/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinitionSet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSMacroDefinitionSet.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.Iterator;
 import java.util.List;
@@ -54,11 +56,11 @@ public class PSMacroDefinitionSet extends PSCollectionComponent {
   public void fromXml(Element source, IPSDocument parent, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (source == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(source.getNodeName())) {
       Object[] args = {XML_NODE_NAME, source.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSNamedReplacementValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNamedReplacementValue.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -107,14 +109,14 @@ public abstract class PSNamedReplacementValue extends PSComponent
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {getNodeName(), ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     try {
       setName(tree.getElementData("name"));
     } catch (IllegalArgumentException e) {
       Object[] args = {getNodeName(), "name", "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSNotifier.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNotifier.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.error.PSException;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.util.PSCollection;
@@ -108,8 +110,7 @@ public class PSNotifier extends PSComponent {
   private static PSIllegalArgumentException validateProviderType(int provider) {
     if (provider != MP_TYPE_SMTP) {
       Object[] args = {Integer.valueOf(provider)};
-      return new PSIllegalArgumentException(
-          IPSObjectStoreErrors.NOTIFIER_PROVIDER_TYPE_INVALID, args);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.NOTIFIER_PROVIDER_TYPE_INVALID.numericCode(), args);
     }
 
     return null;
@@ -140,10 +141,10 @@ public class PSNotifier extends PSComponent {
 
   private static PSIllegalArgumentException validateServer(String name) {
     if ((null == name) || (name.length() == 0))
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.NOTIFIER_SERVER_NULL);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.NOTIFIER_SERVER_NULL.numericCode());
     else if (name.length() > SERVER_NAME_MAX_LEN) {
       Object[] args = {Integer.valueOf(SERVER_NAME_MAX_LEN), Integer.valueOf(name.length())};
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.NOTIFIER_SERVER_TOO_BIG, args);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.NOTIFIER_SERVER_TOO_BIG.numericCode(), args);
     }
 
     return null;
@@ -178,7 +179,7 @@ public class PSNotifier extends PSComponent {
   private static PSIllegalArgumentException validateFrom(String from) {
     if (from.length() > FROM_NAME_MAX_LEN) {
       Object[] args = {Integer.valueOf(FROM_NAME_MAX_LEN), Integer.valueOf(from.length())};
-      return new PSIllegalArgumentException(IPSObjectStoreErrors.NOTIFIER_FROM_TOO_BIG, args);
+      return new PSIllegalArgumentException(ObjectStoreErrorCodes.NOTIFIER_FROM_TOO_BIG.numericCode(), args);
     }
 
     return null;
@@ -219,7 +220,7 @@ public class PSNotifier extends PSComponent {
       if (!com.percussion.design.objectstore.PSRecipient.class.isAssignableFrom(
           recipients.getMemberClassType())) {
         Object[] args = {"Recipient", "PSRecipient", recipients.getMemberClassName()};
-        return new PSIllegalArgumentException(IPSObjectStoreErrors.COLL_BAD_CONTENT_TYPE, args);
+        return new PSIllegalArgumentException(ObjectStoreErrorCodes.COLL_BAD_CONTENT_TYPE.numericCode(), args);
       }
     }
     return null;
@@ -330,11 +331,11 @@ public class PSNotifier extends PSComponent {
 
     try {
       if (sourceNode == null)
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
       if (false == ms_NodeType.equals(sourceNode.getNodeName())) {
         Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -344,18 +345,18 @@ public class PSNotifier extends PSComponent {
         m_id = Integer.parseInt(sTemp);
       } catch (Exception e) {
         Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
       }
 
       // better be our only supported provider type
       sTemp = tree.getElementData("providerType");
       if (sTemp == null) {
         Object[] args = {ms_NodeType, "providerType", ""};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       } else if (sTemp.equalsIgnoreCase(XML_FLAG_SMTP)) m_providerType = MP_TYPE_SMTP;
       else {
         Object[] args = {ms_NodeType, "providerType", sTemp};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
 
       try { // which server should we send mail through?
@@ -421,7 +422,7 @@ public class PSNotifier extends PSComponent {
 
     try {
       if (m_recipients == null)
-        cxt.validationWarning(this, IPSObjectStoreErrors.NOTIFIER_RECIPIENTS_EMPTY, null);
+        cxt.validationWarning(this, ObjectStoreErrorCodes.NOTIFIER_RECIPIENTS_EMPTY.numericCode(), null);
       else {
         for (int i = 0; i < m_recipients.size(); i++) {
           Object o = m_recipients.get(i);

--- a/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNullEntry.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -146,11 +148,11 @@ public final class PSNullEntry extends PSEntry {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -179,7 +181,7 @@ public final class PSNullEntry extends PSEntry {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, SORT_ORDER_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -196,7 +198,7 @@ public final class PSNullEntry extends PSEntry {
         }
         if (!found) {
           Object[] args = {XML_NODE_NAME, INCLUDE_WHEN_ATTR, data};
-          throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+          throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
         }
       }
 
@@ -230,12 +232,12 @@ public final class PSNullEntry extends PSEntry {
         && m_sortOrder != SORT_ORDER_LAST
         && m_sortOrder != SORT_ORDER_SORTED) {
       Object[] args = {SORT_ORDER_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_SORT_ORDER, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_SORT_ORDER, args);
     }
 
     if (m_includeWhen != INCLUDE_WHEN_ALWAYS && m_includeWhen != INCLUDE_WHEN_ONLY_IF_NULL) {
       Object[] args = {INCLUDE_WHEN_ENUM};
-      context.validationError(this, IPSObjectStoreErrors.UNSUPPORTED_INCLUDE_WHEN, args);
+      context.validationError(this, ObjectStoreErrorCodes.UNSUPPORTED_INCLUDE_WHEN, args);
     }
 
     super.validate(context);

--- a/system/src/main/java/com/percussion/design/objectstore/PSNumericLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNumericLiteral.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.math.BigDecimal;
@@ -236,12 +238,12 @@ public class PSNumericLiteral extends PSLiteral {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     // make sure we got the ACL type node
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -251,7 +253,7 @@ public class PSNumericLiteral extends PSLiteral {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     // get the number format object first
@@ -261,13 +263,13 @@ public class PSNumericLiteral extends PSLiteral {
       m_format = new DecimalFormat(format);
     } catch (Throwable t) {
       Object[] args = {ms_NodeType, "format", (format + " (Exception: " + t.toString() + ")")};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     // then get the number and parse it using the formatter
     sTemp = tree.getElementData("number");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "number", "null"};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     try {
       // TODO: support big decimal formatting somehow, this approach
@@ -277,7 +279,7 @@ public class PSNumericLiteral extends PSLiteral {
 
     } catch (Throwable t) {
       Object[] args = {ms_NodeType, "format", (format + " (Exception: " + t.toString() + ")")};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSObjectStore.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSObjectStore.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.conn.IPSConnectionErrors;
 import com.percussion.conn.PSDesignerConnection;
 import com.percussion.conn.PSServerException;
@@ -283,7 +285,7 @@ public class PSObjectStore {
     Document respDoc = makeRequest("design-objectstore-datasource-conndetail", request);
     Element respRoot = respDoc.getDocumentElement();
     if (respRoot == null) {
-      throw new PSServerException(IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, null);
+      throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), null);
     }
     return new PSConnectionDetail(
         respRoot.getAttribute("datasource"),
@@ -363,8 +365,7 @@ public class PSObjectStore {
           throw new PSServerException(e);
         }
       } else {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
 
       return config;
@@ -834,8 +835,7 @@ public class PSObjectStore {
           throw new PSServerException(e);
         }
       } else {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT,
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(),
             new Object[] {PSApplication.ms_NodeType, null});
       }
       return app;
@@ -877,7 +877,7 @@ public class PSObjectStore {
           PSAuthenticationFailedException,
           PSNotFoundException {
     Object[] args = {appName, startTime, endTime};
-    throw new PSNotFoundException(IPSObjectStoreErrors.GET_APP_LOG_NO_DATA, args);
+    throw new PSNotFoundException(ObjectStoreErrorCodes.GET_APP_LOG_NO_DATA.numericCode(), args);
   }
 
   /**
@@ -1233,8 +1233,7 @@ public class PSObjectStore {
           try {
             app.setId(Integer.parseInt(appId));
           } catch (NumberFormatException e) {
-            throw new PSServerException(
-                IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT,
+            throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(),
                 respDoc.getDocumentElement().getNodeName());
           }
           Element historyEl = respWalker.getNextElement("PSXRevisionHistory");
@@ -2036,8 +2035,7 @@ public class PSObjectStore {
             throw new PSServerException(e);
           }
         } else {
-          throw new PSServerException(
-              IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, root.getNodeName());
+          throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), root.getNodeName());
         }
       }
 
@@ -2236,8 +2234,7 @@ public class PSObjectStore {
           throw new PSServerException(e);
         }
       } else {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
 
       return config;
@@ -2469,8 +2466,7 @@ public class PSObjectStore {
           throw new PSServerException(e);
         }
       } else {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
 
       return featureSet;
@@ -2505,8 +2501,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXGetJndiDatasourcesResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(respDoc);
@@ -2568,8 +2563,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXSaveJndiDatasourcesResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
     } catch (PSServerException e) {
       PSException throwExc = e.getOriginatingException();
@@ -2602,8 +2596,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXGetDatasourceConfigsResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(respDoc);
@@ -2614,8 +2607,7 @@ public class PSObjectStore {
                 PSDatasourceResolver.BEAN_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
 
         if (dsEl == null)
-          throw new PSServerException(
-              IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+          throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
 
         PSDatasourceResolver resolver = new PSDatasourceResolver();
         resolver.fromXml(dsEl);
@@ -2657,8 +2649,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXSaveDatasourceConfigsResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
     } catch (PSServerException e) {
       PSException throwExc = e.getOriginatingException();
@@ -2691,8 +2682,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXGetHibernateDialectsResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(respDoc);
@@ -2702,8 +2692,7 @@ public class PSObjectStore {
             tree.getNextElement(PSDatasourceResolver.BEAN_NODE_NAME, tree.GET_NEXT_ALLOW_CHILDREN);
 
         if (cfgEl == null)
-          throw new PSServerException(
-              IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+          throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
 
         PSHibernateDialectConfig config = new PSHibernateDialectConfig();
         config.fromXml(cfgEl);
@@ -2745,8 +2734,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXSaveHibernateDialectsResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
     } catch (PSServerException e) {
       PSException throwExc = e.getOriginatingException();
@@ -2779,8 +2767,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXGetCatalogerConfigsResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
 
       PSXmlTreeWalker tree = new PSXmlTreeWalker(respDoc);
@@ -2855,8 +2842,7 @@ public class PSObjectStore {
 
       Element respRoot = respDoc.getDocumentElement();
       if (!respRoot.getNodeName().equals("PSXSaveCatalogerConfigsResults")) {
-        throw new PSServerException(
-            IPSObjectStoreErrors.MALFORMED_RESPONSE_DOCUMENT, respRoot.getNodeName());
+        throw new PSServerException(ObjectStoreErrorCodes.MALFORMED_RESPONSE_DOCUMENT.numericCode(), respRoot.getNodeName());
       }
     } catch (PSServerException e) {
       PSException throwExc = e.getOriginatingException();

--- a/system/src/main/java/com/percussion/design/objectstore/PSOriginatingRelationshipProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSOriginatingRelationshipProperty.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import java.util.List;
 import org.w3c.dom.Element;
 
@@ -79,7 +81,7 @@ public class PSOriginatingRelationshipProperty extends PSNamedReplacementValue {
 
   // see base class for description
   public int getErrorCode() {
-    return IPSObjectStoreErrors.RELATIONSHIP_PROPERTY_NAME_EMPTY;
+    return ObjectStoreErrorCodes.RELATIONSHIP_PROPERTY_NAME_EMPTY.numericCode();
   }
 
   /** The value type associated with instances of this class. */

--- a/system/src/main/java/com/percussion/design/objectstore/PSOutputTranslations.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSOutputTranslations.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -98,11 +100,11 @@ public class PSOutputTranslations extends PSCollectionComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSPageDataTank.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.error.PSException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -229,11 +231,11 @@ public final class PSPageDataTank extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, ms_NodeType);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ms_NodeType);
 
     if (!ms_NodeType.equals(sourceNode.getNodeName())) {
       Object[] args = {ms_NodeType, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -243,19 +245,19 @@ public final class PSPageDataTank extends PSComponent {
       m_id = Integer.parseInt(sTemp);
     } catch (Exception e) {
       Object[] args = {ms_NodeType, ((sTemp == null) ? "null" : sTemp)};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ID, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ID, args);
     }
 
     sTemp = tree.getElementData("schemaSource");
     if ((sTemp == null) || (sTemp.length() == 0)) {
       Object[] args = {ms_NodeType, "schemaSource", ""};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
     try {
       m_schemaSource = new URL(sTemp);
     } catch (MalformedURLException e) {
       Object[] args = {ms_NodeType, "schemaSource", "(URL: " + sTemp + ") " + e.getMessage()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     try {

--- a/system/src/main/java/com/percussion/design/objectstore/PSParam.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSParam.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import org.w3c.dom.Document;
@@ -203,11 +205,11 @@ public class PSParam extends PSComponent implements IPSParameter {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -227,19 +229,19 @@ public class PSParam extends PSComponent implements IPSParameter {
       m_name = tree.getElementData(NAME_ATTR);
       if (m_name == null || m_name.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // REQUIRED: get the parameter value
       node = tree.getNextElement(DATA_LOCATOR_ELEM, firstFlags);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, DATA_LOCATOR_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       node = tree.getNextElement(true);
       if (node == null) {
         Object[] args = {XML_NODE_NAME, DATA_LOCATOR_ELEM, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
       }
       m_value =
           PSReplacementValueFactory.getReplacementValueFromXml(
@@ -269,14 +271,14 @@ public class PSParam extends PSComponent implements IPSParameter {
     if (!context.startValidation(this, null)) return;
 
     if (m_name == null || m_name.trim().length() == 0)
-      context.validationError(this, IPSObjectStoreErrors.INVALID_PARAM, null);
+      context.validationError(this, ObjectStoreErrorCodes.INVALID_PARAM, null);
 
     // do children
     context.pushParent(this);
     try {
       if (m_value != null) {
         if (m_value instanceof IPSComponent) ((IPSComponent) m_value).validate(context);
-      } else context.validationError(this, IPSObjectStoreErrors.INVALID_PARAM, null);
+      } else context.validationError(this, ObjectStoreErrorCodes.INVALID_PARAM, null);
     } finally {
       context.popParent();
     }

--- a/system/src/main/java/com/percussion/design/objectstore/PSProcessCheck.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProcessCheck.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.util.PSCollection;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -115,11 +117,11 @@ public class PSProcessCheck extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);
@@ -139,27 +141,27 @@ public class PSProcessCheck extends PSComponent {
       m_name = tree.getElementData(NAME_ATTR);
       if (m_name == null || m_name.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, NAME_ATTR, (m_name == null) ? "null" : "empty"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // REQUIRED: context attribute
       m_context = tree.getElementData(CONTEXT_ATTR);
       if (m_context == null || m_context.trim().length() == 0) {
         Object[] args = {XML_NODE_NAME, CONTEXT_ATTR, (m_context == null) ? "null" : "empty"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       // REQUIRED: sequence attribute
       data = tree.getElementData(SEQUENCE_ATTR);
       if (data == null) {
         Object[] args = {XML_NODE_NAME, SEQUENCE_ATTR, "null"};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
       try {
         m_sequence = Integer.parseInt(data);
       } catch (NumberFormatException e) {
         Object[] args = {XML_NODE_NAME, SEQUENCE_ATTR, data};
-        throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
+        throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
       }
 
       Node current = tree.getCurrent();

--- a/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProperty.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
@@ -224,11 +226,11 @@ public class PSProperty extends PSComponent {
   public final void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);
@@ -241,7 +243,7 @@ public class PSProperty extends PSComponent {
     Element valueEl = tree.getNextElement(XML_VALUE_NODE);
     if (valueEl == null) {
       Object[] args = {XML_NODE_NAME, null};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_CHILD, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_CHILD, args);
     }
 
     String type = getEnumeratedAttribute(tree, XML_ATTR_TYPE, TYPE_ENUM);

--- a/system/src/main/java/com/percussion/design/objectstore/PSPropertySet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSPropertySet.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,11 +57,11 @@ public class PSPropertySet extends PSCollectionComponent {
       Element sourceNode, @SuppressWarnings("unused") IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     parentComponents = updateParentList(parentComponents);

--- a/system/src/main/java/com/percussion/design/objectstore/PSProvider.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSProvider.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.design.objectstore;
 
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.List;
 import java.util.Objects;
@@ -137,11 +139,11 @@ public class PSProvider extends PSComponent {
   public void fromXml(Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (sourceNode == null)
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_NAME);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_NULL, XML_NODE_NAME);
 
     if (!XML_NODE_NAME.equals(sourceNode.getNodeName())) {
       Object[] args = {XML_NODE_NAME, sourceNode.getNodeName()};
-      throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK2Test.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK2Test.java
@@ -219,4 +219,60 @@ public class PSDesignObjectstoreTypedErrorCodeBatchK2Test {
     assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
     assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
   }
+
+  /**
+   * {@link PSLockedException#constructArguments()} was rewritten from a {@code switch} on
+   * {@code IPSObjectStoreErrors} ints to {@code if/else} on typed {@link ObjectStoreErrorCodes}
+   * numeric codes. Guard both branches: LOCK_ALREADY_HELD uses 3 args; SAME_USER / default uses 4
+   * (includes session id).
+   */
+  @Test
+  public void lockedExceptionConstructArgumentsLockAlreadyHeldUsesThreeArgs() {
+    PSLockedException ex =
+        new PSLockedException(ObjectStoreErrorCodes.LOCK_ALREADY_HELD.numericCode());
+    ex.setObjectName("app-A");
+    ex.setLockingUser("alice");
+    ex.setExpirationMinutes(12L);
+    ex.setLockingSession("sess-ignored-for-held");
+    ex.constructArguments();
+    Object[] args = ex.getErrorArguments();
+    assertEquals(3, args.length);
+    assertEquals("app-A", args[0]);
+    assertEquals("alice", args[1]);
+    assertEquals("12", args[2]);
+  }
+
+  @Test
+  public void lockedExceptionConstructArgumentsSameUserIncludesSessionId() {
+    PSLockedException ex =
+        new PSLockedException(ObjectStoreErrorCodes.LOCK_ALREADY_HELD_SAME_USER.numericCode());
+    ex.setObjectName("app-B");
+    ex.setLockingUser("bob");
+    ex.setExpirationMinutes(5L);
+    ex.setLockingSession("sess-xyz");
+    ex.constructArguments();
+    Object[] args = ex.getErrorArguments();
+    assertEquals(4, args.length);
+    assertEquals("app-B", args[0]);
+    assertEquals("bob", args[1]);
+    assertEquals("5", args[2]);
+    assertEquals("sess-xyz", args[3]);
+  }
+
+  @Test
+  public void lockedExceptionConstructArgumentsUnknownCodeDefaultsToFourArgs() {
+    // default branch of former switch — any non-LOCK_ALREADY_HELD code
+    PSLockedException ex = new PSLockedException(0);
+    ex.setObjectName("app-C");
+    ex.setLockingUser("carol");
+    ex.setExpirationMinutes(0L);
+    ex.setLockingSession("sess-default");
+    ex.constructArguments();
+    Object[] args = ex.getErrorArguments();
+    assertEquals(4, args.length);
+    assertEquals("app-C", args[0]);
+    assertEquals("carol", args[1]);
+    assertEquals("0", args[2]);
+    assertEquals("sess-default", args[3]);
+  }
 }

--- a/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK2Test.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSDesignObjectstoreTypedErrorCodeBatchK2Test.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.error.PSIllegalArgumentException;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.text.DecimalFormat;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Batch K2 (#3063): design.objectstore I–P cohort call sites must throw typed {@link
+ * ObjectStoreErrorCodes} (not bare {@code IPSObjectStoreErrors} ints) where IPSErrorCode ctors
+ * exist.
+ */
+public class PSDesignObjectstoreTypedErrorCodeBatchK2Test {
+
+  @Test
+  public void inputTranslationsNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSInputTranslations((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void inputTranslationsWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotInputTranslations");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSInputTranslations(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void paramNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSParam((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void paramWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotParam");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSParam(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void providerNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSProvider((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void providerWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotProvider");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSProvider(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void processCheckNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class,
+            () -> new PSProcessCheck((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void processCheckWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotProcessCheck");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSProcessCheck(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void propertyNullSourceUsesTypedNull() {
+    // Ctor rejects null with IllegalArgumentException; typed null is thrown from fromXml.
+    PSProperty property = new PSProperty("sample");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> property.fromXml(null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void propertyWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotProperty");
+    PSProperty property = new PSProperty("sample");
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> property.fromXml(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void locationNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSLocation((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void locationWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotLocation");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSLocation(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void nullEntryNullSourceUsesTypedNull() {
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> new PSNullEntry((Element) null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void nullEntryWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotNullEntry");
+    PSUnknownNodeTypeException ex =
+        assertThrows(PSUnknownNodeTypeException.class, () -> new PSNullEntry(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void numericLiteralNullSourceUsesTypedNull() {
+    PSNumericLiteral literal = new PSNumericLiteral(1, new DecimalFormat("0"));
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> literal.fromXml(null, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_NULL.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_NULL, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void numericLiteralWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotNumericLiteral");
+    PSNumericLiteral literal = new PSNumericLiteral(1, new DecimalFormat("0"));
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> literal.fromXml(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+
+  @Test
+  public void notifierNullServerUsesNumericObjectStoreCode() {
+    PSIllegalArgumentException ex =
+        assertThrows(PSIllegalArgumentException.class, () -> new PSNotifier(PSNotifier.MP_TYPE_SMTP, null));
+    assertEquals(ObjectStoreErrorCodes.NOTIFIER_SERVER_NULL.numericCode(), ex.getErrorCode());
+  }
+
+  @Test
+  public void notifierWrongRootUsesTypedWrongType() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(doc, "NotNotifier");
+    PSNotifier notifier = new PSNotifier();
+    PSUnknownNodeTypeException ex =
+        assertThrows(
+            PSUnknownNodeTypeException.class, () -> notifier.fromXml(wrong, null, null));
+    assertEquals(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode(), ex.getErrorCode());
+    assertSame(ObjectStoreErrorCodes.XML_ELEMENT_WRONG_TYPE, ex.getTypedErrorCode());
+  }
+}


### PR DESCRIPTION
## Summary
Call-site migration **batch K2** for parent residual #3050 / grandparent #2616 / issue #3063: migrate `com.percussion.design.objectstore` **I–P alphabetical cohort** from raw `IPSObjectStoreErrors` ints to typed `ObjectStoreErrorCodes`.

### Scope
- **24 files**, ~**114** call sites migrated (root I–P only)
- Typed construction via existing `IPSErrorCode` ctors (`PSUnknownNodeTypeException`, `validationError`)
- Int-only APIs use `.numericCode()`: `PSIllegalArgumentException`, `PSServerException`, `PSNotFoundException`, `validationWarning`, `getErrorCode()` returns
- `PSLockedException.constructArguments()` rewritten from switch-on-int to if/else (enum `.numericCode()` is not a switch-case constant)
- All 23 distinct codes used in this cohort already exist on `ObjectStoreErrorCodes` (no new enum values)

### Out of scope (remain on residual)
- Q–Z design.objectstore root + `server/` + `legacy/` → residual #3067 (K3)
- D–H (K1 #3062 / PR #3066, independent of this PR)
- Design ACL codes / new enums

### Parent
Parent residual: #3050 · Grandparent: #2616 · Prior: #3040 batch I; #3062 batch K1

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` (JDK 21) — **BUILD SUCCESS**
- [x] New `PSDesignObjectstoreTypedErrorCodeBatchK2Test` — **Tests run: 18, Failures: 0**
- [x] Module suite aggregate surefire — **Tests run: 1881, Failures: 0, Errors: 0, Skipped: 241**

## Product documentation
- [x] N/A — pure tech-debt call-site migration; no operator/user/API surface change

## Build evidence (C3)
- **modules_built:** `system`
- **build_evidence:** `cd system; $env:JAVA_HOME=…jdk-21…; ..\mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1881, Failures: 0; BatchK2Test: 18
- **downstream_checked:** none (call-site only; no public/protected signature or `final`/`sealed` changes)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #3063
Partial residual: #3067 (K3 Q–Z + server/legacy)

> Co-Authored by Grok Build using grok-4.5 with agent main.
